### PR TITLE
go/tendermint/abci: Fix timer ID mismatch

### DIFF
--- a/go/tendermint/abci/timer.go
+++ b/go/tendermint/abci/timer.go
@@ -55,7 +55,7 @@ func NewTimer(ctx *Context, app Application, id string, data []byte) *Timer {
 	}
 
 	t := &Timer{
-		ID:           id,
+		ID:           state.ID,
 		currentState: state,
 		pendingState: state,
 	}


### PR DESCRIPTION
Likely related to #1117 and #1047.

**NOTE: This is a breaking change requiring state wipe as the internal timer ID will change.**