### PR TITLE
Bump backend protocol version to 0.1.0

### DIFF
--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -33,7 +33,7 @@ var (
 	//
 	// NOTE: Any change in the major or minor versions are considered
 	//       breaking changes for the protocol.
-	BackendProtocol = Version{Major: 0, Minor: 0, Patch: 1}
+	BackendProtocol = Version{Major: 0, Minor: 1, Patch: 0}
 )
 
 // Versions contains all known protocol versions.


### PR DESCRIPTION
After masking out the patch version I forgot to bump the backend protocol version to 0.1.0 in #1441.