### PR TITLE
go/ekiden/cmd/common/metrics: Disable metrics server by default

### DIFF
--- a/go/ekiden/cmd/common/metrics/metrics.go
+++ b/go/ekiden/cmd/common/metrics/metrics.go
@@ -224,8 +224,8 @@ func New(ctx context.Context) (service.BackgroundService, error) {
 }
 
 func init() {
-	Flags.String(cfgMetricsMode, metricsModePull, "metrics (prometheus) mode")
-	Flags.String(cfgMetricsAddr, "0.0.0.0:3000", "metrics pull/push address")
+	Flags.String(cfgMetricsMode, metricsModeNone, "metrics (prometheus) mode")
+	Flags.String(cfgMetricsAddr, "127.0.0.1:3000", "metrics pull/push address")
 	Flags.String(cfgMetricsPushJobName, "", "metrics push job name")
 	Flags.String(cfgMetricsPushInstanceLabel, "", "metrics push instance label")
 	Flags.Duration(cfgMetricsPushInterval, 5*time.Second, "metrics push interval")


### PR DESCRIPTION
Fixes #2155 

Also change the default bind address to 127.0.0.1 instead of listening
on all interfaces by default.