### PR TITLE
Use memory-mapped files when parsing contract

### DIFF
--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -19,6 +19,7 @@ toml = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 error-chain = "0.11.0"
+filebuffer = "0.3"
 
 [[bin]]
 name = "cargo-ekiden"

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate ansi_term;
 extern crate cc;
 extern crate error_chain;
+extern crate filebuffer;
 extern crate mktemp;
 extern crate protobuf;
 extern crate protoc;

--- a/tools/src/utils.rs
+++ b/tools/src/utils.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use std::process::Command;
 
 use cc;
+use filebuffer::FileBuffer;
 use mktemp;
 use protobuf;
 use protoc_rust;
@@ -314,8 +315,8 @@ pub fn get_contract_identity<P: AsRef<Path>>(contract: P) -> Result<Vec<u8>> {
     const SIGSTRUCT_HEADER_2: &[u8] =
         b"\x01\x01\x00\x00\x60\x00\x00\x00\x60\x00\x00\x00\x01\x00\x00\x00";
 
-    let contract_file = fs::File::open(contract)?;
-    let mut reader = io::BufReader::new(contract_file);
+    let contract_file = FileBuffer::open(contract)?;
+    let mut reader = io::Cursor::new(&contract_file);
     loop {
         // Update current offset.
         let current_offset = reader.seek(io::SeekFrom::Current(0)).unwrap();


### PR DESCRIPTION
See #153 