### PR TITLE
go/tendermint: Fix IAVL tree.Load being slower and slower

### DIFF
--- a/go/Gopkg.toml
+++ b/go/Gopkg.toml
@@ -36,7 +36,7 @@
 [[constraint]]
   name = "github.com/tendermint/iavl"
   source = "https://github.com/oasislabs/iavl"
-  version = "=0.11.0-ekiden1"
+  version = "=0.11.0-ekiden2"
 
 [[constraint]]
   name = "github.com/tendermint/tendermint"
@@ -85,7 +85,7 @@
 
 [[override]]
   name = "github.com/tendermint/iavl"
-  version = "=0.11.0-ekiden1"
+  version = "=0.11.0-ekiden2"
 
 [[override]]
   name = "github.com/tendermint/tendermint"

--- a/go/tendermint/abci/mux.go
+++ b/go/tendermint/abci/mux.go
@@ -630,7 +630,7 @@ func (s *ApplicationState) doCommit() error {
 
 		// Reset CheckTx state to latest version. This is safe because Tendermint
 		// holds a lock on the mempool for commit.
-		cerr := s.checkTxTree.LoadVersionFast(blockHeight)
+		_, cerr := s.checkTxTree.LoadVersionFast(blockHeight)
 		if cerr != nil {
 			panic(cerr)
 		}


### PR DESCRIPTION
Fixes #939 

Actual fix is in oasislabs/iavl#2.