### PR TITLE
buildkite: promote image to latest-beta

### DIFF
--- a/.buildkite/deploy.pipeline.yml
+++ b/.buildkite/deploy.pipeline.yml
@@ -91,11 +91,6 @@ steps:
   - label: Deploy docker image (master branches only)
     branches: master
     command:
-      - .buildkite/scripts/promote_deployment_image_to.sh latest-testing
+      - .buildkite/scripts/promote_deployment_image_to.sh latest-beta
     env:
       DEPLOYMENT_VARIANT: testing
-
-  - label: Deploy production-track docker image (master branches only)
-    branches: master
-    command:
-      - .buildkite/scripts/promote_deployment_image_to.sh latest


### PR DESCRIPTION
This is so we can start merging in breaking changes.

We also probably want to create a branch that's kept on currently deployed version of ekiden on staging