### PR TITLE
go/roothash/api: Move `Block`, `Header` and `Round` into a sub package

### DIFF
--- a/go/roothash/api/block/header.go
+++ b/go/roothash/api/block/header.go
@@ -1,4 +1,4 @@
-package api
+package block
 
 import (
 	"bytes"
@@ -192,7 +192,7 @@ func (h *Header) Equal(cmp *Header) bool {
 // FromProto deserializes a protobuf into a header.
 func (h *Header) FromProto(pb *pbRoothash.Header) error { // nolint: gocyclo
 	if pb == nil {
-		return ErrNilProtobuf
+		return errNilProtobuf
 	}
 
 	// Version (range check)

--- a/go/roothash/api/block/header_test.go
+++ b/go/roothash/api/block/header_test.go
@@ -1,4 +1,4 @@
-package api
+package block
 
 import (
 	"testing"

--- a/go/roothash/grpc.go
+++ b/go/roothash/grpc.go
@@ -7,6 +7,7 @@ import (
 	"github.com/oasislabs/ekiden/go/common/crypto/signature"
 	pb "github.com/oasislabs/ekiden/go/grpc/roothash"
 	"github.com/oasislabs/ekiden/go/roothash/api"
+	"github.com/oasislabs/ekiden/go/roothash/api/block"
 )
 
 var _ pb.RootHashServer = (*grpcServer)(nil)
@@ -50,7 +51,7 @@ func (s *grpcServer) GetBlocksSince(req *pb.BlockSinceRequest, stream pb.RootHas
 		return err
 	}
 
-	var round api.Round
+	var round block.Round
 	if err := round.UnmarshalBinary(req.GetRound()); err != nil {
 		return err
 	}
@@ -149,9 +150,9 @@ type blockSender interface {
 	Send(*pb.BlockResponse) error
 }
 
-func grpcSendBlocks(ch <-chan *api.Block, stream blockSender) error {
+func grpcSendBlocks(ch <-chan *block.Block, stream blockSender) error {
 	for {
-		var blk *api.Block
+		var blk *block.Block
 		var ok bool
 
 		select {

--- a/go/tendermint/apps/roothash/roothash.go
+++ b/go/tendermint/apps/roothash/roothash.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oasislabs/ekiden/go/common/runtime"
 	epochtime "github.com/oasislabs/ekiden/go/epochtime/api"
 	roothash "github.com/oasislabs/ekiden/go/roothash/api"
+	"github.com/oasislabs/ekiden/go/roothash/api/block"
 	scheduler "github.com/oasislabs/ekiden/go/scheduler/api"
 	storage "github.com/oasislabs/ekiden/go/storage/api"
 	"github.com/oasislabs/ekiden/go/tendermint/abci"
@@ -260,7 +261,8 @@ func (app *rootHashApplication) ForeignDeliverTx(ctx *abci.Context, other abci.A
 			}
 
 			// Create genesis block.
-			block := newGenesisBlock(ctx, runtime.ID)
+			now := ctx.Now().Unix()
+			block := block.NewGenesisBlock(runtime.ID, uint64(now))
 
 			// Create new state containing the genesis block.
 			timerCtx := &timerContext{ID: runtime.ID}
@@ -567,6 +569,7 @@ func New(
 	}
 }
 
+/*
 func newGenesisBlock(ctx *abci.Context, id signature.PublicKey) *roothash.Block {
 	var blk roothash.Block
 
@@ -579,3 +582,4 @@ func newGenesisBlock(ctx *abci.Context, id signature.PublicKey) *roothash.Block 
 
 	return &blk
 }
+*/

--- a/go/tendermint/apps/roothash/state.go
+++ b/go/tendermint/apps/roothash/state.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/oasislabs/ekiden/go/common/cbor"
 	"github.com/oasislabs/ekiden/go/common/crypto/signature"
-	"github.com/oasislabs/ekiden/go/roothash/api"
+	"github.com/oasislabs/ekiden/go/roothash/api/block"
 	"github.com/oasislabs/ekiden/go/tendermint/abci"
 )
 
@@ -28,7 +28,7 @@ var (
 // RuntimeState is the per-runtime roothash state.
 type RuntimeState struct {
 	ID           signature.PublicKey `codec:"id"`
-	CurrentBlock *api.Block          `codec:"current_block"`
+	CurrentBlock *block.Block        `codec:"current_block"`
 	Round        *round              `codec:"round"`
 	Timer        abci.Timer          `codec:"timer"`
 }


### PR DESCRIPTION
Part of #1097