### PR TITLE
tools: detect unsupported use of --output

### DIFF
--- a/tools/src/command_buildcontract.rs
+++ b/tools/src/command_buildcontract.rs
@@ -66,10 +66,9 @@ pub fn build_contract(args: &ArgMatches) -> Result<()> {
                 }
             };
             if args.is_present("output") {
-                return Err(Error::new(
-                    "The --output option is not used when implicitly \
-                     building the current project directory.",
-                ));
+                return Err("The --output option is not used when implicitly \
+                            building the current project directory."
+                    .into());
             }
 
             ContractBuilder::new(


### PR DESCRIPTION
The `--output` option is not used when implicitly building the current project directory. This PR makes it an error to specify it, so that you'll know immediately.