### PR TITLE
go/roothash/api: Remove `Block.Update()`

### DIFF
--- a/go/roothash/api/block.go
+++ b/go/roothash/api/block.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"github.com/oasislabs/ekiden/go/common/cbor"
-	scheduler "github.com/oasislabs/ekiden/go/scheduler/api"
 
 	pbRoothash "github.com/oasislabs/ekiden/go/grpc/roothash"
 )
@@ -16,13 +15,6 @@ var (
 type Block struct {
 	// Header is the block header.
 	Header Header `codec:"header"`
-}
-
-// Update updates the block header based on the provided computation
-// group and commitments list.
-func (b *Block) Update(computationGroup []*scheduler.CommitteeNode, commitments []*Commitment) {
-	b.Header.GroupHash.From(computationGroup)
-	b.Header.CommitmentsHash.From(commitments)
 }
 
 // FromProto deserializes a protobuf into a block.

--- a/go/roothash/memory/round.go
+++ b/go/roothash/memory/round.go
@@ -178,6 +178,7 @@ func (r *round) tryFinalize() (*api.Block, error) {
 	block := new(api.Block)
 	block.Header = *header
 	block.Header.Timestamp = uint64(time.Now().Unix())
+	block.Header.GroupHash.From(r.roundState.committee.Members)
 	var blockCommitments []*api.Commitment
 	for _, node := range r.roundState.committee.Members {
 		id := node.PublicKey.ToMapKey()
@@ -187,7 +188,7 @@ func (r *round) tryFinalize() (*api.Block, error) {
 		}
 		blockCommitments = append(blockCommitments, commit.toCommitment())
 	}
-	block.Update(r.roundState.committee.Members, blockCommitments)
+	block.Header.CommitmentsHash.From(blockCommitments)
 
 	return block, nil
 }

--- a/go/tendermint/apps/roothash/round.go
+++ b/go/tendermint/apps/roothash/round.go
@@ -188,6 +188,7 @@ func (r *round) tryFinalize(ctx *abci.Context, runtime *runtime.Runtime) (*api.B
 	block := new(api.Block)
 	block.Header = *header
 	block.Header.Timestamp = uint64(ctx.Now().Unix())
+	block.Header.GroupHash.From(r.RoundState.Committee.Members)
 	var blockCommitments []*api.Commitment
 	for _, node := range r.RoundState.Committee.Members {
 		id := node.PublicKey.ToMapKey()
@@ -197,7 +198,7 @@ func (r *round) tryFinalize(ctx *abci.Context, runtime *runtime.Runtime) (*api.B
 		}
 		blockCommitments = append(blockCommitments, commit.toCommitment())
 	}
-	block.Update(r.RoundState.Committee.Members, blockCommitments)
+	block.Header.CommitmentsHash.From(blockCommitments)
 
 	r.RoundState.State = stateFinalized
 	r.RoundState.Commitments = make(map[signature.MapKey]*commitment)


### PR DESCRIPTION
This removes the `Block` dependency on the `scheduler/api` package.

Part of #1097.