### PR TITLE
go/common/ias: Add SigRL retreival to the IAS proxy

### DIFF
--- a/go/common/ias/grpc.go
+++ b/go/common/ias/grpc.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/oasislabs/ekiden/go/common/cbor"
 	"github.com/oasislabs/ekiden/go/common/crypto/signature"
-	//commonPB "github.com/oasislabs/ekiden/go/grpc/common"
 	pb "github.com/oasislabs/ekiden/go/grpc/ias"
 )
 
@@ -106,6 +105,19 @@ func (s *grpcServer) GetSPIDInfo(ctx context.Context, req *pb.GetSPIDInfoRequest
 	return &pb.GetSPIDInfoResponse{
 		Spid:               spid,
 		QuoteSignatureType: uint32(info.QuoteSignatureType),
+	}, nil
+}
+
+func (s *grpcServer) GetSigRL(ctx context.Context, req *pb.GetSigRLRequest) (*pb.GetSigRLResponse, error) {
+	// TODO: Validate the EPID group ID.
+
+	sigRL, err := s.endpoint.GetSigRL(ctx, req.GetEpidGid())
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.GetSigRLResponse{
+		SigRl: sigRL,
 	}, nil
 }
 

--- a/go/grpc/ias/ias.proto
+++ b/go/grpc/ias/ias.proto
@@ -10,6 +10,8 @@ service IAS {
     rpc GetSPIDInfo (GetSPIDInfoRequest) returns (GetSPIDInfoResponse) {}
 	// Verify attestation evidence.
 	rpc VerifyEvidence (VerifyEvidenceRequest) returns (VerifyEvidenceResponse) {}
+	// Get SigRL.
+	rpc GetSigRL (GetSigRLRequest) returns (GetSigRLResponse) {}
 }
 
 message GetSPIDInfoRequest {
@@ -29,4 +31,12 @@ message VerifyEvidenceResponse {
 	bytes avr = 1;
 	bytes signature = 2;
 	bytes certificate_chain = 3;
+}
+
+message GetSigRLRequest {
+	uint32 epid_gid = 1;
+}
+
+message GetSigRLResponse {
+	bytes sig_rl = 1;
 }

--- a/go/worker/handler.go
+++ b/go/worker/handler.go
@@ -48,6 +48,15 @@ func (h *hostHandler) Handle(ctx context.Context, body *protocol.Body) (*protoco
 			Certificates: certs,
 		}}, nil
 	}
+	if body.HostIasSigRlRequest != nil {
+		sigRL, err := h.ias.GetSigRL(ctx, body.HostIasSigRlRequest.GID)
+		if err != nil {
+			return nil, err
+		}
+		return &protocol.Body{HostIasSigRlResponse: &protocol.HostIasSigRlResponse{
+			SigRL: sigRL,
+		}}, nil
+	}
 	// Storage.
 	if body.HostStorageGetRequest != nil {
 		value, err := h.storage.Get(ctx, body.HostStorageGetRequest.Key)

--- a/go/worker/ias/ias.go
+++ b/go/worker/ias/ias.go
@@ -86,6 +86,25 @@ func (s *IAS) VerifyEvidence(ctx context.Context, quote, pseManifest []byte) (av
 	return
 }
 
+// GetSigRL returns the Signature Revocation List associated with the given
+// SPID group.
+func (s *IAS) GetSigRL(ctx context.Context, epidGID uint32) ([]byte, error) {
+	if s.client == nil {
+		// If the client is not configured, return a empty SigRL.
+		return nil, nil
+	}
+
+	req := iasGrpc.GetSigRLRequest{
+		EpidGid: epidGID,
+	}
+	res, err := s.client.GetSigRL(ctx, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.SigRl, nil
+}
+
 // New creates a new IAS client instance.
 func New(identity *signature.PrivateKey, proxyAddr string) (*IAS, error) {
 	s := &IAS{


### PR DESCRIPTION
At some point this needs to have the ability to whitelist based on EPID
GID so that we don't provide arbitrary ones to absolutely everyone.

Part of #1241.