### PR TITLE
go/worker: Add `worker.runtime.sgx_ids`

### DIFF
--- a/go/common/crypto/signature/signature.go
+++ b/go/common/crypto/signature/signature.go
@@ -160,6 +160,16 @@ func (k PublicKey) MarshalPEM() (data []byte, err error) {
 	return marshalPEM(pubPEMType, k[:])
 }
 
+// UnmarshalHex deserializes a hexadecimal text string into the given type.
+func (k *PublicKey) UnmarshalHex(text string) error {
+	b, err := hex.DecodeString(text)
+	if err != nil {
+		return err
+	}
+
+	return k.UnmarshalBinary(b)
+}
+
 // Equal compares vs another public key for equality.
 func (k PublicKey) Equal(cmp PublicKey) bool {
 	return bytes.Equal(k, cmp)

--- a/go/worker/registration.go
+++ b/go/worker/registration.go
@@ -17,6 +17,7 @@ func (w *Worker) registryRegisterRuntime(cfg *RuntimeConfig) error {
 
 	rtDesc := registry.Runtime{
 		ID:                     cfg.ID,
+		FeaturesSGX:            cfg.SGX,
 		ReplicaGroupSize:       cfg.ReplicaGroupSize,
 		ReplicaGroupBackupSize: cfg.ReplicaGroupBackupSize,
 		StorageGroupSize:       1,

--- a/go/worker/worker.go
+++ b/go/worker/worker.go
@@ -31,6 +31,7 @@ type RuntimeConfig struct {
 	Binary string
 
 	// XXX: This is needed until we decide how we want to actually register runtimes.
+	SGX                    bool
 	ReplicaGroupSize       uint64
 	ReplicaGroupBackupSize uint64
 }


### PR DESCRIPTION
As a stopgap while the real runtime registration is developed, add a
command line option that allows specifying a comma separated list of
runtime IDs that should be registered as requiring SGX when
scheduling.