### PR TITLE
staking: Don't emit zero-amount staking events

### DIFF
--- a/.changelog/2983.bugfix.md
+++ b/.changelog/2983.bugfix.md
@@ -1,0 +1,8 @@
+staking: Don't emit zero-amount staking events
+
+If fees were set to 0, staking events related to the fee accumulator
+would still get emitted with zero amounts, which is pointless.
+
+This fix affects only events related to the internal fee accumulator
+and common pool accounts, manual transfers with 0 as the amount will
+still get emitted.

--- a/go/consensus/tendermint/apps/staking/fees.go
+++ b/go/consensus/tendermint/apps/staking/fees.go
@@ -63,7 +63,7 @@ func (app *stakingApplication) disburseFeesP(
 
 	// Pay the proposer.
 	feeProposerAmt := totalFees.Clone()
-	if proposerEntity != nil {
+	if proposerEntity != nil && !feeProposerAmt.IsZero() {
 		acct, err := stakeState.Account(ctx, *proposerEntity)
 		if err != nil {
 			return fmt.Errorf("failed to fetch proposer account: %w", err)

--- a/go/consensus/tendermint/apps/staking/state/gas.go
+++ b/go/consensus/tendermint/apps/staking/state/gas.go
@@ -98,13 +98,15 @@ func AuthenticateAndPayFees(
 		return fmt.Errorf("failed to set account: %w", err)
 	}
 
-	// Emit transfer event.
-	ev := cbor.Marshal(&staking.TransferEvent{
-		From:   id,
-		To:     staking.FeeAccumulatorAccountID,
-		Tokens: fee.Amount,
-	})
-	ctx.EmitEvent(abciAPI.NewEventBuilder(AppName).Attribute(KeyTransfer, ev))
+	// Emit transfer event if fee is non-zero.
+	if !fee.Amount.IsZero() {
+		ev := cbor.Marshal(&staking.TransferEvent{
+			From:   id,
+			To:     staking.FeeAccumulatorAccountID,
+			Tokens: fee.Amount,
+		})
+		ctx.EmitEvent(abciAPI.NewEventBuilder(AppName).Attribute(KeyTransfer, ev))
+	}
 
 	// Configure gas accountant on the context.
 	ctx.SetGasAccountant(abciAPI.NewCompositeGasAccountant(


### PR DESCRIPTION
If fees were set to 0, staking events related to the fee accumulator
would still get emitted with zero amounts, which is pointless.

This fix affects only events related to the internal fee accumulator
and common pool accounts, manual transfers with 0 as the amount will
still get emitted.