### PR TITLE
ci: Fix testing/production image tagging

### DIFF
--- a/.buildkite/deploy.pipeline.yml
+++ b/.buildkite/deploy.pipeline.yml
@@ -91,6 +91,11 @@ steps:
   - label: Deploy docker image (master branches only)
     branches: master
     command:
-      - .buildkite/scripts/promote_deployment_image_to.sh latest-beta
+      - .buildkite/scripts/promote_deployment_image_to.sh latest-testing
     env:
       DEPLOYMENT_VARIANT: testing
+
+  - label: Deploy production-track docker image (master branches only)
+    branches: master
+    command:
+      - .buildkite/scripts/promote_deployment_image_to.sh latest-beta


### PR DESCRIPTION
Previous tags were incorrect as they meant that we will be using a testing image on staging instead of the production image and the actual testing image was never updated which meant that benchmarks were using an old image.