### PR TITLE
go/roothash/tendermint: Prune tags

### DIFF
--- a/go/tendermint/api/roothash.go
+++ b/go/tendermint/api/roothash.go
@@ -21,10 +21,6 @@ var (
 	// TagRootHashUpdateValue is the only allowed value for TagRootHashUpdate.
 	TagRootHashUpdateValue = []byte("1")
 
-	// TagRootHashCommit is an ABCI transaction tag for new commit
-	// submissions (value is commit hash).
-	TagRootHashCommit = []byte("roothash.commit")
-
 	// TagRootHashDiscrepancyDetected is an ABCI transaction tag for
 	// discrepancy detected events (value is input batch hash).
 	TagRootHashDiscrepancyDetected = []byte("roothash.discrepancy")
@@ -34,11 +30,8 @@ var (
 	TagRootHashRoundFailed = []byte("roothash.round_failed")
 
 	// TagRootHashFinalized is an ABCI transaction tag for finalized
-	// blocks (value is serialized block header).
-	TagRootHashFinalized = []byte("roothash.finalized")
-	// TagRootHashFinalizedRound is an ABCI transaction tag for finalized
 	// blocks (value is round number as string).
-	TagRootHashFinalizedRound = []byte("roothash.finalized_round")
+	TagRootHashFinalized = []byte("roothash.finalized")
 
 	// TagRootHashID is an ABCI transaction tag for specifying the
 	// contract ID.

--- a/go/tendermint/apps/roothash/roothash.go
+++ b/go/tendermint/apps/roothash/roothash.go
@@ -3,7 +3,7 @@ package roothash
 
 import (
 	"encoding/hex"
-	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -265,8 +265,7 @@ func (app *rootHashApplication) ForeignDeliverTx(ctx *abci.Context, other abci.A
 			id, _ := contract.ID.MarshalBinary()
 			ctx.EmitTag(api.TagRootHashUpdate, api.TagRootHashUpdateValue)
 			ctx.EmitTag(api.TagRootHashID, id)
-			ctx.EmitTag(api.TagRootHashFinalized, block.MarshalCBOR())
-			ctx.EmitTag(api.TagRootHashFinalizedRound, []byte("0"))
+			ctx.EmitTag(api.TagRootHashFinalized, []byte("0"))
 		}
 	}
 
@@ -429,12 +428,11 @@ func (app *rootHashApplication) tryFinalize(
 		contractState.CurrentBlock = block
 
 		roundNr, _ := block.Header.Round.ToU64()
-		roundStr := fmt.Sprintf("%d", roundNr)
+		roundStr := strconv.FormatUint(roundNr, 10)
 
 		ctx.EmitTag(api.TagRootHashUpdate, api.TagRootHashUpdateValue)
 		ctx.EmitTag(api.TagRootHashID, id)
-		ctx.EmitTag(api.TagRootHashFinalized, block.MarshalCBOR())
-		ctx.EmitTag(api.TagRootHashFinalizedRound, []byte(roundStr))
+		ctx.EmitTag(api.TagRootHashFinalized, []byte(roundStr))
 		return
 	case errStillWaiting:
 		if forced {


### PR DESCRIPTION
 * `roothash.commit` - Removed (unused).
 * `roothash.finalized` - Now stores round number.
 * `roothash.finalized_round` - Removed (moved to `roothash.finalized`).

The discrepancy/round failure tags likely could be trimmed down a bit,
as well, but those are uncommon cases, and eliminating the CBOR
serialized block header from the `roothash.finalized` tag is likely the
biggest win here.