### PR TITLE
go: Use `context.Canceled` consistently

### DIFF
--- a/go/dummydebug/grpc.go
+++ b/go/dummydebug/grpc.go
@@ -72,7 +72,7 @@ Loop:
 				}
 			}
 		case <-ctx.Done():
-			return nil, errors.New("dummydebug: canceled by context")
+			return nil, context.Canceled
 		}
 	}
 

--- a/go/roothash/memory/memory.go
+++ b/go/roothash/memory/memory.go
@@ -448,7 +448,7 @@ func (r *memoryRootHash) Commit(ctx context.Context, id signature.PublicKey, com
 
 	select {
 	case <-ctx.Done():
-		return errors.New("roothash/memory: canceled by context")
+		return context.Canceled
 	case err = <-cmd.errCh:
 	}
 

--- a/go/worker/committee/node.go
+++ b/go/worker/committee/node.go
@@ -236,7 +236,7 @@ func (n *Node) HandleBatchFromCommittee(ctx context.Context, batchHash hash.Hash
 	case resp := <-respCh:
 		return resp
 	case <-ctx.Done():
-		return errors.New("aborted by context")
+		return context.Canceled
 	}
 }
 
@@ -274,7 +274,7 @@ func (n *Node) queueExternalBatch(ctx context.Context, batchHash hash.Hash, hdr 
 	select {
 	case n.incomingExtBatch <- &externalBatch{batch, hdr, respCh}:
 	case <-ctx.Done():
-		return nil, errors.New("aborted by context")
+		return nil, context.Canceled
 	}
 
 	return respCh, nil
@@ -487,7 +487,7 @@ func (n *Node) startProcessingBatch(batch runtime.Batch) {
 			n.logger.Error("batch processing aborted by context, interrupting worker")
 
 			// Interrupt the worker, so we can start processing the next batch.
-			err := n.workerHost.InterruptWorker(n.ctx)
+			err = n.workerHost.InterruptWorker(n.ctx)
 			if err != nil {
 				n.logger.Error("failed to interrupt the worker",
 					"err", err,

--- a/go/worker/host/protocol/protocol.go
+++ b/go/worker/host/protocol/protocol.go
@@ -65,7 +65,7 @@ func (p *Protocol) Call(ctx context.Context, body *Body) (*Body, error) {
 
 		return resp, nil
 	case <-ctx.Done():
-		return nil, errors.New("aborted by context")
+		return nil, context.Canceled
 	}
 }
 
@@ -92,7 +92,7 @@ func (p *Protocol) MakeRequest(ctx context.Context, body *Body) (<-chan *Body, e
 	case <-p.closeCh:
 		return nil, errors.New("connection closed")
 	case <-ctx.Done():
-		return nil, errors.New("aborted by context")
+		return nil, context.Canceled
 	}
 
 	return ch, nil

--- a/go/worker/host/sandboxed.go
+++ b/go/worker/host/sandboxed.go
@@ -408,7 +408,7 @@ func (h *sandboxedHost) MakeRequest(ctx context.Context, body *protocol.Body) (<
 	select {
 	case h.requestCh <- &hostRequest{ctx, body, respCh}:
 	case <-ctx.Done():
-		return nil, errors.New("aborted by context")
+		return nil, context.Canceled
 	}
 
 	// Wait for response from the manager goroutine.
@@ -416,7 +416,7 @@ func (h *sandboxedHost) MakeRequest(ctx context.Context, body *protocol.Body) (<
 	case resp := <-respCh:
 		return resp.ch, resp.err
 	case <-ctx.Done():
-		return nil, errors.New("aborted by context")
+		return nil, context.Canceled
 	}
 }
 
@@ -427,7 +427,7 @@ func (h *sandboxedHost) InterruptWorker(ctx context.Context) error {
 	select {
 	case h.interruptCh <- &interruptRequest{ctx, respCh}:
 	case <-ctx.Done():
-		return errors.New("aborted by context")
+		return context.Canceled
 	}
 
 	// Wait for response from the manager goroutine.
@@ -435,7 +435,7 @@ func (h *sandboxedHost) InterruptWorker(ctx context.Context) error {
 	case resp := <-respCh:
 		return resp
 	case <-ctx.Done():
-		return errors.New("aborted by context")
+		return context.Canceled
 	}
 }
 
@@ -688,7 +688,7 @@ func (h *sandboxedHost) handleInterruptWorker(ctx context.Context) error {
 	select {
 	case <-h.activeWorker.quitCh:
 	case <-ctx.Done():
-		return errors.New("aborted by context")
+		return context.Canceled
 	}
 
 	// Respawn worker.


### PR DESCRIPTION
Instead of returning new errors, return the context package's standard
`Canceled` error on cancelation.