### PR TITLE
Add rudimentary encryption support to DB

### DIFF
--- a/clients/utils/src/db.rs
+++ b/clients/utils/src/db.rs
@@ -12,7 +12,7 @@ use ekiden_core::futures::prelude::*;
 use ekiden_core::futures::streamfollow;
 use ekiden_core::uint::U256;
 use ekiden_db_trusted::patricia_trie::PatriciaTrie;
-use ekiden_db_trusted::Database;
+use ekiden_db_trusted::{Database, DatabaseHandle};
 use ekiden_di::Container;
 use ekiden_roothash_base::{Block, RootHashBackend};
 use ekiden_storage_base::BackendIdentityMapper;
@@ -46,6 +46,13 @@ impl Database for Snapshot {
 
     fn clear(&mut self) {
         panic!("Can't clear Snapshot")
+    }
+
+    fn with_encryption<F>(&mut self, _contract_id: H256, _f: F)
+    where
+        F: FnOnce(&mut DatabaseHandle) -> (),
+    {
+        unimplemented!();
     }
 }
 

--- a/db/trusted/Cargo.toml
+++ b/db/trusted/Cargo.toml
@@ -11,6 +11,7 @@ ekiden-common = { path = "../../common", version = "0.2.0-alpha" }
 ekiden-enclave-trusted = { path = "../../enclave/trusted", version = "0.2.0-alpha" }
 ekiden-storage-base = { path = "../../storage/base", version = "0.2.0-alpha" }
 ekiden-storage-lru = { path = "../../storage/lru_cache", version = "0.2.0-alpha" }
+ekiden-keymanager-common = { path = "../../key-manager/common", version = "0.2.0-alpha" }
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
 protobuf = "~2.0"
 sodalite = "0.3.0"

--- a/db/trusted/src/handle.rs
+++ b/db/trusted/src/handle.rs
@@ -5,6 +5,9 @@ use std::sync::{Mutex, MutexGuard};
 use ekiden_common::bytes::H256;
 use ekiden_common::error::Result;
 use ekiden_common::hash::empty_hash;
+use ekiden_common::mrae::sivaessha2::{SivAesSha2, KEY_SIZE, NONCE_SIZE};
+use ekiden_common::ring::digest;
+use ekiden_keymanager_common::ContractId;
 use ekiden_storage_base::mapper::BackendIdentityMapper;
 #[cfg(not(target_env = "sgx"))]
 use ekiden_storage_dummy::DummyStorageBackend;
@@ -14,6 +17,19 @@ use super::patricia_trie::PatriciaTrie;
 #[cfg(target_env = "sgx")]
 use super::untrusted::UntrustedStorageBackend;
 use super::Database;
+
+/// Encryption context.
+///
+/// This contains the MRAE context for encrypting and decrypting values stored
+/// in the database.
+/// It is set up with db.with_encryption() and lasts only for the duration of
+/// the closure that's passed to that method.
+struct EncryptionContext {
+    /// MRAE context.
+    mrae_ctx: SivAesSha2,
+    /// Nonce for the MRAE context (should be unique for all time for a given key).
+    nonce: Vec<u8>,
+}
 
 /// Database handle.
 ///
@@ -25,6 +41,8 @@ pub struct DatabaseHandle {
     state: PatriciaTrie,
     /// Root hash.
     root_hash: Option<H256>,
+    /// Encryption context with which to perform all operations (optional).
+    enc_ctx: Option<EncryptionContext>,
 }
 
 lazy_static! {
@@ -51,6 +69,7 @@ impl DatabaseHandle {
         DatabaseHandle {
             state: PatriciaTrie::new(mapper),
             root_hash: None,
+            enc_ctx: None,
         }
     }
 
@@ -88,12 +107,34 @@ impl Database for DatabaseHandle {
     }
 
     fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        self.state.get(self.root_hash, key)
+        let value = self.state.get(self.root_hash, key);
+
+        if self.enc_ctx.is_some() && value.is_some() {
+            // Decrypt value using the encryption context.
+            let ctx = self.enc_ctx.as_ref().unwrap();
+
+            let decrypted = ctx.mrae_ctx.open(ctx.nonce.clone(), value.unwrap(), vec![]);
+
+            decrypted.ok()
+        } else {
+            value
+        }
     }
 
     fn insert(&mut self, key: &[u8], value: &[u8]) -> Option<Vec<u8>> {
         let previous_value = self.get(key);
-        self.root_hash = Some(self.state.insert(self.root_hash, key, value));
+
+        if self.enc_ctx.is_some() {
+            // Encrypt value using the encryption context.
+            let ctx = self.enc_ctx.as_ref().unwrap();
+            let encrypted_value = &ctx.mrae_ctx
+                .seal(ctx.nonce.clone(), value.to_vec(), vec![])
+                .unwrap();
+
+            self.root_hash = Some(self.state.insert(self.root_hash, key, encrypted_value));
+        } else {
+            self.root_hash = Some(self.state.insert(self.root_hash, key, value));
+        }
 
         previous_value
     }
@@ -109,11 +150,43 @@ impl Database for DatabaseHandle {
     fn clear(&mut self) {
         self.root_hash = None;
     }
+
+    /// Run given closure in an encrypted context for given contract.
+    fn with_encryption<F>(&mut self, contract_id: ContractId, f: F)
+    where
+        F: FnOnce(&mut DatabaseHandle) -> (),
+    {
+        // TODO: Get encryption key from the key manager.
+
+        // Set up dummy encryption key for now!
+        let hash = digest::digest(&digest::SHA512, &contract_id.to_vec());
+        let key: Vec<u8> = hash.as_ref()[..KEY_SIZE].to_vec();
+        let nonce: Vec<u8> = hash.as_ref()[KEY_SIZE..KEY_SIZE + NONCE_SIZE].to_vec();
+
+        // Make sure that the encryption context doesn't already exist,
+        // as we don't support nested contexts.
+        assert!(self.enc_ctx.is_none());
+
+        // Set up encryption context.
+        self.enc_ctx = Some(EncryptionContext {
+            mrae_ctx: SivAesSha2::new(key).unwrap(),
+            nonce,
+        });
+
+        // Run provided function.
+        f(self);
+
+        // Clear encryption context.
+        // Keys are securely erased by the Drop handler on SivAesSha2,
+        // we might want to do the same for the nonce.
+        self.enc_ctx = None;
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use ekiden_common::hash::empty_hash;
+    use ekiden_keymanager_common::ContractId;
 
     use super::{Database, DatabaseHandle};
 
@@ -140,5 +213,55 @@ mod tests {
 
         assert!(!db.contains_key(b"bar"));
         assert_eq!(db.get_root_hash(), Ok(empty_hash()));
+    }
+
+    #[test]
+    fn test_db_encryption() {
+        let mut db = DatabaseHandle::instance();
+
+        db.clear();
+        db.insert(b"unencrypted", b"hello world");
+
+        db.with_encryption(ContractId::from([0u8; 32]), |db| {
+            db.insert(b"encrypted", b"top secret");
+            assert!(db.contains_key(b"encrypted"));
+        });
+
+        // Encrypted value should actually be encrypted.
+        assert_ne!(db.get(b"encrypted"), Some(b"top secret".to_vec()));
+
+        // Unencrypted value should be readable.
+        assert_eq!(db.get(b"unencrypted"), Some(b"hello world".to_vec()));
+
+        // Accessing encrypted value with a different contract ID should fail.
+        db.with_encryption(ContractId::from([42u8; 32]), |db| {
+            assert_ne!(db.get(b"encrypted"), Some(b"top secret".to_vec()));
+        });
+
+        // Accessing encrypted value with the original contract ID should succeed.
+        db.with_encryption(ContractId::from([0u8; 32]), |db| {
+            assert_eq!(db.get(b"encrypted"), Some(b"top secret".to_vec()));
+        });
+
+        db.clear();
+        assert!(!db.contains_key(b"unencrypted"));
+        assert!(!db.contains_key(b"encrypted"));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_db_encryption_nested() {
+        let mut db = DatabaseHandle::instance();
+
+        db.clear();
+
+        // Nesting encryption contexts isn't supported and should panic!
+        db.with_encryption(ContractId::from([0u8; 32]), |db| {
+            db.insert(b"encrypted", b"top secret");
+
+            db.with_encryption(ContractId::from([42u8; 32]), |db| {
+                db.insert(b"also_encrypted", b"bottom secret");
+            });
+        });
     }
 }

--- a/db/trusted/src/lib.rs
+++ b/db/trusted/src/lib.rs
@@ -17,6 +17,7 @@ extern crate bincode;
 
 extern crate ekiden_common;
 extern crate ekiden_enclave_trusted;
+extern crate ekiden_keymanager_common;
 extern crate ekiden_storage_base;
 #[cfg(not(target_env = "sgx"))]
 extern crate ekiden_storage_dummy;
@@ -33,6 +34,8 @@ pub use handle::DatabaseHandle;
 pub mod patricia_trie;
 #[macro_use]
 pub mod schema;
+
+use ekiden_keymanager_common::ContractId;
 
 /// Database interface exposed to contracts.
 pub trait Database {
@@ -58,4 +61,9 @@ pub trait Database {
 
     /// Clear database state.
     fn clear(&mut self);
+
+    /// Run given closure in an encrypted context for given contract.
+    fn with_encryption<F>(&mut self, contract_id: ContractId, f: F)
+    where
+        F: FnOnce(&mut DatabaseHandle) -> ();
 }


### PR DESCRIPTION
See #686.

This PR adds really basic encryption support to the database layer using the newly-implemented MRAE primitives.  Keys are currently generated deterministically from the Contract ID, but that will soon be replaced with key manager integration (in a separate PR).

I'm not sure what the `Snapshot` DB implementation in `clients/utils/src/db.rs` is used for -- currently, I've just marked the `with_encryption` method there as `unimplemented!()`, let me know if I should add encryption support there as well.