### PR TITLE
ekiden: Fix breakage caused by untrusted/ring/webpki upstream

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -16,13 +16,13 @@ ekiden-di = { path = "../di", version = "0.2.0-alpha" }
 protobuf = "~2.0"
 byteorder = "1.2.1"
 rustc-hex = "1.0"
-ring = { git = "https://github.com/oasislabs/ring", default-features = false, features = [ "rsa_signing" ], branch = "0.12.1-ekiden" }
+ring = { git = "https://github.com/oasislabs/ring", default-features = false, features = ["use_heap"], branch = "0.14.0-ekiden" }
 # We need aes, block-modes, and crypto-ops as well, since ring doesn't export AES-CTR stuff, nor does it export a secure memset :/
 aes-soft = "0.1.0"
 block-modes = "0.1.0"
 crypto-ops = "0.1.1"
 sodalite = "0.3.0"
-untrusted = "0.5.1"
+untrusted = "0.6.2"
 bigint = { version = "4.4.0", features = ["std"] }
 chrono = "0.4.2"
 serde = "1.0.71"

--- a/common/src/identity/local.rs
+++ b/common/src/identity/local.rs
@@ -123,7 +123,10 @@ struct EntityKeyPair {
 impl KeyPair for EntityKeyPair {
     fn generate() -> Self {
         let rng = SystemRandom::new();
-        let seed = Ed25519KeyPair::generate_pkcs8(&rng).unwrap().to_vec();
+        let seed = Ed25519KeyPair::generate_pkcs8(&rng)
+            .unwrap()
+            .as_ref()
+            .to_vec();
 
         Self { seed }
     }
@@ -247,7 +250,10 @@ struct NodeKeyPair {
 impl KeyPair for NodeKeyPair {
     fn generate() -> Self {
         let rng = SystemRandom::new();
-        let seed = Ed25519KeyPair::generate_pkcs8(&rng).unwrap().to_vec();
+        let seed = Ed25519KeyPair::generate_pkcs8(&rng)
+            .unwrap()
+            .as_ref()
+            .to_vec();
         let key_pair = Ed25519KeyPair::from_pkcs8(untrusted::Input::from(&seed)).unwrap();
         let signer = InMemorySigner::new(key_pair);
         let (tls_certificate, tls_private_key) = x509::Certificate::generate(&signer).unwrap();

--- a/common/src/signature.rs
+++ b/common/src/signature.rs
@@ -11,6 +11,7 @@ use serde_cbor;
 
 use super::bytes::{B256, B512, B64, H256};
 use super::error::{Error, Result};
+use super::ring::signature::KeyPair;
 use super::ring::{digest, signature};
 use super::untrusted;
 
@@ -98,7 +99,7 @@ impl Signer for InMemorySigner {
     }
 
     fn get_public_key(&self) -> B256 {
-        B256::from(self.key_pair.public_key_bytes())
+        B256::from(self.key_pair.public_key().as_ref())
     }
 
     fn attest(&self, _data: &H256) -> Option<Vec<u8>> {

--- a/common/src/x509.rs
+++ b/common/src/x509.rs
@@ -242,7 +242,10 @@ mod test {
     fn test_x509_serialization() {
         // Generate new node private key and certificate.
         let rng = SystemRandom::new();
-        let seed = Ed25519KeyPair::generate_pkcs8(&rng).unwrap().to_vec();
+        let seed = Ed25519KeyPair::generate_pkcs8(&rng)
+            .unwrap()
+            .as_ref()
+            .to_vec();
         let key_pair = Ed25519KeyPair::from_pkcs8(untrusted::Input::from(&seed)).unwrap();
         let signer = InMemorySigner::new(key_pair);
         let (tls_certificate, _) = Certificate::generate(&signer).unwrap();

--- a/enclave/common/Cargo.toml
+++ b/enclave/common/Cargo.toml
@@ -21,7 +21,7 @@ serde_cbor = { git = "https://github.com/oasislabs/cbor", tag = "v0.9.0-ekiden1"
 serde_derive = "1.0.71"
 serde_json = "1.0"
 sodalite = "0.3.0"
-webpki = { git = "https://github.com/oasislabs/webpki", branch = "0.17.0-ekiden", default-features = false }
+webpki = { git = "https://github.com/oasislabs/webpki", branch = "0.19.0-ekiden", default-features = false }
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
 rand = "0.4.2"

--- a/enclave/trusted/src/capabilitytee.rs
+++ b/enclave/trusted/src/capabilitytee.rs
@@ -10,22 +10,17 @@ use std::sync::RwLock as SgxRwLock;
 #[cfg(target_env = "sgx")]
 use std::sync::SgxRwLock;
 
+#[cfg(target_env = "sgx")]
+use ekiden_common::ring::rand;
 use ekiden_common::ring::signature::Ed25519KeyPair;
+#[cfg(target_env = "sgx")]
+use ekiden_common::ring::signature::KeyPair;
 
 const HASH_CONTEXT: [u8; 8] = *b"EkNodReg";
 
 lazy_static! {
     // Global runtime attestation key.
     static ref RAK: SgxRwLock<Option<Ed25519KeyPair>> = SgxRwLock::new(None);
-}
-
-/// Uses ekiden-common's get_random_bytes for Ring's SecureRandom.
-struct CommonRng;
-impl ekiden_common::ring::rand::SecureRandom for CommonRng {
-    fn fill(&self, dest: &mut [u8]) -> Result<(), ekiden_common::ring::error::Unspecified> {
-        ekiden_common::random::get_random_bytes(dest)
-            .map_err(|_| ekiden_common::ring::error::Unspecified)
-    }
 }
 
 #[cfg(target_env = "sgx")]
@@ -36,21 +31,25 @@ pub extern "C" fn capabilitytee_init(
     report: &mut sgx_types::sgx_report_t,
 ) {
     // Generate new runtime attestation private key.
-    let rak_pkcs8 = Ed25519KeyPair::generate_pkcs8(&CommonRng).unwrap().to_vec();
+    let rng = rand::SystemRandom::new();
+    let rak_pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng)
+        .unwrap()
+        .as_ref()
+        .to_vec();
     let rak =
         Ed25519KeyPair::from_pkcs8(ekiden_common::untrusted::Input::from(&rak_pkcs8)).unwrap();
 
     // Prepare report data.
     let mut message = [0; 40];
     message[0..8].copy_from_slice(&HASH_CONTEXT);
-    message[8..40].copy_from_slice(rak.public_key_bytes());
+    message[8..40].copy_from_slice(rak.public_key().as_ref());
     let message_hash =
         ekiden_common::ring::digest::digest(&ekiden_common::ring::digest::SHA512_256, &message);
     let mut report_data = sgx_types::sgx_report_data_t::default();
     report_data.d[0..32].copy_from_slice(message_hash.as_ref());
 
     // Get public key and report for output.
-    rak_pub.copy_from_slice(rak.public_key_bytes());
+    rak_pub.copy_from_slice(rak.public_key().as_ref());
     *report = sgx_tse::rsgx_create_report(target_info, &report_data).expect("rsgx_create_report");
 
     // Move the key out to the global variable.

--- a/registry/base/src/test.rs
+++ b/registry/base/src/test.rs
@@ -6,7 +6,7 @@ use ekiden_common::bytes::B256;
 use ekiden_common::entity::Entity;
 use ekiden_common::futures::Future;
 use ekiden_common::node::{Capabilities, Node};
-use ekiden_common::ring::signature::Ed25519KeyPair;
+use ekiden_common::ring::signature::{Ed25519KeyPair, KeyPair};
 use ekiden_common::signature::{InMemorySigner, Signed};
 use ekiden_common::untrusted;
 use ekiden_common::x509::Certificate;
@@ -19,7 +19,7 @@ pub fn populate_entity_registry(registry: Arc<EntityRegistryBackend>, public_key
     // Fake entity owning the compute nodes.
     let entity_sk =
         Ed25519KeyPair::from_seed_unchecked(untrusted::Input::from(&B256::random())).unwrap();
-    let entity_pk = B256::from(entity_sk.public_key_bytes());
+    let entity_pk = B256::from(entity_sk.public_key().as_ref());
     let entity_signer = InMemorySigner::new(entity_sk);
     let signed_entity = Signed::sign(
         &entity_signer,


### PR DESCRIPTION
 * Point the dependencies to the new versions.
 * Fix the things broken by upstream API changes.
 * Our ring fork provides a working CSPRNG inside enclaves now.

Fixes #1285.