### PR TITLE
go/tendermint: Expose block timeout config options

### DIFF
--- a/go/ekiden/cmd/root.go
+++ b/go/ekiden/cmd/root.go
@@ -102,7 +102,7 @@ func nodeMain(cmd *cobra.Command, args []string) {
 	env.svcMgr.Register(metrics)
 
 	// Initialize tendermint.
-	env.svcTmnt = tendermint.New(dataDir, env.identity)
+	env.svcTmnt = tendermint.New(cmd, dataDir, env.identity)
 	env.svcMgr.Register(env.svcTmnt)
 
 	// Initialize the varous node backends.
@@ -233,6 +233,7 @@ func init() {
 		roothash.RegisterFlags,
 		scheduler.RegisterFlags,
 		storage.RegisterFlags,
+		tendermint.RegisterFlags,
 	} {
 		v(rootCmd)
 	}


### PR DESCRIPTION
This exposes the following tendermint consesus config options as command
line arguments to facilitate testing:

 - `Consensus.TimeoutCommit` - The straggler timeout (1000 ms)
 - `Consensus.SkipTimeoutCommit` - Skip `TimeoutCommit` (false)

Setting either of these values will change how fast blocks are
generated, and will impact how fast the epoch advances in terms of civil
time iff the tendermint epochtime backend is used.