### PR TITLE
go/tendermint: Disable Mempool cache

### DIFF
--- a/go/tendermint/tendermint.go
+++ b/go/tendermint/tendermint.go
@@ -303,6 +303,7 @@ func (t *tendermintService) lazyInit() error {
 	tenderConfig.Instrumentation.Prometheus = true
 	tenderConfig.TxIndex.Indexer = "null"
 	tenderConfig.RPC.ListenAddress = ""
+	tenderConfig.Mempool.CacheSize = 0
 
 	tendermintPV := tmpriv.LoadOrGenFilePV(tenderConfig.PrivValidatorFile())
 	tenderValIdent := crypto.PrivateKeyToTendermint(t.validatorKey)


### PR DESCRIPTION
This needs a better design like nonces/timestamps in the near future,
but for now this should unbreak prod.