### PR TITLE
go/registry: Enforce node expiration

### DIFF
--- a/go/tendermint/api/registry.go
+++ b/go/tendermint/api/registry.go
@@ -16,9 +16,16 @@ const (
 	RegistryAppName string = "registry"
 )
 
-// TagRegistryRuntimeRegistered is an ABCI transaction tag for new
-// runtime registrations (value is runtime id).
-var TagRegistryRuntimeRegistered = []byte("registry.runtime.registered")
+var (
+	// TagRegistryRuntimeRegistered is an ABCI transaction tag for new
+	// runtime registrations (value is runtime id).
+	TagRegistryRuntimeRegistered = []byte("registry.runtime.registered")
+
+	// TagRegistryNodesExpired is an ABCI transaction tag for node
+	// deregistrations due to expiration (value is a CBOR serialized
+	//  vector of node descriptors).
+	TagRegistryNodesExpired = []byte("registry.nodes.expired")
+)
 
 const (
 	// QueryRegistryGetEntity is a path for GetEntity query.

--- a/go/tendermint/apps/registry/state.go
+++ b/go/tendermint/apps/registry/state.go
@@ -288,6 +288,12 @@ func (s *MutableState) CreateNode(node *node.Node) error {
 	return nil
 }
 
+// RemoveNode removes a node.
+func (s *MutableState) RemoveNode(node *node.Node) {
+	s.tree.Remove([]byte(fmt.Sprintf(stateNodeMap, node.ID.String())))
+	s.tree.Remove([]byte(fmt.Sprintf(stateNodeByEntityMap, node.EntityID.String(), node.ID.String())))
+}
+
 // CreateRuntime creates a new runtime.
 func (s *MutableState) CreateRuntime(con *registry.Runtime) {
 	s.tree.Set(


### PR DESCRIPTION
Nodes will expire on the first epoch past the expiration provided as
part of the registration.

 * [x] Memory backend
 * [x] Tendermint backend
 * [x] Update the test driver

Part of #1096 