### PR TITLE
Set the number of Cargo build jobs on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
       - run: echo 'export SGX_MODE=SIM' >> $BASH_ENV
       - run: echo 'export INTEL_SGX_SDK=/opt/sgxsdk' >> $BASH_ENV
       - run: echo 'export EKIDEN_UNSAFE_SKIP_AVR_VERIFY=1' >> $BASH_ENV
+      - run: echo 'export CARGO_BUILD_JOBS=2' >> $BASH_ENV
       - checkout
 
       # Check if all core crates have the same version (issue #175)


### PR DESCRIPTION
See #411

It sets the number of (parallel) Cargo build jobs to 2.

This should reduce memory usage but comes at a cost of slower builds (e.g., builds seem ~10 min slower). We could also experiment with more parallel jobs and see where the sweet spot is.