### PR TITLE
Add aggregating commits and reveals in consensus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Add generic instrumentation framework (`ekiden-instrumentation`) and a Prometheus
   frontend (`ekiden-instrumentation-prometheus`).
 * Added the multilayer storage backend described in RFC 0004.
+* Add aggregating commits and reveals in consensus.
 
 # 0.1.0
 

--- a/common/src/node_group.rs
+++ b/common/src/node_group.rs
@@ -7,12 +7,12 @@ use super::error::{Error, Result};
 use super::futures::{future, BoxFuture, Future};
 
 /// Group of nodes speaking the same API.
-pub struct NodeGroup<T> {
-    /// Active nodes.
-    nodes: Arc<Mutex<Vec<T>>>,
+pub struct NodeGroup<T, U> {
+    /// Active nodes and their metadata.
+    nodes: Arc<Mutex<Vec<(T, U)>>>,
 }
 
-impl<T> NodeGroup<T> {
+impl<T, U> NodeGroup<T, U> {
     /// Construct new empty node group.
     pub fn new() -> Self {
         Self {
@@ -27,15 +27,16 @@ impl<T> NodeGroup<T> {
     }
 
     /// Add a new node.
-    pub fn add_node(&self, client: T) {
+    pub fn add_node(&self, client: T, meta: U) {
         let mut nodes = self.nodes.lock().unwrap();
-        nodes.push(client);
+        nodes.push((client, meta));
     }
 
-    /// Call all nodes in the group.
-    pub fn call_all<F, Rs>(&self, method: F) -> BoxFuture<Vec<Result<Rs>>>
+    /// Call all nodes in the group that match the filter predicate.
+    pub fn call_filtered<F, G, Rs>(&self, filter: F, method: G) -> BoxFuture<Vec<Result<Rs>>>
     where
-        F: Fn(&T) -> grpcio::Result<grpcio::ClientUnaryReceiver<Rs>>
+        F: Fn(&T, &U) -> bool,
+        G: Fn(&T, &U) -> grpcio::Result<grpcio::ClientUnaryReceiver<Rs>>
             + Clone
             + Send
             + Sync
@@ -46,8 +47,9 @@ impl<T> NodeGroup<T> {
 
         let calls: Vec<BoxFuture<Result<Rs>>> = nodes
             .iter()
-            .map(|node| -> BoxFuture<Result<Rs>> {
-                match method.clone()(node) {
+            .filter(|&&(ref node, ref meta)| filter(&node, &meta))
+            .map(|&(ref node, ref meta)| -> BoxFuture<Result<Rs>> {
+                match method.clone()(&node, &meta) {
                     Ok(call) => Box::new(call.then(|result| {
                         future::ok(result.map_err(|error| Error::from(error)))
                     })),
@@ -57,5 +59,18 @@ impl<T> NodeGroup<T> {
             .collect();
 
         Box::new(future::join_all(calls))
+    }
+
+    /// Call all nodes in the group.
+    pub fn call_all<G, Rs>(&self, method: G) -> BoxFuture<Vec<Result<Rs>>>
+    where
+        G: Fn(&T, &U) -> grpcio::Result<grpcio::ClientUnaryReceiver<Rs>>
+            + Clone
+            + Send
+            + Sync
+            + 'static,
+        Rs: Send + Sync + 'static,
+    {
+        self.call_filtered(|_, _| true, method)
     }
 }

--- a/compute/api/Cargo.toml
+++ b/compute/api/Cargo.toml
@@ -9,6 +9,7 @@ build = "build.rs"
 
 [dependencies]
 ekiden-common-api = { path = "../../common/api", version = "0.2.0-alpha" }
+ekiden-consensus-api = { path = "../../consensus/api", version = "0.2.0-alpha" }
 protobuf = "~2.0"
 grpcio = { git = "https://github.com/ekiden/grpc-rs", tag = "v0.3.0-ekiden1", features = ["openssl"] }
 futures = "0.1"

--- a/compute/api/build.rs
+++ b/compute/api/build.rs
@@ -6,7 +6,7 @@ fn main() {
     // Must be done first to create src/generated directory
     ekiden_tools::generate_mod_with_imports(
         "src/generated",
-        &["common"],
+        &["common", "consensus"],
         &[
             "computation_group",
             "computation_group_grpc",

--- a/compute/api/src/computation_group.proto
+++ b/compute/api/src/computation_group.proto
@@ -1,12 +1,17 @@
 syntax = "proto3";
 
 import "common/api/src/common.proto";
+import "consensus/api/src/consensus.proto";
 
 package computation_group;
 
 service ComputationGroup {
     // Submit a batch to a worker in the same computation group.
     rpc SubmitBatch (SubmitBatchRequest) returns (SubmitBatchResponse) {}
+    // Submit a commit to the leader for aggregation.
+    rpc SubmitAggCommit (SubmitAggCommitRequest) returns (SubmitAggResponse) {}
+    // Submit a reveal to the leader for aggregation.
+    rpc SubmitAggReveal (SubmitAggRevealRequest) returns (SubmitAggResponse) {}
 }
 
 message SubmitBatchRequest {
@@ -15,4 +20,18 @@ message SubmitBatchRequest {
 }
 
 message SubmitBatchResponse {
+}
+
+message SubmitAggCommitRequest {
+    consensus.Commitment commit = 1;
+    common.Signature signature = 2;
+}
+
+message SubmitAggRevealRequest {
+    consensus.Reveal reveal = 1;
+    common.Signature signature = 2;
+}
+
+message SubmitAggResponse {
+    bytes receipt = 1;
 }

--- a/compute/api/src/lib.rs
+++ b/compute/api/src/lib.rs
@@ -3,10 +3,12 @@ extern crate grpcio;
 extern crate protobuf;
 
 extern crate ekiden_common_api;
+extern crate ekiden_consensus_api;
 
 mod generated;
 
 use ekiden_common_api as common;
+use ekiden_consensus_api as consensus;
 
 pub use generated::computation_group::*;
 pub use generated::computation_group_grpc::*;

--- a/consensus/api/src/consensus.proto
+++ b/consensus/api/src/consensus.proto
@@ -11,6 +11,8 @@ service Consensus {
   rpc GetEvents (EventRequest) returns (stream EventResponse) {}
   rpc Commit (CommitRequest) returns (CommitResponse) {}
   rpc Reveal (RevealRequest) returns (RevealResponse) {}
+  rpc CommitMany (CommitManyRequest) returns (CommitResponse) {}
+  rpc RevealMany (RevealManyRequest) returns (RevealResponse) {}
 }
 
 message Block {
@@ -34,6 +36,12 @@ message Header {
   bytes output_hash = 7;
   bytes state_root = 8;
   bytes commitments_hash = 9;
+}
+
+message Reveal {
+  Header header = 2;
+  bytes nonce = 3;
+  common.Signature signature = 4;
 }
 
 message LatestBlockRequest {
@@ -88,10 +96,18 @@ message CommitResponse {
 
 message RevealRequest {
   bytes contract_id = 1;
-  Header header = 2;
-  bytes nonce = 3;
-  common.Signature signature = 4;
+  Reveal reveal = 2;
 }
 
 message RevealResponse {
+}
+
+message CommitManyRequest {
+    bytes contract_id = 1;
+    repeated Commitment commitments = 2;
+}
+
+message RevealManyRequest {
+    bytes contract_id = 1;
+    repeated Reveal reveals = 2;
 }

--- a/consensus/base/src/backend.rs
+++ b/consensus/base/src/backend.rs
@@ -59,4 +59,12 @@ pub trait ConsensusBackend: Sync + Send {
 
     /// Reveal the block header that was committed to previously using `commit`.
     fn reveal(&self, contract_id: B256, reveal: Reveal<Header>) -> BoxFuture<()>;
+
+    /// Commit to results of processing multiple batches of contract invocations.
+    ///
+    /// Each passed `commitment` must be over the block header.
+    fn commit_many(&self, contract_id: B256, commitments: Vec<Commitment>) -> BoxFuture<()>;
+
+    /// Reveal multiple block headers that were committed to previously using `commit` or `commit_many`.
+    fn reveal_many(&self, contract_id: B256, reveals: Vec<Reveal<Header>>) -> BoxFuture<()>;
 }


### PR DESCRIPTION
See issue #329.

Done!

This PR implements the following:
* Consensus backend has been extended with two additional commands (`CommitMany` and `RevealMany`), which take multiple commits and reveals at once.
* Computation group API has been extended with two additional commands (`SubmitAggCommit` and `SubmitAggReveal`), which submit a single commit/reveal to the group leader for aggregation.
* Commands for handling a commit or reveal for aggregation have been added to the consensus frontend.  Aggregated commits/reveals are sent to the backend when all the workers in the committee have sent a commit/reveal (timeouts will be added later).
* Workers now use aggregate commits and reveals.
* The `SubmitAgg{Commit,Reveal}` commands are sent only to the leader instead of the whole group.

I'm still new to all this, so any comments/suggestions/improvements are welcome :)