### PR TITLE
Enable client authentication override

### DIFF
--- a/contracts/key-manager/client/src/client.rs
+++ b/contracts/key-manager/client/src/client.rs
@@ -79,7 +79,7 @@ impl KeyManager {
                 _ => return Err(Error::new("Failed to create key manager client backend")),
             };
 
-            let client = key_manager::Client::new(Arc::new(backend), mr_enclave);
+            let client = key_manager::Client::new(Arc::new(backend), mr_enclave, Some(true));
             self.client.get_or_insert(client);
         }
 

--- a/rpc/client/src/client.rs
+++ b/rpc/client/src/client.rs
@@ -301,7 +301,9 @@ impl<Backend: RpcClientBackend + 'static> RpcClientContext<Backend> {
                         let mut request = api::ChannelAuthRequest::new();
                         let credentials = match context.backend.get_credentials() {
                                 Some(credentials) => credentials,
-                                None => return future::Either::A(future::err(Error::new("Channel requires client authentication and backend has no credentials"))),
+                                None => return future::Either::A(future::err(Error::new(
+                                    "Channel requires client authentication and backend has no credentials"
+                                ))),
                             };
                         let bastpk = match context.secure_channel.get_authentication(
                             &credentials.long_term_private_key,

--- a/rpc/client/src/macros.rs
+++ b/rpc/client/src/macros.rs
@@ -50,14 +50,24 @@ macro_rules! create_client_rpc {
             #[allow(dead_code)]
             impl<Backend: RpcClientBackend + 'static> Client<Backend> {
                 /// Create new client instance.
-                pub fn new(backend: Arc<Backend>,
-                           mr_enclave: $crate::macros::quote::MrEnclave) -> Self {
-
-                    Client {
+                ///
+                /// If you set `client_authentication` to `None` the default value from the API
+                /// definition will be used. Otherwise this option can be used to override whether
+                /// client authentication is enabled.
+                pub fn new(
+                    backend: Arc<Backend>,
+                    mr_enclave: $crate::macros::quote::MrEnclave,
+                    client_authentication: Option<bool>
+                ) -> Self {
+                    Self {
                         client: RpcClient::new(
                             backend,
                             mr_enclave,
-                            $client_attestation_required,
+                            if let Some(client_authentication) = client_authentication {
+                                client_authentication
+                            } else {
+                                $client_attestation_required
+                            },
                         ),
                     }
                 }


### PR DESCRIPTION
Fixes #675 

Previously enclave RPC client authentication was always enabled if it was specified in the API definition. This commit makes it possible to construct clients which override that setting (e.g., in cases where some methods can also be invoked without client authentication).