### PR TITLE
go storage: handle interim toarray form of LogEntry

### DIFF
--- a/go/storage/mkvs/urkel/writelog/writelog.go
+++ b/go/storage/mkvs/urkel/writelog/writelog.go
@@ -19,14 +19,14 @@ type LogEntry struct {
 	Value []byte
 }
 
-func (le *LogEntry) UnmarshalJSON(src []byte) error {
+func (k *LogEntry) UnmarshalJSON(src []byte) error {
 	var kv [2][]byte
 	if err := json.Unmarshal(src, &kv); err != nil {
 		return err
 	}
 
-	le.Key = kv[0]
-	le.Value = kv[1]
+	k.Key = kv[0]
+	k.Value = kv[1]
 
 	return nil
 }


### PR DESCRIPTION
Currently the Rust side is still serializing LogEntry as a sequence. Patch up an unmarshaler to handle that until we get #2183 in and start serializing it as a dictionary uniformly.