### PR TITLE
go worker: state transitions for txnscheduler leader

### DIFF
--- a/go/worker/compute/committee/state.go
+++ b/go/worker/compute/committee/state.go
@@ -25,6 +25,8 @@ var validStateTransitions = map[string][]string{
 		"WaitingForBlock",
 		// Received batch, current block is up to date.
 		"ProcessingBatch",
+		// Sent a batch as transaction scheduler leader.
+		"WaitingForFinalize",
 		// Epoch transition occurred and we are no longer in the committee.
 		"NotReady",
 	},


### PR DESCRIPTION
we can't stay in NotReady when we're transaction scheduler leader and compute non-member, because then checkIncomingQueue will never do anything. so transition to WaitingForBatch in that case.

and while we're at it, transition to WaitingForFinalize once we send the batch (and we're not compute member). there's still a little inaccuracy when we're transaction scheduler leader and compute backup worker, but that won't be resolved until we separate the two state machines (#1669)

blocks #1697