### PR TITLE
storage/mkvs/urkel: Fix incorrect root usage in prefetch

### DIFF
--- a/go/storage/mkvs/urkel/cache.go
+++ b/go/storage/mkvs/urkel/cache.go
@@ -368,7 +368,7 @@ func (c *cache) derefValue(v *internal.Value) ([]byte, error) {
 }
 
 // prefetch prefetches a given subtree up to the configured prefetch depth.
-func (c *cache) prefetch(subtree hash.Hash, depth uint8) (*internal.Pointer, error) {
+func (c *cache) prefetch(subtreeRoot hash.Hash, subtreePath hash.Hash, depth uint8) (*internal.Pointer, error) {
 	if c.prefetchDepth == 0 {
 		return nil, nil
 	}
@@ -377,7 +377,7 @@ func (c *cache) prefetch(subtree hash.Hash, depth uint8) (*internal.Pointer, err
 	ctx, cancel := context.WithTimeout(context.Background(), c.syncerPrefetchTimeout)
 	defer cancel()
 
-	st, err := c.rs.GetSubtree(ctx, c.syncRoot, internal.NodeID{Path: subtree, Depth: depth}, c.prefetchDepth)
+	st, err := c.rs.GetSubtree(ctx, c.syncRoot, internal.NodeID{Path: subtreePath, Depth: depth}, c.prefetchDepth)
 	switch err {
 	case nil:
 	case syncer.ErrUnsupported:
@@ -386,7 +386,7 @@ func (c *cache) prefetch(subtree hash.Hash, depth uint8) (*internal.Pointer, err
 		return nil, err
 	}
 
-	ptr, err := c.reconstructSubtree(subtree, st, 0, c.prefetchDepth)
+	ptr, err := c.reconstructSubtree(subtreeRoot, st, 0, c.prefetchDepth)
 	if err != nil {
 		return nil, err
 	}

--- a/go/storage/mkvs/urkel/urkel.go
+++ b/go/storage/mkvs/urkel/urkel.go
@@ -123,7 +123,9 @@ func NewWithRoot(rs syncer.ReadSyncer, ndb db.NodeDB, root hash.Hash, options ..
 	t.cache.setSyncRoot(root)
 
 	// Try to prefetch the subtree at the root.
-	ptr, err := t.cache.prefetch(root, 0)
+	// NOTE: Path can be anything here as the depth is 0 so it is actually ignored.
+	var path hash.Hash
+	ptr, err := t.cache.prefetch(root, path, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/src/storage/mkvs/urkel/cache/cache.rs
+++ b/runtime/src/storage/mkvs/urkel/cache/cache.rs
@@ -94,7 +94,13 @@ pub trait Cache {
     ) -> Fallible<NodePtrRef>;
 
     /// Prefetch a subtree from the read syncer.
-    fn prefetch(&mut self, ctx: &Arc<Context>, root: Hash, depth: u8) -> Fallible<NodePtrRef>;
+    fn prefetch(
+        &mut self,
+        ctx: &Arc<Context>,
+        subtree_root: Hash,
+        subtree_path: Hash,
+        depth: u8,
+    ) -> Fallible<NodePtrRef>;
 }
 
 /// Cacheable objects must implement this trait to enable the cache to cache them.

--- a/runtime/src/storage/mkvs/urkel/cache/lru_cache.rs
+++ b/runtime/src/storage/mkvs/urkel/cache/lru_cache.rs
@@ -466,7 +466,8 @@ impl Cache for LRUCache {
     fn prefetch(
         &mut self,
         ctx: &Arc<Context>,
-        subtree_hash: Hash,
+        subtree_root: Hash,
+        subtree_path: Hash,
         depth: u8,
     ) -> Fallible<NodePtrRef> {
         if self.prefetch_depth == 0 {
@@ -477,7 +478,7 @@ impl Cache for LRUCache {
             Context::create_child(ctx),
             self.sync_root,
             NodeID {
-                path: subtree_hash,
+                path: subtree_path,
                 depth: depth,
             },
             self.prefetch_depth,
@@ -494,6 +495,6 @@ impl Cache for LRUCache {
             }
             Ok(ref st) => st,
         };
-        self.reconstruct_subtree(ctx, subtree_hash, st, 0, self.prefetch_depth)
+        self.reconstruct_subtree(ctx, subtree_root, st, 0, self.prefetch_depth)
     }
 }

--- a/runtime/src/storage/mkvs/urkel/tree/tree.rs
+++ b/runtime/src/storage/mkvs/urkel/tree/tree.rs
@@ -123,7 +123,11 @@ impl UrkelTree {
                     ..Default::default()
                 })));
             tree.cache.borrow_mut().set_sync_root(root_hash);
-            let ptr = tree.cache.borrow_mut().prefetch(&ctx, root_hash, 0)?;
+            // NOTE: Path can be anything here as the depth is 0 so it is actually ignored.
+            let ptr = tree
+                .cache
+                .borrow_mut()
+                .prefetch(&ctx, root_hash, Hash::default(), 0)?;
             if !ptr.borrow().is_null() {
                 tree.cache.borrow_mut().set_pending_root(ptr);
             }


### PR DESCRIPTION
The only reason this worked is that we currently always only prefetch
at depth zero (the root node), so the actual path is ignored.

Thanks @matevz for the find!