### PR TITLE
go/storage/client: Ensure remote storage is accessible

### DIFF
--- a/go/roothash/tendermint/tendermint.go
+++ b/go/roothash/tendermint/tendermint.go
@@ -458,6 +458,9 @@ func New(
 		return nil, errors.New("roothash/tendermint: need a block-based scheduler backend")
 	}
 
+	// HACK/#1380: Wait for storage to actually be fully initialized.
+	<-storage.Initialized()
+
 	// Initialize and register the tendermint service component.
 	app := tmroothash.New(blockTimeSource, blockScheduler, storage, genesisBlocks, roundTimeout)
 	if err := service.RegisterApplication(app); err != nil {


### PR DESCRIPTION
It is neccesarry to ensure that remote storage is accessible before
the tendermint node is created due to the current ABCI roothash
implementation's use of storage.  Failures during block replay due
to initialization can/will result in non-deterministic behavior.

Fixes #1380.