### PR TITLE
instrumentation: adds measure_future_histogram_timer macro

### DIFF
--- a/instrumentation/src/macros.rs
+++ b/instrumentation/src/macros.rs
@@ -113,3 +113,23 @@ macro_rules! measure_histogram_timer {
         });
     };
 }
+
+/// Times future execution time and stores the elapsed time (in seconds) into an
+/// instrumentation histogram.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// {
+///     measure_future_histogram_timer!("my_timer", future);
+/// }
+/// ```
+#[macro_export]
+macro_rules! measure_future_histogram_timer {
+    ($name:expr, $future:expr) => {{
+        let before = ::std::time::Instant::now();
+        $future.inspect(move |_| {
+            measure_histogram!($name, before.elapsed().as_secs());
+        })
+    }};
+}


### PR DESCRIPTION
Needed for measuring the non-blocking actions