### PR TITLE
Lock up compiler-builtins version

### DIFF
--- a/xargo/Xargo.toml.template
+++ b/xargo/Xargo.toml.template
@@ -6,6 +6,7 @@ panic_abort = {}
 [dependencies.compiler_builtins]
 features = ["c", "compiler-builtins"]
 git = "https://github.com/rust-lang-nursery/compiler-builtins"
+rev = "86bf357a14cacb4a4169455e729d409b5ecc1da0"
 stage = 1
 
 [dependencies.std]


### PR DESCRIPTION
stops us before this https://github.com/rust-lang-nursery/compiler-builtins/commit/411a12fc029f0aa4df73f47e4496b14125df7e61

for #629 