### PR TITLE
Pin bigint dep to before 128-bit types

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -18,7 +18,7 @@ byteorder = "1.2.1"
 rustc-hex = "1.0"
 ring = { git = "https://github.com/ekiden/ring", default-features = false, features = [ "rsa_signing" ], branch = "0.12.1-ekiden" }
 untrusted = "0.5.1"
-bigint = { version = "4", features = ["std"] }
+bigint = { version = "~4.3", features = ["std"] }
 chrono = "0.4.2"
 # We cannot use serde>=1.0.60 as it requires rustc 1.26+.
 serde = "=1.0.59"


### PR DESCRIPTION
The `bigint` crate [recently bumped its minor version](https://github.com/paritytech/bigint/commit/30b3004dd6400c65ed6a34894a9f1eac95d61041) and now [includes the rust 128-bit types](https://github.com/paritytech/bigint/commit/e58c922d6511f9e47ffb528cfabaee2cb3e10417).

This PR pins `bigint` to `0.4.3` which does not include iu128. We should consider updating to the most recent rust-sgx-sdk nightly, though, since the big integer types seem to be catching on.