### PR TITLE
runtime/common/sgx: Add the `egetkey` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "crypto-ops"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +477,8 @@ dependencies = [
  "slog-scope 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-stdlog 3.0.4-pre (registry+https://github.com/rust-lang/crates.io-index)",
  "snow 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp800-185 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1521,6 +1528,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp800-185"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,6 +1651,14 @@ dependencies = [
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2019,6 +2043,7 @@ dependencies = [
 "checksum crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "04c9e3102cc2d69cd681412141b390abd55a362afc1540965dad0ad4d34280b4"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
+"checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum crypto-ops 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a863ab067e5cb1e44c4b8430ba0df65c9778e86ca7017bcd8120fafeda18816f"
 "checksum curve25519-dalek 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1f8a6fc0376eb52dc18af94915cc04dfdf8353746c0e8c550ae683a0815e5c1"
 "checksum deoxysii 0.1.0 (git+https://github.com/oasislabs/deoxysii-rust)" = "<none>"
@@ -2137,6 +2162,7 @@ dependencies = [
 "checksum slog-stdlog 3.0.4-pre (registry+https://github.com/rust-lang/crates.io-index)" = "f058f4598ced50a3eb3e8aa72b2d621a7460dda814a0c58f403fd9fa68071342"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum snow 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5a64f02fd208ef15bd2d1a65861df4707e416151e1272d02c8faafad1c138100"
+"checksum sp800-185 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b18e3b1ddbf090b195425aca6edf8efb8e9b1fd42708131adf0f882db24fc9"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum static_slice 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "92a7e0c5e3dfb52e8fbe0e63a1b947bbb17b4036408b151353c4491374931362"
@@ -2150,6 +2176,7 @@ dependencies = [
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thrift_codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb61fb3d0a0af14949f3a6949b2639112e13226647112824f4d081533f9b1a8"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e9175261fbdb60781fcd388a4d6cc7e14764a2b629a7ad94abb439aed223a44f"
 "checksum tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "65641e515a437b308ab131a82ce3042ff9795bef5d6c5a9be4eb24195c417fd9"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
 "checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -43,3 +43,5 @@ tokio-executor = "0.1.6"
 io-context = "0.2.0"
 x25519-dalek = "0.5.1"
 deoxysii = { git = "https://github.com/oasislabs/deoxysii-rust" }
+tiny-keccak = "1.4.2"
+sp800-185 = "0.2.0"

--- a/runtime/src/common/sgx/egetkey.rs
+++ b/runtime/src/common/sgx/egetkey.rs
@@ -1,0 +1,106 @@
+//! SGX per-CPU package sealing key accessor.
+
+use sgx_isa::Keypolicy;
+use sp800_185::KMac;
+
+#[cfg(target_env = "sgx")]
+use sgx_isa::{Keyname, Keyrequest};
+#[cfg(target_env = "sgx")]
+use tiny_keccak::sha3_256;
+
+// This crate is not portable due to dependencies, even when using the mock
+// key derivation:
+//
+//  * sp800_185 relies on tiny_keccak, which as of 1.4.2, will produce
+//    incorrect results on big endian targets, and will crash on any
+//    architecture that requires aligned 64 bit loads and stores.
+#[cfg(not(target_arch = "x86_64"))]
+error!("Only x86_64 is supported");
+
+#[cfg(not(target_env = "sgx"))]
+const MOCK_MRENCLAVE_KEY: &[u8] = b"Ekiden Test MRENCLAVE KEY";
+#[cfg(not(target_env = "sgx"))]
+const MOCK_MRSIGNER_KEY: &[u8] = b"Ekiden Test MRSIGNER KEY";
+#[cfg(not(target_env = "sgx"))]
+const MOCK_KDF_CUSTOM: &[u8] = b"Ekiden Extract Test SGX Seal Key";
+
+const SEAL_KDF_CUSTOM: &[u8] = b"Ekiden Expand SGX Seal Key";
+
+#[cfg(target_env = "sgx")]
+fn egetkey_impl(key_policy: Keypolicy, context: &[u8]) -> [u8; 16] {
+    let mut req = Keyrequest::default();
+
+    req.keyname = Keyname::Seal as u16;
+    req.keypolicy = key_policy;
+    req.keyid = sha3_256(context);
+    // Fucking sgx_isa::Attributes doesn't have a -> [u64;2].
+    req.attributemask[0] = 1 | 2 | 4; // SGX_FLAGS_INITTED | SGX_FLAGS_DEBUG | SGX_FLAGS_MODE64BIT
+    req.attributemask[1] = 3; // SGX_XFRM_LEGACY
+
+    match req.egetkey() {
+        Err(e) => panic!("EGETKEY failed: {:?}", e),
+        Ok(k) => k,
+    }
+}
+
+#[cfg(not(target_env = "sgx"))]
+fn egetkey_impl(key_policy: Keypolicy, context: &[u8]) -> [u8; 16] {
+    let mut k = [0u8; 16];
+
+    // Deterministically generate a test master key from the context.
+    let mut kdf = match key_policy {
+        Keypolicy::MRENCLAVE => KMac::new_kmac256(MOCK_MRENCLAVE_KEY, MOCK_KDF_CUSTOM),
+        Keypolicy::MRSIGNER => KMac::new_kmac256(MOCK_MRSIGNER_KEY, MOCK_KDF_CUSTOM),
+        _ => panic!("Invalid key_policy"),
+    };
+    kdf.update(&context);
+    kdf.finalize(&mut k);
+
+    k
+}
+
+/// egetkey returns a 256 bit key suitable for sealing secrets to the
+/// enclave in cold storage, derived from the results of the `EGETKEY`
+/// instruction.  The `context` field a domain separation tag.
+///
+/// Note: The key can also be used for other things (eg: as an X25519
+/// private key).
+pub fn egetkey(key_policy: Keypolicy, context: &[u8]) -> [u8; 32] {
+    let mut k = [0u8; 32];
+
+    // Obtain the per-CPU package SGX sealing key, with the requested
+    // policy.
+    let master_secret = egetkey_impl(key_policy, context);
+
+    // Expand the 128 bit EGETKEY result into a 256 bit key, suitable
+    // for use with our MRAE primitives.
+    let mut kdf = KMac::new_kmac256(&master_secret, SEAL_KDF_CUSTOM);
+    kdf.update(&context);
+    kdf.finalize(&mut k);
+
+    k
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_egetkey() {
+        // Ensure key policies works.
+        let mrsigner_key = egetkey(Keypolicy::MRSIGNER, b"MRSIGNER");
+        assert!(mrsigner_key != [0u8; 32]);
+        let mrenclave_key = egetkey(Keypolicy::MRENCLAVE, b"MRENCLAVE");
+        assert!(mrenclave_key != [0u8; 32]);
+        assert!(mrsigner_key != mrenclave_key);
+
+        // Ensure the context does something.
+        let a_key = egetkey(Keypolicy::MRENCLAVE, b"Context A");
+        let b_key = egetkey(Keypolicy::MRENCLAVE, b"Context B");
+        assert!(a_key != b_key);
+
+        // Ensure determinism.
+        let aa_key = egetkey(Keypolicy::MRENCLAVE, b"Context A");
+        assert!(a_key == aa_key);
+    }
+}

--- a/runtime/src/common/sgx/mod.rs
+++ b/runtime/src/common/sgx/mod.rs
@@ -1,3 +1,4 @@
 //! SGX-specific functionality.
 
 pub mod avr;
+pub mod egetkey;


### PR DESCRIPTION
This provides a way to get the MRENCLAVE or MRSIGNER key when running in
an enclave, and a passable (deterministic/insecure) mocked analog when
running outside the enclave.

Part of #1550.