### PR TITLE
Update serde and bigint deps

### DIFF
--- a/clients/utils/Cargo.toml
+++ b/clients/utils/Cargo.toml
@@ -33,7 +33,7 @@ ekiden-registry-client = { path = "../../registry/client", version = "0.2.0-alph
 ekiden-rpc-client = { path = "../../rpc/client", version = "0.2.0-alpha" }
 pretty_env_logger = "0.2"
 log = "0.4"
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_derive = "1.0"
 serde_json = "1.0"
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -18,10 +18,9 @@ byteorder = "1.2.1"
 rustc-hex = "1.0"
 ring = { git = "https://github.com/oasislabs/ring", default-features = false, features = [ "rsa_signing" ], branch = "0.12.1-ekiden" }
 untrusted = "0.5.1"
-bigint = { version = "~4.3", features = ["std"] }
+bigint = { version = "4.4.0", features = ["std"] }
 chrono = "0.4.2"
-# We cannot use serde>=1.0.60 as it requires rustc 1.26+.
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_derive = "1.0"
 serde_cbor = "0.8.2"
 serde_bytes = "~0.10"

--- a/contract/client/Cargo.toml
+++ b/contract/client/Cargo.toml
@@ -15,7 +15,7 @@ ekiden-scheduler-base = { path = "../../scheduler/base", version = "0.2.0-alpha"
 ekiden-storage-base = { path = "../../storage/base", version = "0.2.0-alpha" }
 ekiden-registry-base = { path = "../../registry/base", version = "0.2.0-alpha" }
 ekiden-compute-api = { path = "../../compute/api", version = "0.2.0-alpha" }
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_cbor = "0.8.2"
 log = "0.4"
 ekiden-grpcio = { version = "0.3.2", features = ["openssl"] }

--- a/contract/common/Cargo.toml
+++ b/contract/common/Cargo.toml
@@ -8,6 +8,6 @@ repository = "https://github.com/oasislabs/ekiden"
 
 [dependencies]
 ekiden-common = { path = "../../common", version = "0.2.0-alpha" }
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_derive = "1.0"
 serde_cbor = "0.8.2"

--- a/contract/trusted/Cargo.toml
+++ b/contract/trusted/Cargo.toml
@@ -11,7 +11,7 @@ ekiden-common = { path = "../../common", version = "0.2.0-alpha" }
 ekiden-contract-common = { path = "../common", version = "0.2.0-alpha" }
 ekiden-enclave-trusted = { path = "../../enclave/trusted", version = "0.2.0-alpha" }
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_cbor = "0.8.2"
 
 [dev-dependencies]

--- a/contract/untrusted/Cargo.toml
+++ b/contract/untrusted/Cargo.toml
@@ -15,7 +15,7 @@ sgx_urts = { git = "https://github.com/oasislabs/rust-sgx-sdk", tag = "v1.0.1-ek
 ekiden-common = { path = "../../common", version = "0.2.0-alpha" }
 ekiden-contract-common = { path = "../common", version = "0.2.0-alpha" }
 ekiden-enclave-untrusted = { path = "../../enclave/untrusted", version = "0.2.0-alpha" }
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_cbor = "0.8.2"
 
 [build-dependencies]

--- a/contracts/token/api/Cargo.toml
+++ b/contracts/token/api/Cargo.toml
@@ -10,7 +10,7 @@ build = "build.rs"
 [dependencies]
 ekiden-core = { path = "../../../core/common" }
 protobuf = "~2.0"
-serde = "=1.0.59"
+serde = "1.0.71"
 
 [build-dependencies]
 ekiden-tools = { path = "../../../tools" }

--- a/db/trusted/Cargo.toml
+++ b/db/trusted/Cargo.toml
@@ -14,7 +14,7 @@ ekiden-storage-lru = { path = "../../storage/lru_cache", version = "0.2.0-alpha"
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
 protobuf = "~2.0"
 sodalite = "0.3.0"
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_derive = "1.0"
 bincode = "1.0.0"
 

--- a/enclave/common/Cargo.toml
+++ b/enclave/common/Cargo.toml
@@ -16,8 +16,8 @@ protobuf = "~2.0"
 sodalite = "0.3.0"
 pem-iterator = "0.2"
 percent-encoding = "1.0.1"
+serde = "1.0.71"
 webpki = { git = "https://github.com/oasislabs/webpki", branch = "0.17.0-ekiden", default-features = false }
-serde = "=1.0.59"
 serde_json = "1.0"
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]

--- a/enclave/trusted/Cargo.toml
+++ b/enclave/trusted/Cargo.toml
@@ -11,7 +11,7 @@ ekiden-enclave-common = { path = "../common", version = "0.2.0-alpha" }
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
 protobuf = "~2.0"
 sodalite = "0.3.0"
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_cbor = "0.8.2"
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]

--- a/ethereum/Cargo.toml
+++ b/ethereum/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = "1.0"
 tiny-keccak = "1.4.2"
 tokio-core = "0.1.17"
 web3 = { git = "https://github.com/oasislabs/rust-web3", branch = "0.3.0-ekiden" }
-bigint = { version = "~4.3", features = ["std"] }
+bigint = { version = "4.4.0", features = ["std"] }
 itertools = "0.7.8"
 lazy_static = "1.0.1"
 

--- a/key-manager/api/Cargo.toml
+++ b/key-manager/api/Cargo.toml
@@ -10,7 +10,7 @@ build = "build.rs"
 [dependencies]
 ekiden-core = { path = "../../core/common", version = "0.2.0-alpha" }
 protobuf = "~2.0"
-serde = "=1.0.59"
+serde = "1.0.71"
 
 [build-dependencies]
 ekiden-tools = { path = "../../tools", version = "0.2.0-alpha" }

--- a/key-manager/client/Cargo.toml
+++ b/key-manager/client/Cargo.toml
@@ -15,7 +15,7 @@ ekiden-keymanager-api = { path = "../api", version = "0.2.0-alpha" }
 ekiden-keymanager-common = { path = "../common", version = "0.2.0-alpha" }
 ekiden-enclave-logger = { path = "../../enclave/logger", version = "0.2.0-alpha" }
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_cbor = "0.8.2"
 
 [target.'cfg(target_env = "sgx")'.dependencies]

--- a/key-manager/common/Cargo.toml
+++ b/key-manager/common/Cargo.toml
@@ -9,5 +9,5 @@ repository = "https://github.com/oasislabs/ekiden"
 [dependencies]
 sodalite = "0.3.0"
 ekiden-common = { path = "../../common", version = "0.2.0-alpha" }
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_derive = "1.0"

--- a/registry/dummy/Cargo.toml
+++ b/registry/dummy/Cargo.toml
@@ -12,7 +12,7 @@ ekiden-di = { path = "../../di", version = "0.2.0-alpha" }
 ekiden-epochtime = { path = "../../epochtime", version = "0.2.0-alpha" }
 ekiden-instrumentation = { path = "../../instrumentation", version = "0.2.0-alpha" }
 ekiden-registry-base = { path = "../base", version = "0.2.0-alpha" }
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_cbor = "0.8.2"
 
 [dev-dependencies]

--- a/roothash/base/Cargo.toml
+++ b/roothash/base/Cargo.toml
@@ -13,7 +13,7 @@ ekiden-storage-base = { path = "../../storage/base", version = "0.2.0-alpha" }
 ekiden-roothash-api = { path = "../api", version = "0.2.0-alpha" }
 protobuf = "~2.0"
 ekiden-grpcio = { version = "0.3.2", features = ["openssl"] }
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_derive = "1.0"
 serde_cbor = "0.8.2"
 serde_bytes = "~0.10"

--- a/roothash/dummy/Cargo.toml
+++ b/roothash/dummy/Cargo.toml
@@ -17,7 +17,7 @@ ekiden-storage-base = { path = "../../storage/base", version = "0.2.0-alpha" }
 ekiden-storage-mutablestate = { path = "../../storage/mutablestate", version = "0.2.0-alpha" }
 ekiden-registry-base = { path = "../../registry/base", version = "0.2.0-alpha" }
 log = "0.4"
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_cbor = "0.8.2"
 serde_derive = "1.0"
 exonum_rocksdb = "~0.7.4"

--- a/rpc/client/Cargo.toml
+++ b/rpc/client/Cargo.toml
@@ -12,7 +12,7 @@ ekiden-enclave-common = { path = "../../enclave/common", version = "0.2.0-alpha"
 ekiden-rpc-common = { path = "../common", version = "0.2.0-alpha" }
 protobuf = "~2.0"
 sodalite = "0.3.0"
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_cbor = "0.8.2"
 
 [target.'cfg(target_env = "sgx")'.dependencies]

--- a/rpc/common/Cargo.toml
+++ b/rpc/common/Cargo.toml
@@ -13,7 +13,7 @@ ekiden-enclave-common = { path = "../../enclave/common", version = "0.2.0-alpha"
 protobuf = "~2.0"
 sodalite = "0.3.0"
 byteorder = "1.2.1"
-serde = "=1.0.59"
+serde = "1.0.71"
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
 rand = "0.4.2"

--- a/rpc/trusted/Cargo.toml
+++ b/rpc/trusted/Cargo.toml
@@ -15,7 +15,7 @@ ekiden-enclave-common = { path = "../../enclave/common", version = "0.2.0-alpha"
 ekiden-enclave-trusted = { path = "../../enclave/trusted", version = "0.2.0-alpha" }
 ekiden-rpc-common = { path = "../common", version = "0.2.0-alpha" }
 ekiden-rpc-client = { path = "../client", version = "0.2.0-alpha" }
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_cbor = "0.8.2"
 
 [target.'cfg(target_env = "sgx")'.dependencies]

--- a/rpc/untrusted/Cargo.toml
+++ b/rpc/untrusted/Cargo.toml
@@ -17,7 +17,7 @@ lazy_static = "1.0"
 ekiden-common = { path = "../../common", version = "0.2.0-alpha" }
 ekiden-enclave-untrusted = { path = "../../enclave/untrusted", version = "0.2.0-alpha" }
 ekiden-rpc-common = { path = "../common", version = "0.2.0-alpha" }
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_cbor = "0.8.2"
 
 [build-dependencies]

--- a/scheduler/base/Cargo.toml
+++ b/scheduler/base/Cargo.toml
@@ -12,5 +12,5 @@ ekiden-epochtime = { path = "../../epochtime", version = "0.2.0-alpha" }
 ekiden-scheduler-api = { path = "../api", version = "0.2.0-alpha" }
 ekiden-grpcio = { version = "0.3.2", features = ["openssl"] }
 protobuf = "~2.0"
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_derive = "1.0"

--- a/scheduler/dummy/Cargo.toml
+++ b/scheduler/dummy/Cargo.toml
@@ -23,5 +23,5 @@ rand = "0.4.2"
 ekiden-beacon-dummy = { path = "../../beacon/dummy", version = "0.2.0-alpha" }
 ekiden-registry-dummy = { path = "../../registry/dummy", version = "0.2.0-alpha" }
 ekiden-grpcio = { version = "0.3.2", features = ["openssl"] }
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_cbor = "0.8.2"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -17,7 +17,7 @@ sgx_edl = { git = "https://github.com/oasislabs/rust-sgx-sdk", tag = "v1.0.1-eki
 clap = "2.29.1"
 ansi_term = "0.11"
 toml = "0.4"
-serde = "=1.0.59"
+serde = "1.0.71"
 serde_derive = "1.0"
 error-chain = "0.12.0"
 filebuffer = "0.3"


### PR DESCRIPTION
pwasm contracts use `bigint = 4.4.0` which clashes with ekiden's `~4.3`. I also updated the serde dep now that we're on a newer version of rustc.