### PR TITLE
made some functions package private and add README.md

### DIFF
--- a/go/scheduler/alg/iterflag/README.md
+++ b/go/scheduler/alg/iterflag/README.md
@@ -1,0 +1,178 @@
+# Iterable Flags
+
+The `iterflag` package is designed to make it easy to control
+iterating a variable through a range of values via a mechanism similar
+to the `flag` package.
+
+In one particular use case, starting off with simulation code with
+various simulation parameters that can be set at the command-line via
+the `flag` package, we can quickly change the code to use `iterflag`
+instead to automatically iterate through ranges of simulation
+parameters, for example, to explore a design space.
+
+Multiple flags can be iterated at once.  All iterations are with fixed
+increments and are additive.  (NB: if we need to use multiplicative
+factors, this can be coded additively via an `iterflag`-controlled
+exponent for a given base.)  While the dimensionality of the space
+being explored can be high, the API is the same: the code obtains an
+`Iterator` object via `MakeIterator`, runs the simulation, and then
+invokes the iterator's `Incr` function to move to the next point in
+the iteration space.  `Incr` returns false when the iterator is done,
+i.e., cannot be incremented to a next location.
+
+A particular iteration nesting order can be specified via the
+`MakeIteratorForFlags` interface, specifying the iterable flags by
+name.  The flags in the strings slice parameter will be iterated in
+odometric order, i.e., the last flag named will iterate from start to
+finish before the next flag is incremented, then the last flag cycles
+from start to finish again, etc.  If, for example, we invoked
+
+```go
+iterator := iterflag.MakeIteratorForFlags([]string{"foo", "bar", "baz"})
+for {
+        simulate()
+        if !iterator.Incr() {
+                break
+        }
+}
+```
+
+and used the iterator, it would be equivalent to
+
+```go
+for fooIterator := fooStart; fooIterator < fooEnd; fooIterator += fooIncr {
+        for barIterator := barStart; barIterator < barEnd; barIterator += barIncr {
+                for bazIterator := bazStart; bazIterator< bazEnd; bazIterator += bazIncr {
+                        simulate()
+                }
+        }
+}
+```
+
+## API
+
+### `func IntVar`
+
+`func IntVar(p *int, name string, start, end, incr int, usage string)`
+
+### `func Int64Var`
+
+`func Int64Var(p *int64, name string, start, end, incr int64, usage string)`
+
+### `func Float64Var`
+
+`func Float64Var(p *float64, name string, start, end, incr float64, usage string)`
+
+Variables that should be iterable are associated with command-line
+flags using `IntVar`, `Int64Var`, and `Float64Var` in the same spirit
+as the `flag` package counterparts, but instead of a single default
+value, we supply three values: a starting value, an ending value, and
+an increment value.  Iterating down instead of up is supported: to
+iterate down, the starting value should be greater than the ending
+value, and the increment value should be negative.
+
+Iterable flag values do not necessarily have to actually iterate.  To
+specify that the value should _not_ iterate by default, use an `incr` value of 0.
+
+### `func AllIterableFlags() []string`
+
+`AllIterableFlags` return the names of all iterable flags that have
+been registered.  This can be used to specify an iteration order for
+`MakeIteratorForFlags` below.
+
+### `type Iterator`
+
+```go
+
+type Iterator struct {
+	Control []IterControl
+}
+```
+
+#### `func (it *Iterator) AtStart(numIters int) bool`
+
+`AtStart` returns `true` iff the right-most `numIters` iterating iterable flags
+are at their `start` value.  Only
+
+#### `func (it *Iterator) Incr() bool`
+
+### `func MakeIteratorForFlags(flagName []string) (*Iterator, error)`
+
+### `func MakeIterator() (*Iterator, error)`
+
+### `type IterControl`
+
+```go
+type IterControl interface {
+	WillIterate() bool
+	Key() string
+	Value(colWidth, precision int) string
+	String() string
+}
+```
+
+#### `func (*ic) WillIterate() bool`
+
+`WillIterate` returns true if the iterable flag is configured to
+iterate, i.e., the `incr` value is non-zero.  Note that if `start +
+incr > end` holds, even though `WillIterate` returns true, the
+iterable flag will only ever take on the `start` value.
+
+#### `func (*ic) Key() string`
+
+`Key` returns the flag name associated with the iterable variable.
+
+#### `func (*ic) Value(colWidth, precision int) string`
+
+`Value` returns a string representing the current value of the
+iterable flag variable.  The value is converted to a string using
+either `"%*d"` or `"%*.*g` format specifiers as appropriate for the
+iterable variable type.
+
+#### `func (*ic) String() string`
+
+`String` returns a string representing the iterable flag setting,
+formatted as a triple using the format `"%d:%d:%d` or `%g:%g:%g` as
+appropriate for the iterable variable type.
+
+## Example usage
+
+```go
+fooFlag int
+barFlag float64
+bazFlag int64
+
+func init() {
+	iterflag.IntVar(&fooFlag, "foo", 0, 10, 1, "foo controls the simulator...")
+	iterflag.Float64Var(&barFlag, "bar", 1.0, 10.0, 0.1, "bar controls...")
+	iterflag.Int64Var(&bazFlag, "baz", 10, 15, 1, "baz controls...")
+}
+
+func main() {
+	flag.Parse()
+	iterflag.Parse()
+
+	colWidth=16
+	precision=4 // for float64 values
+
+	iterator := iterflag.MakeIterator()
+	// Print varying headers
+	for _, c := range iterator.Control {
+		if c.WillIterate() {
+			fmt.Printf("|%*s", colWidth, c.Key())
+		}
+	}
+	fmt.Printf("|%*s|\n", colWidth, "Results")
+	for {
+		for _, c := range iterator.Control {
+			if c.WillIterate() {
+				fmt.Printf("|%*s", colWidth, c.Value(colWidth, precision))
+			}
+		}
+		fmt.Printf("|%*.*g|\n", colWidth, precision, runSimulation())
+	}
+	if !iterator.Incr() {
+		break
+	}
+}
+```

--- a/go/scheduler/alg/iterflag/iter_control.go
+++ b/go/scheduler/alg/iterflag/iter_control.go
@@ -8,16 +8,16 @@ import (
 // sense.  This means int, int64, float64.  (We don't use float32.)  The ability to increment
 // such values is used to iterate through the space of simulation parameters.
 type IterControl interface {
-	Reset()
-	AtStart() bool
-	HasNext() bool
+	reset()
+	atStart() bool
+	hasNext() bool
 	WillIterate() bool
-	Incr()
+	increment()
 	Key() string
 	Value(colWidth, precision int) string
 	// Displays the current value as string; we do not use String() since Stringer
 	// interface expect something that represents the "whole" object (end/incr)
-	Parse(input string) error
+	parse(input string) error
 	String() string
 	// To output for reproducible simulations: fmt.Printf("-%s=%s", ic.Key(), ic.String())
 }
@@ -37,20 +37,20 @@ type IntIterControl struct {
 	incr  int
 }
 
-// Reset resets the parameter being incremented to the initial value.  This is used when, for
+// reset resets the parameter being incremented to the initial value.  This is used when, for
 // example, the parameter being controlled is not in the outer-most loop.
-func (iic *IntIterControl) Reset() {
+func (iic *IntIterControl) reset() {
 	*iic.vp = iic.start
 }
 
-// AtStart return true if the control is at the starting value
-func (iic *IntIterControl) AtStart() bool {
+// atStart return true if the control is at the starting value
+func (iic *IntIterControl) atStart() bool {
 	return *iic.vp == iic.start
 }
 
-// HasNext returns true when it is permissible to invoke Incr, i.e., we have not reached the
-// end of iteration for this parameter value.
-func (iic *IntIterControl) HasNext() bool {
+// hasNext returns true when it is permissible to invoke increment(), i.e., we have not reached
+// the end of iteration for this parameter value.
+func (iic *IntIterControl) hasNext() bool {
 	if iic.incr == 0 {
 		return false
 	} else if iic.incr > 0 {
@@ -68,8 +68,8 @@ func (iic *IntIterControl) WillIterate() bool {
 	return iic.incr != 0
 }
 
-// Incr increments the parameter value to the next value as controlled by this iterator.
-func (iic *IntIterControl) Incr() {
+// increment increments the parameter value to the next value as controlled by this iterator.
+func (iic *IntIterControl) increment() {
 	*iic.vp += iic.incr
 }
 
@@ -91,11 +91,11 @@ func (iic IntIterControl) String() string {
 	return fmt.Sprintf("%d:%d:%d", iic.start, iic.end, iic.incr)
 }
 
-// Parse decodes a string representing an IntIterControl and sets the internal state
+// parse decodes a string representing an IntIterControl and sets the internal state
 // accordingly. A non-nil error is returned if there is a parsing error.  There are two input
 // formats accepted: %d:%d:%d or %d.  The first form is the triple start:end:incr.  The latter
 // is just the start value, with end=start and incr=0, i.e., the value will not change.
-func (iic *IntIterControl) Parse(input string) error {
+func (iic *IntIterControl) parse(input string) error {
 	var start, end, incr int
 	// Note that Sscanf is "loose" in that extraneous characters after the last %d are ignored.
 	scanned, err := fmt.Sscanf(input, "%d:%d:%d", &start, &end, &incr)
@@ -138,20 +138,20 @@ type Int64IterControl struct {
 	incr  int64
 }
 
-// Reset resets the parameter being incremented to the initial value.  This is used when, for
+// reset resets the parameter being incremented to the initial value.  This is used when, for
 // example, the parameter being controlled is not in the outer-most loop.
-func (i64ic *Int64IterControl) Reset() {
+func (i64ic *Int64IterControl) reset() {
 	*i64ic.vp = i64ic.start
 }
 
-// AtStart return true if the control is at the starting value
-func (i64ic *Int64IterControl) AtStart() bool {
+// atStart return true if the control is at the starting value
+func (i64ic *Int64IterControl) atStart() bool {
 	return *i64ic.vp == i64ic.start
 }
 
-// HasNext returns true when it is permissible to invoke Incr, i.e., we have not reached the
-// end of iteration for this parameter value.
-func (i64ic *Int64IterControl) HasNext() bool {
+// hasNext returns true when it is permissible to invoke increment(), i.e., we have not reached
+// the end of iteration for this parameter value.
+func (i64ic *Int64IterControl) hasNext() bool {
 	if i64ic.incr == 0 {
 		return false
 	} else if i64ic.incr > 0 {
@@ -169,8 +169,8 @@ func (i64ic *Int64IterControl) WillIterate() bool {
 	return i64ic.incr != 0
 }
 
-// Incr increments the parameter value to the next value as controlled by this iterator.
-func (i64ic *Int64IterControl) Incr() {
+// increment increments the parameter value to the next value as controlled by this iterator.
+func (i64ic *Int64IterControl) increment() {
 	*i64ic.vp += i64ic.incr
 }
 
@@ -192,11 +192,11 @@ func (i64ic Int64IterControl) String() string {
 	return fmt.Sprintf("%d:%d:%d", i64ic.start, i64ic.end, i64ic.incr)
 }
 
-// Parse decodes a string representing an IntIterControl and sets the internal state
+// parse decodes a string representing an IntIterControl and sets the internal state
 // accordingly. A non-nil error is returned if there is a parsing error.  There are two input
 // formats accepted: %d:%d:%d or %d.  The first form is the triple start:end:incr.  The latter
 // is just the start value, with end=start and incr=0, i.e., the value will not change.
-func (i64ic *Int64IterControl) Parse(input string) error {
+func (i64ic *Int64IterControl) parse(input string) error {
 	var start, end, incr int64
 	// Note that Sscanf is "loose" in that extraneous characters after the last %d are ignored.
 	scanned, err := fmt.Sscanf(input, "%d:%d:%d", &start, &end, &incr)
@@ -240,20 +240,20 @@ type Float64IterControl struct {
 	incr  float64
 }
 
-// Reset resets the parameter being incremented to the initial value.  This is used when, for
+// reset resets the parameter being incremented to the initial value.  This is used when, for
 // example, the parameter being controlled is not in the outer-most loop.
-func (f64ic *Float64IterControl) Reset() {
+func (f64ic *Float64IterControl) reset() {
 	*f64ic.vp = f64ic.start
 }
 
-// AtStart return true if the control is at the starting value
-func (f64ic *Float64IterControl) AtStart() bool {
+// atStart return true if the control is at the starting value
+func (f64ic *Float64IterControl) atStart() bool {
 	return *f64ic.vp == f64ic.start
 }
 
-// HasNext returns true when it is permissible to invoke Incr, i.e., we have not reached the
-// end of iteration for this parameter value.
-func (f64ic *Float64IterControl) HasNext() bool {
+// hasNext returns true when it is permissible to invoke increment(), i.e., we have not reached
+// the end of iteration for this parameter value.
+func (f64ic *Float64IterControl) hasNext() bool {
 	// NB: negative zero in IEEE754 will compare equal to zero.
 	if f64ic.incr == 0.0 {
 		return false
@@ -273,8 +273,8 @@ func (f64ic *Float64IterControl) WillIterate() bool {
 	return f64ic.incr != 0.0
 }
 
-// Incr increments the parameter value to the next value as controlled by this iterator.
-func (f64ic *Float64IterControl) Incr() {
+// increment increments the parameter value to the next value as controlled by this iterator.
+func (f64ic *Float64IterControl) increment() {
 	*f64ic.vp += f64ic.incr
 }
 
@@ -296,11 +296,11 @@ func (f64ic Float64IterControl) String() string {
 	return fmt.Sprintf("%g:%g:%g", f64ic.start, f64ic.end, f64ic.incr)
 }
 
-// Parse decodes a string representing an IntIterControl and sets the internal state
+// parse decodes a string representing an IntIterControl and sets the internal state
 // accordingly. A non-nil error is returned if there is a parsing error.  There are two input
 // formats accepted: %d:%d:%d or %d.  The first form is the triple start:end:incr.  The latter
 // is just the start value, with end=start and incr=0, i.e., the value will not change.
-func (f64ic *Float64IterControl) Parse(input string) error {
+func (f64ic *Float64IterControl) parse(input string) error {
 	var start, end, incr float64
 	// Note that Sscanf is "loose" in that extraneous characters after the last %d are ignored.
 	scanned, err := fmt.Sscanf(input, "%g:%g:%g", &start, &end, &incr)


### PR DESCRIPTION
The README.md file describes the interface and provides sample
usage. There were some functions that could be private, and this
change switches them from public to private to reduce exposued API
surface and remove the need to document them.