### PR TITLE
Support per-method attributes in enclave RPC API

### DIFF
--- a/rpc/client/src/macros.rs
+++ b/rpc/client/src/macros.rs
@@ -29,6 +29,7 @@ macro_rules! create_client_rpc {
         }
 
         $(
+            $(#[$($attribute:tt)*])*
             rpc $method_name: ident ( $request_type: ty ) -> $response_type: ty ;
         )*
     ) => {


### PR DESCRIPTION
See #632 

While the enclave RPC dispatcher already supported per-method attributes like the requirement for client attestation, it was not possible to configure these attributes through the API definitions.

This commit introduces method attributes using the standard Rust syntax for attributes, starting with the `client_attestation` attribute. This enables a specific method to not require client attestation while it is
required for other methods.

Example use in API definitions:
```rust
#[client_attestation(false)]
rpc my_extrnal_method(FooRequest) -> FooResponse;
``` 