### PR TITLE
go/registry/tendermint: Remove unused tags

### DIFF
--- a/go/tendermint/api/registry.go
+++ b/go/tendermint/api/registry.go
@@ -16,22 +16,9 @@ const (
 	RegistryAppName string = "registry"
 )
 
-var (
-	// TagRegistryEntityRegistered is an ABCI transaction tag for new entity
-	// registrations (value is entity id).
-	TagRegistryEntityRegistered = []byte("registry.entity.registered")
-	// TagRegistryEntityDeregistered is an ABCI transaction tag for new
-	// entity registrations (value is entity id).
-	TagRegistryEntityDeregistered = []byte("registry.entity.deregistered")
-
-	// TagRegistryNodeRegistered is an ABCI transaction tag for new node
-	// registrations (value is node id).
-	TagRegistryNodeRegistered = []byte("registry.node.registered")
-
-	// TagRegistryRuntimeRegistered is an ABCI transaction tag for new
-	// runtime registrations (value is runtime id).
-	TagRegistryRuntimeRegistered = []byte("registry.runtime.registered")
-)
+// TagRegistryRuntimeRegistered is an ABCI transaction tag for new
+// runtime registrations (value is runtime id).
+var TagRegistryRuntimeRegistered = []byte("registry.runtime.registered")
 
 const (
 	// QueryRegistryGetEntity is a path for GetEntity query.

--- a/go/tendermint/apps/registry/registry.go
+++ b/go/tendermint/apps/registry/registry.go
@@ -190,7 +190,6 @@ func (app *registryApplication) registerEntity(
 				Entity: *ent,
 			},
 		})
-		ctx.EmitTag(api.TagRegistryEntityRegistered, ent.ID)
 	}
 
 	return nil
@@ -220,7 +219,6 @@ func (app *registryApplication) deregisterEntity(
 				Nodes:  removedNodes,
 			},
 		})
-		ctx.EmitTag(api.TagRegistryEntityDeregistered, id)
 	}
 
 	return nil
@@ -255,7 +253,6 @@ func (app *registryApplication) registerNode(
 				Node: *node,
 			},
 		})
-		ctx.EmitTag(api.TagRegistryNodeRegistered, node.ID)
 	}
 
 	return nil


### PR DESCRIPTION
There are a number of tendermint transaction tags that are emitted but
unused.  This wastes a miniscule amount of storage space.

Fixes #1105.