### PR TITLE
keymanager-client: lru caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,7 @@ dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "io-context 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/keymanager-client/Cargo.toml
+++ b/keymanager-client/Cargo.toml
@@ -11,6 +11,7 @@ ekiden-keymanager-api = { path = "../keymanager-runtime/api" }
 failure = "0.1.5"
 futures = "0.1.25"
 io-context = "0.2.0"
+lru = "0.1.15"
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
 grpcio = "0.4.4"

--- a/keymanager-client/src/lib.rs
+++ b/keymanager-client/src/lib.rs
@@ -7,6 +7,7 @@ extern crate futures;
 #[cfg(not(target_env = "sgx"))]
 extern crate grpcio;
 extern crate io_context;
+extern crate lru;
 
 pub mod client;
 pub mod mock;

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -270,6 +270,7 @@ fn main() {
             None,
             protocol.clone(),
             rak.clone(),
+            1024,
         ));
 
         txn.set_context_initializer(move |ctx: &mut TxnContext| {


### PR DESCRIPTION
Closes: #1720

TODO:
- [x] should probably made the sizes configurable
- [x] what are appropriate default values for sizes
  - set to `1024` in simple-keyvalue - only place where this is used atm?