### PR TITLE
Revert "Key manager store uses hardcoded keys (#1237)"

### DIFF
--- a/key-manager/common/src/confidential.rs
+++ b/key-manager/common/src/confidential.rs
@@ -5,8 +5,7 @@
 use ekiden_core::error::{Error, Result};
 use ekiden_core::mrae::sivaessha2;
 
-use super::{PrivateKeyType, PublicKeyType, StateKeyType, EMPTY_PRIVATE_KEY, EMPTY_PUBLIC_KEY,
-            EMPTY_STATE_KEY};
+use super::{PrivateKeyType, PublicKeyType, EMPTY_PRIVATE_KEY, EMPTY_PUBLIC_KEY};
 
 /// Encrypts the given plaintext using the symmetric key derived from
 /// peer_public_key and secret_key. Uses the given public_key to return
@@ -90,20 +89,4 @@ fn split_encrypted_payload(data: Vec<u8>) -> Result<(Vec<u8>, PublicKeyType, Vec
     peer_public_key.copy_from_slice(&data[nonce_size..nonce_size + 32]);
     let cipher = data[nonce_size + 32..].to_vec();
     Ok((nonce, peer_public_key, cipher))
-}
-
-/// Hard coded key manager retrieved contract keys for Web3(c) V0.5.
-/// Public key = 0x9385b8391e06d67c3de1675a58cffc3ad16bcf7cc56ab35d7db1fc03fb227a54.
-/// Private key = 0xd5af0c986e6a9cce52d05803e962d4b19f915905debcb41f35b68eebc954fa49.
-pub fn default_contract_keys() -> (PublicKeyType, PrivateKeyType, StateKeyType) {
-    let seed = [
-        213, 175, 12, 152, 110, 106, 156, 206, 82, 208, 88, 3, 233, 98, 212, 177, 159, 145, 89, 5,
-        222, 188, 180, 31, 53, 182, 142, 235, 201, 84, 250, 73,
-    ];
-    let mut public_key = EMPTY_PUBLIC_KEY;
-    let mut private_key = EMPTY_PRIVATE_KEY;
-    let mut state_key = EMPTY_STATE_KEY;
-    sodalite::box_keypair_seed(&mut public_key, &mut private_key, &seed);
-
-    (public_key, private_key, state_key)
 }

--- a/key-manager/dummy/enclave/src/key_store.rs
+++ b/key-manager/dummy/enclave/src/key_store.rs
@@ -11,9 +11,8 @@ use std::sync::{Mutex, MutexGuard};
 use ekiden_core::error::{Error, Result};
 use ekiden_core::random;
 
-use ekiden_keymanager_common::{confidential,
-                               {ContractId, ContractKey, PublicKeyType, StateKeyType,
-                                EMPTY_PRIVATE_KEY, EMPTY_PUBLIC_KEY, EMPTY_STATE_KEY}};
+use ekiden_keymanager_common::{ContractId, ContractKey, PublicKeyType, StateKeyType,
+                               EMPTY_PRIVATE_KEY, EMPTY_PUBLIC_KEY, EMPTY_STATE_KEY};
 use ekiden_trusted::db::{Database, DatabaseHandle};
 
 /// Key store, which actually stores the key manager keys.
@@ -45,9 +44,6 @@ impl KeyStore {
 
     /// Get or create keys.
     pub fn get_or_create_keys(&mut self, contract_id: ContractId) -> Result<ContractKey> {
-        let (public_key, private_key, state_key) = confidential::default_contract_keys();
-        Ok(ContractKey::new(public_key, private_key, state_key))
-        /*
         DatabaseHandle::instance().with_encryption_key(self.encryption_key(), |db| {
             let serialized_key = db.get(&contract_id).unwrap_or_else(|| {
                 let k = bincode::serialize(&Self::create_random_key()).unwrap();
@@ -56,14 +52,10 @@ impl KeyStore {
             });
             Ok(bincode::deserialize(&serialized_key).expect("Corrupted state"))
         })
-         */
     }
 
     /// Get the public part of the key.
     pub fn get_public_key(&self, contract_id: ContractId) -> Result<PublicKeyType> {
-        let (public_key, _private_key, _state_key) = confidential::default_contract_keys();
-        Ok(public_key)
-        /*
         DatabaseHandle::instance().with_encryption_key(self.encryption_key(), |db| {
             let pk_serialized = db.get(&contract_id);
             if pk_serialized.is_none() {
@@ -76,7 +68,6 @@ impl KeyStore {
                 bincode::deserialize(&pk_serialized.unwrap()).expect("Corrupted state");
             Ok(pk.input_keypair.get_pk())
         })
-         */
     }
 
     /// Returns a random ContractKey.

--- a/key-manager/node/src/bin/test-client.rs
+++ b/key-manager/node/src/bin/test-client.rs
@@ -100,13 +100,11 @@ fn main() {
             let id_1 = ContractId::from_str(&"1".repeat(64)).unwrap();
             let id_2 = ContractId::from_str(&"2".repeat(64)).unwrap();
 
-            /*
             assert!(keymanager.get_or_create_secret_keys(id_1).is_err());
             assert!(keymanager.get_or_create_secret_keys(id_2).is_err());
             assert!(keymanager.get_public_key(id_0).is_ok());
             assert!(keymanager.get_public_key(id_1).is_err());
             assert!(keymanager.get_public_key(id_2).is_err());
-             */
 
             info!("Simple test passed.");
             exit(0);


### PR DESCRIPTION
This reverts commit cbcd84a6a1d45929541f6e5cb0c4920b547cd315.

The actual fix should be https://github.com/oasislabs/runtime-ethereum/pull/452.

Will wait to confirm staging is working before merging this.