### PR TITLE
move nolint comment to end-of-line

### DIFF
--- a/go/scheduler/alg/cmd/driver/main.go
+++ b/go/scheduler/alg/cmd/driver/main.go
@@ -391,12 +391,10 @@ func (h *committeeMemberHeap) Pop() interface{} {
 	return x
 }
 
-// nolint: gocyclo
-//
 // Run simulation: generate transactions and execute them -- and output results to |bw|.
 // Caller is responsible for checking I/O errors via bw.Flush.  Other errors result in panic
 // here.
-func runSimulation(
+func runSimulation( // nolint: gocyclo
 	dcnf distributionConfig,
 	acnf adversaryConfig,
 	lscnf logicalShardingConfig,

--- a/go/scheduler/alg/cmd/load_gen/main.go
+++ b/go/scheduler/alg/cmd/load_gen/main.go
@@ -48,8 +48,7 @@ func init() {
 	flag.UintVar(&numTransactions, "numTransactions", 1<<20, "number of transactions to generate")
 }
 
-// nolint: gosec
-func generateTransactions(
+func generateTransactions( // nolint: gosec
 	numTrans, numReads, numWrites uint,
 	gen randgen.Rng,
 	out *bufio.Writer) {

--- a/go/scheduler/alg/greedy_subgraphs_scheduler.go
+++ b/go/scheduler/alg/greedy_subgraphs_scheduler.go
@@ -57,9 +57,7 @@ func (gs *GreedySubgraphsScheduler) NumDeferred() int {
 
 // Schedule actually performs scheduling and returns a slice containing mutually commutative
 // subgraphs.
-//
-// nolint: gocyclo
-func (gs *GreedySubgraphsScheduler) Schedule() []*Subgraph {
+func (gs *GreedySubgraphsScheduler) Schedule() []*Subgraph { // nolint: gocyclo
 	deferred := make([]*Transaction, 0)
 	readMap := make(map[Location][]int)
 	writeMap := make(map[Location]int)

--- a/go/scheduler/alg/location_range_set_test.go
+++ b/go/scheduler/alg/location_range_set_test.go
@@ -92,8 +92,7 @@ func TestMustReadLocationRange(t *testing.T) {
 	assert.NotNil(lr, "MustReadNewLocationRange should work")
 }
 
-// nolint: gocyclo
-func TestReadNewLocationRange(t *testing.T) {
+func TestReadNewLocationRange(t *testing.T) { // nolint: gocyclo
 	assert := assert.New(t)
 	helper := func(in string) (*LocationRange, error) {
 		return ReadNewLocationRange(TestLocation(0), bufio.NewReader(bytes.NewReader([]byte(in))))
@@ -161,8 +160,7 @@ func TestReadNewLocationRange(t *testing.T) {
 	assert.Error(err, "Unexpected ability to parse input '%s'", input)
 }
 
-// nolint: gocyclo
-func TestLocationRangeSetParse(t *testing.T) {
+func TestLocationRangeSetParse(t *testing.T) { // nolint: gocyclo
 	assert := assert.New(t)
 	helper := func(in string) (*LocationRangeSet, error) {
 		return LocationRangeSetFromString(TestLocation(0), in)

--- a/go/scheduler/alg/location_set.go
+++ b/go/scheduler/alg/location_set.go
@@ -155,9 +155,7 @@ func (ls LocationSet) Write(w *bufio.Writer) {
 // merges it into the receiver LocationSet.  The Location interface argument `l` is needed
 // because LocationSet objects do not know what is the actual type that implements the Location
 // interface, so `l.Read` is used to read in the individual locations from the `*bufio.Reader`.
-//
-// nolint: gocyclo
-func (ls *LocationSet) ReadMerge(l Location, r *bufio.Reader) (err error) {
+func (ls *LocationSet) ReadMerge(l Location, r *bufio.Reader) (err error) { // nolint: gocyclo
 	if err = expectRune('{', r); err != nil {
 		return err
 	}

--- a/go/scheduler/alg/parse_utils.go
+++ b/go/scheduler/alg/parse_utils.go
@@ -30,8 +30,7 @@ func getNonspaceRune(r io.RuneScanner) (ch rune, err error) {
 	return ch, err
 }
 
-// nolint: gosec
-func expectRune(expect rune, r io.RuneScanner) error {
+func expectRune(expect rune, r io.RuneScanner) error { // nolint: gosec
 	actual, err := getNonspaceRune(r)
 	if err != nil {
 		return err

--- a/go/scheduler/alg/randgen/zipf_test.go
+++ b/go/scheduler/alg/randgen/zipf_test.go
@@ -33,8 +33,7 @@ func TestZipfNew(t *testing.T) {
 	assert.Error(err, "MaxInt values should not work")
 }
 
-// nolint: gocyclo
-func TestZipfCdf(t *testing.T) {
+func TestZipfCdf(t *testing.T) { // nolint: gocyclo
 	assert := assert.New(t)
 	const maxValue = 1000000
 	handleTestSeed(t.Logf, &zipfSeed, "zipf CDF test")

--- a/go/scheduler/alg/simulator/adversary.go
+++ b/go/scheduler/alg/simulator/adversary.go
@@ -89,9 +89,7 @@ func (a choiceSort) Less(i, j int) bool { return a[i] < a[j] }
 
 // mapTargets: given a slice of random values `choice` all in half open interval [0,
 // `countTargets(targets)`), return a slice of the `TestLocation` associated with that value.
-//
-// nolint: gocyclo
-func mapTargets(targets *alg.LocationRangeSet, choice []int64) []alg.Location {
+func mapTargets(targets *alg.LocationRangeSet, choice []int64) []alg.Location { // nolint: gocyclo
 	if targets.IsEmpty() || len(choice) == 0 {
 		return nil
 	}

--- a/go/scheduler/alg/simulator/file_transaction_source.go
+++ b/go/scheduler/alg/simulator/file_transaction_source.go
@@ -17,11 +17,8 @@ type FileTransactionSource struct {
 
 // NewFileTransactionSource is a factory for FileTransactionSources where the data is read from
 // the filename supplied in the fn formal parameter.
-//
-// nolint: gosec
-//
-// File inclusion is the intention.
-func NewFileTransactionSource(fn string) (*FileTransactionSource, error) {
+func NewFileTransactionSource(fn string) (*FileTransactionSource, error) { // nolint: gosec
+	// File inclusion is the intention.
 	// Handle "-" case to mean stdin.  This means files named "-" would have to be referred
 	// to via "./-" which is awkward.  We could instead _only_ have the empty string ""
 	// mean standard input, but that is different from the usual Unix convention.


### PR DESCRIPTION
This removes nolint directives from possibly getting merged with godoc
comments.