### PR TITLE
worker/compute/executor: Independently submit commit in case of faults

### DIFF
--- a/.changelog/1807.feature.md
+++ b/.changelog/1807.feature.md
@@ -1,0 +1,1 @@
+worker/compute/executor: Independently submit commit in case of faults

--- a/go/common/crypto/signature/signature.go
+++ b/go/common/crypto/signature/signature.go
@@ -426,6 +426,14 @@ func (s *Signed) Open(context Context, dst interface{}) error {
 	return cbor.Unmarshal(s.Blob, dst)
 }
 
+// Equal compares vs another Signed for equality.
+func (s *Signed) Equal(cmp *Signed) bool {
+	if !s.Signature.Equal(&cmp.Signature) {
+		return false
+	}
+	return bytes.Equal(s.Blob, cmp.Blob)
+}
+
 // PrettySigned is used for pretty-printing signed messages so that
 // the actual content is displayed instead of the binary blob.
 //

--- a/go/keymanager/client/client.go
+++ b/go/keymanager/client/client.go
@@ -89,9 +89,14 @@ func (c *Client) CallRemote(ctx context.Context, data []byte) ([]byte, error) {
 			return err
 		case status.Code(err) == codes.Unavailable:
 			// XXX: HACK: Find a better way to determine the root cause.
-			if strings.Contains(err.Error(), "tls: bad public key") {
+			switch {
+			case strings.Contains(err.Error(), "tls: bad public key"):
 				// Retry as the access policy could be in the process of being updated.
 				return err
+			case strings.Contains(err.Error(), "last resolver error: produced zero addresses"):
+				// Retry as the connection may be in the process of being updated.
+				return err
+			default:
 			}
 
 			fallthrough

--- a/go/roothash/api/commitment/executor.go
+++ b/go/roothash/api/commitment/executor.go
@@ -148,7 +148,17 @@ func (c *ExecutorCommitment) Equal(cmp *ExecutorCommitment) bool {
 type OpenExecutorCommitment struct {
 	ExecutorCommitment
 
-	Body *ComputeBody `json:"body"`
+	Body *ComputeBody `json:"-"` // No need to serialize as it can be reconstructed.
+}
+
+// UnmarshalCBOR handles CBOR unmarshalling from passed data.
+func (c *OpenExecutorCommitment) UnmarshalCBOR(data []byte) error {
+	if err := cbor.Unmarshal(data, &c.ExecutorCommitment); err != nil {
+		return err
+	}
+
+	c.Body = new(ComputeBody)
+	return cbor.Unmarshal(c.Blob, c.Body)
 }
 
 // MostlyEqual returns true if the commitment is mostly equal to another

--- a/go/roothash/api/commitment/executor.go
+++ b/go/roothash/api/commitment/executor.go
@@ -136,6 +136,11 @@ type ExecutorCommitment struct {
 	signature.Signed
 }
 
+// Equal compares vs another ExecutorCommitment for equality.
+func (c *ExecutorCommitment) Equal(cmp *ExecutorCommitment) bool {
+	return c.Signed.Equal(&cmp.Signed)
+}
+
 // OpenExecutorCommitment is an executor commitment that has been verified and
 // deserialized.
 //

--- a/go/roothash/api/commitment/merge.go
+++ b/go/roothash/api/commitment/merge.go
@@ -25,6 +25,11 @@ type MergeCommitment struct {
 	signature.Signed
 }
 
+// Equal compares vs another MergeCommitment for equality.
+func (c *MergeCommitment) Equal(cmp *MergeCommitment) bool {
+	return c.Signed.Equal(&cmp.Signed)
+}
+
 // OpenMergeCommitment is a merge commitment that has been verified and
 // deserialized.
 //

--- a/go/roothash/api/commitment/merge.go
+++ b/go/roothash/api/commitment/merge.go
@@ -4,6 +4,7 @@ package commitment
 import (
 	"errors"
 
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
@@ -37,7 +38,17 @@ func (c *MergeCommitment) Equal(cmp *MergeCommitment) bool {
 type OpenMergeCommitment struct {
 	MergeCommitment
 
-	Body *MergeBody `json:"body"`
+	Body *MergeBody `json:"-"` // No need to serialize as it can be reconstructed.
+}
+
+// UnmarshalCBOR handles CBOR unmarshalling from passed data.
+func (c *OpenMergeCommitment) UnmarshalCBOR(data []byte) error {
+	if err := cbor.Unmarshal(data, &c.MergeCommitment); err != nil {
+		return err
+	}
+
+	c.Body = new(MergeBody)
+	return cbor.Unmarshal(c.Blob, c.Body)
 }
 
 // MostlyEqual returns true if the commitment is mostly equal to another

--- a/go/worker/compute/executor/committee/fault.go
+++ b/go/worker/compute/executor/committee/fault.go
@@ -1,0 +1,186 @@
+package committee
+
+import (
+	"context"
+	"time"
+
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
+	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
+)
+
+type faultSubmitter interface {
+	// SubmitExecutorCommit submits an executor commitment when a fault is detected.
+	SubmitExecutorCommit(ctx context.Context, commit *commitment.ExecutorCommitment) error
+}
+
+type nodeFaultSubmitter struct {
+	node *Node
+}
+
+// Implements faultSubmitter.
+func (nf *nodeFaultSubmitter) SubmitExecutorCommit(ctx context.Context, commit *commitment.ExecutorCommitment) error {
+	tx := roothash.NewExecutorCommitTx(0, nil, nf.node.commonNode.Runtime.ID(), []commitment.ExecutorCommitment{*commit})
+	return consensus.SignAndSubmitTx(ctx, nf.node.commonNode.Consensus, nf.node.commonNode.Identity.NodeSigner, tx)
+}
+
+func newNodeFaultSubmitter(node *Node) faultSubmitter {
+	return &nodeFaultSubmitter{node}
+}
+
+type faultDetector struct {
+	runtime   runtimeRegistry.Runtime
+	submitter faultSubmitter
+	commit    *commitment.ExecutorCommitment
+
+	quitCh  chan struct{}
+	eventCh chan *roothash.Event
+
+	logger *logging.Logger
+}
+
+func (d *faultDetector) notify(ev *roothash.Event) {
+	select {
+	case <-d.quitCh:
+		// In case the worker has quit, prevent blocking on the event channel.
+	case d.eventCh <- ev:
+	}
+}
+
+func (d *faultDetector) submit(ctx context.Context) {
+	d.logger.Warn("independently submitting executor commit")
+
+	err := d.submitter.SubmitExecutorCommit(ctx, d.commit)
+	switch err {
+	case nil:
+		d.logger.Info("independently submitted executor commit")
+	default:
+		d.logger.Error("failed to submit executor commit independently",
+			"err", err,
+		)
+	}
+}
+
+func (d *faultDetector) worker(ctx context.Context) {
+	// We should submit the commitment immediately in case when:
+	//
+	// - We see a merge commit that does not have our commitment.
+	// - We see an executor commit.
+	// - RoundTimeout elapses without seeing our commitment.
+	//
+	defer close(d.quitCh)
+
+	// Determine the round timeout and start a local timer.
+	rtDesc, err := d.runtime.RegistryDescriptor(ctx)
+	if err != nil {
+		d.logger.Error("failed to retrieve runtime registry descriptor",
+			"err", err,
+		)
+		return
+	}
+	// Add a small amount to compensate for network latency.
+	timer := time.NewTimer(rtDesc.Executor.RoundTimeout + 1*time.Second)
+
+	// Extract committee ID for easier comparison.
+	openCommit, err := d.commit.Open()
+	if err != nil {
+		// This should NEVER happen.
+		d.logger.Error("bad own commitment",
+			"err", err,
+		)
+		return
+	}
+
+	// TODO: Once we have P2P gossipsub also look at gossiped commitments in addition to consensus.
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			// Local round timeout expired.
+			d.logger.Warn("local round timeout expired without seeing our commitment")
+			go d.submit(ctx)
+			return
+		case ev := <-d.eventCh:
+			// Received a roothash event for our runtime.
+			switch {
+			case ev.ExecutorCommitted != nil:
+				// Executor committed independently, check if it is for our committee.
+				ec, err := ev.ExecutorCommitted.Commit.Open()
+				if err != nil {
+					// This should NEVER happen as the consensus backend verifies this.
+					d.logger.Error("bad executor commitment from consensus backend?",
+						"err", err,
+					)
+					continue
+				}
+
+				if !ec.Body.CommitteeID.Equal(&openCommit.Body.CommitteeID) {
+					continue
+				}
+
+				// If this is our own commit (in theory anyone could submit it on our behalf), we
+				// don't need to do anything.
+				if ec.Equal(d.commit) {
+					d.logger.Info("our commitment has been submitted to consensus layer by an external party")
+					return
+				}
+
+				// Executor committed independently, we should too as this means that so far we have
+				// not seen any separate commitments.
+				d.logger.Warn("seen another executor independently submit commitments, following",
+					"executor_node_id", ev.ExecutorCommitted.Commit.Signature.PublicKey,
+				)
+				go d.submit(ctx)
+				return
+			case ev.MergeCommitted != nil:
+				// Merge node committed. If our commit is included, then we can stop as there is at
+				// least one honest merge node.
+				mc, err := ev.MergeCommitted.Commit.Open()
+				if err != nil {
+					// This should NEVER happen as the consensus backend verifies this.
+					d.logger.Error("bad merge commitment from consensus backend?",
+						"err", err,
+					)
+					continue
+				}
+
+				for _, ec := range mc.Body.ExecutorCommits {
+					if ec.Equal(d.commit) {
+						// Found our commitment, stop right here.
+						d.logger.Info("our commitment has been submitted to consensus layer by an honest merge node")
+						return
+					}
+				}
+
+				// A merge node submitted commitments but didn't include ours.
+				d.logger.Warn("seen merge commitment without our commitment",
+					"merge_node_id", ev.MergeCommitted.Commit.Signature.PublicKey,
+				)
+				go d.submit(ctx)
+				return
+			}
+		}
+	}
+}
+
+func newFaultDetector(
+	ctx context.Context,
+	rt runtimeRegistry.Runtime,
+	commit *commitment.ExecutorCommitment,
+	submitter faultSubmitter,
+) *faultDetector {
+	d := &faultDetector{
+		runtime:   rt,
+		submitter: submitter,
+		commit:    commit,
+		quitCh:    make(chan struct{}),
+		eventCh:   make(chan *roothash.Event),
+		logger:    logging.GetLogger("worker/executor/committee/fault").With("runtime_id", rt.ID()),
+	}
+	go d.worker(ctx)
+	return d
+}

--- a/go/worker/compute/executor/committee/fault_test.go
+++ b/go/worker/compute/executor/committee/fault_test.go
@@ -1,0 +1,247 @@
+package committee
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
+	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
+	genesisTestHelpers "github.com/oasisprotocol/oasis-core/go/genesis/tests"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
+	"github.com/oasisprotocol/oasis-core/go/runtime/history"
+	"github.com/oasisprotocol/oasis-core/go/runtime/localstorage"
+	"github.com/oasisprotocol/oasis-core/go/runtime/tagindexer"
+	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
+)
+
+type testFaultSubmitter struct {
+	sync.Mutex
+
+	faults []commitment.ExecutorCommitment
+}
+
+// Implements faultSubmitter.
+func (tf *testFaultSubmitter) SubmitExecutorCommit(ctx context.Context, commit *commitment.ExecutorCommitment) error {
+	tf.Lock()
+	defer tf.Unlock()
+
+	tf.faults = append(tf.faults, *commit)
+	return nil
+}
+
+func (tf *testFaultSubmitter) getFaults() []commitment.ExecutorCommitment {
+	tf.Lock()
+	defer tf.Unlock()
+
+	return append([]commitment.ExecutorCommitment{}, tf.faults...)
+}
+
+type testRuntime struct {
+}
+
+// Implements runtimeRegistry.Runtime.
+func (rt *testRuntime) ID() common.Namespace {
+	return common.Namespace{}
+}
+
+// Implements runtimeRegistry.Runtime.
+func (rt *testRuntime) RegistryDescriptor(ctx context.Context) (*registry.Runtime, error) {
+	return &registry.Runtime{}, nil
+}
+
+// Implements runtimeRegistry.Runtime.
+func (rt *testRuntime) WatchRegistryDescriptor() (<-chan *registry.Runtime, pubsub.ClosableSubscription, error) {
+	panic("not implemented")
+}
+
+// Implements runtimeRegistry.Runtime.
+func (rt *testRuntime) History() history.History {
+	panic("not implemented")
+}
+
+// Implements runtimeRegistry.Runtime.
+func (rt *testRuntime) TagIndexer() tagindexer.QueryableBackend {
+	panic("not implemented")
+}
+
+// Implements runtimeRegistry.Runtime.
+func (rt *testRuntime) Storage() storage.Backend {
+	panic("not implemented")
+}
+
+// Implements runtimeRegistry.Runtime.
+func (rt *testRuntime) LocalStorage() localstorage.LocalStorage {
+	panic("not implemented")
+}
+
+func TestFaultDetector(t *testing.T) {
+	require := require.New(t)
+
+	genesisTestHelpers.SetTestChainContext()
+
+	signer := memorySigner.NewTestSigner("worker/compute/executor/committee/fault test")
+	commit, err := commitment.SignExecutorCommitment(signer, &commitment.ComputeBody{})
+	require.NoError(err, "SignExecutorCommitment")
+
+	rt := testRuntime{}
+
+	for _, tc := range []struct {
+		name string
+		fn   func(*testing.T, *faultDetector, *testFaultSubmitter, *commitment.ExecutorCommitment)
+	}{
+		{"Timeout", testFaultDetectorTimeout},
+		{"EarlyExecutor", testFaultDetectorEarlyExecutor},
+		{"ExternalSubmission", testFaultDetectorExternalSubmission},
+		{"FaultyMerge", testFaultDetectorFaultyMerge},
+		{"HonestMerge", testFaultDetectorHonestMerge},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tf := testFaultSubmitter{}
+			fd := newFaultDetector(ctx, &rt, commit, &tf)
+
+			tc.fn(t, fd, &tf, commit)
+		})
+	}
+}
+
+func testFaultDetectorTimeout(t *testing.T, fd *faultDetector, tf *testFaultSubmitter, commit *commitment.ExecutorCommitment) {
+	require := require.New(t)
+
+	// The fault detector should timeout in one second even if we don't do any notifies.
+	time.Sleep(1200 * time.Millisecond)
+
+	faults := tf.getFaults()
+	require.Len(faults, 1, "fault detector should submit commitment after timeout")
+	require.EqualValues(*commit, faults[0], "the submitted commitment should be the same")
+}
+
+func testFaultDetectorEarlyExecutor(t *testing.T, fd *faultDetector, tf *testFaultSubmitter, commit *commitment.ExecutorCommitment) {
+	require := require.New(t)
+
+	signer := memorySigner.NewTestSigner("worker/compute/executor/committee/fault test: EarlyExecutor")
+	earlyCommit, err := commitment.SignExecutorCommitment(signer, &commitment.ComputeBody{
+		CommitteeID: hash.NewFromBytes([]byte("EarlyExecutorBadCommitteeID")),
+	})
+	require.NoError(err, "SignExecutorCommitment")
+
+	// Nothing should happen if the commitee ID doesn't match.
+	fd.notify(&roothash.Event{
+		ExecutorCommitted: &roothash.ExecutorCommittedEvent{
+			Commit: *earlyCommit,
+		},
+	})
+	// Give the fault detector some time to process requests.
+	time.Sleep(100 * time.Millisecond)
+	// There should be no submissions.
+	faults := tf.getFaults()
+	require.Len(faults, 0, "fault detector should not submit anything in case of events for other committees")
+
+	// Notify the detector of an early executor submitting their commitment.
+	earlyCommit, err = commitment.SignExecutorCommitment(signer, &commitment.ComputeBody{})
+	require.NoError(err, "SignExecutorCommitment")
+
+	fd.notify(&roothash.Event{
+		ExecutorCommitted: &roothash.ExecutorCommittedEvent{
+			Commit: *earlyCommit,
+		},
+	})
+	// Give the fault detector some time to process requests.
+	time.Sleep(100 * time.Millisecond)
+	// There should be a submission.
+	faults = tf.getFaults()
+	require.Len(faults, 1, "fault detector should submit commitment after early executor")
+	require.EqualValues(*commit, faults[0], "the submitted commitment should be the same")
+}
+
+func testFaultDetectorExternalSubmission(t *testing.T, fd *faultDetector, tf *testFaultSubmitter, commit *commitment.ExecutorCommitment) {
+	require := require.New(t)
+
+	// Notify the detector of an external process submitting our commitment.
+	fd.notify(&roothash.Event{
+		ExecutorCommitted: &roothash.ExecutorCommittedEvent{
+			Commit: *commit,
+		},
+	})
+	// Give the fault detector some time to process requests.
+	time.Sleep(100 * time.Millisecond)
+	// There should not be a submission.
+	faults := tf.getFaults()
+	require.Len(faults, 0, "fault detector should not submit commitment after seeing own commit")
+
+	// The fault detector should stop after seeing an honest merge node, so even waiting for the
+	// timeout amount should not trigger it.
+	time.Sleep(1200 * time.Millisecond)
+
+	faults = tf.getFaults()
+	require.Len(faults, 0, "fault detector should be stopped")
+}
+
+func testFaultDetectorFaultyMerge(t *testing.T, fd *faultDetector, tf *testFaultSubmitter, commit *commitment.ExecutorCommitment) {
+	require := require.New(t)
+
+	signer := memorySigner.NewTestSigner("worker/compute/executor/committee/fault test: FaultyMerge")
+	earlyCommit, err := commitment.SignExecutorCommitment(signer, &commitment.ComputeBody{})
+	require.NoError(err, "SignExecutorCommitment")
+
+	mergeCommit, err := commitment.SignMergeCommitment(signer, &commitment.MergeBody{
+		ExecutorCommits: []commitment.ExecutorCommitment{*earlyCommit},
+	})
+	require.NoError(err, "SignMergeCommitment")
+
+	// Notify the detector of a merge commit that does not include own commit.
+	fd.notify(&roothash.Event{
+		MergeCommitted: &roothash.MergeCommittedEvent{
+			Commit: *mergeCommit,
+		},
+	})
+	// Give the fault detector some time to process requests.
+	time.Sleep(100 * time.Millisecond)
+	// There should be a submission.
+	faults := tf.getFaults()
+	require.Len(faults, 1, "fault detector should submit commitment after merge without own commit")
+	require.EqualValues(*commit, faults[0], "the submitted commitment should be the same")
+}
+
+func testFaultDetectorHonestMerge(t *testing.T, fd *faultDetector, tf *testFaultSubmitter, commit *commitment.ExecutorCommitment) {
+	require := require.New(t)
+
+	signer := memorySigner.NewTestSigner("worker/compute/executor/committee/fault test: HonestMerge")
+	earlyCommit, err := commitment.SignExecutorCommitment(signer, &commitment.ComputeBody{})
+	require.NoError(err, "SignExecutorCommitment")
+
+	// Merge commit that includes our commit -- should not trigger a submission.
+	mergeCommit, err := commitment.SignMergeCommitment(signer, &commitment.MergeBody{
+		ExecutorCommits: []commitment.ExecutorCommitment{*commit, *earlyCommit},
+	})
+	require.NoError(err, "SignMergeCommitment")
+
+	// Notify the detector of a merge commit that includes own commit.
+	fd.notify(&roothash.Event{
+		MergeCommitted: &roothash.MergeCommittedEvent{
+			Commit: *mergeCommit,
+		},
+	})
+	// Give the fault detector some time to process requests.
+	time.Sleep(100 * time.Millisecond)
+	// There should not be a submission.
+	faults := tf.getFaults()
+	require.Len(faults, 0, "fault detector should not submit commitment after merge without own commit")
+
+	// The fault detector should stop after seeing an honest merge node, so even waiting for the
+	// timeout amount should not trigger it.
+	time.Sleep(1200 * time.Millisecond)
+
+	faults = tf.getFaults()
+	require.Len(faults, 0, "fault detector should be stopped")
+}


### PR DESCRIPTION
Fixes #1807 

TODO
* [x] Tests.