### PR TITLE
go/tendermint/apps/scheduler: Do not elect for the 0th epoch

### DIFF
--- a/go/tendermint/apps/scheduler/scheduler.go
+++ b/go/tendermint/apps/scheduler/scheduler.go
@@ -146,6 +146,15 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 func (app *schedulerApplication) BeginBlock(ctx *abci.Context, request types.RequestBeginBlock) error {
 	// TODO: We'll later have this for each type of committee.
 	if changed, epoch := app.state.EpochChanged(app.timeSource); changed {
+		// The 0th epoch will not have suitable entropy for elections, nor
+		// will it have useful node registrations.
+		if epoch == 0 {
+			app.logger.Info("system in bootstrap period, skipping election",
+				"epoch", epoch,
+			)
+			return nil
+		}
+
 		beaconState := beaconapp.NewMutableState(app.state.DeliverTxTree())
 		beacon, err := beaconState.GetBeacon()
 		if err != nil {


### PR DESCRIPTION
For any random beacon implementation, sensible or not, right as the
system is initializing is unlikely to have sensible entropy.  Refuse
to elect anything for the 0th epoch.

Part of #2123.