### PR TITLE
roothash: Trim the blocks of redundant information

### DIFF
--- a/compute/src/roothash.rs
+++ b/compute/src/roothash.rs
@@ -996,12 +996,11 @@ impl RootHashFrontend {
 
         // Create block from result batches.
         let mut block = Block::new_parent_of(&computed_batch.block);
-        block.computation_group = role.committee.clone();
+        block.header.group_hash = role.committee.get_encoded_hash();
         block.header.input_hash =
             hash_storage_key(&serde_cbor::to_vec(&computed_batch.calls).unwrap());
         block.header.output_hash = hash_storage_key(&encoded_outputs);
         block.header.state_root = computed_batch.new_state_root;
-        block.update();
 
         info!(
             "Proposing new block with {} transaction(s)",

--- a/go/roothash/api/block.go
+++ b/go/roothash/api/block.go
@@ -19,11 +19,15 @@ type Block struct {
 	Header Header `codec:"header"`
 
 	// ComputationGroup is the designated computation group.
-	ComputationGroup []*scheduler.CommitteeNode `codec:"computation_group"`
+	//
+	// Note: This field is omitted from the serialized block.
+	ComputationGroup []*scheduler.CommitteeNode `codec:"-"`
 
 	// Commitments is the vector of commitments from compute nodes,
 	// in the same order as in the computation group.
-	Commitments []*Commitment `codec:"commitments"`
+	//
+	// Note: This field is omitted from the serialized block.
+	Commitments []*Commitment `codec:"-"`
 }
 
 // Update updates the block header based on the current block content.
@@ -45,22 +49,7 @@ func (b *Block) FromProto(pb *pbRoothash.Block) error {
 	}
 
 	b.ComputationGroup = nil
-	for _, v := range pb.GetComputationGroup() {
-		node := new(scheduler.CommitteeNode)
-		if err := node.FromProto(v); err != nil {
-			return err
-		}
-		b.ComputationGroup = append(b.ComputationGroup, node)
-	}
-
 	b.Commitments = nil
-	for _, v := range pb.GetCommitments() {
-		commit := new(Commitment)
-		if err := commit.FromProto(v); err != nil {
-			return err
-		}
-		b.Commitments = append(b.Commitments, commit)
-	}
 
 	return nil
 }
@@ -69,12 +58,6 @@ func (b *Block) FromProto(pb *pbRoothash.Block) error {
 func (b *Block) ToProto() *pbRoothash.Block {
 	resp := new(pbRoothash.Block)
 	resp.Header = b.Header.ToProto()
-	for _, v := range b.ComputationGroup {
-		resp.ComputationGroup = append(resp.ComputationGroup, v.ToProto())
-	}
-	for _, v := range b.Commitments {
-		resp.Commitments = append(resp.Commitments, v.ToProto())
-	}
 
 	return resp
 }

--- a/roothash/api/Cargo.toml
+++ b/roothash/api/Cargo.toml
@@ -9,7 +9,6 @@ build = "build.rs"
 
 [dependencies]
 ekiden-common-api = { path = "../../common/api", version = "0.2.0-alpha" }
-ekiden-scheduler-api = { path = "../../scheduler/api", version = "0.2.0-alpha" }
 protobuf = "~2.0"
 ekiden-grpcio = { version = "0.3.2", features = ["openssl"] }
 futures = "0.1"

--- a/roothash/api/build.rs
+++ b/roothash/api/build.rs
@@ -4,19 +4,11 @@ extern crate protoc_grpcio;
 fn main() {
     // Generate module file.
     // Must be done first to create src/generated directory
-    ekiden_tools::generate_mod_with_imports(
-        "src/generated",
-        &["scheduler"],
-        &["roothash", "roothash_grpc"],
-    );
+    ekiden_tools::generate_mod("src/generated", &["roothash", "roothash_grpc"]);
 
     // Root set to the core ekiden root so that common/api is in scope.
     protoc_grpcio::compile_grpc_protos(&["roothash.proto"], &["src", "../../"], "src/generated")
         .expect("failed to compile gRPC definitions");
 
-    println!(
-        "cargo:rerun-if-changed={}",
-        "../../scheduler/api/src/scheduler.proto"
-    );
     println!("cargo:rerun-if-changed={}", "src/roothash.proto");
 }

--- a/roothash/api/src/lib.rs
+++ b/roothash/api/src/lib.rs
@@ -1,12 +1,9 @@
 extern crate ekiden_common_api;
-extern crate ekiden_scheduler_api;
 extern crate futures;
 extern crate grpcio;
 extern crate protobuf;
 
 mod generated;
-
-use ekiden_scheduler_api as scheduler;
 
 pub use generated::roothash::*;
 pub use generated::roothash_grpc::*;

--- a/roothash/api/src/roothash.proto
+++ b/roothash/api/src/roothash.proto
@@ -1,8 +1,5 @@
 syntax = "proto3";
 
-import "common/api/src/common.proto";
-import "scheduler/api/src/scheduler.proto";
-
 package roothash;
 option go_package = "github.com/oasislabs/ekiden/go/grpc/roothash";
 
@@ -16,8 +13,6 @@ service RootHash {
 
 message Block {
   Header header = 1;
-  repeated scheduler.CommitteeNode computation_group = 2;
-  repeated Commitment commitments = 3;
 }
 
 message Nonce {

--- a/roothash/base/Cargo.toml
+++ b/roothash/base/Cargo.toml
@@ -17,5 +17,4 @@ serde_bytes = "~0.10"
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
 ekiden-grpcio = { version = "0.3.2", features = ["openssl"] }
 ekiden-roothash-api = { path = "../api", version = "0.2.0-alpha" }
-ekiden-scheduler-base = { path = "../../scheduler/base", version = "0.2.0-alpha" }
 protobuf = "~2.0"

--- a/roothash/base/src/block.rs
+++ b/roothash/base/src/block.rs
@@ -3,13 +3,11 @@ use std::convert::TryFrom;
 
 use ekiden_common::bytes::H256;
 use ekiden_common::error::Error;
-use ekiden_common::hash::EncodedHash;
+use ekiden_common::hash::{empty_hash, EncodedHash};
 use ekiden_common::uint::U256;
-use ekiden_scheduler_base::CommitteeNode;
 
 use ekiden_roothash_api as api;
 
-use super::commitment::Commitment;
 use super::header::Header;
 
 /// Block.
@@ -17,16 +15,12 @@ use super::header::Header;
 pub struct Block {
     /// Block header.
     pub header: Header,
-    /// Designated computation group.
-    pub computation_group: Vec<CommitteeNode>,
-    /// Commitments from compute nodes in the same order as in the computation group.
-    pub commitments: Vec<Option<Commitment>>,
 }
 
 impl Block {
     /// Generate a parent block from given child.
     pub fn new_parent_of(child: &Block) -> Block {
-        let mut block = Block {
+        Block {
             header: Header {
                 version: child.header.version,
                 namespace: child.header.namespace,
@@ -37,30 +31,9 @@ impl Block {
                 input_hash: H256::zero(),
                 output_hash: H256::zero(),
                 state_root: H256::zero(),
-                commitments_hash: H256::zero(),
+                commitments_hash: empty_hash(),
             },
-            computation_group: vec![],
-            commitments: vec![],
-        };
-
-        block.update();
-        block
-    }
-
-    /// Update header based on current block content.
-    pub fn update(&mut self) {
-        self.header.group_hash = self.computation_group.get_encoded_hash();
-        self.header.commitments_hash = self.commitments.get_encoded_hash();
-    }
-
-    /// Check if block is internally consistent.
-    ///
-    /// This checks the following:
-    ///   * Computation group matches the hash in the header.
-    ///   * Commitments list matches the hash in the header.
-    pub fn is_internally_consistent(&self) -> bool {
-        self.computation_group.get_encoded_hash() == self.header.group_hash
-            && self.commitments.get_encoded_hash() == self.header.commitments_hash
+        }
     }
 }
 
@@ -69,24 +42,7 @@ impl TryFrom<api::Block> for Block {
     type Error = Error;
     fn try_from(a: api::Block) -> Result<Self, self::Error> {
         let header = Header::try_from(a.get_header().to_owned())?;
-        let mut computation = Vec::new();
-        for item in a.get_computation_group().iter() {
-            computation.push(CommitteeNode::try_from(item.to_owned())?);
-        }
-
-        let mut commits = Vec::new();
-        for item in a.get_commitments().iter() {
-            if item.get_data().is_empty() {
-                commits.push(None);
-            } else {
-                commits.push(Some(Commitment::try_from(item.to_owned())?));
-            }
-        }
-        Ok(Block {
-            header: header,
-            computation_group: computation,
-            commitments: commits,
-        })
+        Ok(Block { header: header })
     }
 }
 
@@ -95,21 +51,6 @@ impl Into<api::Block> for Block {
     fn into(self) -> api::Block {
         let mut b = api::Block::new();
         b.set_header(self.header.into());
-
-        let mut groups = Vec::new();
-        for item in self.computation_group {
-            groups.push(item.into());
-        }
-        b.set_computation_group(groups.into());
-
-        let mut commits = Vec::new();
-        for item in self.commitments {
-            match item {
-                Some(item) => commits.push(item.into()),
-                None => commits.push(api::Commitment::new()),
-            }
-        }
-        b.set_commitments(commits.into());
         b
     }
 }

--- a/roothash/base/src/lib.rs
+++ b/roothash/base/src/lib.rs
@@ -11,12 +11,9 @@ extern crate serde_cbor;
 extern crate serde_derive;
 extern crate serde_bytes;
 
-#[macro_use]
 extern crate ekiden_common;
 #[cfg(not(target_env = "sgx"))]
 extern crate ekiden_roothash_api;
-#[cfg(not(target_env = "sgx"))]
-extern crate ekiden_scheduler_base;
 #[cfg(not(target_env = "sgx"))]
 extern crate ekiden_storage_base;
 


### PR DESCRIPTION
This removes the following fields from blocks as redundant:
 * `compuation_group` - Can be reconstructed from scheduler/beacon/etc.
 * `commitments` - Can be reconstructed from the transaction log to the
   roothash backend.

Notes:
 * The memory backend will not support commitment reconstruction due to
   the absence of a transaction log.
 * This change is BACKWARD incompatible.

Implements #986.