### PR TITLE
go/tendermint/db/bolt: Enable snappy compression

### DIFF
--- a/go/tendermint/db/bolt/bolt.go
+++ b/go/tendermint/db/bolt/bolt.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/golang/snappy"
 	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/node"
 	bolt "go.etcd.io/bbolt"
@@ -17,7 +18,7 @@ import (
 	"github.com/oasislabs/ekiden/go/tendermint/api"
 )
 
-const dbVersion = 0
+const dbVersion = 1
 
 var (
 	baseLogger = logging.GetLogger("tendermint/db/bolt")
@@ -81,11 +82,12 @@ func (d *boltDBImpl) Get(key []byte) []byte {
 	if err := d.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(bktContents)
 
+		var decErr error
 		if value := bkt.Get(k); value != nil {
-			v = append([]byte{}, value...)
+			v, decErr = snappy.Decode(nil, value)
 		}
 
-		return nil
+		return decErr
 	}); err != nil {
 		d.logger.Error("Get() failed",
 			"err", err,
@@ -122,10 +124,12 @@ func (d *boltDBImpl) Has(key []byte) bool {
 func (d *boltDBImpl) Set(key, value []byte) {
 	k := toBoltDBKey(key)
 
+	valueCompressed := snappy.Encode(nil, value)
+
 	if err := d.db.Update(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(bktContents)
 
-		return bkt.Put(k, value)
+		return bkt.Put(k, valueCompressed)
 	}); err != nil {
 		d.logger.Error("Set() failed",
 			"err", err,
@@ -329,7 +333,7 @@ func (d *boltDBImpl) newIterator(start, end []byte, isForward bool) dbm.Iterator
 	if dbm.IsKeyInDomain(k, start, end, !isForward) {
 		// First key happens to be in the domain.
 		iter.current.key = k
-		iter.current.value = v
+		iter.current.valueCompressed = v
 		return iter
 	}
 
@@ -349,7 +353,7 @@ type boltDBIterator struct {
 	// tx is live).  The backing pages can/will be unmapped when tx
 	// is rolled back via Close().
 	current struct {
-		key, value []byte
+		key, valueCompressed, valueDecompressed []byte
 	}
 
 	isValid   bool
@@ -369,12 +373,14 @@ func (iter *boltDBIterator) Next() {
 		panic("Next() with invalid iterator")
 	}
 
+	iter.current.valueDecompressed = nil
+
 	// Traverse the BoltDB cursor to find the next applicable key.
 	for k, v := iter.nextFn(); k != nil; k, v = iter.nextFn() {
 		k = fromBoltDBKeyNoCopy(k)
 		if dbm.IsKeyInDomain(k, iter.start, iter.end, !iter.isForward) {
 			iter.current.key = k
-			iter.current.value = v
+			iter.current.valueCompressed = v
 			return
 		}
 	}
@@ -398,7 +404,20 @@ func (iter *boltDBIterator) Value() []byte {
 		panic("Value() with invalid iterator")
 	}
 
-	return append([]byte{}, iter.current.value...)
+	if iter.current.valueDecompressed == nil {
+		var err error
+		iter.current.valueDecompressed, err = snappy.Decode(nil, iter.current.valueCompressed)
+		if err != nil {
+			iter.db.logger.Error("iterator: Snappy Decode() failed",
+				"err", err,
+			)
+			panic(err)
+		}
+	}
+
+	// Copy, caller might call Value(), alter the slice, and call
+	// Value() again.
+	return append([]byte{}, iter.current.valueDecompressed...)
 }
 
 func (iter *boltDBIterator) Close() {
@@ -442,7 +461,7 @@ type boltDBBatch struct {
 func (b *boltDBBatch) Set(key, value []byte) {
 	b.cmds = append(b.cmds, &batchCmdSet{
 		key:   toBoltDBKey(key),
-		value: value,
+		value: snappy.Encode(nil, value),
 	})
 }
 


### PR DESCRIPTION
This blanket enables Snappy compression of all values stored in the
tendermint databases that are backed by BoltDB, as a quick check with
the e2e test indicates that all databases will benefit.

Note: This change is BACKWARD INCOMPATIBLE.  Migration code is omitted
as the immediate prior change requires a state wipe regardless,
rendering having such a thing moot.

Implements #1032.