### PR TITLE
Pin time transitive dependency

### DIFF
--- a/key-manager/dummy/enclave/Cargo.toml
+++ b/key-manager/dummy/enclave/Cargo.toml
@@ -21,6 +21,8 @@ protobuf = "~2.0"
 sodalite = "0.3.0"
 serde_cbor = { git = "https://github.com/oasislabs/cbor", tag = "v0.9.0-ekiden1" }
 bincode = "1.0.0"
+# (pinning transitive dependency) 0.1.41 is incompatible
+time = "=0.1.40"
 
 [build-dependencies]
 ekiden-tools = { path = "../../../tools", version = "0.2.0-alpha" }

--- a/tests/runtimes/test-db-encryption/Cargo.toml
+++ b/tests/runtimes/test-db-encryption/Cargo.toml
@@ -15,6 +15,8 @@ ekiden-storage-base = { path = "../../../storage/base" }
 protobuf = "~2.0"
 test-db-encryption-api = { path = "./api" }
 lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
+# (pinning transitive dependency) 0.1.41 is incompatible
+time = "=0.1.40"
 
 [build-dependencies]
 ekiden-tools = { path = "../../../tools" }

--- a/tests/runtimes/token/Cargo.toml
+++ b/tests/runtimes/token/Cargo.toml
@@ -12,6 +12,8 @@ ekiden-core = { path = "../../../core/common" }
 ekiden-trusted = { path = "../../../core/trusted" }
 ekiden-storage-base = { path = "../../../storage/base" }
 protobuf = "~2.0"
+# (pinning transitive dependency) 0.1.41 is incompatible
+time = "=0.1.40"
 token-api = { path = "./api" }
 
 [build-dependencies]

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -21,6 +21,8 @@ protobuf = "~2.0"
 sgx_edl = { git = "https://github.com/oasislabs/rust-sgx-sdk", tag = "v1.0.1-ekiden3" }
 clap = "2.29.1"
 ansi_term = "0.11"
+# (pinning transitive dependency) 0.1.41 is incompatible
+time = "=0.1.40"
 toml = "0.4"
 serde = "1.0.71"
 serde_derive = "1.0"


### PR DESCRIPTION
`time` 0.1.41 breaks the build, due to multiple `inner` modules being defined in [sys.rs](https://github.com/rust-lang-deprecated/time/blob/master/src/sys.rs).

I suspect this change is responsible https://github.com/rust-lang-deprecated/time/commit/9bdff26d68cdd2cd8d18783777cfad279b9ad807, because things only break when we run `cargo ekiden build-enclave`. For an example, see https://buildkite.com/oasislabs/ekiden/builds/235#_.

As a result, I've pinned the `time` dependency to 0.1.40