### PR TITLE
go/scheduler: Implement the WatchCommittees gRPC call

### DIFF
--- a/go/scheduler/grpc.go
+++ b/go/scheduler/grpc.go
@@ -33,6 +33,22 @@ func (s *SchedulerServer) GetCommittees(ctx context.Context, req *pb.CommitteeRe
 
 // WatchCommittees implements the corresponding gRPC call.
 func (s *SchedulerServer) WatchCommittees(req *pb.WatchRequest, stream pb.Scheduler_WatchCommitteesServer) error {
+	ch, sub := s.backend.WatchCommittees()
+	defer sub.Close()
+
+	for {
+		committee, ok := <-ch
+		if !ok {
+			break
+		}
+		resp := &pb.WatchResponse{
+			Committee: committee.ToProto(),
+		}
+		if err := stream.Send(resp); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Somehow I forgot to implement this after stubbing it out.