### PR TITLE
enclave: allow GROUP_OUT_OF_DATE in un-strict AVR verification

### DIFF
--- a/enclave/common/src/quote.rs
+++ b/enclave/common/src/quote.rs
@@ -220,9 +220,9 @@ pub fn verify(identity_proof: &IdentityProof) -> Result<IdentityAuthenticatedInf
     match avr_body["isvEnclaveQuoteStatus"].as_str() {
         Some(status) => match status {
             "OK" => {}
-            "CONFIGURATION_NEEDED" => {
+            "GROUP_OUT_OF_DATE" | "CONFIGURATION_NEEDED" => {
                 if strict_avr_verification {
-                    return Err(Error::new("Rejecting quote status CONFIGURATION_NEEDED. Build without EKIDEN_STRICT_AVR_VERIFY=1 to allow"));
+                    return Err(Error::new(format!("Rejecting quote status {}. Build without EKIDEN_STRICT_AVR_VERIFY=1 to allow", status)));
                 }
             }
             _ => {


### PR DESCRIPTION
this brings it in line with the policy in the Go codebase

quick reference https://software.intel.com/sites/default/files/managed/7e/3b/ias-api-spec.pdf:
> **GROUP_OUT_OF_DATE** – The EPID signature of the ISV enclave QUOTE has been verified correctly, but the TCB level of SGX platform is outdated(for further details see Advisory IDs). The platform has not been identified as compromised and thus it is not revoked. It is up to the Service Provider to decide whether or not to trust the content of the QUOTE, and whether or not to trust the platform performing the attestation to protect specific sensitive information. 