### PR TITLE
Recover blocks and round state in Consensus backend

### DIFF
--- a/consensus/dummy/Cargo.toml
+++ b/consensus/dummy/Cargo.toml
@@ -17,6 +17,7 @@ log = "0.4"
 serde = "=1.0.59"
 serde_cbor = "0.8.2"
 serde_derive = "1.0"
+exonum_rocksdb = "~0.7.4"
 
 [dev-dependencies]
 ekiden-beacon-base = { path = "../../beacon/base", version = "0.2.0-alpha" }

--- a/consensus/dummy/src/lib.rs
+++ b/consensus/dummy/src/lib.rs
@@ -5,6 +5,7 @@
 extern crate log;
 #[macro_use]
 extern crate serde_derive;
+extern crate exonum_rocksdb;
 extern crate serde;
 extern crate serde_cbor;
 
@@ -19,6 +20,8 @@ extern crate ekiden_storage_base;
 mod backend;
 mod commitment;
 mod signer;
+mod state_storage;
 
 pub use backend::DummyConsensusBackend;
 pub use signer::DummyConsensusSigner;
+pub use state_storage::StateStorage;

--- a/consensus/dummy/src/state_storage.rs
+++ b/consensus/dummy/src/state_storage.rs
@@ -1,0 +1,86 @@
+//! Ekiden dummy consensus backend persistent local state storage.
+use std::path::Path;
+use std::sync::Arc;
+
+use exonum_rocksdb::{Options, DB};
+
+use ekiden_common::error::{Error, Result};
+
+struct Inner {
+    /// RocksDB database for storing key-value pairs.
+    db: DB,
+}
+
+pub struct StateStorage {
+    inner: Arc<Inner>,
+}
+
+impl StateStorage {
+    /// Create new or open existing local persistent consensus state storage at given path.
+    pub fn new(path: &Path) -> Result<Self> {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.set_use_fsync(true);
+
+        Ok(Self {
+            inner: Arc::new(Inner {
+                db: DB::open(&opts, path)?,
+            }),
+        })
+    }
+
+    /// Retrieve a value (bytes) from persistent storage using the given string key.
+    pub fn get(&self, key: &str) -> Result<Vec<u8>> {
+        match self.inner.db.get(key.as_bytes()) {
+            Ok(Some(v)) => Ok(v.to_vec()),
+            Ok(None) => Err(Error::new("key not found in DB")),
+            _ => Err(Error::new("internal DB error")),
+        }
+    }
+
+    /// Insert or update value (bytes) in persistent storage using the given string key.
+    pub fn insert(&self, key: &str, value: Vec<u8>) -> Result<()> {
+        self.inner.db.put(key.as_bytes(), &value)?;
+        Ok(())
+    }
+
+    /// Remove value that corresponds to the given string key from persistent storage.
+    pub fn remove(&self, key: &str) -> Result<()> {
+        self.inner.db.delete(key.as_bytes())?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env::temp_dir;
+    use std::fs::remove_dir_all;
+
+    use super::*;
+
+    #[test]
+    fn test_local_state_storage() {
+        // We'll create our test DB at /tmp/test_local_state_storage_db.
+        let tmp_db_path = &temp_dir().as_path().join("test_local_state_storage_db");
+
+        // Clean any possible leftovers from previous tests.
+        drop(remove_dir_all(tmp_db_path));
+
+        let state_storage = StateStorage::new(Path::new(tmp_db_path));
+
+        assert!(state_storage.is_ok());
+
+        let state_storage = state_storage.unwrap();
+
+        let test_key = "test_key";
+        let test_value: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7];
+
+        assert_eq!(state_storage.insert(test_key, test_value.clone()), Ok(()));
+
+        assert_eq!(state_storage.get(test_key).unwrap(), test_value);
+
+        assert!(state_storage.remove(test_key).is_ok());
+
+        assert!(state_storage.get(test_key).is_err());
+    }
+}

--- a/node/dummy/src/backend.rs
+++ b/node/dummy/src/backend.rs
@@ -27,9 +27,11 @@ use grpcio::{ChannelBuilder, Server, ServerBuilder};
 use super::service::DebugService;
 
 /// Dummy Backend configuration.
-pub struct DummyBackendConfiguration {
+pub struct DummyBackendConfiguration<'a> {
     /// gRPC server port.
     pub port: u16,
+    /// Path to local state storage for the roothash backend.
+    pub roothash_storage_path: Option<&'a str>,
 }
 
 /// Random Beacon, Consensus, Registry and Storage backends.
@@ -83,6 +85,7 @@ impl DummyBackend {
             scheduler.clone(),
             storage.clone(),
             contract_registry.clone(),
+            config.roothash_storage_path,
         ));
 
         let server_builder = ServerBuilder::new(grpc_environment.clone());

--- a/node/dummy/src/main.rs
+++ b/node/dummy/src/main.rs
@@ -57,6 +57,13 @@ fn main() {
                 .default_value("42261")
                 .display_order(1),
         )
+        .arg(
+            Arg::with_name("roothash-storage-path")
+                .long("roothash-storage-path")
+                .short("S")
+                .takes_value(true)
+                .display_order(2),
+        )
         .args(&known_components.get_arguments())
         .get_matches();
 
@@ -94,6 +101,7 @@ fn main() {
     let mut backends = match DummyBackend::new(
         DummyBackendConfiguration {
             port: value_t!(matches, "port", u16).unwrap(),
+            roothash_storage_path: matches.value_of("roothash-storage-path"),
         },
         container,
     ) {

--- a/scheduler/base/src/backend.rs
+++ b/scheduler/base/src/backend.rs
@@ -60,17 +60,22 @@ impl Into<api::CommitteeNode> for CommitteeNode {
 }
 
 /// The functionality a committee exists to provide.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CommitteeType {
     Compute,
     Storage,
 }
 
 /// A per-contract (per-contract instance) committee instance.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Committee {
     pub kind: CommitteeType,
     pub members: Vec<CommitteeNode>,
+    // We only need to ser/des this struct in the Consensus dummy backend
+    // when storing or restoring current round state.  Arc<> is problematic
+    // to ser/des, but we can recreate the contract from other data we have,
+    // so we don't really need it there.
+    #[serde(skip)]
     pub contract: Arc<Contract>,
     pub valid_for: EpochTime,
 }


### PR DESCRIPTION
See issue #483.

This PR adds local persistent storage to the dummy consensus backend (using RocksDB) and uses it to store blocks and the current round state during execution.  In case of a crash, the round state can be restored.  The latest block is always loaded at startup if it exists in local storage.

A new command-line argument is required for the dummy consensus backends -- `local-storage-path`, which specifies where to store the RocksDB database.