### PR TITLE
Bump rustracing_jaeger to 0.2.1

### DIFF
--- a/db/untrusted/Cargo.toml
+++ b/db/untrusted/Cargo.toml
@@ -17,7 +17,7 @@ ekiden-instrumentation = { path = "../../instrumentation", version = "0.2.0-alph
 ekiden-storage-base = { path = "../../storage/base", version = "0.2.0-alpha" }
 log = "0.4"
 rustracing = "0.2.0"
-rustracing_jaeger = { git = "https://github.com/oasislabs/rustracing_jaeger.git", tag = "0.2.0-ekiden1" }
+rustracing_jaeger = "0.2.1"
 
 [build-dependencies]
 ekiden-tools = { path = "../../tools", version = "0.2.0-alpha" }

--- a/runtime/client/Cargo.toml
+++ b/runtime/client/Cargo.toml
@@ -16,7 +16,7 @@ ekiden-scheduler-base = { path = "../../scheduler/base", version = "0.2.0-alpha"
 ekiden-storage-base = { path = "../../storage/base", version = "0.2.0-alpha" }
 ekiden-registry-base = { path = "../../registry/base", version = "0.2.0-alpha" }
 rustracing = "0.2.0"
-rustracing_jaeger = { git = "https://github.com/oasislabs/rustracing_jaeger.git", tag = "0.2.0-ekiden1" }
+rustracing_jaeger = "0.2.1"
 serde = "1.0.71"
 serde_cbor = { git = "https://github.com/oasislabs/cbor", tag = "v0.9.0-ekiden1" }
 log = "0.4"

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -12,5 +12,5 @@ grpcio = { version = "~0.4.2", features = ["openssl"] }
 lazy_static = "1.0"
 log = "0.4"
 rustracing = "0.2.0"
-rustracing_jaeger = { git = "https://github.com/oasislabs/rustracing_jaeger.git", tag = "0.2.0-ekiden1" }
+rustracing_jaeger = "0.2.1"
 trackable = "0.2.18"

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -23,7 +23,7 @@ ekiden-storage-base = { path = "../storage/base", version = "0.2.0-alpha" }
 ekiden-storage-batch = { path = "../storage/batch", version = "0.2.0-alpha" }
 protobuf = "~2.0"
 rustracing = "0.2.0"
-rustracing_jaeger = { git = "https://github.com/oasislabs/rustracing_jaeger.git", tag = "0.2.0-ekiden1" }
+rustracing_jaeger = "0.2.1"
 sgx_types = { git = "https://github.com/oasislabs/rust-sgx-sdk", tag = "v1.0.5-ekiden1" }
 thread_local = "0.3.5"
 clap = "2.29.1"

--- a/worker/api/Cargo.toml
+++ b/worker/api/Cargo.toml
@@ -13,7 +13,7 @@ ekiden-roothash-base = { path = "../../roothash/base", version = "0.2.0-alpha" }
 ekiden-storage-base = { path = "../../storage/base", version = "0.2.0-alpha" }
 ekiden-tracing = { path = "../../tracing", version = "0.2.0-alpha" }
 rustracing = "0.2.0"
-rustracing_jaeger = { git = "https://github.com/oasislabs/rustracing_jaeger.git", tag = "0.2.0-ekiden1" }
+rustracing_jaeger = "0.2.1"
 sgx_types = { git = "https://github.com/oasislabs/rust-sgx-sdk", tag = "v1.0.5-ekiden1" }
 serde = "1.0.71"
 serde_derive = "1.0"


### PR DESCRIPTION
rustracing_jaeger 0.2.1 has been released with our binary extractor/injector contributions, so we can use upstream version from now on. Please merge after tests have passed.