### PR TITLE
tracing: allow custom agent address

### DIFF
--- a/compute/Cargo.toml
+++ b/compute/Cargo.toml
@@ -37,7 +37,7 @@ ekiden-registry-client = { path = "../registry/client", version = "0.2.0-alpha" 
 ekiden-tools = { path = "../tools", version = "0.2.0-alpha" }
 protobuf = "~2.0"
 rustracing = "0.1.7"
-rustracing_jaeger = "0.1.7"
+rustracing_jaeger = { git = "https://github.com/oasislabs/rustracing_jaeger.git", tag = "0.1.7-ekiden1" }
 sgx_types = { git = "https://github.com/oasislabs/rust-sgx-sdk", tag = "v1.0.1-ekiden1" }
 thread_local = "0.3.5"
 clap = "2.29.1"

--- a/contract/client/Cargo.toml
+++ b/contract/client/Cargo.toml
@@ -17,7 +17,7 @@ ekiden-storage-base = { path = "../../storage/base", version = "0.2.0-alpha" }
 ekiden-registry-base = { path = "../../registry/base", version = "0.2.0-alpha" }
 ekiden-compute-api = { path = "../../compute/api", version = "0.2.0-alpha" }
 rustracing = "0.1.7"
-rustracing_jaeger = "0.1.7"
+rustracing_jaeger = { git = "https://github.com/oasislabs/rustracing_jaeger.git", tag = "0.1.7-ekiden1" }
 serde = "1.0.71"
 serde_cbor = "0.8.2"
 log = "0.4"

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -12,5 +12,5 @@ ekiden-grpcio = { version = "0.3.2", features = ["openssl"] }
 lazy_static = "1.0"
 log = "0.4"
 rustracing = "0.1.7"
-rustracing_jaeger = "0.1.7"
+rustracing_jaeger = { git = "https://github.com/oasislabs/rustracing_jaeger.git", tag = "0.1.7-ekiden1" }
 trackable = "0.2.18"

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(use_extern_macros)]
 
+use std::net::ToSocketAddrs;
 use std::sync::Mutex;
 
 extern crate clap;
@@ -23,6 +24,11 @@ pub fn get_arguments<'a, 'b>() -> Vec<clap::Arg<'a, 'b>> {
             .long("tracing-sample-probability")
             .takes_value(true)
             .default_value("0.001"),
+        clap::Arg::with_name("tracing-agent-addr")
+            .long("tracing-agent-addr")
+            .help("Address of the Jaeger agent's compact thrift UDP port")
+            .takes_value(true)
+            .default_value("127.0.0.1:6831"),
     ]
 }
 
@@ -39,8 +45,16 @@ pub fn report_forever(service_name: &str, matches: &clap::ArgMatches) {
                 f64
             )).unwrap(),
         );
-        let reporter =
+        let agent_addr = matches
+            .value_of("tracing-agent-addr")
+            .unwrap()
+            .to_socket_addrs()
+            .unwrap()
+            .next()
+            .unwrap();
+        let mut reporter =
             rustracing_jaeger::reporter::JaegerCompactReporter::new(service_name).unwrap();
+        reporter.set_agent_addr(agent_addr);
 
         std::thread::spawn(move || {
             // TODO: is it better to batch these?


### PR DESCRIPTION
we're going to deploy jaeger on the testnet cluster, where it'll be a service. we'll need to connect to that service from our app pods

blocks #915