### PR TITLE
Add forwarding extra arguments to Docker in shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   input/output hashes in block header. Content is delegated to storage.
 * **BACKWARD INCOMPATIBLE:** Remove `submit` operation from consensus backend.
 * Add discrepancy resolution by using backup workers majority vote.
+* Add passing extra arguments to Docker in shell (`--docker-extra-args`).
 
 # 0.1.0
 

--- a/tools/bin/main.rs
+++ b/tools/bin/main.rs
@@ -157,7 +157,7 @@ fn main() {
                         )
                         .arg(
                             Arg::with_name("docker-extra-args")
-                                .help("Additional arguments to pass to Docker when creating the environment")
+                                .help("Additional comma-delimited arguments to pass to Docker when creating the environment")
                                 .long("docker-extra-args")
                                 .default_value("")
                         )


### PR DESCRIPTION
See issue #255.

~~This is currently a work-in-progress, but feel free to comment and give any Rust tips, etc. :)~~

Ready for review!

Example usage (map port 1234 to the same port outside the container):
`cargo ekiden shell --docker-extra-args='-p,1234:1234'`