### PR TITLE
go/oasis-node/cmd/stake: Make list command's verbose output consistent

### DIFF
--- a/.changelog/3016.breaking.md
+++ b/.changelog/3016.breaking.md
@@ -1,0 +1,5 @@
+go/oasis-node/cmd/stake: Make `list` command's verbose output consistent
+
+Change `oasis-node stake list --verbose` CLI command's output to not list
+all accounts' information as a single-line JSON string but rather output
+each account's JSON string on a separate line.

--- a/.changelog/3016.internal.md
+++ b/.changelog/3016.internal.md
@@ -1,0 +1,1 @@
+ci: Make Buildkite fail if desired tag of Docker CI image doesn't exist

--- a/go/oasis-node/cmd/stake/account.go
+++ b/go/oasis-node/cmd/stake/account.go
@@ -321,7 +321,7 @@ func registerAccountCmd() {
 }
 
 func init() {
-	accountInfoFlags.String(CfgAccountAddr, "", "Address of the account")
+	accountInfoFlags.String(CfgAccountAddr, "", "account address")
 	_ = viper.BindPFlags(accountInfoFlags)
 	accountInfoFlags.AddFlagSet(cmdFlags.RetriesFlags)
 	accountInfoFlags.AddFlagSet(cmdGrpc.ClientFlags)

--- a/go/oasis-node/cmd/stake/stake.go
+++ b/go/oasis-node/cmd/stake/stake.go
@@ -171,24 +171,28 @@ func doList(cmd *cobra.Command, args []string) {
 
 	ctx := context.Background()
 
-	var addrs []api.Address
+	var addresses []api.Address
 	doWithRetries(cmd, "query addresses", func() error {
 		var err error
-		addrs, err = client.Addresses(ctx, consensus.HeightLatest)
+		addresses, err = client.Addresses(ctx, consensus.HeightLatest)
 		return err
 	})
 
-	if cmdFlags.Verbose() {
-		accts := make(map[api.Address]*api.Account)
-		for _, v := range addrs {
-			accts[v] = getAccount(ctx, cmd, v, client)
+	for _, addr := range addresses {
+		var s string
+		switch cmdFlags.Verbose() {
+		case true:
+			// NOTE: getAccount()'s output doesn't contain an account's address,
+			// so we need to add it manually.
+			acctMap := make(map[api.Address]*api.Account)
+			acctMap[addr] = getAccount(ctx, cmd, addr, client)
+			b, _ := json.Marshal(acctMap)
+			s = string(b)
+		default:
+			s = addr.String()
 		}
-		b, _ := json.Marshal(accts)
-		fmt.Printf("%v\n", string(b))
-	} else {
-		for _, v := range addrs {
-			fmt.Printf("%v\n", v)
-		}
+
+		fmt.Printf("%v\n", s)
 	}
 }
 


### PR DESCRIPTION
Change `oasis-node stake list --verbose` CLI command's output to not list all accounts' information as a single-line JSON string but rather output each account's JSON string on a separate line.

This is consistent with the verbose outputs of the `oasis-node registry entity list` and `oasis-node registry node list` CLI commands.