### PR TITLE
buildkite: mount tmpfs as /tmp in docker jobs

### DIFF
--- a/.buildkite/deploy.pipeline.yml
+++ b/.buildkite/deploy.pipeline.yml
@@ -2,7 +2,7 @@
 # Docker image deployment pipeline
 ##################################
 docker_plugin: &docker_plugin_configuration
-  oasislabs/docker#v2.1.0-oasis4:
+  oasislabs/docker#v3.0.1-oasis1:
     image: "oasislabs/development:0.3.0"
     always_pull: true
     workdir: /workdir

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 # Build pipeline
 ################
 docker_plugin: &docker_plugin_configuration
-  oasislabs/docker#v2.1.0-oasis4:
+  oasislabs/docker#v3.0.1-oasis1:
     image: "oasislabs/testing:0.3.0"
     always_pull: true
     workdir: /workdir


### PR DESCRIPTION
For jobs not ran in docker, this will be handled by: https://github.com/oasislabs/private-packer/pull/40

TODO: similar thing for `runtime-ethereum` repo

Note: `-tmpfs` set's unlimited size (we could also set a fixed size via [mount](https://docs.docker.com/storage/tmpfs/#tmpfs-options))