### PR TITLE
go/tendermint: Disable the transaction indexer

### DIFF
--- a/go/tendermint/tendermint.go
+++ b/go/tendermint/tendermint.go
@@ -296,6 +296,7 @@ func (t *tendermintService) lazyInit() error {
 	tenderConfig.Consensus.CreateEmptyBlocksInterval = int(math.Ceil(emptyBlockInterval.Seconds()))
 	tenderConfig.Consensus.BlockTimeIota = timeoutCommitMsec
 	tenderConfig.Instrumentation.Prometheus = true
+	tenderConfig.TxIndex.Indexer = "null"
 
 	tendermintPV := tmpriv.LoadOrGenFilePV(tenderConfig.PrivValidatorFile())
 	tenderValIdent := crypto.PrivateKeyToTendermint(t.validatorKey)


### PR DESCRIPTION
The transaction indexer was being ran with the default config and was
"only" indexing every transaction by hash.  Since we aren't using the
index, this might as well be disabled to save on a substantial amount
of disk space.

Note: The transaction index database on existing deployments will need
to be removed manually after a version with this commit is deployed.

Implements #1029.