### PR TITLE
go/worker/txnscheduler: Fix deadlock during epoch transition

### DIFF
--- a/go/worker/common/committee/group.go
+++ b/go/worker/common/committee/group.go
@@ -85,6 +85,19 @@ type EpochSnapshot struct {
 	storageCommittee      *CommitteeInfo
 }
 
+// NewMockEpochSnapshot returns a mock epoch snapshot to be used in tests.
+func NewMockEpochSnapshot() *EpochSnapshot {
+	var computeCommitteeID hash.Hash
+	computeCommitteeID.FromBytes([]byte("mock committee id"))
+
+	return &EpochSnapshot{
+		computeCommitteeID: computeCommitteeID,
+		computeCommittees: map[hash.Hash]*CommitteeInfo{
+			computeCommitteeID: &CommitteeInfo{},
+		},
+	}
+}
+
 // GetRuntime returns the current runtime descriptor.
 func (e *EpochSnapshot) GetRuntime() *registry.Runtime {
 	return e.runtime

--- a/go/worker/txnscheduler/algorithm/tests/tester.go
+++ b/go/worker/txnscheduler/algorithm/tests/tester.go
@@ -42,7 +42,7 @@ func AlgorithmImplementationTests(
 	require.NoError(t, err, "Initialize(td)")
 
 	// Simulate an epoch transition.
-	epoch := &committee.EpochSnapshot{}
+	epoch := committee.NewMockEpochSnapshot()
 	err = algorithm.EpochTransition(epoch)
 	require.NoError(t, err, "EpochTransition")
 


### PR DESCRIPTION
Fixes #1965 

Previously the batchingState lock was held while Dispatch was called
which acquired the CrossNode lock. During an epoch transition the
CrossNode lock was held and batchingState lock was acquired to update
the epoch snapshot.

Since the locks were not acquired in a consistent order this could lead
to a deadlock if scheduleBatch was called at the right time.

This commit makes scheduleBatch only hold the batchingState lock for a
limited amount of time to determine the committee ID. The lock is now
released before Dispatch is called, avoiding the deadlock.