### PR TITLE
go/cmd/storage/migrate: Fix documenation and spelling

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -117,8 +117,8 @@ are NOT guaranteed to be compatible across different versions of the
 `ekiden` command.**
 
 ```
-ekiden storage export                 # Export to stdout (Unsafe, redirect logs)
-ekiden storage export -o storage.bin  # Export to storage.bin
+ekiden storage export -log.file=/tmp/export.log  # Export to stdout (MUST log to file.)
+ekiden storage export -o storage.bin             # Export to storage.bin
 ```
 
 #### `storage import`

--- a/go/ekiden/cmd/storage/migrate/migrate.go
+++ b/go/ekiden/cmd/storage/migrate/migrate.go
@@ -56,7 +56,7 @@ func osInterruptContext(logger *logging.Logger) context.Context {
 	return ctx
 }
 
-// Register registes the storage migration sub-commands.
+// Register registers the storage migration sub-commands.
 func Register(parentCmd *cobra.Command) {
 	registerExportCmd(parentCmd)
 	registerImportCmd(parentCmd)


### PR DESCRIPTION
No functional changes.

Followup to #1184.