### PR TITLE
worker: Make storage interface read-only, handle insert on the host

### DIFF
--- a/go/worker/host/handler.go
+++ b/go/worker/host/handler.go
@@ -112,24 +112,6 @@ func (h *hostHandler) Handle(ctx context.Context, body *protocol.Body) (*protoco
 		}
 		return &protocol.Body{HostStorageGetBatchResponse: &protocol.HostStorageGetBatchResponse{Values: values}}, nil
 	}
-	if body.HostStorageInsertRequest != nil {
-		err := h.storage.Insert(
-			ctx,
-			body.HostStorageInsertRequest.Value,
-			body.HostStorageInsertRequest.Expiry,
-		)
-		if err != nil {
-			return nil, err
-		}
-		return &protocol.Body{HostStorageInsertResponse: &protocol.Empty{}}, nil
-	}
-	if body.HostStorageInsertBatchRequest != nil {
-		err := h.storage.InsertBatch(ctx, body.HostStorageInsertBatchRequest.Values)
-		if err != nil {
-			return nil, err
-		}
-		return &protocol.Body{HostStorageInsertBatchResponse: &protocol.Empty{}}, nil
-	}
 
 	return nil, errMethodNotSupported
 }

--- a/go/worker/host/protocol/types.go
+++ b/go/worker/host/protocol/types.go
@@ -69,24 +69,20 @@ type Body struct {
 	WorkerAbortResponse                 *Empty
 
 	// Host interface.
-	HostRPCCallRequest             *HostRPCCallRequest
-	HostRPCCallResponse            *HostRPCCallResponse
-	HostIasGetSpidRequest          *Empty
-	HostIasGetSpidResponse         *HostIasGetSpidResponse
-	HostIasGetQuoteTypeRequest     *Empty
-	HostIasGetQuoteTypeResponse    *HostIasGetQuoteTypeResponse
-	HostIasSigRlRequest            *HostIasSigRlRequest
-	HostIasSigRlResponse           *HostIasSigRlResponse
-	HostIasReportRequest           *HostIasReportRequest
-	HostIasReportResponse          *HostIasReportResponse
-	HostStorageGetRequest          *HostStorageGetRequest
-	HostStorageGetResponse         *HostStorageGetResponse
-	HostStorageGetBatchRequest     *HostStorageGetBatchRequest
-	HostStorageGetBatchResponse    *HostStorageGetBatchResponse
-	HostStorageInsertRequest       *HostStorageInsertRequest
-	HostStorageInsertResponse      *Empty
-	HostStorageInsertBatchRequest  *HostStorageInsertBatchRequest
-	HostStorageInsertBatchResponse *Empty
+	HostRPCCallRequest          *HostRPCCallRequest
+	HostRPCCallResponse         *HostRPCCallResponse
+	HostIasGetSpidRequest       *Empty
+	HostIasGetSpidResponse      *HostIasGetSpidResponse
+	HostIasGetQuoteTypeRequest  *Empty
+	HostIasGetQuoteTypeResponse *HostIasGetQuoteTypeResponse
+	HostIasSigRlRequest         *HostIasSigRlRequest
+	HostIasSigRlResponse        *HostIasSigRlResponse
+	HostIasReportRequest        *HostIasReportRequest
+	HostIasReportResponse       *HostIasReportResponse
+	HostStorageGetRequest       *HostStorageGetRequest
+	HostStorageGetResponse      *HostStorageGetResponse
+	HostStorageGetBatchRequest  *HostStorageGetBatchRequest
+	HostStorageGetBatchResponse *HostStorageGetBatchResponse
 }
 
 // Empty is an empty message body.
@@ -134,6 +130,8 @@ type ComputedBatch struct {
 	Calls runtime.Batch `codec:"calls"`
 	// Batch of runtime outputs.
 	Outputs runtime.Batch `codec:"outputs"`
+	// Batch of storage inserts.
+	StorageInserts []storage.Value `codec:"storage_inserts"`
 	// New state root hash.
 	NewStateRoot hash.Hash `codec:"new_state_root"`
 }
@@ -145,9 +143,8 @@ func (b *ComputedBatch) String() string {
 
 // WorkerRuntimeCallBatchRequest is a worker batch runtime call request message body.
 type WorkerRuntimeCallBatchRequest struct {
-	Calls         runtime.Batch  `codec:"calls"`
-	Block         roothash.Block `codec:"block"`
-	CommitStorage bool           `codec:"commit_storage"`
+	Calls runtime.Batch  `codec:"calls"`
+	Block roothash.Block `codec:"block"`
 }
 
 // WorkerRuntimeCallBatchResponse is a worker batch runtime call response message body.
@@ -227,15 +224,4 @@ type HostStorageGetBatchRequest struct {
 // HostStorageGetBatchResponse is a host storage batch get response message body.
 type HostStorageGetBatchResponse struct {
 	Values [][]byte `codec:"values"`
-}
-
-// HostStorageInsertRequest is a host storage insert request message body.
-type HostStorageInsertRequest struct {
-	Value  []byte `codec:"value"`
-	Expiry uint64 `codec:"expiry"`
-}
-
-// HostStorageInsertBatchRequest is a host storage batch insert request message body.
-type HostStorageInsertBatchRequest struct {
-	Values []storage.Value `codec:"values"`
 }

--- a/worker/api/src/lib.rs
+++ b/worker/api/src/lib.rs
@@ -56,12 +56,7 @@ pub trait Worker: Send + Sync {
     fn rpc_call(&self, request: Vec<u8>) -> BoxFuture<Vec<u8>>;
 
     /// Request the worker to execute a runtime call batch.
-    fn runtime_call_batch(
-        &self,
-        calls: CallBatch,
-        block: Block,
-        commit_storage: bool,
-    ) -> BoxFuture<ComputedBatch>;
+    fn runtime_call_batch(&self, calls: CallBatch, block: Block) -> BoxFuture<ComputedBatch>;
 }
 
 /// Interface exposed by the host.
@@ -86,10 +81,4 @@ pub trait Host: Send + Sync {
 
     /// Request host to fetch a batch of keys from storage.
     fn storage_get_batch(&self, keys: Vec<H256>) -> BoxFuture<Vec<Option<Vec<u8>>>>;
-
-    /// Request host to insert value into storage.
-    fn storage_insert(&self, value: Vec<u8>, expiry: u64) -> BoxFuture<()>;
-
-    /// Request host to insert a batch of values into storage.
-    fn storage_insert_batch(&self, values: Vec<(Vec<u8>, u64)>) -> BoxFuture<()>;
 }

--- a/worker/api/src/types.rs
+++ b/worker/api/src/types.rs
@@ -17,6 +17,8 @@ pub struct ComputedBatch {
     pub calls: CallBatch,
     /// Batch of runtime outputs.
     pub outputs: OutputBatch,
+    /// Batch of storage inserts.
+    pub storage_inserts: Vec<(ByteBuf, u64)>,
     /// New state root hash.
     pub new_state_root: H256,
 }
@@ -64,7 +66,6 @@ pub enum Body {
     WorkerRuntimeCallBatchRequest {
         calls: CallBatch,
         block: Block,
-        commit_storage: bool,
     },
     WorkerRuntimeCallBatchResponse {
         batch: ComputedBatch,
@@ -121,16 +122,6 @@ pub enum Body {
     HostStorageGetBatchResponse {
         values: Vec<Option<ByteBuf>>,
     },
-    HostStorageInsertRequest {
-        #[serde(with = "serde_bytes")]
-        value: Vec<u8>,
-        expiry: u64,
-    },
-    HostStorageInsertResponse {},
-    HostStorageInsertBatchRequest {
-        values: Vec<(ByteBuf, u64)>,
-    },
-    HostStorageInsertBatchResponse {},
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/worker/src/protocol.rs
+++ b/worker/src/protocol.rs
@@ -78,15 +78,10 @@ impl ekiden_worker_api::Worker for ProtocolHandler {
         self.with_worker(|worker| worker.rpc_call(request))
     }
 
-    fn runtime_call_batch(
-        &self,
-        calls: CallBatch,
-        block: Block,
-        commit_storage: bool,
-    ) -> BoxFuture<ComputedBatch> {
+    fn runtime_call_batch(&self, calls: CallBatch, block: Block) -> BoxFuture<ComputedBatch> {
         // TODO: Correlate to an event source
         let sh = Span::inactive().handle();
 
-        self.with_worker(|worker| worker.runtime_call_batch(calls, block, sh, commit_storage))
+        self.with_worker(|worker| worker.runtime_call_batch(calls, block, sh))
     }
 }


### PR DESCRIPTION
Fixes #1332.

Previously the worker process could issue Insert/InsertBatch calls into storage
by itself (via the IPC protocol through the worker host). This required an
additional round-trip and any storage timeouts were attributed directly to the
worker process.

This commit changes the protocol so that workers explicitly return storage
batches together with outputs in WorkerRuntimeCallBatchResponse. It also handles
storage insert timeouts explicitly.