### PR TITLE
MKVS reference implementation

### DIFF
--- a/go/common/crypto/hash/hash.go
+++ b/go/common/crypto/hash/hash.go
@@ -50,8 +50,12 @@ func (h *Hash) From(v interface{}) {
 }
 
 // FromBytes sets the hash to that of an arbitrary byte string.
-func (h *Hash) FromBytes(data []byte) {
-	sum := sha512.Sum512_256(data)
+func (h *Hash) FromBytes(data ...[]byte) {
+	hasher := sha512.New512_256()
+	for _, d := range data {
+		_, _ = hasher.Write(d)
+	}
+	sum := hasher.Sum([]byte{})
 	_ = h.UnmarshalBinary(sum[:])
 }
 

--- a/go/storage/mkvs/urkel/cache.go
+++ b/go/storage/mkvs/urkel/cache.go
@@ -1,0 +1,495 @@
+package urkel
+
+import (
+	"container/list"
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/oasislabs/ekiden/go/common/crypto/hash"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/db"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/internal"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/syncer"
+)
+
+// cache handles the in-memory tree cache.
+type cache struct {
+	db db.NodeDB
+	rs syncer.ReadSyncer
+
+	// pendingRoot is the pending root which will become the new root if
+	// the currently cached contents is committed.
+	pendingRoot *internal.Pointer
+	// syncRoot is the root at which all node database and syncer cache
+	// lookups will be done.
+	syncRoot hash.Hash
+
+	// Current size of leaf values.
+	valueSize uint64
+	// Current number of internal nodes.
+	internalNodeCount uint64
+	// Current number leaf nodes.
+	leafNodeCount uint64
+
+	// Maximum capacity of internal and leaf nodes.
+	nodeCapacity uint64
+	// Maximum capacity of leaf values.
+	valueCapacity uint64
+	// Prefetch depth.
+	prefetchDepth uint8
+	// Syncer remote GetNode timeout.
+	syncerGetNodeTimeout time.Duration
+	// Syncer remote subtree prefetch timeout.
+	syncerPrefetchTimeout time.Duration
+
+	lruNodes  *list.List
+	lruValues *list.List
+}
+
+func newCache(ndb db.NodeDB, rs syncer.ReadSyncer) cache {
+	return cache{
+		db:                    ndb,
+		rs:                    rs,
+		lruNodes:              list.New(),
+		lruValues:             list.New(),
+		syncerGetNodeTimeout:  1 * time.Second,
+		syncerPrefetchTimeout: 5 * time.Second,
+	}
+}
+
+func (c *cache) setSyncRoot(root hash.Hash) {
+	c.syncRoot = root
+}
+
+func (c *cache) setPendingRoot(ptr *internal.Pointer) {
+	c.pendingRoot = ptr
+}
+
+func (c *cache) newLeafNodePtr(node *internal.LeafNode) *internal.Pointer {
+	return &internal.Pointer{
+		Node: node,
+	}
+}
+
+func (c *cache) newLeafNode(key hash.Hash, val []byte) *internal.Pointer {
+	return c.newLeafNodePtr(&internal.LeafNode{
+		Key:   key,
+		Value: c.newValue(val),
+	})
+}
+
+func (c *cache) newInternalNodePtr(node *internal.InternalNode) *internal.Pointer {
+	return &internal.Pointer{
+		Node: node,
+	}
+}
+
+func (c *cache) newInternalNode(left *internal.Pointer, right *internal.Pointer) *internal.Pointer {
+	return c.newInternalNodePtr(&internal.InternalNode{
+		Left:  left,
+		Right: right,
+	})
+}
+
+// useNode moves the node to the front of the LRU list.
+func (c *cache) useNode(ptr *internal.Pointer) {
+	if ptr.LRU == nil {
+		return
+	}
+	c.lruNodes.MoveToFront(ptr.LRU)
+}
+
+// useValue moves the value to the front of the LRU list.
+func (c *cache) useValue(v *internal.Value) {
+	if v.LRU == nil {
+		return
+	}
+	c.lruValues.MoveToFront(v.LRU)
+}
+
+// commitNode makes the node elegible for eviction.
+func (c *cache) commitNode(ptr *internal.Pointer) {
+	if !ptr.IsClean() {
+		panic("urkel: commitNode called on dirty node")
+	}
+	if ptr == nil || ptr.Node == nil {
+		return
+	}
+	if ptr.LRU != nil {
+		c.useNode(ptr)
+		return
+	}
+
+	// Evict nodes till there is enough capacity.
+	if c.nodeCapacity > 0 && c.nodeCapacity-(c.internalNodeCount+c.leafNodeCount) < 1 {
+		c.evictNodes(1)
+	}
+
+	ptr.LRU = c.lruNodes.PushFront(ptr)
+	switch ptr.Node.(type) {
+	case *internal.InternalNode:
+		c.internalNodeCount++
+	case *internal.LeafNode:
+		c.leafNodeCount++
+	}
+}
+
+// commitValue makes the value elegible for eviction.
+func (c *cache) commitValue(v *internal.Value) {
+	if !v.Clean {
+		panic("urkel: commitValue called on dirty value")
+	}
+	if v.LRU != nil {
+		c.useValue(v)
+		return
+	}
+	if v.Value == nil {
+		return
+	}
+
+	valueSize := uint64(len(v.Value))
+
+	// Evict values till there is enough capacity.
+	if c.valueCapacity > 0 && valueSize > c.valueCapacity-c.valueSize {
+		c.evictValues(valueSize)
+	}
+
+	v.LRU = c.lruValues.PushFront(v)
+	c.valueSize += valueSize
+}
+
+func (c *cache) newValuePtr(v *internal.Value) *internal.Value {
+	// TODO: Deduplicate values.
+	return v
+}
+
+func (c *cache) newValue(val []byte) *internal.Value {
+	return c.newValuePtr(&internal.Value{Value: val})
+}
+
+// tryRemoveNode tries to removes a tree node.
+//
+// Note that the node may not be actually removed if it is not possible
+// to do so (e.g., an internal node which still has children).
+func (c *cache) tryRemoveNode(ptr *internal.Pointer) {
+	if ptr.LRU == nil {
+		// Node has not yet been committed to cache.
+		return
+	}
+
+	switch n := ptr.Node.(type) {
+	case *internal.InternalNode:
+		// We can only remove internal nodes if they have no cached children
+		// as otherwise we would need to remove the whole subtree.
+		if (n.Left != nil && n.Left.Node != nil) || (n.Right != nil && n.Right.Node != nil) {
+			return
+		}
+	}
+
+	c.lruNodes.Remove(ptr.LRU)
+
+	switch n := ptr.Node.(type) {
+	case *internal.InternalNode:
+		c.internalNodeCount--
+	case *internal.LeafNode:
+		// Also remove the value
+		c.removeValue(n.Value)
+		c.leafNodeCount--
+	}
+
+	ptr.Node = nil
+	ptr.LRU = nil
+}
+
+// removeValue removes a value.
+func (c *cache) removeValue(v *internal.Value) {
+	if v.LRU == nil {
+		// Value has not yet been committed to cache.
+		return
+	}
+
+	c.lruValues.Remove(v.LRU)
+	c.valueSize -= uint64(len(v.Value))
+	v.Value = nil
+	v.LRU = nil
+}
+
+// evictValues tries to evict values from the cache.
+func (c *cache) evictValues(targetCapacity uint64) {
+	for c.lruValues.Len() > 0 && c.valueCapacity-c.valueSize < targetCapacity {
+		elem := c.lruValues.Back()
+		v := elem.Value.(*internal.Value)
+		c.removeValue(v)
+	}
+}
+
+// evictNodes tries to evict nodes from the cache.
+func (c *cache) evictNodes(targetCapacity uint64) {
+	// TODO: Consider optimizing this to know which nodes are elegible for removal.
+	for c.lruNodes.Len() > 0 && c.nodeCapacity-(c.internalNodeCount+c.leafNodeCount) < targetCapacity {
+		elem := c.lruNodes.Back()
+		n := elem.Value.(*internal.Pointer)
+		c.tryRemoveNode(n)
+	}
+}
+
+func (c *cache) derefNodeID(id internal.NodeID) (*internal.Pointer, error) {
+	curPtr := c.pendingRoot
+	var d uint8
+	for d = 0; d < id.Depth; d++ {
+		node, err := c.derefNodePtr(id.AtDepth(d), curPtr, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		switch n := node.(type) {
+		case nil:
+			return nil, nil
+		case *internal.InternalNode:
+			if getKeyBit(id.Path, d) {
+				curPtr = n.Right
+			} else {
+				curPtr = n.Left
+			}
+		case *internal.LeafNode:
+			break
+		}
+	}
+
+	return curPtr, nil
+}
+
+// derefNodePtr dereferences an internal node pointer.
+//
+// This may result in node database accesses or remote syncing if the node
+// is not available locally.
+func (c *cache) derefNodePtr(id internal.NodeID, ptr *internal.Pointer, key *hash.Hash) (internal.Node, error) {
+	if ptr == nil {
+		return nil, nil
+	}
+
+	if ptr.Node != nil {
+		c.useNode(ptr)
+		return ptr.Node, nil
+	}
+
+	if !ptr.Clean || ptr.Hash.IsEmpty() {
+		return nil, nil
+	}
+
+	// First, attempt to fetch from the local node database.
+	node, err := c.db.GetNode(c.syncRoot, ptr)
+	switch err {
+	case nil:
+		ptr.Node = node
+	case db.ErrNodeNotFound:
+		// Node not found in local node database, try the syncer.
+		// TODO: Ideally use a proper parent context.
+		ctx, cancel := context.WithTimeout(context.Background(), c.syncerGetNodeTimeout)
+		defer cancel()
+
+		if key == nil {
+			// Target key is not known, we need to prefetch the node.
+			if node, err = c.rs.GetNode(ctx, c.syncRoot, id); err != nil {
+				return nil, err
+			}
+
+			if err = node.Validate(ptr.Hash); err != nil {
+				return nil, err
+			}
+
+			ptr.Node = node
+		} else {
+			// If target key is known, we can try prefetching the whole path
+			// instead of one node at a time.
+			var st *syncer.Subtree
+			if st, err = c.rs.GetPath(ctx, c.syncRoot, *key, id.Depth); err != nil {
+				return nil, err
+			}
+
+			var newPtr *internal.Pointer
+			if newPtr, err = c.reconstructSubtree(ptr.Hash, st, id.Depth, (8*hash.Size)-1); err != nil {
+				return nil, err
+			}
+
+			*ptr = *newPtr
+		}
+	default:
+		return nil, err
+	}
+
+	return ptr.Node, nil
+}
+
+// derefValue dereferences an internal value pointer.
+//
+// This may result in node database accesses or remote syncing if the value
+// is not available locally.
+func (c *cache) derefValue(v *internal.Value) ([]byte, error) {
+	// Move the accessed value to the front of the LRU list.
+	if v.LRU != nil || v.Value != nil {
+		c.useValue(v)
+		return v.Value, nil
+	}
+
+	if !v.Clean {
+		return nil, nil
+	}
+
+	val, err := c.db.GetValue(v.Hash)
+	switch err {
+	case nil:
+		v.Value = val
+	case db.ErrNodeNotFound:
+		// Value not found in local node database, try the syncer.
+		// TODO: Ideally use a proper parent context.
+		ctx, cancel := context.WithTimeout(context.Background(), c.syncerGetNodeTimeout)
+		defer cancel()
+
+		var value []byte
+		if value, err = c.rs.GetValue(ctx, c.syncRoot, v.Hash); err != nil {
+			return nil, err
+		}
+
+		v.Value = value
+
+		if err = v.Validate(v.Hash); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, err
+	}
+
+	// Value was fetched, be sure to treat it as committed.
+	c.commitValue(v)
+
+	return v.Value, nil
+}
+
+// prefetch prefetches a given subtree up to the configured prefetch depth.
+func (c *cache) prefetch(subtree hash.Hash, depth uint8) (*internal.Pointer, error) {
+	if c.prefetchDepth == 0 {
+		return nil, nil
+	}
+
+	// TODO: Ideally use a proper parent context.
+	ctx, cancel := context.WithTimeout(context.Background(), c.syncerPrefetchTimeout)
+	defer cancel()
+
+	st, err := c.rs.GetSubtree(ctx, c.syncRoot, internal.NodeID{Path: subtree, Depth: depth}, c.prefetchDepth)
+	switch err {
+	case nil:
+	case syncer.ErrUnsupported:
+		return nil, nil
+	default:
+		return nil, err
+	}
+
+	ptr, err := c.reconstructSubtree(subtree, st, 0, c.prefetchDepth)
+	if err != nil {
+		return nil, err
+	}
+
+	return ptr, nil
+}
+
+// reconstructSubtree reconstructs a tree summary received through a
+// remote syncer.
+func (c *cache) reconstructSubtree(root hash.Hash, st *syncer.Subtree, depth, maxDepth uint8) (*internal.Pointer, error) {
+	ptr, err := c.doReconstructSummary(st, st.Root, depth, maxDepth)
+	if err != nil {
+		return nil, err
+	}
+	if ptr == nil {
+		return nil, errors.New("urkel: reconstructed root pointer is nil")
+	}
+
+	batch := c.db.NewBatch()
+	defer batch.Reset()
+
+	updates := &cacheUpdates{}
+	syncRoot, err := doCommit(c, updates, batch, ptr)
+	if err != nil {
+		return nil, err
+	}
+	if !syncRoot.Equal(&root) {
+		return nil, fmt.Errorf("urkel: syncer returned bad root (expected: %s got: %s)",
+			root,
+			syncRoot,
+		)
+	}
+
+	if err = batch.Commit(root); err != nil {
+		return nil, err
+	}
+	updates.Commit()
+
+	return ptr, nil
+}
+
+// doReconstructSummary reconstructs a tree summary received through a
+// remote syncer.
+func (c *cache) doReconstructSummary(
+	st *syncer.Subtree,
+	sptr syncer.SubtreePointer,
+	depth uint8,
+	maxDepth uint8,
+) (*internal.Pointer, error) {
+	if depth > maxDepth {
+		return nil, errors.New("urkel: maximum depth exceeded")
+	}
+
+	// Mark node as used to ensure that we error if we try to revisit
+	// the same node.
+	defer st.MarkUsed(sptr)
+
+	if !sptr.Valid {
+		return nil, errors.New("urkel: invalid subtree pointer")
+	}
+
+	if sptr.Full {
+		node, err := st.GetFullNodeAt(sptr.Index)
+		if err != nil {
+			return nil, err
+		}
+
+		var ptr *internal.Pointer
+		switch n := node.(type) {
+		case *internal.InternalNode:
+			// Internal node.
+			n.Clean = false
+			ptr = c.newInternalNodePtr(n)
+		case *internal.LeafNode:
+			// Leaf node.
+			n.Clean = false
+			n.Value = c.newValuePtr(n.Value)
+			ptr = c.newLeafNodePtr(n)
+		}
+
+		return ptr, nil
+	}
+
+	// Summary node.
+
+	s, err := st.GetSummaryAt(sptr.Index)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if the summary referes to a dead node.
+	if s == nil {
+		return nil, nil
+	}
+
+	left, err := c.doReconstructSummary(st, s.Left, depth+1, maxDepth)
+	if err != nil {
+		return nil, err
+	}
+	right, err := c.doReconstructSummary(st, s.Right, depth+1, maxDepth)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.newInternalNode(left, right), nil
+}

--- a/go/storage/mkvs/urkel/commit.go
+++ b/go/storage/mkvs/urkel/commit.go
@@ -1,0 +1,116 @@
+package urkel
+
+import (
+	"github.com/oasislabs/ekiden/go/common/crypto/hash"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/db"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/internal"
+)
+
+// cacheUpdates contains a list of pending cache updates to be applied
+// after another operation (e.g., a database commit) has succeeded to
+// avoid corrupting the in-memory cache.
+type cacheUpdates struct {
+	updates []func()
+}
+
+// Add queues a cache update function.
+func (u *cacheUpdates) Add(update func()) {
+	u.updates = append(u.updates, update)
+}
+
+// Commit runs all the queued cache update functions in order.
+func (u *cacheUpdates) Commit() {
+	for _, update := range u.updates {
+		update()
+	}
+	u.updates = []func(){}
+}
+
+// doCommit commits all dirty nodes and values into the underlying node
+// database. This operation may cause committed nodes and values to be
+// evicted from the in-memory cache.
+func doCommit(cache *cache, upd *cacheUpdates, batch db.Batch, ptr *internal.Pointer) (h hash.Hash, err error) {
+	if ptr == nil {
+		h.Empty()
+		return
+	} else if ptr.Clean {
+		h = ptr.Hash
+		return
+	}
+
+	// Pointer is not clean, we need to perform some hash computations.
+
+	// NOTE: Irreversible cache operations like clearing the dirty flags
+	//       and updating node/value cache status must be queued via the
+	//       provided cacheUpdates instance as the database operations
+	//       can fail and this must not cause the in-memory cache to be
+	//       corrupted.
+
+	switch n := ptr.Node.(type) {
+	case nil:
+		// Dead node.
+		ptr.Hash.Empty()
+	case *internal.InternalNode:
+		// Internal node.
+		if n.Clean {
+			ptr.Hash = n.Hash
+			break
+		}
+
+		if _, err = doCommit(cache, upd, batch, n.Left); err != nil {
+			return
+		}
+		if _, err = doCommit(cache, upd, batch, n.Right); err != nil {
+			return
+		}
+
+		n.UpdateHash()
+
+		if cerr := batch.PutNode(ptr); cerr != nil {
+			err = cerr
+			return
+		}
+
+		upd.Add(func() {
+			n.Clean = true
+		})
+		ptr.Hash = n.Hash
+	case *internal.LeafNode:
+		// Leaf node.
+		if n.Clean {
+			ptr.Hash = n.Hash
+			break
+		}
+
+		if !n.Value.Clean {
+			n.Value.UpdateHash()
+
+			if err = batch.PutValue(n.Value.Value); err != nil {
+				return
+			}
+
+			upd.Add(func() {
+				n.Value.Clean = true
+				cache.commitValue(n.Value)
+			})
+		}
+
+		n.UpdateHash()
+
+		if err = batch.PutNode(ptr); err != nil {
+			return
+		}
+
+		upd.Add(func() {
+			n.Clean = true
+		})
+		ptr.Hash = n.Hash
+	}
+
+	upd.Add(func() {
+		ptr.Clean = true
+		cache.commitNode(ptr)
+	})
+	h = ptr.Hash
+	return
+}

--- a/go/storage/mkvs/urkel/db/db.go
+++ b/go/storage/mkvs/urkel/db/db.go
@@ -1,0 +1,108 @@
+// Package db implements a persistent node database for Urkel trees.
+package db
+
+import (
+	"errors"
+
+	"github.com/oasislabs/ekiden/go/common/crypto/hash"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/internal"
+)
+
+var ErrNodeNotFound = errors.New("urkel: node not found in node db")
+
+// NodeDB is the persistence layer used for persisting the in-memory tree.
+type NodeDB interface {
+	// GetNode lookups up a node in the database.
+	GetNode(root hash.Hash, ptr *internal.Pointer) (internal.Node, error)
+
+	// GetNode lookups up a value in the database.
+	GetValue(id hash.Hash) ([]byte, error)
+
+	// NewBatch starts a new batch.
+	NewBatch() Batch
+}
+
+// Batch is a NodeDB-specific batch implementation.
+type Batch interface {
+	// PutNode inserts a node into the database. If a node already
+	// exists it increments its reference counter.
+	//
+	// The passed pointer's DBInternal may be modified by this call.
+	PutNode(ptr *internal.Pointer) error
+
+	// RemoveNode decrements the reference counter on the node with the
+	// given identifier. If the reference counter becomes negative
+	// it removes the node.
+	//
+	// The passed pointer's DBInternal may be modified by this call.
+	RemoveNode(ptr *internal.Pointer) error
+
+	// PutValue inserts a value into the database. If a value already
+	// exists it increments its reference counter.
+	PutValue(value []byte) error
+
+	// RemoveValue decrements the reference counter on the value with the
+	// given identifier. If the reference counter becomes negative
+	// it removes the value.
+	RemoveValue(id hash.Hash) error
+
+	// Commit commits the batch.
+	Commit(root hash.Hash) error
+
+	// Reset resets the batch for another use.
+	Reset()
+}
+
+// nopNodeDB is a no-op node database which doesn't persist anything.
+type nopNodeDB struct{}
+
+// NewNopNodeDB creates a new no-op node database.
+func NewNopNodeDB() NodeDB {
+	return &nopNodeDB{}
+}
+
+// GetNode returns an ErrNodeNotFound error.
+func (d *nopNodeDB) GetNode(root hash.Hash, ptr *internal.Pointer) (internal.Node, error) {
+	return nil, ErrNodeNotFound
+}
+
+// GetValue returns an ErrNodeNotFound error.
+func (d *nopNodeDB) GetValue(id hash.Hash) ([]byte, error) {
+	return nil, ErrNodeNotFound
+}
+
+// nopBatch is a no-op batch.
+type nopBatch struct{}
+
+func (d *nopNodeDB) NewBatch() Batch {
+	return &nopBatch{}
+}
+
+// PutNode does nothing.
+func (b *nopBatch) PutNode(ptr *internal.Pointer) error {
+	return nil
+}
+
+// RemoveNode does nothing.
+func (b *nopBatch) RemoveNode(ptr *internal.Pointer) error {
+	return nil
+}
+
+// PutValue does nothing.
+func (b *nopBatch) PutValue(value []byte) error {
+	return nil
+}
+
+// RemoveValue does nothing.
+func (b *nopBatch) RemoveValue(id hash.Hash) error {
+	return nil
+}
+
+// Commit does nothing.
+func (b *nopBatch) Commit(root hash.Hash) error {
+	return nil
+}
+
+// Reset does nothing.
+func (b *nopBatch) Reset() {
+}

--- a/go/storage/mkvs/urkel/db/memory.go
+++ b/go/storage/mkvs/urkel/db/memory.go
@@ -1,0 +1,161 @@
+package db
+
+import (
+	"sync"
+
+	"github.com/oasislabs/ekiden/go/common/crypto/hash"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/internal"
+)
+
+var _ NodeDB = (*memoryNodeDB)(nil)
+
+type memoryItem struct {
+	refs  int
+	value interface{}
+}
+
+type memoryNodeDB struct {
+	sync.RWMutex
+
+	items map[hash.Hash]*memoryItem
+}
+
+// NewMemoryNodeDB creates a new in-memory node database.
+func NewMemoryNodeDB() NodeDB {
+	return &memoryNodeDB{
+		items: make(map[hash.Hash]*memoryItem),
+	}
+}
+
+func (d *memoryNodeDB) GetNode(root hash.Hash, ptr *internal.Pointer) (internal.Node, error) {
+	if ptr == nil || !ptr.IsClean() {
+		panic("urkel: attempted to get invalid pointer from node database")
+	}
+
+	d.RLock()
+	defer d.RUnlock()
+
+	item, err := d.getLocked(ptr.Hash)
+	if err != nil {
+		return nil, err
+	}
+
+	return item.(internal.Node), nil
+}
+
+func (d *memoryNodeDB) GetValue(id hash.Hash) ([]byte, error) {
+	d.RLock()
+	defer d.RUnlock()
+
+	item, err := d.getLocked(id)
+	if err != nil {
+		return nil, err
+	}
+
+	return item.([]byte), nil
+}
+
+func (d *memoryNodeDB) putLocked(id hash.Hash, item interface{}) error {
+	n := d.items[id]
+	if n == nil {
+		n = new(memoryItem)
+		d.items[id] = n
+	}
+
+	n.refs++
+	n.value = item
+
+	return nil
+}
+
+func (d *memoryNodeDB) getLocked(id hash.Hash) (interface{}, error) {
+	item := d.items[id]
+	if item == nil {
+		return nil, ErrNodeNotFound
+	}
+
+	return item.value, nil
+}
+
+func (d *memoryNodeDB) removeLocked(id hash.Hash) error {
+	item := d.items[id]
+	if item == nil {
+		return nil
+	}
+
+	item.refs--
+	if item.refs <= 0 {
+		delete(d.items, id)
+	}
+
+	return nil
+}
+
+type memoryBatch struct {
+	db *memoryNodeDB
+
+	ops []func() error
+}
+
+func (d *memoryNodeDB) NewBatch() Batch {
+	return &memoryBatch{
+		db: d,
+	}
+}
+
+func (b *memoryBatch) PutNode(ptr *internal.Pointer) error {
+	if ptr == nil || ptr.Node == nil {
+		panic("urkel: attempted to put invalid pointer to node database")
+	}
+
+	b.ops = append(b.ops, func() error {
+		return b.db.putLocked(ptr.Node.GetHash(), ptr.Node)
+	})
+	return nil
+}
+
+func (b *memoryBatch) RemoveNode(ptr *internal.Pointer) error {
+	if ptr == nil || ptr.Node == nil {
+		panic("urkel: attempted to remove invalid pointer from node database")
+	}
+
+	b.ops = append(b.ops, func() error {
+		return b.db.removeLocked(ptr.Node.GetHash())
+	})
+	return nil
+}
+
+func (b *memoryBatch) PutValue(value []byte) error {
+	var id hash.Hash
+	id.FromBytes(value)
+
+	b.ops = append(b.ops, func() error {
+		return b.db.putLocked(id, value)
+	})
+	return nil
+}
+
+func (b *memoryBatch) RemoveValue(id hash.Hash) error {
+	b.ops = append(b.ops, func() error {
+		return b.db.removeLocked(id)
+	})
+	return nil
+}
+
+func (b *memoryBatch) Commit(root hash.Hash) error {
+	b.db.Lock()
+	defer b.db.Unlock()
+
+	for _, op := range b.ops {
+		if err := op(); err != nil {
+			return err
+		}
+	}
+	b.Reset()
+
+	return nil
+}
+
+func (b *memoryBatch) Reset() {
+	b.ops = nil
+}

--- a/go/storage/mkvs/urkel/debug.go
+++ b/go/storage/mkvs/urkel/debug.go
@@ -1,0 +1,85 @@
+package urkel
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/oasislabs/ekiden/go/common/crypto/hash"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/internal"
+)
+
+func (t *Tree) doDump(w io.Writer, ptr *internal.Pointer, path hash.Hash, depth uint8) {
+	prefix := strings.Repeat(" ", int(depth)*2)
+	node, err := t.cache.derefNodePtr(internal.NodeID{Path: path, Depth: depth}, ptr, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	switch n := node.(type) {
+	case nil:
+		fmt.Fprint(w, prefix+"<nil>")
+	case *internal.InternalNode:
+		fmt.Fprintf(w, prefix+"* [%v/%s]: {\n", n.Clean, n.Hash.String())
+		t.doDump(w, n.Left, setKeyBit(path, depth, false), depth+1)
+		fmt.Fprintln(w, ",")
+		t.doDump(w, n.Right, setKeyBit(path, depth, true), depth+1)
+		fmt.Fprintln(w, "")
+		fmt.Fprint(w, prefix+"}")
+	case *internal.LeafNode:
+		value, err := t.cache.derefValue(n.Value)
+		if err != nil {
+			value = []byte(fmt.Sprintf("<ERROR: %s>", err))
+		}
+
+		fmt.Fprintf(w, "%s- %s -> %s [%v/%s]", prefix, n.Key.String(), value, n.Clean, n.Hash.String())
+	default:
+		fmt.Fprintf(w, prefix+"<UNKNOWN>")
+	}
+}
+
+func (t *Tree) doStats(s *Stats, ptr *internal.Pointer, path hash.Hash, depth uint8, maxDepth uint8) uint8 {
+	if maxDepth > 0 && depth > maxDepth {
+		return depth
+	}
+	if depth > s.MaxDepth {
+		s.MaxDepth = depth
+	}
+
+	node, err := t.cache.derefNodePtr(internal.NodeID{Path: path, Depth: depth}, ptr, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	switch n := node.(type) {
+	case nil:
+		s.DeadNodeCount++
+	case *internal.InternalNode:
+		s.InternalNodeCount++
+
+		leftDepth := t.doStats(s, n.Left, setKeyBit(path, depth, false), depth+1, maxDepth)
+		if leftDepth-depth > s.LeftSubtreeMaxDepths[depth] {
+			s.LeftSubtreeMaxDepths[depth] = leftDepth - depth
+		}
+
+		rightDepth := t.doStats(s, n.Right, setKeyBit(path, depth, true), depth+1, maxDepth)
+		if rightDepth-depth > s.RightSubtreeMaxDepths[depth] {
+			s.RightSubtreeMaxDepths[depth] = rightDepth - depth
+		}
+
+		if leftDepth > rightDepth {
+			return leftDepth
+		}
+		return rightDepth
+	case *internal.LeafNode:
+		value, err := t.cache.derefValue(n.Value)
+		if err != nil {
+			panic(err)
+		}
+
+		s.LeafNodeCount++
+		s.LeafValueSize += uint64(len(value))
+	}
+
+	return depth
+}

--- a/go/storage/mkvs/urkel/insert.go
+++ b/go/storage/mkvs/urkel/insert.go
@@ -1,0 +1,83 @@
+package urkel
+
+import (
+	"fmt"
+
+	"github.com/oasislabs/ekiden/go/common/crypto/hash"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/internal"
+)
+
+func (t *Tree) doInsert(ptr *internal.Pointer, depth uint8, key hash.Hash, val []byte) (*internal.Pointer, bool, error) {
+	node, err := t.cache.derefNodePtr(internal.NodeID{Path: key, Depth: depth}, ptr, nil)
+	if err != nil {
+		return nil, false, err
+	}
+
+	switch n := node.(type) {
+	case nil:
+		// Insert into nil node, create a new leaf node.
+		return t.cache.newLeafNode(key, val), false, nil
+	case *internal.InternalNode:
+		var existed bool
+		if getKeyBit(key, depth) {
+			n.Right, existed, err = t.doInsert(n.Right, depth+1, key, val)
+		} else {
+			n.Left, existed, err = t.doInsert(n.Left, depth+1, key, val)
+		}
+		if err != nil {
+			return nil, false, err
+		}
+
+		if !n.Left.IsClean() || !n.Right.IsClean() {
+			n.Clean = false
+			ptr.Clean = false
+		}
+
+		return ptr, existed, nil
+	case *internal.LeafNode:
+		// If the key matches, we can just update the value.
+		if n.Key.Equal(&key) {
+			if n.Value.Equal(val) {
+				return ptr, true, nil
+			}
+
+			t.cache.removeValue(n.Value)
+			n.Value = t.cache.newValue(val)
+			n.Clean = false
+			ptr.Clean = false
+			return ptr, true, nil
+		}
+
+		existingBit := getKeyBit(n.Key, depth)
+		newBit := getKeyBit(key, depth)
+
+		var left, right *internal.Pointer
+		if existingBit != newBit {
+			// No bit collision at this depth, create an internal node with
+			// two leaves.
+			if existingBit {
+				left = t.cache.newLeafNode(key, val)
+				right = ptr
+			} else {
+				left = ptr
+				right = t.cache.newLeafNode(key, val)
+			}
+		} else {
+			// Bit collision at this depth.
+			if existingBit {
+				left = nil
+				right, _, err = t.doInsert(ptr, depth+1, key, val)
+			} else {
+				left, _, err = t.doInsert(ptr, depth+1, key, val)
+				right = nil
+			}
+			if err != nil {
+				return nil, false, err
+			}
+		}
+
+		return t.cache.newInternalNode(left, right), false, nil
+	default:
+		panic(fmt.Sprintf("urkel: unknown node type: %+v", n))
+	}
+}

--- a/go/storage/mkvs/urkel/internal/node.go
+++ b/go/storage/mkvs/urkel/internal/node.go
@@ -1,0 +1,367 @@
+// Package internal defines Urkel tree internals.
+package internal
+
+import (
+	"bytes"
+	"container/list"
+	"encoding"
+	"errors"
+	"fmt"
+
+	"github.com/oasislabs/ekiden/go/common/crypto/hash"
+)
+
+var (
+	ErrMalformed = errors.New("urkel: malformed node")
+)
+
+const (
+	// Prefix used in hash computations of leaf nodes.
+	PrefixLeafNode byte = 0x00
+	// Prefix used in hash computations of internal nodes.
+	PrefixInternalNode byte = 0x01
+)
+
+var (
+	_ encoding.BinaryMarshaler   = (*InternalNode)(nil)
+	_ encoding.BinaryUnmarshaler = (*InternalNode)(nil)
+	_ encoding.BinaryMarshaler   = (*LeafNode)(nil)
+	_ encoding.BinaryUnmarshaler = (*LeafNode)(nil)
+)
+
+// NodeID is a root-relative node identifier which uniquely identifies
+// a node under a given root.
+type NodeID struct {
+	Path  hash.Hash
+	Depth uint8
+}
+
+// AtDepth returns a NodeID representing the same path at a specified
+// depth.
+func (n NodeID) AtDepth(d uint8) NodeID {
+	return NodeID{Path: n.Path, Depth: d}
+}
+
+// Pointer is a pointer to another node.
+type Pointer struct {
+	Clean bool
+	Hash  hash.Hash
+	Node  Node
+	LRU   *list.Element
+
+	// DBInternal contains NodeDB-specific internal metadata to aid
+	// pointer resolution.
+	DBInternal interface{}
+}
+
+// GetHash returns the pointers's cached hash.
+func (p *Pointer) GetHash() hash.Hash {
+	if p == nil {
+		var h hash.Hash
+		h.Empty()
+		return h
+	}
+
+	return p.Hash
+}
+
+// IsClean returns true if the pointer is clean.
+func (p *Pointer) IsClean() bool {
+	if p == nil {
+		return true
+	}
+
+	return p.Clean
+}
+
+// Extract makes a copy of the pointer containing only hash references.
+func (p *Pointer) Extract() *Pointer {
+	if p == nil {
+		return nil
+	}
+	if !p.Clean {
+		panic("urkel: extract called on dirty pointer")
+	}
+
+	return &Pointer{
+		Clean: true,
+		Hash:  p.Hash,
+	}
+}
+
+// Node is either an InternalNode or a LeafNode.
+type Node interface {
+	encoding.BinaryMarshaler
+	encoding.BinaryUnmarshaler
+
+	// GetHash returns the node's cached hash.
+	GetHash() hash.Hash
+
+	// UpdateHash updates the node's cached hash by recomputing it.
+	//
+	// Does not mark the node as clean.
+	UpdateHash()
+
+	// Extract makes a copy of the node containing only hash references.
+	Extract() Node
+
+	// Validate that the node is internally consistent with the given
+	// node hash. This does NOT verify that the whole subtree is
+	// consistent.
+	//
+	// Calling this on a dirty node will return an error.
+	Validate(h hash.Hash) error
+}
+
+// InternalNode is an internal node with two children.
+type InternalNode struct { // nolint: golint
+	Clean bool
+	Hash  hash.Hash
+	Left  *Pointer
+	Right *Pointer
+}
+
+// UpdateHash updates the node's cached hash by recomputing it.
+//
+// Does not mark the node as clean.
+func (n *InternalNode) UpdateHash() {
+	leftHash := n.Left.GetHash()
+	rightHash := n.Right.GetHash()
+
+	n.Hash.FromBytes([]byte{PrefixInternalNode}, leftHash[:], rightHash[:])
+}
+
+// GetHash returns the node's cached hash.
+func (n *InternalNode) GetHash() hash.Hash {
+	return n.Hash
+}
+
+// Extract makes a copy of the node containing only hash references.
+func (n *InternalNode) Extract() Node {
+	if !n.Clean {
+		panic("urkel: extract called on dirty node")
+	}
+
+	return &InternalNode{
+		Clean: true,
+		Hash:  n.Hash,
+		Left:  n.Left.Extract(),
+		Right: n.Right.Extract(),
+	}
+}
+
+// Validate that the node is internally consistent with the given
+// node hash. This does NOT verify that the whole subtree is
+// consistent.
+//
+// Calling this on a dirty node will return an error.
+func (n *InternalNode) Validate(h hash.Hash) error {
+	if !n.Left.IsClean() || !n.Right.IsClean() {
+		return errors.New("urkel: node has dirty pointers")
+	}
+
+	n.UpdateHash()
+
+	if !h.Equal(&n.Hash) {
+		return fmt.Errorf("urkel: node hash mismatch (expected: %s got: %s)",
+			h.String(),
+			n.Hash.String(),
+		)
+	}
+
+	return nil
+}
+
+// MarshalBinary encodes an internal node into binary form.
+func (n *InternalNode) MarshalBinary() (data []byte, err error) {
+	leftHash := n.Left.GetHash()
+	rightHash := n.Right.GetHash()
+
+	data = make([]byte, 1+hash.Size*2)
+	data[0] = PrefixInternalNode
+	copy(data[1:1+hash.Size], leftHash[:])
+	copy(data[1+hash.Size:], rightHash[:])
+	return
+}
+
+// UnmarshalBinary decodes a binary marshaled internal node.
+func (n *InternalNode) UnmarshalBinary(data []byte) error {
+	if len(data) != 1+hash.Size*2 {
+		return ErrMalformed
+	}
+	if data[0] != PrefixInternalNode {
+		return ErrMalformed
+	}
+
+	var leftHash hash.Hash
+	if err := leftHash.UnmarshalBinary(data[1 : 1+hash.Size]); err != nil {
+		return err
+	}
+	var rightHash hash.Hash
+	if err := rightHash.UnmarshalBinary(data[1+hash.Size:]); err != nil {
+		return err
+	}
+
+	n.Clean = false
+	if leftHash.IsEmpty() {
+		n.Left = nil
+	} else {
+		n.Left = &Pointer{Clean: true, Hash: leftHash}
+	}
+
+	if rightHash.IsEmpty() {
+		n.Right = nil
+	} else {
+		n.Right = &Pointer{Clean: true, Hash: rightHash}
+	}
+
+	return nil
+}
+
+// LeafNode is a leaf node containing a key/value pair.
+type LeafNode struct {
+	Clean bool
+	Hash  hash.Hash
+	Key   hash.Hash
+	Value *Value
+}
+
+// GetHash returns the node's cached hash.
+func (n *LeafNode) GetHash() hash.Hash {
+	return n.Hash
+}
+
+// UpdateHash updates the node's cached hash by recomputing it.
+//
+// Does not mark the node as clean.
+func (n *LeafNode) UpdateHash() {
+	n.Hash.FromBytes([]byte{PrefixLeafNode}, n.Key[:], n.Value.Hash[:])
+}
+
+// Extract makes a copy of the node containing only hash references.
+func (n *LeafNode) Extract() Node {
+	if !n.Clean {
+		panic("urkel: extract called on dirty node")
+	}
+
+	return &LeafNode{
+		Clean: true,
+		Hash:  n.Hash,
+		Key:   n.Key,
+		Value: n.Value.Extract(),
+	}
+}
+
+// Validate that the node is internally consistent with the given
+// node hash. This does NOT verify that the whole subtree is
+// consistent.
+//
+// Calling this on a dirty node will return an error.
+func (n *LeafNode) Validate(h hash.Hash) error {
+	if !n.Value.Clean {
+		return errors.New("urkel: node has dirty value")
+	}
+
+	n.UpdateHash()
+
+	if !h.Equal(&n.Hash) {
+		return fmt.Errorf("urkel: node hash mismatch (expected: %s got: %s)",
+			h.String(),
+			n.Hash.String(),
+		)
+	}
+
+	return nil
+}
+
+// MarshalBinary encodes a leaf node into binary form.
+func (n *LeafNode) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, 1+hash.Size*2)
+	data[0] = PrefixLeafNode
+	copy(data[1:1+hash.Size], n.Key[:])
+	copy(data[1+hash.Size:], n.Value.Hash[:])
+	return
+}
+
+// UnmarshalBinary decodes a binary marshaled leaf node.
+func (n *LeafNode) UnmarshalBinary(data []byte) error {
+	if len(data) != 1+hash.Size*2 {
+		return ErrMalformed
+	}
+	if data[0] != PrefixLeafNode {
+		return ErrMalformed
+	}
+
+	var key hash.Hash
+	if err := key.UnmarshalBinary(data[1 : 1+hash.Size]); err != nil {
+		return err
+	}
+	var valueHash hash.Hash
+	if err := valueHash.UnmarshalBinary(data[1+hash.Size:]); err != nil {
+		return err
+	}
+
+	n.Clean = false
+	n.Key = key
+	n.Value = &Value{Clean: true, Hash: valueHash}
+
+	return nil
+}
+
+// Value holds the value.
+type Value struct {
+	Clean bool
+	Hash  hash.Hash
+	Value []byte
+	LRU   *list.Element
+}
+
+// GetHash returns the value's cached hash.
+func (v *Value) GetHash() hash.Hash {
+	return v.Hash
+}
+
+// UpdateHash updates the value's cached hash by recomputing it.
+//
+// Does not mark the node as clean.
+func (v *Value) UpdateHash() {
+	v.Hash.FromBytes(v.Value)
+}
+
+// Equal compares the value with some other value.
+func (v *Value) Equal(other []byte) bool {
+	if v.Value != nil {
+		return bytes.Equal(v.Value, other)
+	}
+
+	var otherHash hash.Hash
+	otherHash.FromBytes(other)
+	return v.Hash.Equal(&otherHash)
+}
+
+// Extract makes a copy of the value containing only hash references.
+func (v *Value) Extract() *Value {
+	if !v.Clean {
+		panic("urkel: extract called on dirty value")
+	}
+
+	return &Value{
+		Clean: true,
+		Hash:  v.Hash,
+	}
+}
+
+// Validate that the value is internally consistent with the given
+// value hash.
+func (v *Value) Validate(h hash.Hash) error {
+	v.UpdateHash()
+
+	if !h.Equal(&v.Hash) {
+		return fmt.Errorf("urkel: value hash mismatch (expected: %s got: %s)",
+			h.String(),
+			v.Hash.String(),
+		)
+	}
+
+	return nil
+}

--- a/go/storage/mkvs/urkel/internal/node_test.go
+++ b/go/storage/mkvs/urkel/internal/node_test.go
@@ -1,0 +1,152 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasislabs/ekiden/go/common/crypto/hash"
+)
+
+func TestSerializationLeafNode(t *testing.T) {
+	var key hash.Hash
+	key.FromBytes([]byte("a golden key"))
+	var valueHash hash.Hash
+	valueHash.FromBytes([]byte("value"))
+
+	leafNode := &LeafNode{
+		Key: key,
+		Value: &Value{
+			Clean: true,
+			Hash:  valueHash,
+			Value: []byte("value"),
+		},
+	}
+
+	rawLeafNode, err := leafNode.MarshalBinary()
+	require.NoError(t, err, "MarshalBinary")
+
+	var decodedLeafNode LeafNode
+	err = decodedLeafNode.UnmarshalBinary(rawLeafNode)
+	require.NoError(t, err, "UnmarshalBinary")
+
+	require.False(t, decodedLeafNode.Clean)
+	require.Equal(t, leafNode.Key, decodedLeafNode.Key)
+	require.True(t, decodedLeafNode.Value.Clean)
+	require.Equal(t, leafNode.Value.Hash, decodedLeafNode.Value.Hash)
+	require.Nil(t, decodedLeafNode.Value.Value)
+}
+
+func TestSerializationInternalNode(t *testing.T) {
+	var leftHash hash.Hash
+	leftHash.FromBytes([]byte("everyone move to the left"))
+	var rightHash hash.Hash
+	rightHash.FromBytes([]byte("everyone move to the right"))
+
+	intNode := &InternalNode{
+		Left:  &Pointer{Clean: true, Hash: leftHash},
+		Right: &Pointer{Clean: true, Hash: rightHash},
+	}
+
+	rawIntNode, err := intNode.MarshalBinary()
+	require.NoError(t, err, "MarshalBinary")
+
+	var decodedIntNode InternalNode
+	err = decodedIntNode.UnmarshalBinary(rawIntNode)
+	require.NoError(t, err, "UnmarshalBinary")
+
+	require.False(t, decodedIntNode.Clean)
+	require.Equal(t, intNode.Left.Hash, decodedIntNode.Left.Hash)
+	require.Equal(t, intNode.Right.Hash, decodedIntNode.Right.Hash)
+	require.True(t, decodedIntNode.Left.Clean)
+	require.True(t, decodedIntNode.Right.Clean)
+	require.Nil(t, decodedIntNode.Left.Node)
+	require.Nil(t, decodedIntNode.Right.Node)
+}
+
+func TestHashLeafNode(t *testing.T) {
+	var key hash.Hash
+	key.FromBytes([]byte("a golden key"))
+	var valueHash hash.Hash
+	valueHash.FromBytes([]byte("value"))
+
+	leafNode := &LeafNode{
+		Key: key,
+		Value: &Value{
+			Clean: true,
+			Hash:  valueHash,
+			Value: []byte("value"),
+		},
+	}
+
+	leafNode.UpdateHash()
+
+	require.Equal(t, leafNode.Hash.String(), "63a651558d7a38c9cf03ac1be3c6d38964b8c39568a10a84056728d024d09646")
+}
+
+func TestHashInternalNode(t *testing.T) {
+	var leftHash hash.Hash
+	leftHash.FromBytes([]byte("everyone move to the left"))
+	var rightHash hash.Hash
+	rightHash.FromBytes([]byte("everyone move to the right"))
+
+	intNode := &InternalNode{
+		Left:  &Pointer{Clean: true, Hash: leftHash},
+		Right: &Pointer{Clean: true, Hash: rightHash},
+	}
+
+	intNode.UpdateHash()
+
+	require.Equal(t, intNode.Hash.String(), "4aed14e40ba69eae81b78b441b277f834b6202097a11ad3ba668c46f44d3717b")
+}
+
+func TestExtractLeafNode(t *testing.T) {
+	var key hash.Hash
+	key.FromBytes([]byte("a golden key"))
+	var valueHash hash.Hash
+	valueHash.FromBytes([]byte("value"))
+
+	leafNode := &LeafNode{
+		Clean: true,
+		Key:   key,
+		Value: &Value{
+			Clean: true,
+			Hash:  valueHash,
+			Value: []byte("value"),
+		},
+	}
+
+	exLeafNode := leafNode.Extract().(*LeafNode)
+
+	require.False(t, leafNode == exLeafNode, "extracted node must have a different address")
+	require.False(t, leafNode.Value == exLeafNode.Value, "extracted value must have a different address")
+	require.Equal(t, true, exLeafNode.Clean, "extracted leaf must be clean")
+	require.Equal(t, key, exLeafNode.Key, "extracted leaf must have the same key")
+	require.Equal(t, true, exLeafNode.Value.Clean, "extracted leaf must have clean value")
+	require.Equal(t, valueHash, exLeafNode.Value.Hash, "extracted leaf's value must have the same hash")
+	require.Nil(t, exLeafNode.Value.Value, "extracted leaf's value must have nil value")
+}
+
+func TestExtractInternalNode(t *testing.T) {
+	var leftHash hash.Hash
+	leftHash.FromBytes([]byte("everyone move to the left"))
+	var rightHash hash.Hash
+	rightHash.FromBytes([]byte("everyone move to the right"))
+
+	intNode := &InternalNode{
+		Clean: true,
+		Left:  &Pointer{Clean: true, Hash: leftHash},
+		Right: &Pointer{Clean: true, Hash: rightHash},
+	}
+
+	exIntNode := intNode.Extract().(*InternalNode)
+
+	require.False(t, intNode == exIntNode, "extracted node must have a different address")
+	require.False(t, intNode.Left == exIntNode.Left, "extracted left pointer must have a different address")
+	require.False(t, intNode.Right == exIntNode.Right, "extracted right pointer must have a different address")
+	require.Equal(t, true, exIntNode.Clean, "extracted internal node must be clean")
+	require.Equal(t, leftHash, exIntNode.Left.Hash, "extracted left pointer must have the same hash")
+	require.Equal(t, true, exIntNode.Left.Clean, "extracted left pointer must be clean")
+	require.Equal(t, rightHash, exIntNode.Right.Hash, "extracted right pointer must have the same hash")
+	require.Equal(t, true, exIntNode.Right.Clean, "extracted right pointer must be clean")
+}

--- a/go/storage/mkvs/urkel/log.go
+++ b/go/storage/mkvs/urkel/log.go
@@ -1,0 +1,29 @@
+package urkel
+
+// WriteLog is a write log.
+//
+// The keys in the write log must be unique.
+type WriteLog []LogEntry
+
+// LogEntry is a write log entry.
+type LogEntry struct {
+	Key   []byte
+	Value []byte
+}
+
+// LogEntryType is a type of a write log entry.
+type LogEntryType int
+
+const (
+	LogInsert LogEntryType = iota
+	LogDelete
+)
+
+// Type returns the type of the write log entry.
+func (k *LogEntry) Type() LogEntryType {
+	if k.Value == nil {
+		return LogDelete
+	}
+
+	return LogInsert
+}

--- a/go/storage/mkvs/urkel/lookup.go
+++ b/go/storage/mkvs/urkel/lookup.go
@@ -1,0 +1,37 @@
+package urkel
+
+import (
+	"fmt"
+
+	"github.com/oasislabs/ekiden/go/common/crypto/hash"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/internal"
+)
+
+func (t *Tree) doGet(ptr *internal.Pointer, depth uint8, key hash.Hash) ([]byte, error) {
+	node, err := t.cache.derefNodePtr(internal.NodeID{Path: key, Depth: depth}, ptr, &key)
+	if err != nil {
+		return nil, err
+	}
+
+	switch n := node.(type) {
+	case nil:
+		// Reached a nil node, there is nothing here.
+		return nil, nil
+	case *internal.InternalNode:
+		// Internal node, decide based on the bit value.
+		if getKeyBit(key, depth) {
+			return t.doGet(n.Right, depth+1, key)
+		}
+
+		return t.doGet(n.Left, depth+1, key)
+	case *internal.LeafNode:
+		// Reached a leaf node, check if key matches.
+		if n.Key.Equal(&key) {
+			return t.cache.derefValue(n.Value)
+		}
+	default:
+		panic(fmt.Sprintf("urkel: unknown node type: %+v", n))
+	}
+
+	return nil, nil
+}

--- a/go/storage/mkvs/urkel/remove.go
+++ b/go/storage/mkvs/urkel/remove.go
@@ -1,0 +1,81 @@
+package urkel
+
+import (
+	"fmt"
+
+	"github.com/oasislabs/ekiden/go/common/crypto/hash"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/internal"
+)
+
+func (t *Tree) doRemove(ptr *internal.Pointer, depth uint8, key hash.Hash) (*internal.Pointer, bool, error) {
+	node, err := t.cache.derefNodePtr(internal.NodeID{Path: key, Depth: depth}, ptr, &key)
+	if err != nil {
+		return nil, false, err
+	}
+
+	switch n := node.(type) {
+	case nil:
+		// Remove from nil node.
+		return nil, false, nil
+	case *internal.InternalNode:
+		// Remove from internal node.
+		var changed bool
+		if getKeyBit(key, depth) {
+			n.Right, changed, err = t.doRemove(n.Right, depth+1, key)
+		} else {
+			n.Left, changed, err = t.doRemove(n.Left, depth+1, key)
+		}
+		if err != nil {
+			return nil, false, err
+		}
+
+		lrID := internal.NodeID{Path: key, Depth: depth + 1}
+		if node, err = t.cache.derefNodePtr(lrID, n.Left, nil); err != nil {
+			return nil, false, err
+		}
+
+		switch node.(type) {
+		case nil:
+			if node, err = t.cache.derefNodePtr(lrID, n.Right, nil); err != nil {
+				return nil, false, err
+			}
+
+			switch node.(type) {
+			case nil:
+				// No more children, delete the internal node as well.
+				t.cache.tryRemoveNode(ptr)
+				return nil, true, nil
+			case *internal.LeafNode:
+				// Left is nil, right is leaf, merge nodes back.
+				return n.Right, true, nil
+			}
+		case *internal.LeafNode:
+			if node, err = t.cache.derefNodePtr(lrID, n.Right, nil); err != nil {
+				return nil, false, err
+			}
+
+			switch node.(type) {
+			case nil:
+				// Right is nil, left is leaf, merge nodes back.
+				return n.Left, true, nil
+			}
+		}
+
+		if changed {
+			n.Clean = false
+			ptr.Clean = false
+		}
+
+		return ptr, changed, nil
+	case *internal.LeafNode:
+		// Remove from leaf node.
+		if n.Key.Equal(&key) {
+			t.cache.tryRemoveNode(ptr)
+			return nil, true, nil
+		}
+
+		return ptr, false, nil
+	default:
+		panic(fmt.Sprintf("urkel: unknown node type: %+v", n))
+	}
+}

--- a/go/storage/mkvs/urkel/sync.go
+++ b/go/storage/mkvs/urkel/sync.go
@@ -1,0 +1,260 @@
+package urkel
+
+import (
+	"context"
+
+	"github.com/oasislabs/ekiden/go/common/crypto/hash"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/internal"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/syncer"
+)
+
+var _ syncer.ReadSyncer = (*Tree)(nil)
+
+// GetSubtree retrieves a compressed subtree summary of the given node
+// under the given root up to the specified depth.
+//
+// It is the responsibility of the caller to validate that the subtree
+// is correct and consistent.
+func (t *Tree) GetSubtree(ctx context.Context, root hash.Hash, id internal.NodeID, maxDepth uint8) (*syncer.Subtree, error) {
+	if !root.Equal(&t.cache.pendingRoot.Hash) {
+		return nil, syncer.ErrInvalidRoot
+	}
+	if !t.cache.pendingRoot.IsClean() {
+		return nil, syncer.ErrDirtyRoot
+	}
+
+	// Extract the node that is at the root of the subtree.
+	subtreeRoot, err := t.cache.derefNodeID(id)
+	if err != nil {
+		return nil, syncer.ErrNodeNotFound
+	}
+	path := hash.Hash{}
+
+	st := &syncer.Subtree{}
+	rootPtr, err := t.doGetSubtree(ctx, subtreeRoot, 0, path, st, maxDepth)
+	if err != nil {
+		return nil, err
+	}
+	st.Root = rootPtr
+	if !st.Root.Valid {
+		return nil, syncer.ErrInvalidRoot
+	}
+
+	return st, nil
+}
+
+func (t *Tree) doGetSubtree(
+	ctx context.Context,
+	ptr *internal.Pointer,
+	depth uint8,
+	path hash.Hash,
+	st *syncer.Subtree,
+	maxDepth uint8,
+) (syncer.SubtreePointer, error) {
+	// Abort in case the context is cancelled.
+	select {
+	case <-ctx.Done():
+		return syncer.SubtreePointer{}, ctx.Err()
+	default:
+	}
+
+	node, err := t.cache.derefNodePtr(internal.NodeID{Path: path, Depth: depth}, ptr, nil)
+	if err != nil {
+		return syncer.SubtreePointer{}, err
+	}
+	if node == nil {
+		return syncer.SubtreePointer{Index: syncer.InvalidSubtreeIndex, Valid: true}, nil
+	}
+
+	if depth >= maxDepth {
+		// Nodes at maxDepth are always full nodes.
+		idx, err := st.AddFullNode(node.Extract())
+		if err != nil {
+			return syncer.SubtreePointer{}, err
+		}
+		return syncer.SubtreePointer{Index: idx, Full: true, Valid: true}, nil
+	}
+
+	switch n := node.(type) {
+	case *internal.InternalNode:
+		// Record internal node summary.
+		s := syncer.InternalNodeSummary{}
+
+		// Left subtree.
+		leftPtr, err := t.doGetSubtree(ctx, n.Left, depth+1, setKeyBit(path, depth, false), st, maxDepth)
+		if err != nil {
+			return syncer.SubtreePointer{}, err
+		}
+		s.Left = leftPtr
+
+		// Right subtree.
+		rightPtr, err := t.doGetSubtree(ctx, n.Right, depth+1, setKeyBit(path, depth, true), st, maxDepth)
+		if err != nil {
+			return syncer.SubtreePointer{}, err
+		}
+		s.Right = rightPtr
+
+		idx, err := st.AddSummary(s)
+		if err != nil {
+			return syncer.SubtreePointer{}, err
+		}
+
+		return syncer.SubtreePointer{Index: idx, Valid: true}, nil
+	case *internal.LeafNode:
+		// All encountered leaves are always full nodes.
+		idx, err := st.AddFullNode(node.Extract())
+		if err != nil {
+			return syncer.SubtreePointer{}, err
+		}
+
+		return syncer.SubtreePointer{Index: idx, Full: true, Valid: true}, nil
+	default:
+		panic("urkel: invalid node type")
+
+	}
+}
+
+// GetPath retrieves a compressed path summary for the given key under
+// the given root, starting at the given depth.
+//
+// It is the responsibility of the caller to validate that the subtree
+// is correct and consistent.
+func (t *Tree) GetPath(ctx context.Context, root hash.Hash, key hash.Hash, startDepth uint8) (*syncer.Subtree, error) {
+	if !root.Equal(&t.cache.pendingRoot.Hash) {
+		return nil, syncer.ErrInvalidRoot
+	}
+	if !t.cache.pendingRoot.IsClean() {
+		return nil, syncer.ErrDirtyRoot
+	}
+
+	subtreeRoot, err := t.cache.derefNodeID(internal.NodeID{Path: key, Depth: startDepth})
+	if err != nil {
+		return nil, syncer.ErrNodeNotFound
+	}
+
+	st := &syncer.Subtree{}
+	rootPtr, err := t.doGetPath(ctx, subtreeRoot, startDepth, key, st)
+	if err != nil {
+		return nil, err
+	}
+	st.Root = rootPtr
+	if !st.Root.Valid {
+		return nil, syncer.ErrInvalidRoot
+	}
+
+	return st, nil
+}
+
+func (t *Tree) doGetPath(
+	ctx context.Context,
+	ptr *internal.Pointer,
+	depth uint8,
+	key hash.Hash,
+	st *syncer.Subtree,
+) (syncer.SubtreePointer, error) {
+	// Abort in case the context is cancelled.
+	select {
+	case <-ctx.Done():
+		return syncer.SubtreePointer{}, ctx.Err()
+	default:
+	}
+
+	node, err := t.cache.derefNodePtr(internal.NodeID{Path: key, Depth: depth}, ptr, &key)
+	if err != nil {
+		return syncer.SubtreePointer{}, err
+	}
+	if node == nil {
+		return syncer.SubtreePointer{Index: syncer.InvalidSubtreeIndex, Valid: true}, nil
+	}
+
+	if !getKeyBit(key, depth) {
+		// Off-path nodes are always full nodes.
+		idx, err := st.AddFullNode(node.Extract())
+		if err != nil {
+			return syncer.SubtreePointer{}, err
+		}
+		return syncer.SubtreePointer{Index: idx, Full: true, Valid: true}, nil
+	}
+
+	switch n := node.(type) {
+	case *internal.InternalNode:
+		// Record internal node summary.
+		s := syncer.InternalNodeSummary{}
+
+		// Left subtree.
+		leftPtr, err := t.doGetPath(ctx, n.Left, depth+1, key, st)
+		if err != nil {
+			return syncer.SubtreePointer{}, err
+		}
+		s.Left = leftPtr
+
+		// Right subtree.
+		rightPtr, err := t.doGetPath(ctx, n.Right, depth+1, key, st)
+		if err != nil {
+			return syncer.SubtreePointer{}, err
+		}
+		s.Right = rightPtr
+
+		idx, err := st.AddSummary(s)
+		if err != nil {
+			return syncer.SubtreePointer{}, err
+		}
+
+		return syncer.SubtreePointer{Index: idx, Full: false, Valid: true}, nil
+	case *internal.LeafNode:
+		// All encountered leaves are always full nodes.
+		idx, err := st.AddFullNode(node.Extract())
+		if err != nil {
+			return syncer.SubtreePointer{}, err
+		}
+
+		return syncer.SubtreePointer{Index: idx, Full: true, Valid: true}, nil
+	default:
+		panic("urkel: invalid node type")
+
+	}
+}
+
+// GetNode retrieves a specific node under the given root.
+//
+// It is the responsibility of the caller to validate that the node
+// is consistent. The node's cached hash should be considered invalid
+// and must be recomputed locally.
+func (t *Tree) GetNode(ctx context.Context, root hash.Hash, id internal.NodeID) (internal.Node, error) {
+	if !root.Equal(&t.cache.pendingRoot.Hash) {
+		return nil, syncer.ErrInvalidRoot
+	}
+	if !t.cache.pendingRoot.IsClean() {
+		return nil, syncer.ErrDirtyRoot
+	}
+
+	ptr, err := t.cache.derefNodeID(id)
+	if err != nil {
+		return nil, syncer.ErrNodeNotFound
+	}
+	node, err := t.cache.derefNodePtr(id, ptr, nil)
+	if err != nil {
+		return nil, syncer.ErrNodeNotFound
+	}
+	return node.Extract(), nil
+}
+
+// GetValue retrieves a specific value under the given root.
+//
+// It is the responsibility of the caller to validate that the value
+// is consistent.
+func (t *Tree) GetValue(ctx context.Context, root hash.Hash, id hash.Hash) ([]byte, error) {
+	if !root.Equal(&t.cache.pendingRoot.Hash) {
+		return nil, syncer.ErrInvalidRoot
+	}
+	if !t.cache.pendingRoot.IsClean() {
+		return nil, syncer.ErrDirtyRoot
+	}
+
+	val, err := t.cache.derefValue(&internal.Value{Clean: true, Hash: id})
+	if err != nil {
+		return nil, syncer.ErrValueNotFound
+	}
+
+	return val, nil
+}

--- a/go/storage/mkvs/urkel/syncer/stats.go
+++ b/go/storage/mkvs/urkel/syncer/stats.go
@@ -1,0 +1,48 @@
+package syncer
+
+import (
+	"context"
+
+	"github.com/oasislabs/ekiden/go/common/crypto/hash"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/internal"
+)
+
+// StatsCollector is a ReadSyncer which collects call statistics.
+type StatsCollector struct {
+	SubtreeFetches int
+	PathFetches    int
+	NodeFetches    int
+	ValueFetches   int
+
+	rs ReadSyncer
+}
+
+// NewnopReadSyncer creates a new no-op read syncer.
+func NewStatsCollector(rs ReadSyncer) *StatsCollector {
+	return &StatsCollector{
+		rs: rs,
+	}
+}
+
+// GetSubtree retrieves a compressed subtree summary of the given root.
+func (c *StatsCollector) GetSubtree(ctx context.Context, root hash.Hash, id internal.NodeID, maxDepth uint8) (*Subtree, error) {
+	c.SubtreeFetches++
+	return c.rs.GetSubtree(ctx, root, id, maxDepth)
+}
+
+func (c *StatsCollector) GetPath(ctx context.Context, root hash.Hash, key hash.Hash, startDepth uint8) (*Subtree, error) {
+	c.PathFetches++
+	return c.rs.GetPath(ctx, root, key, startDepth)
+}
+
+// GetNode retrieves a specific node under the given root.
+func (c *StatsCollector) GetNode(ctx context.Context, root hash.Hash, id internal.NodeID) (internal.Node, error) {
+	c.NodeFetches++
+	return c.rs.GetNode(ctx, root, id)
+}
+
+// GetValue retrieves a specific value under the given root.
+func (c *StatsCollector) GetValue(ctx context.Context, root hash.Hash, id hash.Hash) ([]byte, error) {
+	c.ValueFetches++
+	return c.rs.GetValue(ctx, root, id)
+}

--- a/go/storage/mkvs/urkel/syncer/subtree.go
+++ b/go/storage/mkvs/urkel/syncer/subtree.go
@@ -1,0 +1,112 @@
+package syncer
+
+import (
+	"errors"
+
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/internal"
+)
+
+var (
+	ErrTooManyFullNodes    = errors.New("urkel: too many full nodes")
+	ErrInvalidSubtreeIndex = errors.New("urkel: invalid subtree index")
+)
+
+// SubtreeIndex is a subtree index.
+type SubtreeIndex uint16
+
+// InvalidSubtreeIndex is an invalid subtree index.
+const InvalidSubtreeIndex SubtreeIndex = (1 << 16) - 1
+
+// SubtreePointer is a pointer into the compressed representation of a
+// subtree.
+type SubtreePointer struct {
+	Index SubtreeIndex
+	Full  bool
+	Valid bool
+}
+
+// InternalNodeSummary is a compressed (index-only) representation of an
+// internal node.
+type InternalNodeSummary struct {
+	invalid bool
+
+	Left  SubtreePointer
+	Right SubtreePointer
+}
+
+// Subtree is a compressed representation of a subtree.
+type Subtree struct {
+	Root SubtreePointer
+
+	Summaries []InternalNodeSummary
+	FullNodes []internal.Node
+}
+
+func checkSubtreeIndex(idx int) (SubtreeIndex, error) {
+	si := SubtreeIndex(idx)
+	if si >= InvalidSubtreeIndex {
+		return InvalidSubtreeIndex, ErrTooManyFullNodes
+	}
+
+	return si, nil
+}
+
+// AddSummary adds a new internal node summary to the subtree.
+func (s *Subtree) AddSummary(ns InternalNodeSummary) (SubtreeIndex, error) {
+	idx, err := checkSubtreeIndex(len(s.Summaries))
+	if err != nil {
+		return idx, err
+	}
+	s.Summaries = append(s.Summaries, ns)
+	return idx, nil
+}
+
+// AddFullNode adds a new full node to the subtree.
+func (s *Subtree) AddFullNode(n internal.Node) (SubtreeIndex, error) {
+	idx, err := checkSubtreeIndex(len(s.FullNodes))
+	if err != nil {
+		return idx, err
+	}
+	s.FullNodes = append(s.FullNodes, n)
+	return idx, nil
+}
+
+// GetFullNodeAt retrieves a full node at a specific index.
+//
+// If the index has already been marked as used it returns an error.
+func (s *Subtree) GetFullNodeAt(idx SubtreeIndex) (internal.Node, error) {
+	if idx == InvalidSubtreeIndex || int(idx) >= len(s.FullNodes) {
+		return nil, ErrInvalidSubtreeIndex
+	}
+	node := s.FullNodes[idx]
+	if node == nil {
+		return nil, ErrInvalidSubtreeIndex
+	}
+	return node, nil
+}
+
+// GetSummaryAt retrieves an internal node summary at a specific index.
+//
+// If the index has already been marked as used it returns an error.
+func (s *Subtree) GetSummaryAt(idx SubtreeIndex) (*InternalNodeSummary, error) {
+	if idx == InvalidSubtreeIndex {
+		return nil, nil
+	}
+	if int(idx) >= len(s.Summaries) {
+		return nil, ErrInvalidSubtreeIndex
+	}
+	sum := s.Summaries[idx]
+	if sum.invalid {
+		return nil, ErrInvalidSubtreeIndex
+	}
+	return &sum, nil
+}
+
+// MarkUsed marks the given index as used.
+func (s *Subtree) MarkUsed(ptr SubtreePointer) {
+	if ptr.Full {
+		s.FullNodes[ptr.Index] = nil
+	} else if ptr.Index != InvalidSubtreeIndex {
+		s.Summaries[ptr.Index].invalid = true
+	}
+}

--- a/go/storage/mkvs/urkel/syncer/syncer.go
+++ b/go/storage/mkvs/urkel/syncer/syncer.go
@@ -1,0 +1,73 @@
+// Package syncer provides the read-only sync interface.
+package syncer
+
+import (
+	"context"
+	"errors"
+
+	"github.com/oasislabs/ekiden/go/common/crypto/hash"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/internal"
+)
+
+var (
+	ErrDirtyRoot     = errors.New("urkel: root is dirty")
+	ErrInvalidRoot   = errors.New("urkel: invalid root")
+	ErrNodeNotFound  = errors.New("urkel: node not found during sync")
+	ErrValueNotFound = errors.New("urkel: value not found during sync")
+	ErrUnsupported   = errors.New("urkel: method not supported")
+)
+
+// ReadSyncer is the interface for synchronizing the in-memory cache
+// with another (potentially untrusted) MKVS.
+type ReadSyncer interface {
+	// GetSubtree retrieves a compressed subtree summary of the given node
+	// under the given root up to the specified depth.
+	//
+	// It is the responsibility of the caller to validate that the subtree
+	// is correct and consistent.
+	GetSubtree(ctx context.Context, root hash.Hash, id internal.NodeID, maxDepth uint8) (*Subtree, error)
+
+	// GetPath retrieves a compressed path summary for the given key under
+	// the given root, starting at the given depth.
+	//
+	// It is the responsibility of the caller to validate that the subtree
+	// is correct and consistent.
+	GetPath(ctx context.Context, root hash.Hash, key hash.Hash, startDepth uint8) (*Subtree, error)
+
+	// GetNode retrieves a specific node under the given root.
+	//
+	// It is the responsibility of the caller to validate that the node
+	// is consistent. The node's cached hash should be considered invalid
+	// and must be recomputed locally.
+	GetNode(ctx context.Context, root hash.Hash, id internal.NodeID) (internal.Node, error)
+
+	// GetValue retrieves a specific value under the given root.
+	//
+	// It is the responsibility of the caller to validate that the value
+	// is consistent.
+	GetValue(ctx context.Context, root hash.Hash, id hash.Hash) ([]byte, error)
+}
+
+// nopReadSyncer is a no-op read syncer.
+type nopReadSyncer struct{}
+
+// NewNopReadSyncer creates a new no-op read syncer.
+func NewNopReadSyncer() ReadSyncer {
+	return &nopReadSyncer{}
+}
+
+func (r *nopReadSyncer) GetSubtree(ctx context.Context, root hash.Hash, id internal.NodeID, maxDepth uint8) (*Subtree, error) {
+	return nil, ErrUnsupported
+}
+
+func (r *nopReadSyncer) GetPath(ctx context.Context, root hash.Hash, key hash.Hash, startDepth uint8) (*Subtree, error) {
+	return nil, ErrUnsupported
+}
+
+func (r *nopReadSyncer) GetNode(ctx context.Context, root hash.Hash, id internal.NodeID) (internal.Node, error) {
+	return nil, ErrUnsupported
+}
+
+func (r *nopReadSyncer) GetValue(ctx context.Context, root hash.Hash, id hash.Hash) ([]byte, error) {
+	return nil, ErrUnsupported
+}

--- a/go/storage/mkvs/urkel/urkel.go
+++ b/go/storage/mkvs/urkel/urkel.go
@@ -1,0 +1,228 @@
+// Package urkel provides an Urkel tree implementation.
+package urkel
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/oasislabs/ekiden/go/common/crypto/hash"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/db"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/internal"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/syncer"
+)
+
+type Stats struct {
+	MaxDepth          uint8
+	InternalNodeCount uint64
+	LeafNodeCount     uint64
+	LeafValueSize     uint64
+	DeadNodeCount     uint64
+
+	LeftSubtreeMaxDepths  map[uint8]uint8
+	RightSubtreeMaxDepths map[uint8]uint8
+
+	Cache struct {
+		InternalNodeCount uint64
+		LeafNodeCount     uint64
+		LeafValueSize     uint64
+	}
+}
+
+// Tree is an Urkel tree.
+type Tree struct {
+	cache cache
+
+	// NOTE: This can be a map as updates are commutative.
+	pendingWriteLog map[hash.Hash]*pendingLogEntry
+}
+
+type pendingLogEntry struct {
+	key     []byte
+	value   []byte
+	existed bool
+}
+
+// Option is a configuration option used when instantiating the tree.
+type Option func(t *Tree)
+
+// PrefetchDepth sets the depth of subtree prefetching.
+//
+// If no prefetch depth is specified, no prefetching will be done.
+func PrefetchDepth(depth uint8) Option {
+	return func(t *Tree) {
+		t.cache.prefetchDepth = depth
+	}
+}
+
+// Capacity sets the capacity of the in-memory cache.
+//
+// If no capacity is specified, the cache will have an unlimited size.
+func Capacity(nodeCapacity uint64, valueCapacityBytes uint64) Option {
+	return func(t *Tree) {
+		t.cache.nodeCapacity = nodeCapacity
+		t.cache.valueCapacity = valueCapacityBytes
+	}
+}
+
+// SyncerGetNodeTimeout sets the timeout for remote node fetches.
+//
+// If not specified, the default of 1 second will be used.
+func SyncerGetNodeTimeout(timeout time.Duration) Option {
+	return func(t *Tree) {
+		t.cache.syncerGetNodeTimeout = timeout
+	}
+}
+
+// SyncerPrefetchTimeout sets the timeout for remote subtree fetches.
+//
+// If not specified, the default of 5 seconds will be used.
+func SyncerPrefetchTimeout(timeout time.Duration) Option {
+	return func(t *Tree) {
+		t.cache.syncerPrefetchTimeout = timeout
+	}
+}
+
+// New creates a new empty Urkel tree backed by the given node database.
+func New(rs syncer.ReadSyncer, ndb db.NodeDB, options ...Option) *Tree {
+	if rs == nil {
+		rs = syncer.NewNopReadSyncer()
+	}
+	if ndb == nil {
+		ndb = db.NewNopNodeDB()
+	}
+
+	t := &Tree{
+		cache:           newCache(ndb, rs),
+		pendingWriteLog: make(map[hash.Hash]*pendingLogEntry),
+	}
+
+	for _, v := range options {
+		v(t)
+	}
+
+	return t
+}
+
+// NewWithRoot creates a new Urkel tree with an existing root, backed by
+// the given node database.
+func NewWithRoot(rs syncer.ReadSyncer, ndb db.NodeDB, root hash.Hash, options ...Option) (*Tree, error) {
+	t := New(rs, ndb, options...)
+	t.cache.setPendingRoot(&internal.Pointer{
+		Clean: true,
+		Hash:  root,
+	})
+	t.cache.setSyncRoot(root)
+
+	// Try to prefetch the subtree at the root.
+	ptr, err := t.cache.prefetch(root, 0)
+	if err != nil {
+		return nil, err
+	}
+	if ptr != nil {
+		t.cache.setPendingRoot(ptr)
+	}
+
+	return t, nil
+}
+
+// Insert inserts a key/value pair into the tree.
+func (t *Tree) Insert(key []byte, value []byte) error {
+	hkey := hashKey(key)
+	var existed bool
+	newRoot, existed, err := t.doInsert(t.cache.pendingRoot, 0, hkey, value)
+	if err != nil {
+		return err
+	}
+
+	// Update the pending write log.
+	entry := t.pendingWriteLog[hkey]
+	if entry == nil {
+		t.pendingWriteLog[hkey] = &pendingLogEntry{key, value, existed}
+	} else {
+		entry.value = value
+	}
+
+	t.cache.setPendingRoot(newRoot)
+	return nil
+}
+
+// Remove removes a key from the tree.
+func (t *Tree) Remove(key []byte) error {
+	hkey := hashKey(key)
+	var changed bool
+	newRoot, changed, err := t.doRemove(t.cache.pendingRoot, 0, hkey)
+	if err != nil {
+		return err
+	}
+
+	// Update the pending write log.
+	entry := t.pendingWriteLog[hkey]
+	if entry == nil {
+		t.pendingWriteLog[hkey] = &pendingLogEntry{key, nil, changed}
+	} else {
+		entry.value = nil
+	}
+
+	t.cache.setPendingRoot(newRoot)
+	return nil
+}
+
+// Get looks up an existing key.
+func (t *Tree) Get(key []byte) ([]byte, error) {
+	hkey := hashKey(key)
+	return t.doGet(t.cache.pendingRoot, 0, hkey)
+}
+
+// Dump dumps the tree into the given writer.
+func (t *Tree) Dump(w io.Writer) {
+	t.doDump(w, t.cache.pendingRoot, hash.Hash{}, 0)
+	fmt.Fprintln(w, "")
+}
+
+// Stats traverses the tree and dumps some statistics.
+func (t *Tree) Stats(maxDepth uint8) Stats {
+	stats := &Stats{
+		LeftSubtreeMaxDepths:  make(map[uint8]uint8),
+		RightSubtreeMaxDepths: make(map[uint8]uint8),
+	}
+	stats.Cache.InternalNodeCount = t.cache.internalNodeCount
+	stats.Cache.LeafNodeCount = t.cache.leafNodeCount
+	stats.Cache.LeafValueSize = t.cache.valueSize
+
+	t.doStats(stats, t.cache.pendingRoot, hash.Hash{}, 0, maxDepth)
+	return *stats
+}
+
+// Commit commits tree updates to the underlying database and returns
+// the write log and new merkle root.
+func (t *Tree) Commit() (WriteLog, hash.Hash, error) {
+	batch := t.cache.db.NewBatch()
+	defer batch.Reset()
+
+	updates := &cacheUpdates{}
+	root, err := doCommit(&t.cache, updates, batch, t.cache.pendingRoot)
+	if err != nil {
+		return nil, hash.Hash{}, err
+	}
+
+	if err := batch.Commit(root); err != nil {
+		return nil, hash.Hash{}, err
+	}
+	updates.Commit()
+
+	var log WriteLog
+	for _, entry := range t.pendingWriteLog {
+		// Skip all entries that do not exist after all the updates and
+		// did not exist before.
+		if entry.value == nil && !entry.existed {
+			continue
+		}
+
+		log = append(log, LogEntry{entry.key, entry.value})
+	}
+	t.pendingWriteLog = make(map[hash.Hash]*pendingLogEntry)
+	t.cache.setSyncRoot(root)
+
+	return log, root, nil
+}

--- a/go/storage/mkvs/urkel/urkel_test.go
+++ b/go/storage/mkvs/urkel/urkel_test.go
@@ -1,0 +1,368 @@
+package urkel
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasislabs/ekiden/go/common/crypto/hash"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/db"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/syncer"
+)
+
+const (
+	insertItems  = 10000
+	allItemsRoot = "fecf46042f82fd1ec38c9f5ee40f941d8a147976d51b59f4c16bc5c0467c7f4f"
+)
+
+func TestBasic(t *testing.T) {
+	ndb := db.NewMemoryNodeDB()
+	tree := New(nil, ndb)
+
+	keyZero := []byte("foo")
+	valueZero := []byte("bar")
+	err := tree.Insert(keyZero, valueZero)
+	require.NoError(t, err, "Insert")
+	value, err := tree.Get(keyZero)
+	require.NoError(t, err, "Get")
+	require.Equal(t, valueZero, value)
+
+	err = tree.Insert(keyZero, valueZero)
+	require.NoError(t, err, "Insert")
+	value, err = tree.Get(keyZero)
+	require.NoError(t, err, "Get")
+	require.Equal(t, valueZero, value)
+
+	log, root, err := tree.Commit()
+	require.NoError(t, err, "Commit")
+	require.Equal(t, "f83b5a082f1d05c31aadc863c44df9b2b322b570e47e7528faf484ca2084ad08", root.String())
+	require.Equal(t, log, WriteLog{LogEntry{keyZero, valueZero}})
+	require.Equal(t, log[0].Type(), LogInsert)
+
+	keyOne := []byte("moo")
+	valueOne := []byte("foo")
+	err = tree.Insert(keyOne, valueOne)
+	require.NoError(t, err, "Insert")
+	value, err = tree.Get(keyOne)
+	require.NoError(t, err, "Get")
+	require.Equal(t, valueOne, value)
+
+	log, root, err = tree.Commit()
+	require.NoError(t, err, "Commit")
+	require.Equal(t, "839bb81bff8bc8bb0bee99405a094bcb1d983f9f830cc3e3475e07cb7da4b90c", root.String())
+	require.Equal(t, log, WriteLog{LogEntry{keyOne, valueOne}})
+	require.Equal(t, log[0].Type(), LogInsert)
+
+	// Create a new tree backed by the same database.
+	tree, err = NewWithRoot(nil, ndb, root)
+	require.NoError(t, err, "NewWithRoot")
+
+	value, err = tree.Get(keyZero)
+	require.NoError(t, err, "Get")
+	require.Equal(t, valueZero, value)
+	value, err = tree.Get(keyOne)
+	require.NoError(t, err, "Get")
+	require.Equal(t, valueOne, value)
+
+	err = tree.Remove(keyOne)
+	require.NoError(t, err, "Remove")
+	value, err = tree.Get(keyOne)
+	require.NoError(t, err, "Get")
+	require.Nil(t, value)
+
+	log, root, err = tree.Commit()
+	require.NoError(t, err, "Commit")
+	require.Equal(t, "f83b5a082f1d05c31aadc863c44df9b2b322b570e47e7528faf484ca2084ad08", root.String())
+	require.Equal(t, log, WriteLog{LogEntry{keyOne, nil}})
+	require.Equal(t, log[0].Type(), LogDelete)
+}
+
+func TestInsertCommitBatch(t *testing.T) {
+	ndb := db.NewMemoryNodeDB()
+	tree := New(nil, ndb)
+
+	keys, values := generateKeyValuePairs()
+	for i := 0; i < len(keys); i++ {
+		err := tree.Insert(keys[i], values[i])
+		require.NoError(t, err, "Insert")
+
+		value, err := tree.Get(keys[i])
+		require.NoError(t, err, "Get")
+		require.Equal(t, values[i], value)
+	}
+
+	_, root, err := tree.Commit()
+	require.NoError(t, err, "Commit")
+	require.Equal(t, allItemsRoot, root.String())
+}
+
+func TestInsertCommitEach(t *testing.T) {
+	ndb := db.NewMemoryNodeDB()
+	tree := New(nil, ndb)
+
+	keys, values := generateKeyValuePairs()
+	for i := 0; i < len(keys); i++ {
+		err := tree.Insert(keys[i], values[i])
+		require.NoError(t, err, "Insert")
+
+		value, err := tree.Get(keys[i])
+		require.NoError(t, err, "Get")
+		require.Equal(t, values[i], value)
+
+		_, _, err = tree.Commit()
+		require.NoError(t, err, "Commit")
+	}
+
+	_, root, err := tree.Commit()
+	require.NoError(t, err, "Commit")
+	require.Equal(t, allItemsRoot, root.String())
+}
+
+func TestRemove(t *testing.T) {
+	ndb := db.NewMemoryNodeDB()
+	tree := New(nil, ndb)
+
+	var roots []hash.Hash
+	keys, values := generateKeyValuePairs()
+	for i := 0; i < len(keys); i++ {
+		err := tree.Insert(keys[i], values[i])
+		require.NoError(t, err, "Insert")
+
+		value, err := tree.Get(keys[i])
+		require.NoError(t, err, "Get")
+		require.Equal(t, values[i], value)
+
+		_, root, err := tree.Commit()
+		require.NoError(t, err, "Commit")
+		roots = append(roots, root)
+	}
+
+	require.Equal(t, allItemsRoot, roots[len(roots)-1].String())
+
+	for i := len(keys) - 1; i > 0; i-- {
+		err := tree.Remove(keys[i])
+		require.NoError(t, err, "Remove")
+
+		_, root, err := tree.Commit()
+		require.NoError(t, err, "Commit")
+		require.Equal(t, roots[i-1], root, "root after removal at index %d", i)
+	}
+
+	err := tree.Remove(keys[0])
+	require.NoError(t, err, "Remove")
+
+	_, root, err := tree.Commit()
+	require.NoError(t, err, "Commit")
+	require.True(t, root.IsEmpty())
+}
+
+func TestSyncerBasic(t *testing.T) {
+	ndb := db.NewMemoryNodeDB()
+	tree := New(nil, ndb)
+
+	keys, values := generateKeyValuePairs()
+	for i := 0; i < len(keys); i++ {
+		err := tree.Insert(keys[i], values[i])
+		require.NoError(t, err, "Insert")
+	}
+
+	_, root, err := tree.Commit()
+	require.NoError(t, err, "Commit")
+	require.Equal(t, allItemsRoot, root.String())
+
+	// Create a "remote" tree that talks to the original tree via the
+	// syncer interface. First try with no prefetching and then with
+	// prefetching.
+
+	stats := syncer.NewStatsCollector(tree)
+	remoteTree, err := NewWithRoot(stats, nil, root)
+	require.NoError(t, err, "NewWithRoot")
+
+	for i := 0; i < len(keys); i++ {
+		var value []byte
+		value, err = remoteTree.Get(keys[i])
+		require.NoError(t, err, "Get")
+		require.Equal(t, values[i], value)
+	}
+
+	require.Equal(t, 0, stats.SubtreeFetches, "subtree fetches (no prefetch)")
+	require.Equal(t, 0, stats.NodeFetches, "node fetches (no prefetch)")
+	require.Equal(t, 12056, stats.PathFetches, "path fetches (no prefetch)")
+	require.Equal(t, 10000, stats.ValueFetches, "value fetches (no prefetch)")
+
+	stats = syncer.NewStatsCollector(tree)
+	remoteTree, err = NewWithRoot(stats, nil, root, PrefetchDepth(10))
+	require.NoError(t, err, "NewWithRoot")
+
+	for i := 0; i < len(keys); i++ {
+		value, err := remoteTree.Get(keys[i])
+		require.NoError(t, err, "Get")
+		require.Equal(t, values[i], value)
+	}
+
+	require.Equal(t, 1, stats.SubtreeFetches, "subtree fetches (with prefetch)")
+	require.Equal(t, 0, stats.NodeFetches, "node fetches (with prefetch)")
+	require.Equal(t, 12158, stats.PathFetches, "path fetches (no prefetch)")
+	require.Equal(t, 10000, stats.ValueFetches, "value fetches (with prefetch)")
+}
+
+func TestValueEviction(t *testing.T) {
+	ndb := db.NewMemoryNodeDB()
+	tree := New(nil, ndb, Capacity(0, 1024))
+
+	keys, values := generateKeyValuePairs()
+	for i := 0; i < len(keys); i++ {
+		err := tree.Insert(keys[i], values[i])
+		require.NoError(t, err, "Insert")
+	}
+
+	_, _, err := tree.Commit()
+	require.NoError(t, err, "Commit")
+
+	stats := tree.Stats(0)
+	require.EqualValues(t, 14331, stats.Cache.InternalNodeCount, "Cache.InternalNodeCount")
+	require.EqualValues(t, 10000, stats.Cache.LeafNodeCount, "Cache.LeafNodeCount")
+	// Only a subset of the leaf values should remain in cache.
+	require.EqualValues(t, 1021, stats.Cache.LeafValueSize, "Cache.LeafValueSize")
+}
+
+func TestNodeEviction(t *testing.T) {
+	ndb := db.NewMemoryNodeDB()
+	tree := New(nil, ndb, Capacity(1000, 0))
+
+	keys, values := generateKeyValuePairs()
+	for i := 0; i < len(keys); i++ {
+		err := tree.Insert(keys[i], values[i])
+		require.NoError(t, err, "Insert")
+	}
+
+	_, _, err := tree.Commit()
+	require.NoError(t, err, "Commit")
+
+	stats := tree.Stats(0)
+	// Only a subset of nodes should remain in cache.
+	require.EqualValues(t, 590, stats.Cache.InternalNodeCount, "Cache.InternalNodeCount")
+	require.EqualValues(t, 410, stats.Cache.LeafNodeCount, "Cache.LeafNodeCount")
+	// Only a subset of the leaf values should remain in cache.
+	require.EqualValues(t, 4050, stats.Cache.LeafValueSize, "Cache.LeafValueSize")
+}
+
+func TestDebugDump(t *testing.T) {
+	ndb := db.NewMemoryNodeDB()
+	tree := New(nil, ndb)
+
+	err := tree.Insert([]byte("foo 1"), []byte("bar 1"))
+	require.NoError(t, err, "Insert")
+	err = tree.Insert([]byte("foo 2"), []byte("bar 2"))
+	require.NoError(t, err, "Insert")
+	err = tree.Insert([]byte("foo 3"), []byte("bar 3"))
+	require.NoError(t, err, "Insert")
+
+	buffer := &bytes.Buffer{}
+	tree.Dump(buffer)
+	require.True(t, len(buffer.Bytes()) > 0)
+}
+
+func TestDebugStats(t *testing.T) {
+	ndb := db.NewMemoryNodeDB()
+	tree := New(nil, ndb)
+
+	keys, values := generateKeyValuePairs()
+	for i := 0; i < len(keys); i++ {
+		err := tree.Insert(keys[i], values[i])
+		require.NoError(t, err, "Insert")
+	}
+
+	stats := tree.Stats(0)
+	require.EqualValues(t, 28, stats.MaxDepth, "MaxDepth")
+	require.EqualValues(t, 14331, stats.InternalNodeCount, "InternalNodeCount")
+	require.EqualValues(t, 10000, stats.LeafNodeCount, "LeafNodeCount")
+	require.EqualValues(t, 98890, stats.LeafValueSize, "LeafValueSize")
+	require.EqualValues(t, 4332, stats.DeadNodeCount, "DeadNodeCount")
+	// Cached node counts will update on commit.
+	require.EqualValues(t, 0, stats.Cache.InternalNodeCount, "Cache.InternalNodeCount")
+	require.EqualValues(t, 0, stats.Cache.LeafNodeCount, "Cache.LeafNodeCount")
+	// Cached leaf value size will update on commit.
+	require.EqualValues(t, 0, stats.Cache.LeafValueSize, "Cache.LeafValueSize")
+
+	_, _, err := tree.Commit()
+	require.NoError(t, err, "Commit")
+
+	// Values are not counted as cached until they are committed (since
+	// they cannot be evicted while uncommitted).
+	stats = tree.Stats(0)
+	require.EqualValues(t, 28, stats.MaxDepth, "MaxDepth")
+	require.EqualValues(t, 14331, stats.InternalNodeCount, "InternalNodeCount")
+	require.EqualValues(t, 10000, stats.LeafNodeCount, "LeafNodeCount")
+	require.EqualValues(t, 98890, stats.LeafValueSize, "LeafValueSize")
+	require.EqualValues(t, 4332, stats.DeadNodeCount, "DeadNodeCount")
+	require.EqualValues(t, 14331, stats.Cache.InternalNodeCount, "Cache.InternalNodeCount")
+	require.EqualValues(t, 10000, stats.Cache.LeafNodeCount, "Cache.LeafNodeCount")
+	require.EqualValues(t, 98890, stats.Cache.LeafValueSize, "Cache.LeafValueSize")
+}
+
+// TODO: More tests for write logs.
+// TODO: More tests with bad syncer outputs.
+
+func BenchmarkInsertCommitBatch1(b *testing.B) {
+	benchmarkInsertBatch(b, 1, true)
+}
+
+func BenchmarkInsertCommitBatch10(b *testing.B) {
+	benchmarkInsertBatch(b, 10, true)
+}
+
+func BenchmarkInsertCommitBatch100(b *testing.B) {
+	benchmarkInsertBatch(b, 100, true)
+}
+
+func BenchmarkInsertCommitBatch1000(b *testing.B) {
+	benchmarkInsertBatch(b, 1000, true)
+}
+
+func BenchmarkInsertNoCommitBatch1(b *testing.B) {
+	benchmarkInsertBatch(b, 1, false)
+}
+
+func BenchmarkInsertNoCommitBatch10(b *testing.B) {
+	benchmarkInsertBatch(b, 10, false)
+}
+
+func BenchmarkInsertNoCommitBatch100(b *testing.B) {
+	benchmarkInsertBatch(b, 100, false)
+}
+
+func BenchmarkInsertNoCommitBatch1000(b *testing.B) {
+	benchmarkInsertBatch(b, 1000, false)
+}
+
+func benchmarkInsertBatch(b *testing.B, numValues int, commit bool) {
+	for n := 0; n < b.N; n++ {
+		ndb := db.NewMemoryNodeDB()
+		tree := New(nil, ndb)
+
+		for i := 0; i < numValues; i++ {
+			key := []byte(fmt.Sprintf("key %d", i))
+			value := []byte(fmt.Sprintf("value %d", i))
+
+			_ = tree.Insert(key, value)
+		}
+
+		if commit {
+			_, _, _ = tree.Commit()
+		}
+	}
+}
+
+func generateKeyValuePairs() ([][]byte, [][]byte) {
+	keys := make([][]byte, insertItems)
+	values := make([][]byte, insertItems)
+	for i := 0; i < insertItems; i++ {
+		keys[i] = []byte(fmt.Sprintf("key %d", i))
+		values[i] = []byte(fmt.Sprintf("value %d", i))
+	}
+
+	return keys, values
+}

--- a/go/storage/mkvs/urkel/utils.go
+++ b/go/storage/mkvs/urkel/utils.go
@@ -1,0 +1,25 @@
+package urkel
+
+import "github.com/oasislabs/ekiden/go/common/crypto/hash"
+
+func hashKey(key []byte) (h hash.Hash) {
+	h.FromBytes(key)
+	return
+}
+
+func getKeyBit(key hash.Hash, bit uint8) bool {
+	return key[bit/8]&(1<<(7-(bit%8))) != 0
+}
+
+func setKeyBit(key hash.Hash, bit uint8, val bool) hash.Hash {
+	var h hash.Hash
+	copy(h[:], key[:])
+
+	mask := byte(1 << (7 - (bit % 8)))
+	if val {
+		h[bit/8] |= mask
+	} else {
+		h[bit/8] &= mask
+	}
+	return h
+}


### PR DESCRIPTION
This is a WIP exploration of the Urkel tree with cache sync and persistence interfaces (see storage hierarchy v2 RFC).

TODO
* [x] Urkel tree data structure with in-memory persistence, logs, basic benchmarks and tests.
* [x] Cache should use the `ReadSyncer` interface to prefetch, the tree itself should implement this interface.
* [x] Nodes should be serializable.
* [x] Cache should evict values based on configured limits.
* [x] Cache should evict nodes based on configured limits. 