### PR TITLE
go/keymanager: Add missing struct tag annotations

### DIFF
--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -293,8 +293,8 @@ func (w *Worker) updateStatus(status *api.Status) error {
 func extractMessageResponsePayload(raw []byte) ([]byte, error) {
 	// See: runtime/src/rpc/types.rs
 	type MessageResponseBody struct {
-		Success interface{}
-		Error   *string
+		Success interface{} `json:",omitempty"`
+		Error   *string     `json:",omitempty"`
 	}
 	type MessageResponse struct {
 		Response *struct {


### PR DESCRIPTION
Trivial.  Everything else I found (before I gave up) requires changes to the rust side.