### PR TITLE
Add BUILD_IMAGE_TAG to the docker labels

### DIFF
--- a/docker/deployment/Dockerfile.runtime
+++ b/docker/deployment/Dockerfile.runtime
@@ -1,8 +1,10 @@
 FROM tozd/sgx:ubuntu-bionic
 
 ARG EKIDEN_COMMIT_SHA
+ARG EKIDEN_BUILD_IMAGE_TAG
 
 LABEL com.oasislabs.ekiden-commit-sha="${EKIDEN_COMMIT_SHA}"
+LABEL com.oasislabs.ekiden-build-image-tag="${EKIDEN_BUILD_IMAGE_TAG}"
 
 ENV PATH="/ekiden/bin:${PATH}"
 

--- a/docker/deployment/build-images.sh
+++ b/docker/deployment/build-images.sh
@@ -31,4 +31,4 @@ else
 fi
 
 # Build the deployable image from the output.
-docker build --rm --force-rm --build-arg EKIDEN_COMMIT_SHA=$ekiden_commit_sha -t oasislabs/testnet:$BUILD_IMAGE_TAG - <target/docker-deployment/context.tar.gz
+docker build --rm --force-rm --build-arg EKIDEN_BUILD_IMAGE_TAG=$BUILD_IMAGE_TAG --build-arg EKIDEN_COMMIT_SHA=$ekiden_commit_sha -t oasislabs/testnet:$BUILD_IMAGE_TAG - <target/docker-deployment/context.tar.gz


### PR DESCRIPTION
Similar to oasislabs/runtime-ethereum#116 see that.