### PR TITLE
Add `--register-addr` to the compute node.

### DIFF
--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -15,7 +15,7 @@ use ekiden_common_api as api;
 
 /// Address represents a public location that can be used to connect to an entity in ekiden.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct Address(SocketAddr);
+pub struct Address(pub SocketAddr);
 
 impl Address {
     /// Generate a list of addresses for the local node and a given port.


### PR DESCRIPTION
This allows overriding the addresses that will be published to the
registry as the external contact point for the compute node, but has no
impact on what address/port combination(s) the node will bind to.

Probably sufficient for #242 for at least the medium term.