### PR TITLE
Remove expiry accounting from persistent storage

### DIFF
--- a/storage/multilayer/src/lib.rs
+++ b/storage/multilayer/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeMap;
 use std::ops::Deref;
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -239,10 +240,7 @@ fn di_factory(
         .wait()
         .unwrap()
         .chain_err(|| "Couldn't create rector core")?;
-    let sled = Arc::new(PersistentStorageBackend::new(
-        Box::new(ekiden_epochtime::local::SystemTimeSource {}),
-        "./",
-    ).map_err(|e| {
+    let sled = Arc::new(PersistentStorageBackend::new(Path::new("./")).map_err(|e| {
         // Can't use chain_error because ekiden_common Error doesn't implement std Error.
         ekiden_di::error::Error::from(format!("Couldn't create sled layer: {:?}", e))
     })?);
@@ -284,8 +282,10 @@ create_component!(
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+    use std::sync::Arc;
+
     use ekiden_common;
-    use ekiden_epochtime::local::SystemTimeSource;
     use ekiden_storage_base;
     use ekiden_storage_base::StorageBackend;
     use ekiden_storage_dynamodb::DynamoDbBackend;
@@ -294,7 +294,6 @@ mod tests {
     use log::warn;
     use rusoto_core;
     use rusoto_core::ProvideAwsCredentials;
-    use std::sync::Arc;
     use tokio_core;
 
     use MultilayerBackend;
@@ -311,10 +310,8 @@ mod tests {
         }
 
         let sled = Arc::new(
-            PersistentStorageBackend::new(
-                Box::new(SystemTimeSource {}),
-                "/tmp/ekiden-test-storage-persistent/",
-            ).unwrap(),
+            PersistentStorageBackend::new(Path::new("/tmp/ekiden-test-storage-persistent/"))
+                .unwrap(),
         );
         let aws = Arc::new(DynamoDbBackend::new(
             core.remote(),

--- a/storage/persistent/tests/backend.rs
+++ b/storage/persistent/tests/backend.rs
@@ -8,17 +8,18 @@ extern crate ekiden_storage_persistent;
 extern crate test;
 
 use std::fs;
+use std::path::Path;
+
 use test::Bencher;
 
 use ekiden_common::futures::Future;
-use ekiden_epochtime::local::SystemTimeSource;
 use ekiden_storage_base::{hash_storage_key, StorageBackend};
 use ekiden_storage_persistent::PersistentStorageBackend;
 
 #[test]
 fn test_persistent_backend() {
-    let db_path = String::from("./db/");
-    let backend = PersistentStorageBackend::new(Box::new(SystemTimeSource {}), &db_path);
+    let db_path = Path::new("./db/");
+    let backend = PersistentStorageBackend::new(db_path);
     assert!(!backend.is_err());
     let backend = backend.unwrap();
     let key = hash_storage_key(b"value");
@@ -34,8 +35,8 @@ fn test_persistent_backend() {
 fn bench_persistent_speed(b: &mut Bencher) {
     use ekiden_storage_base::StorageBackend;
 
-    let db_path = String::from("./db/");
-    let backend = PersistentStorageBackend::new(Box::new(SystemTimeSource {}), &db_path);
+    let db_path = Path::new("./db/");
+    let backend = PersistentStorageBackend::new(db_path);
     assert!(!backend.is_err());
     let backend = backend.unwrap();
 


### PR DESCRIPTION
See #142 

Also did some minor cleanup of the storage backend.

Before:
```
test bench_persistent_speed ... bench:   2,924,284 ns/iter (+/- 4,176,327)
```

After:
```
test bench_persistent_speed ... bench:       4,659 ns/iter (+/- 5,591)
```