### PR TITLE
Fix some anti-patterns

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,13 @@
+version = 1
+
+test_patterns = [
+  "**/*_test.go",
+  "tests/**"
+]
+
+[[analyzers]]
+name = "go"
+enabled = true
+
+  [analyzers.meta]
+  import_path = "github.com/oasislabs/oasis-core"

--- a/go/common/crypto/hash/hash.go
+++ b/go/common/crypto/hash/hash.go
@@ -83,7 +83,7 @@ func (h *Hash) FromBytes(data ...[]byte) {
 		_, _ = hasher.Write(d)
 	}
 	sum := hasher.Sum([]byte{})
-	_ = h.UnmarshalBinary(sum[:])
+	_ = h.UnmarshalBinary(sum)
 }
 
 // Equal compares vs another hash for equality.
@@ -124,7 +124,7 @@ func (b *Builder) Write(p []byte) (int, error) {
 // It does not change the underlying hash state.
 func (b *Builder) Build() (h Hash) {
 	sum := b.hasher.Sum([]byte{})
-	_ = h.UnmarshalBinary(sum[:])
+	_ = h.UnmarshalBinary(sum)
 	return
 }
 

--- a/go/common/crypto/signature/signer.go
+++ b/go/common/crypto/signature/signer.go
@@ -225,5 +225,5 @@ func PrepareSignerMessage(context Context, message []byte) ([]byte, error) {
 	_, _ = h.Write(message)
 	sum := h.Sum(nil)
 
-	return sum[:], nil
+	return sum, nil
 }

--- a/go/common/crypto/signature/signers/file/file_signer.go
+++ b/go/common/crypto/signature/signers/file/file_signer.go
@@ -202,7 +202,7 @@ func (s *Signer) Reset() {
 }
 
 func (s *Signer) marshalPEM() ([]byte, error) {
-	return pem.Marshal(privateKeyPemType, s.privateKey[:])
+	return pem.Marshal(privateKeyPemType, s.privateKey)
 }
 
 func (s *Signer) unmarshalPEM(data []byte) error {

--- a/go/common/crypto/signature/signers/memory/memory_signer.go
+++ b/go/common/crypto/signature/signers/memory/memory_signer.go
@@ -87,7 +87,7 @@ func (s *Signer) Reset() {
 // UnsafeBytes returns the byte representation of the private key.  This
 // MUST be removed for HSM support.
 func (s *Signer) UnsafeBytes() []byte {
-	return s.privateKey[:]
+	return s.privateKey
 }
 
 // NewSigner creates a new signer.

--- a/go/common/grpc/grpc.go
+++ b/go/common/grpc/grpc.go
@@ -465,12 +465,12 @@ func NewServer(config *ServerConfig) (*Server, error) {
 		unaryInterceptors = append(unaryInterceptors, wrapper.unaryInterceptor)
 		streamInterceptors = append(streamInterceptors, wrapper.streamInterceptor)
 	}
-	sOpts = append(sOpts, grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(unaryInterceptors...)))
-	sOpts = append(sOpts, grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(streamInterceptors...)))
-	sOpts = append(sOpts, grpc.MaxRecvMsgSize(maxRecvMsgSize))
-	sOpts = append(sOpts, grpc.MaxSendMsgSize(maxSendMsgSize))
-	sOpts = append(sOpts, grpc.KeepaliveParams(serverKeepAliveParams))
-	sOpts = append(sOpts, grpc.CustomCodec(&CBORCodec{}))
+	sOpts = append(sOpts, grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(unaryInterceptors...)),
+		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(streamInterceptors...))),
+		grpc.MaxRecvMsgSize(maxRecvMsgSize),
+		grpc.MaxSendMsgSize(maxSendMsgSize),
+		grpc.KeepaliveParams(serverKeepAliveParams),
+		grpc.CustomCodec(&CBORCodec{})
 	sOpts = append(sOpts, config.CustomOptions...)
 
 	if config.Certificate != nil {

--- a/go/common/keyformat/key_format.go
+++ b/go/common/keyformat/key_format.go
@@ -103,9 +103,9 @@ func (k *KeyFormat) Encode(values ...interface{}) []byte {
 				panic(fmt.Sprintf("key format: failed to marshal: %s", err))
 			}
 
-			copy(buf[:], data)
+			copy(buf, data)
 		case []byte:
-			copy(buf[:], t)
+			copy(buf, t)
 		default:
 			panic(fmt.Sprintf("unsupported type: %T", t))
 		}

--- a/go/common/node/address.go
+++ b/go/common/node/address.go
@@ -169,7 +169,7 @@ func (ca *CommitteeAddress) ParseCertificate() (*x509.Certificate, error) {
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (ca *CommitteeAddress) MarshalText() ([]byte, error) {
-	certificateStr := base64.StdEncoding.EncodeToString(ca.Certificate[:])
+	certificateStr := base64.StdEncoding.EncodeToString(ca.Certificate)
 	addrStr, err := ca.Address.MarshalText()
 	if err != nil {
 		return nil, fmt.Errorf("node: error marshalling committee address' TCP address: %w", err)


### PR DESCRIPTION
Changes:
- Club `append` in single call
- Use slice directly `foo` instead of `foo[:]`
- Add DeepSource config `.deepsource.toml` to detect these issues on every commit/pull-request

---

Find the other issues found here - [https://deepsource.io/gh/jaipradeesh/oasis-core/issues/?category=all](https://deepsource.io/gh/jaipradeesh/oasis-core/issues/?category=all)

This PR also adds `.deepsource.toml` configuration file to run Continuous Quality analysis on the repo with [DeepSource](https://deepsource.io). Upon enabling DeepSource, quality analysis will be run on every PR to detect 180+ types of issues in the changes — including bug risks, anti-patterns, security vulnerabilities, etc.

DeepSource is free to use for open-source projects, and is used by teams at Uber, ThoughtWorks, Intel among many others.

To enable DeepSource analysis after merging this PR, please follow these steps:
1. [Signup](https://deepsource.io/signup/) on DeepSource with your GitHub account and grant access to this repo.
2. Activate analysis on this repo [here](https://deepsource.io/gh/oasislabs/oasis-core).

You can also look at the [docs](https://deepsource.io/docs/guides/quickstart.html) for more details. Do let me know if I can be of any help!
  Also added a `.deepsource.toml` configuration file to run continuous static analysis on the repository with DeepSource.

Signed-off-by: Jai <jai@deepsource.io>