### PR TITLE
scheduler/trivial: support for node roles

### DIFF
--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -80,10 +80,10 @@ type Node struct {
 type RolesMask uint32
 
 const (
-	// ComputeWorker Role is Ekiden Compute Worker role.
-	ComputeWorker RolesMask = 1 << iota
-	// StorageWorker Roles is Ekiden Storage node role.
-	StorageWorker
+	// RoleComputeWorker is Ekiden Compute Worker role.
+	RoleComputeWorker RolesMask = 1 << 0
+	// RoleStorageWorker is Ekiden Storage node role.
+	RoleStorageWorker RolesMask = 1 << 1
 )
 
 // AddRoles adds the Node roles

--- a/go/common/node/node_test.go
+++ b/go/common/node/node_test.go
@@ -14,7 +14,7 @@ func TestSerialization(t *testing.T) {
 		ID:         signature.PublicKey(key),
 		EntityID:   signature.PublicKey(key),
 		Expiration: 42,
-		Roles:      ComputeWorker,
+		Roles:      RoleComputeWorker,
 	}
 
 	np := n.ToProto()

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -387,9 +387,9 @@ func (ent *TestEntity) NewTestNodes(nCompute int, nStorage int, runtimes []*Test
 
 		var role node.RolesMask
 		if i < nCompute {
-			role = node.ComputeWorker
+			role = node.RoleComputeWorker
 		} else {
-			role = node.StorageWorker
+			role = node.RoleStorageWorker
 		}
 
 		nod.Node = &node.Node{

--- a/go/scheduler/tests/tester.go
+++ b/go/scheduler/tests/tester.go
@@ -92,10 +92,10 @@ func SchedulerImplementationTests(t *testing.T, backend api.Backend, epochtime e
 
 	var nCompute, nStorage int
 	for _, n := range nodes {
-		if n.HasRoles(node.ComputeWorker) {
+		if n.HasRoles(node.RoleComputeWorker) {
 			nCompute++
 		}
-		if n.HasRoles(node.StorageWorker) {
+		if n.HasRoles(node.RoleStorageWorker) {
 			nStorage++
 		}
 	}

--- a/go/scheduler/trivial/trivial.go
+++ b/go/scheduler/trivial/trivial.go
@@ -110,7 +110,7 @@ func (s *trivialSchedulerState) elect(rt *registry.Runtime, epoch epochtime.Epoc
 		for _, n := range runtimeTeeNodeList {
 			switch kind {
 			case api.Compute:
-				if n.HasRoles(node.ComputeWorker) {
+				if n.HasRoles(node.RoleComputeWorker) {
 					nodeList = append(nodeList, n)
 				}
 			case api.Storage:

--- a/go/worker/compute/worker.go
+++ b/go/worker/compute/worker.go
@@ -479,7 +479,7 @@ func newWorker(
 			// so should probably be set elsewhere in future.
 			n.P2P = w.p2p.Info()
 
-			n.AddRoles(node.ComputeWorker)
+			n.AddRoles(node.RoleComputeWorker)
 			n.Runtimes = w.getNodeRuntimes()
 
 			return nil


### PR DESCRIPTION
Closes: #1650 

- extends scheduler to support node roles
- also adds `StorageWorker` role (although it's not used yet, it made sense adding it, as scheduler also has storage committee support already) 
