### PR TITLE
go/storage/mkvs/urkel: Fix memory leak

### DIFF
--- a/go/storage/mkvs/urkel/remove.go
+++ b/go/storage/mkvs/urkel/remove.go
@@ -44,7 +44,7 @@ func (t *Tree) doRemove(ctx context.Context, ptr *internal.Pointer, depth uint8,
 			switch node.(type) {
 			case nil:
 				// No more children, delete the internal node as well.
-				t.cache.tryRemoveNode(ptr)
+				t.cache.removeNode(ptr)
 				return nil, true, nil
 			case *internal.LeafNode:
 				// Left is nil, right is leaf, merge nodes back.
@@ -71,7 +71,7 @@ func (t *Tree) doRemove(ctx context.Context, ptr *internal.Pointer, depth uint8,
 	case *internal.LeafNode:
 		// Remove from leaf node.
 		if n.Key.Equal(&key) {
-			t.cache.tryRemoveNode(ptr)
+			t.cache.removeNode(ptr)
 			return nil, true, nil
 		}
 

--- a/go/storage/mkvs/urkel/urkel.go
+++ b/go/storage/mkvs/urkel/urkel.go
@@ -66,7 +66,11 @@ func PrefetchDepth(depth uint8) Option {
 
 // Capacity sets the capacity of the in-memory cache.
 //
-// If no capacity is specified, the cache will have an unlimited size.
+// If no capacity is specified, the cache will have a maximum capacity of
+// 16MB for values and 5000 for nodes.
+//
+// If a capacity of 0 is specified, the cache will have an unlimited size
+// (not recommended, as this will cause unbounded memory growth).
 func Capacity(nodeCapacity uint64, valueCapacityBytes uint64) Option {
 	return func(t *Tree) {
 		t.cache.nodeCapacity = nodeCapacity


### PR DESCRIPTION
See #1745.

The problem was with the low-level Urkel node/value cache (no limits set + eviction bug).
This PR contains also a few other minor improvements.

Memory usage has reduced a lot, but there's still a leak somewhere, will continue with investigation in another PR.