### PR TITLE
Use new Go compute worker in E2E tests

### DIFF
--- a/.buildkite/scripts/test_e2e.sh
+++ b/.buildkite/scripts/test_e2e.sh
@@ -1,11 +1,29 @@
 #!/bin/bash
 
 ############################################################
-# This script tests the Ekiden rust project.
+# This script tests the Ekiden project.
 #
 # Usage:
-# test_e2e.sh
+# test_e2e.sh [-w <workdir>] [-t <test-name>]
 ############################################################
+
+# Defaults.
+WORKDIR=$(pwd)
+TEST_FILTER=""
+
+#########################
+# Process test arguments.
+#########################
+while getopts 'f:t:' arg
+do
+    case ${arg} in
+        w) WORKDIR=${OPTARG};;
+        t) TEST_FILTER=${OPTARG};;
+        *)
+            echo "Usage: $0 [-w <workdir>] [-t <test-name>]"
+            exit 1
+    esac
+done
 
 # Helpful tips on writing build scripts:
 # https://buildkite.com/docs/pipelines/writing-build-scripts
@@ -15,267 +33,121 @@ source .buildkite/scripts/common.sh
 source .buildkite/scripts/common_e2e.sh
 source .buildkite/rust/common.sh
 
-# Working directory.
-WORKDIR=${1:-$(pwd)}
+###################
+# Test definitions.
+###################
+scenario_basic() {
+    local runtime=$1
 
-# Global test counter used for parallelizing jobs.
-E2E_TEST_COUNTER=0
+    # Initialize compute nodes.
+    run_compute_node 1 ${runtime} --worker.runtime.replica_group_size 2 --worker.runtime.replica_group_backup_size 1
+    run_compute_node 2 ${runtime} --worker.runtime.replica_group_size 2 --worker.runtime.replica_group_backup_size 1
+    run_compute_node 3 ${runtime} --worker.runtime.replica_group_size 2 --worker.runtime.replica_group_backup_size 1
 
-##############################
-# Run a specific test scenario
-##############################
-run_test() {
-    local scenario=$1
-    local description=$2
-    local client=$3
-    local epochs=$4
-    local dummy_node_runner=$5
-    local restart_dummy_after=${6:-0}
-    local pre_epochs=${7:-0}
-    local start_client_first=${8:-0}
-    local test_km=${9:-0}
-    local enclave=${10:-token}
-    local on_success_hook=${11:-""}
-
-    # Check if we should run this test.
-    local test_index=$E2E_TEST_COUNTER
-    let E2E_TEST_COUNTER+=1 1
-
-    if [[ -n ${BUILDKITE_PARALLEL_JOB+x} ]]; then
-        let test_index%=BUILDKITE_PARALLEL_JOB_COUNT 1
-
-        if [[ $BUILDKITE_PARALLEL_JOB != $test_index ]]; then
-            echo "Skipping test '${description}' (assigned to different parallel build)."
-            return
-        fi
-    fi
-
-    echo -e "\n\e[36;7;1mRUNNING TEST:\e[27m ${description}\e[0m\n"
-
-    # Start the key manager before starting anything else.
-    run_keymanager_node
-    sleep 1
-
-    if [[ "${test_km}" > 0 ]]; then
-        # Test the key manager.
-        ${WORKDIR}/target/debug/ekiden-keymanager-test-client \
-            --mrenclave $(cat ${WORKDIR}/target/enclave/ekiden-keymanager-trusted.mrenclave) \
-            --node-key-pair ${WORKDIR}/tests/keymanager/km.key
-    fi
-
-    if [[ "${start_client_first}" == 0 ]]; then
-        # Start dummy node.
-        $dummy_node_runner
-        dummy_pid=$!
-        sleep 1
-    fi
-
-    # Advance epochs before starting any compute nodes.
-    if [[ "${pre_epochs}" > 0 ]]; then
-        for epoch in $(seq $pre_epochs); do
-            sleep 1
-            ${WORKDIR}/go/ekiden/ekiden debug dummy set-epoch --epoch $epoch
-        done
-    fi
-
-    # Handle restarting the dummy node after a delay.
-    if [[ "${restart_dummy_after}" > 0 ]]; then
-        (sleep ${restart_dummy_after}; echo -e "\n\n\e[1;7;35m*** RESTARTING DUMMY NODE ***\e[0m\n\n"; kill -9 ${dummy_pid}; ${dummy_node_runner}) &
-    fi
-
-    # Run the client. We run the client first so that we test whether it waits for the
-    # committee to be elected and connects to the leader.
-    ${WORKDIR}/target/debug/${client}-client \
-        --storage-backend remote \
-        --mr-enclave $(cat ${WORKDIR}/target/enclave/${enclave}.mrenclave) \
-        --test-runtime-id 0000000000000000000000000000000000000000000000000000000000000000 \
-        &
-    client_pid=$!
-
-    if [[ "${start_client_first}" == 1 ]]; then
-        # Start dummy node.
-        $dummy_node_runner
-        dummy_pid=$!
-        sleep 1
-    fi
-
-    # Start compute nodes and wait for them to register.
-    $scenario
-    ${WORKDIR}/go/ekiden/ekiden debug dummy wait-nodes --nodes 3
+    # Wait for all compute nodes to start.
+    wait_compute_nodes 3
 
     # Advance epoch to elect a new committee.
-    let epochs_offset=pre_epochs+1
-    let epochs+=pre_epochs
-    for epoch in $(seq $epochs_offset $epochs); do
-        sleep 3
-        ${WORKDIR}/go/ekiden/ekiden debug dummy set-epoch --epoch $epoch
-    done
-
-    # Wait on the client and check its exit status.
-    wait ${client_pid}
-
-    if [[ "$on_success_hook" != "" ]]; then
-        $on_success_hook
-    fi
-
-    # Cleanup.
-    cleanup
+    set_epoch 1
 }
 
-scenario_basic() {
-    run_compute_node 1 --compute-replicas 2
-    sleep 1
-    run_compute_node 2 --compute-replicas 2
-    sleep 1
-    run_compute_node 3 --compute-replicas 2
+scenario_discrepancy() {
+    local runtime=$1
+
+    # Initialize compute nodes.
+    run_compute_node 1 ${runtime} \
+        --worker.runtime.replica_group_size 2 \
+        --worker.runtime.replica_group_backup_size 1 \
+        --worker.byzantine.inject_discrepancies
+
+    run_compute_node 2 ${runtime} --worker.runtime.replica_group_size 2 --worker.runtime.replica_group_backup_size 1
+    run_compute_node 3 ${runtime} --worker.runtime.replica_group_size 2 --worker.runtime.replica_group_backup_size 1
+
+    # Wait for all compute nodes to start.
+    wait_compute_nodes 3
+
+    # Advance epoch to elect a new committee.
+    set_epoch 1
 }
 
-scenario_basic_db() {
-    run_compute_node_db 1 --compute-replicas 2
-    sleep 1
-    run_compute_node_db 2 --compute-replicas 2
-    sleep 1
-    run_compute_node_db 3 --compute-replicas 2
+# Test the key manager node.
+test_keymanager() {
+    sleep 3
+
+    ${WORKDIR}/target/debug/ekiden-keymanager-test-client \
+        --mrenclave $(cat ${WORKDIR}/target/enclave/ekiden-keymanager-trusted.mrenclave) \
+        --node-key-pair ${WORKDIR}/tests/keymanager/km.key
 }
 
-scenario_discrepancy_worker() {
-    run_compute_node 1 --compute-replicas 2
-    sleep 1
-    run_compute_node 2 --compute-replicas 2 --test-inject-discrepancy
-    sleep 1
-    run_compute_node 3 --compute-replicas 2
-}
-
-scenario_discrepancy_leader() {
-    run_compute_node 1 --compute-replicas 2
-    sleep 1
-    run_compute_node 2 --compute-replicas 2
-    sleep 1
-    run_compute_node 3 --compute-replicas 2 --test-inject-discrepancy
-}
-
-# Scenario where one node is always idle (not part of computation group).
-scenario_one_idle() {
-    run_compute_node 1 --compute-replicas 1
-    sleep 1
-    run_compute_node 2 --compute-replicas 1
-    sleep 1
-    run_compute_node 3 --compute-replicas 1
-}
-
-scenario_multilayer_remote() {
-    run_compute_node_storage_multilayer_remote 1 --compute-replicas 2
-    sleep 1
-    run_compute_node_storage_multilayer_remote 2 --compute-replicas 2
-    sleep 1
-    run_compute_node_storage_multilayer_remote 3 --compute-replicas 2
-}
-
-scenario_fail_worker_after_registration() {
-    run_compute_node 1 --compute-replicas 2 --compute-allowed-stragglers 1
-    sleep 1
-    run_compute_node 2 --compute-replicas 2 --compute-allowed-stragglers 1 --test-fail-after-registration
-    sleep 1
-    run_compute_node 3 --compute-replicas 2 --compute-allowed-stragglers 1
-}
-
-scenario_fail_worker_after_commit() {
-    run_compute_node 1 --compute-replicas 2 --compute-allowed-stragglers 1
-    sleep 1
-    run_compute_node 2 --compute-replicas 2 --compute-allowed-stragglers 1 --test-fail-after-commit
-    sleep 1
-    run_compute_node 3 --compute-replicas 2 --compute-allowed-stragglers 1
-}
-
-scenario_leader_skip_commit() {
-    local leader_pid
-
-    run_compute_node 1 --compute-replicas 2 --compute-allowed-stragglers 0
-    sleep 1
-    run_compute_node 2 --compute-replicas 2 --compute-allowed-stragglers 0
-    sleep 1
-    # Make the leader node skip sending commits for 3 rounds. This test should pass if the
-    # roothash backend emits empty blocks for failed rounds, otherwise it may run forever.
-    run_compute_node 3 --compute-replicas 2 --compute-allowed-stragglers 0 --test-skip-commit-until-round 3
-}
-
-scenario_kill_worker() {
-    run_compute_node 1 --compute-replicas 2
-    sleep 1
-    run_compute_node 2 --compute-replicas 2
-    sleep 1
-    run_compute_node 3 --compute-replicas 2
-
-    # Wait for all nodes to register.
-    ${WORKDIR}/go/ekiden/ekiden debug dummy wait-nodes --nodes 3
-
-    # Kill newest worker. The compute node should restart it.
-    pkill -9 --newest worker
-    sleep 1
-}
-
-scenario_logger() {
-    run_compute_node_logger 1
-    sleep 1
-    run_compute_node_logger 2
-    sleep 1
-    run_compute_node_logger 3
-}
-
-check_logger_logs() {
-    log_files=()
-    for id in 1 2 3; do
-        log_files+="/tmp/ekiden-test-logger-$id "
-    done
+# Assert that the logger works.
+assert_logger_works() {
+    assert_basic_success
 
     # test-logger-client sends five distinct messages to five distinct log levels.
     # Check, if they are correctly reported by the enclave and then by pretty_env_logger.
-    grep "ERROR" $log_files | grep "<enclave>::test_logger" | grep -q "hello_error"
-    grep "WARN" $log_files | grep "<enclave>::test_logger" | grep -q "hello_warn"
-    grep "INFO" $log_files | grep "<enclave>::test_logger" | grep -q "hello_info"
-    grep "DEBUG" $log_files | grep "<enclave>::test_logger" | grep -q "hello_debug"
-    grep "TRACE" $log_files | grep "<enclave>::test_logger" | grep -q "hello_trace"
+    cat_compute_logs | grep "ERROR" | grep "<enclave>::test_logger" | grep -q "hello_error"
+    cat_compute_logs | grep "WARN" | grep "<enclave>::test_logger" | grep -q "hello_warn"
+    cat_compute_logs | grep "INFO" | grep "<enclave>::test_logger" | grep -q "hello_info"
+    cat_compute_logs | grep "DEBUG" | grep "<enclave>::test_logger" | grep -q "hello_debug"
+    cat_compute_logs | grep "TRACE" | grep "<enclave>::test_logger" | grep -q "hello_trace"
 
     # Then a new max_log_level is set to ERROR.
     # Check, if hello_new_error is reported and other hello_new messages omitted.
-    grep "ERROR" $log_files | grep "<enclave>::test_logger" | grep -q "hello_new_error"
-    grep "WARN" $log_files | grep "<enclave>::test_logger" | (! grep -q "hello_new_warn")
-    grep "INFO" $log_files | grep "<enclave>::test_logger" | (! grep -q "hello_new_info")
-    grep "DEBUG" $log_files | grep "<enclave>::test_logger" | (! grep -q "hello_new_debug")
-    grep "TRACE" $log_files | grep "<enclave>::test_logger" | (! grep -q "hello_new_trace")
+    cat_compute_logs | grep "ERROR" | grep "<enclave>::test_logger" | grep -q "hello_new_error"
+    cat_compute_logs | grep "WARN" | grep "<enclave>::test_logger" | (! grep -q "hello_new_warn")
+    cat_compute_logs | grep "INFO" | grep "<enclave>::test_logger" | (! grep -q "hello_new_info")
+    cat_compute_logs | grep "DEBUG" | grep "<enclave>::test_logger" | (! grep -q "hello_new_debug")
+    cat_compute_logs | grep "TRACE" | grep "<enclave>::test_logger" | (! grep -q "hello_new_trace")
 }
 
-# Tendermint backends.
-run_test scenario_basic "e2e-basic-tm-full" token 1 run_dummy_node_go_tm
-run_test scenario_basic_db "e2e-basic-tm-db" test-db-encryption 1 run_dummy_node_go_tm_mock 0 0 0 1 test-db-encryption
-run_test scenario_basic "e2e-basic-tm" token 1 run_dummy_node_go_tm_mock
-run_test scenario_multilayer_remote "e2e-multilayer-remote-tm" token 1 run_dummy_node_go_tm_mock
-run_test scenario_discrepancy_worker "e2e-discrepancy-worker-tm" token 1 run_dummy_node_go_tm_mock
-run_test scenario_discrepancy_leader "e2e-discrepancy-leader-tm" token 1 run_dummy_node_go_tm_mock
-run_test scenario_fail_worker_after_registration "e2e-fail-worker-after-registration-tm" token 1 run_dummy_node_go_tm_mock
-run_test scenario_fail_worker_after_commit "e2e-fail-worker-after-commit-tm" token 1 run_dummy_node_go_tm_mock
-run_test scenario_basic "e2e-long-tm" test-long-term 2 run_dummy_node_go_tm_mock
-run_test scenario_one_idle "e2e-long-one-idle-tm" test-long-term 2 run_dummy_node_go_tm_mock
-run_test scenario_leader_skip_commit "e2e-leader-skip-commit-tm" token 1 run_dummy_node_go_tm_mock
+#############
+# Test suite.
+#
+# Arguments:
+#    backend_name - name of the backend to use in test name
+#    backend_runner - function that will prepare and run the backend services
+#############
+test_suite() {
+    local backend_name=$1
+    local backend_runner=$2
 
-run_test scenario_basic "e2e-basic-tm-full-distributed" token 1 run_committee_go_tm
+    # Basic scenario using the token runtime and client.
+    run_test \
+        scenario=scenario_basic \
+        name="e2e-${backend_name}-basic-full" \
+        backend_runner=$backend_runner \
+        runtime=token \
+        client=token
 
-# Alternate starting order (client before dummy node).
-run_test scenario_basic "e2e-basic-client-starts-first" token 1 run_dummy_node_go_dummy 0 0 1
-run_test scenario_basic "e2e-basic-client-starts-first-tm-full" token 1 run_dummy_node_go_tm 0 0 1
-run_test scenario_basic "e2e-basic-client-starts-first-tm" token 1 run_dummy_node_go_tm_mock 0 0 1
+    # Database encryption test.
+    run_test \
+        scenario=scenario_basic \
+        name="e2e-${backend_name}-basic-db-encryption" \
+        backend_runner=$backend_runner \
+        runtime=test-db-encryption \
+        client=test-db-encryption \
+        post_km_hook=test_keymanager
 
-# Dummy backends.
-run_test scenario_basic "e2e-basic" token 1 run_dummy_node_go_dummy
-run_test scenario_basic "e2e-basic-pre-epochs" token 1 run_dummy_node_go_dummy 0 3
-run_test scenario_discrepancy_worker "e2e-discrepancy-worker" token 1 run_dummy_node_go_dummy
-run_test scenario_discrepancy_leader "e2e-discrepancy-leader" token 1 run_dummy_node_go_dummy
-run_test scenario_fail_worker_after_registration "e2e-fail-worker-after-registration" token 1 run_dummy_node_go_dummy
-run_test scenario_fail_worker_after_commit "e2e-fail-worker-after-commit" token 1 run_dummy_node_go_dummy
-run_test scenario_basic "e2e-long" test-long-term 2 run_dummy_node_go_dummy
-run_test scenario_one_idle "e2e-long-one-idle" test-long-term 2 run_dummy_node_go_dummy
-run_test scenario_leader_skip_commit "e2e-leader-skip-commit" token 1 run_dummy_node_go_dummy
-run_test scenario_kill_worker "e2e-kill-worker" token 1 run_dummy_node_go_dummy
+    # Enclave logger test.
+    run_test \
+        scenario=scenario_basic \
+        name="e2e-${backend_name}-logger" \
+        backend_runner=$backend_runner \
+        runtime=test-logger \
+        client=test-logger \
+        on_success_hook=assert_logger_works
 
-# Logging.
-run_test scenario_logger "e2e-logging" test-logger 1 run_dummy_node_go_dummy 0 0 0 1 test-logger check_logger_logs
+    # Discrepancy scenario.
+    run_test \
+        scenario=scenario_discrepancy \
+        name="e2e-${backend_name}-discrepancy" \
+        backend_runner=$backend_runner \
+        runtime=token \
+        client=token \
+        on_success_hook=assert_no_round_timeouts
+}
+
+##########################################
+# Multiple validators tendermint backends.
+##########################################
+test_suite tm-committee run_backend_tendermint_committee

--- a/go/ekiden/node_test.go
+++ b/go/ekiden/node_test.go
@@ -38,8 +38,8 @@ var (
 		{"storage.backend", "leveldb"},
 		{"tendermint.consensus.skip_timeout_commit", true},
 		{"worker.backend", "mock"},
-		{"worker.runtime", "mock-runtime"},
-		{"worker.runtime_id", "0000000000000000000000000000000000000000000000000000000000000000"},
+		{"worker.runtime.binary", "mock-runtime"},
+		{"worker.runtime.id", "0000000000000000000000000000000000000000000000000000000000000000"},
 	}
 
 	initConfigOnce sync.Once

--- a/go/worker/committee/registration.go
+++ b/go/worker/committee/registration.go
@@ -15,8 +15,8 @@ func (n *Node) registerRuntime() error {
 
 	rtDesc := registry.Runtime{
 		ID:                     n.runtimeID,
-		ReplicaGroupSize:       1,
-		ReplicaGroupBackupSize: 0,
+		ReplicaGroupSize:       n.cfg.ReplicaGroupSize,
+		ReplicaGroupBackupSize: n.cfg.ReplicaGroupBackupSize,
 		StorageGroupSize:       1,
 		RegistrationTime:       uint64(time.Now().Unix()),
 	}

--- a/go/worker/enclaverpc/enclaverpc.go
+++ b/go/worker/enclaverpc/enclaverpc.go
@@ -43,7 +43,7 @@ func (c *Client) CallEnclave(ctx context.Context, request []byte) ([]byte, error
 
 // NewClient creates a new enclave RPC client instance.
 func NewClient(address string, certFile string, enclaveID []byte) (*Client, error) {
-	creds, err := credentials.NewClientTLSFromFile(certFile, "")
+	creds, err := credentials.NewClientTLSFromFile(certFile, "ekiden-node")
 	if err != nil {
 		return nil, err
 	}

--- a/go/worker/host/sandboxed.go
+++ b/go/worker/host/sandboxed.go
@@ -95,7 +95,13 @@ func (p *process) worker() {
 	// Wait for the process to exit.
 	err := <-p.waitCh
 
-	p.logger.Warn("worker process terminated")
+	if err == nil {
+		p.logger.Warn("worker process terminated")
+	} else {
+		p.logger.Error("worker process terminated unexpectedly",
+			"err", err,
+		)
+	}
 
 	// Close connection after worker process has exited.
 	p.protocol.Close()

--- a/go/worker/worker.go
+++ b/go/worker/worker.go
@@ -27,6 +27,10 @@ import (
 type RuntimeConfig struct {
 	ID     signature.PublicKey
 	Binary string
+
+	// XXX: This is needed until we decide how we want to actually register runtimes.
+	ReplicaGroupSize       uint64
+	ReplicaGroupBackupSize uint64
 }
 
 // Config is the worker configuration.
@@ -236,6 +240,10 @@ func (w *Worker) registerRuntime(cfg *Config, rtCfg *RuntimeConfig) error {
 	}
 
 	// Create committee node for the given runtime.
+	nodeCfg := cfg.Committee
+	nodeCfg.ReplicaGroupSize = rtCfg.ReplicaGroupSize
+	nodeCfg.ReplicaGroupBackupSize = rtCfg.ReplicaGroupBackupSize
+
 	node, err := committee.NewNode(
 		rtCfg.ID,
 		w.identity,
@@ -246,7 +254,7 @@ func (w *Worker) registerRuntime(cfg *Config, rtCfg *RuntimeConfig) error {
 		w.scheduler,
 		workerHost,
 		w.p2p,
-		cfg.Committee,
+		nodeCfg,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
See #1263 
Fixes #1283 

This also refactors the E2E test runner scripts so they are easier to use and extend.