### PR TITLE
go/cmd/ias: Use `DataDir` instead of `DataDirOrPwd`

### DIFF
--- a/go/ekiden/cmd/ias/proxy.go
+++ b/go/ekiden/cmd/ias/proxy.go
@@ -91,11 +91,9 @@ func doProxy(cmd *cobra.Command, args []string) {
 		cmdCommon.EarlyLogAndExit(err)
 	}
 
-	dataDir, err := cmdCommon.DataDirOrPwd()
-	if err != nil {
-		logger.Error("failed to query data directory",
-			"err", err,
-		)
+	dataDir := cmdCommon.DataDir()
+	if dataDir == "" {
+		logger.Error("failed to query data directory")
 		return
 	}
 


### PR DESCRIPTION
This is a long lived service, so it probably should use `DataDir` to be
consistent with the node.

Related to #2116, though it is not a bug.