### PR TITLE
go/worker/{compute,merge}: Handle early discrepancy event

### DIFF
--- a/go/worker/compute/committee/state.go
+++ b/go/worker/compute/committee/state.go
@@ -9,6 +9,7 @@ import (
 	"github.com/oasislabs/ekiden/go/common/crypto/hash"
 	"github.com/oasislabs/ekiden/go/common/crypto/signature"
 	"github.com/oasislabs/ekiden/go/common/runtime"
+	roothash "github.com/oasislabs/ekiden/go/roothash/api"
 	"github.com/oasislabs/ekiden/go/roothash/api/block"
 	"github.com/oasislabs/ekiden/go/worker/common/host/protocol"
 )
@@ -113,6 +114,9 @@ func (s StateNotReady) String() string {
 
 // StateWaitingForBatch is the waiting for batch state.
 type StateWaitingForBatch struct {
+	// Pending compute discrepancy detected event in case the node is a
+	// backup worker and the event was received before the batch.
+	pendingEvent *roothash.ComputeDiscrepancyDetectedEvent
 }
 
 // Name returns the name of the state.

--- a/go/worker/merge/committee/state.go
+++ b/go/worker/merge/committee/state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	roothash "github.com/oasislabs/ekiden/go/roothash/api"
 	"github.com/oasislabs/ekiden/go/roothash/api/commitment"
 )
 
@@ -95,6 +96,9 @@ type StateWaitingForResults struct {
 	pool    *commitment.MultiPool
 	timer   *time.Timer
 	results []*commitment.ComputeResultsHeader
+	// Pending merge discrepancy detected event in case the node is a
+	// backup worker and the event was received before the results.
+	pendingEvent *roothash.MergeDiscrepancyDetectedEvent
 }
 
 // Name returns the name of the state.
@@ -107,7 +111,7 @@ func (s StateWaitingForResults) String() string {
 	return string(s.Name())
 }
 
-// StateWaitingForEvent is the waiting for results state.
+// StateWaitingForEvent is the waiting for event state.
 type StateWaitingForEvent struct {
 	commitments []commitment.ComputeCommitment
 	results     []*commitment.ComputeResultsHeader


### PR DESCRIPTION
Previously, if a discrepancy event was seen before the batch (compute)
or results (merge) it was ignored, leading to timeouts.

This commit changes the states and processing so that the event is
instead recorded in StateWaitingForBatch/StateWaitingForResults and
batch/results processed immediately after being received in case of a
pending discrepancy event.