### PR TITLE
go/storage/cachingclient: Fix a race in the test cases

### DIFF
--- a/go/storage/cachingclient/cachingclient_test.go
+++ b/go/storage/cachingclient/cachingclient_test.go
@@ -82,6 +82,7 @@ func TestBatch(t *testing.T) {
 }
 
 func requireNewClient(t *testing.T, remote api.Backend) (api.Backend, string) {
+	<-remote.Initialized()
 	cacheDir, err := ioutil.TempDir("", "ekiden-cachingclient-test_")
 	require.NoError(t, err, "create cache dir")
 


### PR DESCRIPTION
Wait for the memory remote backend to have a coherent view of the mock
time before instantiating the test cachingclient.