### PR TITLE
Use oasislabs/time instead of upstream time

### DIFF
--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -14,8 +14,8 @@ cc = "1.0"
 backtrace-sys = "=0.1.24"
 # (pinning transitive dependency) backtrace 0.3.10 incompatible with failure 0.1
 backtrace = "=0.3.9"
-# (pinning transitive dependency) time 0.1.41 is broken?
-time = "0.1"
+# upstream time 0.1.41+ is currently broken with sgx and unix flags enabled. (see issue ekiden#1235)
+time = { git = "https://github.com/oasislabs/time", version = "0.1" }
 # (pinning transitive dependency) rustc-demangle 0.1.10 requires `rename-dependency` feature
 rustc-demangle = "=0.1.9"
 # (pinning transitive dependency) in 0.4.18,


### PR DESCRIPTION
Use github.com/oasislabs/time instead of github.com/rust-lang-deprecated/time in ekiden/tools/Cargo.toml until https://github.com/rust-lang-deprecated/time/pull/176 is merged upstream.