### PR TITLE
go/worker/{compute,merge}: Fix state transitions

### DIFF
--- a/go/worker/compute/committee/state.go
+++ b/go/worker/compute/committee/state.go
@@ -58,6 +58,10 @@ var validStateTransitions = map[StateName][]StateName{
 		WaitingForBatch,
 		// Seen block that we were waiting for.
 		ProcessingBatch,
+		// Seen block that we were waiting for, waiting for disrepancy event.
+		WaitingForEvent,
+		// Epoch transition occurred and we are no longer in the committee.
+		NotReady,
 	},
 
 	// Transitions from WaitingForEvent state.
@@ -66,6 +70,8 @@ var validStateTransitions = map[StateName][]StateName{
 		WaitingForBatch,
 		// Discrepancy event received.
 		ProcessingBatch,
+		// Epoch transition occurred and we are no longer in the committee.
+		NotReady,
 	},
 
 	// Transitions from ProcessingBatch state.

--- a/go/worker/merge/committee/state.go
+++ b/go/worker/merge/committee/state.go
@@ -48,9 +48,11 @@ var validStateTransitions = map[StateName][]StateName{
 	// Transitions from WaitingForEvent state.
 	WaitingForEvent: {
 		// Abort: seen newer block while waiting for event.
-		WaitingForFinalize,
+		WaitingForResults,
 		// Discrepancy event received.
 		ProcessingMerge,
+		// Epoch transition occurred and we are not in the committee.
+		NotReady,
 	},
 
 	// Transitions from ProcessingMerge state.


### PR DESCRIPTION
Fixes #1826 