### PR TITLE
go/runtime/transaction: Use stable sort when sorting transactions

### DIFF
--- a/go/runtime/transaction/transaction.go
+++ b/go/runtime/transaction/transaction.go
@@ -260,7 +260,7 @@ func (t *Tree) GetInputBatch(ctx context.Context) (RawBatch, error) {
 	}
 
 	// Sort transactions to be in batch order.
-	sort.Sort(bo)
+	sort.Stable(bo)
 	bo.order = nil
 
 	return bo.batch, nil


### PR DESCRIPTION
Otherwise a malicious transaction scheduler could specify a batch order
that would result in non-deterministic transaction processing and cause
a discrepancy.