### PR TITLE
go/beacon: epochtime cleanup

### DIFF
--- a/go/beacon/api/api.go
+++ b/go/beacon/api/api.go
@@ -4,8 +4,6 @@ package api
 import (
 	"context"
 	"errors"
-
-	"github.com/oasislabs/ekiden/go/common/pubsub"
 )
 
 // ErrBeaconNotAvailable is the error returned when a beacon is not
@@ -19,17 +17,6 @@ const BeaconSize = 32
 type Backend interface {
 	// GetBeacon gets the beacon for the provided block height.
 	// Calling this method with height `0`, should return the
-	// beacon for latest finished block.
+	// beacon for latest finalized block.
 	GetBeacon(context.Context, int64) ([]byte, error)
-
-	// WatchBeacons returns a channel that produces a stream of
-	// GenerateEvent.  Upon subscription, the most recently generate
-	// beacon will be sent immediately if available.
-	WatchBeacons() (<-chan *GenerateEvent, *pubsub.Subscription)
-}
-
-// GenerateEvent is the event that is returned via WatchBeacons to
-// signify beacon generation.
-type GenerateEvent struct {
-	Beacon []byte `codec:"beacon"`
 }

--- a/go/beacon/tests/tester.go
+++ b/go/beacon/tests/tester.go
@@ -4,7 +4,6 @@ package tests
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -13,37 +12,19 @@ import (
 	epochtimeTests "github.com/oasislabs/ekiden/go/epochtime/tests"
 )
 
-const recvTimeout = 1 * time.Second
-
 // BeaconImplementationTests exercises the basic functionality of a
 // beacon backend.
 func BeaconImplementationTests(t *testing.T, backend api.Backend, epochtime epochtime.SetableBackend) {
 	require := require.New(t)
 
-	ch, sub := backend.WatchBeacons()
-	defer sub.Close()
-
-recvLoop:
-	for {
-		select {
-		case ev := <-ch:
-			require.Len(ev.Beacon, api.BeaconSize, "WatchBeacons - length")
-
-			b, err := backend.GetBeacon(context.Background(), 0)
-			require.NoError(err, "GetBeacon")
-			require.Equal(b, ev.Beacon, "GetBeacon - beacon")
-			break recvLoop
-		case <-time.After(recvTimeout):
-			t.Fatalf("failed to receive current beacon on WatchBeacons")
-		}
-	}
+	beacon, err := backend.GetBeacon(context.Background(), 0)
+	require.NoError(err, "GetBeacon")
+	require.Len(beacon, api.BeaconSize, "GetBeacon - length")
 
 	_ = epochtimeTests.MustAdvanceEpoch(t, epochtime, 1)
 
-	select {
-	case ev := <-ch:
-		require.Len(ev.Beacon, api.BeaconSize, "WatchBeacons - length")
-	case <-time.After(recvTimeout):
-		t.Fatalf("failed to receive current beacon after transition")
-	}
+	newBeacon, err := backend.GetBeacon(context.Background(), 0)
+	require.NoError(err, "GetBeacon")
+	require.Len(newBeacon, api.BeaconSize, "GetBeacon - length")
+	require.NotEqual(beacon, newBeacon, "After epoch transition, new beacon should be generated.")
 }

--- a/go/tendermint/apps/beacon/beacon.go
+++ b/go/tendermint/apps/beacon/beacon.go
@@ -9,8 +9,6 @@ import (
 	"github.com/tendermint/tendermint/abci/types"
 	"golang.org/x/crypto/sha3"
 
-	beacon "github.com/oasislabs/ekiden/go/beacon/api"
-	"github.com/oasislabs/ekiden/go/common/cbor"
 	"github.com/oasislabs/ekiden/go/common/logging"
 	epochtime "github.com/oasislabs/ekiden/go/epochtime/api"
 	"github.com/oasislabs/ekiden/go/genesis"
@@ -153,13 +151,13 @@ func (app *beaconApplication) onBeaconEpochChange(ctx *abci.Context, epoch epoch
 		"height", app.state.BlockHeight(),
 	)
 
-	return app.onNewBeacon(ctx, &beacon.GenerateEvent{Beacon: b})
+	return app.onNewBeacon(ctx, b)
 }
 
-func (app *beaconApplication) onNewBeacon(ctx *abci.Context, event *beacon.GenerateEvent) error {
+func (app *beaconApplication) onNewBeacon(ctx *abci.Context, beacon []byte) error {
 	state := NewMutableState(app.state.DeliverTxTree())
 
-	if err := state.setBeacon(event); err != nil {
+	if err := state.setBeacon(beacon); err != nil {
 		app.logger.Error("onNewBeacon: failed to set beacon",
 			"err", err,
 		)
@@ -167,7 +165,7 @@ func (app *beaconApplication) onNewBeacon(ctx *abci.Context, event *beacon.Gener
 	}
 
 	ctx.EmitTag([]byte(app.Name()), api.TagAppNameValue)
-	ctx.EmitTag(TagGenerated, cbor.Marshal(event))
+	ctx.EmitTag(TagGenerated, beacon)
 
 	return nil
 }

--- a/go/tendermint/apps/beacon/state.go
+++ b/go/tendermint/apps/beacon/state.go
@@ -41,14 +41,14 @@ type MutableState struct {
 	tree *iavl.MutableTree
 }
 
-func (s *MutableState) setBeacon(event *beacon.GenerateEvent) error {
-	if l := len(event.Beacon); l != beacon.BeaconSize {
+func (s *MutableState) setBeacon(newBeacon []byte) error {
+	if l := len(newBeacon); l != beacon.BeaconSize {
 		return fmt.Errorf("tendermint/beacon: unexpected beacon size: %d", l)
 	}
 
 	s.tree.Set(
 		[]byte(stateBeacon),
-		event.Beacon,
+		newBeacon,
 	)
 
 	return nil


### PR DESCRIPTION
Similar as https://github.com/oasislabs/ekiden/pull/1899 but for `beacon`.

Few more things to discuss:
- `WatchBeacons` is not used at all (other than tests) maybe might make sense completely removing it?
- `Beacon` is not used by anything other than the scheduler at the moment, we discussed with @Yawning once if it would make sense completely folding it into scheduler, but did not make a decision