### PR TITLE
Fix E2E benchmark script

### DIFF
--- a/clients/benchmark/src/main.rs
+++ b/clients/benchmark/src/main.rs
@@ -69,30 +69,16 @@ fn main() {
     let app = benchmark_app!();
     let signer = create_key_pair();
 
-    benchmark_client!(app, signer, token, None, scenario_null, None);
-    benchmark_client!(
+    benchmark_multiple!(
         app,
         signer,
         token,
-        None,
-        scenario_null_storage_insert_1,
-        None
+        [
+            scenario_null,
+            scenario_null_storage_insert_1,
+            scenario_null_storage_insert_2,
+            scenario_null_storage_insert_10,
+            scenario_list_storage_insert
+        ]
     );
-    benchmark_client!(
-        app,
-        signer,
-        token,
-        None,
-        scenario_null_storage_insert_2,
-        None
-    );
-    benchmark_client!(
-        app,
-        signer,
-        token,
-        None,
-        scenario_null_storage_insert_10,
-        None
-    );
-    benchmark_client!(app, signer, token, None, scenario_list_storage_insert, None);
 }

--- a/clients/utils/Cargo.toml
+++ b/clients/utils/Cargo.toml
@@ -31,6 +31,9 @@ ekiden-registry-client = { path = "../../registry/client", version = "0.2.0-alph
 ekiden-rpc-client = { path = "../../rpc/client", version = "0.2.0-alpha" }
 pretty_env_logger = "0.2"
 log = "0.4"
+serde = "=1.0.59"
+serde_derive = "1.0"
+serde_json = "1.0"
 
 [dev-dependencies]
 ekiden-storage-dummy = { path = "../../storage/dummy", version = "0.2.0-alpha" }

--- a/clients/utils/src/benchmark.rs
+++ b/clients/utils/src/benchmark.rs
@@ -2,6 +2,7 @@ use std::sync::mpsc::channel;
 use std::sync::Arc;
 
 use histogram::Histogram;
+use serde_json;
 use threadpool::ThreadPool;
 use time;
 
@@ -61,28 +62,108 @@ pub struct BenchmarkResults {
     pub threads: usize,
 }
 
-impl BenchmarkResults {
-    /// Show one benchmark result.
-    fn show_result(&self, name: &str, result: &Histogram) {
-        println!("{}:", name);
+/// Benchmark results output format.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OutputFormat {
+    Text,
+    Json,
+}
+
+/// Latency results.
+#[derive(Debug, Serialize)]
+pub struct LatencyResults {
+    /// 50th percentile latency (in ms).
+    p50: u64,
+    /// 90th percentile latency (in ms).
+    p90: u64,
+    /// 99th percentile latency (in ms).
+    p99: u64,
+    /// 99.9th percentile latency (in ms).
+    p999: u64,
+    /// Minimum latency (in ms).
+    min: u64,
+    /// Average latency (in ms).
+    avg: u64,
+    /// Maximum latency (in ms).
+    max: u64,
+    /// Standard deviation of latency (in ms).
+    std_dev: u64,
+}
+
+/// Throughput results.
+#[derive(Debug, Serialize)]
+pub struct ThroughputResults {
+    /// Number of requests in the middle 80%.
+    middle80_request_count: usize,
+    /// Total non-overlapping time taken to do the requests.
+    total_nonoverlapping_time: u64,
+    /// Request throughput in requests per second.
+    throughput_per_sec: f64,
+}
+
+/// Aggregated benchmark results.
+#[derive(Debug, Serialize)]
+pub struct AggregatedBenchmarkResults {
+    /// Scenario title.
+    title: String,
+    /// Number of threads used.
+    threads: usize,
+    /// Number of requests per thread.
+    requests: usize,
+    /// Number of non-panicked requests.
+    non_panicked_request_count: u64,
+    /// Number of panicked requests.
+    panicked_request_count: u64,
+    /// Latency.
+    latency: LatencyResults,
+    /// Throughput.
+    throughput: ThroughputResults,
+}
+
+impl AggregatedBenchmarkResults {
+    /// Print aggregated results in text format.
+    pub fn print_text(&self) {
+        println!("------ {} ------", self.title);
+        println!("=== Benchmark Results ===");
+        println!("Threads:                   {}", self.threads);
+        println!("Requests per thread:       {}", self.requests);
         println!(
-            "    Percentiles: p50: {} ms / p90: {} ms / p99: {} ms / p999: {} ms",
-            result.percentile(50.0).unwrap(),
-            result.percentile(90.0).unwrap(),
-            result.percentile(99.0).unwrap(),
-            result.percentile(99.9).unwrap(),
+            "Non-panicked (npr):        {}",
+            self.non_panicked_request_count
+        );
+        println!("Panicked:                  {}", self.panicked_request_count);
+
+        println!("--- Latency ---");
+        println!(
+            "Percentiles: p50: {} ms / p90: {} ms / p99: {} ms / p999: {} ms",
+            self.latency.p50, self.latency.p90, self.latency.p99, self.latency.p999,
         );
         println!(
-            "    Min: {} ms / Avg: {} ms / Max: {} ms / StdDev: {} ms",
-            result.minimum().unwrap(),
-            result.mean().unwrap(),
-            result.maximum().unwrap(),
-            result.stddev().unwrap(),
+            "Min: {} ms / Avg: {} ms / Max: {} ms / StdDev: {} ms",
+            self.latency.min, self.latency.avg, self.latency.max, self.latency.std_dev,
         );
+
+        println!("--- Throughput ---");
+        println!(
+            "Middle 80%:                {} npr",
+            self.throughput.middle80_request_count
+        );
+        println!(
+            "Scenario (middle 80%):     {} ms ({} npr / sec)",
+            self.throughput.total_nonoverlapping_time, self.throughput.throughput_per_sec,
+        );
+        println!("");
     }
 
+    /// Print aggregated results in JSON format.
+    pub fn print_json(&self) {
+        println!("{}", serde_json::to_string(self).unwrap());
+    }
+}
+
+impl BenchmarkResults {
     /// Show benchmark results in a human-readable form.
-    pub fn show(&self) {
+    pub fn show(&self, title: &str, format: OutputFormat) {
         // Prepare histograms.
         let mut histogram_scenario = Histogram::new();
         let mut count = 0;
@@ -110,22 +191,38 @@ impl BenchmarkResults {
 
         let failures = (self.threads * self.runs) as u64 - count;
 
-        println!("=== Benchmark Results ===");
-        println!("Threads:                   {}", self.threads);
-        println!("Runs per thread:           {}", self.runs);
-        println!("Non-panicked (npr):        {}", count);
-        println!("Panicked:                  {}", failures);
+        let results = AggregatedBenchmarkResults {
+            title: title.into(),
+            threads: self.threads,
+            requests: self.runs,
+            non_panicked_request_count: count,
+            panicked_request_count: failures,
+            latency: LatencyResults {
+                p50: histogram_scenario.percentile(50.0).unwrap(),
+                p90: histogram_scenario.percentile(90.0).unwrap(),
+                p99: histogram_scenario.percentile(99.0).unwrap(),
+                p999: histogram_scenario.percentile(99.9).unwrap(),
+                min: histogram_scenario.minimum().unwrap(),
+                avg: histogram_scenario.mean().unwrap(),
+                max: histogram_scenario.maximum().unwrap(),
+                std_dev: histogram_scenario.stddev().unwrap(),
+            },
+            throughput: ThroughputResults {
+                middle80_request_count: throughput_runs.len(),
+                total_nonoverlapping_time: total_nonoverlapping / 1_000_000,
+                throughput_per_sec: throughput_runs.len() as f64
+                    / (total_nonoverlapping as f64 / 1e9),
+            },
+        };
 
-        println!("--- Latency ---");
-        self.show_result("Scenario", &histogram_scenario);
-
-        println!("--- Throughput ---");
-        println!("Middle 80%:                {} npr", throughput_runs.len());
-        println!(
-            "Scenario (middle 80%):     {} ms ({} npr / sec)",
-            total_nonoverlapping / 1_000_000,
-            throughput_runs.len() as f64 / (total_nonoverlapping as f64 / 1e9)
-        );
+        match format {
+            OutputFormat::Text => {
+                results.print_text();
+            }
+            OutputFormat::Json => {
+                results.print_json();
+            }
+        }
     }
 }
 
@@ -172,19 +269,25 @@ where
         init: Option<fn(&mut Factory::Client, usize, usize)>,
         scenario: fn(&mut Factory::Client),
         finalize: Option<fn(&mut Factory::Client, usize, usize)>,
+        verbose: bool,
     ) -> BenchmarkResults {
         // Initialize.
-        println!("Initializing benchmark...");
+        if verbose {
+            println!("Initializing benchmark...");
+        }
+
         let mut client = self.client_factory.create();
         if let Some(init) = init {
             init(&mut client, self.runs, self.pool.max_count());
         }
 
-        println!(
-            "Running benchmark with {} threads, each doing {} requests...",
-            self.pool.max_count(),
-            self.runs
-        );
+        if verbose {
+            println!(
+                "Running benchmark with {} threads, each doing {} requests...",
+                self.pool.max_count(),
+                self.runs
+            );
+        }
 
         let (tx, rx) = channel();
         for _ in 0..self.pool.max_count() {
@@ -218,7 +321,9 @@ where
         let results = collect_vec(rx.try_iter());
 
         // Finalize.
-        println!("Finalizing benchmark...");
+        if verbose {
+            println!("Finalizing benchmark...");
+        }
         let mut client = self.client_factory.create();
         if let Some(finalize) = finalize {
             finalize(&mut client, self.runs, self.pool.max_count());

--- a/clients/utils/src/lib.rs
+++ b/clients/utils/src/lib.rs
@@ -3,6 +3,10 @@ extern crate histogram;
 #[macro_use]
 extern crate log;
 extern crate pretty_env_logger;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
 #[cfg(feature = "benchmark")]
 extern crate threadpool;
 #[cfg(feature = "benchmark")]


### PR DESCRIPTION
Results:

### Batch storage: `immediate_remote`
```
RUNNING BENCHMARK: e2e-benchmark
Initializing benchmark...
Running benchmark with 50 threads, each doing 1000 requests...
Finalizing benchmark...
------ scenario_null ------
=== Benchmark Results ===
Threads:                   50
Runs per thread:           1000
Non-panicked (npr):        50000
Panicked:                  0
--- Latency ---
Scenario:
    Percentiles: p50: 12 ms / p90: 14 ms / p99: 17 ms / p999: 199 ms
    Min: 5 ms / Avg: 13 ms / Max: 205 ms / StdDev: 12 ms
--- Throughput ---
Middle 80%:                40000 npr
Scenario (middle 80%):     9801 ms (4080.992844164529 npr / sec)

Initializing benchmark...
Running benchmark with 50 threads, each doing 1000 requests...
Finalizing benchmark...
------ scenario_null_storage_insert_1 ------
=== Benchmark Results ===
Threads:                   50
Runs per thread:           1000
Non-panicked (npr):        50000
Panicked:                  0
--- Latency ---
Scenario:
    Percentiles: p50: 18 ms / p90: 25 ms / p99: 28 ms / p999: 201 ms
    Min: 8 ms / Avg: 19 ms / Max: 211 ms / StdDev: 13 ms
--- Throughput ---
Middle 80%:                40000 npr
Scenario (middle 80%):     14858 ms (2692.006472081311 npr / sec)

Initializing benchmark...
Running benchmark with 50 threads, each doing 1000 requests...
Finalizing benchmark...
------ scenario_null_storage_insert_2 ------
=== Benchmark Results ===
Threads:                   50
Runs per thread:           1000
Non-panicked (npr):        50000
Panicked:                  0
--- Latency ---
Scenario:
    Percentiles: p50: 22 ms / p90: 30 ms / p99: 174 ms / p999: 205 ms
    Min: 10 ms / Avg: 26 ms / Max: 223 ms / StdDev: 19 ms
--- Throughput ---
Middle 80%:                40000 npr
Scenario (middle 80%):     19657 ms (2034.8055125001194 npr / sec)

Initializing benchmark...
Running benchmark with 50 threads, each doing 1000 requests...
Finalizing benchmark...
------ scenario_null_storage_insert_10 ------
=== Benchmark Results ===
Threads:                   50
Runs per thread:           1000
Non-panicked (npr):        50000
Panicked:                  0
--- Latency ---
Scenario:
    Percentiles: p50: 50 ms / p90: 68 ms / p99: 73 ms / p999: 198 ms
    Min: 22 ms / Avg: 55 ms / Max: 233 ms / StdDev: 14 ms
--- Throughput ---
Middle 80%:                40000 npr
Scenario (middle 80%):     44453 ms (899.824318093176 npr / sec)

Initializing benchmark...
Running benchmark with 50 threads, each doing 1000 requests...
Finalizing benchmark...
------ scenario_list_storage_insert ------
=== Benchmark Results ===
Threads:                   50
Runs per thread:           1000
Non-panicked (npr):        50000
Panicked:                  0
--- Latency ---
Scenario:
    Percentiles: p50: 41 ms / p90: 55 ms / p99: 60 ms / p999: 205 ms
    Min: 18 ms / Avg: 45 ms / Max: 237 ms / StdDev: 15 ms
--- Throughput ---
Middle 80%:                40000 npr
Scenario (middle 80%):     36541 ms (1094.6508074811804 npr / sec)
```
### Batch storage: `multilayer` (sled + remote)
```
RUNNING BENCHMARK: e2e-benchmark-multilayer-remote
Initializing benchmark...
Running benchmark with 50 threads, each doing 1000 requests...
Finalizing benchmark...
------ scenario_null ------
=== Benchmark Results ===
Threads:                   50
Runs per thread:           1000
Non-panicked (npr):        50000
Panicked:                  0
--- Latency ---
Scenario:
    Percentiles: p50: 191 ms / p90: 566 ms / p99: 1710 ms / p999: 2337 ms
    Min: 20 ms / Avg: 276 ms / Max: 2577 ms / StdDev: 278 ms
--- Throughput ---
Middle 80%:                40000 npr
Scenario (middle 80%):     222973 ms (179.3937707610333 npr / sec)
```
Other benchmarks were not run as even the null scenario showed a huge degradation in performance.