### PR TITLE
Fix measure_configure macro

### DIFF
--- a/instrumentation/src/macros.rs
+++ b/instrumentation/src/macros.rs
@@ -30,7 +30,7 @@ macro_rules! measure {
 /// ```
 #[macro_export]
 macro_rules! measure_configure {
-    ($name:expr, $description:expr, $config:expr) => {
+    ($name:expr, $description:expr, $config:expr) => {{
         use $crate::MetricConfig;
 
         $crate::metric_collector().collect(&$crate::Metric::builder()
@@ -41,7 +41,7 @@ macro_rules! measure_configure {
             .file(Some(file!()))
             .line(Some(line!()))
             .build());
-    };
+    }};
 }
 
 /// Increment an instrumentation counter.


### PR DESCRIPTION
See #560 

Since the macro outputs an import statement this would result in a compiler error if the macro is used multiple times in the same scope. The updated macro creates a new scope for each invocation.