### PR TITLE
Use bincode for db serialization

### DIFF
--- a/db/trusted/Cargo.toml
+++ b/db/trusted/Cargo.toml
@@ -15,8 +15,8 @@ lazy_static = { version = "1.0", features = ["spin_no_std"] }
 protobuf = "~2.0"
 sodalite = "0.3.0"
 serde = "=1.0.59"
-serde_cbor = "0.8.2"
 serde_derive = "1.0"
+bincode = "1.0.0"
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
 ekiden-storage-dummy = { path = "../../storage/dummy", version = "0.2.0-alpha" }

--- a/db/trusted/src/lib.rs
+++ b/db/trusted/src/lib.rs
@@ -10,9 +10,9 @@ extern crate sgx_types;
 extern crate lazy_static;
 extern crate protobuf;
 extern crate serde;
-extern crate serde_cbor;
 #[macro_use]
 extern crate serde_derive;
+extern crate bincode;
 
 extern crate ekiden_common;
 extern crate ekiden_enclave_trusted;

--- a/db/trusted/src/patricia_trie/node.rs
+++ b/db/trusted/src/patricia_trie/node.rs
@@ -1,4 +1,4 @@
-use serde_cbor;
+use bincode;
 
 use ekiden_common::bytes::H256;
 
@@ -72,7 +72,7 @@ impl Node {
 
     /// Size of serialized node.
     pub fn size(&self) -> usize {
-        serde_cbor::to_vec(self).unwrap().len()
+        bincode::serialize(self).unwrap().len()
     }
 
     /// Check if node can be embedded instead of requiring a pointer.

--- a/db/trusted/src/schema/descriptor.rs
+++ b/db/trusted/src/schema/descriptor.rs
@@ -2,9 +2,9 @@
 use std::borrow::Borrow;
 use std::marker::PhantomData;
 
+use bincode;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use serde_cbor;
 
 use super::super::{Database, DatabaseHandle};
 
@@ -38,7 +38,7 @@ where
 
     /// Derive the key for storing this field in the underlying database.
     fn get_key(&self) -> Vec<u8> {
-        serde_cbor::to_vec(&(&self.namespace, &self.name)).unwrap()
+        bincode::serialize(&(&self.namespace, &self.name)).unwrap()
     }
 
     /// Insert a value for this field.
@@ -59,9 +59,9 @@ where
         Q: ?Sized + Serialize,
     {
         let mut db = DatabaseHandle::instance();
-        let value = serde_cbor::to_vec(&(value.borrow())).unwrap();
+        let value = bincode::serialize(&(value.borrow())).unwrap();
         match db.insert(&self.get_key(), &value) {
-            Some(value) => Some(serde_cbor::from_slice(&value).expect("Corrupted state")),
+            Some(value) => Some(bincode::deserialize(&value).expect("Corrupted state")),
             None => None,
         }
     }
@@ -70,7 +70,7 @@ where
     pub fn get(&self) -> Option<T> {
         let db = DatabaseHandle::instance();
         match db.get(&self.get_key()) {
-            Some(value) => Some(serde_cbor::from_slice(&value).expect("Corrupted state")),
+            Some(value) => Some(bincode::deserialize(&value).expect("Corrupted state")),
             None => None,
         }
     }
@@ -80,7 +80,7 @@ where
     pub fn remove(&self) -> Option<T> {
         let mut db = DatabaseHandle::instance();
         match db.remove(&self.get_key()) {
-            Some(value) => Some(serde_cbor::from_slice(&value).expect("Corrupted state")),
+            Some(value) => Some(bincode::deserialize(&value).expect("Corrupted state")),
             None => None,
         }
     }
@@ -118,7 +118,7 @@ where
         K: Borrow<Q>,
         Q: ?Sized + Serialize,
     {
-        serde_cbor::to_vec(&(&self.namespace, &self.name, subkey)).unwrap()
+        bincode::serialize(&(&self.namespace, &self.name, subkey)).unwrap()
     }
 
     /// Insert a value for this field.
@@ -144,9 +144,9 @@ where
         P: ?Sized + Serialize,
     {
         let mut db = DatabaseHandle::instance();
-        let value = serde_cbor::to_vec(&(value.borrow())).unwrap();
+        let value = bincode::serialize(&(value.borrow())).unwrap();
         match db.insert(&self.get_key_for_subkey(key), &value) {
-            Some(value) => Some(serde_cbor::from_slice(&value).expect("Corrupted state")),
+            Some(value) => Some(bincode::deserialize(&value).expect("Corrupted state")),
             None => None,
         }
     }
@@ -164,7 +164,7 @@ where
     {
         let db = DatabaseHandle::instance();
         match db.get(&self.get_key_for_subkey(key)) {
-            Some(value) => Some(serde_cbor::from_slice(&value).expect("Corrupted state")),
+            Some(value) => Some(bincode::deserialize(&value).expect("Corrupted state")),
             None => None,
         }
     }
@@ -183,7 +183,7 @@ where
     {
         let mut db = DatabaseHandle::instance();
         match db.remove(&self.get_key_for_subkey(key)) {
-            Some(value) => Some(serde_cbor::from_slice(&value).expect("Corrupted state")),
+            Some(value) => Some(bincode::deserialize(&value).expect("Corrupted state")),
             None => None,
         }
     }


### PR DESCRIPTION
See #438 

**Note that changing the serialization format is a backwards incompatible change so any persistent existing state needs to be cleared.**

Previously CBOR was used and it seemed to be much slower than bincode in trie benchmarks. This replaces it with bincode for both the trie and the schema-based state.

Results on my local machine (benchmarks are in #437):

With CBOR:
```
running 1 test
test patricia_trie::trie::test::bench_feather ... bench:     490,297 ns/iter (+/- 50,103)
```

With bincode:
```
running 1 test
test patricia_trie::trie::test::bench_feather ... bench:     280,864 ns/iter (+/- 8,711)
```
