### PR TITLE
compute: use Display to format roothash state

### DIFF
--- a/compute/src/roothash.rs
+++ b/compute/src/roothash.rs
@@ -183,7 +183,7 @@ macro_rules! require_state_impl {
             $( $state )|* $(if $cond)* => {}
             state => {
                 require_state_impl!(@$failed_handler Error::new(format!(
-                    "incorrect state for {}: {:?}",
+                    "incorrect state for {}: {}",
                     $message, state
                 )))
             }
@@ -202,7 +202,7 @@ macro_rules! require_state_impl {
             $( $state )|* $(if $cond)* => $output,
             state => {
                 require_state_impl!(@$failed_handler Error::new(format!(
-                    "incorrect state for {}: {:?}",
+                    "incorrect state for {}: {}",
                     $message, state
                 )))
             }


### PR DESCRIPTION
fixes #845 

we can't (probably shouldn't, either) include the decimal-formatted batch data in error messages, due to a 8 KiB limit on grpc trailing metadata. the Display formatter only includes the state name and role, which I think is suitable for use in these messages.