### PR TITLE
roothash: Remove support for legacy roothash format

### DIFF
--- a/go/roothash/api/block/header.go
+++ b/go/roothash/api/block/header.go
@@ -167,14 +167,8 @@ func (h *Header) FromProto(pb *pbRoothash.Header) error { // nolint: gocyclo
 	if err := h.OutputHash.UnmarshalBinary(pb.GetOutputHash()); err != nil {
 		return err
 	}
-	// TODO: This is needed for migrating from legacy versions, remove after
-	//       everything is migrated to the new version.
-	if len(pb.GetTagHash()) > 0 {
-		if err := h.TagHash.UnmarshalBinary(pb.GetTagHash()); err != nil {
-			return err
-		}
-	} else {
-		h.TagHash.Empty()
+	if err := h.TagHash.UnmarshalBinary(pb.GetTagHash()); err != nil {
+		return err
 	}
 	if err := h.StateRoot.UnmarshalBinary(pb.GetStateRoot()); err != nil {
 		return err


### PR DESCRIPTION
Closes: https://github.com/oasislabs/ekiden/issues/1620

Not needed anymore as https://github.com/oasislabs/ekiden/pull/1649 has been deployed on prod