### PR TITLE
go/storage: Remove tree LRU cache

### DIFF
--- a/go/storage/badger/badger.go
+++ b/go/storage/badger/badger.go
@@ -38,7 +38,6 @@ type badgerBackend struct {
 func New(
 	dbDir string,
 	signer signature.Signer,
-	lruSizeInBytes uint64,
 	applyLockLRUSlots uint64,
 	insecureSkipChecks bool,
 ) (api.Backend, error) {
@@ -52,7 +51,7 @@ func New(
 		return nil, errors.Wrap(err, "storage/badger: failed to open node database")
 	}
 
-	rootCache, err := api.NewRootCache(ndb, nil, lruSizeInBytes, applyLockLRUSlots, insecureSkipChecks)
+	rootCache, err := api.NewRootCache(ndb, nil, applyLockLRUSlots, insecureSkipChecks)
 	if err != nil {
 		ndb.Close()
 		return nil, errors.Wrap(err, "storage/badger: failed to create root cache")
@@ -120,6 +119,7 @@ func (ba *badgerBackend) GetSubtree(ctx context.Context, root api.Root, id api.N
 	if err != nil {
 		return nil, err
 	}
+	defer tree.Close()
 
 	return tree.GetSubtree(ctx, root, id, maxDepth)
 }
@@ -129,6 +129,7 @@ func (ba *badgerBackend) GetPath(ctx context.Context, root api.Root, id api.Node
 	if err != nil {
 		return nil, err
 	}
+	defer tree.Close()
 
 	return tree.GetPath(ctx, root, id, key)
 }
@@ -138,6 +139,7 @@ func (ba *badgerBackend) GetNode(ctx context.Context, root api.Root, id api.Node
 	if err != nil {
 		return nil, err
 	}
+	defer tree.Close()
 
 	return tree.GetNode(ctx, root, id)
 }

--- a/go/storage/badger/badger_test.go
+++ b/go/storage/badger/badger_test.go
@@ -25,7 +25,7 @@ func TestStorageBadger(t *testing.T) {
 	signer, err := memorySigner.NewSigner(rand.Reader)
 	require.NoError(t, err, "NewPrivateKey()")
 
-	backend, err := New(filepath.Join(tmpDir, DBFile), signer, 32*1024*1024, 100, false)
+	backend, err := New(filepath.Join(tmpDir, DBFile), signer, 100, false)
 	require.NoError(t, err, "New()")
 	defer backend.Cleanup()
 

--- a/go/storage/cachingclient/cachingclient.go
+++ b/go/storage/cachingclient/cachingclient.go
@@ -97,6 +97,7 @@ func (b *cachingClientBackend) GetSubtree(ctx context.Context, root api.Root, id
 	if err != nil {
 		return nil, err
 	}
+	defer tree.Close()
 
 	return tree.GetSubtree(ctx, root, id, maxDepth)
 }
@@ -106,6 +107,7 @@ func (b *cachingClientBackend) GetPath(ctx context.Context, root api.Root, id ap
 	if err != nil {
 		return nil, err
 	}
+	defer tree.Close()
 
 	return tree.GetPath(ctx, root, id, key)
 }
@@ -115,6 +117,7 @@ func (b *cachingClientBackend) GetNode(ctx context.Context, root api.Root, id ap
 	if err != nil {
 		return nil, err
 	}
+	defer tree.Close()
 
 	return tree.GetNode(ctx, root, id)
 }
@@ -149,7 +152,7 @@ func New(remote api.Backend, insecureSkipChecks bool) (api.Backend, error) {
 		return nil, err
 	}
 
-	rootCache, err := api.NewRootCache(local, remote, lruCacheSizeInBytes/8, 1000, insecureSkipChecks)
+	rootCache, err := api.NewRootCache(local, remote, 1000, insecureSkipChecks)
 	if err != nil {
 		local.Close()
 		return nil, err

--- a/go/storage/init.go
+++ b/go/storage/init.go
@@ -27,7 +27,6 @@ const (
 	cfgBackend             = "storage.backend"
 	cfgDebugMockSigningKey = "storage.debug.mock_signing_key"
 	cfgCrashEnabled        = "storage.crash.enabled"
-	cfgLRUSize             = "storage.root_cache.lru_size"
 	cfgLRUSlots            = "storage.root_cache.apply_lock_lru_slots"
 	cfgInsecureSkipChecks  = "storage.debug.insecure_skip_checks"
 )
@@ -53,7 +52,6 @@ func New(
 	tlsCert := identity.TLSCertificate
 
 	backend := viper.GetString(cfgBackend)
-	lruSize := uint64(viper.GetSizeInBytes(cfgLRUSize))
 	applyLockLRUSlots := uint64(viper.GetInt(cfgLRUSlots))
 	insecureSkipChecks := viper.GetBool(cfgInsecureSkipChecks)
 
@@ -62,10 +60,10 @@ func New(
 		impl = memory.New(signer, insecureSkipChecks)
 	case badger.BackendName:
 		dbDir := filepath.Join(dataDir, badger.DBFile)
-		impl, err = badger.New(dbDir, signer, lruSize, applyLockLRUSlots, insecureSkipChecks)
+		impl, err = badger.New(dbDir, signer, applyLockLRUSlots, insecureSkipChecks)
 	case leveldb.BackendName:
 		dbDir := filepath.Join(dataDir, leveldb.DBFile)
-		impl, err = leveldb.New(dbDir, signer, lruSize, applyLockLRUSlots, insecureSkipChecks)
+		impl, err = leveldb.New(dbDir, signer, applyLockLRUSlots, insecureSkipChecks)
 	case client.BackendName:
 		impl, err = client.New(ctx, tlsCert, schedulerBackend, registryBackend)
 	case cachingclient.BackendName:
@@ -98,7 +96,6 @@ func RegisterFlags(cmd *cobra.Command) {
 		cmd.Flags().String(cfgBackend, memory.BackendName, "Storage backend")
 		cmd.Flags().Bool(cfgDebugMockSigningKey, false, "Generate volatile mock signing key")
 		cmd.Flags().Bool(cfgCrashEnabled, false, "Enable the crashing storage wrapper")
-		cmd.Flags().String(cfgLRUSize, "128m", "Maximum LRU size in bytes to use in the MKVS tree root cache")
 		cmd.Flags().Int(cfgLRUSlots, 1000, "How many LRU slots to use for Apply call locks in the MKVS tree root cache")
 
 		cmd.Flags().Bool(cfgInsecureSkipChecks, false, "INSECURE: Skip known root checks")
@@ -109,7 +106,6 @@ func RegisterFlags(cmd *cobra.Command) {
 		cfgBackend,
 		cfgDebugMockSigningKey,
 		cfgCrashEnabled,
-		cfgLRUSize,
 		cfgLRUSlots,
 		cfgInsecureSkipChecks,
 	} {

--- a/go/storage/leveldb/leveldb.go
+++ b/go/storage/leveldb/leveldb.go
@@ -76,6 +76,7 @@ func (b *leveldbBackend) GetSubtree(ctx context.Context, root api.Root, id api.N
 	if err != nil {
 		return nil, err
 	}
+	defer tree.Close()
 
 	return tree.GetSubtree(ctx, root, id, maxDepth)
 }
@@ -85,6 +86,7 @@ func (b *leveldbBackend) GetPath(ctx context.Context, root api.Root, id api.Node
 	if err != nil {
 		return nil, err
 	}
+	defer tree.Close()
 
 	return tree.GetPath(ctx, root, id, key)
 }
@@ -94,6 +96,7 @@ func (b *leveldbBackend) GetNode(ctx context.Context, root api.Root, id api.Node
 	if err != nil {
 		return nil, err
 	}
+	defer tree.Close()
 
 	return tree.GetNode(ctx, root, id)
 }
@@ -127,7 +130,6 @@ func (b *leveldbBackend) Initialized() <-chan struct{} {
 func New(
 	dbDir string,
 	signer signature.Signer,
-	lruSizeInBytes uint64,
 	applyLockLRUSlots uint64,
 	insecureSkipChecks bool,
 ) (api.Backend, error) {
@@ -137,7 +139,7 @@ func New(
 		return nil, err
 	}
 
-	rootCache, err := api.NewRootCache(ndb, nil, lruSizeInBytes, applyLockLRUSlots, insecureSkipChecks)
+	rootCache, err := api.NewRootCache(ndb, nil, applyLockLRUSlots, insecureSkipChecks)
 	if err != nil {
 		ndb.Close()
 		return nil, err

--- a/go/storage/leveldb/leveldb_test.go
+++ b/go/storage/leveldb/leveldb_test.go
@@ -25,7 +25,7 @@ func TestStorageLevelDB(t *testing.T) {
 	signer, err := memorySigner.NewSigner(rand.Reader)
 	require.NoError(t, err, "NewSigner()")
 
-	backend, err := New(filepath.Join(tmpDir, DBFile), signer, 32*1024*1024, 100, false)
+	backend, err := New(filepath.Join(tmpDir, DBFile), signer, 100, false)
 	require.NoError(t, err, "New()")
 	defer backend.Cleanup()
 


### PR DESCRIPTION
It does not make much sense to cache multiple trees on local backends
which are usually backed by memory-mapped files and thus do their own
caching.

For remote backends we now have a NodeDB that caches nodes so that
should be enough.

This also removes the --storage.root_cache.lru_size argument.