### PR TITLE
ethereum: panic build.rs if truffle compile fails

### DIFF
--- a/ethereum/build.rs
+++ b/ethereum/build.rs
@@ -2,10 +2,13 @@ use std::process::Command;
 
 fn main() {
     // Generate contracts.
-    Command::new("truffle")
+    let status = Command::new("truffle")
         .arg("compile")
         .status()
         .expect("truffle failed to build");
+    if !status.success() {
+        panic!("truffle failed to build");
+    }
 
     println!(
         "cargo:rerun-if-changed={}",


### PR DESCRIPTION
Check the status code when we get one. Panic if it exits with nonzero status.