### PR TITLE
byzantine node: libp2p listener

### DIFF
--- a/go/ekiden/cmd/debug/byzantine/steps.go
+++ b/go/ekiden/cmd/debug/byzantine/steps.go
@@ -2,6 +2,7 @@ package byzantine
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -23,9 +24,28 @@ import (
 	schedulerapp "github.com/oasislabs/ekiden/go/tendermint/apps/scheduler"
 	stakingapp "github.com/oasislabs/ekiden/go/tendermint/apps/staking"
 	"github.com/oasislabs/ekiden/go/tendermint/service"
+	"github.com/oasislabs/ekiden/go/worker/common/p2p"
 )
 
-var _ api.Backend = (*fakeTimeBackend)(nil)
+const (
+	defaultRuntimeIDHex = "0000000000000000000000000000000000000000000000000000000000000000"
+)
+
+var (
+	defaultRuntimeID signature.PublicKey
+
+	_ api.Backend = (*fakeTimeBackend)(nil)
+	_ p2p.Handler = (*p2pRecvHandler)(nil)
+)
+
+func initDefaultIdentity(dataDir string) (*identity.Identity, error) {
+	signerFactory := fileSigner.NewFactory(dataDir, signature.SignerNode, signature.SignerP2P, signature.SignerEntity)
+	id, err := identity.LoadOrGenerate(dataDir, signerFactory)
+	if err != nil {
+		return nil, errors.Wrap(err, "identity LoadOrGenerate")
+	}
+	return id, nil
+}
 
 // fakeTimeBackend is like TendermintBackend (of epochtime), but without
 // any workers.
@@ -57,21 +77,16 @@ func newHonestTendermint() *honestTendermint {
 	return &honestTendermint{}
 }
 
-func (ht *honestTendermint) start(dataDir string) error {
+func (ht *honestTendermint) start(id *identity.Identity, dataDir string) error {
 	if ht.service != nil {
 		return errors.New("honest Tendermint service already started")
 	}
 
-	signerFactory := fileSigner.NewFactory(dataDir, signature.SignerNode, signature.SignerP2P, signature.SignerEntity)
-	identity, err := identity.LoadOrGenerate(dataDir, signerFactory)
-	if err != nil {
-		return errors.Wrap(err, "identity LoadOrGenerate")
-	}
 	genesis, err := genesis.New()
 	if err != nil {
 		return errors.Wrap(err, "genesis New")
 	}
-	ht.service = tendermint.New(context.Background(), dataDir, identity, genesis)
+	ht.service = tendermint.New(context.Background(), dataDir, id, genesis)
 
 	if err := ht.service.ForceInitialize(); err != nil {
 		return errors.Wrap(err, "honest Tendermint service ForceInitialize")
@@ -134,4 +149,84 @@ func (ht honestTendermint) stop() error {
 	ht.service = nil
 
 	return nil
+}
+
+type p2pReqRes struct {
+	peerID     signature.PublicKey
+	msg        *p2p.Message
+	responseCh chan<- error
+}
+
+type p2pHandle struct {
+	context  context.Context
+	cancel   context.CancelFunc
+	service  *p2p.P2P
+	requests chan p2pReqRes
+}
+
+func newP2PHandle() *p2pHandle {
+	return &p2pHandle{
+		requests: make(chan p2pReqRes),
+	}
+}
+
+// p2pRecvHandler forwards requests to, and responses from, a goroutine.
+type p2pRecvHandler struct {
+	target *p2pHandle
+}
+
+// IsPeerAuthorized implements p2p Handler.
+func (h *p2pRecvHandler) IsPeerAuthorized(peerID signature.PublicKey) bool {
+	// The Byzantine node itself isn't especially robust. We assume that
+	// the other nodes are honest.
+	return true
+}
+
+// HandlePeerMessage implements p2p Handler.
+func (h *p2pRecvHandler) HandlePeerMessage(peerID signature.PublicKey, msg *p2p.Message) error {
+	responseCh := make(chan error)
+	h.target.requests <- p2pReqRes{
+		peerID:     peerID,
+		msg:        msg,
+		responseCh: responseCh,
+	}
+	return <-responseCh
+}
+
+func (ph *p2pHandle) start(id *identity.Identity, runtimeID signature.PublicKey) error {
+	if ph.service != nil {
+		return errors.New("P2P service already started")
+	}
+
+	ph.context, ph.cancel = context.WithCancel(context.Background())
+	var err error
+	ph.service, err = p2p.New(ph.context, id)
+	if err != nil {
+		return errors.Wrap(err, "P2P service New")
+	}
+
+	ph.service.RegisterHandler(runtimeID, &p2pRecvHandler{
+		target: ph,
+	})
+
+	return nil
+}
+
+func (ph *p2pHandle) stop() error {
+	if ph.service == nil {
+		return errors.New("P2P service not started")
+	}
+
+	ph.cancel()
+	ph.service = nil
+	ph.context = nil
+	ph.cancel = nil
+
+	return nil
+}
+
+func init() {
+	if err := defaultRuntimeID.UnmarshalHex(defaultRuntimeIDHex); err != nil {
+		panic(fmt.Sprintf("default runtime ID UnmarshalHex: %+v", err))
+	}
 }


### PR DESCRIPTION
fixes #1937 

This adds a wrapper for starting and stopping an instance of the p2p service. Example sending and receiving are drafted in a separate PR #2006

Also, this adds some routines for interacting with the registry under the default identity and default runtime.