### PR TITLE
Use `streamfollow` to improve robustness

### DIFF
--- a/registry/dummy/src/entity.rs
+++ b/registry/dummy/src/entity.rs
@@ -6,7 +6,7 @@ use ekiden_common::bytes::B256;
 use ekiden_common::entity::Entity;
 use ekiden_common::environment::Environment;
 use ekiden_common::error::Error;
-use ekiden_common::futures::{future, BoxFuture, BoxStream, StreamExt};
+use ekiden_common::futures::prelude::*;
 use ekiden_common::node::Node;
 use ekiden_common::signature::Signed;
 use ekiden_common::subscribers::StreamSubscribers;

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -113,7 +113,7 @@ run_test() {
     local dummy_node_runner=$5
     local restart_dummy_after=$6
 
-    echo "RUNNING TEST: ${description}"
+    echo -e "\n\e[36;7;1mRUNNING TEST:\e[27m ${description}\e[0m\n"
 
     # Ensure cleanup on exit.
     trap 'kill -- -0' EXIT


### PR DESCRIPTION
This PR is an attempt to improve robustness of the Ekiden codebase to random stream disconnects by using the new `streamfollow` combinator in various places.

Manual testing shows that even though the compute node now recovers from a backend restart (it resubscribes to streams, etc.), the rest of the dummy nodes are still a bit shaky and need more work -- in some cases, the contract client just hangs and nothing advances, in other cases there's a random RPC failure that I haven't traced yet, etc.

I've also changed the `RUNNING TEST` output of `scripts/test-e2e.sh` to be more visible, so it's easier to tell apart the verbose output of one test from another.