### PR TITLE
Cleanup Rust client backend arguments

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -64,6 +64,8 @@ pub mod profiling;
 #[macro_use]
 pub mod protobuf;
 pub mod random;
+#[cfg(not(target_env = "sgx"))]
+pub mod remote_node;
 pub mod signature;
 #[macro_use]
 pub mod uint;

--- a/common/src/remote_node.rs
+++ b/common/src/remote_node.rs
@@ -1,0 +1,58 @@
+use clap::value_t;
+
+/// Dependency used for injecting `--node-host` and `--node-port` command line arguments when
+/// using create_component() macro.
+pub struct RemoteNodeInfo {
+    // Remote node host.
+    node_host: String,
+    // Remote node port.
+    node_port: u16,
+}
+
+pub trait RemoteNode: Sync + Send {
+    /// Return remote node host.
+    fn get_node_host(&self) -> &str;
+
+    /// Return remote node port.
+    fn get_node_port(&self) -> u16;
+}
+
+impl RemoteNode for RemoteNodeInfo {
+    fn get_node_host(&self) -> &str {
+        self.node_host.as_str()
+    }
+
+    fn get_node_port(&self) -> u16 {
+        self.node_port
+    }
+}
+
+// Register for dependency injection.
+create_component!(
+    remote_node,
+    "remote-node",
+    RemoteNodeInfo,
+    RemoteNode,
+    (|container: &mut Container| -> Result<Box<Any>> {
+        let args = container.get_arguments().unwrap();
+
+        let rnode: Arc<RemoteNode> = Arc::new(RemoteNodeInfo {
+            node_host: value_t!(args.value_of("node-host"), String).unwrap_or_else(|e| e.exit()),
+            node_port: value_t!(args.value_of("node-port"), u16).unwrap_or_else(|e| e.exit()),
+        });
+
+        Ok(Box::new(rnode))
+    }),
+    [
+        Arg::with_name("node-host")
+            .long("node-host")
+            .help("Remote node hostname that the client should connect to")
+            .takes_value(true)
+            .default_value("127.0.0.1"),
+        Arg::with_name("node-port")
+            .long("node-port")
+            .help("Remote node port that the client should connect to")
+            .takes_value(true)
+            .default_value("42261")
+    ]
+);

--- a/compute/src/main.rs
+++ b/compute/src/main.rs
@@ -89,6 +89,8 @@ fn register_components(known_components: &mut KnownComponents) {
     ekiden_core::identity::LocalNodeIdentity::register(known_components);
     // Instrumentation.
     ekiden_instrumentation_prometheus::PrometheusMetricCollector::register(known_components);
+    // Remote node.
+    ekiden_core::remote_node::RemoteNodeInfo::register(known_components);
 }
 
 fn main() {

--- a/di/src/di.rs
+++ b/di/src/di.rs
@@ -316,7 +316,7 @@ impl<'a> Container<'a> {
         // Create new instance.
         let component = match self.components.remove(&type_id) {
             Some(component) => component,
-            None => return Err("component not found".into()),
+            None => return Err("to-be-owned component not found".into()),
         };
 
         let instance = component.factory.build(self)?;

--- a/key-manager/node/src/bin/test-client.rs
+++ b/key-manager/node/src/bin/test-client.rs
@@ -31,6 +31,7 @@ fn main() {
     ekiden_common::environment::GrpcEnvironment::register(&mut known_components);
     ekiden_common::identity::LocalNodeIdentity::register(&mut known_components);
     ekiden_common::identity::LocalEntityIdentity::register(&mut known_components);
+    ekiden_common::remote_node::RemoteNodeInfo::register(&mut known_components);
 
     let matches = App::new("Ekiden key manager client test")
         .version(crate_version!())

--- a/key-manager/node/src/main.rs
+++ b/key-manager/node/src/main.rs
@@ -120,6 +120,7 @@ fn register_known_components() -> ekiden_di::KnownComponents {
     ekiden_common::environment::GrpcEnvironment::register(&mut known_components);
     ekiden_common::identity::LocalNodeIdentity::register(&mut known_components);
     ekiden_common::identity::LocalEntityIdentity::register(&mut known_components);
+    ekiden_common::remote_node::RemoteNodeInfo::register(&mut known_components);
     ekiden_storage_dummy::DummyStorageBackend::register(&mut known_components);
     ekiden_storage_persistent::PersistentStorageBackend::register(&mut known_components);
     known_components

--- a/tests/clients/utils/src/components.rs
+++ b/tests/clients/utils/src/components.rs
@@ -26,6 +26,8 @@ pub fn register_components(known_components: &mut KnownComponents) {
     // Storage.
     ekiden_storage_frontend::StorageClient::register(known_components);
     ekiden_storage_multilayer::MultilayerBackend::register(known_components);
+    // Remote node.
+    ekiden_core::remote_node::RemoteNodeInfo::register(known_components);
 }
 
 /// Create known component registry.


### PR DESCRIPTION
This adds a new RemoteNode component for the `--node-host` and `--node-port` arguments and injects it into registry, roothash, scheduler, key-manager, and tests clients. See #1240 for details.