### PR TITLE
fixup! go/tendermint: Enable empty block generation

### DIFF
--- a/go/tendermint/tendermint.go
+++ b/go/tendermint/tendermint.go
@@ -411,7 +411,7 @@ func initNodeKey(dataDir string) (*signature.PrivateKey, error) {
 func RegisterFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(&flagConsensusTimeoutCommit, cfgConsensusTimeoutCommit, 1*time.Second, "tendermint commit timeout")
 	cmd.Flags().BoolVar(&flagConsensusSkipTimeoutCommit, cfgConsensusSkipTimeoutCommit, false, "skip tendermint commit timeout")
-	cmd.Flags().DurationVar(&flagConsensusEmptyBlockInterval, cfgConsensusEmptyBlockInterval, 5*time.Second, "tendermint empty block interval")
+	cmd.Flags().DurationVar(&flagConsensusEmptyBlockInterval, cfgConsensusEmptyBlockInterval, 0, "tendermint empty block interval")
 
 	for _, v := range []string{
 		cfgConsensusTimeoutCommit,


### PR DESCRIPTION
It turns out that empty blocks are generated immediately with the
default configuration, and all that increasing the value does, is
delay epoch transitions.

There's no harm in leaving the fallback interval exposed, but it is
now set to 0 (immediate) by default.

Fixes #1013.