### PR TITLE
runtime: Switch the ed25519 implementation to -dalek

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +352,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519-dalek"
+version = "1.0.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "either"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +446,7 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "deoxysii 0.2.0 (git+https://github.com/oasislabs/deoxysii-rust)",
+ "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -511,6 +548,11 @@ dependencies = [
  "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fixedbitset"
@@ -851,6 +893,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl"
@@ -1372,6 +1419,17 @@ dependencies = [
  "sgx-isa 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sgxs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sha2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1993,6 +2051,9 @@ dependencies = [
 "checksum bincode 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "959c8e54c1ad412ffeeb95f05a9cade02d2d40a7b3c2f852d3353148f4beff35"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
+"checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+"checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
+"checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5f3fee5eeb60324c2781f1e41286bdee933850fff9b3c672587fed5ec58c83"
@@ -2018,10 +2079,12 @@ dependencies = [
 "checksum deoxysii 0.2.0 (git+https://github.com/oasislabs/deoxysii-rust)" = "<none>"
 "checksum derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6ca414e896ae072546f4d789f452daaecf60ddee4c9df5dc6d5936d769e3d87c"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
+"checksum ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81956bcf7ef761fb4e1d88de3fa181358a0d26cbcb9755b587a08f9119824b86"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum enclave-runner 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47a063bd924484ca6cb05e5bcdd679b8cc8f1e0682a7d892f704759040908f80"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
+"checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
@@ -2066,6 +2129,7 @@ dependencies = [
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
+"checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)" = "5a0d6b781aac4ac1bd6cafe2a2f0ad8c16ae8e1dd5184822a16c50139f8838d9"
 "checksum openssl-sys 0.9.43 (registry+https://github.com/rust-lang/crates.io-index)" = "33c86834957dd5b915623e94f2f4ab2c70dd8f6b70679824155d5ae21dbd495d"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
@@ -2124,6 +2188,7 @@ dependencies = [
 "checksum sgx-isa 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2df74e26e738f5dcf66574a188026fec224a75012fd74cd7bc877b46ce5cdb3"
 "checksum sgxs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eefb2add3a98ced70a150f8d049aa0b8cf19c7eb1546f1ec5bcdea95bffb6282"
 "checksum sgxs-loaders 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af1f603c75f866b96b3eddfaf2307803ffc302e54f1d39f397c37f308107fc85"
+"checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e1a2eec401952cd7b12a84ea120e2d57281329940c3f93c2bf04f462539508e"
 "checksum slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -37,6 +37,7 @@ tokio-current-thread = "0.1.5"
 tokio-executor = "0.1.6"
 io-context = "0.2.0"
 x25519-dalek = "0.5.1"
+ed25519-dalek = "1.0.0-pre.1"
 deoxysii = { git = "https://github.com/oasislabs/deoxysii-rust" }
 tiny-keccak = "1.4.2"
 sp800-185 = "0.2.0"

--- a/runtime/src/common/crypto/signature.rs
+++ b/runtime/src/common/crypto/signature.rs
@@ -1,64 +1,66 @@
 //! Signature types.
+use std::io::Cursor;
+
+use byteorder::{LittleEndian, ReadBytesExt};
+use ed25519_dalek;
 use failure::Fallible;
-use ring::{
-    rand,
-    signature::{verify, Ed25519KeyPair, KeyPair, ED25519},
-};
+use rand::rngs::OsRng;
 use serde_derive::{Deserialize, Serialize};
-use untrusted;
 
 use super::hash::Hash;
 
-impl_bytes!(PublicKey, 32, "An Ed25519 public key.");
+impl_bytes!(
+    PublicKey,
+    ed25519_dalek::PUBLIC_KEY_LENGTH,
+    "An Ed25519 public key."
+);
+
+/// Signature error.
+#[derive(Debug, Fail)]
+enum SignatureError {
+    #[fail(display = "signature malleability check failed")]
+    MalleabilityError,
+}
+
+static CURVE_ORDER: &'static [u64] = &[
+    0x1000000000000000,
+    0,
+    0x14def9dea2f79cd6,
+    0x5812631a5cf5d3ed,
+];
 
 /// An Ed25519 private key.
-pub struct PrivateKey(pub Ed25519KeyPair);
+pub struct PrivateKey(pub ed25519_dalek::Keypair);
 
 impl PrivateKey {
     /// Generates a new private key pair.
     pub fn generate() -> Self {
-        let rng = rand::SystemRandom::new();
-        let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng)
-            .unwrap()
-            .as_ref()
-            .to_vec();
-        let key = Ed25519KeyPair::from_pkcs8(untrusted::Input::from(&key_pkcs8)).unwrap();
+        let mut rng = OsRng::new().unwrap();
 
-        PrivateKey(key)
+        PrivateKey(ed25519_dalek::Keypair::generate(&mut rng))
     }
 
     /// Generate a new private key from a test key seed.
     pub fn from_test_seed(seed: String) -> Self {
         let seed = Hash::digest_bytes(seed.as_bytes());
-        let key =
-            Ed25519KeyPair::from_seed_unchecked(untrusted::Input::from(seed.as_ref())).unwrap();
+        let secret = ed25519_dalek::SecretKey::from_bytes(seed.as_ref()).unwrap();
+        let pk: ed25519_dalek::PublicKey = (&secret).into();
 
-        PrivateKey(key)
-    }
-
-    /// Loads the private key pair from PKCS8 encoded data.
-    pub fn from_pkcs8(key: &[u8]) -> Fallible<Self> {
-        let key = Ed25519KeyPair::from_pkcs8(untrusted::Input::from(key))?;
-        Ok(PrivateKey(key))
+        PrivateKey(ed25519_dalek::Keypair { secret, public: pk })
     }
 
     /// Returns the public key.
     pub fn public_key(&self) -> PublicKey {
-        let mut data = [0u8; 32];
-        data[..].copy_from_slice(self.0.public_key().as_ref());
-
-        PublicKey(data)
+        PublicKey(self.0.public.to_bytes())
     }
 }
 
 impl Signer for PrivateKey {
     fn sign(&self, context: &[u8], message: &[u8]) -> Fallible<Signature> {
+        // TODO/#2103: Replace this with Ed25519ctx.
         let digest = Hash::digest_bytes_list(&[context, message]);
 
-        let mut result = [0u8; 64];
-        result[..].copy_from_slice(self.0.sign(digest.as_ref()).as_ref());
-
-        Ok(Signature(result))
+        Ok(Signature(self.0.sign(digest.as_ref()).to_bytes()))
     }
 }
 
@@ -67,13 +69,19 @@ impl_bytes!(Signature, 64, "An Ed25519 signature.");
 impl Signature {
     /// Verify signature.
     pub fn verify(&self, pk: &PublicKey, context: &[u8], message: &[u8]) -> Fallible<()> {
+        // TODO/#2103: Replace this with Ed25519ctx.
+        let pk = ed25519_dalek::PublicKey::from_bytes(pk.as_ref()).unwrap();
         let digest = Hash::digest_bytes_list(&[context, message]);
+        let sig_slice = self.as_ref();
+        let sig = ed25519_dalek::Signature::from_bytes(sig_slice).unwrap();
 
-        let pk = untrusted::Input::from(pk.as_ref());
-        let digest = untrusted::Input::from(digest.as_ref());
-        let sig = untrusted::Input::from(self.as_ref());
+        // ed25519-dalek does not enforce the RFC 8032 mandated constraint
+        // that s is in range [0, order), so signatures are malleable.
+        if !sc_minimal(&sig_slice[32..]) {
+            return Err(SignatureError::MalleabilityError.into());
+        }
 
-        Ok(verify(&ED25519, pk, digest, sig)?)
+        Ok(pk.verify(digest.as_ref(), &sig)?)
     }
 }
 
@@ -90,4 +98,99 @@ pub struct SignatureBundle {
 pub trait Signer: Send + Sync {
     /// Generates a signature over the context and message.
     fn sign(&self, context: &[u8], message: &[u8]) -> Fallible<Signature>;
+}
+
+// Check if s < L, per RFC 8032, inspired by the Go runtime library's version
+// of this check.
+fn sc_minimal(raw_s: &[u8]) -> bool {
+    let mut rd = Cursor::new(raw_s);
+    let mut s = [0u64; 4];
+
+    // Read the raw scalar into limbs, and reverse it, because the raw
+    // representation is little-endian.
+    rd.read_u64_into::<LittleEndian>(&mut s[..]).unwrap();
+    s.reverse();
+
+    // Compare each limb, from most significant to least.
+    for i in 0..4 {
+        if s[i] > CURVE_ORDER[i] {
+            return false;
+        } else if s[i] < CURVE_ORDER[i] {
+            return true;
+        }
+    }
+
+    // The scalar is equal to the order of the curve.
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sc_minimal() {
+        // L - 2^0
+        assert!(sc_minimal(&[
+            0xec, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9,
+            0xde, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x10
+        ]));
+
+        // L - 2^64
+        assert!(sc_minimal(&[
+            0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd5, 0x9c, 0xf7, 0xa2, 0xde, 0xf9,
+            0xde, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x10
+        ]));
+
+        // L - 2^192
+        assert!(sc_minimal(&[
+            0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd5, 0x9c, 0xf7, 0xa2, 0xde, 0xf9,
+            0xde, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0x0f,
+        ]));
+
+        // L
+        assert!(!sc_minimal(&[
+            0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9,
+            0xde, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x10
+        ]));
+
+        // L + 2^0
+        assert!(!sc_minimal(&[
+            0xef, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9,
+            0xde, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x10
+        ]));
+
+        // L + 2^64
+        assert!(!sc_minimal(&[
+            0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd7, 0x9c, 0xf7, 0xa2, 0xde, 0xf9,
+            0xde, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x10
+        ]));
+
+        // L + 2^128
+        assert!(!sc_minimal(&[
+            0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9,
+            0xde, 0x14, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x10
+        ]));
+
+        // L + 2^192
+        assert!(!sc_minimal(&[
+            0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9,
+            0xde, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x10
+        ]));
+
+        // Scalar from the go runtime's test case.
+        assert!(!sc_minimal(&[
+            0x67, 0x65, 0x4b, 0xce, 0x38, 0x32, 0xc2, 0xd7, 0x6f, 0x8f, 0x6f, 0x5d, 0xaf, 0xc0,
+            0x8d, 0x93, 0x39, 0xd4, 0xee, 0xf6, 0x76, 0x57, 0x33, 0x36, 0xa5, 0xc5, 0x1e, 0xb6,
+            0xf9, 0x46, 0xb3, 0x1d,
+        ]))
+    }
 }


### PR DESCRIPTION
Just what it says on the tin.  Still needs the RFC 8032 s < L check in the verification path before anyone should even think about merging this.