### PR TITLE
go/registry: update node info

### DIFF
--- a/go/tendermint/apps/registry/state.go
+++ b/go/tendermint/apps/registry/state.go
@@ -31,6 +31,8 @@ const (
 var (
 	// errEntityNotFound is the error returned when an entity is not found.
 	errEntityNotFound = errors.New("registry state: entity not found")
+	// errNodeNotFound is the error returned when node is not found.
+	errNodeNotFound = errors.New("registry state: node not found")
 )
 
 type immutableState struct {
@@ -86,6 +88,9 @@ func (s *immutableState) GetNode(id signature.PublicKey) (*node.Node, error) {
 	nodeRaw, err := s.getNodeRaw(id)
 	if err != nil {
 		return nil, err
+	}
+	if nodeRaw == nil {
+		return nil, errNodeNotFound
 	}
 	node := node.Node{}
 	err = cbor.Unmarshal(nodeRaw, &node)


### PR DESCRIPTION
Required for: #1762  (probably not 100% related to this issue anymore)

This restricts registration updates to addresses/p2p/certificate/expiration. For other changes de-registration & re-registration is needed (this could be improved in future, but is probably fine for now).

With these changes (and #1889 we can start updating & propagating node-list updates mid-epoch as well). Probably suited for a separate PR.