### PR TITLE
keymanager: Rename APIs referencing "contracts"

### DIFF
--- a/.changelog/2844.feature.md
+++ b/.changelog/2844.feature.md
@@ -1,0 +1,5 @@
+keymanager: Rename APIs referencing "contracts"
+
+Each runtime does not neccecarily have a notion for contracts, so the
+key manager now operates in terms of `KeyPairId`s that identify a given
+`KeyPair`.

--- a/keymanager-client/src/lib.rs
+++ b/keymanager-client/src/lib.rs
@@ -16,18 +16,18 @@ pub trait KeyManagerClient: Send + Sync {
     /// This will make the client re-fetch the keys from the key manager.
     fn clear_cache(&self);
 
-    /// Get or create named key.
+    /// Get or create named key pair.
     ///
     /// If the key does not yet exist, the key manager will generate one. If
     /// the key has already been cached locally, it will be retrieved from
     /// cache.
-    fn get_or_create_keys(&self, ctx: Context, contract_id: ContractId) -> BoxFuture<ContractKey>;
+    fn get_or_create_keys(&self, ctx: Context, key_pair_id: KeyPairId) -> BoxFuture<KeyPair>;
 
-    /// Get public key for a contract.
+    /// Get public key for a key pair id.
     fn get_public_key(
         &self,
         ctx: Context,
-        contract_id: ContractId,
+        key_pair_id: KeyPairId,
     ) -> BoxFuture<Option<SignedPublicKey>>;
 
     /// Get a copy of the master secret for replication.
@@ -39,16 +39,16 @@ impl<T: ?Sized + KeyManagerClient> KeyManagerClient for Arc<T> {
         KeyManagerClient::clear_cache(&**self)
     }
 
-    fn get_or_create_keys(&self, ctx: Context, contract_id: ContractId) -> BoxFuture<ContractKey> {
-        KeyManagerClient::get_or_create_keys(&**self, ctx, contract_id)
+    fn get_or_create_keys(&self, ctx: Context, key_pair_id: KeyPairId) -> BoxFuture<KeyPair> {
+        KeyManagerClient::get_or_create_keys(&**self, ctx, key_pair_id)
     }
 
     fn get_public_key(
         &self,
         ctx: Context,
-        contract_id: ContractId,
+        key_pair_id: KeyPairId,
     ) -> BoxFuture<Option<SignedPublicKey>> {
-        KeyManagerClient::get_public_key(&**self, ctx, contract_id)
+        KeyManagerClient::get_public_key(&**self, ctx, key_pair_id)
     }
 
     fn replicate_master_secret(&self, ctx: Context) -> BoxFuture<Option<MasterSecret>> {

--- a/keymanager-client/src/mock.rs
+++ b/keymanager-client/src/mock.rs
@@ -11,7 +11,7 @@ use super::KeyManagerClient;
 
 /// Mock key manager client which stores everything locally.
 pub struct MockClient {
-    keys: Mutex<HashMap<ContractId, ContractKey>>,
+    keys: Mutex<HashMap<KeyPairId, KeyPair>>,
 }
 
 impl MockClient {
@@ -26,13 +26,13 @@ impl MockClient {
 impl KeyManagerClient for MockClient {
     fn clear_cache(&self) {}
 
-    fn get_or_create_keys(&self, _ctx: Context, contract_id: ContractId) -> BoxFuture<ContractKey> {
+    fn get_or_create_keys(&self, _ctx: Context, key_pair_id: KeyPairId) -> BoxFuture<KeyPair> {
         let mut keys = self.keys.lock().unwrap();
-        let key = match keys.get(&contract_id) {
+        let key = match keys.get(&key_pair_id) {
             Some(key) => key.clone(),
             None => {
-                let key = ContractKey::generate_mock();
-                keys.insert(contract_id, key.clone());
+                let key = KeyPair::generate_mock();
+                keys.insert(key_pair_id, key.clone());
                 key
             }
         };
@@ -43,9 +43,9 @@ impl KeyManagerClient for MockClient {
     fn get_public_key(
         &self,
         ctx: Context,
-        contract_id: ContractId,
+        key_pair_id: KeyPairId,
     ) -> BoxFuture<Option<SignedPublicKey>> {
-        Box::new(self.get_or_create_keys(ctx, contract_id).map(|ck| {
+        Box::new(self.get_or_create_keys(ctx, key_pair_id).map(|ck| {
             Some(SignedPublicKey {
                 key: ck.input_keypair.get_pk(),
                 checksum: vec![],

--- a/keymanager-lib/src/methods.rs
+++ b/keymanager-lib/src/methods.rs
@@ -6,7 +6,7 @@ use oasis_core_runtime::rpc::Context as RpcContext;
 use crate::{kdf::Kdf, policy::Policy};
 
 /// See `Kdf::get_or_create_keys`.
-pub fn get_or_create_keys(req: &RequestIds, ctx: &mut RpcContext) -> Fallible<ContractKey> {
+pub fn get_or_create_keys(req: &RequestIds, ctx: &mut RpcContext) -> Fallible<KeyPair> {
     // Authenticate the source enclave based on the MRSIGNER/MRENCLAVE/request
     // so that the keys are never released to an incorrect enclave.
     if !Policy::unsafe_skip() {

--- a/tests/clients/simple-keyvalue-enc/src/main.rs
+++ b/tests/clients/simple-keyvalue-enc/src/main.rs
@@ -6,7 +6,7 @@ use io_context::Context;
 use tokio::runtime::Runtime;
 
 use oasis_core_client::{create_txn_api_client, Node, TxnClient};
-use oasis_core_keymanager_client::{self, ContractId, KeyManagerClient};
+use oasis_core_keymanager_client::{self, KeyManagerClient, KeyPairId};
 use oasis_core_runtime::common::{crypto::hash::Hash, runtime::RuntimeId};
 use simple_keyvalue_api::{with_api, KeyValue};
 
@@ -94,16 +94,16 @@ fn main() {
         1024,
     ));
 
-    // Request public key for some "contract id".
-    let contract_id = ContractId::from(Hash::empty_hash().as_ref());
+    // Request public key for some "key pair id".
+    let key_pair_id = KeyPairId::from(Hash::empty_hash().as_ref());
     let r = rt
-        .block_on(km_client.get_public_key(Context::background(), contract_id))
+        .block_on(km_client.get_public_key(Context::background(), key_pair_id))
         .unwrap();
     assert!(r.is_some(), "get_public_key should return a public key");
     let pkey = r;
 
     let r = rt
-        .block_on(km_client.get_public_key(Context::background(), contract_id))
+        .block_on(km_client.get_public_key(Context::background(), key_pair_id))
         .unwrap();
     assert_eq!(r, pkey, "get_public_key should return the same public key");
 

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use failure::{format_err, Fallible};
 use io_context::Context as IoContext;
 
-use oasis_core_keymanager_client::{ContractId, KeyManagerClient};
+use oasis_core_keymanager_client::{KeyManagerClient, KeyPairId};
 use oasis_core_runtime::{
     common::{
         crypto::{
@@ -88,12 +88,12 @@ fn remove(args: &String, ctx: &mut TxnContext) -> Fallible<Option<String>> {
 fn get_encryption_context(ctx: &mut TxnContext, key: &[u8]) -> Fallible<EncryptionContext> {
     let rctx = runtime_context!(ctx, Context);
 
-    // Derive contract ID based on key.
-    let contract_id = ContractId::from(Hash::digest_bytes(key).as_ref());
+    // Derive key pair ID based on key.
+    let key_pair_id = KeyPairId::from(Hash::digest_bytes(key).as_ref());
 
     // Fetch encryption keys.
     let io_ctx = IoContext::create_child(&ctx.io_ctx);
-    let result = rctx.km_client.get_or_create_keys(io_ctx, contract_id);
+    let result = rctx.km_client.get_or_create_keys(io_ctx, key_pair_id);
     let key = Executor::with_current(|executor| executor.block_on(result))?;
 
     Ok(EncryptionContext::new(key.state_key.as_ref()))


### PR DESCRIPTION
Each runtime does not neccecarily have a notion for contracts, so the
key manager now operates in terms of `KeyPairId`s that identify a given
`KeyPair`.

Fixes #2844.