### PR TITLE
Add SYS_PTRACE cap to shell by default

### DIFF
--- a/tools/src/command_shell.rs
+++ b/tools/src/command_shell.rs
@@ -58,6 +58,8 @@ fn docker_create(
         "INTEL_SGX_SDK=/opt/sgxsdk",
         "-w",
         "/code",
+        "--cap-add",
+        "SYS_PTRACE",
         "--detach-keys",
         escape_keys,
         image,


### PR DESCRIPTION
See issue #289.

To be able to run `gdb` inside the containers created by `cargo ekiden shell`, we have to add the `SYS_PTRACE` capability.  With this PR, this capability is added by default for every container, so `gdb` should work without issues.