### PR TITLE
lock regex version

### DIFF
--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -21,7 +21,7 @@ serde = "=1.0.59"
 serde_derive = "1.0"
 error-chain = "0.11.0"
 filebuffer = "0.3"
-regex = "~1.0.0"
+regex = "=1.0.0"
 rustc-hex = "1.0.0"
 
 [[bin]]


### PR DESCRIPTION
We can't compile version 1.0.1 on the Rust version we're using