### PR TITLE
Do not require mutable client reference for generated RPC methods

### DIFF
--- a/rpc/client/src/macros.rs
+++ b/rpc/client/src/macros.rs
@@ -78,7 +78,7 @@ macro_rules! create_client_rpc {
                 // Generate methods.
                 $(
                     pub fn $method_name(
-                        &mut self,
+                        &self,
                         request: $request_type
                     ) -> ClientFuture<$response_type> {
                         self.client.call(stringify!($method_name), request)


### PR DESCRIPTION
As @kostko pointed out, the contract client macro fix is also needed for rpc client.