### PR TITLE
go: Fix gometalinter configuration, for real.

### DIFF
--- a/go/.gometalinter.json
+++ b/go/.gometalinter.json
@@ -1,9 +1,37 @@
 {
-  "Skip": ["vendor"],
-  "Enable": ["gofmt"],
+  "DisableAll": true,
+  "Enable": [
+    "deadcode",
+    "errcheck",
+    "goconst",
+    "gocyclo",
+    "gofmt",
+    "golint",
+    "gosec",
+    "gotype",
+    "gotypex",
+    "ineffassign",
+    "interfacer",
+    "maligned",
+    "megacheck",
+    "structcheck",
+    "unconvert",
+    "varcheck",
+    "vet",
+    "vetshadow"
+  ],
   "Linters": {
     "gofmt": {
         "Command": "gofmt -l"
+    },
+    "gosec": {
+        "Command": "gosec -fmt=csv -exclude=G104"
+    },
+    "vet": {
+        "Command": "go vet -composites=false"
     }
-  }
+  },
+  "Deadline": "10m",
+  "Vendor": true,
+  "EnableGC": true
 }

--- a/go/common/crypto/mrae/gen_vectors/testvector/testvector.go
+++ b/go/common/crypto/mrae/gen_vectors/testvector/testvector.go
@@ -44,7 +44,7 @@ func KATInputs() (msg, aad []byte) {
 
 // ValidateKATs validates the Known Answer Tests.
 func ValidateKATs(a *require.Assertions, fn string, ctorFn func([]byte) (cipher.AEAD, error)) {
-	raw, err := ioutil.ReadFile(fn)
+	raw, err := ioutil.ReadFile(fn) //nolint:gosec
 	a.NoError(err, "Load test vectors")
 
 	var kats KnownAnswerTests


### PR DESCRIPTION
Instead of just running `gofmt`, this now will run the default
linters in addition to `gofmt`.

Additionally this will globally suppress:

 * `go sec`'s unused error check.

 * `go vet`'s unkeyed composite literal check, as it complains about
   idiomatic syntax when using composite types.