### PR TITLE
go/storage: Use correct node ID in Remove against a remote tree

### DIFF
--- a/go/storage/mkvs/urkel/remove.go
+++ b/go/storage/mkvs/urkel/remove.go
@@ -30,14 +30,16 @@ func (t *Tree) doRemove(ctx context.Context, ptr *node.Pointer, depth uint8, key
 			return nil, false, err
 		}
 
-		lrID := node.ID{Path: key, Depth: depth + 1}
-		if nd, err = t.cache.derefNodePtr(ctx, lrID, n.Left, nil); err != nil {
+		leftID := node.ID{Path: setKeyBit(key, depth, false), Depth: depth + 1}
+		rightID := node.ID{Path: setKeyBit(key, depth, true), Depth: depth + 1}
+
+		if nd, err = t.cache.derefNodePtr(ctx, leftID, n.Left, nil); err != nil {
 			return nil, false, err
 		}
 
 		switch nd.(type) {
 		case nil:
-			if nd, err = t.cache.derefNodePtr(ctx, lrID, n.Right, nil); err != nil {
+			if nd, err = t.cache.derefNodePtr(ctx, rightID, n.Right, nil); err != nil {
 				return nil, false, err
 			}
 
@@ -54,7 +56,7 @@ func (t *Tree) doRemove(ctx context.Context, ptr *node.Pointer, depth uint8, key
 				return right, true, nil
 			}
 		case *node.LeafNode:
-			if nd, err = t.cache.derefNodePtr(ctx, lrID, n.Right, nil); err != nil {
+			if nd, err = t.cache.derefNodePtr(ctx, rightID, n.Right, nil); err != nil {
 				return nil, false, err
 			}
 

--- a/runtime/src/storage/mkvs/urkel/tree/remove.rs
+++ b/runtime/src/storage/mkvs/urkel/tree/remove.rs
@@ -5,7 +5,11 @@ use io_context::Context;
 
 use crate::{
     common::crypto::hash::Hash,
-    storage::mkvs::urkel::{cache::*, tree::*, utils::*},
+    storage::mkvs::urkel::{
+        cache::*,
+        tree::*,
+        utils::{self, *},
+    },
 };
 
 impl UrkelTree {
@@ -82,22 +86,24 @@ impl UrkelTree {
                     noderef_as!(node_ref, Internal).right.clone(),
                 );
 
-                let lr_id = NodeID {
-                    path: key,
+                let left_id = NodeID {
+                    path: utils::set_key_bit(&key, depth, false),
+                    depth: depth + 1,
+                };
+                let right_id = NodeID {
+                    path: utils::set_key_bit(&key, depth, true),
                     depth: depth + 1,
                 };
 
-                let left_ref = self.cache.borrow_mut().deref_node_ptr(
-                    ctx,
-                    lr_id.clone(),
-                    int_left.clone(),
-                    None,
-                )?;
+                let left_ref =
+                    self.cache
+                        .borrow_mut()
+                        .deref_node_ptr(ctx, left_id, int_left.clone(), None)?;
                 match left_ref {
                     None => {
                         let right_ref = self.cache.borrow_mut().deref_node_ptr(
                             ctx,
-                            lr_id,
+                            right_id,
                             int_right.clone(),
                             None,
                         )?;
@@ -120,7 +126,7 @@ impl UrkelTree {
                         if let NodeBox::Leaf(_) = *left_ref.borrow() {
                             let right_ref = self.cache.borrow_mut().deref_node_ptr(
                                 ctx,
-                                lr_id,
+                                right_id,
                                 int_right.clone(),
                                 None,
                             )?;


### PR DESCRIPTION
See #1869.

Cherry-picked from #1857.