### PR TITLE
Makefile: Suppress package already installed error for tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ all: tools runtimes rust go
 
 tools:
 	@$(ECHO) "$(CYAN)*** Building Rust tools...$(OFF)"
-	@cargo install --quiet --path tools || true
+	@# Suppress "binary already exists" error by redirecting stderr and stdout to /dev/null.
+	@cargo install --path tools >/dev/null 2>&1 || true
 
 runtimes:
 	@$(ECHO) "$(CYAN)*** Building runtimes...$(OFF)"


### PR DESCRIPTION
The new rust version prints error on `cargo install`, if the package is already installed despite the `--quiet` switch. This hack just redirects error output to `/dev/null` to get rid of the message. See https://github.com/rust-lang/cargo/pull/7116 for details.