### PR TITLE
go/common/debug: Add a debug package with debug only helpers

### DIFF
--- a/go/common/debug/debug.go
+++ b/go/common/debug/debug.go
@@ -1,0 +1,10 @@
+// Package debug implements various debugging utilities.
+package debug
+
+//go:noescape
+func debugTrap()
+
+// Trap crashes the current process with `SIGTRAP`.
+func Trap() {
+	debugTrap()
+}

--- a/go/common/debug/debug_amd64.s
+++ b/go/common/debug/debug_amd64.s
@@ -1,0 +1,7 @@
+// +build !noasm
+
+#include "textflag.h"
+
+TEXT ·debugTrap(SB), NOSPLIT|NOFRAME, $0-0
+	BYTE $0xcc // INT 3
+	RET


### PR DESCRIPTION
Currently the only function implemented is `Trap()` that force crashes
the program immediately via the `int 3` x86 trap.