### PR TITLE
Fix ekiden shell to use hex rather than base64 container names.

### DIFF
--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -8,7 +8,6 @@ repository = "https://github.com/ekiden/ekiden"
 
 [dependencies]
 mktemp = "0.3.1"
-base64 = "0.9.0"
 cc = "1.0"
 protoc = "1.4"
 protoc-rust = "1.4"

--- a/tools/src/command_shell.rs
+++ b/tools/src/command_shell.rs
@@ -1,5 +1,4 @@
 //! Tool subcommand for entering contract environment.
-extern crate base64;
 extern crate clap;
 extern crate ekiden_common;
 
@@ -91,12 +90,7 @@ fn container_default_name(project: &cargo::ProjectRoot, hardware: bool) -> Strin
         sgx = "-sgx";
     }
     let hash = s.finish();
-    format!(
-        "{}-{}{}",
-        package_name,
-        base64::encode(&format!("{}", hash)),
-        sgx
-    )
+    format!("{}-{}{}", package_name, format!("{:x}", hash), sgx)
 }
 
 /// Enter an Ekiden environment.


### PR DESCRIPTION
Fix #138