### PR TITLE
roothash: Use zero timestamp when submitting commits

### DIFF
--- a/roothash/base/src/block.rs
+++ b/roothash/base/src/block.rs
@@ -1,6 +1,5 @@
 //! Block type.
 use std::convert::TryFrom;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use ekiden_common::bytes::H256;
 use ekiden_common::error::Error;
@@ -27,14 +26,12 @@ pub struct Block {
 impl Block {
     /// Generate a parent block from given child.
     pub fn new_parent_of(child: &Block) -> Block {
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-
         let mut block = Block {
             header: Header {
                 version: child.header.version,
                 namespace: child.header.namespace,
                 round: child.header.round + U256::from(1),
-                timestamp: now.as_secs(),
+                timestamp: 0,
                 previous_hash: child.header.get_encoded_hash(),
                 group_hash: H256::zero(),
                 input_hash: H256::zero(),


### PR DESCRIPTION
Should fix #890.

Previously generating a new block defaulted to using the current system
time as the timestamp which introduced non-determinism.

Since the timestamp is overwritten by the roothash backend on block
finalization anyway, there is no reason why the timestamp should be set
to a non-zero value when sending block commits.