### PR TITLE
go/storage/leveldb: Enable compression

### DIFF
--- a/go/storage/leveldb/leveldb.go
+++ b/go/storage/leveldb/leveldb.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/syndtr/goleveldb/leveldb"
-	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/util"
 	"golang.org/x/net/context"
 
@@ -190,9 +189,7 @@ func New(fn string, timeSource epochtime.Backend) (api.Backend, error) {
 		prometheus.MustRegister(leveldbCollectors...)
 	})
 
-	db, err := leveldb.OpenFile(fn, &opt.Options{
-		Compression: opt.NoCompression,
-	})
+	db, err := leveldb.OpenFile(fn, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Snappy's overhead when data is in-compressible is negligible, so this is
likely to help more than hurt, even if what gets written to storage ends
up being incompressible part of the time.

Note: This change is BACKWARDS INCOMPATIBLE.

Implements #1035.