### PR TITLE
go/tendermint/abci: Use the iavl fork's `LoadVersionFast` call

### DIFF
--- a/go/Gopkg.toml
+++ b/go/Gopkg.toml
@@ -35,7 +35,8 @@
 
 [[constraint]]
   name = "github.com/tendermint/iavl"
-  version = "0.11.0"
+  source = "https://github.com/oasislabs/iavl"
+  version = "=0.11.0-ekiden1"
 
 [[constraint]]
   name = "github.com/tendermint/tendermint"
@@ -84,7 +85,7 @@
 
 [[override]]
   name = "github.com/tendermint/iavl"
-  version = "0.11.0"
+  version = "=0.11.0-ekiden1"
 
 [[override]]
   name = "github.com/tendermint/tendermint"

--- a/go/tendermint/abci/mux.go
+++ b/go/tendermint/abci/mux.go
@@ -630,14 +630,9 @@ func (s *ApplicationState) doCommit() error {
 
 		// Reset CheckTx state to latest version. This is safe because Tendermint
 		// holds a lock on the mempool for commit.
-		s.checkTxTree.Rollback()
-		loadedVersion, cerr := s.checkTxTree.LoadVersion(blockHeight)
+		cerr := s.checkTxTree.LoadVersionFast(blockHeight)
 		if cerr != nil {
 			panic(cerr)
-		}
-
-		if blockHeight != loadedVersion {
-			panic("state: inconsistent trees")
 		}
 	}
 


### PR DESCRIPTION
Fixes #934.