### PR TITLE
Prevent worker network proxies from starting for unconfined backend

### DIFF
--- a/go/worker/host/sandboxed.go
+++ b/go/worker/host/sandboxed.go
@@ -87,10 +87,15 @@ type ProxySpecification struct {
 	ProxyType string
 	// SourceName is the path of the unix socket outside the sandbox.
 	SourceName string
+	// OuterAddr is the address to which the proxy is forwarding outside.
+	OuterAddr string
 	// mapName is the name of the unix socket inside the sandbox.
 	mapName string
-	// innerAddr is the address on which the proxy will listen inside the sandbox.
+	// innerAddr is the address on which the proxy will listen inside the sandbox;
+	// if bypass is true, innerAddr is the same as OuterAddr
 	innerAddr string
+	// bypass specifies if a proxy is needed or if the service will connect directly.
+	bypass bool
 }
 
 type process struct {
@@ -231,20 +236,23 @@ func prepareWorkerArgs(hostSocket, runtimeBinary string, proxies map[string]Prox
 	args := []string{
 		"--host-socket", hostSocket,
 	}
-	if _, ok := proxies[MetricsProxyKey]; ok {
+	if spec, ok := proxies[MetricsProxyKey]; ok {
 		config := metrics.GetServiceConfig()
 		args = append(args, "--prometheus-mode", config.Mode)
-		args = append(args, "--prometheus-metrics-addr", workerProxyInnerAddrs[MetricsProxyKey])
+		args = append(args, "--prometheus-metrics-addr", spec.innerAddr)
 		args = append(args, "--prometheus-push-job-name", config.JobName)
 		args = append(args, "--prometheus-push-instance-label", config.InstanceLabel)
 	}
-	if _, ok := proxies[TracingProxyKey]; ok {
+	if spec, ok := proxies[TracingProxyKey]; ok {
 		config := tracing.GetServiceConfig()
 		args = append(args, "--tracing-enable")
 		args = append(args, "--tracing-sample-probability", strconv.FormatFloat(config.SamplerParam, 'f', -1, 64))
-		args = append(args, "--tracing-agent-addr", workerProxyInnerAddrs[TracingProxyKey])
+		args = append(args, "--tracing-agent-addr", spec.innerAddr)
 	}
 	for name, proxy := range proxies {
+		if proxy.bypass {
+			continue
+		}
 		args = append(args, fmt.Sprintf("--proxy-bind=%s,%s,%s,%s", proxy.ProxyType, name, proxy.innerAddr, proxy.mapName))
 	}
 	args = append(args, runtimeBinary)
@@ -795,7 +803,12 @@ func NewSandboxedHost(
 	for name, mappedSocket := range workerMountSocketMap {
 		if proxy, ok := proxies[name]; ok {
 			proxy.mapName = mappedSocket
-			proxy.innerAddr = workerProxyInnerAddrs[name]
+			if noSandbox {
+				proxy.innerAddr = proxy.OuterAddr
+			} else {
+				proxy.innerAddr = workerProxyInnerAddrs[name]
+			}
+			proxy.bypass = noSandbox
 			knownProxies[name] = proxy
 		}
 	}

--- a/go/worker/proxy.go
+++ b/go/worker/proxy.go
@@ -22,6 +22,8 @@ type NetworkProxy interface {
 	Type() string
 	// UnixPath returns the path of the unix socket used by this proxy.
 	UnixPath() string
+	// RemoteAddress returns the address on the outside the proxy is forwarding to.
+	RemoteAddress() string
 
 	service.BackgroundService
 }
@@ -57,6 +59,11 @@ func (p *proxyCommon) Type() string {
 // UnixPath returns the Unix socket path on which the proxy is listening.
 func (p *proxyCommon) UnixPath() string {
 	return p.localPath
+}
+
+// RemoteAddress returns the address on the outside the proxy is forwarding to.
+func (p *proxyCommon) RemoteAddress() string {
+	return p.remoteAddress
 }
 
 // Stop triggers a proxy shutdown.

--- a/go/worker/worker.go
+++ b/go/worker/worker.go
@@ -252,6 +252,7 @@ func (w *Worker) newWorkerHost(cfg *Config, rtCfg *RuntimeConfig) (h host.Host, 
 		proxies[k] = host.ProxySpecification{
 			ProxyType:  v.Type(),
 			SourceName: v.UnixPath(),
+			OuterAddr:  v.RemoteAddress(),
 		}
 	}
 	switch strings.ToLower(cfg.Backend) {


### PR DESCRIPTION
See #1479. Unconfined workers shouldn't need proxies.