### PR TITLE
Add a simple proof-of-storage mechanism

### DIFF
--- a/go/ekiden/cmd/node/node.go
+++ b/go/ekiden/cmd/node/node.go
@@ -103,11 +103,11 @@ func (n *Node) initBackends() error {
 		return err
 	}
 	n.svcMgr.RegisterCleanupOnly(n.Scheduler, "scheduler backend")
-	if n.Storage, err = storage.New(n.Epochtime, dataDir); err != nil {
+	if n.Storage, err = storage.New(n.Epochtime, dataDir, nil); err != nil {
 		return err
 	}
 	n.svcMgr.RegisterCleanupOnly(n.Storage, "storage backend")
-	if n.RootHash, err = roothash.New(n.svcMgr.Ctx, n.Epochtime, n.Scheduler, n.Storage, n.Registry, n.svcTmnt); err != nil {
+	if n.RootHash, err = roothash.New(n.svcMgr.Ctx, n.Epochtime, n.Scheduler, n.Registry, n.svcTmnt); err != nil {
 		return err
 	}
 	n.svcMgr.RegisterCleanupOnly(n.RootHash, "roothash backend")

--- a/go/ekiden/cmd/storage/benchmark/benchmark.go
+++ b/go/ekiden/cmd/storage/benchmark/benchmark.go
@@ -59,7 +59,7 @@ func doBenchmark(cmd *cobra.Command, args []string) {
 
 	// Initialize the various backends.
 	timeSource := mock.New()
-	storage, err := storage.New(timeSource, dataDir)
+	storage, err := storage.New(timeSource, dataDir, nil)
 	if err != nil {
 		logger.Error("failed to initialize storage",
 			"err", err,

--- a/go/ekiden/node_test.go
+++ b/go/ekiden/node_test.go
@@ -42,6 +42,7 @@ var (
 		{"roothash.backend", "tendermint"},
 		{"scheduler.backend", "trivial"},
 		{"storage.backend", "leveldb"},
+		{"storage.debug.mock_signing_key", true},
 		{"tendermint.consensus.skip_timeout_commit", true},
 		{"tendermint.debug.block_time_iota", 1 * time.Millisecond},
 		{"worker.backend", "mock"},

--- a/go/grpc/roothash/roothash.proto
+++ b/go/grpc/roothash/roothash.proto
@@ -22,13 +22,15 @@ message Header {
   bytes namespace = 2;
   bytes round = 3;
   uint64 timestamp = 4;
-  uint32 header_type = 11;
-  bytes previous_hash = 5;
-  bytes group_hash = 6;
-  bytes input_hash = 7;
-  bytes output_hash = 8;
-  bytes state_root = 9;
-  bytes commitments_hash = 10;
+  uint32 header_type = 5;
+  bytes previous_hash = 6;
+  bytes group_hash = 7;
+  bytes input_hash = 8;
+  bytes output_hash = 9;
+  bytes state_root = 10;
+  bytes commitments_hash = 11;
+
+  bytes storage_receipt = 12;
 }
 
 // This is used for exporting a runtime's latest block to a file.

--- a/go/grpc/storage/storage.proto
+++ b/go/grpc/storage/storage.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/oasislabs/ekiden/go/grpc/storage";
 service Storage {
     rpc Get(GetRequest) returns (GetResponse) {}
     rpc GetBatch(GetBatchRequest) returns (GetBatchResponse) {}
+    rpc GetReceipt(GetReceiptRequest) returns (GetReceiptResponse) {}
     rpc Insert(InsertRequest) returns (InsertResponse) {}
     rpc InsertBatch(InsertBatchRequest) returns (InsertBatchResponse) {}
     rpc GetKeys(GetKeysRequest) returns (stream GetKeysResponse) {}
@@ -24,7 +25,15 @@ message GetBatchRequest {
 }
 
 message GetBatchResponse {
-    repeated bytes data = 2;
+    repeated bytes data = 1;
+}
+
+message GetReceiptRequest {
+    repeated bytes ids = 1;
+}
+
+message GetReceiptResponse {
+    bytes data = 1;
 }
 
 message InsertRequest {

--- a/go/roothash/init.go
+++ b/go/roothash/init.go
@@ -21,7 +21,6 @@ import (
 	"github.com/oasislabs/ekiden/go/roothash/memory"
 	"github.com/oasislabs/ekiden/go/roothash/tendermint"
 	scheduler "github.com/oasislabs/ekiden/go/scheduler/api"
-	storage "github.com/oasislabs/ekiden/go/storage/api"
 	"github.com/oasislabs/ekiden/go/tendermint/service"
 )
 
@@ -36,7 +35,6 @@ func New(
 	ctx context.Context,
 	timeSource epochtime.Backend,
 	scheduler scheduler.Backend,
-	storage storage.Backend,
 	registry registry.Backend,
 	tmService service.TendermintService,
 ) (api.Backend, error) {
@@ -73,9 +71,9 @@ func New(
 
 	switch strings.ToLower(backend) {
 	case memory.BackendName:
-		impl = memory.New(ctx, scheduler, storage, registry, genesisBlocks, roundTimeout)
+		impl = memory.New(ctx, scheduler, registry, genesisBlocks, roundTimeout)
 	case tendermint.BackendName:
-		impl, err = tendermint.New(ctx, timeSource, scheduler, storage, tmService, genesisBlocks, roundTimeout)
+		impl, err = tendermint.New(ctx, timeSource, scheduler, tmService, genesisBlocks, roundTimeout)
 	default:
 		return nil, fmt.Errorf("roothash: unsupported backend: '%v'", backend)
 	}

--- a/go/roothash/memory/memory_test.go
+++ b/go/roothash/memory/memory_test.go
@@ -2,10 +2,12 @@ package memory
 
 import (
 	"context"
+	"crypto/rand"
 	"testing"
 	"time"
 
 	"github.com/oasislabs/ekiden/go/beacon/insecure"
+	"github.com/oasislabs/ekiden/go/common/crypto/signature"
 	"github.com/oasislabs/ekiden/go/epochtime/mock"
 	registry "github.com/oasislabs/ekiden/go/registry/memory"
 	"github.com/oasislabs/ekiden/go/roothash/tests"
@@ -21,10 +23,11 @@ func TestRootHashMemory(t *testing.T) {
 	registry := registry.New(ctx, timeSource)
 	defer registry.Cleanup()
 	scheduler := trivial.New(ctx, timeSource, registry, beacon, nil)
-	storage := storage.New(timeSource)
+	storagePrivKey, _ := signature.NewPrivateKey(rand.Reader)
+	storage := storage.New(timeSource, &storagePrivKey)
 	defer storage.Cleanup()
 
-	backend := New(ctx, scheduler, storage, registry, nil, 10*time.Second)
+	backend := New(ctx, scheduler, registry, nil, 10*time.Second)
 
 	tests.RootHashImplementationTests(t, backend, timeSource, scheduler, storage, registry)
 }

--- a/go/roothash/tendermint/tendermint.go
+++ b/go/roothash/tendermint/tendermint.go
@@ -21,7 +21,6 @@ import (
 	"github.com/oasislabs/ekiden/go/roothash/api"
 	"github.com/oasislabs/ekiden/go/roothash/api/block"
 	scheduler "github.com/oasislabs/ekiden/go/scheduler/api"
-	storage "github.com/oasislabs/ekiden/go/storage/api"
 	tmapi "github.com/oasislabs/ekiden/go/tendermint/api"
 	tmroothash "github.com/oasislabs/ekiden/go/tendermint/apps/roothash"
 	"github.com/oasislabs/ekiden/go/tendermint/service"
@@ -433,7 +432,6 @@ func New(
 	ctx context.Context,
 	timeSource epochtime.Backend,
 	sched scheduler.Backend,
-	storage storage.Backend,
 	service service.TendermintService,
 	genesisBlocks map[signature.MapKey]*block.Block,
 	roundTimeout time.Duration,
@@ -450,11 +448,8 @@ func New(
 		return nil, errors.New("roothash/tendermint: need a block-based scheduler backend")
 	}
 
-	// HACK/#1380: Wait for storage to actually be fully initialized.
-	<-storage.Initialized()
-
 	// Initialize and register the tendermint service component.
-	app := tmroothash.New(ctx, blockTimeSource, blockScheduler, storage, genesisBlocks, roundTimeout)
+	app := tmroothash.New(ctx, blockTimeSource, blockScheduler, genesisBlocks, roundTimeout)
 	if err := service.RegisterApplication(app); err != nil {
 		return nil, err
 	}

--- a/go/storage/cachingclient/cachingclient.go
+++ b/go/storage/cachingclient/cachingclient.go
@@ -100,6 +100,10 @@ func (b *cachingClientBackend) GetBatch(ctx context.Context, keys []api.Key) ([]
 	return values, nil
 }
 
+func (b *cachingClientBackend) GetReceipt(ctx context.Context, keys []api.Key) (*api.SignedReceipt, error) {
+	return b.remote.GetReceipt(ctx, keys)
+}
+
 func (b *cachingClientBackend) Insert(ctx context.Context, value []byte, expiration uint64, opts api.InsertOptions) error {
 	// Write-through.
 	var err error

--- a/go/storage/grpc.go
+++ b/go/storage/grpc.go
@@ -54,6 +54,26 @@ func (s *grpcServer) GetBatch(ctx context.Context, req *pb.GetBatchRequest) (*pb
 	return &pb.GetBatchResponse{Data: values}, nil
 }
 
+func (s *grpcServer) GetReceipt(ctx context.Context, req *pb.GetReceiptRequest) (*pb.GetReceiptResponse, error) {
+	var keys []api.Key
+	for _, id := range req.GetIds() {
+		if len(id) != api.KeySize {
+			return nil, errors.New("storage: malformed key")
+		}
+
+		var k api.Key
+		copy(k[:], id)
+		keys = append(keys, k)
+	}
+
+	signed, err := s.backend.GetReceipt(ctx, keys)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.GetReceiptResponse{Data: signed.MarshalCBOR()}, nil
+}
+
 func (s *grpcServer) Insert(ctx context.Context, req *pb.InsertRequest) (*pb.InsertResponse, error) {
 	if err := s.backend.Insert(ctx, req.GetData(), req.GetExpiry(), api.InsertOptions{}); err != nil {
 		return nil, err

--- a/go/storage/init.go
+++ b/go/storage/init.go
@@ -2,6 +2,7 @@
 package storage
 
 import (
+	"crypto/rand"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/oasislabs/ekiden/go/common/crypto/signature"
 	epochtime "github.com/oasislabs/ekiden/go/epochtime/api"
 	"github.com/oasislabs/ekiden/go/storage/api"
 	"github.com/oasislabs/ekiden/go/storage/cachingclient"
@@ -17,20 +19,31 @@ import (
 	"github.com/oasislabs/ekiden/go/storage/memory"
 )
 
-const cfgBackend = "storage.backend"
+const (
+	cfgBackend             = "storage.backend"
+	cfgDebugMockSigningKey = "storage.debug.mock_signing_key"
+)
 
 // New constructs a new Backend based on the configuration flags.
-func New(timeSource epochtime.Backend, dataDir string) (api.Backend, error) {
+func New(timeSource epochtime.Backend, dataDir string, signingKey *signature.PrivateKey) (api.Backend, error) {
 	var impl api.Backend
 	var err error
+
+	if viper.GetBool(cfgDebugMockSigningKey) {
+		var keyTmp signature.PrivateKey
+		if keyTmp, err = signature.NewPrivateKey(rand.Reader); err != nil {
+			return nil, err
+		}
+		signingKey = &keyTmp
+	}
 
 	backend := viper.GetString(cfgBackend)
 	switch strings.ToLower(backend) {
 	case memory.BackendName:
-		impl = memory.New(timeSource)
+		impl = memory.New(timeSource, signingKey)
 	case leveldb.BackendName:
 		fn := filepath.Join(dataDir, leveldb.DBFile)
-		impl, err = leveldb.New(fn, timeSource)
+		impl, err = leveldb.New(fn, timeSource, signingKey)
 	case client.BackendName:
 		impl, err = client.New()
 	case cachingclient.BackendName:
@@ -50,10 +63,12 @@ func New(timeSource epochtime.Backend, dataDir string) (api.Backend, error) {
 func RegisterFlags(cmd *cobra.Command) {
 	if !cmd.Flags().Parsed() {
 		cmd.Flags().String(cfgBackend, memory.BackendName, "Storage backend")
+		cmd.Flags().Bool(cfgDebugMockSigningKey, false, "Generate volatile mock signing key")
 	}
 
 	for _, v := range []string{
 		cfgBackend,
+		cfgDebugMockSigningKey,
 	} {
 		viper.BindPFlag(v, cmd.Flags().Lookup(v)) //nolint: errcheck
 	}

--- a/go/storage/leveldb/leveldb_test.go
+++ b/go/storage/leveldb/leveldb_test.go
@@ -18,7 +18,7 @@ func TestStorageLevelDB(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	timeSource := mock.New()
-	backend, err := New(filepath.Join(tmpDir, DBFile), timeSource)
+	backend, err := New(filepath.Join(tmpDir, DBFile), timeSource, nil)
 	require.NoError(t, err, "New()")
 	defer backend.Cleanup()
 

--- a/go/storage/memory/memory_test.go
+++ b/go/storage/memory/memory_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestStorageMemory(t *testing.T) {
 	timeSource := mock.New()
-	backend := New(timeSource)
+	backend := New(timeSource, nil)
 	defer backend.Cleanup()
 
 	tests.StorageImplementationTests(t, backend, timeSource, true)

--- a/go/storage/metrics.go
+++ b/go/storage/metrics.go
@@ -50,6 +50,7 @@ var (
 
 	labelGet         = prometheus.Labels{"call": "get"}
 	labelGetBatch    = prometheus.Labels{"call": "get_batch"}
+	labelGetReceipt  = prometheus.Labels{"call": "get_receipt"}
 	labelInsert      = prometheus.Labels{"call": "insert"}
 	labelInsertBatch = prometheus.Labels{"call": "insert_batch"}
 	labelGetKeys     = prometheus.Labels{"call": "get_keys"}
@@ -95,6 +96,19 @@ func (w *metricsWrapper) GetBatch(ctx context.Context, keys []api.Key) ([][]byte
 
 	storageCalls.With(labelGetBatch).Inc()
 	return values, err
+}
+
+func (w *metricsWrapper) GetReceipt(ctx context.Context, keys []api.Key) (*api.SignedReceipt, error) {
+	start := time.Now()
+	receipt, err := w.Backend.GetReceipt(ctx, keys)
+	storageLatency.With(labelGetReceipt).Observe(time.Since(start).Seconds())
+	if err != nil {
+		storageFailures.With(labelGetReceipt).Inc()
+		return nil, err
+	}
+
+	storageCalls.With(labelGetReceipt).Inc()
+	return receipt, err
 }
 
 func (w *metricsWrapper) Insert(ctx context.Context, value []byte, expiration uint64, opts api.InsertOptions) error {

--- a/go/worker/host/sandboxed_test.go
+++ b/go/worker/host/sandboxed_test.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/hex"
 	"os"
 	"testing"
@@ -56,7 +57,9 @@ func TestSandboxedHost(t *testing.T) {
 	_ = runtimeID.UnmarshalBinary(runtimeIDRaw)
 
 	timeSource := epochtimeMock.New()
-	storage := storageMemory.New(timeSource)
+	storagePrivKey, err := signature.NewPrivateKey(rand.Reader)
+	require.NoError(t, err, "signature.NewPrivateKey")
+	storage := storageMemory.New(timeSource, &storagePrivKey)
 	<-storage.Initialized()
 
 	ias, err := ias.New(nil, "")


### PR DESCRIPTION
Till the v1 storage design with propper recipts can be implemented, add
a simple proof-of-storage mechanism based around an explicity query.

While this consumes an extra round-trip, it is significantly easier to
implement, and 1xRTT per batch is likely negligible in the grand scheme
of things.

**WARNING**: This is *BREAKING* in a "your futile attempts to migrate the roothash won't save you now" way.