### PR TITLE
ci: don't retry timeout jobs

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -64,8 +64,6 @@ docker_plugin_sgx: &docker_plugin_sgx
 
 retry: &retry_agent_failure
   automatic:
-    - exit_status: -1  # Agent was lost
-      limit: 2
     - exit_status: 125 # ERRO[0092] error waiting for container: unexpected EOF
       limit: 2
     - exit_status: 255 # Forced agent shutdown

--- a/.changelog/2969.internal.md
+++ b/.changelog/2969.internal.md
@@ -1,0 +1,1 @@
+ci: don't retry jobs that timeout


### PR DESCRIPTION
Apparently jobs that hit the time-out limit exit with status `-1`  and get automatically retried (which we actually don't want). Haven't seen any other job fail with `-1` (agents getting killed appears to be `125`) so i think it's fine just not retrying these. 