### PR TITLE
go/common/crypto/mrae/deoxysii: Fix the HMAC hash

### DIFF
--- a/go/common/crypto/mrae/deoxysii/asymmetric.go
+++ b/go/common/crypto/mrae/deoxysii/asymmetric.go
@@ -2,7 +2,7 @@
 package deoxysii
 
 import (
-	"crypto/sha512"
+	"crypto/sha256"
 
 	"github.com/oasislabs/deoxysii"
 	"github.com/oasislabs/ekiden/go/common/crypto/mrae/api"
@@ -18,7 +18,7 @@ var (
 type boxImpl struct{}
 
 func (impl *boxImpl) DeriveSymmetricKey(key []byte, publicKey, privateKey *[32]byte) {
-	api.ECDHAndTweak(key, publicKey, privateKey, sha512.New512_256, boxKDFTweak)
+	api.ECDHAndTweak(key, publicKey, privateKey, sha256.New, boxKDFTweak)
 }
 
 func (impl *boxImpl) Seal(dst, nonce, plaintext, additionalData []byte, peersPublicKey, privateKey *[32]byte) []byte {


### PR DESCRIPTION
Unlike most other places where we use SHA512/256, this is specced out to
use SHA256 for implementation ease across multiple languages.