### PR TITLE
go/ekiden: Increase gRPC message size limits to 100 MiB

### DIFF
--- a/go/ekiden/cmd/grpc.go
+++ b/go/ekiden/cmd/grpc.go
@@ -309,6 +309,8 @@ func newGrpcService(cmd *cobra.Command) (*grpcService, error) {
 	var sOpts []grpc.ServerOption
 	sOpts = append(sOpts, grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(logAdapter.unaryLogger, grpc_opentracing.UnaryServerInterceptor())))
 	sOpts = append(sOpts, grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(logAdapter.streamLogger, grpc_opentracing.StreamServerInterceptor())))
+	sOpts = append(sOpts, grpc.MaxRecvMsgSize(104857600)) // 100 MiB
+	sOpts = append(sOpts, grpc.MaxSendMsgSize(104857600)) // 100 MiB
 
 	return &grpcService{
 		BaseBackgroundService: svc,


### PR DESCRIPTION
Discovered we hit the default 4 MiB limit while doing benchmarks with larger batch sizes.