### PR TITLE
WIP: Add optimistic consensus backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "consensus/base",
     "consensus/client",
     "consensus/dummy",
+    "consensus/optimistic",
 
     # Storage interface.
     "storage/api",

--- a/common/src/macros.rs
+++ b/common/src/macros.rs
@@ -1,9 +1,25 @@
 //! Misc Macros used across Ekiden.
 
-/// Close out a gRPC service call with a given error
+/// Close out a gRPC service call with a given error.
 #[macro_export]
 macro_rules! invalid_rpc {
     ($sink:ident, $code:ident, $e:expr) => {
         $sink.fail(::grpcio::RpcStatus::new($code, Some(format!("{:?}", $e))))
+    };
+}
+
+/// Handle a gRPC service call.
+#[macro_export]
+macro_rules! handle_rpc {
+    ($ctx:ident, $sink:ident, $handler:block, $response:expr) => {
+        let handler = || -> $crate::error::Result<_> { $handler };
+        let response = match handler() {
+            Ok(()) => $sink.success($response),
+            Err(error) => $sink.fail(RpcStatus::new(
+                ::grpcio::RpcStatusCode::Internal,
+                Some(error.description().to_owned()),
+            )),
+        };
+        $ctx.spawn(response.map_err(|_error| ()));
     };
 }

--- a/compute/api/src/computation_group.proto
+++ b/compute/api/src/computation_group.proto
@@ -11,6 +11,9 @@ service ComputationGroup {
     rpc SubmitAggCommit (SubmitAggCommitRequest) returns (SubmitAggResponse) {}
     // Submit a reveal to the leader for aggregation.
     rpc SubmitAggReveal (SubmitAggRevealRequest) returns (SubmitAggResponse) {}
+
+    // Gossip consensus messages
+    rpc ConsensusGossip (ConsensusGossipRequest) returns (ConsensusGossipResponse) {}
 }
 
 message SubmitBatchRequest {
@@ -30,4 +33,11 @@ message SubmitAggRevealRequest {
 
 message SubmitAggResponse {
     bytes receipt = 1;
+}
+
+message ConsensusGossipRequest {
+    consensus.Content content = 1;
+}
+
+message ConsensusGossipResponse {
 }

--- a/compute/src/group.rs
+++ b/compute/src/group.rs
@@ -1,8 +1,8 @@
 //! Computation group structures.
 use std::sync::{Arc, Mutex};
 
-use ekiden_compute_api::{ComputationGroupClient, SubmitAggCommitRequest, SubmitAggRevealRequest,
-                         SubmitBatchRequest};
+use ekiden_compute_api as api;
+use ekiden_consensus_base::network::{ConsensusNetwork, Content, Message, Recipient};
 use ekiden_consensus_base::{Commitment, Reveal};
 use ekiden_core::bytes::{B256, H256};
 use ekiden_core::environment::Environment;
@@ -26,6 +26,8 @@ enum Command {
     SubmitAggCommit(Commitment),
     /// Submit a reveal to the leader for aggregation.
     SubmitAggReveal(Reveal),
+    /// Submit consensus gossip.
+    SubmitConsensusGossip(Recipient, Content),
 }
 
 struct Inner {
@@ -36,7 +38,7 @@ struct Inner {
     /// Entity registry.
     entity_registry: Arc<EntityRegistryBackend>,
     /// Computation node group.
-    node_group: NodeGroup<ComputationGroupClient, CommitteeNode>,
+    node_group: NodeGroup<api::ComputationGroupClient, CommitteeNode>,
     /// Computation committee metadata.
     committee: Mutex<Vec<CommitteeNode>>,
     /// Compute node's public key.
@@ -53,6 +55,8 @@ struct Inner {
     command_receiver: Mutex<Option<mpsc::UnboundedReceiver<Command>>>,
     /// Role subscribers.
     role_subscribers: StreamSubscribers<Option<Role>>,
+    /// Message subscribers.
+    message_subscribers: StreamSubscribers<Message>,
 }
 
 impl Inner {
@@ -99,6 +103,7 @@ impl ComputationGroup {
                 command_sender,
                 command_receiver: Mutex::new(Some(command_receiver)),
                 role_subscribers: StreamSubscribers::new(),
+                message_subscribers: StreamSubscribers::new(),
             }),
         };
         instance.start();
@@ -156,6 +161,9 @@ impl ComputationGroup {
                     }
                     Command::SubmitAggReveal(reveal) => {
                         Self::handle_submit_agg_reveal(inner.clone(), reveal)
+                    }
+                    Command::SubmitConsensusGossip(recipient, content) => {
+                        Self::handle_submit_consensus_gossip(inner.clone(), recipient, content)
                     }
                 },
             )
@@ -222,7 +230,7 @@ impl ComputationGroup {
                     for (node, committee_node) in nodes {
                         let channel =
                             node.connect(inner.environment.clone(), inner.identity.clone());
-                        let client = ComputationGroupClient::new(channel);
+                        let client = api::ComputationGroupClient::new(channel);
                         inner.node_group.add_node(client, committee_node);
                     }
 
@@ -261,7 +269,7 @@ impl ComputationGroup {
         trace!("Submitting batch to workers");
 
         // Submit batch.
-        let mut request = SubmitBatchRequest::new();
+        let mut request = api::SubmitBatchRequest::new();
         request.set_batch_hash(batch_hash.to_vec());
 
         inner
@@ -287,7 +295,7 @@ impl ComputationGroup {
         trace!("Submitting aggregate commit to leader");
 
         // Submit commit.
-        let mut request = SubmitAggCommitRequest::new();
+        let mut request = api::SubmitAggCommitRequest::new();
         request.set_commit(commit.into());
 
         inner
@@ -318,7 +326,7 @@ impl ComputationGroup {
         trace!("Submitting aggregate reveal to leader");
 
         // Submit reveal.
-        let mut request = SubmitAggRevealRequest::new();
+        let mut request = api::SubmitAggRevealRequest::new();
         request.set_reveal(reveal.into());
 
         inner
@@ -334,6 +342,41 @@ impl ComputationGroup {
                     if let Err(error) = result {
                         error!(
                             "Failed to submit aggregate reveal to node: {}",
+                            error.message
+                        );
+                    }
+                }
+
+                Ok(())
+            })
+            .into_box()
+    }
+
+    /// Handle submission of a consensus gossip message.
+    fn handle_submit_consensus_gossip(
+        inner: Arc<Inner>,
+        recipient: Recipient,
+        content: Content,
+    ) -> BoxFuture<()> {
+        // Prepare request.
+        let mut request = api::ConsensusGossipRequest::new();
+        request.set_content(content.into());
+
+        inner
+            .node_group
+            .call_filtered(
+                |_, node| match recipient {
+                    Recipient::Node(node_id) => node.public_key == node_id,
+                    Recipient::OnlyRole(role) => node.role == role,
+                    Recipient::AllNodes => true,
+                },
+                move |client, _| client.consensus_gossip_async(&request),
+            )
+            .and_then(|results| {
+                for result in results {
+                    if let Err(error) = result {
+                        error!(
+                            "Failed to submit consensus gossip to node: {}",
                             error.message
                         );
                     }
@@ -470,5 +513,38 @@ impl ComputationGroup {
     /// Check if the local node is a leader of the computation group.
     pub fn is_leader(&self) -> bool {
         self.get_role() == Some(Role::Leader)
+    }
+
+    /// Deliver incoming consensus gossip from network backend.
+    pub fn deliver_incoming_consensus_gossip(&self, message: Message) {
+        // Ensure that message comes from a committee member.
+        {
+            let committee = self.inner.committee.lock().unwrap();
+            if !committee
+                .iter()
+                .any(|node| node.public_key == message.sender)
+            {
+                warn!(
+                    "Dropping incoming message from non-committee member {:?}",
+                    message.sender
+                );
+                return;
+            }
+        }
+
+        self.inner.message_subscribers.notify(&message);
+    }
+}
+
+impl ConsensusNetwork for ComputationGroup {
+    fn watch_messages(&self) -> BoxStream<Message> {
+        self.inner.message_subscribers.subscribe().1
+    }
+
+    fn send(&self, recipient: Recipient, content: Content) {
+        self.inner
+            .command_sender
+            .unbounded_send(Command::SubmitConsensusGossip(recipient, content))
+            .unwrap();
     }
 }

--- a/compute/src/node.rs
+++ b/compute/src/node.rs
@@ -158,7 +158,7 @@ impl ComputeNode {
         let web3 =
             ekiden_compute_api::create_web3(Web3Service::new(worker, consensus_frontend.clone()));
         let inter_node = ekiden_compute_api::create_computation_group(
-            ComputationGroupService::new(consensus_frontend.clone()),
+            ComputationGroupService::new(consensus_frontend.clone(), computation_group.clone()),
         );
         let server = grpcio::ServerBuilder::new(grpc_environment.clone())
             .channel_args(

--- a/compute/src/services/computation_group.rs
+++ b/compute/src/services/computation_group.rs
@@ -3,21 +3,24 @@ use std::convert::TryFrom;
 use std::sync::Arc;
 
 use grpcio;
-use grpcio::{RpcStatus, RpcStatusCode};
+use grpcio::RpcStatus;
 
-use ekiden_compute_api::{ComputationGroup, SubmitAggCommitRequest, SubmitAggResponse,
-                         SubmitAggRevealRequest, SubmitBatchRequest, SubmitBatchResponse};
+use ekiden_compute_api as api;
+use ekiden_consensus_base::network::{Content, Message};
+use ekiden_consensus_base::{Commitment, Reveal};
 use ekiden_core::bytes::H256;
-use ekiden_core::error::Result;
-use ekiden_core::futures::Future;
+use ekiden_core::futures::prelude::*;
+use ekiden_core::handle_rpc;
 use ekiden_core::x509::get_node_id;
 
 use super::super::consensus::ConsensusFrontend;
-use ekiden_consensus_base::{Commitment, Reveal};
+use super::super::group::ComputationGroup;
 
 struct Inner {
     /// Consensus frontend.
     consensus_frontend: Arc<ConsensusFrontend>,
+    /// Computation group.
+    computation_group: Arc<ComputationGroup>,
 }
 
 #[derive(Clone)]
@@ -27,101 +30,121 @@ pub struct ComputationGroupService {
 
 impl ComputationGroupService {
     /// Create new computation group service.
-    pub fn new(consensus_frontend: Arc<ConsensusFrontend>) -> Self {
+    pub fn new(
+        consensus_frontend: Arc<ConsensusFrontend>,
+        computation_group: Arc<ComputationGroup>,
+    ) -> Self {
         ComputationGroupService {
-            inner: Arc::new(Inner { consensus_frontend }),
+            inner: Arc::new(Inner {
+                consensus_frontend,
+                computation_group,
+            }),
         }
     }
 }
 
-impl ComputationGroup for ComputationGroupService {
+impl api::ComputationGroup for ComputationGroupService {
     fn submit_batch(
         &self,
         ctx: grpcio::RpcContext,
-        request: SubmitBatchRequest,
-        sink: grpcio::UnarySink<SubmitBatchResponse>,
+        request: api::SubmitBatchRequest,
+        sink: grpcio::UnarySink<api::SubmitBatchResponse>,
     ) {
         measure_histogram_timer!("submit_batch_time");
         measure_counter_inc!("submit_batch_calls");
 
-        let f = || -> Result<()> {
-            let node_id = get_node_id(&ctx)?;
-            let batch_hash = H256::try_from(request.get_batch_hash())?;
+        handle_rpc!(
+            ctx,
+            sink,
+            {
+                let node_id = get_node_id(&ctx)?;
+                let batch_hash = H256::try_from(request.get_batch_hash())?;
 
-            self.inner
-                .consensus_frontend
-                .process_remote_batch(node_id, batch_hash)?;
+                self.inner
+                    .consensus_frontend
+                    .process_remote_batch(node_id, batch_hash)?;
 
-            Ok(())
-        };
-
-        let f = match f() {
-            Ok(()) => sink.success(SubmitBatchResponse::new()),
-            Err(error) => sink.fail(RpcStatus::new(
-                RpcStatusCode::Internal,
-                Some(error.description().to_owned()),
-            )),
-        };
-        ctx.spawn(f.map_err(|_error| ()));
+                Ok(())
+            },
+            api::SubmitBatchResponse::new()
+        );
     }
 
     fn submit_agg_commit(
         &self,
         ctx: grpcio::RpcContext,
-        request: SubmitAggCommitRequest,
-        sink: grpcio::UnarySink<SubmitAggResponse>,
+        request: api::SubmitAggCommitRequest,
+        sink: grpcio::UnarySink<api::SubmitAggResponse>,
     ) {
         measure_histogram_timer!("submit_agg_commit_time");
         measure_counter_inc!("submit_agg_commit_calls");
 
-        let f = || -> Result<()> {
-            let node_id = get_node_id(&ctx)?;
-            let commitment = Commitment::try_from(request.get_commit().clone())?;
+        handle_rpc!(
+            ctx,
+            sink,
+            {
+                let node_id = get_node_id(&ctx)?;
+                let commitment = Commitment::try_from(request.get_commit().clone())?;
 
-            self.inner
-                .consensus_frontend
-                .process_agg_commit(node_id, commitment)?;
+                self.inner
+                    .consensus_frontend
+                    .process_agg_commit(node_id, commitment)?;
 
-            Ok(())
-        };
-
-        let f = match f() {
-            Ok(()) => sink.success(SubmitAggResponse::new()),
-            Err(error) => sink.fail(RpcStatus::new(
-                RpcStatusCode::Internal,
-                Some(error.description().to_owned()),
-            )),
-        };
-        ctx.spawn(f.map_err(|_error| ()));
+                Ok(())
+            },
+            api::SubmitAggResponse::new()
+        );
     }
 
     fn submit_agg_reveal(
         &self,
         ctx: grpcio::RpcContext,
-        request: SubmitAggRevealRequest,
-        sink: grpcio::UnarySink<SubmitAggResponse>,
+        request: api::SubmitAggRevealRequest,
+        sink: grpcio::UnarySink<api::SubmitAggResponse>,
     ) {
         measure_histogram_timer!("submit_agg_reveal_time");
         measure_counter_inc!("submit_agg_reveal_calls");
 
-        let f = || -> Result<()> {
-            let node_id = get_node_id(&ctx)?;
-            let reveal = Reveal::try_from(request.get_reveal().clone())?;
+        handle_rpc!(
+            ctx,
+            sink,
+            {
+                let node_id = get_node_id(&ctx)?;
+                let reveal = Reveal::try_from(request.get_reveal().clone())?;
 
-            self.inner
-                .consensus_frontend
-                .process_agg_reveal(node_id, reveal)?;
+                self.inner
+                    .consensus_frontend
+                    .process_agg_reveal(node_id, reveal)?;
 
-            Ok(())
-        };
+                Ok(())
+            },
+            api::SubmitAggResponse::new()
+        );
+    }
 
-        let f = match f() {
-            Ok(()) => sink.success(SubmitAggResponse::new()),
-            Err(error) => sink.fail(RpcStatus::new(
-                RpcStatusCode::Internal,
-                Some(error.description().to_owned()),
-            )),
-        };
-        ctx.spawn(f.map_err(|_error| ()));
+    fn consensus_gossip(
+        &self,
+        ctx: grpcio::RpcContext,
+        request: api::ConsensusGossipRequest,
+        sink: grpcio::UnarySink<api::ConsensusGossipResponse>,
+    ) {
+        measure_histogram_timer!("consensus_gossip_time");
+        measure_counter_inc!("consensus_gossip_calls");
+
+        handle_rpc!(
+            ctx,
+            sink,
+            {
+                let sender = get_node_id(&ctx)?;
+                let content = Content::try_from(request.get_content().clone())?;
+
+                self.inner
+                    .computation_group
+                    .deliver_incoming_consensus_gossip(Message { sender, content });
+
+                Ok(())
+            },
+            api::ConsensusGossipResponse::new()
+        );
     }
 }

--- a/consensus/api/src/consensus.proto
+++ b/consensus/api/src/consensus.proto
@@ -18,7 +18,7 @@ service Consensus {
 message Block {
   Header header = 1;
   repeated scheduler.CommitteeNode computation_group = 2;
-  repeated Commitment commitments = 3;
+  repeated Reveal reveals = 3;
 }
 
 message Nonce {
@@ -38,7 +38,7 @@ message Header {
   bytes input_hash = 6;
   bytes output_hash = 7;
   bytes state_root = 8;
-  bytes commitments_hash = 9;
+  bytes reveals_hash = 9;
 }
 
 message Reveal {
@@ -111,4 +111,11 @@ message CommitManyRequest {
 message RevealManyRequest {
     bytes contract_id = 1;
     repeated Reveal reveals = 2;
+}
+
+message Content {
+    oneof content {
+        Reveal reveal = 1;
+        Block latest_block = 2;
+    }
 }

--- a/consensus/base/src/header.rs
+++ b/consensus/base/src/header.rs
@@ -27,8 +27,8 @@ pub struct Header {
     pub output_hash: H256,
     /// State root hash.
     pub state_root: H256,
-    /// Commitments hash.
-    pub commitments_hash: H256,
+    /// Reveals hash.
+    pub reveals_hash: H256,
 }
 
 impl Header {
@@ -50,7 +50,7 @@ impl TryFrom<api::Header> for Header {
             input_hash: H256::try_from(a.get_input_hash())?,
             output_hash: H256::try_from(a.get_output_hash())?,
             state_root: H256::try_from(a.get_state_root())?,
-            commitments_hash: H256::try_from(a.get_commitments_hash())?,
+            reveals_hash: H256::try_from(a.get_reveals_hash())?,
         })
     }
 }
@@ -66,7 +66,7 @@ impl Into<api::Header> for Header {
         h.set_input_hash(self.input_hash.to_vec());
         h.set_output_hash(self.output_hash.to_vec());
         h.set_state_root(self.state_root.to_vec());
-        h.set_commitments_hash(self.commitments_hash.to_vec());
+        h.set_reveals_hash(self.reveals_hash.to_vec());
         h
     }
 }

--- a/consensus/base/src/lib.rs
+++ b/consensus/base/src/lib.rs
@@ -19,6 +19,7 @@ pub mod backend;
 pub mod block;
 pub mod commitment;
 pub mod header;
+pub mod network;
 pub mod service;
 
 pub use backend::*;

--- a/consensus/base/src/network.rs
+++ b/consensus/base/src/network.rs
@@ -1,0 +1,78 @@
+//! Network interface required by consensus.
+use std::convert::TryFrom;
+
+use ekiden_common::bytes::B256;
+use ekiden_common::error::{Error, Result};
+use ekiden_common::futures::prelude::*;
+use ekiden_consensus_api as api;
+use ekiden_scheduler_base::Role;
+
+use super::{Block, Reveal};
+
+/// Consensus message content.
+#[derive(Clone, Debug)]
+pub enum Content {
+    Reveal(Reveal),
+    LatestBlock(Block),
+}
+
+impl TryFrom<api::Content> for Content {
+    type Error = Error;
+
+    fn try_from(other: api::Content) -> Result<Self> {
+        match other.content {
+            Some(api::Content_oneof_content::reveal(reveal)) => {
+                Ok(Content::Reveal(Reveal::try_from(reveal)?))
+            }
+            Some(api::Content_oneof_content::latest_block(block)) => {
+                Ok(Content::LatestBlock(Block::try_from(block)?))
+            }
+            _ => Err(Error::new("unsupported message")),
+        }
+    }
+}
+
+impl Into<api::Content> for Content {
+    fn into(self) -> api::Content {
+        let mut other = api::Content::new();
+        match self {
+            Content::Reveal(reveal) => other.set_reveal(reveal.into()),
+            Content::LatestBlock(block) => other.set_latest_block(block.into()),
+        }
+
+        other
+    }
+}
+
+/// Consensus message.
+///
+/// Each message contains an authenticated sender's public key which is obtained
+/// implicitly by the network layer (e.g., from gRPC authentication context for
+/// simple topologies).
+#[derive(Clone, Debug)]
+pub struct Message {
+    /// Authenticated sender.
+    pub sender: B256,
+    /// Message content.
+    pub content: Content,
+}
+
+/// Message recipient.
+#[derive(Clone, Debug)]
+pub enum Recipient {
+    /// A specific node.
+    Node(B256),
+    /// All nodes with a specific role.
+    OnlyRole(Role),
+    /// All nodes in the committee.
+    AllNodes,
+}
+
+/// Network interface required by consensus.
+pub trait ConsensusNetwork: Send + Sync {
+    /// Subscribe to incoming messages from other nodes in the committee.
+    fn watch_messages(&self) -> BoxStream<Message>;
+
+    /// Send messages to other nodes in the committee.
+    fn send(&self, recipient: Recipient, content: Content);
+}

--- a/consensus/dummy/src/backend.rs
+++ b/consensus/dummy/src/backend.rs
@@ -419,11 +419,11 @@ impl Round {
         block.header = header;
         block.computation_group = self.committee.members.clone();
         for node in &self.committee.members {
-            block.commitments.push(
-                self.commitments
+            block.reveals.push(
+                self.reveals
                     .get(&node.public_key)
                     .cloned()
-                    .map(|commitment| commitment.into()),
+                    .map(|reveal| reveal.into()),
             );
         }
         block.update();
@@ -602,10 +602,10 @@ impl DummyConsensusBackend {
                 input_hash: empty_hash(),
                 output_hash: empty_hash(),
                 state_root: empty_hash(),
-                commitments_hash: H256::zero(),
+                reveals_hash: H256::zero(),
             },
             computation_group: vec![],
-            commitments: vec![],
+            reveals: vec![],
         };
 
         block.update();

--- a/consensus/dummy/src/signer.rs
+++ b/consensus/dummy/src/signer.rs
@@ -1,8 +1,10 @@
 //! Signer for the dummy consensus backend.
+use std::convert::TryFrom;
 use std::sync::Arc;
 
 use ekiden_common::bytes::B256;
-use ekiden_common::error::Result;
+use ekiden_common::error::Error;
+use ekiden_common::futures::prelude::*;
 use ekiden_common::identity::NodeIdentity;
 use ekiden_consensus_base::{Commitment as OpaqueCommitment, ConsensusSigner, Header, Nonce,
                             Reveal as OpaqueReveal};
@@ -21,26 +23,53 @@ impl DummyConsensusSigner {
 }
 
 impl ConsensusSigner for DummyConsensusSigner {
-    fn sign_commitment(&self, header: &Header) -> Result<(OpaqueCommitment, Nonce)> {
+    fn sign_commitment(&self, header: &Header) -> BoxFuture<(OpaqueCommitment, Nonce)> {
         let nonce = B256::random();
         let commitment = Commitment::new(&self.identity.get_node_signer(), &nonce, header);
 
-        Ok((
+        future::ok((
             commitment.into(),
             Nonce {
                 data: nonce.to_vec(),
             },
-        ))
+        )).into_box()
     }
 
-    fn sign_reveal(&self, header: &Header, nonce: &Nonce) -> Result<OpaqueReveal> {
+    fn sign_reveal(&self, header: &Header, nonce: &Nonce) -> BoxFuture<OpaqueReveal> {
         let reveal = Reveal::new(
             &self.identity.get_node_signer(),
             &B256::from(&nonce.data[..]),
             header,
         );
 
-        Ok(reveal.into())
+        future::ok(reveal.into()).into_box()
+    }
+
+    fn verify_reveal(
+        &self,
+        node_id: B256,
+        header: &Header,
+        reveal: &OpaqueReveal,
+    ) -> BoxFuture<()> {
+        let reveal: Reveal<Header> = match Reveal::try_from(reveal.clone()) {
+            Ok(reveal) => reveal,
+            _ => return future::err(Error::new("reveal decoding failed")).into_box(),
+        };
+
+        if !reveal.verify_value(header) || reveal.signature.public_key != node_id {
+            return future::err(Error::new("reveal verification failed")).into_box();
+        }
+
+        future::ok(()).into_box()
+    }
+
+    fn get_reveal_header(&self, reveal: &OpaqueReveal) -> BoxFuture<Header> {
+        let reveal: Reveal<Header> = match Reveal::try_from(reveal.clone()) {
+            Ok(reveal) => reveal,
+            _ => return future::err(Error::new("reveal decoding failed")).into_box(),
+        };
+
+        future::ok(reveal.value).into_box()
     }
 }
 

--- a/consensus/optimistic/Cargo.toml
+++ b/consensus/optimistic/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ekiden-consensus-optimistic"
+version = "0.2.0-alpha"
+authors = ["Oasis Labs Inc. <info@oasislabs.com>"]
+description = "Ekiden dummy in-memory consensus backend"
+keywords = ["ekiden"]
+repository = "https://github.com/oasislabs/ekiden"
+
+[dependencies]
+ekiden-common = { path = "../../common", version = "0.2.0-alpha" }
+ekiden-consensus-base = { path = "../base", version = "0.2.0-alpha" }
+ekiden-scheduler-base = { path = "../../scheduler/base", version = "0.2.0-alpha" }
+ekiden-storage-base = { path = "../../storage/base", version = "0.2.0-alpha" }
+log = "0.4"

--- a/consensus/optimistic/src/backend.rs
+++ b/consensus/optimistic/src/backend.rs
@@ -1,0 +1,432 @@
+//! Optimistic consensus backend.
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use ekiden_common::bytes::B256;
+use ekiden_common::environment::Environment;
+use ekiden_common::error::Error;
+use ekiden_common::futures::prelude::*;
+use ekiden_common::subscribers::StreamSubscribers;
+use ekiden_consensus_base::network::{ConsensusNetwork, Content, Message};
+use ekiden_consensus_base::{Block, Commitment, ConsensusBackend, ConsensusSigner, Event, Reveal,
+                            RootHashBackend};
+use ekiden_scheduler_base::{CommitteeNode, CommitteeType, Scheduler};
+
+enum Command {
+    /// Incoming network gossip.
+    Gossip(Message),
+    /// Notification on the new anchor block.
+    AnchorBlock(Block),
+    /// Committee update.
+    UpdateCommittee(Vec<CommitteeNode>),
+}
+
+/// State of optimistic consensus.
+///
+/// See the `transition` method for valid state transitions.
+#[derive(Clone, Debug)]
+enum State {
+    /// We are waiting for a valid anchor block and/or committee.
+    NotReady(Option<Block>, Option<Vec<CommitteeNode>>),
+    /// We are syncing intermediate blocks.
+    SyncingBlocks(Block, Vec<CommitteeNode>),
+    /// We are ready to process reveals.
+    Ready(Block, Vec<CommitteeNode>),
+}
+
+impl fmt::Display for State {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match *self {
+                State::NotReady(..) => "NotReady",
+                State::SyncingBlocks(..) => "SyncingBlocks",
+                State::Ready(..) => "Ready",
+            }
+        )
+    }
+}
+
+/// Helper macro for ensuring state is correct.
+///
+/// In case the state doesn't match the passed pattern, an error future is
+/// returned.
+macro_rules! require_state {
+    ($inner:ident, $( $state:pat )|* $(if $cond:expr)*, $message:expr) => {{
+        let state = $inner.state.lock().unwrap();
+        match state.clone() {
+            $( $state )|* $(if $cond)* => {}
+            state => {
+                return future::err(Error::new(format!(
+                    "incorrect state for {}: {:?}",
+                    $message, state
+                ))).into_box()
+            }
+        }
+    }};
+
+    ($inner:ident, $( $state:pat )|* $(if $cond:expr)* => $output:expr, $message:expr) => {{
+        let state = $inner.state.lock().unwrap();
+        match state.clone() {
+            $( $state )|* $(if $cond)* => $output,
+            state => {
+                return future::err(Error::new(format!(
+                    "incorrect state for {}: {:?}",
+                    $message, state
+                ))).into_box()
+            }
+        }
+    }};
+}
+
+/// Helper macro for ensuring state is correct.
+///
+/// In case the state doesn't match the passed pattern, an ok future is
+/// returned.
+macro_rules! require_state_ignore {
+    ($inner:ident, $( $state:pat )|* $(if $cond:expr)*) => {{
+        let state = $inner.state.lock().unwrap();
+        match state.clone() {
+            $( $state )|* $(if $cond)* => {}
+            _ => return future::ok(()).into_box(),
+        }
+    }};
+
+    ($inner:ident, $( $state:pat )|* $(if $cond:expr)* => $output:expr) => {{
+        let state = $inner.state.lock().unwrap();
+        match state.clone() {
+            $( $state )|* $(if $cond)* => $output,
+            _ => return future::ok(()).into_box(),
+        }
+    }};
+}
+
+struct Inner {
+    /// Contract identifier.
+    contract_id: B256,
+    /// Root hash backend.
+    root_hash: Arc<RootHashBackend>,
+    /// Signer.
+    signer: Arc<ConsensusSigner>,
+    /// Network layer.
+    network: Arc<ConsensusNetwork>,
+    /// Scheduler.
+    scheduler: Arc<Scheduler>,
+    /// Execution environment.
+    environment: Arc<Environment>,
+    /// Block subscribers.
+    block_subscribers: StreamSubscribers<Block>,
+    /// Event subscribers.
+    event_subscribers: StreamSubscribers<Event>,
+    /// Current state.
+    state: Mutex<State>,
+    /// Reveals collected for the current round, keyed by signer.
+    reveals: Mutex<HashMap<B256, Reveal>>,
+}
+
+/// Optimistic consensus backend.
+pub struct OptimisticConsensusBackend {
+    inner: Arc<Inner>,
+}
+
+impl OptimisticConsensusBackend {
+    /// Construct new optimistic consensus backend.
+    pub fn new(
+        contract_id: B256,
+        root_hash: Arc<RootHashBackend>,
+        signer: Arc<ConsensusSigner>,
+        network: Arc<ConsensusNetwork>,
+        scheduler: Arc<Scheduler>,
+        environment: Arc<Environment>,
+    ) -> Self {
+        let instance = Self {
+            inner: Arc::new(Inner {
+                contract_id,
+                root_hash,
+                signer,
+                network,
+                scheduler,
+                environment,
+                block_subscribers: StreamSubscribers::new(),
+                event_subscribers: StreamSubscribers::new(),
+                state: Mutex::new(State::NotReady(None, None)),
+                reveals: Mutex::new(HashMap::new()),
+            }),
+        };
+        instance.start();
+
+        instance
+    }
+
+    /// Start consensus backend.
+    fn start(&self) {
+        info!("Optimistic consensus backend starting");
+
+        let mut event_sources = stream::SelectAll::new();
+
+        // Subscribe to incoming network messages.
+        event_sources.push(
+            self.inner
+                .network
+                .watch_messages()
+                .map(|message| Command::Gossip(message))
+                .into_box(),
+        );
+
+        // Subscribe to incoming blocks from dispute resolution backend.
+        event_sources.push(
+            self.inner
+                .root_hash
+                .watch_blocks()
+                .map(|block| Command::AnchorBlock(block))
+                .into_box(),
+        );
+
+        // Subscribe to scheduler committee updates.
+        let contract_id = self.inner.contract_id;
+        event_sources.push(
+            self.inner
+                .scheduler
+                .watch_committees()
+                .filter(|committee| committee.kind == CommitteeType::Compute)
+                .filter(move |committee| committee.contract.id == contract_id)
+                .map(|committee| Command::UpdateCommittee(committee.members))
+                .into_box(),
+        );
+
+        // Process consensus commands.
+        self.inner.environment.spawn({
+            let inner = self.inner.clone();
+
+            event_sources.for_each_log_errors(
+                module_path!(),
+                "Unexpected error while processing consensus commands",
+                move |command| match command {
+                    Command::Gossip(message) => Self::handle_gossip(inner.clone(), message),
+                    Command::AnchorBlock(block) => Self::handle_anchor_block(inner.clone(), block),
+                    Command::UpdateCommittee(members) => {
+                        Self::handle_update_committee(inner.clone(), members)
+                    }
+                },
+            )
+        });
+    }
+
+    /// Transition the backend to a new state.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic in case of an invalid state transition.
+    fn transition(inner: Arc<Inner>, to: State) {
+        let mut state = inner.state.lock().unwrap();
+        match (&*state, &to) {
+            // Transitions from NotReady when anchor block and committee are resolved.
+            (&State::NotReady(None, None), &State::NotReady(Some(_), None)) => {}
+            (&State::NotReady(None, None), &State::NotReady(None, Some(_))) => {}
+            (&State::NotReady(None, None), &State::NotReady(Some(_), Some(_))) => {}
+            (
+                &State::NotReady(Some(ref block_a), None),
+                &State::NotReady(Some(ref block_b), Some(_)),
+            ) if block_a == block_b => {}
+            (
+                &State::NotReady(None, Some(ref committee_a)),
+                &State::NotReady(Some(_), Some(ref committee_b)),
+            ) if committee_a == committee_b => {}
+            (
+                &State::NotReady(Some(ref block_a), Some(ref committee_a)),
+                &State::SyncingBlocks(ref block_b, ref committee_b),
+            ) if block_a == block_b && committee_a == committee_b => {}
+
+            // Transitions from SyncingBlocks.
+            (&State::SyncingBlocks(_, ref committee_a), &State::Ready(_, ref committee_b))
+                if committee_a == committee_b => {}
+
+            // Transitions from Ready.
+            (&State::Ready(_, ref committee_a), &State::Ready(_, ref committee_b))
+                if committee_a == committee_b => {}
+
+            transition => panic!(
+                "illegal optimistic consensus state transition: {:?}",
+                transition
+            ),
+        }
+
+        trace!("Optimistic consensus transitioning to {}", to);
+        *state = to;
+    }
+
+    /// Handle incoming gossip.
+    fn handle_gossip(inner: Arc<Inner>, message: Message) -> BoxFuture<()> {
+        match message.content {
+            Content::Reveal(reveal) => Self::handle_gossip_reveal(inner, message.sender, reveal),
+            Content::LatestBlock(block) => Self::handle_gossip_latest_block(inner, block),
+        }
+    }
+
+    /// Handle new reveal gossip.
+    fn handle_gossip_reveal(inner: Arc<Inner>, sender: B256, reveal: Reveal) -> BoxFuture<()> {
+        let (block, committee) = require_state!(
+            inner,
+            State::Ready(block, committee) => (block, committee),
+            "handling reveals"
+        );
+
+        // Check that sender is a member of the current committee.
+        if !committee.iter().any(|member| member.public_key == sender) {
+            warn!(
+                "Discarding gossiped reveal from non-committee member {:?}",
+                sender
+            );
+            return future::ok(()).into_box();
+        }
+
+        // Extract header from reveal.
+        inner
+            .signer
+            .get_reveal_header(&reveal)
+            .and_then(move |header| {
+                // Check if header is based on previous block.
+                if !header.is_parent_of(&block.header) {
+                    warn!("Discarding gossiped reveal not based on previous block");
+                    return future::ok(()).into_box();
+                }
+
+                // Check if reveal is valid and comes from sender.
+                inner
+                    .signer
+                    .verify_reveal(sender, &header, &reveal)
+                    .and_then(move |_| {
+                        // Add to list of current reveals.
+                        let mut reveals = inner.reveals.lock().unwrap();
+                        reveals.insert(sender, reveal);
+
+                        // Check if we have enough reveals for processing.
+                        if reveals.len() == committee.len() {
+                            // TODO: Process reveals.
+                        }
+
+                        Ok(())
+                    })
+                    .into_box()
+            })
+            .into_box()
+    }
+
+    /// Handle latest block gossip.
+    fn handle_gossip_latest_block(inner: Arc<Inner>, block: Block) -> BoxFuture<()> {
+        // TODO: Collect latest blocks from multiple committee members, ensure they match.
+
+        // TODO: Validate that the latest block comes from the anchor block by traversing
+        //       the chain of backward hashes through storage.
+
+        future::ok(()).into_box()
+    }
+
+    fn start_syncing_blocks(inner: Arc<Inner>) -> BoxFuture<()> {
+        // TODO: Implement requesting the latest block.
+
+        future::ok(()).into_box()
+    }
+
+    /// Handle anchor block.
+    fn handle_anchor_block(inner: Arc<Inner>, block: Block) -> BoxFuture<()> {
+        let new_state = {
+            let state = inner.state.lock().unwrap();
+            match &*state {
+                &State::NotReady(_, ref committee) => {
+                    State::NotReady(Some(block), committee.clone())
+                }
+                &State::SyncingBlocks(..) => {
+                    unimplemented!("anchor block change while syncing blocks");
+                }
+                &State::Ready(..) => {
+                    unimplemented!("anchor block change while ready");
+                }
+            }
+        };
+
+        Self::transition(inner.clone(), new_state.clone());
+
+        if let State::NotReady(Some(_), Some(_)) = new_state {
+            // Start syncing blocks.
+            Self::start_syncing_blocks(inner.clone())
+        } else {
+            future::ok(()).into_box()
+        }
+    }
+
+    /// Handle committee update.
+    fn handle_update_committee(inner: Arc<Inner>, members: Vec<CommitteeNode>) -> BoxFuture<()> {
+        let new_state = {
+            let state = inner.state.lock().unwrap();
+            match &*state {
+                &State::NotReady(ref block, _) => State::NotReady(block.clone(), Some(members)),
+                &State::SyncingBlocks(..) => {
+                    unimplemented!("committee update while syncing blocks");
+                }
+                &State::Ready(..) => {
+                    unimplemented!("committee update while ready");
+                }
+            }
+        };
+
+        Self::transition(inner.clone(), new_state.clone());
+
+        if let State::NotReady(Some(_), Some(_)) = new_state {
+            // Start syncing blocks.
+            Self::start_syncing_blocks(inner.clone())
+        } else {
+            future::ok(()).into_box()
+        }
+    }
+}
+
+impl ConsensusBackend for OptimisticConsensusBackend {
+    fn get_blocks(&self, contract_id: B256) -> BoxStream<Block> {
+        assert!(contract_id == self.inner.contract_id);
+
+        unimplemented!();
+    }
+
+    fn get_events(&self, contract_id: B256) -> BoxStream<Event> {
+        assert!(contract_id == self.inner.contract_id);
+
+        self.inner.event_subscribers.subscribe().1
+    }
+
+    fn commit(&self, contract_id: B256, commitment: Commitment) -> BoxFuture<()> {
+        assert!(contract_id == self.inner.contract_id);
+
+        // TODO: Remove this function.
+
+        unimplemented!();
+    }
+
+    fn reveal(&self, contract_id: B256, reveal: Reveal) -> BoxFuture<()> {
+        assert!(contract_id == self.inner.contract_id);
+
+        // TODO: Gossip reveal to everyone.
+
+        // TODO: Perform local reveal handling.
+
+        unimplemented!();
+    }
+
+    fn commit_many(&self, contract_id: B256, commitments: Vec<Commitment>) -> BoxFuture<()> {
+        assert!(contract_id == self.inner.contract_id);
+
+        // TODO: Remove this function.
+
+        unimplemented!();
+    }
+
+    fn reveal_many(&self, contract_id: B256, reveals: Vec<Reveal>) -> BoxFuture<()> {
+        assert!(contract_id == self.inner.contract_id);
+
+        // TODO: Remove this function.
+
+        unimplemented!();
+    }
+}

--- a/consensus/optimistic/src/lib.rs
+++ b/consensus/optimistic/src/lib.rs
@@ -1,0 +1,13 @@
+//! Optimistic consensus backend.
+
+#[macro_use]
+extern crate log;
+
+extern crate ekiden_common;
+extern crate ekiden_consensus_base;
+extern crate ekiden_scheduler_base;
+extern crate ekiden_storage_base;
+
+mod backend;
+
+pub use backend::OptimisticConsensusBackend;


### PR DESCRIPTION
See #554 

TODO
* [x] Define network gossip interfaces required for optimistic consensus.
* [x] Add skeleton optimistic consensus backend in `ekiden-consensus-optimistic`.
* [x] Implement network gossip interfaces in compute node. Currently assumes a fully-connected mesh topology between committee members.
* [x] Add `RootHashBackend` interface (based on #558 and #564).
* [x] Add reveal verification to consensus signer interface and make it return futures.
* [ ] Change network implementation so nodes subscribe to gossip instead of pushing to other nodes directly. This way non-committee members can easily subscribe.
* [ ] Add dummy implementation of a root hash backend for testing.
* [ ] Add dummy implementation of network gossip interfaces for testing.
* [ ] Implement optimistic rounds using the gossip network interface to collect commitments/reveals.
* [ ] Remove commit/reveal aggregation.
* [ ] Remove commitments, only have reveals (see #566).
* [ ] Tests.
 