### PR TITLE
runtime: Use a persistent RAK, derived from EGETKEY

### DIFF
--- a/runtime/src/common/crypto/signature.rs
+++ b/runtime/src/common/crypto/signature.rs
@@ -32,6 +32,12 @@ impl PrivateKey {
         Ok(PrivateKey(key))
     }
 
+    /// Loads the private key unchecked from a raw seed.
+    pub fn from_seed_unchecked(key: &[u8]) -> Fallible<Self> {
+        let key = Ed25519KeyPair::from_seed_unchecked(untrusted::Input::from(key))?;
+        Ok(PrivateKey(key))
+    }
+
     /// Returns the public key.
     pub fn public_key(&self) -> PublicKey {
         let mut data = [0u8; 32];


### PR DESCRIPTION
This is somewhat of an abuse of the SGX Sealing key, but it should be
safe to use it in this context (additionally there is sufficient domain
separation, both at the EGETKEY instruction level, and at the KDF
applied after).

Note: If we ever decide to enable RAKs for "simulation mode", all
instances will have the same key.

Fixes #1637.