### PR TITLE
enclave/common: Add missing serde feature to log dependency

### DIFF
--- a/enclave/common/Cargo.toml
+++ b/enclave/common/Cargo.toml
@@ -12,7 +12,7 @@ base64 = "0.9.0"
 byteorder = "1.2.1"
 chrono = "0.4.2"
 ekiden-common = { path = "../../common", version = "0.2.0-alpha" }
-log = { version = "0.4", features = [] }
+log = { version = "0.4", features = ["serde"] }
 protobuf = "~2.0"
 pem-iterator = "0.2"
 percent-encoding = "1.0.1"


### PR DESCRIPTION
For some strange reason this was not caught by usual tests, it only failed when building in release mode when merged into the master branch.