### PR TITLE
go/storage/cachingclient: Implement caching for MKVS ops

### DIFF
--- a/go/common/cache/lru/lru.go
+++ b/go/common/cache/lru/lru.go
@@ -93,6 +93,21 @@ func (c *Cache) Peek(key interface{}) (interface{}, bool) {
 	return c.getEntry(key, true)
 }
 
+// Remove removes the key from the cache and returns true if the key existed, otherwise false.
+func (c *Cache) Remove(key interface{}) bool {
+	c.Lock()
+	defer c.Unlock()
+
+	elem, ok := c.entries[key]
+	if ok {
+		c.lru.Remove(elem)
+		delete(c.entries, key)
+		c.size -= c.getValueSize(elem.Value.(*cacheEntry).value)
+	}
+
+	return ok
+}
+
 // Keys returns the keys for every entry in the cache, from the least-recently-used
 // to the most-recently-used.
 func (c *Cache) Keys() []interface{} {

--- a/go/common/cache/lru/lru_test.go
+++ b/go/common/cache/lru/lru_test.go
@@ -114,6 +114,34 @@ func TestLRUCapacityBytes(t *testing.T) {
 	require.False(ok, "Put - expected entry evicted")
 }
 
+func TestLRURemoval(t *testing.T) {
+	require := require.New(t)
+
+	const cacheSize = 5
+
+	cache, err := New(
+		Capacity(uint64(cacheSize*sha256.Size), true),
+	)
+	require.NoError(err, "New")
+
+	entries := makeEntries(cacheSize)
+	for _, ent := range entries {
+		err = cache.Put(ent.key, ent)
+		require.NoError(err, "Put")
+	}
+
+	sizeBeforeRemoval := cache.Size()
+
+	existed := cache.Remove(entries[0].key)
+	require.True(existed, "Remove - expected entry to exist")
+
+	sizeAfterRemoval := cache.Size()
+
+	_, ok := cache.Peek(entries[0].key)
+	require.False(ok, "Peek - expected entry to not exist after removal")
+	require.Equal(sizeBeforeRemoval-entries[0].Size(), sizeAfterRemoval, "Size - expected size to reduce by entry size after removal")
+}
+
 type testEntry struct {
 	key   string
 	value []byte

--- a/go/storage/badger/badger.go
+++ b/go/storage/badger/badger.go
@@ -45,7 +45,7 @@ func New(dbDir string, signingKey *signature.PrivateKey, lruSizeInBytes, applyLo
 		return nil, errors.Wrap(err, "storage/badger: failed to open node database")
 	}
 
-	rootCache, err := api.NewRootCache(ndb, lruSizeInBytes, applyLockLRUSlots)
+	rootCache, err := api.NewRootCache(ndb, nil, lruSizeInBytes, applyLockLRUSlots)
 	if err != nil {
 		ndb.Close()
 		return nil, errors.Wrap(err, "storage/badger: failed to create root cache")

--- a/go/storage/cachingclient/cachingclient.go
+++ b/go/storage/cachingclient/cachingclient.go
@@ -1,19 +1,18 @@
 // Package cachingclient implements a storage client wrapped with a
-// disk-persisted in-memory local cache.
+// disk-persisted in-memory local LRU cache.
 package cachingclient
 
 import (
 	"context"
-	"sync"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/oasislabs/ekiden/go/common/cache/lru"
 	"github.com/oasislabs/ekiden/go/common/crypto/hash"
 	"github.com/oasislabs/ekiden/go/common/logging"
 	"github.com/oasislabs/ekiden/go/storage/api"
+	nodedb "github.com/oasislabs/ekiden/go/storage/mkvs/urkel/db/api"
+	lrudb "github.com/oasislabs/ekiden/go/storage/mkvs/urkel/db/lru"
 )
 
 const (
@@ -27,137 +26,100 @@ const (
 	cfgCacheSize = "storage.cachingclient.cache_size"
 )
 
-var (
-	_ api.Backend  = (*cachingClientBackend)(nil)
-	_ lru.Sizeable = (*cachedValue)(nil)
-
-	cacheHits = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "ekiden_storage_cachingclient_cache_hits",
-			Help: "Number of cache hits to local cache in caching remote storage client backend.",
-		},
-	)
-	cacheMisses = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "ekiden_storage_cachingclient_cache_misses",
-			Help: "Number of cache misses from local cache in caching remote storage client backend.",
-		},
-	)
-	remoteMisses = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "ekiden_storage_cachingclient_remote_misses",
-			Help: "Number of queries for non-existent keys.",
-		},
-	)
-
-	cacheCollectors = []prometheus.Collector{
-		cacheHits,
-		cacheMisses,
-		remoteMisses,
-	}
-
-	metricsOnce sync.Once
-)
+var _ api.Backend = (*cachingClientBackend)(nil)
 
 type cachingClientBackend struct {
 	logger *logging.Logger
 
-	remote api.Backend
-	local  *lru.Cache
-
-	dbPath string
-}
-
-type cachedValue struct {
-	value []byte
-}
-
-func (v *cachedValue) Size() uint64 {
-	return uint64(len(v.value))
+	remote    api.Backend
+	local     nodedb.NodeDB
+	rootCache *api.RootCache
 }
 
 func (b *cachingClientBackend) Apply(ctx context.Context, root hash.Hash, expectedNewRoot hash.Hash, log api.WriteLog) ([]*api.Receipt, error) {
-	// TODO: Implement caching for MKVS operations (issue #1664).
+	// Apply to both local and remote DB.
+	_, _ = b.rootCache.Apply(ctx, root, expectedNewRoot, log)
+
 	return b.remote.Apply(ctx, root, expectedNewRoot, log)
 }
 
 func (b *cachingClientBackend) ApplyBatch(ctx context.Context, ops []api.ApplyOp) ([]*api.Receipt, error) {
-	// TODO: Implement caching for MKVS operations (issue #1664).
+	// Apply to both local and remote DB.
+	for _, op := range ops {
+		_, err := b.rootCache.Apply(ctx, op.Root, op.ExpectedNewRoot, op.WriteLog)
+		if err != nil {
+			break
+		}
+	}
+
 	return b.remote.ApplyBatch(ctx, ops)
 }
 
 func (b *cachingClientBackend) GetSubtree(ctx context.Context, root hash.Hash, id api.NodeID, maxDepth uint8) (*api.Subtree, error) {
-	// TODO: Implement caching for MKVS operations (issue #1664).
-	return b.remote.GetSubtree(ctx, root, id, maxDepth)
+	tree, err := b.rootCache.GetTree(ctx, root)
+	if err != nil {
+		return nil, err
+	}
+
+	return tree.GetSubtree(ctx, root, id, maxDepth)
 }
 
 func (b *cachingClientBackend) GetPath(ctx context.Context, root hash.Hash, key hash.Hash, startDepth uint8) (*api.Subtree, error) {
-	// TODO: Implement caching for MKVS operations (issue #1664).
-	return b.remote.GetPath(ctx, root, key, startDepth)
+	tree, err := b.rootCache.GetTree(ctx, root)
+	if err != nil {
+		return nil, err
+	}
+
+	return tree.GetPath(ctx, root, key, startDepth)
 }
 
 func (b *cachingClientBackend) GetNode(ctx context.Context, root hash.Hash, id api.NodeID) (api.Node, error) {
-	// TODO: Implement caching for MKVS operations (issue #1664).
-	return b.remote.GetNode(ctx, root, id)
+	tree, err := b.rootCache.GetTree(ctx, root)
+	if err != nil {
+		return nil, err
+	}
+
+	return tree.GetNode(ctx, root, id)
 }
 
 func (b *cachingClientBackend) GetValue(ctx context.Context, root hash.Hash, id hash.Hash) ([]byte, error) {
-	// TODO: Implement caching for MKVS operations (issue #1664).
-	return b.remote.GetValue(ctx, root, id)
+	tree, err := b.rootCache.GetTree(ctx, root)
+	if err != nil {
+		return nil, err
+	}
+
+	return tree.GetValue(ctx, root, id)
 }
 
 func (b *cachingClientBackend) Cleanup() {
 	b.remote.Cleanup()
-	if err := b.save(); err != nil {
-		b.logger.Error("failed to persist cache to disk",
-			"err", err,
-		)
-	}
+	b.local.Close()
 }
 
 func (b *cachingClientBackend) Initialized() <-chan struct{} {
 	return b.remote.Initialized()
 }
 
-func (b *cachingClientBackend) load() error {
-	b.logger.Info("loading cache from disk",
-		"path", b.dbPath,
-	)
-
-	// TODO: Implement caching for MKVS operations (issue #1664).
-	return nil
-}
-
-func (b *cachingClientBackend) save() error {
-	b.logger.Info("persisting cache to disk",
-		"path", b.dbPath,
-	)
-
-	// TODO: Implement caching for MKVS operations (issue #1664).
-	return nil
-}
-
 func New(remote api.Backend) (api.Backend, error) {
-	// Register metrics for cache hits and misses.
-	metricsOnce.Do(func() {
-		prometheus.MustRegister(cacheCollectors...)
-	})
+	lruCacheSizeInBytes := uint64(viper.GetSizeInBytes(cfgCacheSize))
+	lruFile := viper.GetString(cfgCacheFile)
 
-	local, err := lru.New(
-		lru.Capacity(uint64(viper.GetSizeInBytes(cfgCacheSize)), true),
-	)
+	local, err := lrudb.New(lruCacheSizeInBytes, lruFile)
 	if err != nil {
 		return nil, err
 	}
 
-	b := &cachingClientBackend{
-		logger: logging.GetLogger("storage/cachingclient"),
-		remote: remote,
-		local:  local,
-		dbPath: viper.GetString(cfgCacheFile),
-	}
-	if err := b.load(); err != nil {
+	rootCache, err := api.NewRootCache(local, remote, lruCacheSizeInBytes/8, 1000)
+	if err != nil {
+		local.Close()
 		return nil, err
+	}
+
+	b := &cachingClientBackend{
+		logger:    logging.GetLogger("storage/cachingclient"),
+		remote:    remote,
+		local:     local,
+		rootCache: rootCache,
 	}
 
 	return b, nil
@@ -167,7 +129,7 @@ func New(remote api.Backend) (api.Backend, error) {
 // command.
 func RegisterFlags(cmd *cobra.Command) {
 	if !cmd.Flags().Parsed() {
-		cmd.Flags().String(cfgCacheFile, "cachingclient.storage.leveldb", "Path to file for persistent cache storage")
+		cmd.Flags().String(cfgCacheFile, "cachingclient.storage.file", "Path to file for persistent cache storage")
 		cmd.Flags().String(cfgCacheSize, "512mb", "Cache size (bytes)")
 	}
 

--- a/go/storage/leveldb/leveldb.go
+++ b/go/storage/leveldb/leveldb.go
@@ -129,7 +129,7 @@ func New(dbDir string, signingKey *signature.PrivateKey, lruSizeInBytes uint64, 
 		return nil, err
 	}
 
-	rootCache, err := api.NewRootCache(ndb, lruSizeInBytes, applyLockLRUSlots)
+	rootCache, err := api.NewRootCache(ndb, nil, lruSizeInBytes, applyLockLRUSlots)
 	if err != nil {
 		ndb.Close()
 		return nil, err

--- a/go/storage/mkvs/urkel/db/lru/lru.go
+++ b/go/storage/mkvs/urkel/db/lru/lru.go
@@ -1,0 +1,286 @@
+// Package lru provides a lossy LRU-cache based node database.
+package lru
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"sync"
+	"unsafe"
+
+	"github.com/oasislabs/go-codec/codec"
+	"github.com/pkg/errors"
+
+	lruCache "github.com/oasislabs/ekiden/go/common/cache/lru"
+	"github.com/oasislabs/ekiden/go/common/cbor"
+	"github.com/oasislabs/ekiden/go/common/crypto/hash"
+	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/db/api"
+	urkel "github.com/oasislabs/ekiden/go/storage/mkvs/urkel/node"
+)
+
+var (
+	_ api.NodeDB        = (*lruNodeDB)(nil)
+	_ lruCache.Sizeable = (*valueCacheItem)(nil)
+	_ lruCache.Sizeable = (*nodeCacheItem)(nil)
+)
+
+type lruNodeDB struct {
+	sync.RWMutex
+
+	items *lruCache.Cache
+	fname string
+}
+
+type valueCacheItem struct {
+	v []byte
+}
+
+func (vci *valueCacheItem) Size() uint64 {
+	return uint64(len(vci.v))
+}
+
+type nodeCacheItem struct {
+	n urkel.Node
+}
+
+func (nci *nodeCacheItem) Size() uint64 {
+	return uint64(unsafe.Sizeof(nci.n))
+}
+
+// New creates a new in-memory node database with LRU replacement policy based on given size.
+func New(sizeInBytes uint64, filename string) (api.NodeDB, error) {
+	i, err := lruCache.New(lruCache.Capacity(sizeInBytes, true))
+	if err != nil {
+		return nil, err
+	}
+
+	db := &lruNodeDB{items: i, fname: filename}
+	err = db.load()
+	if err != nil {
+		return nil, err
+	}
+
+	return db, nil
+}
+
+func (d *lruNodeDB) GetNode(root hash.Hash, ptr *urkel.Pointer) (urkel.Node, error) {
+	if ptr == nil || !ptr.IsClean() {
+		panic("urkel/db/lru: attempted to get invalid pointer from node database")
+	}
+
+	d.RLock()
+	defer d.RUnlock()
+
+	item, err := d.getLocked(ptr.Hash)
+	if err != nil {
+		return nil, err
+	}
+
+	return item.(*nodeCacheItem).n, nil
+}
+
+func (d *lruNodeDB) GetValue(id hash.Hash) ([]byte, error) {
+	d.RLock()
+	defer d.RUnlock()
+
+	item, err := d.getLocked(id)
+	if err != nil {
+		return nil, err
+	}
+
+	return item.(*valueCacheItem).v, nil
+}
+
+func (d *lruNodeDB) Close() {
+	_ = d.save()
+}
+
+func (d *lruNodeDB) save() error {
+	f, err := os.OpenFile(d.fname, os.O_CREATE|os.O_APPEND|os.O_TRUNC|os.O_WRONLY, 0600)
+	if err != nil {
+		return errors.Wrap(err, "urkel/db/lru: failed to open cache file for writing")
+	}
+	defer f.Close()
+
+	w := bufio.NewWriter(f)
+	defer w.Flush()
+
+	ch := make(chan []byte)
+
+	go func() {
+		defer close(ch)
+
+		for _, k := range d.items.Keys() {
+			item, _ := d.items.Get(k)
+
+			// Serialize key.
+			key := k.(hash.Hash)
+			bytes := append([]byte{'K'}, key[:]...)
+
+			switch item := item.(type) {
+			case *valueCacheItem:
+				// Serialize value.
+				bytes = append(bytes, []byte{'V'}...)
+				bytes = append(bytes, item.v...)
+			case *nodeCacheItem:
+				// Serialize node.
+				nodeBytes, nerr := item.n.MarshalBinary()
+				if nerr != nil {
+					continue
+				}
+				bytes = append(bytes, []byte{'N'}...)
+				bytes = append(bytes, nodeBytes...)
+			default:
+				continue
+			}
+
+			ch <- bytes
+		}
+	}()
+
+	enc := codec.NewEncoder(w, cbor.Handle)
+	defer enc.Release()
+	if err = enc.Encode(ch); err != nil {
+		return errors.Wrap(err, "urkel/db/lru: failed to serialize cache")
+	}
+
+	return nil
+}
+
+func (d *lruNodeDB) load() error {
+	f, err := os.Open(d.fname)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Nothing wrong if we don't have a cache file yet.
+			return nil
+		}
+		return errors.Wrap(err, "urkel/db/lru: failed to open cache file")
+	}
+	defer f.Close()
+
+	r := bufio.NewReader(f)
+	ch := make(chan []byte)
+	doneCh := make(chan struct{})
+
+	go func() {
+		defer close(doneCh)
+		for v := range ch {
+			if v[0] != 'K' || len(v) < 1+hash.Size+1 {
+				continue
+			}
+
+			// Deserialize key.
+			var key hash.Hash
+			kerr := key.UnmarshalBinary(v[1 : 1+hash.Size])
+			if kerr != nil {
+				continue
+			}
+
+			switch v[1+hash.Size] {
+			case 'V':
+				// Deserialize value.
+				_ = d.putLocked(key, &valueCacheItem{v: v[1+hash.Size+1:]})
+			case 'N':
+				// Deserialize node.
+				node, nerr := urkel.UnmarshalBinary(v[1+hash.Size+1:])
+				if nerr != nil {
+					continue
+				}
+				_ = d.putLocked(key, &nodeCacheItem{n: node})
+			default:
+				continue
+			}
+		}
+	}()
+
+	dec := codec.NewDecoder(r, cbor.Handle)
+	defer dec.Release()
+	err = dec.Decode(&ch)
+	close(ch)
+	<-doneCh
+
+	if err != nil && err != io.EOF {
+		return errors.Wrap(err, "failed to deserialize cache")
+	}
+
+	return nil
+}
+
+func (d *lruNodeDB) putLocked(id hash.Hash, item interface{}) error {
+	return d.items.Put(id, item)
+}
+
+func (d *lruNodeDB) getLocked(id hash.Hash) (interface{}, error) {
+	item, found := d.items.Get(id)
+	if !found {
+		return nil, api.ErrNodeNotFound
+	}
+
+	return item, nil
+}
+
+type memoryBatch struct {
+	api.BaseBatch
+
+	db *lruNodeDB
+
+	ops []func() error
+}
+
+func (d *lruNodeDB) NewBatch() api.Batch {
+	return &memoryBatch{
+		db: d,
+	}
+}
+
+func (b *memoryBatch) MaybeStartSubtree(subtree api.Subtree, depth uint8, subtreeRoot *urkel.Pointer) api.Subtree {
+	if subtree == nil {
+		return &memorySubtree{batch: b}
+	}
+	return subtree
+}
+
+func (b *memoryBatch) Commit(root hash.Hash) error {
+	b.db.Lock()
+	defer b.db.Unlock()
+
+	for _, op := range b.ops {
+		if err := op(); err != nil {
+			return err
+		}
+	}
+	b.Reset()
+
+	return b.BaseBatch.Commit(root)
+}
+
+func (b *memoryBatch) Reset() {
+	b.ops = nil
+}
+
+type memorySubtree struct {
+	batch *memoryBatch
+}
+
+func (s *memorySubtree) PutNode(depth uint8, ptr *urkel.Pointer) error {
+	switch n := ptr.Node.(type) {
+	case *urkel.InternalNode:
+		s.batch.ops = append(s.batch.ops, func() error {
+			return s.batch.db.putLocked(n.Hash, &nodeCacheItem{n: ptr.Node})
+		})
+	case *urkel.LeafNode:
+		s.batch.ops = append(s.batch.ops, func() error {
+			_ = s.batch.db.putLocked(n.Value.Hash, &valueCacheItem{v: n.Value.Value})
+			return s.batch.db.putLocked(n.Hash, &nodeCacheItem{n: ptr.Node})
+		})
+	}
+	return nil
+}
+
+func (s *memorySubtree) VisitCleanNode(depth uint8, ptr *urkel.Pointer) error {
+	return nil
+}
+
+func (s *memorySubtree) Commit() error {
+	return nil
+}

--- a/go/storage/mkvs/urkel/urkel.go
+++ b/go/storage/mkvs/urkel/urkel.go
@@ -92,6 +92,16 @@ func SyncerPrefetchTimeout(timeout time.Duration) Option {
 	}
 }
 
+// PersistEverythingFromSyncer sets whether to persist all the nodes and
+// values obtained from the remote syncer to local database.
+//
+// If not specified, the default is false.
+func PersistEverythingFromSyncer(doit bool) Option {
+	return func(t *Tree) {
+		t.cache.persistEverythingFromSyncer = doit
+	}
+}
+
 // New creates a new empty Urkel tree backed by the given node database.
 func New(rs syncer.ReadSyncer, ndb db.NodeDB, options ...Option) *Tree {
 	if rs == nil {

--- a/go/storage/mkvs/urkel/urkel_test.go
+++ b/go/storage/mkvs/urkel/urkel_test.go
@@ -15,6 +15,7 @@ import (
 	db "github.com/oasislabs/ekiden/go/storage/mkvs/urkel/db/api"
 	badgerDb "github.com/oasislabs/ekiden/go/storage/mkvs/urkel/db/badger"
 	levelDb "github.com/oasislabs/ekiden/go/storage/mkvs/urkel/db/leveldb"
+	lruDb "github.com/oasislabs/ekiden/go/storage/mkvs/urkel/db/lru"
 	memoryDb "github.com/oasislabs/ekiden/go/storage/mkvs/urkel/db/memory"
 	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/node"
 	"github.com/oasislabs/ekiden/go/storage/mkvs/urkel/syncer"
@@ -572,6 +573,53 @@ func TestUrkelBadgerBackend(t *testing.T) {
 			require.True(t, ok, "finiBackend")
 
 			os.RemoveAll(dir)
+		})
+}
+
+func TestUrkelLRUBackend(t *testing.T) {
+	testBackend(t, func(t *testing.T) (db.NodeDB, interface{}) {
+		// Create a new random temporary file under /tmp.
+		f, err := ioutil.TempFile("", "mkvs.test.lrudb")
+		require.NoError(t, err, "TempFile")
+		fname := f.Name()
+		f.Close()
+
+		// Create a LRU-backed Node DB.
+		ndb, err := lruDb.New(16*1024*1024, fname)
+		require.NoError(t, err, "New")
+
+		return ndb, fname
+	},
+		func(t *testing.T, ndb db.NodeDB, custom interface{}) {
+			// Save something to test persistence.
+			tree := New(nil, ndb)
+			persistenceKey := []byte("persistenceTest")
+			persistenceVal := []byte("nothing lasts forever")
+			err := tree.Insert(context.Background(), persistenceKey, persistenceVal)
+			require.NoError(t, err, "Insert")
+			_, root, err := tree.Commit(context.Background())
+			require.NoError(t, err, "Commit")
+
+			// Close the database (this persists the LRU cache to file).
+			ndb.Close()
+
+			// Now try reopening it to see if loading works.
+			fname, ok := custom.(string)
+			require.True(t, ok, "finiBackend")
+
+			d, derr := lruDb.New(16*1024*1024, fname)
+			require.NoError(t, derr, "New (persistence)")
+
+			// Fetch persisted value.
+			tree, terr := NewWithRoot(context.Background(), nil, d, root)
+			require.NoError(t, terr, "NewWithRoot (persistence)")
+			v, verr := tree.Get(context.Background(), persistenceKey)
+			require.NoError(t, verr, "Get (persistence)")
+			require.Equal(t, persistenceVal, v)
+
+			// OK, we're done, clean up.
+			d.Close()
+			os.Remove(fname)
 		})
 }
 


### PR DESCRIPTION
This PR implements caching of MKVS operations in the `cachingclient`.

A new MKVS NodeDB backend had been added -- LRU DB -- this is an in-memory LRU-cache for storing MKVS nodes and values (it's limited in size, so obviously don't use this to store stuff you want to keep permanently :stuck_out_tongue:).  This backend is necessary in order to limit the size of the cache (existing backends can grow as much as needed, which is not what we want for a cache).

The new `cachingclient` uses the LRU DB as the local node database and the remote as the read syncer for the Urkel tree.  If everything works properly, this should work as follows: if a node/value isn't found in the local database, the Urkel tree automatically queries the read syncer and fetches the node/value from there.

TODO:
- [x] Implement saving/loading of LRU struct to/from file in LRU NodeDB backend to make its storage persistent.
- [x] Reimplement `cachingclient` tests.
- [x] Run `genesis-playback` via a `cachingclient` to see if there are any bugs.
