### PR TITLE
go: Bump the badger dependency to master (again)

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d // indirect
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 // indirect
 	github.com/cznic/strutil v0.0.0-20181122101858-275e90344537 // indirect
-	github.com/dgraph-io/badger/v2 v2.0.0-rc.2.0.20190624233936-91ce6876dbdc
+	github.com/dgraph-io/badger v2.0.0-rc.2.0.20190625224416-e0016993b790+incompatible
 	github.com/eapache/channels v1.1.0
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -62,6 +62,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f h1:6itBiEUtu+gOzXZWn46bM5/qm8LlV6/byR7Yflx/y6M=
 github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=
+github.com/dgraph-io/badger v2.0.0-rc.2.0.20190625224416-e0016993b790+incompatible h1:QCayAe+QHJd0AEkfV2YwSffQYEehnsexYvqFqT2Y9zc=
+github.com/dgraph-io/badger v2.0.0-rc.2.0.20190625224416-e0016993b790+incompatible/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=
 github.com/dgraph-io/badger/v2 v2.0.0-rc.2.0.20190624233936-91ce6876dbdc h1:zN9BXruI1ztEloj+lPvpJkovZkniJLfF0oyP6U9h00M=
 github.com/dgraph-io/badger/v2 v2.0.0-rc.2.0.20190624233936-91ce6876dbdc/go.mod h1:jUaIjOV835xZ/mCLG/8P/38ZxiT4bG/K1khDNZJxuwU=
 github.com/dgraph-io/badger/v2 v2.0.0-rc2 h1:Lxx0mkjYCrqiqIp75+UOwN3pwRChXZyLQMz+oidMEMs=

--- a/go/storage/badger/badger.go
+++ b/go/storage/badger/badger.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dgraph-io/badger/v2"
+	"github.com/dgraph-io/badger"
 	"github.com/pkg/errors"
 
 	"github.com/oasislabs/ekiden/go/common/crypto/hash"

--- a/go/storage/mkvs/urkel/db/badger/badger.go
+++ b/go/storage/mkvs/urkel/db/badger/badger.go
@@ -2,7 +2,7 @@
 package badger
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	"github.com/dgraph-io/badger"
 	"github.com/pkg/errors"
 
 	"github.com/oasislabs/ekiden/go/common/crypto/hash"

--- a/go/storage/mkvs/urkel/urkel_test.go
+++ b/go/storage/mkvs/urkel/urkel_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	"github.com/dgraph-io/badger"
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasislabs/ekiden/go/common/crypto/hash"

--- a/go/tendermint/db/badger/badger.go
+++ b/go/tendermint/db/badger/badger.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/dgraph-io/badger/v2"
+	"github.com/dgraph-io/badger"
 	"github.com/golang/snappy"
 	"github.com/pkg/errors"
 	dbm "github.com/tendermint/tendermint/libs/db"


### PR DESCRIPTION
Upstream pulled the "fully drank the Go modules flavor aid" bits from
master, so all the import paths changed.

https://github.com/dgraph-io/badger/pull/896