### PR TITLE
go/tendermint: Fix t.Unsubscribe() with defered start

### DIFF
--- a/go/tendermint/tendermint.go
+++ b/go/tendermint/tendermint.go
@@ -223,7 +223,11 @@ func (t *tendermintService) Subscribe(ctx context.Context, subscriber string, qu
 }
 
 func (t *tendermintService) Unsubscribe(ctx context.Context, subscriber string, query tmpubsub.Query) error {
-	return t.node.EventBus().Unsubscribe(ctx, subscriber, query)
+	if t.started() {
+		return t.node.EventBus().Unsubscribe(ctx, subscriber, query)
+	}
+
+	return errors.New("tendermint: unsubscribe called with no backing service")
 }
 
 func (t *tendermintService) Genesis() (*tmrpctypes.ResultGenesis, error) {


### PR DESCRIPTION
The counterpart to `t.Subscribe()` to account for the defered node
initialization.  If the node is not present, the unsubscribe call
will not actually get propagated, but the code only unsubscribes on
teardown.