### PR TITLE
go/tendermint: Use the address book for the genesis validators

### DIFF
--- a/.buildkite/scripts/common_e2e.sh
+++ b/.buildkite/scripts/common_e2e.sh
@@ -119,6 +119,7 @@ run_backend_tendermint_committee() {
             --tendermint.core.genesis_file ${genesis_file} \
             --tendermint.core.listen_address tcp://0.0.0.0:${tm_port} \
             --tendermint.consensus.timeout_commit 250ms \
+            --tendermint.debug.addr_book_lenient \
             --tendermint.log.debug \
             --datadir ${datadir} \
             ${extra_args} \
@@ -184,6 +185,7 @@ run_compute_node() {
         --tendermint.core.genesis_file ${EKIDEN_TM_GENESIS_FILE} \
         --tendermint.core.listen_address tcp://0.0.0.0:${tm_port} \
         --tendermint.consensus.timeout_commit 250ms \
+        --tendermint.debug.addr_book_lenient \
         --tendermint.log.debug \
         --worker.backend sandboxed \
         --worker.binary ${WORKDIR}/target/debug/ekiden-worker \


### PR DESCRIPTION
The `PersistentPeers` hack causes log spam and potential problems,
so replace it with a different hack consisting of forcing the genesis
validator addresses into the address book on startup.

The "correct" way to actually handle all of this is probably "seed nodes
with the validators setup as persistent peers", but that requires
running tendermint nodes that just seed.