### PR TITLE
release-process: create a stable branch when preparing a new release

### DIFF
--- a/.changelog/2993.process.md
+++ b/.changelog/2993.process.md
@@ -1,0 +1,7 @@
+release: Create a stable branch when preparing a new release
+
+Currently we create a stable release branch only once we need to backport some
+changes. This PR changes the release process to create the stable branch when
+creating a new release. This will ensure CI jobs hooked to stable/ branches,
+such as building a release tagged CI docker image, will be run for every
+release.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -106,6 +106,15 @@ while tagging the next release.
 
 After those checks have passed, it will ask for confirmation before proceeding.
 
+### Create a `stable/YY.MINOR.x` branch
+
+Prepare a new stable branch from the tag and push it to the origin:
+
+```bash
+git checkout -b stable/${TAG_VERSION}.x v${TAG_VERSION}
+git push -u origin stable/${TAG_VERSION}.x
+```
+
 ### Ensure a GitHub release was published
 
 After the tag with the next release is pushed to the [canonical git repository],
@@ -139,15 +148,6 @@ BACKPORT_VERSION="20.1"
 ```
 
 [Versioning scheme]: versioning.md
-
-### Create a `stable/YY.MINOR.x` branch
-
-Prepare a new branch from the appropriate tag and push it to the origin:
-
-```bash
-git checkout -b stable/${BACKPORT_VERSION}.x v${BACKPORT_VERSION}
-git push -u origin stable/${BACKPORT_VERSION}.x
-```
 
 ### Back-port the changes
 


### PR DESCRIPTION
Currently we create a stable release branch only once we need to backport some
changes. This PR changes the release process to create the stable branch when
creating a new release. This will ensure CI jobs hooked to stable/ branches,
such as building a release tagged CI docker image will be run for every
release.


NOTE: this could probably be automated within the `tag-next-release` make step (with an additional check to only run this when creating a new release and not when backporting), but I'm afraid i'm not enough of a makefile enthusiast to tackle that :/ - can open an issue though.