### PR TITLE
tendermint: Adjust `ConsesusParams.Block.TimeIotaMs`

### DIFF
--- a/go/tendermint/tendermint.go
+++ b/go/tendermint/tendermint.go
@@ -551,6 +551,11 @@ func (t *tendermintService) getGenesis(tenderConfig *tmconfig.Config) (*tmtypes.
 		return nil, errors.Wrap(err, "tendermint: failed to create genesis doc")
 	}
 
+	// HACK: Certain test cases use TimeoutCommit < 1 sec, and care about the
+	// BFT view of time pulling ahead.
+	timeoutCommit := viper.GetDuration(cfgConsensusTimeoutCommit)
+	tmGenDoc.ConsensusParams.Block.TimeIotaMs = int64(timeoutCommit / time.Millisecond)
+
 	return tmGenDoc, nil
 }
 


### PR DESCRIPTION
As it turns out, the runtime-ethereum test cases use an accelerated
TimeoutCommit, and will break if the BFT time disagrees too much with
civil time.

Fixes #1562 