### PR TITLE
Update issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,9 +1,3 @@
----
-name: Bug report
-about: Create a report to help us improve
-
----
-
 _A clear and concise description of what the bug is._
 
 ## Details


### PR DESCRIPTION
Previous PR didn't get rid of the extra step of choosing the issue template

This one moves to the "legacy style issue template" per
https://help.github.com/articles/manually-creating-a-single-issue-template-for-your-repository/