### PR TITLE
storage/mkvs: Implement rollback_node in rust and use it

### DIFF
--- a/runtime/src/storage/mkvs/urkel/cache/cache.rs
+++ b/runtime/src/storage/mkvs/urkel/cache/cache.rs
@@ -81,6 +81,10 @@ pub trait Cache {
     /// for the one being committed.
     fn commit_value(&mut self, ptr: ValuePtrRef);
 
+    // Mark a tree node as no longer being eligible for eviction
+    // due to it becoming dirty.
+    fn rollback_node(&mut self, ptr: NodePtrRef, kind: NodeKind);
+
     /// Reconstruct a subtree of nodes and return a pointer to its root.
     ///
     /// Call this to resurrect a subtree summary as returned by a read syncer.

--- a/runtime/src/storage/mkvs/urkel/tree/insert.rs
+++ b/runtime/src/storage/mkvs/urkel/tree/insert.rs
@@ -86,6 +86,10 @@ impl UrkelTree {
                     if !int.left.borrow().clean || !int.right.borrow().clean {
                         int.clean = false;
                         ptr.borrow_mut().clean = false;
+                        // No longer eligible for eviction as it is dirty.
+                        self.cache
+                            .borrow_mut()
+                            .rollback_node(ptr.clone(), NodeKind::Internal);
                     }
                 }
                 return Ok((ptr.clone(), old_val));
@@ -109,6 +113,10 @@ impl UrkelTree {
                         leaf.value = self.cache.borrow_mut().new_value(val);
                         leaf.clean = false;
                         ptr.borrow_mut().clean = false;
+                        // No longer eligible for eviction as it is dirty.
+                        self.cache
+                            .borrow_mut()
+                            .rollback_node(ptr.clone(), NodeKind::Leaf);
                         return Ok((ptr.clone(), old_val));
                     }
                 }

--- a/runtime/src/storage/mkvs/urkel/tree/remove.rs
+++ b/runtime/src/storage/mkvs/urkel/tree/remove.rs
@@ -139,6 +139,10 @@ impl UrkelTree {
                         int.clean = false;
                     }
                     ptr.borrow_mut().clean = false;
+                    // No longer eligible for eviction as it is dirty.
+                    self.cache
+                        .borrow_mut()
+                        .rollback_node(ptr.clone(), NodeKind::Internal);
                 }
 
                 return Ok((ptr.clone(), changed, old_val));


### PR DESCRIPTION
Cache::rollbackNode() was already implemented in go. This PR also ports it to rust.