### PR TITLE
byzantine node: scheduler steps

### DIFF
--- a/go/ekiden/cmd/debug/byzantine/steps.go
+++ b/go/ekiden/cmd/debug/byzantine/steps.go
@@ -1,11 +1,13 @@
 package byzantine
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
+	tmtypes "github.com/tendermint/tendermint/types"
 
 	beacon "github.com/oasislabs/ekiden/go/beacon/api"
 	"github.com/oasislabs/ekiden/go/common/cbor"
@@ -226,6 +228,94 @@ func registryGetNodes(svc service.TendermintService, height int64) ([]*node.Node
 	}
 
 	return nodes, nil
+}
+
+func schedulerNextElectionHeight(svc service.TendermintService, kind scheduler.CommitteeKind) (int64, error) { // nolint: deadcode, unused
+	sub, err := svc.Subscribe("script", schedulerapp.QueryApp)
+	if err != nil {
+		return 0, errors.Wrap(err, "Tendermint Subscribe")
+	}
+	defer func() {
+		// Drain our unbuffered subscription while we work on unsubscribing.
+		go func() {
+			for {
+				select {
+				case <-sub.Out():
+				case <-sub.Cancelled():
+					break
+				}
+			}
+		}()
+		err := svc.Unsubscribe("script", schedulerapp.QueryApp)
+		if err != nil {
+			panic(fmt.Sprintf("Tendermint Unsubscribe: %+v", err))
+		}
+	}()
+
+	for {
+		ev := (<-sub.Out()).Data().(tmtypes.EventDataNewBlock)
+		for _, tmEv := range ev.ResultBeginBlock.GetEvents() {
+			if tmEv.GetType() != tmapi.EventTypeEkiden {
+				continue
+			}
+
+			for _, pair := range tmEv.GetAttributes() {
+				if bytes.Equal(pair.GetKey(), schedulerapp.TagElected) {
+					var kinds []scheduler.CommitteeKind
+					if err := cbor.Unmarshal(pair.GetValue(), &kinds); err != nil {
+						return 0, errors.Wrap(err, "CBOR Unmarshal kinds")
+					}
+
+					for _, k := range kinds {
+						if k == kind {
+							return ev.Block.Header.Height, nil
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func schedulerGetCommittee(svc service.TendermintService, height int64, kind scheduler.CommitteeKind, runtimeID signature.PublicKey) (*scheduler.Committee, error) { // nolint: deadcode, unused
+	raw, err := svc.Query(schedulerapp.QueryKindsCommittees, []scheduler.CommitteeKind{kind}, height)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Tendermint Query %s", schedulerapp.QueryKindsCommittees)
+	}
+
+	var committees []*scheduler.Committee
+	if err := cbor.Unmarshal(raw, &committees); err != nil {
+		return nil, errors.Wrap(err, "CBOR Unmarshal committees")
+	}
+
+	for _, committee := range committees {
+		if committee.Kind != kind {
+			return nil, errors.Errorf("query returned a committee of the wrong kind %s, expected %s", committee.Kind, kind)
+		}
+
+		if !committee.RuntimeID.Equal(runtimeID) {
+			continue
+		}
+
+		return committee, nil
+	}
+	return nil, errors.New("query didn't return a committee for our runtime")
+}
+
+func schedulerCheckScheduled(committee *scheduler.Committee, nodeID signature.PublicKey, role scheduler.Role) error { // nolint: deadcode, unused
+	for _, member := range committee.Members {
+		if !member.PublicKey.Equal(nodeID) {
+			continue
+		}
+
+		if member.Role != role {
+			return errors.Errorf("we're scheduled as %s, expected %s", member.Role, role)
+		}
+
+		// All good.
+		return nil
+	}
+	return errors.New("we're not scheduled")
 }
 
 type p2pReqRes struct {


### PR DESCRIPTION
This adds some steps to access the Tendermint scheduler.

fixes #1942
fixes #1943