### PR TITLE
go/worker: Make node registration be better behaved

### DIFF
--- a/go/worker/registration.go
+++ b/go/worker/registration.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"time"
 
+	"github.com/cenkalti/backoff"
+
 	"github.com/oasislabs/ekiden/go/common/node"
 	epochtime "github.com/oasislabs/ekiden/go/epochtime/api"
 	registry "github.com/oasislabs/ekiden/go/registry/api"
@@ -18,26 +20,37 @@ func (w *Worker) doNodeRegistration() {
 	defer sub.Close()
 
 	regFn := func(epoch epochtime.EpochTime, retry bool) error {
-		for {
-			err := w.registerNode(epoch)
-			switch err {
-			case nil, context.Canceled:
-				return err
-			default:
-				if !retry {
-					return err
+		var off backoff.BackOff
+
+		switch retry {
+		case true:
+			expBackoff := backoff.NewExponentialBackOff()
+			expBackoff.MaxElapsedTime = 0
+			off = expBackoff
+		case false:
+			off = &backoff.StopBackOff{}
+		}
+		off = backoff.WithContext(off, w.ctx)
+
+		// WARNING: This can potentially infinite loop, on certain
+		// "shouldn't be possible" pathological failures.
+		//
+		// w.ctx being canceled will break out of the loop correctly
+		// but it's entirely possible to sit around in an ininite
+		// retry loop with no hope of success.
+		return backoff.Retry(func() error {
+			// Update the epoch if it happens to change while retrying.
+			var ok bool
+			select {
+			case epoch, ok = <-ch:
+				if !ok {
+					return context.Canceled
 				}
+			default:
 			}
 
-			// WARNING: This can potentially infinite loop, on certain
-			// "shouldn't be possible" pathological failures.
-			//
-			// w.ctx being canceled will break out of the loop correctly
-			// but it's entirely possible to sit around in an ininite
-			// retry loop with no hope of success.
-
-			time.Sleep(1 * time.Second)
-		}
+			return w.registerNode(epoch)
+		}, off)
 	}
 
 	epoch := <-ch


### PR DESCRIPTION
 * Update the epoch if it changes mid-retry.
 * Use an exponential backoff policy (max 60 sec) for the initial
   registration retry.

Note: We still should wait till tendermint is synced.