### PR TITLE
Move proxy sockets into the node's datadir

### DIFF
--- a/go/ekiden/cmd/node/node.go
+++ b/go/ekiden/cmd/node/node.go
@@ -231,6 +231,7 @@ func NewNode() (*Node, error) {
 
 	// Initialize the worker.
 	node.Worker, err = worker.New(
+		cmdCommon.DataDir(),
 		node.Identity,
 		node.Storage,
 		node.RootHash,

--- a/go/worker/init.go
+++ b/go/worker/init.go
@@ -100,6 +100,7 @@ func getSGXRuntimeIDs() (map[signature.MapKey]bool, error) {
 
 // New creates a new worker.
 func New(
+	dataDir string,
 	identity *identity.Identity,
 	storage storage.Backend,
 	roothash roothash.Backend,
@@ -195,7 +196,7 @@ func New(
 		Runtimes:        runtimes,
 	}
 
-	return newWorker(identity, storage, roothash, registry, epochtime, scheduler, ias, keyManager, cfg)
+	return newWorker(dataDir, identity, storage, roothash, registry, epochtime, scheduler, ias, keyManager, cfg)
 }
 
 // RegisterFlags registers the configuration flags with the provided

--- a/go/worker/proxy.go
+++ b/go/worker/proxy.go
@@ -126,6 +126,11 @@ func (p *streamProxy) handleConnection(innerSocket net.Conn) {
 
 // Start makes the proxy start listening on its Unix socket.
 func (p *streamProxy) Start() error {
+	err := os.Remove(p.localPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
 	listener, err := net.Listen("unix", p.localPath)
 	if err != nil {
 		p.BaseBackgroundService.Stop()
@@ -189,6 +194,11 @@ func (p *dgramProxy) proxy(localSocket *net.UnixConn, remoteSocket net.Conn) {
 
 // Start makes the proxy start listening on its Unix socket.
 func (p *dgramProxy) Start() error {
+	err := os.Remove(p.localPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
 	localSocket, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: p.localPath})
 	if err != nil {
 		p.BaseBackgroundService.Stop()

--- a/go/worker/worker.go
+++ b/go/worker/worker.go
@@ -3,9 +3,8 @@ package worker
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -31,6 +30,7 @@ import (
 )
 
 const (
+	proxySocketDirName     = "proxy-sockets"
 	metricsProxySocketName = "metrics.sock"
 	tracingProxySocketName = "tracing.sock"
 )
@@ -354,6 +354,7 @@ func (w *Worker) registerRuntime(cfg *Config, rtCfg *RuntimeConfig) error {
 }
 
 func newWorker(
+	dataDir string,
 	identity *identity.Identity,
 	storage storage.Backend,
 	roothash roothash.Backend,
@@ -370,7 +371,8 @@ func newWorker(
 	}
 
 	startedOk := false
-	socketDir, err := ioutil.TempDir("", "ekiden-proxy-sockets")
+	socketDir := filepath.Join(dataDir, proxySocketDirName)
+	err := common.Mkdir(socketDir)
 	if err != nil {
 		return nil, err
 	}
@@ -433,7 +435,7 @@ func newWorker(
 			if err != nil {
 				return nil, err
 			}
-			proxy, err := NewNetworkProxy(host.MetricsProxyKey, "stream", path.Join(w.socketDir, metricsProxySocketName), address)
+			proxy, err := NewNetworkProxy(host.MetricsProxyKey, "stream", filepath.Join(w.socketDir, metricsProxySocketName), address)
 			if err != nil {
 				return nil, err
 			}
@@ -446,7 +448,7 @@ func newWorker(
 			if err != nil {
 				return nil, err
 			}
-			proxy, err := NewNetworkProxy(host.TracingProxyKey, "dgram", path.Join(w.socketDir, tracingProxySocketName), address)
+			proxy, err := NewNetworkProxy(host.TracingProxyKey, "dgram", filepath.Join(w.socketDir, tracingProxySocketName), address)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
The proxy socket directories were left over after each run in e2e tests. This moves the socket directory into the node's data directory and removes any stale sockets on startup.