### PR TITLE
feature: allow setting docker detach keys

### DIFF
--- a/scripts/sgx-enter.sh
+++ b/scripts/sgx-enter.sh
@@ -9,22 +9,25 @@ EKIDEN_CONTAINER_NAME=${EKIDEN_CONTAINER_NAME:-$(basename ${WORK_DIR})}
 ekiden_image=${EKIDEN_DOCKER_IMAGE:-ekiden/development:0.1.0-alpha.0}
 ekiden_shell=${EKIDEN_DOCKER_SHELL:-bash}
 
+# Setting the environment variable EKIDEN_DOCKER_DETACH_KEYS to
+# something like 'ctrl-[,ctrl-q' will change it from the default of
+# ctrl-p,ctrl-q which can be annoying to bash users used to
+# emacs-style previous-history (as opposed to using up-arrow) to go back
+# through the command history.  NB: it would be bad if the environment
+# variable contained spaces.
+
+DETACH=${EKIDEN_DOCKER_DETACH_KEYS:+"--detach-keys ${EKIDEN_DOCKER_DETACH_KEYS}"}
+
 which docker >/dev/null || {
   echo "ERROR: Please install Docker first."
   exit 1
 }
 
-# Setting the environment variable EKIDEN_DOCKER_DETACH_KEYS to something
-# like 'ctrl-[,ctrl-q' will change it from the default of ctrl-p,ctrl-q
-# which can be annoying to bash users used to emacs-style previous-line
-# (as opposed to using up-arrow) to go back through the command history.
-DETACH=${EKIDEN_DOCKER_DETACH_KEYS:+"--detach-keys ${EKIDEN_DOCKER_DETACH_KEYS}"}
-
 # Start SGX Rust Docker container.
 if [ ! "$(docker ps -q -f name=${EKIDEN_CONTAINER_NAME})" ]; then
   if [ "$(docker ps -aq -f name=${EKIDEN_CONTAINER_NAME})" ]; then
     docker start ${EKIDEN_CONTAINER_NAME}
-    docker exec -i -t $DETACH ${EKIDEN_CONTAINER_NAME} /usr/bin/env $ekiden_shell
+    docker exec -i -t ${DETACH} ${EKIDEN_CONTAINER_NAME} /usr/bin/env $ekiden_shell
   else
     docker run -t -i \
       --name "${EKIDEN_CONTAINER_NAME}" \
@@ -32,10 +35,10 @@ if [ ! "$(docker ps -q -f name=${EKIDEN_CONTAINER_NAME})" ]; then
       -e "SGX_MODE=SIM" \
       -e "INTEL_SGX_SDK=/opt/sgxsdk" \
       -w /code \
-      $DETACH \
+      ${DETACH} \
       "$ekiden_image" \
       /usr/bin/env $ekiden_shell
   fi
 else
-  docker exec -i -t $DETACH ${EKIDEN_CONTAINER_NAME} /usr/bin/env $ekiden_shell
+  docker exec -i -t ${DETACH} ${EKIDEN_CONTAINER_NAME} /usr/bin/env $ekiden_shell
 fi


### PR DESCRIPTION
Issue #78 

This change allows users to set the EKIDEN_DOCKER_DETACH_KEYS environment variable to cause the docker detach key sequence to be changed for the development docker image.  The default is c-p,c-q, which is annoying for people who use c-p for its previous-history binding in bash.

If the environment variable is not set, the behavior of the script should be unchanged.