### PR TITLE
common/epochtime: watch_epochs()'s catchup mechanism was broken.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Add passing extra arguments to Docker in shell (`--docker-extra-args`).
 * Add `common::futures::retry` which implements retrying futures on failure.
 * Add support for dependency injection.
+* Bugfix: `epochtime::LocalTimeSourceNotifier::watch_epochs()` will now
+  correctly broadcast the current epoch if it is available.
 
 # 0.1.0
 

--- a/common/src/epochtime/local.rs
+++ b/common/src/epochtime/local.rs
@@ -161,7 +161,7 @@ impl TimeSourceNotifier for LocalTimeSourceNotifier {
 
         // Iff the notifications for the current epoch went out already,
         // send the current epoch to the subscriber.
-        let now = self.time_source.get_epoch().unwrap().1;
+        let now = self.time_source.get_epoch().unwrap().0;
         if now == inner.last_notify {
             trace!("watch_epochs(): Catch up: Epoch: {}", now);
             send.unbounded_send(now).unwrap();


### PR DESCRIPTION
Treating `till` as the current epoch does not, and will not give the
correct results in most circumstances.