### PR TITLE
Revert "go/tendermint: Disable Mempool cache"

### DIFF
--- a/go/tendermint/tendermint.go
+++ b/go/tendermint/tendermint.go
@@ -305,7 +305,6 @@ func (t *tendermintService) lazyInit() error {
 	tenderConfig.Instrumentation.Prometheus = true
 	tenderConfig.TxIndex.Indexer = "null"
 	tenderConfig.RPC.ListenAddress = ""
-	tenderConfig.Mempool.CacheSize = 0
 
 	tendermintPV := tmpriv.LoadOrGenFilePV(tenderConfig.PrivValidatorFile())
 	tenderValIdent := crypto.PrivateKeyToTendermint(t.validatorKey)


### PR DESCRIPTION
This reverts commit 82093d22cb2507cf2af0949a36aff745d524876c.

Supersedes #1116.