### PR TITLE
 Make commit/reveal messages consensus-dependent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 * **BACKWARD INCOMPATIBLE:** Use TLS for compute node gRPC channels.
 * **BACKWARD INCOMPATIBLE:** Separate node/entity key pair arguments and change serialized
   node key pair format in a backward-incompatible way.
+* **BACKWARD INCOMPATIBLE:** Make commitment and reveal message format consensus backend
+  dependent and introduce `ConsensusSigner` interface to generate them
 * Add discrepancy resolution by using backup workers majority vote.
 * Add passing extra arguments to Docker in shell (`--docker-extra-args`).
 * Add `common::futures::retry` which implements retrying futures on failure.

--- a/compute/Cargo.toml
+++ b/compute/Cargo.toml
@@ -18,6 +18,7 @@ ekiden-rpc-client = { path = "../rpc/client", version = "0.2.0-alpha" }
 ekiden-compute-api = { path = "./api", version = "0.2.0-alpha" }
 ekiden-consensus-base = { path = "../consensus/base", version = "0.2.0-alpha" }
 ekiden-consensus-client = { path = "../consensus/client", version = "0.2.0-alpha" }
+ekiden-consensus-dummy = { path = "../consensus/dummy", version = "0.2.0-alpha" }
 ekiden-storage-base = { path = "../storage/base", version = "0.2.0-alpha" }
 ekiden-storage-batch = { path = "../storage/batch", version = "0.2.0-alpha" }
 ekiden-storage-frontend = { path = "../storage/frontend", version = "0.2.0-alpha" }

--- a/compute/src/group.rs
+++ b/compute/src/group.rs
@@ -15,7 +15,7 @@ use ekiden_core::subscribers::StreamSubscribers;
 use ekiden_registry_base::EntityRegistryBackend;
 use ekiden_scheduler_base::{CommitteeNode, CommitteeType, Role, Scheduler};
 
-use ekiden_consensus_base::{Commitment, Header, Reveal};
+use ekiden_consensus_base::{Commitment, Reveal};
 
 /// Signature context used for batch submission.
 const SUBMIT_BATCH_SIGNATURE_CONTEXT: B64 = B64(*b"EkCgBaSu");
@@ -35,7 +35,7 @@ enum Command {
     /// Submit a commit to the leader for aggregation.
     SubmitAggCommit(Commitment),
     /// Submit a reveal to the leader for aggregation.
-    SubmitAggReveal(Reveal<Header>),
+    SubmitAggReveal(Reveal),
 }
 
 struct Inner {
@@ -332,7 +332,7 @@ impl ComputationGroup {
     }
 
     /// Handle submission of a single reveal to the leader for aggregation.
-    fn handle_submit_agg_reveal(inner: Arc<Inner>, reveal: Reveal<Header>) -> BoxFuture<()> {
+    fn handle_submit_agg_reveal(inner: Arc<Inner>, reveal: Reveal) -> BoxFuture<()> {
         trace!("Submitting aggregate reveal to leader");
 
         // Sign reveal.
@@ -396,7 +396,7 @@ impl ComputationGroup {
     /// Submit a reveal to the leader for aggregation.
     ///
     /// Returns the current leader of the computation group.
-    pub fn submit_agg_reveal(&self, reveal: Reveal<Header>) -> CommitteeNode {
+    pub fn submit_agg_reveal(&self, reveal: Reveal) -> CommitteeNode {
         self.inner
             .command_sender
             .unbounded_send(Command::SubmitAggReveal(reveal))
@@ -467,10 +467,7 @@ impl ComputationGroup {
         ))
     }
 
-    pub fn open_agg_reveal(
-        &self,
-        signed_reveal: Signed<Reveal<Header>>,
-    ) -> Result<(Reveal<Header>, Role)> {
+    pub fn open_agg_reveal(&self, signed_reveal: Signed<Reveal>) -> Result<(Reveal, Role)> {
         // Check if reveal was signed by a worker and that we're the
         // current leader, drop otherwise.  Also note that the leader and
         // backup workers also count as workers.

--- a/compute/src/main.rs
+++ b/compute/src/main.rs
@@ -42,6 +42,7 @@ extern crate clap;
 extern crate pretty_env_logger;
 
 extern crate ekiden_consensus_client;
+extern crate ekiden_consensus_dummy;
 extern crate ekiden_di;
 extern crate ekiden_epochtime;
 extern crate ekiden_ethereum;
@@ -75,6 +76,7 @@ fn register_components(known_components: &mut KnownComponents) {
     ekiden_storage_frontend::StorageClient::register(known_components);
     // Consensus.
     ekiden_consensus_client::ConsensusClient::register(known_components);
+    ekiden_consensus_dummy::DummyConsensusSigner::register(known_components);
     // Scheduler.
     ekiden_scheduler_client::SchedulerClient::register(known_components);
     // Entity registry.

--- a/compute/src/node.rs
+++ b/compute/src/node.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use grpcio;
 
 use ekiden_compute_api;
-use ekiden_consensus_base::ConsensusBackend;
+use ekiden_consensus_base::{ConsensusBackend, ConsensusSigner};
 use ekiden_core::bytes::B256;
 use ekiden_core::contract::Contract;
 use ekiden_core::environment::Environment;
@@ -71,6 +71,7 @@ impl ComputeNode {
         let scheduler = container.inject::<Scheduler>()?;
         let storage_backend = container.inject::<StorageBackend>()?;
         let consensus_backend = container.inject::<ConsensusBackend>()?;
+        let consensus_signer = container.inject::<ConsensusSigner>()?;
 
         // Register entity with the registry.
         // TODO: This should probably be done independently?
@@ -147,8 +148,8 @@ impl ComputeNode {
             worker.clone(),
             computation_group.clone(),
             consensus_backend.clone(),
+            consensus_signer.clone(),
             storage_backend.clone(),
-            node_identity.get_node_signer(),
         ));
 
         // Create compute node gRPC server.

--- a/compute/src/services/computation_group.rs
+++ b/compute/src/services/computation_group.rs
@@ -13,7 +13,7 @@ use ekiden_core::futures::Future;
 use ekiden_core::signature::{Signature, Signed};
 
 use super::super::consensus::ConsensusFrontend;
-use ekiden_consensus_base::{Commitment, Header, Reveal};
+use ekiden_consensus_base::{Commitment, Reveal};
 
 struct Inner {
     /// Consensus frontend.
@@ -107,7 +107,7 @@ impl ComputationGroup for ComputationGroupService {
         measure_counter_inc!("submit_agg_reveal_calls");
 
         let mut f = || -> Result<()> {
-            let reveal = Reveal::<Header>::try_from(request.get_reveal().clone())?;
+            let reveal = Reveal::try_from(request.get_reveal().clone())?;
             let signature = Signature::try_from(request.take_signature())?;
             let signed_reveal = Signed::from_parts(reveal, signature);
 

--- a/consensus/api/build.rs
+++ b/consensus/api/build.rs
@@ -6,7 +6,7 @@ fn main() {
     // Must be done first to create src/generated directory
     ekiden_tools::generate_mod_with_imports(
         "src/generated",
-        &["common", "scheduler"],
+        &["scheduler"],
         &["consensus", "consensus_grpc"],
     );
 
@@ -14,10 +14,6 @@ fn main() {
     protoc_grpcio::compile_grpc_protos(&["consensus.proto"], &["src", "../../"], "src/generated")
         .expect("failed to compile gRPC definitions");
 
-    println!(
-        "cargo:rerun-if-changed={}",
-        "../../common/api/src/common.proto"
-    );
     println!(
         "cargo:rerun-if-changed={}",
         "../../scheduler/api/src/scheduler.proto"

--- a/consensus/api/src/consensus.proto
+++ b/consensus/api/src/consensus.proto
@@ -21,9 +21,12 @@ message Block {
   repeated Commitment commitments = 3;
 }
 
+message Nonce {
+  bytes data = 1;
+}
+
 message Commitment {
-  bytes digest = 1;
-  common.Signature signature = 2;
+  bytes data = 1;
 }
 
 message Header {
@@ -39,9 +42,7 @@ message Header {
 }
 
 message Reveal {
-  Header header = 2;
-  bytes nonce = 3;
-  common.Signature signature = 4;
+  bytes data = 1;
 }
 
 message LatestBlockRequest {

--- a/consensus/api/src/lib.rs
+++ b/consensus/api/src/lib.rs
@@ -6,7 +6,6 @@ extern crate protobuf;
 
 mod generated;
 
-use ekiden_common_api as common;
 use ekiden_scheduler_api as scheduler;
 
 pub use generated::consensus::*;

--- a/consensus/base/Cargo.toml
+++ b/consensus/base/Cargo.toml
@@ -16,3 +16,4 @@ grpcio = { git = "https://github.com/ekiden/grpc-rs", tag = "v0.3.0-ekiden1", fe
 serde = "=1.0.59"
 serde_derive = "1.0"
 serde_cbor = "0.8.2"
+serde_bytes = "~0.10"

--- a/consensus/base/src/block.rs
+++ b/consensus/base/src/block.rs
@@ -75,7 +75,7 @@ impl TryFrom<api::Block> for Block {
 
         let mut commits = Vec::new();
         for item in a.get_commitments().iter() {
-            if item.get_digest().is_empty() {
+            if item.get_data().is_empty() {
                 commits.push(None);
             } else {
                 commits.push(Some(Commitment::try_from(item.to_owned())?));
@@ -110,37 +110,5 @@ impl Into<api::Block> for Block {
         }
         b.set_commitments(commits.into());
         b
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use ekiden_common::bytes::B256;
-    use ekiden_common::ring::signature::Ed25519KeyPair;
-    use ekiden_common::signature::InMemorySigner;
-    use ekiden_common::untrusted;
-
-    use super::super::*;
-    use super::*;
-
-    #[test]
-    fn test_block_commitment() {
-        let block = Block::default();
-        let nonce = B256::zero();
-        let key_pair =
-            Ed25519KeyPair::from_seed_unchecked(untrusted::Input::from(&B256::random())).unwrap();
-        let signer = InMemorySigner::new(key_pair);
-
-        let header = block.header.clone();
-
-        // Test commitment.
-        let commitment = Commitment::new(&signer, &nonce, &header);
-        assert!(commitment.verify());
-
-        // Test reveal.
-        let reveal = Reveal::new(&signer, &nonce, &header);
-        assert!(reveal.verify());
-        assert!(reveal.verify_commitment(&commitment));
-        assert!(reveal.verify_value(&header));
     }
 }

--- a/consensus/base/src/commitment.rs
+++ b/consensus/base/src/commitment.rs
@@ -1,181 +1,85 @@
-//! Commitment type.
+//! Opaque commitment types.
 use std::convert::TryFrom;
-use std::fmt::Debug;
 
-use serde::Serialize;
-use serde_cbor;
+use serde_bytes;
 
+use ekiden_common::error::Error;
 use ekiden_consensus_api as api;
 
-use ekiden_common::bytes::{B256, B64, H256};
-use ekiden_common::error::Error;
-use ekiden_common::ring::digest;
-use ekiden_common::signature::{Signature, Signer};
-
-use super::header::Header;
-
-/// Signature context used for commitments.
-const COMMITMENT_SIGNATURE_CONTEXT: B64 = B64(*b"EkCommit");
-/// Signature context used for reveals.
-const REVEAL_SIGNATURE_CONTEXT: B64 = B64(*b"EkReveal");
-
-/// Commitment.
-///
-/// A commitment is a signature over a specific piece of data using the
-/// `COMMITMENT_SIGNATURE_CONTEXT` context.
+/// Opaque backend-specific nonce.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Commitment {
-    /// Hash of the encoded value being committed to and a nonce.
-    pub digest: H256,
-    /// Commitment signature over the digest.
-    pub signature: Signature,
+pub struct Nonce {
+    #[serde(with = "serde_bytes")]
+    pub data: Vec<u8>,
 }
 
-impl Commitment {
-    /// Construct a new commitment.
-    pub fn new<T: Commitable>(signer: &Signer, nonce: &B256, value: &T) -> Self {
-        let digest = value.get_commitment_digest(&nonce);
-
-        Commitment {
-            digest,
-            signature: Signature::sign(signer, &COMMITMENT_SIGNATURE_CONTEXT, &digest),
-        }
+impl TryFrom<api::Nonce> for Nonce {
+    /// Converts a protobuf `api::Nonce` into a `Nonce`.
+    type Error = Error;
+    fn try_from(mut other: api::Nonce) -> Result<Self, Error> {
+        Ok(Nonce {
+            data: other.take_data(),
+        })
     }
+}
 
-    /// Verify that the commitment has a valid signature.
-    pub fn verify(&self) -> bool {
-        self.signature
-            .verify(&COMMITMENT_SIGNATURE_CONTEXT, &self.digest)
+impl Into<api::Nonce> for Nonce {
+    /// Converts a nonce into a protobuf `api::Nonce` representation.
+    fn into(self) -> api::Nonce {
+        let mut other = api::Nonce::new();
+        other.set_data(self.data);
+        other
     }
+}
+
+/// Opaque backend-specific commitment.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Commitment {
+    #[serde(with = "serde_bytes")]
+    pub data: Vec<u8>,
 }
 
 impl TryFrom<api::Commitment> for Commitment {
-    /// try_from Converts a protobuf commitment into a commitment.
+    /// Converts a protobuf `api::Commitment` into a `Commitment`.
     type Error = Error;
-    fn try_from(a: api::Commitment) -> Result<Self, Error> {
-        let sig = Signature::try_from(a.get_signature().to_owned())?;
-        let digest = a.get_digest();
+    fn try_from(mut other: api::Commitment) -> Result<Self, Error> {
         Ok(Commitment {
-            digest: H256::from(digest),
-            signature: sig,
+            data: other.take_data(),
         })
     }
 }
 
 impl Into<api::Commitment> for Commitment {
-    /// into Converts a block into a protobuf `consensus::api::Block` representation.
+    /// Converts a commitment into a protobuf `api::Commitment` representation.
     fn into(self) -> api::Commitment {
-        let mut c = api::Commitment::new();
-        c.set_digest(self.digest.to_vec());
-        c.set_signature(self.signature.into());
-        c
+        let mut other = api::Commitment::new();
+        other.set_data(self.data);
+        other
     }
 }
 
-/// Reveal.
-///
-/// A reveal of a value previously committed to. The signature on the reveal
-/// is made using the `REVEAL_SIGNATURE_CONTEXT` context.
+/// Opaque backend-specific reveal.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Reveal<T: Commitable> {
-    /// Revealed value.
-    pub value: T,
-    /// Nonce used in commitment.
-    pub nonce: B256,
-    /// Signature over `value` and `nonce`.
-    pub signature: Signature,
+pub struct Reveal {
+    #[serde(with = "serde_bytes")]
+    pub data: Vec<u8>,
 }
 
-impl<T: Commitable> Reveal<T> {
-    /// Generate a reveal for a commitable value.
-    pub fn new(signer: &Signer, nonce: &B256, value: &T) -> Self {
-        let digest = value.get_commitment_digest(nonce);
-
-        Reveal {
-            value: value.clone(),
-            nonce: nonce.clone(),
-            signature: Signature::sign(signer, &REVEAL_SIGNATURE_CONTEXT, &digest),
-        }
-    }
-
-    /// Verify that the reveal has a valid signature.
-    pub fn verify(&self) -> bool {
-        let digest = self.value.get_commitment_digest(&self.nonce);
-
-        self.signature.verify(&REVEAL_SIGNATURE_CONTEXT, &digest)
-    }
-
-    /// Verify that the reveal matches commitment.
-    pub fn verify_commitment(&self, commitment: &Commitment) -> bool {
-        // Verify that both signatures were made using the same public key.
-        if self.signature.public_key != commitment.signature.public_key {
-            return false;
-        }
-
-        // Verify reveal signature.
-        if !self.verify() {
-            return false;
-        }
-
-        // Verify commitment signature.
-        if !commitment.verify() {
-            return false;
-        }
-
-        // Verify that value matches commitment.
-        let digest = self.value.get_commitment_digest(&self.nonce);
-
-        digest == commitment.digest
-    }
-
-    /// Verify that the reveal matches value.
-    pub fn verify_value(&self, value: &T) -> bool {
-        // Verify reveal signature.
-        if !self.verify() {
-            return false;
-        }
-
-        // Verify that reveal matches given value.
-        let reveal_digest = self.value.get_commitment_digest(&self.nonce);
-        let value_digest = value.get_commitment_digest(&self.nonce);
-
-        reveal_digest == value_digest
-    }
-}
-
-impl TryFrom<api::Reveal> for Reveal<Header> {
-    /// try_from Converts a protobuf reveal into a Reveal.
+impl TryFrom<api::Reveal> for Reveal {
+    /// Converts a protobuf `api::Reveal` into a `Reveal`.
     type Error = Error;
-    fn try_from(a: api::Reveal) -> Result<Self, Error> {
-        let hdr = Header::try_from(a.get_header().to_owned())?;
-        let non = B256::from(a.get_nonce());
-        let sig = Signature::try_from(a.get_signature().to_owned())?;
+    fn try_from(mut other: api::Reveal) -> Result<Self, Error> {
         Ok(Reveal {
-            value: hdr,
-            nonce: non,
-            signature: sig,
+            data: other.take_data(),
         })
     }
 }
 
-impl Into<api::Reveal> for Reveal<Header> {
-    /// into Converts a reveal into a protobuf `consensus::api::Reveal` representation.
+impl Into<api::Reveal> for Reveal {
+    /// Converts a reveal into a protobuf `api::Reveal` representation.
     fn into(self) -> api::Reveal {
-        let mut c = api::Reveal::new();
-        c.set_header(self.value.into());
-        c.set_nonce(self.nonce.to_vec());
-        c.set_signature(self.signature.into());
-        c
-    }
-}
-
-/// A type that a commitment can be generated for.
-pub trait Commitable: Sized + Clone + Debug + PartialEq + Eq + Serialize {
-    /// Return hash over nonce and commitment value.
-    fn get_commitment_digest(&self, nonce: &B256) -> H256 {
-        let mut ctx = digest::Context::new(&digest::SHA512_256);
-        ctx.update(&serde_cbor::to_vec(self).unwrap());
-        ctx.update(&nonce);
-        H256::from(ctx.finish().as_ref())
+        let mut other = api::Reveal::new();
+        other.set_data(self.data);
+        other
     }
 }

--- a/consensus/base/src/header.rs
+++ b/consensus/base/src/header.rs
@@ -8,8 +8,6 @@ use ekiden_common::error::Error;
 use ekiden_common::hash::EncodedHash;
 use ekiden_common::uint::U256;
 
-use super::commitment::Commitable;
-
 /// Block header.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Header {
@@ -39,8 +37,6 @@ impl Header {
         self.previous_hash == child.get_encoded_hash()
     }
 }
-
-impl Commitable for Header {}
 
 impl TryFrom<api::Header> for Header {
     type Error = Error;

--- a/consensus/base/src/lib.rs
+++ b/consensus/base/src/lib.rs
@@ -7,6 +7,7 @@ extern crate serde;
 extern crate serde_cbor;
 #[macro_use]
 extern crate serde_derive;
+extern crate serde_bytes;
 
 #[macro_use]
 extern crate ekiden_common;

--- a/consensus/base/src/service.rs
+++ b/consensus/base/src/service.rs
@@ -10,7 +10,6 @@ use grpcio::{RpcContext, ServerStreamingSink, UnarySink, WriteFlags};
 
 use super::backend::{ConsensusBackend, Event};
 use commitment::{Commitment, Reveal};
-use header::Header;
 
 #[derive(Clone)]
 pub struct ConsensusService {
@@ -221,7 +220,7 @@ impl api::Consensus for ConsensusService {
     ) {
         let f = move || -> Result<_> {
             let contract_id = B256::try_from(req.get_contract_id())?;
-            let mut reveals: Vec<Reveal<Header>> = Vec::new();
+            let mut reveals: Vec<Reveal> = Vec::new();
 
             for r in req.get_reveals() {
                 let reveal = Reveal::try_from(r.clone())?;

--- a/consensus/client/src/client.rs
+++ b/consensus/client/src/client.rs
@@ -11,7 +11,7 @@ use ekiden_common::futures::prelude::*;
 use ekiden_common::node::Node;
 use ekiden_common::protobuf::RepeatedField;
 use ekiden_consensus_api as api;
-use ekiden_consensus_base::{Block, Commitment, ConsensusBackend, Event, Header, Reveal};
+use ekiden_consensus_base::{Block, Commitment, ConsensusBackend, Event, Reveal};
 
 /// Consensus client implements the Consensus interface.
 pub struct ConsensusClient(api::ConsensusClient);
@@ -91,7 +91,7 @@ impl ConsensusBackend for ConsensusClient {
         }
     }
 
-    fn reveal(&self, contract_id: B256, reveal: Reveal<Header>) -> BoxFuture<()> {
+    fn reveal(&self, contract_id: B256, reveal: Reveal) -> BoxFuture<()> {
         let mut req = api::RevealRequest::new();
         req.set_contract_id(contract_id.to_vec());
         req.set_reveal(reveal.into());
@@ -115,7 +115,7 @@ impl ConsensusBackend for ConsensusClient {
         }
     }
 
-    fn reveal_many(&self, contract_id: B256, reveals: Vec<Reveal<Header>>) -> BoxFuture<()> {
+    fn reveal_many(&self, contract_id: B256, reveals: Vec<Reveal>) -> BoxFuture<()> {
         let mut req = api::RevealManyRequest::new();
 
         req.set_contract_id(contract_id.to_vec());

--- a/consensus/dummy/Cargo.toml
+++ b/consensus/dummy/Cargo.toml
@@ -13,6 +13,9 @@ ekiden-consensus-base = { path = "../base", version = "0.2.0-alpha" }
 ekiden-scheduler-base = { path = "../../scheduler/base", version = "0.2.0-alpha" }
 ekiden-storage-base = { path = "../../storage/base", version = "0.2.0-alpha" }
 log = "0.4"
+serde = "=1.0.59"
+serde_cbor = "0.8.2"
+serde_derive = "1.0"
 
 [dev-dependencies]
 ekiden-beacon-base = { path = "../../beacon/base", version = "0.2.0-alpha" }
@@ -23,5 +26,3 @@ ekiden-registry-dummy = { path = "../../registry/dummy", version = "0.2.0-alpha"
 ekiden-scheduler-dummy = { path = "../../scheduler/dummy", version = "0.2.0-alpha" }
 ekiden-storage-dummy = { path = "../../storage/dummy", version = "0.2.0-alpha" }
 grpcio = { git = "https://github.com/ekiden/grpc-rs", tag = "v0.3.0-ekiden1", features = ["openssl"] }
-serde = "=1.0.59"
-serde_cbor = "0.8.2"

--- a/consensus/dummy/src/commitment.rs
+++ b/consensus/dummy/src/commitment.rs
@@ -1,0 +1,199 @@
+//! Commitment/reveal types used in the dummy backend.
+use std::convert::TryFrom;
+use std::fmt::Debug;
+
+use serde::Serialize;
+use serde_cbor;
+
+use ekiden_common::bytes::{B256, B64, H256};
+use ekiden_common::error::{Error, Result};
+use ekiden_common::ring::digest;
+use ekiden_common::signature::{Signature, Signer};
+use ekiden_consensus_base::{Commitment as OpaqueCommitment, Header, Reveal as OpaqueReveal};
+
+/// Signature context used for commitments.
+const COMMITMENT_SIGNATURE_CONTEXT: B64 = B64(*b"EkCommit");
+/// Signature context used for reveals.
+const REVEAL_SIGNATURE_CONTEXT: B64 = B64(*b"EkReveal");
+
+/// Commitment.
+///
+/// A commitment is a signature over a specific piece of data using the
+/// `COMMITMENT_SIGNATURE_CONTEXT` context.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Commitment {
+    /// Hash of the encoded value being committed to and a nonce.
+    pub digest: H256,
+    /// Commitment signature over the digest.
+    pub signature: Signature,
+}
+
+impl Commitment {
+    /// Construct a new commitment.
+    pub fn new<T: Commitable>(signer: &Signer, nonce: &B256, value: &T) -> Self {
+        let digest = value.get_commitment_digest(&nonce);
+
+        Commitment {
+            digest,
+            signature: Signature::sign(signer, &COMMITMENT_SIGNATURE_CONTEXT, &digest),
+        }
+    }
+
+    /// Verify that the commitment has a valid signature.
+    pub fn verify(&self) -> bool {
+        self.signature
+            .verify(&COMMITMENT_SIGNATURE_CONTEXT, &self.digest)
+    }
+}
+
+impl TryFrom<OpaqueCommitment> for Commitment {
+    /// Converts an `OpaqueCommitment` into a `Commitment`.
+    type Error = Error;
+
+    fn try_from(other: OpaqueCommitment) -> Result<Self> {
+        Ok(serde_cbor::from_slice(&other.data)?)
+    }
+}
+
+impl Into<OpaqueCommitment> for Commitment {
+    /// Converts a `Commitment` into an `OpaqueCommitment`.
+    fn into(self) -> OpaqueCommitment {
+        OpaqueCommitment {
+            data: serde_cbor::to_vec(&self).unwrap(),
+        }
+    }
+}
+
+/// Reveal.
+///
+/// A reveal of a value previously committed to. The signature on the reveal
+/// is made using the `REVEAL_SIGNATURE_CONTEXT` context.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Reveal<T: Commitable> {
+    /// Revealed value.
+    pub value: T,
+    /// Nonce used in commitment.
+    pub nonce: B256,
+    /// Signature over `value` and `nonce`.
+    pub signature: Signature,
+}
+
+impl<T: Commitable> Reveal<T> {
+    /// Generate a reveal for a commitable value.
+    pub fn new(signer: &Signer, nonce: &B256, value: &T) -> Self {
+        let digest = value.get_commitment_digest(nonce);
+
+        Reveal {
+            value: value.clone(),
+            nonce: nonce.clone(),
+            signature: Signature::sign(signer, &REVEAL_SIGNATURE_CONTEXT, &digest),
+        }
+    }
+
+    /// Verify that the reveal has a valid signature.
+    pub fn verify(&self) -> bool {
+        let digest = self.value.get_commitment_digest(&self.nonce);
+
+        self.signature.verify(&REVEAL_SIGNATURE_CONTEXT, &digest)
+    }
+
+    /// Verify that the reveal matches commitment.
+    pub fn verify_commitment(&self, commitment: &Commitment) -> bool {
+        // Verify that both signatures were made using the same public key.
+        if self.signature.public_key != commitment.signature.public_key {
+            return false;
+        }
+
+        // Verify reveal signature.
+        if !self.verify() {
+            return false;
+        }
+
+        // Verify commitment signature.
+        if !commitment.verify() {
+            return false;
+        }
+
+        // Verify that value matches commitment.
+        let digest = self.value.get_commitment_digest(&self.nonce);
+
+        digest == commitment.digest
+    }
+
+    /// Verify that the reveal matches value.
+    pub fn verify_value(&self, value: &T) -> bool {
+        // Verify reveal signature.
+        if !self.verify() {
+            return false;
+        }
+
+        // Verify that reveal matches given value.
+        let reveal_digest = self.value.get_commitment_digest(&self.nonce);
+        let value_digest = value.get_commitment_digest(&self.nonce);
+
+        reveal_digest == value_digest
+    }
+}
+
+impl TryFrom<OpaqueReveal> for Reveal<Header> {
+    /// Converts an `OpaqueReveal` into a `Reveal<Header>`.
+    type Error = Error;
+
+    fn try_from(other: OpaqueReveal) -> Result<Self> {
+        Ok(serde_cbor::from_slice(&other.data)?)
+    }
+}
+
+impl Into<OpaqueReveal> for Reveal<Header> {
+    /// Converts a `Reveal<Header>` into an `OpaqueReveal`.
+    fn into(self) -> OpaqueReveal {
+        OpaqueReveal {
+            data: serde_cbor::to_vec(&self).unwrap(),
+        }
+    }
+}
+
+/// A type that a commitment can be generated for.
+pub trait Commitable: Sized + Clone + Debug + PartialEq + Eq + Serialize {
+    /// Return hash over nonce and commitment value.
+    fn get_commitment_digest(&self, nonce: &B256) -> H256 {
+        let mut ctx = digest::Context::new(&digest::SHA512_256);
+        ctx.update(&serde_cbor::to_vec(self).unwrap());
+        ctx.update(&nonce);
+        H256::from(ctx.finish().as_ref())
+    }
+}
+
+impl Commitable for Header {}
+
+#[cfg(test)]
+mod tests {
+    use ekiden_common::bytes::B256;
+    use ekiden_common::ring::signature::Ed25519KeyPair;
+    use ekiden_common::signature::InMemorySigner;
+    use ekiden_common::untrusted;
+    use ekiden_consensus_base::Block;
+
+    use super::*;
+
+    #[test]
+    fn test_block_commitment() {
+        let block = Block::default();
+        let nonce = B256::zero();
+        let key_pair =
+            Ed25519KeyPair::from_seed_unchecked(untrusted::Input::from(&B256::random())).unwrap();
+        let signer = InMemorySigner::new(key_pair);
+
+        let header = block.header.clone();
+
+        // Test commitment.
+        let commitment = Commitment::new(&signer, &nonce, &header);
+        assert!(commitment.verify());
+
+        // Test reveal.
+        let reveal = Reveal::new(&signer, &nonce, &header);
+        assert!(reveal.verify());
+        assert!(reveal.verify_commitment(&commitment));
+        assert!(reveal.verify_value(&header));
+    }
+}

--- a/consensus/dummy/src/lib.rs
+++ b/consensus/dummy/src/lib.rs
@@ -1,6 +1,12 @@
 //! Ekiden dummy consensus backend.
+#![feature(try_from)]
+
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
+extern crate serde_cbor;
 
 extern crate ekiden_common;
 extern crate ekiden_consensus_base;
@@ -10,5 +16,8 @@ extern crate ekiden_scheduler_base;
 extern crate ekiden_storage_base;
 
 mod backend;
+mod commitment;
+mod signer;
 
 pub use backend::DummyConsensusBackend;
+pub use signer::DummyConsensusSigner;

--- a/consensus/dummy/src/signer.rs
+++ b/consensus/dummy/src/signer.rs
@@ -1,0 +1,54 @@
+//! Signer for the dummy consensus backend.
+use std::sync::Arc;
+
+use ekiden_common::bytes::B256;
+use ekiden_common::error::Result;
+use ekiden_common::identity::NodeIdentity;
+use ekiden_consensus_base::{Commitment as OpaqueCommitment, ConsensusSigner, Header, Nonce,
+                            Reveal as OpaqueReveal};
+
+use super::commitment::{Commitment, Reveal};
+
+/// Signer for the dummy consensus backend.
+pub struct DummyConsensusSigner {
+    identity: Arc<NodeIdentity>,
+}
+
+impl DummyConsensusSigner {
+    pub fn new(identity: Arc<NodeIdentity>) -> Self {
+        Self { identity }
+    }
+}
+
+impl ConsensusSigner for DummyConsensusSigner {
+    fn sign_commitment(&self, header: &Header) -> Result<(OpaqueCommitment, Nonce)> {
+        let nonce = B256::random();
+        let commitment = Commitment::new(&self.identity.get_node_signer(), &nonce, header);
+
+        Ok((
+            commitment.into(),
+            Nonce {
+                data: nonce.to_vec(),
+            },
+        ))
+    }
+
+    fn sign_reveal(&self, header: &Header, nonce: &Nonce) -> Result<OpaqueReveal> {
+        let reveal = Reveal::new(
+            &self.identity.get_node_signer(),
+            &B256::from(&nonce.data[..]),
+            header,
+        );
+
+        Ok(reveal.into())
+    }
+}
+
+// Register for dependency injection.
+create_component!(
+    dummy,
+    "consensus-signer",
+    DummyConsensusSigner,
+    ConsensusSigner,
+    [NodeIdentity]
+);

--- a/consensus/dummy/tests/backend.rs
+++ b/consensus/dummy/tests/backend.rs
@@ -24,7 +24,7 @@ use ekiden_common::signature::{InMemorySigner, Signed};
 use ekiden_common::untrusted;
 use ekiden_consensus_base::test::generate_simulated_nodes;
 use ekiden_consensus_base::ConsensusBackend;
-use ekiden_consensus_dummy::DummyConsensusBackend;
+use ekiden_consensus_dummy::{DummyConsensusBackend, DummyConsensusSigner};
 use ekiden_epochtime::interface::EPOCH_INTERVAL;
 use ekiden_epochtime::local::{LocalTimeSourceNotifier, MockTimeSource};
 use ekiden_registry_base::test::populate_entity_registry;
@@ -116,7 +116,10 @@ fn test_dummy_backend_two_rounds() {
     let mut tasks = vec![];
     tasks.append(&mut nodes
         .iter()
-        .map(|n| n.start(backend.clone(), scheduler.clone()))
+        .map(|node| {
+            let signer = Arc::new(DummyConsensusSigner::new(node.get_identity()));
+            node.start(backend.clone(), signer, scheduler.clone())
+        })
         .collect());
 
     // Send compute requests to all nodes.


### PR DESCRIPTION
See #462 

Previously the format of commitment and reveal messages was defined by the consensus interface. Some backends have different requirements and need to use their own format, so this commit changes the interface to make the format of commitment and reveal messages opaque.

To handle signing it introduces a new `ConsensusSigner` interface which provides two methods: `sign_commitment` and `sign_reveal`. The returned structures can then be used to communicate with consensus.