### PR TITLE
test/e2e/sentry: don't set seed node for nodes running with sentries

### DIFF
--- a/.changelog/2989.internal.md
+++ b/.changelog/2989.internal.md
@@ -1,0 +1,1 @@
+test/e2e/sentry: don't set seed node for nodes running with sentries

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -274,7 +274,6 @@ func (km *Keymanager) startNode() error {
 		workerKeymanagerEnabled().
 		workerKeymanagerRuntimeID(km.runtime.id).
 		appendNetwork(km.net).
-		appendSeedNodes(km.net).
 		appendEntity(km.entity)
 
 	if km.mayGenerate {

--- a/go/oasis-test-runner/oasis/storage.go
+++ b/go/oasis-test-runner/oasis/storage.go
@@ -103,7 +103,6 @@ func (worker *Storage) startNode() error {
 		workerStorageDebugIgnoreApplies(worker.ignoreApplies).
 		workerStorageCheckpointCheckInterval(worker.checkpointCheckInterval).
 		appendNetwork(worker.net).
-		appendSeedNodes(worker.net).
 		appendEntity(worker.entity)
 	for _, v := range worker.net.runtimes {
 		if v.kind != registry.KindCompute {


### PR DESCRIPTION
we currently append seeds twice in these two places, instead of only in case when not using sentries (see bellow, not visible in the PR diff)