### PR TITLE
go/common: Check the owner of a directory if it already exists

### DIFF
--- a/go/common/mkdir.go
+++ b/go/common/mkdir.go
@@ -3,6 +3,7 @@ package common
 import (
 	"fmt"
 	"os"
+	"syscall"
 )
 
 // Mkdir creates a directory iff it does not exist, and otherwise
@@ -29,6 +30,12 @@ func Mkdir(d string) error {
 	}
 	if fm.Perm() != permDir {
 		return fmt.Errorf("common/Mkdir: path '%s' has invalid permissions: %v", d, fm.Perm())
+	}
+	if fs, ok := fi.Sys().(*syscall.Stat_t); ok {
+		euid := os.Geteuid()
+		if euid != int(fs.Uid) {
+			return fmt.Errorf("common/Mkdir: path '%s' has invalid owner: %d", d, fs.Uid)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
I'm not sure if this is possible on Windows.  I don't care either.

Fixes #2118.