### PR TITLE
The AVR timestamp isn't strictly RFC 3339 compliant.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Bugfix: Release script updates shell environment.
 * Scheduler interface / centralized implementation added.
 * Use new storage interface in the compute node.
+* Bugfix: AVR timestamp parsing should now be correct.
 
 # 0.1.0-alpha.4
 


### PR DESCRIPTION
The parser requrires the time zone offset component, but the timestamp
from Intel does not have one.

Fixes #187.