### PR TITLE
go: Add `--grpc.debug.port`

### DIFF
--- a/.buildkite/scripts/common_e2e.sh
+++ b/.buildkite/scripts/common_e2e.sh
@@ -100,11 +100,13 @@ run_backend_tendermint_committee() {
         local datadir=${base_datadir}-${idx}
 
         let tm_port=(idx-1)+26656
+        let grpc_debug_port=tm_port+36656
 
         ${WORKDIR}/go/ekiden/ekiden \
             --log.level debug \
             --log.file ${committee_dir}/validator-${idx}.log \
             --grpc.log.verbose_debug \
+            --grpc.debug.port ${grpc_debug_port} \
             --epochtime.backend ${epochtime_backend} \
             --epochtime.tendermint.interval 30 \
             --beacon.backend tendermint \

--- a/go/ekiden/cmd/common/grpc/grpc.go
+++ b/go/ekiden/cmd/common/grpc/grpc.go
@@ -15,11 +15,11 @@ import (
 )
 
 const (
-	cfgGRPCPort = "grpc.port"
+	cfgGRPCPort  = "grpc.port"
+	cfgDebugPort = "grpc.debug.port"
+	cfgAddress   = "address"
 
-	cfgAddress     = "address"
-	defaultAddress = "127.0.0.1:42261"
-
+	defaultAddress      = "127.0.0.1:42261"
 	localSocketFilename = "internal.sock"
 )
 
@@ -44,8 +44,10 @@ func NewServerLocal() (*cmnGrpc.Server, error) {
 		return nil, errors.New("data directory must be set")
 	}
 
+	debugPort := uint16(viper.GetInt(cfgDebugPort))
+
 	path := filepath.Join(dataDir, localSocketFilename)
-	return cmnGrpc.NewServerLocal("internal", path)
+	return cmnGrpc.NewServerLocal("internal", path, debugPort)
 }
 
 // RegisterServerTCPFlags registers the flags used by the gRPC server.
@@ -66,6 +68,16 @@ func RegisterServerTCPFlags(cmd *cobra.Command) {
 // RegisterServerLocalFlags registers the flags used by the gRPC server.
 func RegisterServerLocalFlags(cmd *cobra.Command) {
 	cmnGrpc.RegisterServerFlags(cmd)
+
+	if !cmd.Flags().Parsed() {
+		cmd.Flags().Uint16(cfgDebugPort, 0, "gRPC server debug port (INSECURE/UNSAFE)")
+	}
+
+	for _, v := range []string{
+		cfgDebugPort,
+	} {
+		_ = viper.BindPFlag(v, cmd.Flags().Lookup(v))
+	}
 }
 
 // RegisterClientFlags registers the flags for a gRPC client.


### PR DESCRIPTION
This *debug only* option will expose the internal gRPC service endpoint
on `:port` (as in, externally accessible), for the sake of development
convenience.

Using this option MUST be done with care, as the exposed services are
not intended to be globally accessible.