### PR TITLE
go/registry: epochtime cleanup

### DIFF
--- a/go/grpc/registry/entity.proto
+++ b/go/grpc/registry/entity.proto
@@ -116,6 +116,5 @@ message WatchNodeListRequest {
 }
 
 message WatchNodeListResponse {
-    uint64 epoch = 1;
-    repeated common.Node node = 2;
+    repeated common.Node node = 1;
 }

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -14,7 +14,6 @@ import (
 	"github.com/oasislabs/ekiden/go/common/logging"
 	"github.com/oasislabs/ekiden/go/common/node"
 	"github.com/oasislabs/ekiden/go/common/pubsub"
-	epochtime "github.com/oasislabs/ekiden/go/epochtime/api"
 )
 
 const (
@@ -155,7 +154,7 @@ type Backend interface {
 	// all runtimes will be sent immediately.
 	WatchRuntimes() (<-chan *Runtime, *pubsub.Subscription)
 
-	// Cleanup cleans up the regsitry backend.
+	// Cleanup cleans up the registry backend.
 	Cleanup()
 }
 
@@ -182,7 +181,6 @@ type NodeEvent struct {
 
 // NodeList is a per-epoch immutable node list.
 type NodeList struct {
-	Epoch epochtime.EpochTime
 	Nodes []*node.Node
 }
 

--- a/go/registry/grpc.go
+++ b/go/registry/grpc.go
@@ -253,8 +253,7 @@ func (s *grpcServer) WatchNodeList(req *pb.WatchNodeListRequest, stream pb.Entit
 			nodes = append(nodes, n.ToProto())
 		}
 		resp := &pb.WatchNodeListResponse{
-			Epoch: uint64(nl.Epoch),
-			Node:  nodes,
+			Node: nodes,
 		}
 		if err := stream.Send(resp); err != nil {
 			return err

--- a/go/storage/client/client.go
+++ b/go/storage/client/client.go
@@ -660,13 +660,18 @@ func (b *storageClientBackend) watcher(ctx context.Context) {
 			if ev == nil {
 				continue
 			}
-			b.logger.Debug("got new storage node list")
+			b.logger.Debug("got new storage node list", ev.Nodes)
 			if err := b.state.updateStorageNodeList(ctx, ev.Nodes); err != nil {
 				b.logger.Error("worker: failed to update storage list",
 					"err", err,
 				)
 				continue
 			}
+			// Update storage node connection.
+			b.updateNodeConnections()
+
+			b.logger.Debug("updated connections to nodes")
+
 		case committee := <-schedCh:
 			b.logger.Debug("worker: scheduler committee for epoch",
 				"committee", committee,

--- a/go/tendermint/apps/registry/api.go
+++ b/go/tendermint/apps/registry/api.go
@@ -31,6 +31,9 @@ var (
 	// descriptors).
 	TagNodesExpired = []byte("registry.nodes.expired")
 
+	// TagRegistryNodeListEpoch is an ABCI tag for registry epochs.
+	TagRegistryNodeListEpoch = []byte("registry.nodes.epoch")
+
 	// QueryApp is a query for filtering events processed by
 	// the registry application.
 	QueryApp = api.QueryForEvent([]byte(AppName), api.TagAppNameValue)


### PR DESCRIPTION
Some changes to registry that would otherwise be part of #1889 
The goal is to reduce the dependence on the "global epoch" in the registry. 

The idea is that in #1889 we can than use a different interval for the registry.

Hopefully the changes make sense.

- Removes `epoch` references in `WatchNodeList` (only tests relied on those)
- `WatchNodeList` watches ABCI tags for instead of a separate worker polling (removes dependency to `WatchEpochs()` in the `registry/tendermint.go`)
  - currently it was pretty messy imo, since both the ABCI app & the `registry/tendermint.go` followed epoch changes - now only the ABCI app does that and sends a tag 
- removes the whole `func (r *tendermintBackend) getRuntimes`:
  - only called from `workerPerEpochList` and result was only used for logging 
  - seems like this only updated the cache - which was not used anywhere
- removes caching per epoch in `regisitry/tendermint.go`
  - i think ideally only the ABCI app "knows" about the "registry epochs", this change enables removing the timesource from the `registry/tendermint.go`
  - can add it back if desired - not sure what's the performance benefit vs querying the tm app
  - most of it was probably left over from before removing non-tm backends where we needed to keep the per epoch lists