### PR TITLE
Use Web3 Branch allowing empty logs

### DIFF
--- a/ethereum/Cargo.toml
+++ b/ethereum/Cargo.toml
@@ -25,7 +25,7 @@ serde_derive = "1.0"
 serde_cbor = "0.8.2"
 serde_json = "1.0"
 tokio-core = "0.1.17"
-web3 = { git = "https://github.com/ekiden/rust-web3" }
+web3 = { git = "https://github.com/ekiden/rust-web3", branch = "0.3.0-ekiden" }
 
 [dev-dependencies]
 ekiden-storage-dummy = { path = "../storage/dummy", version = "0.2.0-alpha" }


### PR DESCRIPTION
the web3 crate interprets the `data` field of evm logs as being of the `bytes` type, which are specified as having a 0 representation of `0x`.

However, in practice the data field can take on the `value` type when empty, in which case it will be communicated over the wire as `0x0`.

This patches it by allowing the `bytes` conversion in the crate to accept `0x0` as a 0-length byte array, which keeps things happy.