### PR TITLE
ci: Don't store go node twice

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,12 +147,6 @@ jobs:
           paths:
             - "/go/pkg"
 
-      # Store built files.
-      - persist_to_workspace:
-          root: .
-          paths:
-            - go/ekiden/ekiden
-
   lint-git:
     docker:
       - image: circleci/python:3.6.6


### PR DESCRIPTION
Storing the go node to workspace twice causes some "workspace conflict" failures on CircleCI, so the go node is now only stored to workspace with the `build-rust` job together with the other things.

This will likely be revised later if we decide to split the E2E tests into a separate job that runs for both Go-only and Rust-only builds.