### PR TITLE
Add agent requirements to buildkite jobs

### DIFF
--- a/.buildkite/deploy.pipeline.yml
+++ b/.buildkite/deploy.pipeline.yml
@@ -4,6 +4,8 @@
 steps:
   - label: Get docker tag and save it as metadata for use later
     command: .buildkite/scripts/set_docker_tag_meta_data.sh
+    agents:
+      buildkite_agent_class: stable
 
   - wait
 
@@ -13,6 +15,7 @@ steps:
       - .buildkite/scripts/build_tag_push_deployment_image.sh
     agents:
       buildkite_agent_size: large
+      buildkite_agent_class: stable
 
   - label: Build hardware docker image (master branches only)
     branches: master
@@ -21,6 +24,9 @@ steps:
     env:
       SGX_MODE: HW
       DEPLOYMENT_VARIANT: hw
+    agents:
+      buildkite_agent_size: large
+      buildkite_agent_class: stable
 
   - block: Human approval required to deploy docker image
     branches: "*"
@@ -36,6 +42,8 @@ steps:
     branches: master
     command:
       - .buildkite/scripts/promote_deployment_image_to.sh latest
+    agents:
+      buildkite_agent_class: stable
 
   - label: Deploy hardware docker image (master branches only)
     branches: master
@@ -43,3 +51,5 @@ steps:
       - .buildkite/scripts/promote_deployment_image_to.sh latest-hw
     env:
       DEPLOYMENT_VARIANT: hw
+    agents:
+      buildkite_agent_class: stable


### PR DESCRIPTION
Mark hardware docker image jobs as both large/stable.
Mark docker image promotion jobs as stable.

@pro-wh FYI, I added agent requirements to the hardware jobs you added to the pipeline. I'm confident in the tags and there is no harm marking them as large/stable for now. Feel free to change to suit your needs if I got them wrong.