### PR TITLE
go/scheduler/trivial: On catchup write to channel, not broadcast

### DIFF
--- a/go/scheduler/trivial/trivial.go
+++ b/go/scheduler/trivial/trivial.go
@@ -432,7 +432,7 @@ func New(timeSource epochtime.Backend, registry registry.Backend, beacon beacon.
 
 		for _, v := range comMap {
 			for _, vv := range v {
-				s.notifier.Broadcast(vv)
+				ch.In() <- vv
 			}
 		}
 	})


### PR DESCRIPTION
The old code was horrifically broken and would re-broadcast all the
committees instead of catching the subscriber up.

Probably fixes #889.