### PR TITLE
go/tendermint: Update to tendermint 0.31.1

### DIFF
--- a/go/ekiden/node_test.go
+++ b/go/ekiden/node_test.go
@@ -49,7 +49,6 @@ var (
 		{"staking.backend", "tendermint"},
 		{"staking.debug.genesis_state", stakingTests.InitialBalancesArg},
 		{"tendermint.consensus.skip_timeout_commit", true},
-		{"tendermint.debug.block_time_iota", 1 * time.Millisecond},
 		{"worker.backend", "mock"},
 		{"worker.runtime.binary", "mock-runtime"},
 		{"worker.runtime.id", testRuntimeID},

--- a/go/go.mod
+++ b/go/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/tendermint/go-amino v0.14.1 // indirect
 	github.com/tendermint/iavl v0.12.0
-	github.com/tendermint/tendermint v0.30.1
+	github.com/tendermint/tendermint v0.31.1
 	github.com/uber-go/atomic v1.3.2 // indirect
 	github.com/uber/jaeger-client-go v2.16.0+incompatible
 	github.com/uber/jaeger-lib v2.0.0+incompatible // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -304,8 +304,8 @@ github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFd
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tendermint/go-amino v0.14.1 h1:o2WudxNfdLNBwMyl2dqOJxiro5rfrEaU0Ugs6offJMk=
 github.com/tendermint/go-amino v0.14.1/go.mod h1:i/UKE5Uocn+argJJBb12qTZsCDBcAYMbR92AaJVmKso=
-github.com/tendermint/tendermint v0.30.1 h1:PqGXWDomu6SmICQgcwvCstfvTqxsOn/tn+w9is4FcxI=
-github.com/tendermint/tendermint v0.30.1/go.mod h1:ymcPyWblXCplCPQjbOYbrF1fWnpslATMVqiGgWbZrlc=
+github.com/tendermint/tendermint v0.31.1 h1:1O2kb95A3dAU2ijzz6Dpweo9jv+mWjKHsLGC+ujKTZw=
+github.com/tendermint/tendermint v0.31.1/go.mod h1:ymcPyWblXCplCPQjbOYbrF1fWnpslATMVqiGgWbZrlc=
 github.com/uber-go/atomic v1.3.2 h1:Azu9lPBWRNKzYXSIwRfgRuDuS0YKsK4NFhiQv98gkxo=
 github.com/uber-go/atomic v1.3.2/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
 github.com/uber/jaeger-client-go v2.16.0+incompatible h1:Q2Pp6v3QYiocMxomCaJuwQGFt7E53bPYqEgug/AoBtY=

--- a/go/tendermint/db/bolt/bolt.go
+++ b/go/tendermint/db/bolt/bolt.go
@@ -481,6 +481,10 @@ func (b *boltDBBatch) WriteSync() {
 	b.db.sync()
 }
 
+func (b *boltDBBatch) Close() {
+	b.cmds = nil
+}
+
 func toBoltDBKey(key []byte) []byte {
 	// BoltDB doesn't allow zero-length keys, so make all keys at least
 	// 1 byte long.

--- a/go/tendermint/service/service.go
+++ b/go/tendermint/service/service.go
@@ -2,8 +2,6 @@
 package service
 
 import (
-	"context"
-
 	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
 	tmrpctypes "github.com/tendermint/tendermint/rpc/core/types"
 	tmtypes "github.com/tendermint/tendermint/types"
@@ -59,12 +57,10 @@ type TendermintService interface {
 	Query(path string, query interface{}, height int64) ([]byte, error)
 
 	// Subscribe subscribes to tendermint events.
-	// TODO: ctx should be removed from API since we use tendermintService.ctx now -Matevz
-	Subscribe(ctx context.Context, subscriber string, query tmpubsub.Query, out chan<- interface{}) error
+	Subscribe(subscriber string, query tmpubsub.Query) (tmtypes.Subscription, error)
 
 	// Unsubscribe unsubscribes from tendermint events.
-	// TODO: ctx should be removed from API since we use tendermintService.ctx now -Matevz
-	Unsubscribe(ctx context.Context, subscriber string, query tmpubsub.Query) error
+	Unsubscribe(subscriber string, query tmpubsub.Query) error
 
 	// Genesis returns the tendermint genesis block information.
 	Genesis() (*tmrpctypes.ResultGenesis, error)


### PR DESCRIPTION
 * Use the "new" tendermint pubsub interface
 * Deprecate `tendermint.debug.block_time_iota`

Note: This *may* require a roothash migration, the block time iota was
moved to a consensus parameter.

Fixes #1536