### PR TITLE
instrumentation: make push_metrics public

### DIFF
--- a/instrumentation/prometheus/src/push.rs
+++ b/instrumentation/prometheus/src/push.rs
@@ -10,7 +10,7 @@ use ekiden_common::futures::prelude::*;
 use ekiden_common::tokio::timer::Interval;
 
 /// Pushes metrics to Prometheus pushgateway.
-fn push_metrics(address: &str, job_name: &str, instance_name: &str) -> Result<()> {
+pub fn push_metrics(address: &str, job_name: &str, instance_name: &str) -> Result<()> {
     prometheus::push_metrics(
         job_name,
         labels!{"instance".to_owned() => instance_name.to_owned(),},


### PR DESCRIPTION
I want this for one-shot delivery of metrics, which will work for recording benchmark results.