### PR TITLE
Change panic strategy to abort for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,3 +106,6 @@ members = [
     "key-manager/node",
 ]
 exclude = [ "thirdparty" ]
+
+[profile.release]
+panic = "abort"


### PR DESCRIPTION
Fixes #795.

Stack traces work with `RUST_BACKTRACE=1`.