### PR TITLE
Add 'to' address to txclient.

### DIFF
--- a/ethereum/test/web3.js
+++ b/ethereum/test/web3.js
@@ -15,7 +15,8 @@ var makeTxn = function (client) {
         client.eth.sendTransaction({
             from: "1cca28600d7491365520b31b466f88647b9839ec",
             gas: 100000,
-            gasPrice: 0
+            gasPrice: 0,
+            to: "1cca28600d7491365520b31b466f88647b9839ec"
         }, function(err, txn) {
           if (err) {
             reject(err);


### PR DESCRIPTION
Currently `txclient` transactions are being counted as contract creations. 

See: https://github.com/oasislabs/runtime-ethereum/issues/133

This should fix it (i think)