### PR TITLE
Add more prerequisite packages to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ Prerequisites:
 * install the [Fortanix Rust SGX](https://edp.fortanix.com) target by
   `rustup target add x86_64-fortanix-unknown-sgx` and utilities by
   `cargo install fortanix-sgx-tools sgxs-tools`,
-* install [Go](https://golang.org) (at least version 1.12),
+* install [Go](https://golang.org) (at least version 1.12) and
+  [protoc-gen-go](https://github.com/golang/protobuf),
 * install [bubblewrap](https://github.com/projectatomic/bubblewrap) (at
-  least version 0.3.1).
+  least version 0.3.1),
+* install `libssl-dev`, `protobuf-compiler`, `cmake`, and `libseccomp-dev`
+  packages. On typical Ubuntu, you can just run:
+  ```sudo apt install libssl-dev protobuf-compiler cmake libseccomp-dev```
 
 In the following instructions, the top-level directory is the directory
 where the code has been checked out.


### PR DESCRIPTION
With new fortanix and moving away from docker-only environment, some more prerequisite package are required for ekiden to compile on typical Ubuntu. This PR adds those in the beginning of the README.