### PR TITLE
docker/deployment: Add the Go ekiden node to the image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,13 +57,14 @@ jobs:
       # Integration tests.
       - attach_workspace:
           at: /workspace
-      - run: cp /workspace/go/ekiden/ekiden go/ekiden/ekiden
+      - run: cp /workspace/go/ekiden/ekiden target/debug/ekiden-node
       - run: ./scripts/test-e2e.sh
 
       # Store built files.
       - persist_to_workspace:
           root: .
           paths:
+            - target/debug/ekiden-node
             - target/debug/ekiden-node-dummy
             - target/debug/ekiden-node-dummy-controller
             - target/debug/ekiden-compute

--- a/docker/deployment/build-images-inner.sh
+++ b/docker/deployment/build-images-inner.sh
@@ -14,11 +14,19 @@ EOF
     exit 1
 fi
 
-# Build all Ekiden binaries and resources.
+# Build all Ekiden Rust binaries and resources.
 cargo install --force --path tools
 (cd contracts/token && cargo ekiden build-enclave --release)
 (cd compute && cargo build --release)
 (cd node/dummy && cargo build --release)
+
+# Build all Ekiden Go binaries and resources.
+GO_SRC_BASE=${GOPATH}/src/github.com/oasislabs
+mkdir -p ${GO_SRC_BASE}
+ln -s ${GO_SRC_BASE}/ekiden ./
+(cd ${GO_SRC_BASE}/ekiden/go && dep ensure)
+(cd ${GO_SRC_BASE}/ekiden/go && go generate ./...)
+(cd ${GO_SRC_BASE}/ekiden/go && go build -o ./ekiden/ekiden ./ekiden)
 
 # Package all binaries and resources.
 mkdir -p target/docker-deployment/context/bin target/docker-deployment/context/lib target/docker-deployment/context/res
@@ -26,6 +34,7 @@ ln target/enclave/token.so target/docker-deployment/context/lib
 ln target/release/ekiden-compute target/docker-deployment/context/bin
 ln target/release/ekiden-node-dummy target/docker-deployment/context/bin
 ln target/release/ekiden-node-dummy-controller target/docker-deployment/context/bin
+ln go/ekiden/ekiden target/docker-deployment/context/bin/ekiden-node
 if [ -e docker/deployment/Dockerfile.generated ]
 then
     ln docker/deployment/Dockerfile.generated target/docker-deployment/context/Dockerfile

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -6,7 +6,7 @@ run_dummy_node_go_default() {
     local datadir=/tmp/ekiden-dummy-data
     rm -rf ${datadir}
 
-    ${WORKDIR}/go/ekiden/ekiden \
+    ${WORKDIR}/target/debug/ekiden-node \
         --log.level debug \
         --grpc.port 42261 \
         --epochtime.backend mock \


### PR DESCRIPTION
The binary is included in the image in addition to the existing dummy
node as `bin/ekiden-node-dummy-go`.

Part of #816.