### PR TITLE
go/tenderming/apps/roothash: Don't panic on spurious timeout

### DIFF
--- a/go/tendermint/apps/roothash/roothash.go
+++ b/go/tendermint/apps/roothash/roothash.go
@@ -327,12 +327,8 @@ func (app *rootHashApplication) FireTimer(ctx *abci.Context, timer *abci.Timer) 
 			"current_round", blockNr,
 		)
 
-		// XXX: This should just disarm the timer and attempt to continue
-		// in production, but tracking down #1047 is more important.
-		panic("BUG: spurious timeout, check logs")
-
-		// timer.Stop(ctx)
-		// return
+		timer.Stop(ctx)
+		return
 	}
 
 	app.logger.Warn("FireTimer: round timeout expired, forcing finalization",


### PR DESCRIPTION
This broke prod, which is good because it shows that the bug still
happens, but bad because it's hard to recover from because the faulty
timer gets replayed on restart.

Part of #1047.