### PR TITLE
ci: verbose dep ensure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
           go install
       - run: |
           curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /tmp/bin v1.10.1
-      - run: cd go && dep ensure
+      - run: cd go && dep ensure -v
       - run: cd go && go generate ./...
       - run: cd go && /tmp/bin/golangci-lint run
       - run: cd go && go build -v -o ./ekiden/ekiden ./ekiden


### PR DESCRIPTION
- Send output to CI so that it knows when it's making progress.
- Reveal more information so we can determine if some dependencies are problematic in the future.

cross-reference: #896 