### PR TITLE
go/storage: Add support for InsertOptions

### DIFF
--- a/go/ekiden/cmd/storage/benchmark/benchmark.go
+++ b/go/ekiden/cmd/storage/benchmark/benchmark.go
@@ -85,7 +85,7 @@ func doBenchmark(cmd *cobra.Command, args []string) {
 				_, _ = io.ReadFull(rand.Reader, buf)
 				b.StartTimer()
 
-				if err = storage.Insert(context.Background(), buf, 9001); err != nil {
+				if err = storage.Insert(context.Background(), buf, 9001, storageAPI.InsertOptions{}); err != nil {
 					b.Fatalf("failed to Insert(): %v", err)
 				}
 			}

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -346,7 +346,7 @@ func mustGetCommittee(t *testing.T, rt *registryTests.TestRuntime, epoch epochti
 func mustStore(t *testing.T, store storage.Backend, value []byte) hash.Hash {
 	require := require.New(t)
 
-	err := store.Insert(context.Background(), value, uint64(1)<<63)
+	err := store.Insert(context.Background(), value, uint64(1)<<63, storage.InsertOptions{})
 	require.NoError(err, "Insert")
 
 	key := storage.HashStorageKey(value)

--- a/go/storage/api/api.go
+++ b/go/storage/api/api.go
@@ -61,6 +61,14 @@ func (v Value) String() string {
 	return hex.EncodeToString(v.Data)
 }
 
+// InsertOptions specify the behavior of insert operations.
+type InsertOptions struct {
+	// LocalOnly specifies that certain backends which support combined
+	// local/remote inserts (e.g., caching backends) should only insert
+	// into the local cache and not propagate inserts remotely.
+	LocalOnly bool
+}
+
 // Backend is a storage backend implementation.
 type Backend interface {
 	// Get returns the value for a specific immutable key.
@@ -72,7 +80,7 @@ type Backend interface {
 	// Insert inserts a specific value, which can later be retreived by
 	// it's hash.  The expiration is the number of epochs for which the
 	// value should remain available.
-	Insert(context.Context, []byte, uint64) error
+	Insert(context.Context, []byte, uint64, InsertOptions) error
 
 	// InsertBatch inserts multiple values into storage. They can be later
 	// retrieved by their hashes. The expiration is the number of epochs
@@ -80,7 +88,7 @@ type Backend interface {
 	//
 	// If the storage backend is unable to store any of the values, no
 	// values will be stored.
-	InsertBatch(context.Context, []Value) error
+	InsertBatch(context.Context, []Value, InsertOptions) error
 
 	// GetKeys returns all of the keys in the storage database, along
 	// with their associated metadata.

--- a/go/storage/client/client.go
+++ b/go/storage/client/client.go
@@ -61,7 +61,7 @@ func (b *storageClientBackend) GetBatch(ctx context.Context, keys []api.Key) ([]
 	return resp.GetData(), nil
 }
 
-func (b *storageClientBackend) Insert(ctx context.Context, value []byte, expiration uint64) error {
+func (b *storageClientBackend) Insert(ctx context.Context, value []byte, expiration uint64, opts api.InsertOptions) error {
 	var req storage.InsertRequest
 
 	req.Data = value
@@ -71,7 +71,7 @@ func (b *storageClientBackend) Insert(ctx context.Context, value []byte, expirat
 	return err
 }
 
-func (b *storageClientBackend) InsertBatch(ctx context.Context, values []api.Value) error {
+func (b *storageClientBackend) InsertBatch(ctx context.Context, values []api.Value, opts api.InsertOptions) error {
 	var req storage.InsertBatchRequest
 
 	req.Items = make([]*storage.InsertRequest, 0, len(values))

--- a/go/storage/grpc.go
+++ b/go/storage/grpc.go
@@ -55,7 +55,7 @@ func (s *grpcServer) GetBatch(ctx context.Context, req *pb.GetBatchRequest) (*pb
 }
 
 func (s *grpcServer) Insert(ctx context.Context, req *pb.InsertRequest) (*pb.InsertResponse, error) {
-	if err := s.backend.Insert(ctx, req.GetData(), req.GetExpiry()); err != nil {
+	if err := s.backend.Insert(ctx, req.GetData(), req.GetExpiry(), api.InsertOptions{}); err != nil {
 		return nil, err
 	}
 	return &pb.InsertResponse{}, nil
@@ -70,7 +70,7 @@ func (s *grpcServer) InsertBatch(ctx context.Context, req *pb.InsertBatchRequest
 		})
 	}
 
-	if err := s.backend.InsertBatch(ctx, values); err != nil {
+	if err := s.backend.InsertBatch(ctx, values, api.InsertOptions{}); err != nil {
 		return nil, err
 	}
 

--- a/go/storage/leveldb/leveldb.go
+++ b/go/storage/leveldb/leveldb.go
@@ -89,11 +89,11 @@ func (b *leveldbBackend) GetBatch(ctx context.Context, keys []api.Key) ([][]byte
 	return values, nil
 }
 
-func (b *leveldbBackend) Insert(ctx context.Context, value []byte, expiration uint64) error {
-	return b.InsertBatch(ctx, []api.Value{api.Value{Data: value, Expiration: expiration}})
+func (b *leveldbBackend) Insert(ctx context.Context, value []byte, expiration uint64, opts api.InsertOptions) error {
+	return b.InsertBatch(ctx, []api.Value{api.Value{Data: value, Expiration: expiration}}, opts)
 }
 
-func (b *leveldbBackend) InsertBatch(ctx context.Context, values []api.Value) error {
+func (b *leveldbBackend) InsertBatch(ctx context.Context, values []api.Value, opts api.InsertOptions) error {
 	b.logger.Debug("InsertBatch",
 		"values", values,
 	)

--- a/go/storage/memory/memory.go
+++ b/go/storage/memory/memory.go
@@ -73,7 +73,7 @@ func (b *memoryBackend) GetBatch(ctx context.Context, keys []api.Key) ([][]byte,
 	return values, nil
 }
 
-func (b *memoryBackend) Insert(ctx context.Context, value []byte, expiration uint64) error {
+func (b *memoryBackend) Insert(ctx context.Context, value []byte, expiration uint64, opts api.InsertOptions) error {
 	epoch := b.sweeper.GetEpoch()
 	if epoch == epochtime.EpochInvalid {
 		return api.ErrIncoherentTime
@@ -106,10 +106,10 @@ func (b *memoryBackend) Insert(ctx context.Context, value []byte, expiration uin
 	return nil
 }
 
-func (b *memoryBackend) InsertBatch(ctx context.Context, values []api.Value) error {
+func (b *memoryBackend) InsertBatch(ctx context.Context, values []api.Value, opts api.InsertOptions) error {
 	// No atomicity for in-memory backend, we just repeatedly insert.
 	for _, value := range values {
-		if err := b.Insert(ctx, value.Data, value.Expiration); err != nil {
+		if err := b.Insert(ctx, value.Data, value.Expiration, opts); err != nil {
 			return err
 		}
 	}

--- a/go/storage/metrics.go
+++ b/go/storage/metrics.go
@@ -97,9 +97,9 @@ func (w *metricsWrapper) GetBatch(ctx context.Context, keys []api.Key) ([][]byte
 	return values, err
 }
 
-func (w *metricsWrapper) Insert(ctx context.Context, value []byte, expiration uint64) error {
+func (w *metricsWrapper) Insert(ctx context.Context, value []byte, expiration uint64, opts api.InsertOptions) error {
 	start := time.Now()
-	err := w.Backend.Insert(ctx, value, expiration)
+	err := w.Backend.Insert(ctx, value, expiration, opts)
 	storageLatency.With(labelInsert).Observe(time.Since(start).Seconds())
 	storageValueSize.With(labelInsert).Observe(float64(len(value)))
 	if err != nil {
@@ -111,9 +111,9 @@ func (w *metricsWrapper) Insert(ctx context.Context, value []byte, expiration ui
 	return err
 }
 
-func (w *metricsWrapper) InsertBatch(ctx context.Context, values []api.Value) error {
+func (w *metricsWrapper) InsertBatch(ctx context.Context, values []api.Value, opts api.InsertOptions) error {
 	start := time.Now()
-	err := w.Backend.InsertBatch(ctx, values)
+	err := w.Backend.InsertBatch(ctx, values, opts)
 	storageLatency.With(labelInsertBatch).Observe(time.Since(start).Seconds())
 
 	var size int

--- a/go/storage/tests/tester.go
+++ b/go/storage/tests/tester.go
@@ -38,7 +38,7 @@ func StorageImplementationTests(t *testing.T, backend api.Backend, timeSource ep
 	}
 
 	for i, v := range testValues {
-		err := backend.Insert(context.Background(), v, 1)
+		err := backend.Insert(context.Background(), v, 1, api.InsertOptions{})
 		require.NoError(t, err, "Insert(%d)", i)
 	}
 
@@ -55,7 +55,7 @@ func StorageImplementationTests(t *testing.T, backend api.Backend, timeSource ep
 		batchValues = append(batchValues, api.Value{Data: v, Expiration: 1})
 	}
 
-	err := backend.InsertBatch(context.Background(), batchValues)
+	err := backend.InsertBatch(context.Background(), batchValues, api.InsertOptions{})
 	require.NoError(t, err, "InsertBatch(testValuesBatch)")
 
 	v, err := backend.GetBatch(context.Background(), hashes)


### PR DESCRIPTION
Fixes #1376.

Currently there is only a LocalOnly insert option which specifies that backends
like cachingclient should only insert to the local cache and not propagate the
insert remotely. This is used to keep the local cache warm on workers while
still inserting things correctly on the leader/backup workers.