### PR TITLE
Add chmod to README.md for configs/single-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ protected enclave:
 
 Before we can launch an Ekiden node, we need to copy over the identity keys
 that are configured in the genesis file (instead of doing this, you could
-also generate your own keys):
+also generate your own keys) and set correct permissions:
 ```
 # cp -a configs/single_node /tmp/ekiden-single-node/
+# chmod -R go-rwx /tmp/ekiden-single-node
 ```
 Ekiden node stores data in `/tmp/ekiden-single-node` regardless of the loaded
 runtime. In case you restart it, you may need to remove this directory first


### PR DESCRIPTION
New version of ekiden requires config files and directory without read/execute bits. Since git doesn't support setting permissions for folders, user needs to run `chmod` manually. This PR adds this to readme.