### PR TITLE
go/staking: Remove Approve/Withdraw support

### DIFF
--- a/go/grpc/staking/staking.proto
+++ b/go/grpc/staking/staking.proto
@@ -12,19 +12,15 @@ service Staking {
 	rpc GetThreshold(GetThresholdRequest) returns (GetThresholdResponse) {}
 	rpc GetAccounts(GetAccountsRequest) returns (GetAccountsResponse) {} // TODO: Stream this?
 	rpc GetAccountInfo(GetAccountInfoRequest) returns (GetAccountInfoResponse) {}
-	rpc GetAllowance(GetAllowanceRequest) returns (GetAllowanceResponse) {}
 
 	// Calls that mutate state.
 	rpc Transfer(TransferRequest) returns (TransferResponse) {}
-	rpc Approve(ApproveRequest) returns (ApproveResponse) {}
-	rpc Withdraw(WithdrawRequest) returns (WithdrawResponse) {}
 	rpc Burn(BurnRequest) returns (BurnResponse) {}
 	rpc AddEscrow(AddEscrowRequest) returns (AddEscrowResponse) {}
 	rpc ReclaimEscrow(ReclaimEscrowRequest) returns (ReclaimEscrowResponse) {}
 
 	// Calls that watch events.
 	rpc WatchTransfers (WatchTransfersRequest) returns (stream WatchTransfersResponse) {}
-	rpc WatchApprovals (WatchApprovalsRequest) returns (stream WatchApprovalsResponse) {}
 	rpc WatchBurns (WatchBurnsRequest) returns (stream WatchBurnsResponse) {}
 	rpc WatchEscrows (WatchEscrowsRequest) returns (stream WatchEscrowsResponse) {}
 }
@@ -84,32 +80,11 @@ message GetAccountInfoResponse {
 	uint64 nonce = 4;
 }
 
-message GetAllowanceRequest {
-	bytes owner = 1;
-	bytes spender = 2;
-}
-
-message GetAllowanceResponse {
-	bytes allowance = 1;
-}
-
 message TransferRequest {
 	bytes signed_transfer = 1;
 }
 
 message TransferResponse {}
-
-message ApproveRequest {
-	bytes signed_approval = 1;
-}
-
-message ApproveResponse {}
-
-message WithdrawRequest {
-	bytes signed_withdrawal = 1;
-}
-
-message WithdrawResponse {}
 
 message BurnRequest {
 	bytes signed_burn = 1;
@@ -132,12 +107,6 @@ message ReclaimEscrowResponse {}
 message WatchTransfersRequest {}
 
 message WatchTransfersResponse {
-	bytes event = 1;
-}
-
-message WatchApprovalsRequest {}
-
-message WatchApprovalsResponse {
 	bytes event = 1;
 }
 

--- a/go/tendermint/apps/staking/api.go
+++ b/go/tendermint/apps/staking/api.go
@@ -1,7 +1,6 @@
 package staking
 
 import (
-	"github.com/oasislabs/ekiden/go/common/crypto/signature"
 	staking "github.com/oasislabs/ekiden/go/staking/api"
 	"github.com/oasislabs/ekiden/go/tendermint/api"
 )
@@ -49,9 +48,6 @@ const (
 	// QueryAccountInfo is the path for an AccountInfo query.
 	QueryAccountInfo = AppName + "/account_info"
 
-	// QueryAllowance is the path for an Allowance query.
-	QueryAllowance = AppName + "/allowance"
-
 	// QueryDebondingInterval is the path for a DebondingInterval query.
 	QueryDebondingInterval = AppName + "/debonding_interval"
 
@@ -64,8 +60,6 @@ type Tx struct {
 	_struct struct{} `codec:",omitempty"` // nolint
 
 	*TxTransfer      `codec:"Transfer"`
-	*TxApprove       `codec:"Approve"`
-	*TxWithdraw      `codec:"Withdraw"`
 	*TxBurn          `codec:"Burn"`
 	*TxAddEscrow     `codec:"AddEscrow"`
 	*TxReclaimEscrow `codec:"ReclaimEscrow"`
@@ -74,16 +68,6 @@ type Tx struct {
 // TxTransfer is a transaction for a transfer.
 type TxTransfer struct {
 	SignedTransfer staking.SignedTransfer
-}
-
-// TxApprove is a transaction for an Approve.
-type TxApprove struct {
-	SignedApproval staking.SignedApproval
-}
-
-// TxWithdraw is a transaction for a Withdraw.
-type TxWithdraw struct {
-	SignedWithdrawal staking.SignedWithdrawal
 }
 
 // TxBurn is a transaction for a Burn.
@@ -106,7 +90,6 @@ type Output struct {
 	_struct struct{} `codec:",omitemtpy"` // nolint
 
 	OutputTransfer      *staking.TransferEvent      `codec:"Transfer"`
-	OutputApprove       *staking.ApprovalEvent      `codec:"Approve"`
 	OutputBurn          *staking.BurnEvent          `codec:"Burn"`
 	OutputAddEscrow     *staking.EscrowEvent        `codec:"AddEscrow"`
 	OutputReclaimEscrow *staking.ReclaimEscrowEvent `codec:"ReclaimEscrow"`
@@ -118,10 +101,4 @@ type QueryAccountInfoResponse struct {
 	EscrowBalance   staking.Quantity `codec:"escrow_balance"`
 	DebondStartTime uint64           `codec:"debond_start_time"`
 	Nonce           uint64           `codec:"nonce"`
-}
-
-// QueryAllowanceRequest is a request to QueryAllowance.
-type QueryAllowanceRequest struct {
-	Owner   signature.PublicKey `codec:"owner"`
-	Spender signature.PublicKey `codec:"spender"`
 }


### PR DESCRIPTION
The staking ledger backend doesn't need to be ERC20 compliant to provide
staking services, and this is a dramatic reduction in code.

Fixes #2021