### PR TITLE
go/storage: Treat empty root as always implicitly present

### DIFF
--- a/go/storage/mkvs/urkel/db/badger/badger.go
+++ b/go/storage/mkvs/urkel/db/badger/badger.go
@@ -137,6 +137,11 @@ func (d *badgerNodeDB) GetWriteLog(ctx context.Context, startRoot node.Root, end
 }
 
 func (d *badgerNodeDB) HasRoot(root node.Root) bool {
+	// An empty root is always implicitly present.
+	if root.Hash.IsEmpty() {
+		return true
+	}
+
 	_, err := d.GetNode(root, &node.Pointer{
 		Clean: true,
 		Hash:  root.Hash,

--- a/go/storage/mkvs/urkel/db/leveldb/leveldb.go
+++ b/go/storage/mkvs/urkel/db/leveldb/leveldb.go
@@ -97,6 +97,11 @@ func (d *leveldbNodeDB) GetWriteLog(ctx context.Context, startRoot node.Root, en
 }
 
 func (d *leveldbNodeDB) HasRoot(root node.Root) bool {
+	// An empty root is always implicitly present.
+	if root.Hash.IsEmpty() {
+		return true
+	}
+
 	_, err := d.GetNode(root, &node.Pointer{
 		Clean: true,
 		Hash:  root.Hash,

--- a/go/storage/mkvs/urkel/db/lru/lru.go
+++ b/go/storage/mkvs/urkel/db/lru/lru.go
@@ -93,6 +93,11 @@ func (d *lruNodeDB) GetCheckpoint(ctx context.Context, hash urkel.Root) (api.Wri
 }
 
 func (d *lruNodeDB) HasRoot(root urkel.Root) bool {
+	// An empty root is always implicitly present.
+	if root.Hash.IsEmpty() {
+		return true
+	}
+
 	_, err := d.GetNode(root, &urkel.Pointer{
 		Clean: true,
 		Hash:  root.Hash,

--- a/go/storage/mkvs/urkel/db/memory/memory.go
+++ b/go/storage/mkvs/urkel/db/memory/memory.go
@@ -96,6 +96,11 @@ func (d *memoryNodeDB) GetWriteLog(ctx context.Context, startRoot node.Root, end
 }
 
 func (d *memoryNodeDB) HasRoot(root node.Root) bool {
+	// An empty root is always implicitly present.
+	if root.Hash.IsEmpty() {
+		return true
+	}
+
 	_, err := d.GetNode(root, &node.Pointer{
 		Clean: true,
 		Hash:  root.Hash,

--- a/go/storage/mkvs/urkel/urkel_test.go
+++ b/go/storage/mkvs/urkel/urkel_test.go
@@ -1021,6 +1021,16 @@ func testOnCommitHooks(t *testing.T, ndb db.NodeDB) {
 // TODO: More tests for write logs.
 // TODO: More tests with bad syncer outputs.
 
+func testHasRoot(t *testing.T, ndb db.NodeDB) {
+	// Test that an empty root is always implicitly present.
+	root := node.Root{
+		Namespace: testNs,
+		Round:     0,
+	}
+	root.Hash.Empty()
+	require.True(t, ndb.HasRoot(root), "HasRoot should return true on empty root")
+}
+
 func testBackend(t *testing.T, initBackend func(t *testing.T) (db.NodeDB, interface{}), finiBackend func(t *testing.T, ndb db.NodeDB, custom interface{})) {
 	t.Run("Basic", func(t *testing.T) {
 		backend, custom := initBackend(t)
@@ -1111,6 +1121,11 @@ func testBackend(t *testing.T, initBackend func(t *testing.T) (db.NodeDB, interf
 		backend, custom := initBackend(t)
 		defer finiBackend(t, backend, custom)
 		testOnCommitHooks(t, backend)
+	})
+	t.Run("HasRoot", func(t *testing.T) {
+		backend, custom := initBackend(t)
+		defer finiBackend(t, backend, custom)
+		testHasRoot(t, backend)
 	})
 }
 


### PR DESCRIPTION
Cherry-picked from #1902.