### PR TITLE
Allow CARGO_TARGET_DIR override for rust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,11 @@
 RUNTIMES = keymanager-runtime \
 	tests/runtimes/simple-keyvalue
 
+# Ekiden cargo target directory.
+EKIDEN_CARGO_TARGET_DIR := $(if $(CARGO_TARGET_DIR),$(CARGO_TARGET_DIR),$$(pwd)/target)
+
 # Key manager enclave path.
-KM_ENCLAVE_PATH ?= target/x86_64-fortanix-unknown-sgx/debug/ekiden-keymanager-runtime.sgxs
+KM_ENCLAVE_PATH ?= $(EKIDEN_CARGO_TARGET_DIR)/x86_64-fortanix-unknown-sgx/debug/ekiden-keymanager-runtime.sgxs
 
 # Check if we're running in an interactive terminal.
 ISATTY := $(shell [ -t 0 ] && echo 1)
@@ -41,7 +44,7 @@ tools:
 runtimes:
 	@$(ECHO) "$(CYAN)*** Building runtimes...$(OFF)"
 	@for e in $(RUNTIMES); do \
-		export KM_ENCLAVE_PATH=$$(pwd)/$(KM_ENCLAVE_PATH) && \
+		export KM_ENCLAVE_PATH=$(KM_ENCLAVE_PATH) && \
 		\
 		$(ECHO) "$(MAGENTA)*** Building runtime: $$e$(OFF)"; \
 		(cd $$e && \
@@ -53,7 +56,7 @@ runtimes:
 
 rust:
 	@$(ECHO) "$(CYAN)*** Building Rust libraries and runtime loader...$(OFF)"
-	@export KM_ENCLAVE_PATH=$$(pwd)/$(KM_ENCLAVE_PATH) && \
+	@export KM_ENCLAVE_PATH=$(KM_ENCLAVE_PATH) && \
 		cargo build
 
 go:
@@ -68,7 +71,7 @@ test: test-unit test-e2e
 
 test-unit:
 	@$(ECHO) "$(CYAN)*** Running Rust unit tests...$(OFF)"
-	@export KM_ENCLAVE_PATH=$$(pwd)/$(KM_ENCLAVE_PATH) && \
+	@export KM_ENCLAVE_PATH=$(KM_ENCLAVE_PATH) && \
 		cargo test
 	@$(ECHO) "$(CYAN)*** Running Go unit tests...$(OFF)"
 	@$(MAKE) -C go test


### PR DESCRIPTION
Building rust in docker on macOS is painfully slow. Setting the `CARGO_TARGET_DIR` speeds things up. This PR allows the make scripts (at least the ones used to build `runtime-ethereum`) to override `CARGO_TARGET_DIR`. Corresponding runtime pr: https://github.com/oasislabs/runtime-ethereum/pull/697