### PR TITLE
Add Rust Deoxys-II-256-128 MRAE primitives (depends on Fortanix branch!)

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,7 @@
+[build]
+rustflags = ["-C", "target-feature=+aes,+ssse3"]
+rustdocflags = ["-C", "target-feature=+aes,+ssse3"]
+
+[test]
+rustflags = ["-C", "target-feature=+aes,+ssse3"]
+rustdocflags = ["-C", "target-feature=+aes,+ssse3"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "deoxysii-rust"
+version = "0.1.0"
+source = "git+https://github.com/oasislabs/deoxysii-rust#876f3067715b583d7dae3d09d4e1c1f021992ccc"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +406,7 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-ops 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deoxysii-rust 0.1.0 (git+https://github.com/oasislabs/deoxysii-rust)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "io-context 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1774,6 +1785,24 @@ dependencies = [
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "zeroize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "zeroize_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum aes-soft 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91f401742d8c1b0a3d01f53563f98d8ef0beea460b8d37322faf9fb4c7977cfa"
 "checksum aesm-client 0.1.0 (git+https://github.com/fortanix/rust-sgx?rev=ecf51e6b48c854242841f169edbfb14445fd59fb)" = "<none>"
@@ -1812,6 +1841,7 @@ dependencies = [
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum crypto-ops 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a863ab067e5cb1e44c4b8430ba0df65c9778e86ca7017bcd8120fafeda18816f"
 "checksum curve25519-dalek 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1f8a6fc0376eb52dc18af94915cc04dfdf8353746c0e8c550ae683a0815e5c1"
+"checksum deoxysii-rust 0.1.0 (git+https://github.com/oasislabs/deoxysii-rust)" = "<none>"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum enclave-runner 0.1.1 (git+https://github.com/fortanix/rust-sgx?rev=ecf51e6b48c854242841f169edbfb14445fd59fb)" = "<none>"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
@@ -1960,3 +1990,5 @@ dependencies = [
 "checksum winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum x25519-dalek 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4aca1ba6bec2719576bd20dfe5b24d9359552e616d10bff257e50cd85f745d17"
+"checksum zeroize 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e68403b858b6af538b11614e62dfe9ab2facba9f13a0cafb974855cfb495ec95"
+"checksum zeroize_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3f07490820219949839d0027b965ffdd659d75be9220c00798762e36c6cd281"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -39,3 +39,4 @@ tokio-current-thread = "0.1.5"
 tokio-executor = "0.1.6"
 io-context = "0.2.0"
 x25519-dalek = "0.5.1"
+deoxysii-rust = { git = "https://github.com/oasislabs/deoxysii-rust" }

--- a/runtime/src/common/crypto/mrae/deoxysii.rs
+++ b/runtime/src/common/crypto/mrae/deoxysii.rs
@@ -1,0 +1,177 @@
+//! Deoxys-II-256-128 MRAE primitives implementation.
+
+pub use super::deoxysii_rust::{DeoxysII, KEY_SIZE, NONCE_SIZE, TAG_SIZE};
+
+use super::{
+    ring::{digest, hmac},
+    x25519_dalek,
+};
+
+use failure::Fallible;
+use rand::rngs::OsRng;
+
+/// Derives a MRAE AEAD symmetric key suitable for use with the asymmetric
+/// box primitives from the provided X25519 public and private keys.
+fn derive_symmetric_key(public: &[u8; 32], private: &[u8; 32]) -> [u8; KEY_SIZE] {
+    let public = x25519_dalek::PublicKey::from(public.clone());
+    let private = x25519_dalek::StaticSecret::from(private.clone());
+
+    let pmk = private.diffie_hellman(&public);
+
+    let k = hmac::SigningKey::new(&digest::SHA256, b"MRAE_Box_Deoxys-II-256-128");
+    let mut ctx = hmac::SigningContext::with_key(&k);
+
+    ctx.update(pmk.as_bytes());
+    drop(pmk);
+
+    let mut derived_key = [0u8; KEY_SIZE];
+    derived_key.copy_from_slice(&ctx.sign().as_ref()[..KEY_SIZE]);
+
+    derived_key
+}
+
+/// Generates a public/private key pair suitable for use with
+/// `derive_symmetric_key`, `box_seal`, and `box_open`.
+pub fn generate_key_pair() -> ([u8; 32], [u8; 32]) {
+    let mut rng = OsRng::new().unwrap();
+
+    let sk = x25519_dalek::StaticSecret::new(&mut rng);
+    let pk = x25519_dalek::PublicKey::from(&sk);
+
+    (pk.as_bytes().clone(), sk.to_bytes())
+}
+
+/// Boxes ("seals") the provided additional data and plaintext via
+/// Deoxys-II-256-128 using a symmetric key derived from the provided
+/// X25519 public and private keys.
+/// The nonce should be `NONCE_SIZE` bytes long and unique for all time
+/// for a given public and private key tuple.
+pub fn box_seal(
+    nonce: &[u8; NONCE_SIZE],
+    plaintext: Vec<u8>,
+    additional_data: Vec<u8>,
+    peers_public_key: &[u8; 32],
+    private_key: &[u8; 32],
+) -> Fallible<Vec<u8>> {
+    let key = derive_symmetric_key(peers_public_key, private_key);
+
+    let d2 = DeoxysII::new(&key)?;
+
+    d2.seal(nonce, plaintext, additional_data)
+}
+
+/// Unboxes ("opens") the provided additional data and ciphertext via
+/// Deoxys-II-256-128 using a symmetric key derived from the provided
+/// X25519 public and private keys.
+/// The nonce should be `NONCE_SIZE` bytes long and both it and the additional
+/// data must match the value passed to `box_seal`.
+pub fn box_open(
+    nonce: &[u8; NONCE_SIZE],
+    ciphertext: Vec<u8>,
+    additional_data: Vec<u8>,
+    peers_public_key: &[u8; 32],
+    private_key: &[u8; 32],
+) -> Fallible<Vec<u8>> {
+    let key = derive_symmetric_key(peers_public_key, private_key);
+
+    let d2 = DeoxysII::new(&key)?;
+
+    d2.open(nonce, ciphertext, additional_data)
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate test;
+
+    use self::test::{black_box, Bencher};
+    use super::*;
+    use rand::RngCore;
+
+    #[test]
+    fn test_mrae_asymmetric() {
+        let (a_pub, a_priv) = generate_key_pair(); // Alice
+        let (b_pub, b_priv) = generate_key_pair(); // Bob
+
+        // None of the generated keys should be the same.
+        assert_ne!(a_pub, b_pub);
+        assert_ne!(a_priv, b_priv);
+        assert_ne!(a_pub, a_priv);
+        assert_ne!(b_pub, b_priv);
+
+        // Should successfully seal the text in a box.
+        let nonce = [1u8; NONCE_SIZE];
+        let text = String::from("This is a test!").as_bytes().to_vec();
+        let aad = vec![42u8; 10];
+
+        let sealed = box_seal(&nonce, text.clone(), aad.clone(), &b_pub, &a_priv);
+        assert!(sealed.is_ok());
+
+        // Should successfully open the sealed box.
+        let opened = box_open(&nonce, sealed.unwrap(), aad, &a_pub, &b_priv);
+        assert!(opened.is_ok());
+
+        // The deciphered text should match the original.
+        let deciphered = opened.unwrap();
+        assert_eq!(deciphered, text);
+    }
+
+    #[bench]
+    fn bench_mrae_box_seal_4096(b: &mut Bencher) {
+        let mut rng = OsRng::new().unwrap();
+
+        // Set up the keys.
+        let (_a_pub, a_priv) = generate_key_pair(); // Alice
+        let (b_pub, _b_priv) = generate_key_pair(); // Bob
+
+        // Set up the payload.
+        let mut nonce = [0u8; NONCE_SIZE];
+        rng.fill_bytes(&mut nonce);
+        let mut text = [0u8; 4096];
+        rng.fill_bytes(&mut text);
+        let mut aad = [0u8; 64];
+        rng.fill_bytes(&mut aad);
+
+        // Benchmark box sealing.
+        b.iter(|| {
+            let _sealed = black_box(box_seal(
+                &nonce,
+                text.to_vec(),
+                aad.to_vec(),
+                &b_pub,
+                &a_priv,
+            ));
+        });
+    }
+
+    #[bench]
+    fn bench_mrae_box_open_4096(b: &mut Bencher) {
+        let mut rng = OsRng::new().unwrap();
+
+        // Set up the keys.
+        let (a_pub, a_priv) = generate_key_pair(); // Alice
+        let (b_pub, b_priv) = generate_key_pair(); // Bob
+
+        // Set up the payload.
+        let mut nonce = [0u8; NONCE_SIZE];
+        rng.fill_bytes(&mut nonce);
+        let mut text = [0u8; 4096];
+        rng.fill_bytes(&mut text);
+        let mut aad = [0u8; 64];
+        rng.fill_bytes(&mut aad);
+
+        // Seal the payload.
+        let sealed = box_seal(&nonce, text.to_vec(), aad.to_vec(), &b_pub, &a_priv);
+        let ciphertext = sealed.unwrap();
+
+        // Benchmark box opening.
+        b.iter(|| {
+            let _opened = black_box(box_open(
+                &nonce,
+                ciphertext.clone(),
+                aad.to_vec(),
+                &a_pub,
+                &b_priv,
+            ));
+        });
+    }
+}

--- a/runtime/src/common/crypto/mrae/mod.rs
+++ b/runtime/src/common/crypto/mrae/mod.rs
@@ -1,9 +1,11 @@
-//! SIV_CTR-AES128_HMAC-SHA256-128 MRAE primitives.
+//! MRAE primitives.
 extern crate aes_soft as aes;
 extern crate block_modes;
 extern crate crypto_ops;
+extern crate deoxysii_rust;
 extern crate ring;
 extern crate x25519_dalek;
 
+pub mod deoxysii;
 pub mod nonce;
 pub mod sivaessha2;


### PR DESCRIPTION
The actual implementation is in the new [oasislabs/deoxysii-rust](https://github.com/oasislabs/deoxysii-rust) crate, this just adds box mode primitives and integrates it with Ekiden.