### PR TITLE
go/storage/cachingclient: Fix termination safety

### DIFF
--- a/go/storage/cachingclient/cache/cache_test.go
+++ b/go/storage/cachingclient/cache/cache_test.go
@@ -12,73 +12,117 @@ import (
 	"github.com/oasislabs/ekiden/go/storage/api"
 )
 
+const (
+	cacheSize  = 10
+	extraItems = 1
+	backlog    = 5
+)
+
 func TestBasic(t *testing.T) {
-	cacheSize := 10
-	extraItems := 1
+	cache, cacheDir := requireNewCache(t)
+	defer func() {
+		os.RemoveAll(cacheDir)
+		cache.Cleanup()
+	}()
 
-	cacheDir, err := ioutil.TempDir("", "ekiden-cachingclient-test_")
-	require.NoError(t, err, "create cache dir")
-	defer os.RemoveAll(cacheDir)
+	kvs := makeTestKeyValues(cacheSize + extraItems)
+	for _, v := range kvs {
+		cache.Set(v.Key, v.Value)
 
-	cache, err := New(filepath.Join(cacheDir, "db"), cacheSize)
-	require.NoError(t, err, "New")
-
-	for i := 0; i < cacheSize+extraItems; i++ {
-		value := []byte(fmt.Sprintf("value-%d", i))
-		key := api.HashStorageKey(value)
-
-		cache.Set(key, value)
-		cachedValue := cache.Get(key)
-		require.EqualValues(t, value, cachedValue)
+		cachedValue, err := cache.Get(v.Key)
+		require.EqualValues(t, v.Value, cachedValue)
+		require.NoError(t, err, "Get(hit)")
 	}
 
-	valuesInCache := 0
-	for i := 0; i < cacheSize+extraItems; i++ {
-		value := []byte(fmt.Sprintf("value-%d", i))
-		key := api.HashStorageKey(value)
-
-		cachedValue := cache.Get(key)
-		if cachedValue != nil {
+	var valuesInCache int
+	for _, v := range kvs {
+		if requireGet(t, cache, v.Key, v.Value) {
 			valuesInCache++
-			require.EqualValues(t, value, cachedValue)
 		}
 	}
-
 	require.Equal(t, cacheSize, valuesInCache)
 }
 
 func TestBatchSet(t *testing.T) {
-	cacheSize := 10
-	extraItems := 1
+	cache, cacheDir := requireNewCache(t)
+	defer func() {
+		os.RemoveAll(cacheDir)
+		cache.Cleanup()
+	}()
 
-	cacheDir, err := ioutil.TempDir("", "ekiden-cachingclient-test_")
-	require.NoError(t, err, "create cache dir")
-	defer os.RemoveAll(cacheDir)
-
-	cache, err := New(filepath.Join(cacheDir, "db"), cacheSize)
-	require.NoError(t, err, "New")
-
-	var kvs []KeyValue
-	for i := 0; i < cacheSize+extraItems; i++ {
-		value := []byte(fmt.Sprintf("value-%d", i))
-		key := api.HashStorageKey(value)
-
-		kvs = append(kvs, KeyValue{key, value})
-	}
-
+	kvs := makeTestKeyValues(cacheSize + extraItems)
 	cache.SetBatch(kvs)
 
-	valuesInCache := 0
-	for i := 0; i < cacheSize+extraItems; i++ {
-		value := []byte(fmt.Sprintf("value-%d", i))
-		key := api.HashStorageKey(value)
-
-		cachedValue := cache.Get(key)
-		if cachedValue != nil {
+	var valuesInCache int
+	for _, v := range kvs {
+		if requireGet(t, cache, v.Key, v.Value) {
 			valuesInCache++
-			require.EqualValues(t, value, cachedValue)
 		}
 	}
-
 	require.Equal(t, cacheSize, valuesInCache)
+}
+
+func TestAsyncSet(t *testing.T) {
+	cache, cacheDir := requireNewCache(t)
+	defer func() {
+		os.RemoveAll(cacheDir)
+		// Leaves cache dangling, but whatever, this is a test case.
+	}()
+
+	kvs := makeTestKeyValues(cacheSize + extraItems)
+	cache.SetBatchAsync(kvs)
+
+	cache.Cleanup() // Force flush to disk.
+
+	var err error
+	cache, err = New(filepath.Join(cacheDir, "db"), cacheSize, backlog)
+	require.NoError(t, err, "New(reopen)")
+
+	var valuesInCache int
+	for _, v := range kvs {
+		if requireGet(t, cache, v.Key, v.Value) {
+			valuesInCache++
+		}
+	}
+	require.Equal(t, cacheSize, valuesInCache)
+}
+
+func requireNewCache(t *testing.T) (*Cache, string) {
+	cacheDir, err := ioutil.TempDir("", "ekiden-cachingclient-test_")
+	require.NoError(t, err, "create cache dir")
+
+	cache, err := New(filepath.Join(cacheDir, "db"), cacheSize, backlog)
+	if err != nil {
+		os.RemoveAll(cacheDir)
+	}
+	require.NoError(t, err, "New")
+
+	return cache, cacheDir
+}
+
+func makeTestKeyValues(n int) []KeyValue {
+	var kvs []KeyValue
+	for i := 0; i < n; i++ {
+		v := []byte(fmt.Sprintf("value-%d", i))
+		kvs = append(kvs, KeyValue{
+			Key:   api.HashStorageKey(v),
+			Value: v,
+		})
+	}
+
+	return kvs
+}
+
+func requireGet(t *testing.T, cache *Cache, key api.Key, expected []byte) bool {
+	value, err := cache.Get(key)
+	switch value {
+	case nil:
+		require.Error(t, err, "Get(miss)")
+		require.Equal(t, api.ErrKeyNotFound, err, "Get(miss) error is ErrKeyNotFound")
+		return false
+	default:
+		require.NoError(t, err, "Get(hit)")
+		require.EqualValues(t, expected, value, "Get() returned expected value")
+		return true
+	}
 }


### PR DESCRIPTION
This fixes termination safety by using a dedicated go routine to handle
async set operations, and moving the bulk of the cache cleanup into a
critical section.

Additionally, an attempt is made to combine async set operations such
that they are batched and written to the database en-masse.