### PR TITLE
Document incorrect DI factory use in docs

### DIFF
--- a/di/src/di.rs
+++ b/di/src/di.rs
@@ -178,11 +178,24 @@ pub trait ComponentFactory: Sync + Send {
     /// on [`Container`]). If the factory returns the latter the component can only be
     /// injected as shared.
     ///
+    /// Note, you should explicitly **not** return a type-erased `Box<Box<Struct>>` or a
+    /// `Box<Arc<Struct>>`.
+    ///
     /// # Examples
     ///
     /// ```ignore
     /// fn build(&self, container: &mut Container) -> Result<Box<Any>> {
     ///     let instance: Box<Trait> = Box::new(MyInstance::new());
+    ///     Box::new(instance)
+    /// }
+    /// ```
+    ///
+    /// The following example shows **incorrect usage** which will result in a panic at
+    /// injection time:
+    ///
+    /// ```ignore
+    /// fn build(&self, container: &mut Container) -> Result<Box<Any>> {
+    ///     let instance = Box::new(MyInstance::new());
     ///     Box::new(instance)
     /// }
     /// ```


### PR DESCRIPTION
See #458 

If the DI factory returns a type-erased `Box<Struct>` instead of a type-erased `Box<Trait>` this will result in a panic at injection time.

This adds explicit documentation of incorrect usage.