### PR TITLE
gitlint: fetch origin master before linting

### DIFF
--- a/.buildkite/scripts/lint_git.sh
+++ b/.buildkite/scripts/lint_git.sh
@@ -14,5 +14,6 @@ set -euxo pipefail
 #############
 # Run gitlint
 #############
+git fetch origin master
 echo "Linting from $(git rev-parse origin/master)"
 gitlint --commits origin/master...HEAD


### PR DESCRIPTION
This should significantly speed up `gitlint` and mirrors the change in the common private-oasis-buildkite-tools Buildkite plugin: oasislabs/private-oasis-buildkite-tools-buildkite-plugin#6.