### PR TITLE
tendermint/apps: use unique application tags

### DIFF
--- a/go/tendermint/abci/mux.go
+++ b/go/tendermint/abci/mux.go
@@ -536,7 +536,7 @@ func (mux *abciMux) DeliverTx(tx []byte) types.ResponseDeliverTx {
 
 	// Append application name tag.
 	ctx := NewContext(ContextDeliverTx, mux.currentTime)
-	ctx.EmitTag(api.TagApplication, []byte(app.Name()))
+	ctx.EmitTag([]byte(app.Name()), api.TagAppNameValue)
 
 	err = app.DeliverTx(ctx, tx[1:])
 	if err != nil {

--- a/go/tendermint/api/api.go
+++ b/go/tendermint/api/api.go
@@ -55,9 +55,9 @@ func (c Code) String() string {
 	}
 }
 
-// TagApplication is an ABCI transaction tag for denoting which application
-// processed the given transaction. Value is the given application name.
-var TagApplication = []byte("ekiden.app")
+// TagAppNameValue is the value that should be used in the `AppName` tag
+// used for denoting which application processed the given transaction.
+var TagAppNameValue = []byte("1")
 
 // GetTag looks up a specific tag in a list of tags and returns its value if any.
 //

--- a/go/tendermint/apps/beacon/api.go
+++ b/go/tendermint/apps/beacon/api.go
@@ -21,5 +21,5 @@ var (
 
 	// QueryApp is a query for filtering transactions processed by the
 	// beacon application.
-	QueryApp = api.QueryForEvent(api.TagApplication, []byte(AppName))
+	QueryApp = api.QueryForEvent([]byte(AppName), api.TagAppNameValue)
 )

--- a/go/tendermint/apps/beacon/beacon.go
+++ b/go/tendermint/apps/beacon/beacon.go
@@ -132,7 +132,7 @@ func (app *beaconApplication) onNewBeacon(ctx *abci.Context, event *beacon.Gener
 		return errors.Wrap(err, "tendermint/beacon: failed to set beacon")
 	}
 
-	ctx.EmitTag(api.TagApplication, []byte(app.Name()))
+	ctx.EmitTag([]byte(app.Name()), api.TagAppNameValue)
 	ctx.EmitTag(TagGenerated, cbor.Marshal(event))
 
 	return nil

--- a/go/tendermint/apps/epochtime_mock/api.go
+++ b/go/tendermint/apps/epochtime_mock/api.go
@@ -26,7 +26,7 @@ var (
 
 	// QueryApp is a query for filtering transactions processed by
 	// the mock epochtime application.
-	QueryApp = api.QueryForEvent(api.TagApplication, []byte(AppName))
+	QueryApp = api.QueryForEvent([]byte(AppName), api.TagAppNameValue)
 )
 
 // Tx is a transaction to be accepted by the mock epochtime app.

--- a/go/tendermint/apps/epochtime_mock/epochtime_mock.go
+++ b/go/tendermint/apps/epochtime_mock/epochtime_mock.go
@@ -119,7 +119,7 @@ func (app *epochTimeMockApplication) BeginBlock(ctx *abci.Context, request types
 	)
 
 	state.setEpoch(future.Epoch, height)
-	ctx.EmitTag(api.TagApplication, []byte(app.Name()))
+	ctx.EmitTag([]byte(app.Name()), api.TagAppNameValue)
 	ctx.EmitTag(TagEpoch, cbor.Marshal(future.Epoch))
 
 	return nil

--- a/go/tendermint/apps/keymanager/api.go
+++ b/go/tendermint/apps/keymanager/api.go
@@ -21,7 +21,7 @@ var (
 
 	// QueryApp is a query for filtering transactions processed by the
 	// key manager application.
-	QueryApp = api.QueryForEvent(api.TagApplication, []byte(AppName))
+	QueryApp = api.QueryForEvent([]byte(AppName), api.TagAppNameValue)
 )
 
 const (

--- a/go/tendermint/apps/keymanager/keymanager.go
+++ b/go/tendermint/apps/keymanager/keymanager.go
@@ -169,7 +169,7 @@ func (app *keymanagerApplication) onEpochChange(ctx *abci.Context, epoch epochti
 
 	// Emit the update event if required.
 	if len(toEmit) > 0 {
-		ctx.EmitTag(tmapi.TagApplication, []byte(app.Name()))
+		ctx.EmitTag([]byte(app.Name()), tmapi.TagAppNameValue)
 		ctx.EmitTag(TagStatusUpdate, cbor.Marshal(toEmit))
 	}
 

--- a/go/tendermint/apps/registry/api.go
+++ b/go/tendermint/apps/registry/api.go
@@ -33,7 +33,7 @@ var (
 
 	// QueryApp is a query for filtering transactions processed by
 	// the registry application.
-	QueryApp = api.QueryForEvent(api.TagApplication, []byte(AppName))
+	QueryApp = api.QueryForEvent([]byte(AppName), api.TagAppNameValue)
 )
 
 const (

--- a/go/tendermint/apps/registry/registry.go
+++ b/go/tendermint/apps/registry/registry.go
@@ -156,7 +156,7 @@ func (app *registryApplication) InitChain(ctx *abci.Context, request types.Reque
 	}
 
 	if len(st.Entities) > 0 || len(st.Runtimes) > 0 {
-		ctx.EmitTag(api.TagApplication, []byte(app.Name()))
+		ctx.EmitTag([]byte(app.Name()), api.TagAppNameValue)
 	}
 
 	return nil
@@ -217,7 +217,7 @@ func (app *registryApplication) onEpochChange(ctx *abci.Context, epoch epochtime
 
 	// Iff any nodes have expired, force-emit the application tag so
 	// the change is picked up.
-	ctx.EmitTag(api.TagApplication, []byte(app.Name()))
+	ctx.EmitTag([]byte(app.Name()), api.TagAppNameValue)
 	ctx.EmitTag(TagNodesExpired, cbor.Marshal(expiredNodes))
 
 	return nil

--- a/go/tendermint/apps/roothash/api.go
+++ b/go/tendermint/apps/roothash/api.go
@@ -38,7 +38,7 @@ var (
 
 	// QueryApp is a query for filtering transactions processed by
 	// the root hash application.
-	QueryApp = api.QueryForEvent(api.TagApplication, []byte(AppName))
+	QueryApp = api.QueryForEvent([]byte(AppName), api.TagAppNameValue)
 
 	// QueryUpdate is a query for filtering transactions where root hash
 	// application state has been updated. This is required as state can

--- a/go/tendermint/apps/staking/api.go
+++ b/go/tendermint/apps/staking/api.go
@@ -26,7 +26,7 @@ var (
 
 	// QueryApp is a query for filtering transactions processed by
 	// the staking application.
-	QueryApp = api.QueryForEvent(api.TagApplication, []byte(AppName))
+	QueryApp = api.QueryForEvent([]byte(AppName), api.TagAppNameValue)
 )
 
 const (


### PR DESCRIPTION
Replaces `api.TagApplication` with a per tendermint app unique tag as otherwise the tag can get overridden. This happens if multiple applications set the tag in the same block (currently this happens on the first epoch when both key-manager and beacon set the tag).

~Can revert the `common_e2e.sh` change to tendermint beacon if we rather use the trivail - but this was the only way to actually notice the bug at the moment (migration tests failed with tendermint beacon)~ Nevermind cannot use tendermint beacon at the moment due to discrepancy tests (could override it for some tests)