### PR TITLE
client-utils: expose contract ID

### DIFF
--- a/clients/utils/Cargo.toml
+++ b/clients/utils/Cargo.toml
@@ -10,6 +10,7 @@ authors = [
 benchmark = ["threadpool", "time", "histogram"]
 
 [dependencies]
+clap = { version = "2.29.1" }
 threadpool = { version = "1.7.1", optional = true }
 time = { version = "0.1", optional = true }
 histogram = { version = "0.6.8", optional = true }

--- a/clients/utils/src/args.rs
+++ b/clients/utils/src/args.rs
@@ -1,0 +1,12 @@
+use clap;
+
+use ekiden_core::bytes::B256;
+
+/// Determine contract identifier.
+pub fn get_contract_id(args: &clap::ArgMatches) -> B256 {
+    if args.is_present("test-contract-id") {
+        value_t_or_exit!(args, "test-contract-id", B256)
+    } else {
+        value_t_or_exit!(args, "mr-enclave", B256)
+    }
+}

--- a/clients/utils/src/lib.rs
+++ b/clients/utils/src/lib.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+extern crate clap;
 #[cfg(feature = "benchmark")]
 extern crate histogram;
 #[macro_use]
@@ -36,4 +38,5 @@ pub mod components;
 #[macro_use]
 pub mod macros;
 
+pub mod args;
 pub mod db;

--- a/clients/utils/src/macros.rs
+++ b/clients/utils/src/macros.rs
@@ -61,15 +61,8 @@ macro_rules! contract_client {
             $crate::macros::set_boxed_metric_collector(metrics).unwrap();
         }
 
-        // Determine contract identifier.
-        let contract_id = if $args.is_present("test-contract-id") {
-            value_t_or_exit!($args, "test-contract-id", B256)
-        } else {
-            value_t_or_exit!($args, "mr-enclave", B256)
-        };
-
         $contract::Client::new(
-            contract_id,
+            $crate::args::get_contract_id(&$args),
             value_t_or_exit!($args, "mr-enclave", MrEnclave),
             if $args.is_present("rpc-timeout") {
                 Some(std::time::Duration::new(


### PR DESCRIPTION
This moves logic into an new public function `client_utils::args::get_contract_id(&ArgMatches) -> B256`.

for https://github.com/oasislabs/runtime-ethereum/issues/89