### PR TITLE
go: Fix gometalinter configuration

### DIFF
--- a/go/.gometalinter.json
+++ b/go/.gometalinter.json
@@ -1,4 +1,9 @@
 {
-  "Exclude": ["vendor"],
-  "Enable": ["gofmt"]
+  "Skip": ["vendor"],
+  "Enable": ["gofmt"],
+  "Linters": {
+    "gofmt": {
+        "Command": "gofmt -l"
+    }
+  }
 }

--- a/go/README.md
+++ b/go/README.md
@@ -17,3 +17,8 @@ dep ensure
 go generate ./...
 go build -v -o ./ekiden/ekiden ./ekiden
 ```
+
+To lint run:
+```
+gometalinter ./...
+```


### PR DESCRIPTION
This changes the following:

* gofmt does not use -s anymore as that forces code simplification which is not part of default go fmt

* Use Skip instead of Exclude to skip linting the vendor directory as Exclude means something else