### PR TITLE
Support lockfile in build-enclave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,7 @@ target/
 *.so
 **/generated
 Cargo.lock
-Xargo.toml
-
-# Enclave compilation
-Enclave_t.c
-Enclave_t.h
+Cargo.enclave.lock
 
 # IDE.
 .idea/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Update rust-sgx-sdk to v1.0.1 and rustc to 1.29 nightly
+* **BACKWARD INCOMPATIBLE:** Update rust-sgx-sdk to v1.0.1 and rustc to 1.29 nightly.
 * **BACKWARD INCOMPATIBLE:** Store batches in storage and distribute only signed batch
   hashes to workers.
 * **BACKWARD INCOMPATIBLE:** Remove `transactions` from consensus blocks and only store
@@ -51,6 +51,8 @@
 * You can now configure the last resort layer in the multilayer storage backend.
 * Handle stragglers in dummy consensus backend.
 * Change async contract call submission protocol to avoid the use of enclave RPC.
+* Honor `Cargo.enclave.lock` in `build-enclave` subcommand. This makes it possible to use
+  a specific `Cargo.lock` for building enclaves with deterministic versions.
 
 # 0.1.0
 

--- a/tools/src/command_buildenclave.rs
+++ b/tools/src/command_buildenclave.rs
@@ -16,7 +16,9 @@ use utils::{get_contract_identity, SgxMode};
 
 /// Build an Ekiden enclave.
 pub fn build_enclave(args: &ArgMatches) -> Result<()> {
-    let cargo_addendum = args.value_of("cargo-addendum").map(|s| PathBuf::from(s));
+    let cargo_addendum = args.value_of("cargo-addendum")
+        .map(|path| PathBuf::from(path));
+
     let mut builder = match args.value_of("enclave-crate") {
         Some(crate_name) => EnclaveBuilder::new(
             // Crate name.
@@ -51,6 +53,7 @@ pub fn build_enclave(args: &ArgMatches) -> Result<()> {
                 }
             },
             cargo_addendum,
+            None,
         )?,
         None => {
             // Invoke enclave-build in the current project directory.
@@ -82,6 +85,9 @@ pub fn build_enclave(args: &ArgMatches) -> Result<()> {
                     path: project.get_path(),
                 }),
                 cargo_addendum,
+                // We currently cannot use a workspace-wide Cargo.lock because if we build
+                // multiple enclaves, the lock files would be overwritten.
+                Some(project.get_path().join("Cargo.enclave.lock")),
             )?
         }
     };


### PR DESCRIPTION
Fixes #756 

This makes it possible to use a `Cargo.enclave.lock` file for ensuring that enclave builds use locked crate versions. A separate filename is used to avoid collisions between SGX and non-SGX builds as SGX builds may require different crates.

As an upside this also makes repeated enclave builds slightly faster as it is now no longer necessary to perform the repository update on each build.