### PR TITLE
Increase SGX E2E tests parallelism to 3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -207,7 +207,7 @@ steps:
   # E2E test jobs - intel-sgx
   ###########################
   - label: E2E tests - intel-sgx (%n)
-    parallelism: 2
+    parallelism: 3
     timeout_in_minutes: 10
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh


### PR DESCRIPTION
Currently, we run 3 End-to-End tests on SGX. Since the SGX-enabled Buildkite instances are not the fastest, this represents the slowest part of the whole Buildkite testing pipeline.
The job that runs 2 End-to-End tests usually takes between 7 and 8 minutes, whereas the job that runs a single End-to-End test only takes between 3 and 4 minutes.
In combination with increasing the number of SGX-enabled Buildkite agents, we can increase SGX End-to-End tests parallelism to 3 and expect overall build times to reduce for more than 3 minutes.