### PR TITLE
Add end-to-end test for database encryption

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
 
       - checkout
       - run:
-          name: Checking if rust code has changed
+          name: Checking if Rust code has changed
           command: ./scripts/ci-changed.sh \.circleci beacon clients common compute contract contracts core db di enclave epochtime instrumentation keys node registry rpc roothash scheduler scripts/test-e2e.sh stake storage tools xargo
 
       # Check if all core crates have the same version (issue #175)
@@ -28,10 +28,17 @@ jobs:
       - run: cargo install --force --path tools
       # Build key manager enclave.
       - run:
+          name: Building key manager enclave
           command: cargo ekiden build-enclave --output-identity
           working_directory: key-manager/dummy/enclave
-      # Build token contract.
+      # Build DB encryption test enclave.
       - run:
+          name: Building database encryption test enclave
+          command: cargo ekiden build-enclave --output-identity
+          working_directory: contracts/test-db-encryption
+      # Build token enclave.
+      - run:
+          name: Building token enclave
           command: cargo ekiden build-enclave --output-identity
           working_directory: contracts/token
       # Run token contract tests.
@@ -75,12 +82,15 @@ jobs:
             - target/debug/ekiden-compute
             - target/debug/token-client
             - target/debug/test-long-term-client
+            - target/debug/test-db-encryption-client
             - target/debug/ekiden-keymanager-node
             - target/debug/ekiden-keymanager-test-client
             - target/enclave/token.so
             - target/enclave/token.mrenclave
             - target/enclave/ekiden-keymanager-trusted.so
             - target/enclave/ekiden-keymanager-trusted.mrenclave
+            - target/enclave/test-db-encryption.so
+            - target/enclave/test-db-encryption.mrenclave
             - tests
             - scripts
   cover-rust:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,11 +73,13 @@ members = [
 
     # Core contracts.
     "contracts/token",
+    "contracts/test-db-encryption",
 
     # Clients.
     "clients/token",
     "clients/test-long-term",
     "clients/benchmark",
+    "clients/test-db-encryption",
 
     # Registry.
     "registry/api",

--- a/clients/test-db-encryption/Cargo.toml
+++ b/clients/test-db-encryption/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "test-db-encryption-client"
+version = "0.2.0-alpha"
+authors = ["Oasis Labs Inc. <info@oasislabs.com>"]
+description = "Ekiden DB encryption end-to-end test client"
+
+[features]
+default = []
+
+[dependencies]
+client-utils = { path = "../utils" }
+ekiden-core = { path = "../../core/common" }
+ekiden-contract-client = { path = "../../contract/client" }
+ekiden-rpc-client = { path = "../../rpc/client" }
+test-db-encryption-api = { path = "../../contracts/test-db-encryption/api" }
+clap = "2.29.1"
+rand = "0.4"
+futures = "0.1"

--- a/clients/test-db-encryption/src/main.rs
+++ b/clients/test-db-encryption/src/main.rs
@@ -1,0 +1,90 @@
+#[macro_use]
+extern crate clap;
+extern crate futures;
+extern crate rand;
+
+#[macro_use]
+extern crate client_utils;
+extern crate ekiden_contract_client;
+extern crate ekiden_core;
+extern crate ekiden_rpc_client;
+
+extern crate test_db_encryption_api;
+
+use clap::{App, Arg};
+use futures::Future;
+use std::env::current_exe;
+use std::fs::File;
+use std::io::prelude::*;
+
+use ekiden_contract_client::create_contract_client;
+use test_db_encryption_api::with_api;
+
+with_api! {
+    create_contract_client!(test_db_encryption, test_db_encryption_api, api);
+}
+
+fn main() {
+    println!("[test_db_encryption] Hello from DB encryption test client!");
+
+    let client = contract_client!(test_db_encryption);
+
+    println!("[test_db_encryption] Setting KM enclave...");
+
+    // Get path to the key manager's mrenclave file.
+    //
+    // TODO: Once the `contract_client!` macro supports custom app arguments
+    // (see issue #1052), the key manager's mrenclave should be given as a
+    // command-line argument instead.
+    let mut mrenclave_path = current_exe().unwrap();
+    mrenclave_path.pop(); // Pop executable name.
+    mrenclave_path.pop(); // Pop debug/release build dir.
+    mrenclave_path.push("enclave");
+    mrenclave_path.push("ekiden-keymanager-trusted.mrenclave");
+
+    let mut km_mrenclave = String::new();
+    File::open(mrenclave_path.as_path())
+        .expect("Key manager mrenclave file not found -- have you built the enclave with '--output-identity'?")
+        .read_to_string(&mut km_mrenclave)
+        .expect("An error occurred while reading the key manager mrenclave file.");
+    km_mrenclave = km_mrenclave.trim().to_string();
+
+    println!("[test_db_encryption] KM enclave is '{}'.", km_mrenclave);
+
+    // First, set the key manager's enclave.
+    let mut r_km = test_db_encryption::SetKMEnclaveRequest::new();
+    r_km.set_mrenclave(km_mrenclave);
+
+    client.set_km_enclave(r_km).wait().unwrap();
+
+    println!("[test_db_encryption] Storing with encryption...");
+
+    // Now try storing something with encryption.
+    let mut r_se = test_db_encryption::StoreEncryptedRequest::new();
+    r_se.set_key(String::from("top secret"));
+    r_se.set_value(String::from("hello world!"));
+
+    let response_se = client.store_encrypted(r_se).wait().unwrap();
+
+    if response_se.get_ok() != true {
+        panic!("Failed to store a key-value pair with encryption!");
+    }
+
+    println!("[test_db_encryption] Fetching with encryption...");
+
+    // Fetch it back and see if it's the same.
+    let mut r_fe = test_db_encryption::FetchEncryptedRequest::new();
+    r_fe.set_key(String::from("top secret"));
+
+    let response_fe = client.fetch_encrypted(r_fe).wait().unwrap();
+
+    if response_fe.get_ok() != true {
+        panic!("Failed to fetch a key-value pair with encryption!");
+    }
+
+    if response_fe.get_value() != String::from("hello world!") {
+        panic!("Fetched value doesn't match stored value!");
+    }
+
+    println!("[test_db_encryption] Simple DB encryption test passed.");
+}

--- a/contracts/test-db-encryption/Cargo.toml
+++ b/contracts/test-db-encryption/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "test-db-encryption"
+version = "0.2.0-alpha"
+authors = ["Oasis Labs Inc. <info@oasislabs.com>"]
+description = "Ekiden DB encryption end-to-end test"
+build = "build.rs"
+
+[features]
+default = []
+
+[dependencies]
+ekiden-core = { path = "../../core/common" }
+ekiden-trusted = { path = "../../core/trusted" }
+ekiden-storage-base = { path = "../../storage/base" }
+protobuf = "~2.0"
+test-db-encryption-api = { path = "./api" }
+lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
+
+[build-dependencies]
+ekiden-tools = { path = "../../tools" }
+ekiden-edl = { path = "../../core/edl" }

--- a/contracts/test-db-encryption/api/Cargo.toml
+++ b/contracts/test-db-encryption/api/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "test-db-encryption-api"
+version = "0.2.0-alpha"
+authors = ["Oasis Labs Inc. <info@oasislabs.com>"]
+build = "build.rs"
+
+[dependencies]
+ekiden-core = { path = "../../../core/common" }
+ekiden-trusted = { path = "../../../core/trusted" }
+protobuf = "~2.0"
+serde = "1.0.71"
+
+[build-dependencies]
+ekiden-tools = { path = "../../../tools" }

--- a/contracts/test-db-encryption/api/build.rs
+++ b/contracts/test-db-encryption/api/build.rs
@@ -1,0 +1,6 @@
+extern crate ekiden_tools;
+
+fn main() {
+    ekiden_tools::generate_mod("src/generated", &["api"]);
+    ekiden_tools::build_api();
+}

--- a/contracts/test-db-encryption/api/src/api.proto
+++ b/contracts/test-db-encryption/api/src/api.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package test_db_encryption;
+
+message SetKMEnclaveRequest {
+    string mrenclave = 1;
+}
+
+message SetKMEnclaveResponse {
+}
+
+message StoreEncryptedRequest {
+    string key = 1;
+    string value = 2;
+}
+
+message StoreEncryptedResponse {
+    bool ok = 1;
+}
+
+message FetchEncryptedRequest {
+    string key = 1;
+}
+
+message FetchEncryptedResponse {
+    bool ok = 1;
+    string value = 2;
+}

--- a/contracts/test-db-encryption/api/src/api.rs
+++ b/contracts/test-db-encryption/api/src/api.rs
@@ -1,0 +1,7 @@
+use ekiden_core::contract::contract_api;
+
+contract_api! {
+    pub fn set_km_enclave(SetKMEnclaveRequest) -> SetKMEnclaveResponse;
+    pub fn store_encrypted(StoreEncryptedRequest) -> StoreEncryptedResponse;
+    pub fn fetch_encrypted(FetchEncryptedRequest) -> FetchEncryptedResponse;
+}

--- a/contracts/test-db-encryption/api/src/lib.rs
+++ b/contracts/test-db-encryption/api/src/lib.rs
@@ -1,0 +1,12 @@
+extern crate protobuf;
+extern crate serde;
+
+#[macro_use]
+extern crate ekiden_core;
+extern crate ekiden_trusted;
+
+#[macro_use]
+mod api;
+mod generated;
+
+pub use generated::api::*;

--- a/contracts/test-db-encryption/build.rs
+++ b/contracts/test-db-encryption/build.rs
@@ -1,0 +1,6 @@
+extern crate ekiden_edl;
+extern crate ekiden_tools;
+
+fn main() {
+    ekiden_tools::build_trusted(ekiden_edl::edl());
+}

--- a/contracts/test-db-encryption/src/lib.rs
+++ b/contracts/test-db-encryption/src/lib.rs
@@ -1,0 +1,126 @@
+extern crate protobuf;
+
+extern crate ekiden_core;
+extern crate ekiden_trusted;
+
+extern crate test_db_encryption_api;
+
+#[macro_use]
+extern crate lazy_static;
+
+use std::str::FromStr;
+#[cfg(not(target_env = "sgx"))]
+use std::sync::Mutex;
+#[cfg(target_env = "sgx")]
+use std::sync::SgxMutex as Mutex;
+
+use test_db_encryption_api::{with_api, FetchEncryptedRequest, FetchEncryptedResponse,
+                             SetKMEnclaveRequest, SetKMEnclaveResponse, StoreEncryptedRequest,
+                             StoreEncryptedResponse};
+
+use ekiden_core::bytes::H256;
+use ekiden_core::enclave::quote::MrEnclave;
+use ekiden_core::error::Result;
+use ekiden_trusted::contract::create_contract;
+use ekiden_trusted::contract::dispatcher::ContractCallContext;
+use ekiden_trusted::db::{DBKeyManagerConfig, Database, DatabaseHandle};
+use ekiden_trusted::enclave::enclave_init;
+
+enclave_init!();
+
+// Create enclave contract interface.
+with_api! {
+    create_contract!(api);
+}
+
+lazy_static! {
+    // Key manager's enclave.
+    static ref KM_ENCLAVE: Mutex<MrEnclave> = Mutex::new(MrEnclave::zero());
+}
+
+pub fn set_km_enclave(
+    request: &SetKMEnclaveRequest,
+    _ctx: &ContractCallContext,
+) -> Result<SetKMEnclaveResponse> {
+    *KM_ENCLAVE.lock().unwrap() = MrEnclave::from_str(request.get_mrenclave())?;
+
+    Ok(SetKMEnclaveResponse::new())
+}
+
+#[cfg(target_env = "sgx")]
+pub fn store_encrypted(
+    request: &StoreEncryptedRequest,
+    _ctx: &ContractCallContext,
+) -> Result<StoreEncryptedResponse> {
+    let key = request.get_key().as_bytes();
+    let value = request.get_value().as_bytes();
+
+    let mut db = DatabaseHandle::instance();
+
+    // Configure the key manager enclave.
+    db.configure_key_manager(DBKeyManagerConfig {
+        mrenclave: KM_ENCLAVE.lock().unwrap().clone(),
+    });
+
+    // Use the test contract for now.
+    let contract_id = H256::from_str(&"0".repeat(64))?;
+
+    // Store with encryption!
+    db.with_encryption(contract_id, |db| {
+        db.insert(key, value);
+    });
+
+    let mut response = StoreEncryptedResponse::new();
+    response.set_ok(true);
+    Ok(response)
+}
+
+#[cfg(not(target_env = "sgx"))]
+pub fn store_encrypted(
+    request: &StoreEncryptedRequest,
+    _ctx: &ContractCallContext,
+) -> Result<StoreEncryptedResponse> {
+    panic!("The DB encryption test enclave only works in SGX mode!");
+}
+
+#[cfg(target_env = "sgx")]
+pub fn fetch_encrypted(
+    request: &FetchEncryptedRequest,
+    _ctx: &ContractCallContext,
+) -> Result<FetchEncryptedResponse> {
+    let key = request.get_key().as_bytes();
+
+    let mut db = DatabaseHandle::instance();
+
+    // Configure the key manager enclave.
+    db.configure_key_manager(DBKeyManagerConfig {
+        mrenclave: KM_ENCLAVE.lock().unwrap().clone(),
+    });
+
+    // Use the test contract for now.
+    let contract_id = H256::from_str(&"0".repeat(64))?;
+
+    let mut response = FetchEncryptedResponse::new();
+
+    // Fetch with encryption!
+    db.with_encryption(contract_id, |db| match db.get(key) {
+        None => {
+            response.set_ok(false);
+            response.set_value(String::from(""));
+        }
+        Some(v) => {
+            response.set_ok(true);
+            response.set_value(String::from_utf8(v).unwrap());
+        }
+    });
+
+    Ok(response)
+}
+
+#[cfg(not(target_env = "sgx"))]
+pub fn fetch_encrypted(
+    request: &FetchEncryptedRequest,
+    _ctx: &ContractCallContext,
+) -> Result<FetchEncryptedResponse> {
+    panic!("The DB encryption test enclave only works in SGX mode!");
+}

--- a/db/trusted/src/handle.rs
+++ b/db/trusted/src/handle.rs
@@ -55,11 +55,11 @@ enum Operation {
 /// db.with_encryption().  Pass the struct with db.configure_key_manager().
 pub struct DBKeyManagerConfig {
     /// Identity of key manager enclave.
-    mrenclave: MrEnclave,
+    pub mrenclave: MrEnclave,
     /// gRPC config parameters (only if not running in an enclave).
     #[cfg(not(target_env = "sgx"))]
     #[cfg(not(test))]
-    grpc_config: NetworkRpcClientBackendConfig,
+    pub grpc_config: NetworkRpcClientBackendConfig,
 }
 
 /// Database handle.

--- a/db/trusted/src/lib.rs
+++ b/db/trusted/src/lib.rs
@@ -30,7 +30,7 @@ pub mod ecalls;
 pub mod untrusted;
 
 pub mod handle;
-pub use handle::DatabaseHandle;
+pub use handle::{DBKeyManagerConfig, DatabaseHandle};
 
 pub mod patricia_trie;
 #[macro_use]

--- a/key-manager/client/src/client.rs
+++ b/key-manager/client/src/client.rs
@@ -134,7 +134,12 @@ impl KeyManager {
             }
         };
 
+        #[cfg(target_env = "sgx")]
+        let client = key_manager::Client::new(Arc::new(backend), mr_enclave, Some(true));
+
+        #[cfg(not(target_env = "sgx"))]
         let client = key_manager::Client::new(Arc::new(backend), mr_enclave, Some(false));
+
         self.client.get_or_insert(client);
 
         Ok(())


### PR DESCRIPTION
This PR adds an end-to-end test for DB encryption, as well as fixes a bug in the key manager client, which prevented it being used from within enclaves.

Tasks:
- [x] Write a new enclave that exposes the DB encryption functionality.
- [x] Write a client for the enclave that does a few stores and fetches.
- [x] Run test enclave & client as part of the e2e test script.
- [x] Pass the key manager's certificate to the compute node, so that the gRPC relay works.
- [x] Figure out why it crashes when running the contact :frowning_face: