### PR TITLE
ci: beta -> devnet2

### DIFF
--- a/.buildkite/deploy.pipeline.yml
+++ b/.buildkite/deploy.pipeline.yml
@@ -93,4 +93,4 @@ steps:
   - label: Deploy production-track docker image (master branches only)
     branches: master
     command:
-      - .buildkite/scripts/promote_deployment_image_to.sh latest-beta
+      - .buildkite/scripts/promote_deployment_image_to.sh latest-devnet2


### PR DESCRIPTION
needed for changes downstream in runtime-ethereum. we're closing the beta branch and starting a devnet2 branch