### PR TITLE
logging: fix usage of 'msg' key in logging

### DIFF
--- a/go/common/grpc/grpc.go
+++ b/go/common/grpc/grpc.go
@@ -255,13 +255,13 @@ func (s *grpcStreamLogger) SendMsg(m interface{}) error {
 			s.logAdapter.reqLogger.Debug("SendMsg",
 				"method", s.method,
 				"stream_seq", s.seq,
-				"msg", m,
+				"message", m,
 			)
 		default:
 			s.logAdapter.reqLogger.Debug("SendMsg failed",
 				"method", s.method,
 				"stream_seq", s.seq,
-				"msg", m,
+				"message", m,
 				"err", err,
 			)
 		}

--- a/go/worker/common/host/protocol/protocol.go
+++ b/go/worker/common/host/protocol/protocol.go
@@ -191,7 +191,7 @@ func (p *Protocol) handleMessage(ctx context.Context, message *Message) {
 		close(respCh)
 	default:
 		p.logger.Warn("received a malformed message from worker, ignoring",
-			"msg", fmt.Sprintf("%+v", message),
+			"message", fmt.Sprintf("%+v", message),
 		)
 	}
 }


### PR DESCRIPTION
`msg` fields get overriden in `go/common/logging/logging.go`, so should not be used in log statements (unless desired).