### PR TITLE
common/testing: Add try_init_logging().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 * Bugfix: `epochtime::LocalTimeSourceNotifier::watch_epochs()` will now
   correctly broadcast the current epoch if it is available.
 * The initial Ethereum smart contract based Random Beacon has been added.
+* Add `common::testing::try_init_logging` which can be called from tests to
+  initialize logging while honoring `cargo test`'s capture behavior.
 
 # 0.1.0
 

--- a/beacon/ethereum/Cargo.toml
+++ b/beacon/ethereum/Cargo.toml
@@ -18,5 +18,4 @@ web3 = { git = "https://github.com/ekiden/rust-web3" }
 
 [dev-dependencies]
 ekiden-tools = { path = "../../tools", version = "0.2.0-alpha" }
-pretty_env_logger = "0.2"
 scopeguard = "0.3.3"

--- a/beacon/ethereum/tests/beacon.rs
+++ b/beacon/ethereum/tests/beacon.rs
@@ -9,9 +9,6 @@ extern crate ekiden_tools;
 extern crate scopeguard;
 extern crate web3;
 
-extern crate log;
-extern crate pretty_env_logger;
-
 use ekiden_beacon_base::RandomBeacon;
 use ekiden_beacon_ethereum::EthereumRandomBeacon;
 use ekiden_common::bytes::{B256, H160};
@@ -19,28 +16,10 @@ use ekiden_common::entity::Entity;
 use ekiden_common::epochtime::local::{LocalTimeSourceNotifier, SystemTimeSource};
 use ekiden_common::error::Error;
 use ekiden_common::futures::{cpupool, future, stream, BoxStream, Future, Stream};
+use ekiden_common::testing;
 use ekiden_tools::truffle::{deploy_truffle, start_truffle, DEVELOPMENT_ADDRESS};
-use log::LevelFilter;
 use web3::api::Web3;
 use web3::transports::WebSocket;
-
-fn try_init_logging() {
-    // `pretty_env_logger` logs to stderr by default.  While it could be
-    // re-targetted to log to stdout, Rust/Cargo bugs prevent stdout from
-    // threads being captured, so there's no point.
-    //
-    // See: https://github.com/rust-lang/rust/issues/42474
-
-    for arg in std::env::args() {
-        if arg == "--nocapture" {
-            pretty_env_logger::formatted_builder()
-                .unwrap()
-                .filter(None, LevelFilter::Trace)
-                .init();
-            return;
-        }
-    }
-}
 
 /// Make a stream of transactions between two truffle default accts to keep the chain going.
 fn mine<T: 'static + web3::Transport + Sync + Send>(tport: T) -> BoxStream<u64>
@@ -59,7 +38,7 @@ where
 
 #[test]
 fn beacon_integration() {
-    try_init_logging();
+    testing::try_init_logging();
 
     let mut executor = cpupool::CpuPool::new(4);
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -36,6 +36,8 @@ grpcio = "0.2.2"
 futures = "0.1"
 futures-cpupool = "0.1"
 get_if_addrs = "~0.5.1"
+env_logger = "0.5.10"
+pretty_env_logger = "0.2"
 
 [dev-dependencies]
 serde_json = { git = "https://github.com/ekiden/json" }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -11,6 +11,11 @@ extern crate sgx_rand;
 #[cfg(target_env = "sgx")]
 extern crate sgx_trts;
 
+#[cfg(not(target_env = "sgx"))]
+extern crate env_logger;
+#[cfg(not(target_env = "sgx"))]
+extern crate pretty_env_logger;
+
 extern crate bigint;
 extern crate byteorder;
 extern crate chrono;
@@ -55,3 +60,4 @@ pub mod signature;
 pub mod uint;
 pub mod environment;
 pub mod subscribers;
+pub mod testing;

--- a/common/src/testing.rs
+++ b/common/src/testing.rs
@@ -1,0 +1,39 @@
+//! Testing utilities.
+#[cfg(not(target_env = "sgx"))]
+use std;
+
+#[cfg(not(target_env = "sgx"))]
+use env_logger::fmt::Target;
+#[cfg(not(target_env = "sgx"))]
+use log::LevelFilter;
+#[cfg(not(target_env = "sgx"))]
+use pretty_env_logger;
+
+/// Attempt to initialize the global logger for `Trace` level logging,
+/// outputting to stdout, iff the `--nocapture` command line argument is
+/// passed to the test binary.
+///
+/// This call is idempotent, and failures are silently ignored.
+#[cfg(not(target_env = "sgx"))]
+pub fn try_init_logging() {
+    // Rust/Cargo bugs prevent stdout from threads from being captured, so
+    // manually inspect the command line arguments to see if log output
+    // should be displayed.
+    //
+    // See: https://github.com/rust-lang/rust/issues/42474
+
+    for arg in std::env::args() {
+        if arg == "--nocapture" {
+            let mut builder = match pretty_env_logger::formatted_builder() {
+                Ok(builder) => builder,
+                Err(_) => return,
+            };
+
+            let _ = builder
+                .filter(None, LevelFilter::Trace)
+                .target(Target::Stdout)
+                .try_init();
+            return;
+        }
+    }
+}


### PR DESCRIPTION
Being able to get log output from tests is useful for development and debugging,
and this saves me having to copy + paste the snippet around to all my tests.

Fixes #357.