### PR TITLE
ci: remove references to old testnet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,26 +212,12 @@ jobs:
           name: Load current docker tag
           command: echo 'BUILD_IMAGE_TAG=`cat /workspace/build_image_tag`' >> $BASH_ENV
 
-      - run: |
-          mkdir -p ~/.kube
-          echo "$KUBECONFIG_CONTENT_BASE64" | base64 -di >~/.kube/config
-      - run:
-          name: Kubectl port forwarding
-          command: kubectl port-forward service/parity 8545:8545
-          background: true
-
       # Build deployment image.
       - run: BUILD_IMAGES_NO_ENTER=1 ./docker/deployment/build-images.sh
       # Push deployment image.
       - run: |
           echo "$DOCKERHUB_PASSWORD" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
           docker push oasislabs/testnet:$BUILD_IMAGE_TAG
-      # Update testnet.
-      # https://stackoverflow.com/a/33511811/1864688
-      - run: |
-          REPO_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' oasislabs/testnet:$BUILD_IMAGE_TAG)
-          kubectl set image deployments/ekiden-token-node-dummy ekiden-node-dummy=$REPO_DIGEST
-          kubectl set image deployments/ekiden-token ekiden-compute=$REPO_DIGEST
 
   promote-to-production:
     <<: *defaults


### PR DESCRIPTION
Some steps in our CI config try to access the old testnet, which breaks the build. Remove those.