### PR TITLE
Make raw contract calls unsigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   clear what its role is.
 * **BACKWARD INCOMPATIBLE:** Move local node identity implementations to `ekiden-common`
   (previously they were part of `ekiden-ethereum`).
+* **BACKWARD INCOMPATIBLE:** Make raw contract calls unsigned as signatures and encryption
+  should be handled by the runtime.
 * Add discrepancy resolution by using backup workers majority vote.
 * Add passing extra arguments to Docker in shell (`--docker-extra-args`).
 * Add `common::futures::retry` which implements retrying futures on failure.

--- a/clients/benchmark/src/main.rs
+++ b/clients/benchmark/src/main.rs
@@ -12,27 +12,14 @@ extern crate ekiden_rpc_client;
 
 extern crate token_api;
 
-use std::sync::Arc;
-
 use clap::{App, Arg};
 
 use ekiden_contract_client::create_contract_client;
-use ekiden_core::bytes::B256;
 use ekiden_core::futures::Future;
-use ekiden_core::ring::signature::Ed25519KeyPair;
-use ekiden_core::signature::InMemorySigner;
-use ekiden_core::untrusted;
 use token_api::with_api;
 
 with_api! {
     create_contract_client!(token, token_api, api);
-}
-
-/// Generate client key pair.
-fn create_key_pair() -> Arc<InMemorySigner> {
-    let key_pair =
-        Ed25519KeyPair::from_seed_unchecked(untrusted::Input::from(&B256::random())).unwrap();
-    Arc::new(InMemorySigner::new(key_pair))
 }
 
 fn scenario_null(client: &mut token::Client) {
@@ -67,11 +54,9 @@ fn scenario_list_storage_insert(client: &mut token::Client) {
 
 fn main() {
     let app = benchmark_app!();
-    let signer = create_key_pair();
 
     benchmark_multiple!(
         app,
-        signer,
         token,
         [
             scenario_null,

--- a/clients/test-long-term/src/main.rs
+++ b/clients/test-long-term/src/main.rs
@@ -12,33 +12,20 @@ extern crate ekiden_rpc_client;
 
 extern crate token_api;
 
-use std::sync::Arc;
 use std::{thread, time};
 
 use clap::{App, Arg};
 
 use ekiden_contract_client::create_contract_client;
-use ekiden_core::bytes::B256;
 use ekiden_core::futures::Future;
-use ekiden_core::ring::signature::Ed25519KeyPair;
-use ekiden_core::signature::InMemorySigner;
-use ekiden_core::untrusted;
 use token_api::with_api;
 
 with_api! {
     create_contract_client!(token, token_api, api);
 }
 
-/// Generate client key pair.
-fn create_key_pair() -> Arc<InMemorySigner> {
-    let key_pair =
-        Ed25519KeyPair::from_seed_unchecked(untrusted::Input::from(&B256::random())).unwrap();
-    Arc::new(InMemorySigner::new(key_pair))
-}
-
 fn main() {
-    let signer = create_key_pair();
-    let client = contract_client!(signer, token);
+    let client = contract_client!(token);
 
     // Create new token contract.
     let mut request = token::CreateRequest::new();

--- a/clients/token/src/main.rs
+++ b/clients/token/src/main.rs
@@ -15,17 +15,11 @@ extern crate ekiden_rpc_client;
 
 extern crate token_api;
 
-use std::sync::Arc;
-
 use clap::{App, Arg};
 use futures::future::Future;
 use rand::{thread_rng, Rng};
 
 use ekiden_contract_client::create_contract_client;
-use ekiden_core::bytes::B256;
-use ekiden_core::ring::signature::Ed25519KeyPair;
-use ekiden_core::signature::InMemorySigner;
-use ekiden_core::untrusted;
 use token_api::with_api;
 
 with_api! {
@@ -118,24 +112,15 @@ fn finalize(client: &mut token::Client, runs: usize, threads: usize) {
     );
 }
 
-/// Generate client key pair.
-fn create_key_pair() -> Arc<InMemorySigner> {
-    let key_pair =
-        Ed25519KeyPair::from_seed_unchecked(untrusted::Input::from(&B256::random())).unwrap();
-    Arc::new(InMemorySigner::new(key_pair))
-}
-
 #[cfg(feature = "benchmark")]
 fn main() {
-    let signer = create_key_pair();
-    let results = benchmark_client!(signer, token, init, scenario, finalize);
+    let results = benchmark_client!(token, init, scenario, finalize);
     results.show();
 }
 
 #[cfg(not(feature = "benchmark"))]
 fn main() {
-    let signer = create_key_pair();
-    let mut client = contract_client!(signer, token);
+    let mut client = contract_client!(token);
     init(&mut client, 1, 1);
     scenario(&mut client);
     finalize(&mut client, 1, 1);

--- a/contract/client/src/macros.rs
+++ b/contract/client/src/macros.rs
@@ -2,7 +2,6 @@
 pub use ekiden_common::bytes::B256;
 pub use ekiden_common::environment::Environment;
 pub use ekiden_common::futures::{BoxFuture, Future};
-pub use ekiden_common::signature::Signer;
 pub use ekiden_enclave_common::quote;
 pub use ekiden_registry_base::EntityRegistryBackend;
 pub use ekiden_roothash_base::backend::RootHashBackend;
@@ -58,7 +57,6 @@ macro_rules! create_contract_client {
                     environment: Arc<Environment>,
                     scheduler: Arc<Scheduler>,
                     entity_registry: Arc<EntityRegistryBackend>,
-                    signer: Arc<Signer>,
                     roothash: Arc<RootHashBackend>,
                     storage: Arc<StorageBackend>,
                 ) -> Self {
@@ -70,7 +68,6 @@ macro_rules! create_contract_client {
                             environment,
                             scheduler,
                             entity_registry,
-                            signer,
                             roothash,
                             storage,
                         ),

--- a/contract/client/src/manager.rs
+++ b/contract/client/src/manager.rs
@@ -11,7 +11,6 @@ use ekiden_common::error::Error;
 use ekiden_common::futures::prelude::*;
 use ekiden_common::futures::sync::oneshot;
 use ekiden_common::node::Node;
-use ekiden_common::signature::Signer;
 use ekiden_compute_api;
 use ekiden_enclave_common::quote::MrEnclave;
 use ekiden_registry_base::EntityRegistryBackend;
@@ -40,8 +39,6 @@ struct Inner {
     entity_registry: Arc<EntityRegistryBackend>,
     /// Environment.
     environment: Arc<Environment>,
-    /// Signer.
-    signer: Arc<Signer>,
     /// Shared service for waiting for contract calls.
     call_wait_manager: Arc<super::callwait::Manager>,
     /// Current computation group leader.
@@ -67,7 +64,6 @@ impl ContractClientManager {
         environment: Arc<Environment>,
         scheduler: Arc<Scheduler>,
         entity_registry: Arc<EntityRegistryBackend>,
-        signer: Arc<Signer>,
         roothash: Arc<RootHashBackend>,
         storage: Arc<StorageBackend>,
     ) -> Self {
@@ -86,7 +82,6 @@ impl ContractClientManager {
                 environment,
                 scheduler,
                 entity_registry,
-                signer,
                 call_wait_manager,
                 leader: RwLock::new(None),
                 future_leader: future_leader.shared(),
@@ -153,7 +148,6 @@ impl ContractClientManager {
                                 );
                                 let client = ContractClient::new(
                                     rpc,
-                                    inner.signer.clone(),
                                     inner.call_wait_manager.clone(),
                                     inner.timeout.clone(),
                                 );

--- a/contract/trusted/src/macros.rs
+++ b/contract/trusted/src/macros.rs
@@ -20,7 +20,6 @@ macro_rules! create_contract {
         global_ctors_object! {
             ENCLAVE_CONTRACT_INIT, enclave_contract_init = {
                 use ekiden_core::error::Result;
-                use ekiden_core::contract::call::VerifiedContractCall;
                 use ekiden_trusted::contract::dispatcher::{ContractMethod,
                                                            ContractMethodDescriptor,
                                                            Dispatcher};
@@ -33,7 +32,7 @@ macro_rules! create_contract {
                             ContractMethodDescriptor {
                                 name: stringify!($method_name).to_owned(),
                             },
-                            |args: &VerifiedContractCall<$arguments_type>| -> Result<$output_type> {
+                            |args: &$arguments_type| -> Result<$output_type> {
                                 $method_name(args)
                             },
                         )


### PR DESCRIPTION
Fixes #679 

Since actual transaction processing has been delegated exclusively to the runtime (e.g., Ethereum calls already include a signature and nonce internally), there is no reason why external contract calls need to be signed - they can be arbitrary bytes.

The signatures/encryption should instead be runtime-dependent. This also means that the contract client no longer needs a key pair/signer.

@peterjgilbert since this changes the client interface to no longer require a signer, the web3 gateway will need to be updated as well.