### PR TITLE
Update the Deoxys-II imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,8 +299,8 @@ dependencies = [
 
 [[package]]
 name = "deoxysii"
-version = "0.1.0"
-source = "git+https://github.com/oasislabs/deoxysii-rust#571885e506de4c11b9875a19c686afcc89f4d877"
+version = "0.2.0"
+source = "git+https://github.com/oasislabs/deoxysii-rust#4687841cc6bd090e39a5f2908f34f49d64046200"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -408,7 +408,7 @@ dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "deoxysii 0.1.0 (git+https://github.com/oasislabs/deoxysii-rust)",
+ "deoxysii 0.2.0 (git+https://github.com/oasislabs/deoxysii-rust)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "intrusive-collections 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2004,7 +2004,7 @@ dependencies = [
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum curve25519-dalek 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1f8a6fc0376eb52dc18af94915cc04dfdf8353746c0e8c550ae683a0815e5c1"
-"checksum deoxysii 0.1.0 (git+https://github.com/oasislabs/deoxysii-rust)" = "<none>"
+"checksum deoxysii 0.2.0 (git+https://github.com/oasislabs/deoxysii-rust)" = "<none>"
 "checksum derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6ca414e896ae072546f4d789f452daaecf60ddee4c9df5dc6d5936d769e3d87c"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"

--- a/go/go.mod
+++ b/go/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/libp2p/go-libp2p-peerstore v0.0.1
 	github.com/libp2p/go-libp2p-protocol v0.0.1
 	github.com/multiformats/go-multiaddr v0.0.2
-	github.com/oasislabs/deoxysii v0.0.0-20190329164139-cc54819a5e4c
+	github.com/oasislabs/deoxysii v0.0.0-20190610083944-a3e81dcb2dde
 	github.com/oasislabs/go-codec v0.0.0-20190531083711-36f85e883b2a
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.8.1

--- a/go/go.sum
+++ b/go/go.sum
@@ -272,6 +272,8 @@ github.com/multiformats/go-multistream v0.0.1 h1:JV4VfSdY9n7ECTtY59/TlSyFCzRILvY
 github.com/multiformats/go-multistream v0.0.1/go.mod h1:fJTiDfXJVmItycydCnNx4+wSzZ5NwG2FEVAI30fiovg=
 github.com/oasislabs/deoxysii v0.0.0-20190329164139-cc54819a5e4c h1:HXZEsKsQ6lDd1Afewj+Zt1fZw47RDXEqwj9zfGHtjtk=
 github.com/oasislabs/deoxysii v0.0.0-20190329164139-cc54819a5e4c/go.mod h1:lYp+eM7TUm0n0T/KE8FyKXLC226gDx7/UlGTUAO6W/4=
+github.com/oasislabs/deoxysii v0.0.0-20190610083944-a3e81dcb2dde h1:VtFvwkYI10rPxWK8cfqu4i40EeANErs7Qb0416RgQFc=
+github.com/oasislabs/deoxysii v0.0.0-20190610083944-a3e81dcb2dde/go.mod h1:PyjqElilQd4b7CBW+PT+ylPW06zHsb2Cr6ifPL6pWgM=
 github.com/oasislabs/go-codec v0.0.0-20190513052804-1ee93b6329db h1:7nhxAQ369c4nt6X6Mnn/KO+1CrWuZp3h1E/emD1fVUM=
 github.com/oasislabs/go-codec v0.0.0-20190513052804-1ee93b6329db/go.mod h1:Aun42SeUcfUG7JiwijrAymzM6sPVq1vMpLUDYRNANfo=
 github.com/oasislabs/go-codec v0.0.0-20190529151125-64f68cae5bf3 h1:COvdc1ciEBEPAPV+ihabYAIfbZDRtNqEQNlC2xynbJk=
@@ -418,6 +420,8 @@ golang.org/x/sys v0.0.0-20190219092855-153ac476189d/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190228124157-a34e9553db1e h1:ZytStCyV048ZqDsWHiYDdoI2Vd4msMcrDECFxS+tL9c=
 golang.org/x/sys v0.0.0-20190228124157-a34e9553db1e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e h1:nFYrTHrdrAOpShe27kaFHjsqYSEQ0KWqdWLu3xuZJts=
+golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
The algorithm received a minor change since the version we implemented,
and is now considered stable.  Bump the imports to the updated packages.