### PR TITLE
ci: Remove nonexistent ekiden-enclave-logger crate from coverage

### DIFF
--- a/.buildkite/rust/coverage.sh
+++ b/.buildkite/rust/coverage.sh
@@ -45,7 +45,6 @@ cargo tarpaulin \
   --packages ekiden-db-trusted \
   --packages ekiden-di \
   --packages ekiden-enclave-common \
-  --packages ekiden-enclave-logger \
   --packages ekiden-enclave-trusted \
   --packages ekiden-rpc-client \
   --packages ekiden-rpc-common \


### PR DESCRIPTION
This was removed as part of #1261, but we forgot to remove it from the Rust coverage runner.