### PR TITLE
contract: correct transition retry logic

### DIFF
--- a/contract/client/src/manager.rs
+++ b/contract/client/src/manager.rs
@@ -247,7 +247,7 @@ impl ContractClientManager {
         let inner = self.inner.clone();
         retry_until_ok_or_max(
             move || Self::call_leader(inner.clone(), method, arguments.clone(), sh.clone()),
-            |error| error.message == ContractClient::SHUTDOWN_REASON_TRANSITION,
+            |error| error.message != ContractClient::SHUTDOWN_REASON_TRANSITION,
             // If the network latency and time needed to process the call is short compared to the
             // epoch interval, it is improbable for two consecutive attempts both to be
             // interrupted, so one retry is sufficient. If not, then a retry is not likely to


### PR DESCRIPTION
`error_is_permanent` should return *false* for epoch transitions, so that we retry.

cross reference: #479