### PR TITLE
go/ekiden: Add the bootstrap service

### DIFF
--- a/go/ekiden/cmd/debug/tendermint/bootstrap.go
+++ b/go/ekiden/cmd/debug/tendermint/bootstrap.go
@@ -1,0 +1,86 @@
+package tendermint
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/oasislabs/ekiden/go/common/logging"
+	cmdCommon "github.com/oasislabs/ekiden/go/ekiden/cmd/common"
+	"github.com/oasislabs/ekiden/go/ekiden/cmd/common/background"
+	"github.com/oasislabs/ekiden/go/tendermint/bootstrap"
+)
+
+const (
+	cfgBootstrapAddress    = "debug.tendermint.bootstrap.address"
+	cfgBootstrapValidators = "debug.tendermint.bootstrap.validators"
+)
+
+var (
+	bootstrapCmd = &cobra.Command{
+		Use:   "bootstrap",
+		Short: "testnet bootstrap provisioning server",
+		Run:   doBootstrap,
+	}
+
+	flagBootstrapAddress    string
+	flagBootstrapValidators int
+)
+
+func doBootstrap(cmd *cobra.Command, args []string) {
+	if err := cmdCommon.Init(); err != nil {
+		cmdCommon.EarlyLogAndExit(err)
+	}
+
+	logger := logging.GetLogger("cmd/debug/tendermint/bootstrap")
+	logger.Warn("The bootstrap provisioning server is NOT FOR PRODUCTION USE.")
+
+	dataDir := cmdCommon.DataDir()
+	if dataDir == "" {
+		logger.Warn("data directory not set, genesis file will not be persisted")
+	}
+
+	if flagBootstrapValidators < 1 {
+		logger.Error("insufficient validators",
+			"validators", flagBootstrapValidators,
+		)
+		os.Exit(1)
+	}
+
+	svcMgr := background.NewServiceManager(logger)
+
+	srv, err := bootstrap.NewServer(flagBootstrapAddress, flagBootstrapValidators, dataDir)
+	if err != nil {
+		logger.Error("failed to initialize bootstrap server",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+	svcMgr.Register(srv)
+
+	if err = srv.Start(); err != nil {
+		logger.Error("failed to start bootstrap server",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+
+	logger.Info("initialization complete: will bootstrap")
+
+	svcMgr.Wait()
+}
+
+func registerBootstrap(parentCmd *cobra.Command) {
+	bootstrapCmd.Flags().StringVar(&flagBootstrapAddress, cfgBootstrapAddress, ":19156", "server listen address")
+	bootstrapCmd.Flags().IntVar(&flagBootstrapValidators, cfgBootstrapValidators, 3, "number of validators")
+
+	for _, v := range []string{
+		cfgBootstrapAddress,
+		cfgBootstrapValidators,
+	} {
+		_ = viper.BindPFlag(v, bootstrapCmd.Flags().Lookup(v))
+	}
+
+	parentCmd.AddCommand(bootstrapCmd)
+}

--- a/go/ekiden/cmd/debug/tendermint/tendermint.go
+++ b/go/ekiden/cmd/debug/tendermint/tendermint.go
@@ -27,14 +27,14 @@ var (
 		Short: "dump ABCI mux state as JSON",
 		Run:   doDumpMuxState,
 	}
-
-	logger = logging.GetLogger("cmd/tendermint")
 )
 
 func doDumpMuxState(cmd *cobra.Command, args []string) {
 	if err := cmdCommon.Init(); err != nil {
 		cmdCommon.EarlyLogAndExit(err)
 	}
+
+	logger := logging.GetLogger("cmd/debug/tendermint/dump-abci-mux-state")
 
 	state, err := inspector.OpenMuxState(stateFilename)
 	if err != nil {
@@ -70,6 +70,7 @@ func doDumpMuxState(cmd *cobra.Command, args []string) {
 
 // Register registers the tendermint sub-command and all of it's children.
 func Register(parentCmd *cobra.Command) {
+	registerBootstrap(tmCmd)
 	tmDumpMuxStateCmd.Flags().StringVarP(&stateFilename, "state", "s", "abci-mux-state.bolt.db", "ABCI mux state file to dump")
 
 	tmCmd.AddCommand(tmDumpMuxStateCmd)

--- a/go/ekiden/cmd/tendermint/provision.go
+++ b/go/ekiden/cmd/tendermint/provision.go
@@ -14,7 +14,7 @@ import (
 	"github.com/oasislabs/ekiden/go/common"
 	"github.com/oasislabs/ekiden/go/common/identity"
 	cmdCommon "github.com/oasislabs/ekiden/go/ekiden/cmd/common"
-	"github.com/oasislabs/ekiden/go/tendermint"
+	"github.com/oasislabs/ekiden/go/tendermint/bootstrap"
 )
 
 const (
@@ -84,7 +84,7 @@ func doProvisionValidator(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	validator := tendermint.GenesisValidator{
+	validator := bootstrap.GenesisValidator{
 		PubKey: id.NodeKey.Public(),
 	}
 
@@ -134,7 +134,7 @@ func doProvisionValidator(cmd *cobra.Command, args []string) {
 	}
 }
 
-func provisionInteractive(validator *tendermint.GenesisValidator) error {
+func provisionInteractive(validator *bootstrap.GenesisValidator) error {
 	var qs []*survey.Question
 
 	if flagNodeName == "" || common.IsFQDN(flagNodeName) != nil {

--- a/go/ekiden/cmd/tendermint/tendermint.go
+++ b/go/ekiden/cmd/tendermint/tendermint.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/oasislabs/ekiden/go/common/logging"
 	"github.com/oasislabs/ekiden/go/ekiden/cmd/common"
-	"github.com/oasislabs/ekiden/go/tendermint"
+	"github.com/oasislabs/ekiden/go/tendermint/bootstrap"
 )
 
 const cfgGenesisFile = "genesis_file"
@@ -54,7 +54,7 @@ func doInitGenesis(cmd *cobra.Command, args []string) {
 		common.EarlyLogAndExit(err)
 	}
 
-	validators := make([]*tendermint.GenesisValidator, 0, len(args))
+	validators := make([]*bootstrap.GenesisValidator, 0, len(args))
 	for _, v := range args {
 		b, err := ioutil.ReadFile(v)
 		if err != nil {
@@ -65,7 +65,7 @@ func doInitGenesis(cmd *cobra.Command, args []string) {
 			return
 		}
 
-		var validator tendermint.GenesisValidator
+		var validator bootstrap.GenesisValidator
 		if err := json.Unmarshal(b, &validator); err != nil {
 			logger.Error("failed to parse genesis validator",
 				"err", err,
@@ -78,7 +78,7 @@ func doInitGenesis(cmd *cobra.Command, args []string) {
 		validators = append(validators, &validator)
 	}
 
-	doc := &tendermint.GenesisDocument{
+	doc := &bootstrap.GenesisDocument{
 		Validators:  validators,
 		GenesisTime: time.Now(),
 	}

--- a/go/tendermint/bootstrap/bootstrap.go
+++ b/go/tendermint/bootstrap/bootstrap.go
@@ -1,0 +1,264 @@
+// Package bootstrap implements the genesis validator/document and
+// the testnet (debug) bootstrap service.
+package bootstrap
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	golog "log"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	tmtypes "github.com/tendermint/tendermint/types"
+
+	"github.com/oasislabs/ekiden/go/common/crypto/signature"
+	"github.com/oasislabs/ekiden/go/common/logging"
+	"github.com/oasislabs/ekiden/go/common/service"
+	"github.com/oasislabs/ekiden/go/tendermint/internal/crypto"
+)
+
+const (
+	validatorURIPath = "/bootstrap/v1/validator"
+	genesisURIPath   = "/bootstrap/vi/genesis"
+)
+
+// GenesisDocument is the ekiden format tendermint GenesisDocument.
+type GenesisDocument struct {
+	Validators  []*GenesisValidator `json:"validators"`
+	GenesisTime time.Time           `json:"genesis_time"`
+}
+
+// ToTendermint converts the GenesisDocument to tendermint's format.
+func (d *GenesisDocument) ToTendermint() (*tmtypes.GenesisDoc, error) {
+	doc := tmtypes.GenesisDoc{
+		ChainID:         "0xa515",
+		GenesisTime:     d.GenesisTime,
+		ConsensusParams: tmtypes.DefaultConsensusParams(),
+	}
+
+	var tmValidators []tmtypes.GenesisValidator
+	for _, v := range d.Validators {
+		pk := crypto.PublicKeyToTendermint(&v.PubKey)
+		validator := tmtypes.GenesisValidator{
+			Address: pk.Address(),
+			PubKey:  pk,
+			Power:   v.Power,
+			Name:    v.Name,
+		}
+		tmValidators = append(tmValidators, validator)
+	}
+
+	doc.Validators = tmValidators
+
+	return &doc, nil
+}
+
+// GenesisValidator is the ekiden format tendermint GenesisValidator
+type GenesisValidator struct {
+	PubKey      signature.PublicKey `json:"pub_key"`
+	Name        string              `json:"name"`
+	Power       int64               `json:"power"`
+	CoreAddress string              `json:"core_address"`
+}
+
+type server struct {
+	sync.Mutex
+	service.BaseBackgroundService
+
+	logger *logging.Logger
+	srv    *http.Server
+
+	bootstrappedCh chan struct{}
+
+	genesisPath   string
+	genesisDoc    []byte
+	validators    []*GenesisValidator
+	numValidators int
+}
+
+func (s *server) Start() error {
+	err := s.srv.ListenAndServe()
+	if err == nil {
+		go func() {
+			<-s.Quit()
+			s.srv.Close()
+		}()
+	}
+	return err
+}
+
+func errMethodNotAllowed(w http.ResponseWriter, allowed string) {
+	w.Header().Set("Allow", allowed)
+	w.WriteHeader(http.StatusMethodNotAllowed)
+}
+
+func (s *server) handleValidator(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		errMethodNotAllowed(w, http.MethodPost)
+		return
+	}
+
+	b, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		http.Error(w, "failed to read validator", http.StatusInternalServerError)
+		return
+	}
+
+	var validator GenesisValidator
+	if err = json.Unmarshal(b, &validator); err != nil {
+		http.Error(w, "malformed validator: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// If this was something that should actually be used, sanity checking
+	// the validator would be done here.
+	validator.Power = 10
+
+	s.Lock()
+	defer s.Unlock()
+
+	if s.genesisDoc != nil {
+		http.Error(w, "already have a genesis doc", http.StatusBadRequest)
+		return
+	}
+
+	s.logger.Debug("received validator upload",
+		"validator", string(b),
+	)
+
+	s.validators = append(s.validators, &validator)
+	if len(s.validators) == s.numValidators {
+		go s.buildGenesis()
+	}
+
+	_, _ = io.WriteString(w, "validator upload successful")
+}
+
+func (s *server) handleGenesis(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		errMethodNotAllowed(w, http.MethodGet)
+		return
+	}
+
+	// Block till a genesis document is available.
+	select {
+	case <-s.Quit():
+		http.Error(w, "server shutting down", http.StatusInternalServerError)
+		return
+	case <-s.bootstrappedCh:
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(s.genesisDoc)
+}
+
+func (s *server) buildGenesis() {
+	s.logger.Debug("building genesis document")
+
+	s.Lock()
+	defer s.Unlock()
+
+	doc := &GenesisDocument{
+		Validators:  s.validators,
+		GenesisTime: time.Now(),
+	}
+
+	s.genesisDoc, _ = json.Marshal(doc)
+	if s.genesisPath != "" {
+		_ = ioutil.WriteFile(s.genesisPath, s.genesisDoc, 0600)
+	}
+
+	s.logger.Info("generated genesis document",
+		"genesis_doc", string(s.genesisDoc),
+	)
+
+	close(s.bootstrappedCh)
+}
+
+// NewServer initializes a new testnet (debug) bootstrap server instance.
+func NewServer(addr string, numValidators int, dataDir string) (service.BackgroundService, error) {
+	baseSvc := *service.NewBaseBackgroundService("tendermint/bootstrap/server")
+	s := &server{
+		BaseBackgroundService: baseSvc,
+		logger:                logging.GetLogger("tendermint/boostrap/server"),
+		srv: &http.Server{
+			Addr:     addr,
+			ErrorLog: golog.New(ioutil.Discard, "tendermint/bootstrap/server/http", 0),
+		},
+		bootstrappedCh: make(chan struct{}),
+		numValidators:  numValidators,
+	}
+
+	// Load the old genesis file iff it exists.
+	if dataDir != "" {
+		s.genesisPath = filepath.Join(dataDir, "genesis.json")
+
+		b, err := ioutil.ReadFile(s.genesisPath)
+		if err == nil {
+			s.logger.Info("Using existing genesis document",
+				"path", s.genesisPath,
+				"genesis_doc", string(b),
+			)
+			s.genesisDoc = b
+		}
+	}
+
+	// Initialize the http mux.
+	mux := http.NewServeMux()
+	mux.HandleFunc(validatorURIPath, s.handleValidator)
+	mux.HandleFunc(genesisURIPath, s.handleGenesis)
+	s.srv.Handler = mux
+
+	return s, nil
+}
+
+// Client retrives the genesis document from the specified server.
+func Client(addr string) (*GenesisDocument, error) {
+	resp, err := http.Get("http://" + addr + genesisURIPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "tendermint/bootstrap: HTTP GET failed")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Wrap(statusToError(resp.StatusCode), "tendermint/bootstrap: HTTP GET failed")
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "tendermint/bootstrap: failed to read body")
+	}
+
+	var doc GenesisDocument
+	if err = json.Unmarshal(b, &doc); err != nil {
+		return nil, errors.Wrap(err, "tendermint/bootstrap: failed to parse genesis document")
+	}
+
+	return &doc, nil
+}
+
+// Validator posts the node's GenesisValidator to the specified server,
+// and retrives the genesis document.
+func Validator(addr string, validator *GenesisValidator) (*GenesisDocument, error) {
+	b, _ := json.Marshal(validator)
+	resp, err := http.Post("http://"+addr+validatorURIPath, "application/json", bytes.NewBuffer(b))
+	if err != nil {
+		return nil, errors.Wrap(err, "tendermint/bootstrap: HTTP POST failed")
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Wrap(statusToError(resp.StatusCode), "tendermint/bootstrap: HTTP POST failed")
+	}
+
+	return Client(addr)
+}
+
+func statusToError(statusCode int) error {
+	return fmt.Errorf("%s", http.StatusText(statusCode))
+}


### PR DESCRIPTION
New ekiden commands:
 * `ekiden debug tendermint bootstrap` - Run the bootstrap server.

New ekiden options:
 * `tendermint.debug.bootstrap.address` - Bootstrap server address.
 * `tendermint.debug.bootstrap.node_addr` - Validator node tendermint
     address.
 * `tendermint.debug.bootstrap.node_name` - Validator node name.

Works, tested with a locally hacked up copy of the e2e test scripts.

Fixes #1288.