### PR TITLE
ci: Explicitly exclude some directories from Tarpaulin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,6 @@ jobs:
       - run: echo 'export CIRCLE_BRANCH=$(git rev-parse --abbrev-ref HEAD)' >> $BASH_ENV
       - checkout
       - run: echo "export CIRCLE_SHA1=$(git rev-parse HEAD)" >> $BASH_ENV
-      - run: cargo build
       # install & tarpaulin test.
       - run:
           name: Installing Tarpaulin


### PR DESCRIPTION
It seems that even when using --packages to limit coverage to specific
packages, some additional files from the workspace are still included.