### PR TITLE
Disallow v0 entity/node/runtime descriptors

### DIFF
--- a/.changelog/2992.breaking.md
+++ b/.changelog/2992.breaking.md
@@ -1,0 +1,1 @@
+Disallow v0 entity/node/runtime descriptors

--- a/go/common/entity/entity.go
+++ b/go/common/entity/entity.go
@@ -34,7 +34,7 @@ const (
 	LatestEntityDescriptorVersion = 1
 
 	// Minimum and maximum descriptor versions that are allowed.
-	minEntityDescriptorVersion = 0
+	minEntityDescriptorVersion = 1
 	maxEntityDescriptorVersion = LatestEntityDescriptorVersion
 )
 
@@ -52,11 +52,11 @@ type Entity struct { // nolint: maligned
 	// Nodes is the vector of node identity keys owned by this entity, that
 	// will sign the descriptor with the node signing key rather than the
 	// entity signing key.
-	Nodes []signature.PublicKey `json:"nodes"`
+	Nodes []signature.PublicKey `json:"nodes,omitempty"`
 
 	// AllowEntitySignedNodes is true iff nodes belonging to this entity
 	// may be signed with the entity signing key.
-	AllowEntitySignedNodes bool `json:"allow_entity_signed_nodes"`
+	AllowEntitySignedNodes bool `json:"allow_entity_signed_nodes,omitempty"`
 }
 
 // ValidateBasic performs basic descriptor validity checks.

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -39,7 +39,7 @@ const (
 	LatestNodeDescriptorVersion = 1
 
 	// Minimum and maximum descriptor versions that are allowed.
-	minNodeDescriptorVersion = 0
+	minNodeDescriptorVersion = 1
 	maxNodeDescriptorVersion = LatestNodeDescriptorVersion
 )
 

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -177,7 +177,7 @@ const (
 	LatestRuntimeDescriptorVersion = 1
 
 	// Minimum and maximum descriptor versions that are allowed.
-	minRuntimeDescriptorVersion = 0
+	minRuntimeDescriptorVersion = 1
 	maxRuntimeDescriptorVersion = LatestRuntimeDescriptorVersion
 )
 

--- a/go/upgrade/migrations/dummy.go
+++ b/go/upgrade/migrations/dummy.go
@@ -30,6 +30,7 @@ var (
 
 func init() {
 	entitySigner = memory.NewTestSigner(testSigningSeed)
+	TestEntity.DescriptorVersion = entity.LatestEntityDescriptorVersion
 	TestEntity.ID = entitySigner.Public()
 }
 

--- a/tests/fixture-data/consim/genesis.json
+++ b/tests/fixture-data/consim/genesis.json
@@ -24,10 +24,10 @@
     },
     "entities": [
       {
-        "untrusted_raw_value": "o2JpZFggTqUyj5Q+9vZtqu10yw6Zw7HEX3Ywe0JQA9vHyzY47TVlbm9kZXP2eBlhbGxvd19lbnRpdHlfc2lnbmVkX25vZGVz9Q==",
+        "untrusted_raw_value": "o2F2AWJpZFggTqUyj5Q+9vZtqu10yw6Zw7HEX3Ywe0JQA9vHyzY47TV4GWFsbG93X2VudGl0eV9zaWduZWRfbm9kZXP1",
         "signature": {
           "public_key": "TqUyj5Q+9vZtqu10yw6Zw7HEX3Ywe0JQA9vHyzY47TU=",
-          "signature": "5CnlsannKM749UmwEadxMJ6WTAQA4tffytgwUm8WLYdpcMEBXv9aK4qwATUrO5O3hJyob0uCRRX3MHk8o/qWDw=="
+          "signature": "CHTyRfJoYWxIbX6gmXvCrHg10tZHS6pwKuPdyhrw/5zrA5cnlYAzZwuhtL0j9a9le1mA23v9hRbKSai8XjqAAA=="
         }
       }
     ]


### PR DESCRIPTION
We forgot to do this earlier, v0 descriptors should not be allowed anywhere in 20.8.