### PR TITLE
go/tendermint: Switch the ABCI mux database back to BoltDB

### DIFF
--- a/go/tendermint/api/db.go
+++ b/go/tendermint/api/db.go
@@ -1,0 +1,12 @@
+package api
+
+import dbm "github.com/tendermint/tendermint/libs/db"
+
+// SizeableDB is a tendermint database abstraction DB that supports
+// reporting it's database size for metrics purposes.
+type SizeableDB interface {
+	dbm.DB
+
+	// Size returns the database size.
+	Size() (int64, error)
+}


### PR DESCRIPTION
There's no write contention here, and upstream is thinking about moving
to BoltDB from LevelDB.  Since we still use BoltDB everywhere else for
storing tendermint data, we might as well switch this back to using the
BoltDB provider.

Note: This is BACKWARD INCOMPATIBLE.

Implements #1031.