### PR TITLE
fixup! Add a rand::Rng implementation backed by the HMAC_DRBG.

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -26,7 +26,6 @@ serde_cbor = "0.8.2"
 
 [target.'cfg(target_env = "sgx")'.dependencies]
 futures-sgx = { git = "https://github.com/ekiden/futures-rs" }
-sgx_rand = { git = "https://github.com/ekiden/rust-sgx-sdk", tag = "v0.9.7-ekiden2"}
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
 rand = "0.4.2"


### PR DESCRIPTION
This should unbreak the CircleCI deploy build.  I'll make sure to manually check the release builds next time.