### PR TITLE
go/tendermint: Set `Consensus.BlockTimeIota`

### DIFF
--- a/go/tendermint/tendermint.go
+++ b/go/tendermint/tendermint.go
@@ -271,8 +271,10 @@ func (t *tendermintService) lazyInit() error {
 	_ = viper.Unmarshal(&tenderConfig)
 	tenderConfig.SetRoot(tendermintDataDir)
 	timeoutCommit, _ := t.cmd.Flags().GetDuration(cfgConsensusTimeoutCommit)
-	tenderConfig.Consensus.TimeoutCommit = int(timeoutCommit / time.Millisecond)
+	timeoutCommitMsec := int(timeoutCommit / time.Millisecond)
+	tenderConfig.Consensus.TimeoutCommit = timeoutCommitMsec
 	tenderConfig.Consensus.SkipTimeoutCommit, _ = t.cmd.Flags().GetBool(cfgConsensusSkipTimeoutCommit)
+	tenderConfig.Consensus.BlockTimeIota = timeoutCommitMsec
 	tenderConfig.Instrumentation.Prometheus = true
 
 	tendermintPV := tmpriv.LoadOrGenFilePV(tenderConfig.PrivValidatorFile())


### PR DESCRIPTION
Since we use a non-standard block commit interval, the minimum block
timestamp advancment increment should be altered as well.

Part of #984.