### PR TITLE
go/storage: Add caching remote storage backend

### DIFF
--- a/go/storage/cachingclient/cache/cache.go
+++ b/go/storage/cachingclient/cache/cache.go
@@ -1,0 +1,257 @@
+// LevelDB-backed CLOCK-Pro cache
+//
+// Based on the MIT-licensed code at:
+//     https://github.com/dgryski/go-clockpro/blob/master/clockpro.go
+
+package cache
+
+import (
+	"container/ring"
+	"path/filepath"
+	"sync"
+
+	tenderdb "github.com/tendermint/tendermint/libs/db"
+
+	"github.com/oasislabs/ekiden/go/storage/api"
+)
+
+type pageType int
+
+const (
+	ptTest pageType = iota
+	ptCold
+	ptHot
+)
+
+type entry struct {
+	ptype pageType
+	key   api.Key
+	ref   bool
+}
+
+type Cache struct {
+	sync.Mutex
+
+	db tenderdb.DB
+
+	memMax  int
+	memCold int
+	keys    map[api.Key]*ring.Ring
+
+	handHot  *ring.Ring
+	handCold *ring.Ring
+	handTest *ring.Ring
+
+	countHot  int
+	countCold int
+	countTest int
+}
+
+func New(path string, size int) (*Cache, error) {
+	dir, file := filepath.Split(path)
+	db := tenderdb.NewDB(file, tenderdb.LevelDBBackend, dir)
+
+	c := &Cache{
+		db:      db,
+		memMax:  size,
+		memCold: size,
+		keys:    make(map[api.Key]*ring.Ring),
+	}
+
+	// Populate keys from database.
+	iter := db.Iterator(nil, nil)
+	defer iter.Close()
+
+	for ; iter.Valid(); iter.Next() {
+		// Start with fresh metadata.
+		var key api.Key
+		copy(key[:], iter.Key()[:])
+
+		r := &ring.Ring{Value: &entry{ref: false, ptype: ptCold, key: key}}
+
+		c.keys[key] = r
+		c.metaAdd(key, r)
+		c.countCold++
+	}
+
+	return c, nil
+}
+
+func (c *Cache) Cleanup() {
+	c.db.Close()
+}
+
+func (c *Cache) Get(key api.Key) []byte {
+	c.Lock()
+	defer c.Unlock()
+
+	r := c.keys[key]
+
+	if r == nil {
+		return nil
+	}
+
+	mentry := r.Value.(*entry)
+
+	val := c.db.Get(key[:])
+
+	if val != nil {
+		mentry.ref = true
+		return val
+	}
+
+	return nil
+}
+
+func (c *Cache) Set(key api.Key, value []byte) {
+	c.Lock()
+	defer c.Unlock()
+
+	r := c.keys[key]
+
+	if r == nil {
+		// No cache entry found, add it.
+		c.db.SetSync(key[:], value)
+		r = &ring.Ring{Value: &entry{ref: false, ptype: ptCold, key: key}}
+		c.metaAdd(key, r)
+		c.countCold++
+		return
+	}
+
+	mentry := r.Value.(*entry)
+
+	val := c.db.Get(key[:])
+
+	if val == nil {
+		// Cache entry was a hot or cold page.
+		c.db.SetSync(key[:], value)
+		mentry.ref = true
+		return
+	}
+
+	// Cache entry was a test page.
+	if c.memCold < c.memMax {
+		c.memCold++
+	}
+	mentry.ref = false
+	c.db.SetSync(key[:], value)
+	mentry.ptype = ptHot
+	c.countTest--
+	c.metaDel(r)
+	c.metaAdd(key, r)
+	c.countHot++
+}
+
+func (c *Cache) metaAdd(key api.Key, r *ring.Ring) {
+	c.evict()
+
+	c.keys[key] = r
+	r.Link(c.handHot)
+
+	if c.handHot == nil {
+		// Handle first element.
+		c.handHot = r
+		c.handCold = r
+		c.handTest = r
+	}
+
+	if c.handCold == c.handHot {
+		c.handCold = c.handCold.Prev()
+	}
+}
+
+func (c *Cache) metaDel(r *ring.Ring) {
+	c.db.DeleteSync(r.Value.(*entry).key[:])
+	delete(c.keys, r.Value.(*entry).key)
+
+	if r == c.handHot {
+		c.handHot = c.handHot.Prev()
+	}
+
+	if r == c.handCold {
+		c.handCold = c.handCold.Prev()
+	}
+
+	if r == c.handTest {
+		c.handTest = c.handTest.Prev()
+	}
+
+	r.Prev().Unlink(1)
+}
+
+func (c *Cache) evict() {
+	for c.memMax <= c.countHot+c.countCold {
+		c.runHandCold()
+	}
+}
+
+func (c *Cache) runHandCold() {
+	mentry := c.handCold.Value.(*entry)
+
+	if mentry.ptype == ptCold {
+
+		if mentry.ref {
+			mentry.ptype = ptHot
+			mentry.ref = false
+			c.countCold--
+			c.countHot++
+		} else {
+			mentry.ptype = ptTest
+			c.db.DeleteSync(mentry.key[:])
+			c.countCold--
+			c.countTest++
+			for c.memMax < c.countTest {
+				c.runHandTest()
+			}
+		}
+	}
+
+	c.handCold = c.handCold.Next()
+
+	for c.memMax-c.memCold < c.countHot {
+		c.runHandHot()
+	}
+}
+
+func (c *Cache) runHandHot() {
+	if c.handHot == c.handTest {
+		c.runHandTest()
+	}
+
+	mentry := c.handHot.Value.(*entry)
+
+	if mentry.ptype == ptHot {
+
+		if mentry.ref {
+			mentry.ref = false
+		} else {
+			mentry.ptype = ptCold
+			c.countHot--
+			c.countCold++
+		}
+	}
+
+	c.handHot = c.handHot.Next()
+}
+
+func (c *Cache) runHandTest() {
+	if c.handTest == c.handCold {
+		c.runHandCold()
+	}
+
+	mentry := c.handTest.Value.(*entry)
+
+	if mentry.ptype == ptTest {
+
+		prev := c.handTest.Prev()
+		c.metaDel(c.handTest)
+		c.handTest = prev
+
+		c.countTest--
+		if c.memCold > 1 {
+			c.memCold--
+		}
+	}
+
+	c.handTest = c.handTest.Next()
+}

--- a/go/storage/cachingclient/cachingclient.go
+++ b/go/storage/cachingclient/cachingclient.go
@@ -1,0 +1,179 @@
+package cachingclient
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"golang.org/x/net/context"
+
+	"github.com/oasislabs/ekiden/go/common/logging"
+	"github.com/oasislabs/ekiden/go/storage/api"
+	"github.com/oasislabs/ekiden/go/storage/cachingclient/cache"
+	"github.com/oasislabs/ekiden/go/storage/client"
+)
+
+const (
+	// BackendName is the name of this implementation.
+	BackendName = "cachingclient"
+
+	// Path to file for persistent cache storage.
+	cfgCacheFile = "storage.cachingclient.file"
+
+	// Number of cache entries.
+	cfgCacheSize = "storage.cachingclient.cache_size"
+)
+
+var (
+	_ api.Backend = (*cachingClientBackend)(nil)
+
+	flagCacheFile string
+	flagCacheSize int
+
+	cacheHits = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "ekiden_storage_cachingclient_cache_hits",
+			Help: "Number of cache hits to local cache in caching remote storage client backend.",
+		},
+	)
+	cacheMisses = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "ekiden_storage_cachingclient_cache_misses",
+			Help: "Number of cache misses from local cache in caching remote storage client backend.",
+		},
+	)
+
+	cacheCollectors = []prometheus.Collector{
+		cacheHits,
+		cacheMisses,
+	}
+
+	metricsOnce sync.Once
+)
+
+type cachingClientBackend struct {
+	logger *logging.Logger
+	remote api.Backend
+	cache  *cache.Cache
+}
+
+func (b *cachingClientBackend) Get(ctx context.Context, key api.Key) ([]byte, error) {
+	// Try local cache first, then remote node if missing.
+	if cached := b.cache.Get(key); cached != nil {
+		cacheHits.Inc()
+		return cached, nil
+	}
+	cacheMisses.Inc()
+	return b.remote.Get(ctx, key)
+}
+
+func (b *cachingClientBackend) GetBatch(ctx context.Context, keys []api.Key) ([][]byte, error) {
+	var missingKeys []api.Key
+	var missingIdx []int
+
+	values := make([][]byte, 0, len(keys))
+
+	// Go through each key and try to retrieve its value from local cache.
+	for _, key := range keys {
+		if cached := b.cache.Get(key); cached != nil {
+			cacheHits.Inc()
+			values = append(values, cached)
+		} else {
+			// Cache miss, add to batch for remote.
+			cacheMisses.Inc()
+			values = append(values, nil)
+			missingKeys = append(missingKeys, key)
+			missingIdx = append(missingIdx, len(values)-1)
+		}
+	}
+
+	// Fetch missing values from remote node.
+	if len(missingKeys) > 0 {
+		remote, err := b.remote.GetBatch(ctx, missingKeys)
+		if err != nil {
+			return nil, err
+		}
+
+		for remoteIdx, idx := range missingIdx {
+			values[idx] = remote[remoteIdx]
+		}
+	}
+
+	return values, nil
+}
+
+func (b *cachingClientBackend) Insert(ctx context.Context, value []byte, expiration uint64) error {
+	// Write-through.
+	err := b.remote.Insert(ctx, value, expiration)
+	if err == nil {
+		b.cache.Set(api.HashStorageKey(value), value)
+	}
+	return err
+}
+
+func (b *cachingClientBackend) InsertBatch(ctx context.Context, values []api.Value) error {
+	// Write-through.
+	err := b.remote.InsertBatch(ctx, values)
+	if err == nil {
+		for _, value := range values {
+			b.cache.Set(api.HashStorageKey(value.Data), value.Data)
+		}
+	}
+	return err
+}
+
+func (b *cachingClientBackend) GetKeys(ctx context.Context) (<-chan *api.KeyInfo, error) {
+	// This must always be fetched from remote.
+	return b.remote.GetKeys(ctx)
+}
+
+func (b *cachingClientBackend) Cleanup() {
+	b.remote.Cleanup()
+	b.cache.Cleanup()
+}
+
+func (b *cachingClientBackend) Initialized() <-chan struct{} {
+	return b.remote.Initialized()
+}
+
+func New() (api.Backend, error) {
+	// Register metrics for cache hits and misses.
+	metricsOnce.Do(func() {
+		prometheus.MustRegister(cacheCollectors...)
+	})
+
+	// The remote node address needs to be set with the
+	// "storage.client.address" config parameter.
+	remote, err := client.New()
+	if err != nil {
+		return nil, err
+	}
+
+	cache, err := cache.New(flagCacheFile, flagCacheSize)
+	if err != nil {
+		return nil, err
+	}
+
+	b := &cachingClientBackend{
+		logger: logging.GetLogger("storage/cachingclient"),
+		remote: remote,
+		cache:  cache,
+	}
+
+	return b, nil
+}
+
+// RegisterFlags registers the configuration flags with the provided
+// command.
+func RegisterFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&flagCacheFile, cfgCacheFile, "cachingclient.storage.leveldb", "Path to file for persistent cache storage")
+	cmd.Flags().IntVar(&flagCacheSize, cfgCacheSize, 1000000, "Cache size")
+
+	for _, v := range []string{
+		cfgCacheFile,
+		cfgCacheSize,
+	} {
+		_ = viper.BindPFlag(v, cmd.Flags().Lookup(v))
+	}
+}

--- a/go/storage/init.go
+++ b/go/storage/init.go
@@ -11,6 +11,7 @@ import (
 
 	epochtime "github.com/oasislabs/ekiden/go/epochtime/api"
 	"github.com/oasislabs/ekiden/go/storage/api"
+	"github.com/oasislabs/ekiden/go/storage/cachingclient"
 	"github.com/oasislabs/ekiden/go/storage/client"
 	"github.com/oasislabs/ekiden/go/storage/leveldb"
 	"github.com/oasislabs/ekiden/go/storage/memory"
@@ -37,6 +38,8 @@ func New(cmd *cobra.Command, timeSource epochtime.Backend, dataDir string) (api.
 		impl, err = pgx.New(timeSource)
 	case client.BackendName:
 		impl, err = client.New()
+	case cachingclient.BackendName:
+		impl, err = cachingclient.New()
 	default:
 		err = fmt.Errorf("storage: unsupported backend: '%v'", backend)
 	}


### PR DESCRIPTION
This PR adds a new storage backend that is basically the `client` backend with a local LevelDB-backed CLOCK-Pro cache slapped on top of it.

At the moment, it's completely untested (I'll do that on Monday), but feel free to take a look :)