### PR TITLE
registry: Add runtime-specific staking thresholds

### DIFF
--- a/.changelog/2995.breaking.md
+++ b/.changelog/2995.breaking.md
@@ -1,0 +1,1 @@
+registry: Add runtime-specific staking thresholds

--- a/docs/consensus/registry.md
+++ b/docs/consensus/registry.md
@@ -138,8 +138,17 @@ The node descriptor structure MUST be signed by all of the following keys:
 * P2P key.
 
 Registering a node may require sufficient stake in the owning entity's
-[escrow account]. The exact stake threshold is a consensus parameter (see
-[`Thresholds` in staking consensus parameters]).
+[escrow account]. There are two kinds of thresholds that the node may need to
+satisfy:
+
+* Global thresholds are the same for all runtimes and are defined by the
+  consensus parameters (see [`Thresholds` in staking consensus parameters]).
+
+* In _addition_ to the global thresholds, each runtime the node is registering
+  for may define their own thresholds. In case the node is registering for
+  multiple runtimes, it needs to satisfy the maximum threshold of all the
+  runtimes it is registering for. The runtime-specific thresholds are defined
+  in the [`Staking` field] in the runtime descriptor.
 
 <!-- markdownlint-disable line-length -->
 [`NewRegisterNodeTx`]: https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go/registry/api?tab=doc#NewRegisterNodeTx
@@ -147,6 +156,7 @@ Registering a node may require sufficient stake in the owning entity's
 [`Node`]: https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go/common/node?tab=doc#Node
 [multi-signed envelope]: ../crypto.md#multi-signed-envelope
 [`Thresholds` in staking consensus parameters]: https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go/staking/api?tab=doc#ConsensusParameters.Thresholds
+[`Staking` field]: https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go/registry/api?tab=doc#Runtime.Staking
 <!-- markdownlint-enable line-length -->
 
 ### Unfreeze Node

--- a/go/common/quantity/quantity.go
+++ b/go/common/quantity/quantity.go
@@ -207,6 +207,15 @@ func NewQuantity() (q *Quantity) {
 	return &Quantity{}
 }
 
+// NewFromUint64 creates a new Quantity from an uint64 or panics.
+func NewFromUint64(n uint64) *Quantity {
+	var q Quantity
+	if err := q.FromUint64(n); err != nil {
+		panic(err)
+	}
+	return &q
+}
+
 func isValid(n *big.Int) bool {
 	return n.Cmp(&zero) >= 0
 }

--- a/go/consensus/tendermint/apps/registry/transactions.go
+++ b/go/consensus/tendermint/apps/registry/transactions.go
@@ -51,8 +51,13 @@ func (app *registryApplication) registerEntity(
 
 	if !params.DebugBypassStake {
 		acctAddr := staking.NewAddress(ent.ID)
-		if err = stakingState.AddStakeClaim(ctx, acctAddr, registry.StakeClaimRegisterEntity, []staking.ThresholdKind{staking.KindEntity}); err != nil {
-			ctx.Logger().Error("RegisterEntity: Insufficient stake",
+		if err = stakingState.AddStakeClaim(
+			ctx,
+			acctAddr,
+			registry.StakeClaimRegisterEntity,
+			staking.GlobalStakeThresholds(staking.KindEntity),
+		); err != nil {
+			ctx.Logger().Error("RegisterEntity: Insufficent stake",
 				"err", err,
 				"entity", ent.ID,
 				"account", acctAddr,
@@ -309,7 +314,7 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 		}
 
 		claim := registry.StakeClaimForNode(newNode.ID)
-		thresholds := registry.StakeThresholdsForNode(newNode)
+		thresholds := registry.StakeThresholdsForNode(newNode, paidRuntimes)
 		acctAddr := staking.NewAddress(newNode.EntityID)
 
 		if err = stakeAcc.AddStakeClaim(acctAddr, claim, thresholds); err != nil {

--- a/go/consensus/tendermint/apps/registry/transactions_test.go
+++ b/go/consensus/tendermint/apps/registry/transactions_test.go
@@ -1,0 +1,282 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	requirePkg "github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
+	"github.com/oasisprotocol/oasis-core/go/common/entity"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	registryState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry/state"
+	stakingState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/staking/state"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
+)
+
+func TestRegisterNode(t *testing.T) {
+	require := requirePkg.New(t)
+
+	now := time.Unix(1580461674, 0)
+	appState := abciAPI.NewMockApplicationState(abciAPI.MockApplicationStateConfig{})
+	ctx := appState.NewContext(abciAPI.ContextDeliverTx, now)
+	defer ctx.Close()
+
+	app := registryApplication{appState}
+	state := registryState.NewMutableState(ctx.State())
+	stakeState := stakingState.NewMutableState(ctx.State())
+
+	// Set up default staking consensus parameters.
+	defaultStakeParameters := staking.ConsensusParameters{
+		Thresholds: map[staking.ThresholdKind]quantity.Quantity{
+			staking.KindEntity:            *quantity.NewFromUint64(0),
+			staking.KindNodeValidator:     *quantity.NewFromUint64(0),
+			staking.KindNodeCompute:       *quantity.NewFromUint64(0),
+			staking.KindNodeStorage:       *quantity.NewFromUint64(0),
+			staking.KindNodeKeyManager:    *quantity.NewFromUint64(0),
+			staking.KindRuntimeCompute:    *quantity.NewFromUint64(0),
+			staking.KindRuntimeKeyManager: *quantity.NewFromUint64(0),
+		},
+	}
+	// Set up registry consensus parameters.
+	err := state.SetConsensusParameters(ctx, &registry.ConsensusParameters{
+		MaxNodeExpiration: 5,
+	})
+	require.NoError(err, "registry.SetConsensusParameters")
+
+	tcs := []struct {
+		name        string
+		prepareFn   func(n *node.Node) []signature.Signer
+		stakeParams *staking.ConsensusParameters
+		valid       bool
+	}{
+		// Node without any roles.
+		{"WithoutRoles", nil, nil, false},
+		// A simple validator node.
+		{
+			"Validator",
+			func(n *node.Node) []signature.Signer {
+				n.AddRoles(node.RoleValidator)
+				return nil
+			},
+			nil,
+			true,
+		},
+		// An expired validator node.
+		{
+			"ExpiredValidator",
+			func(n *node.Node) []signature.Signer {
+				n.AddRoles(node.RoleValidator)
+				n.Expiration = 0
+				return nil
+			},
+			nil,
+			false,
+		},
+		// Validator without enough stake.
+		{
+			"ValidatorWithoutStake",
+			func(n *node.Node) []signature.Signer {
+				n.AddRoles(node.RoleValidator)
+				return nil
+			},
+			&staking.ConsensusParameters{
+				Thresholds: map[staking.ThresholdKind]quantity.Quantity{
+					staking.KindEntity:            *quantity.NewFromUint64(0),
+					staking.KindNodeValidator:     *quantity.NewFromUint64(1000),
+					staking.KindNodeCompute:       *quantity.NewFromUint64(0),
+					staking.KindNodeStorage:       *quantity.NewFromUint64(0),
+					staking.KindNodeKeyManager:    *quantity.NewFromUint64(0),
+					staking.KindRuntimeCompute:    *quantity.NewFromUint64(0),
+					staking.KindRuntimeKeyManager: *quantity.NewFromUint64(0),
+				},
+			},
+			false,
+		},
+		// Compute node.
+		{
+			"ComputeNode",
+			func(n *node.Node) []signature.Signer {
+				// Create a new runtime.
+				rtSigner := memorySigner.NewTestSigner("consensus/tendermint/apps/registry: runtime signer: ComputeNode")
+				rt := registry.Runtime{
+					DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
+					ID:                common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNode"), 0),
+					Kind:              registry.KindCompute,
+				}
+				sigRt, _ := registry.SignRuntime(rtSigner, registry.RegisterRuntimeSignatureContext, &rt)
+				_ = state.SetRuntime(ctx, &rt, sigRt, false)
+
+				n.AddRoles(node.RoleComputeWorker)
+				n.Runtimes = []*node.Runtime{
+					&node.Runtime{ID: rt.ID},
+				}
+				return nil
+			},
+			nil,
+			true,
+		},
+		// Compute node without per-runtime stake.
+		{
+			"ComputeNodeWithoutPerRuntimeStake",
+			func(n *node.Node) []signature.Signer {
+				// Create a new runtime.
+				rtSigner := memorySigner.NewTestSigner("consensus/tendermint/apps/registry: runtime signer: ComputeNodeWithoutPerRuntimeStake")
+				rt := registry.Runtime{
+					DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
+					ID:                common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNodeWithoutPerRuntimeStake"), 0),
+					Kind:              registry.KindCompute,
+					Staking: registry.RuntimeStakingParameters{
+						Thresholds: map[staking.ThresholdKind]quantity.Quantity{
+							staking.KindNodeCompute: *quantity.NewFromUint64(1000),
+						},
+					},
+				}
+				sigRt, _ := registry.SignRuntime(rtSigner, registry.RegisterRuntimeSignatureContext, &rt)
+				_ = state.SetRuntime(ctx, &rt, sigRt, false)
+
+				n.AddRoles(node.RoleComputeWorker)
+				n.Runtimes = []*node.Runtime{
+					&node.Runtime{ID: rt.ID},
+				}
+				return nil
+			},
+			nil,
+			false,
+		},
+		// Compute node with ehough per-runtime stake.
+		{
+			"ComputeNodeWithPerRuntimeStake",
+			func(n *node.Node) []signature.Signer {
+				// Create a new runtime.
+				rtSigner := memorySigner.NewTestSigner("consensus/tendermint/apps/registry: runtime signer: ComputeNodeWithPerRuntimeStake")
+				rt := registry.Runtime{
+					DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
+					ID:                common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNodeWithPerRuntimeStake"), 0),
+					Kind:              registry.KindCompute,
+					Staking: registry.RuntimeStakingParameters{
+						Thresholds: map[staking.ThresholdKind]quantity.Quantity{
+							staking.KindNodeCompute: *quantity.NewFromUint64(1000),
+						},
+					},
+				}
+				sigRt, _ := registry.SignRuntime(rtSigner, registry.RegisterRuntimeSignatureContext, &rt)
+				_ = state.SetRuntime(ctx, &rt, sigRt, false)
+
+				// Add bonded stake (hacky, without a self-delegation).
+				_ = stakeState.SetAccount(ctx, staking.NewAddress(n.EntityID), &staking.Account{
+					Escrow: staking.EscrowAccount{
+						Active: staking.SharePool{
+							Balance: *quantity.NewFromUint64(10_000),
+						},
+					},
+				})
+
+				n.AddRoles(node.RoleComputeWorker)
+				n.Runtimes = []*node.Runtime{
+					&node.Runtime{ID: rt.ID},
+				}
+				return nil
+			},
+			nil,
+			true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			require = requirePkg.New(t)
+
+			// Reset staking consensus parameters.
+			stakeParams := tc.stakeParams
+			if stakeParams == nil {
+				stakeParams = &defaultStakeParameters
+			}
+			err = stakeState.SetConsensusParameters(ctx, stakeParams)
+			require.NoError(err, "staking.SetConsensusParameters")
+
+			// Prepare default signers.
+			entitySigner := memorySigner.NewTestSigner("consensus/tendermint/apps/registry: entity signer: " + tc.name)
+			nodeSigner := memorySigner.NewTestSigner("consensus/tendermint/apps/registry: node signer: " + tc.name)
+			consensusSigner := memorySigner.NewTestSigner("consensus/tendermint/apps/registry: consensus signer: " + tc.name)
+			p2pSigner := memorySigner.NewTestSigner("consensus/tendermint/apps/registry: p2p signer: " + tc.name)
+			tlsSigner := memorySigner.NewTestSigner("consensus/tendermint/apps/registry: tls signer: " + tc.name)
+
+			// Prepare a test entity that owns the nodes.
+			ent := entity.Entity{
+				DescriptorVersion: entity.LatestEntityDescriptorVersion,
+				ID:                entitySigner.Public(),
+				Nodes:             []signature.PublicKey{nodeSigner.Public()},
+			}
+			sigEnt, err := entity.SignEntity(entitySigner, registry.RegisterEntitySignatureContext, &ent)
+			require.NoError(err, "SignEntity")
+			err = state.SetEntity(ctx, &ent, sigEnt)
+			require.NoError(err, "SetEntity")
+
+			// Prepare a new minimal node.
+			var address node.Address
+			err = address.UnmarshalText([]byte("8.8.8.8:1234"))
+			require.NoError(err, "address.UnmarshalText")
+
+			n := node.Node{
+				DescriptorVersion: node.LatestNodeDescriptorVersion,
+				ID:                nodeSigner.Public(),
+				EntityID:          ent.ID,
+				Expiration:        3,
+				P2P: node.P2PInfo{
+					ID:        p2pSigner.Public(),
+					Addresses: []node.Address{address},
+				},
+				Consensus: node.ConsensusInfo{
+					ID: consensusSigner.Public(),
+					Addresses: []node.ConsensusAddress{
+						{ID: consensusSigner.Public(), Address: address},
+					},
+				},
+				TLS: node.TLSInfo{
+					PubKey: tlsSigner.Public(),
+					Addresses: []node.TLSAddress{
+						{PubKey: tlsSigner.Public(), Address: address},
+					},
+				},
+			}
+			var signers []signature.Signer
+			if tc.prepareFn != nil {
+				signers = tc.prepareFn(&n)
+			}
+			if signers == nil {
+				signers = []signature.Signer{nodeSigner, p2pSigner, consensusSigner, tlsSigner}
+			}
+
+			// Sign the node.
+			sigNode, err := node.MultiSignNode(signers, registry.RegisterNodeSignatureContext, &n)
+			require.NoError(err, "MultiSignNode")
+
+			// Attempt to register the node.
+			ctx.SetTxSigner(nodeSigner.Public())
+			err = app.registerNode(ctx, state, sigNode)
+			switch tc.valid {
+			case true:
+				require.NoError(err, "node registration should succeed")
+
+				// Make sure the node has been registered.
+				var regNode *node.Node
+				regNode, err = state.Node(ctx, n.ID)
+				require.NoError(err, "node should be registered")
+				require.EqualValues(&n, regNode, "registered node descriptor should be correct")
+			case false:
+				require.Error(err, "node registration should fail")
+
+				// Make sure the state has not changed.
+				_, err = state.Node(ctx, n.ID)
+				require.Error(err, "node should not be registered")
+				require.Equal(registry.ErrNoSuchNode, err)
+			}
+		})
+	}
+}

--- a/go/consensus/tendermint/apps/staking/state/accumulator.go
+++ b/go/consensus/tendermint/apps/staking/state/accumulator.go
@@ -56,7 +56,7 @@ func (c *StakeAccumulatorCache) CheckStakeClaims(addr staking.Address) error {
 func (c *StakeAccumulatorCache) AddStakeClaim(
 	addr staking.Address,
 	claim staking.StakeClaim,
-	thresholds []staking.ThresholdKind,
+	thresholds []staking.StakeThreshold,
 ) error {
 	acct, err := c.getAccount(addr)
 	if err != nil {
@@ -128,7 +128,7 @@ func AddStakeClaim(
 	ctx *abciAPI.Context,
 	addr staking.Address,
 	claim staking.StakeClaim,
-	thresholds []staking.ThresholdKind,
+	thresholds []staking.StakeThreshold,
 ) error {
 	sa, err := NewStakeAccumulatorCache(ctx)
 	if err != nil {

--- a/go/consensus/tendermint/apps/staking/state/accumulator_test.go
+++ b/go/consensus/tendermint/apps/staking/state/accumulator_test.go
@@ -47,7 +47,7 @@ func TestStakeAccumulatorCache(t *testing.T) {
 	err = stakeState.SetAccount(ctx, addr, &acct)
 	require.NoError(err, "SetAccount")
 
-	err = acc.AddStakeClaim(addr, staking.StakeClaim("claim"), []staking.ThresholdKind{staking.KindEntity})
+	err = acc.AddStakeClaim(addr, staking.StakeClaim("claim"), staking.GlobalStakeThresholds(staking.KindEntity))
 	require.NoError(err, "AddStakeClaim")
 
 	err = acc.CheckStakeClaims(addr)
@@ -83,7 +83,7 @@ func TestStakeAccumulatorCache(t *testing.T) {
 	require.Len(acct2.Escrow.StakeAccumulator.Claims, 1, "claims should not be updated")
 
 	// Test convenience functions.
-	err = AddStakeClaim(ctx, addr, staking.StakeClaim("claim"), []staking.ThresholdKind{staking.KindEntity})
+	err = AddStakeClaim(ctx, addr, staking.StakeClaim("claim"), staking.GlobalStakeThresholds(staking.KindEntity))
 	require.NoError(err, "AddStakeClaim")
 	err = RemoveStakeClaim(ctx, addr, staking.StakeClaim("claim"))
 	require.NoError(err, "RemoveStakeClaim")

--- a/go/oasis-test-runner/oasis/cli/registry.go
+++ b/go/oasis-test-runner/oasis/cli/registry.go
@@ -108,6 +108,15 @@ func (r *RegistryHelpers) GenerateRegisterRuntimeTx(
 		return fmt.Errorf("invalid admission policy")
 	}
 
+	for kind, value := range runtime.Staking.Thresholds {
+		kindRaw, _ := kind.MarshalText()
+		valueRaw, _ := value.MarshalText()
+
+		args = append(args,
+			"--"+cmdRegRt.CfgStakingThreshold, fmt.Sprintf("%s=%s", string(kindRaw), string(valueRaw)),
+		)
+	}
+
 	if out, err := r.runSubCommandWithOutput("registry-runtime-gen_register", args); err != nil {
 		return fmt.Errorf("failed to generate register runtime tx: error: %w output: %s", err, out.String())
 	}

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -197,7 +197,8 @@ type RuntimeFixture struct { // nolint: maligned
 	TxnScheduler registry.TxnSchedulerParameters `json:"txn_scheduler"`
 	Storage      registry.StorageParameters      `json:"storage"`
 
-	AdmissionPolicy registry.RuntimeAdmissionPolicy `json:"admission_policy"`
+	AdmissionPolicy registry.RuntimeAdmissionPolicy   `json:"admission_policy"`
+	Staking         registry.RuntimeStakingParameters `json:"staking,omitempty"`
 
 	Pruner RuntimePrunerCfg `json:"pruner,omitempty"`
 
@@ -235,6 +236,7 @@ func (f *RuntimeFixture) Create(netFixture *NetworkFixture, net *Network) (*Runt
 		TxnScheduler:       f.TxnScheduler,
 		Storage:            f.Storage,
 		AdmissionPolicy:    f.AdmissionPolicy,
+		Staking:            f.Staking,
 		Binaries:           f.Binaries,
 		GenesisState:       f.GenesisState,
 		GenesisRound:       f.GenesisRound,

--- a/go/oasis-test-runner/oasis/runtime.go
+++ b/go/oasis-test-runner/oasis/runtime.go
@@ -57,6 +57,7 @@ type RuntimeCfg struct { // nolint: maligned
 	Storage      registry.StorageParameters
 
 	AdmissionPolicy registry.RuntimeAdmissionPolicy
+	Staking         registry.RuntimeStakingParameters
 
 	Pruner RuntimePrunerCfg
 
@@ -125,6 +126,7 @@ func (net *Network) NewRuntime(cfg *RuntimeCfg) (*Runtime, error) {
 		TxnScheduler:      cfg.TxnScheduler,
 		Storage:           cfg.Storage,
 		AdmissionPolicy:   cfg.AdmissionPolicy,
+		Staking:           cfg.Staking,
 	}
 
 	rtDir, err := net.baseDir.NewSubDir("runtime-" + cfg.ID.String())
@@ -221,6 +223,16 @@ func (net *Network) NewRuntime(cfg *RuntimeCfg) (*Runtime, error) {
 	} else {
 		return nil, fmt.Errorf("invalid admission policy")
 	}
+
+	for kind, value := range cfg.Staking.Thresholds {
+		kindRaw, _ := kind.MarshalText()
+		valueRaw, _ := value.MarshalText()
+
+		args = append(args,
+			"--"+cmdRegRt.CfgStakingThreshold, fmt.Sprintf("%s=%s", string(kindRaw), string(valueRaw)),
+		)
+	}
+
 	args = append(args, cfg.Entity.toGenesisArgs()...)
 
 	w, err := rtDir.NewLogWriter("provision.log")

--- a/go/oasis-test-runner/scenario/e2e/registry_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/registry_cli.go
@@ -19,6 +19,7 @@ import (
 	fileSigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/file"
 	"github.com/oasisprotocol/oasis-core/go/common/entity"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/consensus"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
@@ -31,10 +32,11 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis/cli"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
 var (
-	// RegistryCLI is the staking scenario.
+	// RegistryCLI is the registry CLI test scenario.
 	RegistryCLI scenario.Scenario = &registryCLIImpl{
 		runtimeImpl: *newRuntimeImpl("registry-cli", "", nil),
 	}
@@ -605,6 +607,8 @@ func (r *registryCLIImpl) testRuntime(childEnv *env.Env, cli *cli.Helpers) error
 	if err != nil {
 		return fmt.Errorf("TestEntity: %w", err)
 	}
+	var q quantity.Quantity
+	_ = q.FromUint64(100)
 	testRuntime := registry.Runtime{
 		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
 		EntityID:          testEntity.ID,
@@ -640,6 +644,12 @@ func (r *registryCLIImpl) testRuntime(childEnv *env.Env, cli *cli.Helpers) error
 				Entities: map[signature.PublicKey]bool{
 					testEntity.ID: true,
 				},
+			},
+		},
+		Staking: registry.RuntimeStakingParameters{
+			Thresholds: map[staking.ThresholdKind]quantity.Quantity{
+				staking.KindNodeCompute: q,
+				staking.KindNodeStorage: q,
 			},
 		},
 	}

--- a/go/staking/api/api_test.go
+++ b/go/staking/api/api_test.go
@@ -43,17 +43,81 @@ func TestConsensusParameters(t *testing.T) {
 	require.Error(degenerateFeeSplit.SanityCheck(), "consensus parameters with degenerate fee split should be invalid")
 }
 
+func TestThresholdKind(t *testing.T) {
+	require := require.New(t)
+
+	for k := ThresholdKind(0); k <= KindMax; k++ {
+		enc, err := k.MarshalText()
+		require.NoError(err, "MarshalText")
+
+		var d ThresholdKind
+		err = d.UnmarshalText(enc)
+		require.NoError(err, "UnmarshalText")
+		require.Equal(k, d, "threshold kind should round-trip")
+	}
+}
+
+func TestStakeThreshold(t *testing.T) {
+	require := require.New(t)
+
+	// Empty stake threshold is invalid.
+	st := StakeThreshold{}
+	_, err := st.Value(nil)
+	require.Error(err, "empty stake threshold is invalid")
+
+	// Global threshold reference is resolved correctly.
+	tm := map[ThresholdKind]quantity.Quantity{
+		KindEntity: *quantity.NewFromUint64(1_000),
+	}
+	kind := KindEntity
+	st = StakeThreshold{Global: &kind}
+	v, err := st.Value(tm)
+	require.NoError(err, "global threshold reference should be resolved correctly")
+	q := tm[kind]
+	require.True(q.Cmp(v) == 0, "global threshold reference should be resolved correctly")
+
+	// Constant threshold is resolved correctly.
+	c := *quantity.NewFromUint64(5_000)
+	st = StakeThreshold{Constant: &c}
+	v, err = st.Value(tm)
+	require.NoError(err, "constant threshold should be resolved correctly")
+	require.True(c.Cmp(v) == 0, "constant threshold should be resolved correctly")
+
+	// Equality checks.
+	kind2 := KindEntity
+	kind3 := KindNodeCompute
+	c2 := *quantity.NewFromUint64(1_000)
+
+	for _, t := range []struct {
+		a     StakeThreshold
+		b     StakeThreshold
+		equal bool
+	}{
+		{StakeThreshold{Global: &kind}, StakeThreshold{Global: &kind}, true},
+		{StakeThreshold{Global: &kind}, StakeThreshold{Global: &kind2}, true},
+		{StakeThreshold{Global: &kind}, StakeThreshold{Global: &kind3}, false},
+		{StakeThreshold{Global: &kind}, StakeThreshold{Constant: &c2}, false},
+		{StakeThreshold{Constant: &c2}, StakeThreshold{Constant: &c2}, true},
+		{StakeThreshold{Constant: &c}, StakeThreshold{Constant: &c2}, false},
+		{StakeThreshold{}, StakeThreshold{Constant: &c2}, false},
+		{StakeThreshold{}, StakeThreshold{}, false},
+	} {
+		require.True(t.a.Equal(&t.b) == t.equal, "stake threshold equality should work (a == b)")
+		require.True(t.b.Equal(&t.a) == t.equal, "stake threshold equality should work (b == a)")
+	}
+}
+
 func TestStakeAccumulator(t *testing.T) {
 	require := require.New(t)
 
 	thresholds := map[ThresholdKind]quantity.Quantity{
-		KindEntity:            qtyFromInt(1_000),
-		KindNodeValidator:     qtyFromInt(10_000),
-		KindNodeCompute:       qtyFromInt(5_000),
-		KindNodeStorage:       qtyFromInt(2_000),
-		KindNodeKeyManager:    qtyFromInt(50_000),
-		KindRuntimeCompute:    qtyFromInt(100_000),
-		KindRuntimeKeyManager: qtyFromInt(1_000_000),
+		KindEntity:            *quantity.NewFromUint64(1_000),
+		KindNodeValidator:     *quantity.NewFromUint64(10_000),
+		KindNodeCompute:       *quantity.NewFromUint64(5_000),
+		KindNodeStorage:       *quantity.NewFromUint64(2_000),
+		KindNodeKeyManager:    *quantity.NewFromUint64(50_000),
+		KindRuntimeCompute:    *quantity.NewFromUint64(100_000),
+		KindRuntimeKeyManager: *quantity.NewFromUint64(1_000_000),
 	}
 
 	// Empty escrow account tests.
@@ -62,78 +126,86 @@ func TestStakeAccumulator(t *testing.T) {
 	require.NoError(err, "empty escrow account should check out")
 	err = acct.RemoveStakeClaim(StakeClaim("dummy claim"))
 	require.Error(err, "removing a non-existing claim should return an error")
-	err = acct.AddStakeClaim(thresholds, StakeClaim("claim1"), []ThresholdKind{KindEntity, KindNodeValidator})
+	err = acct.AddStakeClaim(thresholds, StakeClaim("claim1"), GlobalStakeThresholds(KindEntity, KindNodeValidator))
 	require.Error(err, "adding a stake claim with insufficient stake should fail")
 	require.Equal(err, ErrInsufficientStake)
 	require.EqualValues(EscrowAccount{}, acct, "account should be unchanged after failure")
 
 	// Add some stake into the account.
-	acct.Active.Balance = qtyFromInt(3_000)
+	acct.Active.Balance = *quantity.NewFromUint64(3_000)
 	err = acct.CheckStakeClaims(thresholds)
 	require.NoError(err, "escrow account with no claims should check out")
 
-	err = acct.AddStakeClaim(thresholds, StakeClaim("claim1"), []ThresholdKind{KindEntity, KindNodeCompute})
+	err = acct.AddStakeClaim(thresholds, StakeClaim("claim1"), GlobalStakeThresholds(KindEntity, KindNodeCompute))
 	require.Error(err, "adding a stake claim with insufficient stake should fail")
 	require.Equal(err, ErrInsufficientStake)
 
-	err = acct.AddStakeClaim(thresholds, StakeClaim("claim1"), []ThresholdKind{KindEntity})
+	err = acct.AddStakeClaim(thresholds, StakeClaim("claim1"), GlobalStakeThresholds(KindEntity))
 	require.NoError(err, "adding a stake claim with sufficient stake should work")
 	err = acct.CheckStakeClaims(thresholds)
 	require.NoError(err, "escrow account should check out")
 
 	// Update an existing claim.
-	err = acct.AddStakeClaim(thresholds, StakeClaim("claim1"), []ThresholdKind{KindEntity, KindNodeCompute})
+	err = acct.AddStakeClaim(thresholds, StakeClaim("claim1"), GlobalStakeThresholds(KindEntity, KindNodeCompute))
 	require.Error(err, "updating a stake claim with insufficient stake should fail")
 	require.Equal(err, ErrInsufficientStake)
 
-	err = acct.AddStakeClaim(thresholds, StakeClaim("claim1"), []ThresholdKind{KindEntity, KindNodeStorage})
+	err = acct.AddStakeClaim(thresholds, StakeClaim("claim1"), GlobalStakeThresholds(KindEntity, KindNodeStorage))
 	require.NoError(err, "updating a stake claim with sufficient stake should work")
 
-	err = acct.AddStakeClaim(thresholds, StakeClaim("claim1"), []ThresholdKind{KindEntity, KindNodeStorage})
+	err = acct.AddStakeClaim(thresholds, StakeClaim("claim1"), GlobalStakeThresholds(KindEntity, KindNodeStorage))
 	require.NoError(err, "updating a stake claim with sufficient stake should work")
 	err = acct.CheckStakeClaims(thresholds)
 	require.NoError(err, "escrow account should check out")
 
 	// Add another claim.
-	err = acct.AddStakeClaim(thresholds, StakeClaim("claim2"), []ThresholdKind{KindNodeStorage})
+	err = acct.AddStakeClaim(thresholds, StakeClaim("claim2"), GlobalStakeThresholds(KindNodeStorage))
 	require.Error(err, "updating a stake claim with insufficient stake should fail")
 	require.Equal(err, ErrInsufficientStake)
 
-	acct.Active.Balance = qtyFromInt(13_000)
+	acct.Active.Balance = *quantity.NewFromUint64(13_000)
 
-	err = acct.AddStakeClaim(thresholds, StakeClaim("claim2"), []ThresholdKind{KindNodeStorage})
+	err = acct.AddStakeClaim(thresholds, StakeClaim("claim2"), GlobalStakeThresholds(KindNodeStorage))
 	require.NoError(err, "adding a stake claim with sufficient stake should work")
 	err = acct.CheckStakeClaims(thresholds)
 	require.NoError(err, "escrow account should check out")
 
 	require.Len(acct.StakeAccumulator.Claims, 2, "stake accumulator should contain two claims")
 
-	err = acct.AddStakeClaim(thresholds, StakeClaim("claim3"), []ThresholdKind{KindNodeValidator})
+	err = acct.AddStakeClaim(thresholds, StakeClaim("claim3"), GlobalStakeThresholds(KindNodeValidator))
 	require.Error(err, "adding a stake claim with insufficient stake should fail")
+	require.Equal(err, ErrInsufficientStake)
+
+	// Add constant claim.
+	q1 := *quantity.NewFromUint64(10)
+	err = acct.AddStakeClaim(thresholds, StakeClaim("claimC1"), []StakeThreshold{{Constant: &q1}})
+	require.NoError(err, "adding a constant stake claim with sufficient stake should work")
+	err = acct.CheckStakeClaims(thresholds)
+	require.NoError(err, "escrow account should check out")
+
+	q2 := *quantity.NewFromUint64(10_000)
+	err = acct.AddStakeClaim(thresholds, StakeClaim("claimC2"), []StakeThreshold{{Constant: &q2}})
+	require.Error(err, "adding a constant stake claim with insufficient stake should fail")
 	require.Equal(err, ErrInsufficientStake)
 
 	// Remove an existing claim.
 	err = acct.RemoveStakeClaim(StakeClaim("claim2"))
 	require.NoError(err, "removing an existing claim should work")
+	require.Len(acct.StakeAccumulator.Claims, 2, "stake accumulator should contain two claims")
+
+	err = acct.RemoveStakeClaim(StakeClaim("claimC1"))
+	require.NoError(err, "removing an existing claim should work")
 	require.Len(acct.StakeAccumulator.Claims, 1, "stake accumulator should contain one claim")
 
-	err = acct.AddStakeClaim(thresholds, StakeClaim("claim3"), []ThresholdKind{KindNodeValidator})
-	require.NoError(err, "adding a stake claim sufficient stake should work")
+	err = acct.AddStakeClaim(thresholds, StakeClaim("claim3"), GlobalStakeThresholds(KindNodeValidator))
+	require.NoError(err, "adding a stake claim with sufficient stake should work")
 	require.Len(acct.StakeAccumulator.Claims, 2, "stake accumulator should contain two claims")
 	err = acct.CheckStakeClaims(thresholds)
 	require.NoError(err, "escrow account should check out")
 
 	// Reduce stake.
-	acct.Active.Balance = qtyFromInt(5_000)
+	acct.Active.Balance = *quantity.NewFromUint64(5_000)
 	err = acct.CheckStakeClaims(thresholds)
 	require.Error(err, "escrow account should no longer check out")
 	require.Equal(err, ErrInsufficientStake)
-}
-
-func qtyFromInt(n int) quantity.Quantity {
-	q := quantity.NewQuantity()
-	if err := q.FromInt64(int64(n)); err != nil {
-		panic(err)
-	}
-	return *q
 }

--- a/go/upgrade/migrations/dummy.go
+++ b/go/upgrade/migrations/dummy.go
@@ -62,10 +62,10 @@ func (th *dummyMigrationHandler) ConsensusUpgrade(ctx *Context, privateCtx inter
 	err = stakeState.SetAccount(abciCtx, testEntityAddr, &staking.Account{
 		Escrow: staking.EscrowAccount{
 			StakeAccumulator: staking.StakeAccumulator{
-				Claims: map[staking.StakeClaim][]staking.ThresholdKind{
-					registry.StakeClaimRegisterEntity: []staking.ThresholdKind{
+				Claims: map[staking.StakeClaim][]staking.StakeThreshold{
+					registry.StakeClaimRegisterEntity: staking.GlobalStakeThresholds(
 						staking.KindEntity,
-					},
+					),
 				},
 			},
 		},

--- a/tests/fixture-data/consim/genesis.json
+++ b/tests/fixture-data/consim/genesis.json
@@ -43,13 +43,13 @@
   "staking": {
     "params": {
       "thresholds": {
-        "0": "0",
-        "1": "0",
-        "2": "0",
-        "3": "0",
-        "4": "0",
-        "5": "0",
-        "6": "0"
+        "entity": "0",
+        "node-validator": "0",
+        "node-compute": "0",
+        "node-storage": "0",
+        "node-keymanager": "0",
+        "runtime-compute": "0",
+        "runtime-keymanager": "0"
       },
       "debonding_interval": 2,
       "commission_schedule_rules": {

--- a/tests/fixture-data/debond/staking-genesis.json
+++ b/tests/fixture-data/debond/staking-genesis.json
@@ -7,13 +7,13 @@
       "max_bound_steps": 12
     },
     "thresholds": {
-      "0": "0",
-      "1": "0",
-      "2": "0",
-      "3": "0",
-      "4": "0",
-      "5": "0",
-      "6": "0"
+      "entity": "0",
+      "node-validator": "0",
+      "node-compute": "0",
+      "node-storage": "0",
+      "node-keymanager": "0",
+      "runtime-compute": "0",
+      "runtime-keymanager": "0"
     }
   },
   "total_supply": "1000",

--- a/tests/fixture-data/net-runner/default.json
+++ b/tests/fixture-data/net-runner/default.json
@@ -71,6 +71,7 @@
             "admission_policy": {
                 "any_node": {}
             },
+            "staking": {},
             "pruner": {
                 "strategy": "",
                 "interval": 0,
@@ -119,6 +120,7 @@
             "admission_policy": {
                 "any_node": {}
             },
+            "staking": {},
             "pruner": {
                 "strategy": "",
                 "interval": 0,

--- a/tests/fixture-data/runtime-dynamic/staking-genesis.json
+++ b/tests/fixture-data/runtime-dynamic/staking-genesis.json
@@ -1,13 +1,13 @@
 {
   "params": {
     "thresholds": {
-      "0": "0",
-      "1": "0",
-      "2": "0",
-      "3": "0",
-      "4": "0",
-      "5": "1000",
-      "6": "1000"
+      "entity": "0",
+      "node-validator": "0",
+      "node-compute": "0",
+      "node-storage": "0",
+      "node-keymanager": "0",
+      "runtime-compute": "1000",
+      "runtime-keymanager": "1000"
     }
   }
 }

--- a/tests/fixture-data/stake-cli/staking-genesis.json
+++ b/tests/fixture-data/stake-cli/staking-genesis.json
@@ -7,13 +7,13 @@
       "max_bound_steps": 12
     },
     "thresholds": {
-      "0": "0",
-      "1": "0",
-      "2": "0",
-      "3": "0",
-      "4": "0",
-      "5": "0",
-      "6": "0"
+      "entity": "0",
+      "node-validator": "0",
+      "node-compute": "0",
+      "node-storage": "0",
+      "node-keymanager": "0",
+      "runtime-compute": "0",
+      "runtime-keymanager": "0"
     }
   }
 }


### PR DESCRIPTION
TODO
* [x] Tests (also improves existing registry tests).