### PR TITLE
common: provide tokio_runtime from Environment

### DIFF
--- a/common/src/environment.rs
+++ b/common/src/environment.rs
@@ -30,7 +30,7 @@ pub struct GrpcEnvironment {
     /// gRPC environment.
     grpc_environment: Arc<grpcio::Environment>,
     /// Tokio runtime.
-    tokio_runtime: Mutex<tokio::runtime::Runtime>,
+    pub tokio_runtime: Mutex<tokio::runtime::Runtime>,
 }
 
 impl GrpcEnvironment {


### PR DESCRIPTION
Philosophically, we are no longer abstracting out our dependence on Tokio. Users of the Ekiden platform must run our futures in an appropriate Tokio environment.

This would allow us to use `block_on` https://docs.rs/tokio/0.1.11/tokio/runtime/struct.Runtime.html#method.block_on, which we wouldn't be able wrap in a generic method on a trait object.

We could also use the native `spawn`, which eliminates one layer of boxing.

downsides: also exposes things like `shutdown_now`, which we intend to manage separately.

cc @peterjgilbert and https://github.com/oasislabs/runtime-ethereum/issues/240