### PR TITLE
go/roothash: Make the round timeout configurable

### DIFF
--- a/go/roothash/memory/memory_test.go
+++ b/go/roothash/memory/memory_test.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"testing"
+	"time"
 
 	"github.com/oasislabs/ekiden/go/beacon/insecure"
 	"github.com/oasislabs/ekiden/go/epochtime/mock"
@@ -20,7 +21,7 @@ func TestRootHashMemory(t *testing.T) {
 	storage := storage.New(timeSource)
 	defer storage.Cleanup()
 
-	backend := New(scheduler, storage, registry, nil)
+	backend := New(scheduler, storage, registry, nil, 10*time.Second)
 
 	tests.RootHashImplementationTests(t, backend, timeSource, scheduler, storage, registry)
 }

--- a/go/roothash/tendermint/tendermint.go
+++ b/go/roothash/tendermint/tendermint.go
@@ -4,6 +4,7 @@ package tendermint
 import (
 	"bytes"
 	"sync"
+	"time"
 
 	"github.com/eapache/channels"
 	"github.com/hashicorp/golang-lru"
@@ -406,6 +407,7 @@ func New(
 	storage storage.Backend,
 	service service.TendermintService,
 	genesisBlocks map[signature.MapKey]*block.Block,
+	roundTimeout time.Duration,
 ) (api.Backend, error) {
 	// We can only work with a block-based epochtime.
 	blockTimeSource, ok := timeSource.(epochtime.BlockBackend)
@@ -420,7 +422,7 @@ func New(
 	}
 
 	// Initialize and register the tendermint service component.
-	app := tmroothash.New(blockTimeSource, blockScheduler, storage, genesisBlocks)
+	app := tmroothash.New(blockTimeSource, blockScheduler, storage, genesisBlocks, roundTimeout)
 	if err := service.RegisterApplication(app); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
A configurable round timeout is beneficial especially while it is not
possible to interrupt a worker (#1010).  This parameter should be
globally consistent across all nodes (ie: be consensus backed, #965)
when there are multiple nodes running.

The parameter is `roothash.round_timeout`, with the default being the
old hard-coded value of 10 seconds.