### PR TITLE
runtime: Move predicted read/write sets to CheckTx results

### DIFF
--- a/client/src/transaction/client.rs
+++ b/client/src/transaction/client.rs
@@ -10,10 +10,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use ekiden_runtime::{
     common::{cbor, crypto::hash::Hash, runtime::RuntimeId},
-    transaction::{
-        rwset::ReadWriteSet,
-        types::{TxnBatch, TxnCall, TxnOutput},
-    },
+    transaction::types::{TxnBatch, TxnCall, TxnOutput},
 };
 
 use super::{
@@ -70,8 +67,6 @@ impl TxnClient {
         let call = TxnCall {
             method: method.to_owned(),
             args: cbor::to_value(args),
-            // TODO: Populate predicted read/write set.
-            predicted_rw_set: ReadWriteSet::default(),
         };
 
         Box::new(

--- a/go/runtime/transaction/types.go
+++ b/go/runtime/transaction/types.go
@@ -8,8 +8,6 @@ type TxnCall struct {
 	Method string `codec:"method"`
 	// Args are the method arguments.
 	Args interface{} `codec:"args"`
-	// PredictedReadWriteSet is the predicted read/write set.
-	PredictedReadWriteSet ReadWriteSet `codec:"predicted_rw_set"`
 }
 
 // TxnOutput is a transaction call output.
@@ -18,4 +16,10 @@ type TxnOutput struct {
 	Success interface{}
 	// Error is a string describing the error message.
 	Error *string
+}
+
+// TxnCheckResult is the result of a successful CheckTx call.
+type TxnCheckResult struct {
+	// PredictedReadWriteSet is the predicted read/write set.
+	PredictedReadWriteSet ReadWriteSet `codec:"predicted_rw_set"`
 }

--- a/runtime/src/transaction/types.rs
+++ b/runtime/src/transaction/types.rs
@@ -16,9 +16,6 @@ pub struct TxnCall {
     pub method: String,
     /// Method arguments.
     pub args: Value,
-    /// Predicted read/write set.
-    #[serde(default)]
-    pub predicted_rw_set: ReadWriteSet,
 }
 
 /// Transaction call output.
@@ -28,6 +25,13 @@ pub enum TxnOutput {
     Success(Value),
     /// Call raised an error.
     Error(String),
+}
+
+/// The result of a successful CheckTx call.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct TxnCheckResult {
+    /// Predicted read/write set.
+    pub predicted_rw_set: ReadWriteSet,
 }
 
 /// Internal module to efficiently serialize batches.

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -46,7 +46,7 @@ fn insert(args: &KeyValue, ctx: &mut TxnContext) -> Fallible<Option<String>> {
         return Err(format_err!("Value too big to be inserted."));
     }
     if ctx.check_only {
-        return Err(CheckOnlySuccess.into());
+        return Err(CheckOnlySuccess::default().into());
     }
     ctx.emit_txn_tag(b"kv_op", b"insert");
     ctx.emit_txn_tag(b"kv_key", args.key.as_bytes());
@@ -64,7 +64,7 @@ fn insert(args: &KeyValue, ctx: &mut TxnContext) -> Fallible<Option<String>> {
 /// Retrieve a key/value pair.
 fn get(args: &String, ctx: &mut TxnContext) -> Fallible<Option<String>> {
     if ctx.check_only {
-        return Err(CheckOnlySuccess.into());
+        return Err(CheckOnlySuccess::default().into());
     }
     ctx.emit_txn_tag(b"kv_op", b"get");
     ctx.emit_txn_tag(b"kv_key", args.as_bytes());
@@ -78,7 +78,7 @@ fn get(args: &String, ctx: &mut TxnContext) -> Fallible<Option<String>> {
 /// Remove a key/value pair.
 fn remove(args: &String, ctx: &mut TxnContext) -> Fallible<Option<String>> {
     if ctx.check_only {
-        return Err(CheckOnlySuccess.into());
+        return Err(CheckOnlySuccess::default().into());
     }
     ctx.emit_txn_tag(b"kv_op", b"remove");
     ctx.emit_txn_tag(b"kv_key", args.as_bytes());


### PR DESCRIPTION
Part of #1963 