### PR TITLE
go/runtime/host/sandbox: Retry Call in case the runtime is not yet ready

### DIFF
--- a/.changelog/2967.bugfix.md
+++ b/.changelog/2967.bugfix.md
@@ -1,0 +1,1 @@
+go/runtime/host/sandbox: Retry Call in case the runtime is not yet ready


### PR DESCRIPTION
Issue discovered in long-term tests.