### PR TITLE
keymanager-runtime: Add custom-keys feature

### DIFF
--- a/.buildkite/deploy.pipeline.yml
+++ b/.buildkite/deploy.pipeline.yml
@@ -9,6 +9,7 @@ docker_plugin: &docker_plugin_configuration
     volumes:
       - .:/workdir
       - /var/lib/buildkite-agent/.ssh:/root/.ssh
+      - /var/lib/buildkite-agent/.ekiden:/root/.ekiden
       # Shared Rust incremental compile caches.
       - /tmp/cargo_ic/release:/workdir/target/release/incremental
       - /tmp/cargo_ic/release_sgx:/workdir/target/x86_64-unknown-linux-sgx/release/incremental
@@ -24,6 +25,8 @@ docker_plugin: &docker_plugin_configuration
       - "LANG=C.UTF-8"
       - "CARGO_TARGET_DIR=/workdir/target"
       - "CARGO_INSTALL_ROOT=/root/.cargo"
+      - "KM_DUMMY_ENCRYPTION_KEY=/root/.ekiden/keymanager_dummy_encryption.key"
+      - "KM_DUMMY_SIGNING_KEY=/root/.ekiden/keymanager_dummy_signing.key"
     propagate-environment: true
 
 steps:

--- a/docker/deployment/build_context.sh
+++ b/docker/deployment/build_context.sh
@@ -14,6 +14,11 @@ dst=$1
 EKIDEN_UNSAFE_SKIP_AVR_VERIFY=1
 export EKIDEN_UNSAFE_SKIP_AVR_VERIFY
 
+extra_args=""
+if [ "${EKIDEN_KM_CUSTOM_KEYS:-1}" == "1" ]; then
+    extra_args="--features custom-keys"
+fi
+
 # Install ekiden-tools
 cargo install --force --path tools
 
@@ -22,8 +27,8 @@ make -C go
 cargo build -p ekiden-runtime-loader --release
 
 pushd keymanager-runtime
-    cargo build --release
-    cargo build --release --target x86_64-fortanix-unknown-sgx
+    cargo build --release ${extra_args}
+    cargo build --release --target x86_64-fortanix-unknown-sgx ${extra_args}
     cargo elf2sgxs --release
 popd
 

--- a/keymanager-runtime/Cargo.toml
+++ b/keymanager-runtime/Cargo.toml
@@ -17,3 +17,13 @@ lazy_static = "1.3.0"
 # TODO: Change to released version when 0.10.0 is released.
 serde_cbor = { git = "https://github.com/pyfisch/cbor", rev = "114ecaeac53799d0bf81ca8d1b980c7c419d76fe" }
 byteorder = "1.3.1"
+
+[features]
+# Use custom dummy encryption/signing keys as defined by the following environment
+# variables which must be set during the build process to a path containing the
+# raw keys (see key_store.rs for the key format):
+#
+#   KM_DUMMY_ENCRYPTION_KEY
+#   KM_DUMMY_SIGNING_KEY
+#
+custom-keys = []

--- a/keymanager-runtime/src/key_store.rs
+++ b/keymanager-runtime/src/key_store.rs
@@ -15,16 +15,22 @@ lazy_static! {
 }
 
 /// A dummy key for use in tests where confidentiality is not needed.
-const UNSECRET_ENCRYPTION_KEY: StateKey = StateKey([
+#[cfg(feature = "custom-keys")]
+const ENCRYPTION_KEY: &'static [u8] = include_bytes!(env!("KM_DUMMY_ENCRYPTION_KEY"));
+#[cfg(not(feature = "custom-keys"))]
+const ENCRYPTION_KEY: &'static [u8] = &[
     119, 206, 190, 82, 117, 21, 62, 84, 119, 212, 117, 60, 32, 158, 183, 32, 68, 55, 131, 112, 38,
     169, 217, 219, 58, 109, 194, 211, 89, 39, 198, 204, 254, 104, 202, 114, 203, 213, 89, 44, 192,
     168, 42, 136, 220, 230, 66, 74, 197, 220, 22, 146, 84, 121, 175, 216, 144, 182, 40, 179, 6, 73,
     177, 9,
-]);
+];
 
 /// A dummy key for use in tests where integrity is not needed.
 /// Public Key: 0x9d41a874b80e39a40c9644e964f0e4f967100c91654bfd7666435fe906af060f
-const UNSECRET_SIGNING_KEY_PKCS8: [u8; 85] = [
+#[cfg(feature = "custom-keys")]
+const SIGNING_KEY_PKCS8: &'static [u8] = include_bytes!(env!("KM_DUMMY_SIGNING_KEY"));
+#[cfg(not(feature = "custom-keys"))]
+const SIGNING_KEY_PKCS8: &'static [u8] = &[
     48, 83, 2, 1, 1, 48, 5, 6, 3, 43, 101, 112, 4, 34, 4, 32, 109, 124, 181, 54, 35, 91, 34, 238,
     29, 127, 17, 115, 64, 41, 135, 165, 19, 211, 246, 106, 37, 136, 149, 157, 187, 145, 157, 192,
     170, 25, 201, 141, 161, 35, 3, 33, 0, 157, 65, 168, 116, 184, 14, 57, 164, 12, 150, 68, 233,
@@ -44,8 +50,8 @@ pub struct KeyStore {
 impl KeyStore {
     fn new() -> Self {
         Self {
-            encryption_key: UNSECRET_ENCRYPTION_KEY,
-            signing_key: signature::PrivateKey::from_pkcs8(&UNSECRET_SIGNING_KEY_PKCS8).unwrap(),
+            encryption_key: StateKey::from(ENCRYPTION_KEY),
+            signing_key: signature::PrivateKey::from_pkcs8(SIGNING_KEY_PKCS8).unwrap(),
         }
     }
 


### PR DESCRIPTION
Needed for including different DUMMY keys for the testnet as requested in https://github.com/oasislabs/private-ops/pull/1094#issuecomment-481495136.

This requires that keys are available on CI agents in the following files:
* `/var/lib/buildkite-agent/.ekiden/keymanager_dummy_encryption.key`
* `/var/lib/buildkite-agent/.ekiden/keymanager_dummy_signing.key`

Note that these must be RAW keys (I think we currently store these keys in some kind of CBOR-encoded structure).