### PR TITLE
go/tendermint/abci/timer: nil out the pending state after persist

### DIFF
--- a/go/tendermint/abci/timer.go
+++ b/go/tendermint/abci/timer.go
@@ -133,6 +133,8 @@ func (t *Timer) persist(state *ApplicationState) {
 	if t.pendingState.Armed {
 		tree.Set(t.pendingState.getDeadlineMapKey(), []byte(t.ID))
 	}
+
+	t.pendingState = nil
 }
 
 func fireTimers(ctx *Context, state *ApplicationState, app Application) {


### PR DESCRIPTION
More of a defense in depth measure than a bug fix.