### PR TITLE
gitlint: Increase the title limit to 72 chars

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -6,7 +6,7 @@ ignore-squash-commits=false
 ignore=body-is-missing
 
 [title-max-length]
-line-length=50
+line-length=72
 
 [B1]
 line-length=80


### PR DESCRIPTION
50 is too restrictive.  72 is the cutoff for where tools start
breaking/displaying ugly output.