### PR TITLE
go/registry/tendermint: Fix node deregistration events

### DIFF
--- a/go/registry/tendermint/tendermint.go
+++ b/go/registry/tendermint/tendermint.go
@@ -312,8 +312,9 @@ func (r *tendermintBackend) workerEvents() {
 
 			// Node deregistrations.
 			for _, node := range output.Nodes {
+				nodeCopy := node
 				r.nodeNotifier.Broadcast(&api.NodeEvent{
-					Node:           &node,
+					Node:           &nodeCopy,
 					IsRegistration: false,
 				})
 			}


### PR DESCRIPTION
At least this doesn't happen anywhere currently because nothing ever deregisters entities.