### PR TITLE
Add missing `--epoch` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To start the compute node for the token contract:
 
 After starting the nodes, to manually advance the epoch in the shared dummy node:
 ```
-# ./target/debug/ekiden-node-dummy-controller set-epoch 1
+# ./target/debug/ekiden-node-dummy-controller set-epoch --epoch 1
 ```
 
 The contract's compute node will listen on `127.0.0.1` (loopback), TCP port `9001` by default.


### PR DESCRIPTION
While going through the README for the first time and following the commands, I noticed that an additional parameter is needed to set the epoch:
```
root@9ad27d888205:/code# ./target/debug/ekiden-node-dummy-controller set-epoch 1
error: Found argument '1' which wasn't expected, or isn't valid in this context

USAGE:
    ekiden-node-dummy-controller --host <host> --port <port> set-epoch --epoch <epoch>

For more information try --help
```