### PR TITLE
registry/runtime: Remove the StoreID field

### DIFF
--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/hex"
 	"errors"
 
 	"github.com/oasislabs/ekiden/go/common"
@@ -22,40 +21,10 @@ var (
 	_ cbor.Unmarshaler = (*Runtime)(nil)
 )
 
-// StoreID is a storage service ID.
-// TODO: Move this to the storage package when it exists.
-type StoreID [32]byte
-
-// MarshalBinary encodes a StoreID into binary form.
-func (id *StoreID) MarshalBinary() (data []byte, err error) {
-	data = append([]byte{}, id[:]...)
-	return
-}
-
-// UnmarshalBinary decodes a binary marshaled StoreID.
-func (id *StoreID) UnmarshalBinary(data []byte) error {
-	const idSize = 32
-
-	if len(data) != idSize {
-		return ErrMalformedStoreID
-	}
-
-	copy(id[:], data)
-	return nil
-}
-
-// String returns a string representation of a StoreID.
-func (id *StoreID) String() string {
-	return hex.EncodeToString(id[:])
-}
-
 // Runtime represents a runtime.
 type Runtime struct {
 	// ID is a globally unique long term identifier of the runtime.
 	ID signature.PublicKey `codec:"id"`
-
-	// StoreID is the storage service ID associated with the runtime.
-	StoreID StoreID `codec:"store_id"`
 
 	// Code is the runtime code body.
 	Code []byte `codec:"code"`
@@ -113,10 +82,6 @@ func (c *Runtime) FromProto(pb *pbRegistry.Runtime) error {
 		return err
 	}
 
-	if err := c.StoreID.UnmarshalBinary(pb.GetStoreId()); err != nil {
-		return err
-	}
-
 	c.Code = append([]byte{}, pb.GetCode()...)
 	c.MinimumBond = pb.GetMinimumBond()
 	c.AdvertisementRate = pb.GetAdvertisementRate()
@@ -143,9 +108,6 @@ func (c *Runtime) ToProto() *pbRegistry.Runtime {
 	var err error
 
 	if pb.Id, err = c.ID.MarshalBinary(); err != nil {
-		return nil
-	}
-	if pb.StoreId, err = c.StoreID.MarshalBinary(); err != nil {
 		return nil
 	}
 	pb.Code = append([]byte{}, c.Code...)

--- a/go/registry/api/runtime_test.go
+++ b/go/registry/api/runtime_test.go
@@ -12,7 +12,6 @@ func TestSerialization(t *testing.T) {
 	key, _, _ := ed25519.GenerateKey(nil)
 	c := Runtime{
 		ID:                       signature.PublicKey(key),
-		StoreID:                  StoreID{100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131},
 		Code:                     []byte{0x12, 0x13, 0x14, 0x15, 0x16},
 		MinimumBond:              42,
 		ModeNonDeterministic:     false,

--- a/registry/api/src/runtime.proto
+++ b/registry/api/src/runtime.proto
@@ -7,30 +7,29 @@ option go_package = "github.com/oasislabs/ekiden/go/grpc/registry";
 
 message Runtime {
     bytes id = 1;
-    bytes store_id = 2;
-    bytes code = 3;
+    bytes code = 2;
 
-    uint64 minimum_bond = 4;
+    uint64 minimum_bond = 3;
     enum Mode {
         Deterministic = 0;
         Nondeterministic = 1;
     }
-    Mode mode = 5;
+    Mode mode = 4;
 
     enum Features {
         SGX = 0;
     }
-    repeated Features features = 6;
+    repeated Features features = 5;
 
-    uint64 advertisement_rate = 7;
+    uint64 advertisement_rate = 6;
 
-    uint64 replica_group_size = 8;
+    uint64 replica_group_size = 7;
 
-    uint64 storage_group_size = 9;
+    uint64 storage_group_size = 8;
 
-    uint64 replica_group_backup_size = 10;
+    uint64 replica_group_backup_size = 9;
 
-    uint64 replica_allowed_stragglers = 11;
+    uint64 replica_allowed_stragglers = 10;
 }
 
 service RuntimeRegistry {

--- a/registry/base/src/runtime.rs
+++ b/registry/base/src/runtime.rs
@@ -11,9 +11,6 @@ pub struct Runtime {
     /// Globally unique long term identifier of the Runtime.
     pub id: B256,
 
-    /// Storage service ID associated with the Runtime.
-    pub store_id: B256,
-
     /// The runtime code body.
     pub code: Vec<u8>,
 
@@ -49,12 +46,8 @@ impl TryFrom<api::Runtime> for Runtime {
         let id = a.get_id();
         let id = B256::from_slice(&id);
 
-        let sid = a.get_store_id();
-        let sid = B256::from_slice(&sid);
-
         Ok(Runtime {
             id: id,
-            store_id: sid,
             code: a.get_code().to_vec(),
             minimum_bond: a.minimum_bond,
             mode_nondeterministic: a.get_mode() == api::Runtime_Mode::Nondeterministic,
@@ -75,7 +68,6 @@ impl Into<api::Runtime> for Runtime {
     fn into(self) -> api::Runtime {
         let mut c = api::Runtime::new();
         c.set_id(self.id.to_vec());
-        c.set_store_id(self.store_id.to_vec());
         c.set_code(self.code);
         c.set_minimum_bond(self.minimum_bond);
         if self.mode_nondeterministic {


### PR DESCRIPTION
This is unused, and there are no plans in the future to use such a
thing.

WARNING: This change is BACKWARDS INCOMPATIBLE.

Fixes #1087.