### PR TITLE
EntityRegistry support for per-epoch node lists. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
   don't respond in time as failing. To enable timeouts, pass
   `--rpc-timeout SECONDS` in clients that use client-utils and
   `--forwarded-rpc-timeout SECONDS` in ekiden-compute.
+* EntityRegistry support for per-epoch node lists.  `get_nodes()` now takes an
+  epoch, and a `watch_node_list()` routine to subscribe to node list generation
+  has been added.
 
 # 0.1.0-alpha.4
 

--- a/consensus/dummy/tests/backend.rs
+++ b/consensus/dummy/tests/backend.rs
@@ -26,7 +26,8 @@ use ekiden_consensus_base::test::generate_simulated_nodes;
 use ekiden_consensus_base::ConsensusBackend;
 use ekiden_consensus_dummy::DummyConsensusBackend;
 use ekiden_registry_base::test::populate_entity_registry;
-use ekiden_registry_base::{ContractRegistryBackend, REGISTER_CONTRACT_SIGNATURE_CONTEXT};
+use ekiden_registry_base::{ContractRegistryBackend, EntityRegistryBackend,
+                           REGISTER_CONTRACT_SIGNATURE_CONTEXT};
 use ekiden_registry_dummy::{DummyContractRegistryBackend, DummyEntityRegistryBackend};
 use ekiden_scheduler_base::Scheduler;
 use ekiden_scheduler_dummy::DummySchedulerBackend;
@@ -41,7 +42,7 @@ fn test_dummy_backend_two_rounds() {
     let time_notifier = Arc::new(LocalTimeSourceNotifier::new(time_source.clone()));
 
     let beacon = Arc::new(InsecureDummyRandomBeacon::new(time_notifier.clone()));
-    let entity_registry = Arc::new(DummyEntityRegistryBackend::new());
+    let entity_registry = Arc::new(DummyEntityRegistryBackend::new(time_notifier.clone()));
     let contract_registry = Arc::new(DummyContractRegistryBackend::new());
     let contract_sk =
         Ed25519KeyPair::from_seed_unchecked(untrusted::Input::from(&B256::random())).unwrap();
@@ -96,6 +97,7 @@ fn test_dummy_backend_two_rounds() {
 
     // Start backends.
     beacon.start(&mut pool);
+    entity_registry.start(&mut pool);
     scheduler.start(&mut pool);
     backend.start(&mut pool);
 

--- a/node/dummy/src/backend.rs
+++ b/node/dummy/src/backend.rs
@@ -90,7 +90,7 @@ impl DummyBackend {
 
         let random_beacon = Arc::new(InsecureDummyRandomBeacon::new(time_notifier.clone()));
         let contract_registry = Arc::new(DummyContractRegistryBackend::new());
-        let entity_registry = Arc::new(DummyEntityRegistryBackend::new());
+        let entity_registry = Arc::new(DummyEntityRegistryBackend::new(time_notifier.clone()));
         let scheduler = Arc::new(DummySchedulerBackend::new(
             random_beacon.clone(),
             contract_registry.clone(),
@@ -153,6 +153,7 @@ impl DummyBackend {
         let mut executor = GrpcExecutor::new(self.grpc_environment.clone());
 
         self.random_beacon.start(&mut executor);
+        self.entity_registry.start(&mut executor);
         self.scheduler.start(&mut executor);
         self.consensus.start(&mut executor);
 

--- a/registry/api/src/entity.proto
+++ b/registry/api/src/entity.proto
@@ -15,6 +15,7 @@ service EntityRegistry {
     rpc GetNodes (NodesRequest) returns (NodesResponse) {}
     rpc GetNodesForEntity (EntityNodesRequest) returns (EntityNodesResponse) {}
     rpc WatchNodes (WatchNodeRequest) returns (stream WatchNodeResponse) {}
+    rpc WatchNodeList (WatchNodeListRequest) returns (stream WatchNodeListResponse) {}
 }
 
 message RegisterRequest {
@@ -77,6 +78,7 @@ message NodeResponse {
 }
 
 message NodesRequest {
+    uint64 epoch = 1;
 }
 
 message NodesResponse {
@@ -101,4 +103,12 @@ message WatchNodeResponse {
     }
     ChangeType event_type = 1;
     common.Node node = 2;
+}
+
+message WatchNodeListRequest {
+}
+
+message WatchNodeListResponse {
+    uint64 epoch = 1;
+    repeated common.Node node = 2;
 }

--- a/registry/client/src/entity.rs
+++ b/registry/client/src/entity.rs
@@ -7,8 +7,9 @@ use grpcio::{Channel, Environment};
 
 use ekiden_common::bytes::B256;
 use ekiden_common::entity::Entity;
+use ekiden_common::epochtime::EpochTime;
 use ekiden_common::error::{Error, Result};
-use ekiden_common::futures::{future, stream, BoxFuture, BoxStream, Future, Stream};
+use ekiden_common::futures::{future, stream, BoxFuture, BoxStream, Executor, Future, Stream};
 use ekiden_common::node::Node;
 use ekiden_common::signature::Signed;
 use ekiden_registry_api as api;
@@ -28,6 +29,8 @@ impl EntityRegistryClient {
 }
 
 impl EntityRegistryBackend for EntityRegistryClient {
+    fn start(&self, _executor: &mut Executor) {}
+
     fn register_entity(&self, entity: Signed<Entity>) -> BoxFuture<()> {
         let mut request = api::RegisterRequest::new();
         request.set_entity(entity.get_value_unsafe().clone().into());
@@ -131,8 +134,9 @@ impl EntityRegistryBackend for EntityRegistryClient {
         }
     }
 
-    fn get_nodes(&self) -> BoxFuture<Vec<Node>> {
-        let request = api::NodesRequest::new();
+    fn get_nodes(&self, epoch: EpochTime) -> BoxFuture<Vec<Node>> {
+        let mut request = api::NodesRequest::new();
+        request.set_epoch(epoch);
         match self.0.get_nodes_async(&request) {
             Ok(f) => Box::new(f.map_err(|error| Error::new(error.description())).and_then(
                 |mut response| {
@@ -183,6 +187,27 @@ impl EntityRegistryBackend for EntityRegistryClient {
                             Ok(RegistryEvent::Deregistered(node))
                         }
                     }
+                }
+                Err(error) => Err(Error::new(error.description())),
+            })),
+            Err(error) => Box::new(stream::once(Err(Error::new(error.description())))),
+        }
+    }
+
+    fn watch_node_list(&self) -> BoxStream<(EpochTime, Vec<Node>)> {
+        let request = api::WatchNodeListRequest::new();
+        match self.0.watch_node_list(&request) {
+            Ok(stream) => Box::new(stream.then(|result| match result {
+                Ok(mut response) => {
+                    let epoch = response.get_epoch();
+                    let mut response = response.take_node().into_vec();
+                    let mut nodes = vec![];
+                    for raw_node in response {
+                        let node = Node::try_from(raw_node)?;
+                        nodes.push(node);
+                    }
+
+                    Ok((epoch, nodes))
                 }
                 Err(error) => Err(Error::new(error.description())),
             })),

--- a/registry/dummy/tests/entity.rs
+++ b/registry/dummy/tests/entity.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use ekiden_common::bytes::B256;
 use ekiden_common::entity::Entity;
+use ekiden_common::epochtime::local::{LocalTimeSourceNotifier, MockTimeSource};
 use ekiden_common::futures::{future, BoxFuture, Future};
 use ekiden_common::ring::signature::Ed25519KeyPair;
 use ekiden_common::signature::{InMemorySigner, Signature, Signed};
@@ -17,7 +18,10 @@ use ekiden_registry_dummy::DummyEntityRegistryBackend;
 
 #[test]
 fn test_dummy_entity_backend() {
-    let backend = Arc::new(DummyEntityRegistryBackend::new());
+    let time_source = Arc::new(MockTimeSource::new());
+    let time_notifier = Arc::new(LocalTimeSourceNotifier::new(time_source.clone()));
+
+    let backend = Arc::new(DummyEntityRegistryBackend::new(time_notifier));
 
     let mut tasks: Vec<BoxFuture<()>> = Vec::new();
 


### PR DESCRIPTION
The list of all nodes should be globally consistent for each epoch
to allow for consistent/reproducible committee elections.  This PR changes
the entity registry API to allow for this behavior.

 * [x] `get_nodes()` needs to take an epoch.
 * [x] Add a node list event.
 * [x] Change the scheduler to use the new event instead of calling `get_nodes()`.
 * [x] Add support to the RPC registry for the new semantics/call.

Note: This is also required for any sort of scheduling to work at all when the registry or scheduler are backed by Ethereum.