### PR TITLE
Exclude broken ethereum tests from cover-rust

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,7 @@ jobs:
             --exclude ekiden-rpc-untrusted \
             --exclude ekiden-db-trusted \
             --exclude ekiden-db-untrusted \
+            --exclude ekiden-ethereum \
             --exclude ekiden-contract-untrusted \
             --exclude ekiden-keymanager-untrusted \
             --exclude ekiden-keymanager-node \


### PR DESCRIPTION
See #857 