### PR TITLE
Benchmark persistent roothash storage as well

### DIFF
--- a/scripts/benchmark-e2e.sh
+++ b/scripts/benchmark-e2e.sh
@@ -26,6 +26,19 @@ run_dummy_node_storage_persistent() {
         2>${LOGDIR}/dummy.log &
 }
 
+run_dummy_node_storage_roothash() {
+    local db_dir="/tmp/ekiden-benchmark-storage-roothash"
+    rm -rf ${db_dir}
+
+    ${WORKDIR}/target/debug/ekiden-node-dummy \
+        --random-beacon-backend dummy \
+        --entity-ethereum-address 627306090abab3a6e1400e9345bc60c78a8bef57 \
+        --time-source-notifier mockrpc \
+        --storage-backend dummy \
+        --roothash-storage-path ${db_dir} \
+        2>${LOGDIR}/dummy.log &
+}
+
 run_compute_node() {
     local id=$1
     shift
@@ -85,7 +98,7 @@ run_benchmark() {
     local dummy_node_runner=$5
 
     if [[ "${OUTPUT_FORMAT}" == "text" ]]; then
-        echo "RUNNING BENCHMARK: ${description}"
+        echo -e "\n\e[36;7;1mRUNNING BENCHMARK:\e[27m ${description}\e[0m\n"
     fi
 
     # Ensure cleanup on exit.
@@ -145,4 +158,5 @@ scenario_multilayer_remote() {
 
 run_benchmark scenario_basic "e2e-benchmark" benchmark 1 run_dummy_node_storage_dummy
 run_benchmark scenario_basic "e2e-benchmark-persistent" benchmark 1 run_dummy_node_storage_persistent
+run_benchmark scenario_basic "e2e-benchmark-persistent-roothash" benchmark 1 run_dummy_node_storage_roothash
 run_benchmark scenario_multilayer_remote "e2e-benchmark-multilayer-remote" benchmark 1 run_dummy_node_storage_dummy


### PR DESCRIPTION
This PR adds a benchmark for the case where the dummy roothash backend node uses persistent local state storage.

There's a significant drop in performance, so that's something that should be investigated.  Maybe related to fsyncing after every write?

Sample output:
```
RUNNING BENCHMARK: e2e-benchmark-persistent-roothash

Initializing benchmark...
Running benchmark with 50 threads, each doing 1000 requests...
Finalizing benchmark...
------ e2e-benchmark-persistent-roothash - scenario_null ------
=== Benchmark Results ===
Threads:                   50
Requests per thread:       1000
Non-panicked (npr):        50000
Panicked:                  0
--- Latency ---
Percentiles: p50: 160 ms / p90: 308 ms / p99: 377 ms / p999: 386 ms
Min: 19 ms / Avg: 178 ms / Max: 393 ms / StdDev: 92 ms
--- Throughput ---
Middle 80%:                40000 npr
Scenario (middle 80%):     168995 ms (236.69251787158572 npr / sec)

Initializing benchmark...
Running benchmark with 50 threads, each doing 1000 requests...
Finalizing benchmark...
------ e2e-benchmark-persistent-roothash - scenario_null_storage_insert_1 ------
=== Benchmark Results ===
Threads:                   50
Requests per thread:       1000
Non-panicked (npr):        50000
Panicked:                  0
--- Latency ---
Percentiles: p50: 539 ms / p90: 770 ms / p99: 856 ms / p999: 873 ms
Min: 170 ms / Avg: 538 ms / Max: 878 ms / StdDev: 158 ms
--- Throughput ---
Middle 80%:                40000 npr
Scenario (middle 80%):     487234 ms (82.09599365617655 npr / sec)

Initializing benchmark...
Running benchmark with 50 threads, each doing 1000 requests...
Finalizing benchmark...
------ e2e-benchmark-persistent-roothash - scenario_null_storage_insert_2 ------
=== Benchmark Results ===
Threads:                   50
Requests per thread:       1000
Non-panicked (npr):        50000
Panicked:                  0
--- Latency ---
Percentiles: p50: 901 ms / p90: 1293 ms / p99: 1416 ms / p999: 1604 ms
Min: 319 ms / Avg: 912 ms / Max: 1830 ms / StdDev: 269 ms
--- Throughput ---
Middle 80%:                40000 npr
Scenario (middle 80%):     819490 ms (48.81078934903185 npr / sec)

Initializing benchmark...
Running benchmark with 50 threads, each doing 1000 requests...
Finalizing benchmark...
------ e2e-benchmark-persistent-roothash - scenario_null_storage_insert_10 ------
=== Benchmark Results ===
Threads:                   50
Requests per thread:       1000
Non-panicked (npr):        50000
Panicked:                  0
--- Latency ---
Percentiles: p50: 1226 ms / p90: 1791 ms / p99: 1860 ms / p999: 1879 ms
Min: 481 ms / Avg: 1303 ms / Max: 1902 ms / StdDev: 376 ms
--- Throughput ---
Middle 80%:                40000 npr
Scenario (middle 80%):     1164390 ms (34.35273026973329 npr / sec)

[...]
```