### PR TITLE
go/oasis-node: Support non-file signers in registry node init

### DIFF
--- a/.changelog/3011.bugfix.md
+++ b/.changelog/3011.bugfix.md
@@ -1,0 +1,1 @@
+go/oasis-node: Support non-file signers in registry node init

--- a/go/oasis-node/cmd/registry/node/node.go
+++ b/go/oasis-node/cmd/registry/node/node.go
@@ -155,9 +155,15 @@ func doInit(cmd *cobra.Command, args []string) { // nolint: gocyclo
 	}
 
 	// Provision the node identity.
-	nodeSignerFactory, err := fileSigner.NewFactory(dataDir, signature.SignerNode, signature.SignerP2P, signature.SignerConsensus)
+	nodeSignerFactory, err := cmdSigner.NewFactory(
+		cmdSigner.Backend(),
+		dataDir,
+		signature.SignerNode,
+		signature.SignerP2P,
+		signature.SignerConsensus,
+	)
 	if err != nil {
-		logger.Error("failed to create node identity signer factory",
+		logger.Error("failed to initialize signer backend",
 			"err", err,
 		)
 		os.Exit(1)


### PR DESCRIPTION
Fixes #3011 