### PR TITLE
go/registry: Add MinWriteReplication to runtime storage parameters

### DIFF
--- a/.changelog/1821.breaking.md
+++ b/.changelog/1821.breaking.md
@@ -1,0 +1,4 @@
+go/registry: Add MinWriteReplication to runtime storage parameters
+
+The MinWriteReplication specifies the minimum number of nodes to which any
+writes must be replicated before being assumed to be committed.

--- a/.changelog/1821.feature.md
+++ b/.changelog/1821.feature.md
@@ -1,0 +1,1 @@
+go/storage/client: Use MinWriteReplication when waiting for writes

--- a/.changelog/3021.bugfix.md
+++ b/.changelog/3021.bugfix.md
@@ -1,0 +1,1 @@
+go/worker/storage: Fix storage node policy

--- a/.changelog/3021.internal.md
+++ b/.changelog/3021.internal.md
@@ -1,0 +1,1 @@
+go/oasis-test-runner: Use common cli package for provisioning runtimes

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -205,6 +205,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 		},
 		Storage: registry.StorageParameters{
 			GroupSize:               1,
+			MinWriteReplication:     1,
 			MaxApplyWriteLogEntries: 100_000,
 			MaxApplyOps:             2,
 			MaxMergeRoots:           8,

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -98,6 +98,7 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 				},
 				Storage: registry.StorageParameters{
 					GroupSize:               1,
+					MinWriteReplication:     1,
 					MaxApplyWriteLogEntries: 100_000,
 					MaxApplyOps:             2,
 					MaxMergeRoots:           8,

--- a/go/oasis-node/cmd/debug/storage/benchmark.go
+++ b/go/oasis-node/cmd/debug/storage/benchmark.go
@@ -82,7 +82,7 @@ func doBenchmark(cmd *cobra.Command, args []string) { // nolint: gocyclo
 
 	var ns common.Namespace
 
-	storage, err := storage.New(context.Background(), dataDir, ns, ident, nil, nil)
+	storage, err := storage.New(context.Background(), dataDir, ns, ident)
 	if err != nil {
 		logger.Error("failed to initialize storage",
 			"err", err,

--- a/go/oasis-node/cmd/debug/storage/export.go
+++ b/go/oasis-node/cmd/debug/storage/export.go
@@ -172,7 +172,7 @@ func newDirectStorageBackend(dataDir string, namespace common.Namespace) (storag
 		cfg.DB = filepath.Join(cfg.DB, storageDatabase.DefaultFileName(cfg.Backend))
 		return storageDatabase.New(cfg)
 	case storageClient.BackendName:
-		return storageClient.New(context.Background(), namespace, nil, nil, nil)
+		return storageClient.New(context.Background(), namespace, nil, nil, nil, nil)
 	default:
 		return nil, fmt.Errorf("storage: unsupported backend: '%v'", cfg.Backend)
 	}

--- a/go/oasis-node/cmd/debug/txsource/workload/registration.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/registration.go
@@ -64,6 +64,7 @@ func getRuntime(entityID signature.PublicKey, id common.Namespace) *registry.Run
 		},
 		Storage: registry.StorageParameters{
 			GroupSize:               1,
+			MinWriteReplication:     1,
 			MaxApplyWriteLogEntries: 100_000,
 			MaxApplyOps:             2,
 			MaxMergeRoots:           8,

--- a/go/oasis-node/cmd/registry/runtime/runtime.go
+++ b/go/oasis-node/cmd/registry/runtime/runtime.go
@@ -61,6 +61,7 @@ const (
 
 	// Storage committee flags.
 	CfgStorageGroupSize               = "runtime.storage.group_size"
+	CfgStorageMinWriteReplication     = "runtime.storage.min_write_replication"
 	CfgStorageMaxApplyWriteLogEntries = "runtime.storage.max_apply_write_log_entries"
 	CfgStorageMaxApplyOps             = "runtime.storage.max_apply_ops"
 	CfgStorageMaxMergeRoots           = "runtime.storage.max_merge_roots"
@@ -389,6 +390,7 @@ func runtimeFromFlags() (*registry.Runtime, signature.Signer, error) { // nolint
 		},
 		Storage: registry.StorageParameters{
 			GroupSize:               viper.GetUint64(CfgStorageGroupSize),
+			MinWriteReplication:     viper.GetUint64(CfgStorageMinWriteReplication),
 			MaxApplyWriteLogEntries: viper.GetUint64(CfgStorageMaxApplyWriteLogEntries),
 			MaxApplyOps:             viper.GetUint64(CfgStorageMaxApplyOps),
 			MaxMergeRoots:           viper.GetUint64(CfgStorageMaxMergeRoots),
@@ -557,6 +559,7 @@ func init() {
 
 	// Init Storage committee flags.
 	runtimeFlags.Uint64(CfgStorageGroupSize, 1, "Number of storage nodes for the runtime")
+	runtimeFlags.Uint64(CfgStorageMinWriteReplication, 1, "Minimum required storage write replication")
 	runtimeFlags.Uint64(CfgStorageMaxApplyWriteLogEntries, 100_000, "Maximum number of write log entries")
 	runtimeFlags.Uint64(CfgStorageMaxApplyOps, 2, "Maximum number of apply operations in a batch")
 	runtimeFlags.Uint64(CfgStorageMaxMergeRoots, 8, "Maximum number of merge roots")

--- a/go/oasis-node/node_test.go
+++ b/go/oasis-node/node_test.go
@@ -394,7 +394,7 @@ func testStorage(t *testing.T, node *testNode) {
 	require.NoError(t, err, "TempDir")
 	defer os.RemoveAll(dataDir)
 
-	backend, err := storage.New(context.Background(), dataDir, testRuntimeID, node.Identity, node.Consensus.Scheduler(), node.Consensus.Registry())
+	backend, err := storage.New(context.Background(), dataDir, testRuntimeID, node.Identity)
 	require.NoError(t, err, "storage.New")
 	defer backend.Cleanup()
 	// We are always testing a local storage backend here.

--- a/go/oasis-node/node_test.go
+++ b/go/oasis-node/node_test.go
@@ -102,6 +102,7 @@ var (
 		},
 		Storage: registry.StorageParameters{
 			GroupSize:               1,
+			MinWriteReplication:     1,
 			MaxApplyWriteLogEntries: 100_000,
 			MaxApplyOps:             2,
 			MaxMergeRoots:           8,

--- a/go/oasis-test-runner/env/env.go
+++ b/go/oasis-test-runner/env/env.go
@@ -20,6 +20,11 @@ import (
 // sub-process termiantes prior to the Cleanup.
 var ErrEarlyTerm = errors.New("env: sub-process exited early")
 
+// CmdAttrs is the SysProcAttr that will ensure graceful cleanup.
+var CmdAttrs = &syscall.SysProcAttr{
+	Pdeathsig: syscall.SIGKILL,
+}
+
 // CleanupFn is the cleanup hook function prototype.
 type CleanupFn func()
 

--- a/go/oasis-test-runner/oasis/cli/consensus.go
+++ b/go/oasis-test-runner/oasis/cli/consensus.go
@@ -20,7 +20,7 @@ func (c *ConsensusHelpers) SubmitTx(txPath string) error {
 	args := []string{
 		"consensus", "submit_tx",
 		"--" + consensus.CfgTxFile, txPath,
-		"--" + grpc.CfgAddress, "unix:" + c.net.Validators()[0].SocketPath(),
+		"--" + grpc.CfgAddress, "unix:" + c.cfg.NodeSocketPath,
 		"--" + common.CfgDebugAllowTestKeys,
 	}
 	if err := c.runSubCommand("consensus-submit_tx", args); err != nil {

--- a/go/oasis-test-runner/oasis/cli/keymanager.go
+++ b/go/oasis-test-runner/oasis/cli/keymanager.go
@@ -101,7 +101,7 @@ func (k *KeymanagerHelpers) GenUpdate(nonce uint64, polPath string, polSigPaths 
 		"--" + flags.CfgDebugDontBlameOasis,
 		"--" + cmdCommon.CfgDebugAllowTestKeys,
 		"--" + flags.CfgDebugTestEntity,
-		"--" + flags.CfgGenesisFile, k.net.GenesisPath(),
+		"--" + flags.CfgGenesisFile, k.cfg.GenesisFile,
 	}
 	for _, sigPath := range polSigPaths {
 		args = append(args, "--"+cmdKM.CfgPolicySigFile, sigPath)

--- a/go/oasis-test-runner/oasis/cli/registry.go
+++ b/go/oasis-test-runner/oasis/cli/registry.go
@@ -63,6 +63,7 @@ func (r *RegistryHelpers) runRegistryRuntimeSubcommand(
 			"--"+cmdRegRt.CfgMergeAllowedStragglers, strconv.FormatUint(runtime.Merge.AllowedStragglers, 10),
 			"--"+cmdRegRt.CfgMergeRoundTimeout, runtime.Merge.RoundTimeout.String(),
 			"--"+cmdRegRt.CfgStorageGroupSize, strconv.FormatUint(runtime.Storage.GroupSize, 10),
+			"--"+cmdRegRt.CfgStorageMinWriteReplication, strconv.FormatUint(runtime.Storage.MinWriteReplication, 10),
 			"--"+cmdRegRt.CfgStorageMaxApplyWriteLogEntries, strconv.FormatUint(runtime.Storage.MaxApplyWriteLogEntries, 10),
 			"--"+cmdRegRt.CfgStorageMaxApplyOps, strconv.FormatUint(runtime.Storage.MaxApplyOps, 10),
 			"--"+cmdRegRt.CfgStorageMaxMergeRoots, strconv.FormatUint(runtime.Storage.MaxMergeRoots, 10),

--- a/go/oasis-test-runner/scenario/e2e/multiple_runtimes.go
+++ b/go/oasis-test-runner/scenario/e2e/multiple_runtimes.go
@@ -107,6 +107,7 @@ func (mr *multipleRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
 			},
 			Storage: registry.StorageParameters{
 				GroupSize:               1,
+				MinWriteReplication:     1,
 				MaxApplyWriteLogEntries: 100_000,
 				MaxApplyOps:             2,
 				MaxMergeRoots:           8,

--- a/go/oasis-test-runner/scenario/e2e/registry_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/registry_cli.go
@@ -634,6 +634,7 @@ func (r *registryCLIImpl) testRuntime(childEnv *env.Env, cli *cli.Helpers) error
 		},
 		Storage: registry.StorageParameters{
 			GroupSize:               9,
+			MinWriteReplication:     9,
 			MaxApplyWriteLogEntries: 10,
 			MaxApplyOps:             11,
 			MaxMergeRoots:           12,

--- a/go/oasis-test-runner/scenario/e2e/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime.go
@@ -177,6 +177,7 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 				},
 				Storage: registry.StorageParameters{
 					GroupSize:               2,
+					MinWriteReplication:     2,
 					MaxApplyWriteLogEntries: 100_000,
 					MaxApplyOps:             2,
 					MaxMergeRoots:           8,

--- a/go/oasis-test-runner/scenario/e2e/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime.go
@@ -269,13 +269,13 @@ func (sc *runtimeImpl) resolveDefaultKeyManagerBinary() (string, error) {
 	return sc.resolveRuntimeBinary("simple-keymanager")
 }
 
-func (sc *runtimeImpl) startClient(env *env.Env) (*exec.Cmd, error) {
+func (sc *runtimeImpl) startClient(childEnv *env.Env) (*exec.Cmd, error) {
 	clients := sc.net.Clients()
 	if len(clients) == 0 {
 		return nil, fmt.Errorf("scenario/e2e: network has no client nodes")
 	}
 
-	d, err := env.NewSubDir("client")
+	d, err := childEnv.NewSubDir("client")
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +293,7 @@ func (sc *runtimeImpl) startClient(env *env.Env) (*exec.Cmd, error) {
 
 	binary := sc.resolveClientBinary(sc.clientBinary)
 	cmd := exec.Command(binary, args...)
-	cmd.SysProcAttr = oasis.CmdAttrs
+	cmd.SysProcAttr = env.CmdAttrs
 	cmd.Stdout = w
 	cmd.Stderr = w
 

--- a/go/oasis-test-runner/scenario/e2e/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/txsource.go
@@ -316,7 +316,7 @@ func (sc *txSourceImpl) startWorkload(childEnv *env.Env, errCh chan error, name 
 	nodeBinary := sc.net.Config().NodeBinary
 
 	cmd := exec.Command(nodeBinary, args...)
-	cmd.SysProcAttr = oasis.CmdAttrs
+	cmd.SysProcAttr = env.CmdAttrs
 	cmd.Stdout = w
 	cmd.Stderr = w
 

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -1116,6 +1116,18 @@ func VerifyRegisterRuntimeStorageArgs(rt *Runtime, logger *logging.Logger) error
 		)
 		return fmt.Errorf("%w: storage group too small", ErrInvalidArgument)
 	}
+	if params.MinWriteReplication == 0 {
+		logger.Error("RegisterRuntime: storage write replication factor is zero",
+			"runtime", rt,
+		)
+		return fmt.Errorf("%w: storage write replication factor must be non-zero", ErrInvalidArgument)
+	}
+	if params.MinWriteReplication > params.GroupSize {
+		logger.Error("RegisterRuntime: storage write replication factor is too high",
+			"runtime", rt,
+		)
+		return fmt.Errorf("%w: storage write replication factor must be less than or equal to group size", ErrInvalidArgument)
+	}
 
 	// Ensure limit parameters have sensible values.
 	if params.MaxApplyWriteLogEntries < 10 {

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -133,6 +133,10 @@ type StorageParameters struct {
 	// GroupSize is the size of the storage group.
 	GroupSize uint64 `json:"group_size"`
 
+	// MinWriteReplication is the number of nodes to which any writes must be replicated before
+	// being assumed to be committed. It must be less than or equal to the GroupSize.
+	MinWriteReplication uint64 `json:"min_write_replication"`
+
 	// MaxApplyWriteLogEntries is the maximum number of write log entries when performing an Apply
 	// operation.
 	MaxApplyWriteLogEntries uint64 `json:"max_apply_write_log_entries"`

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -425,4 +426,11 @@ func (rtg *RuntimeGenesis) SanityCheck(isGenesis bool) error {
 	}
 
 	return nil
+}
+
+// RuntimeDescriptorProvider is an interface that provides access to runtime descriptors.
+type RuntimeDescriptorProvider interface {
+	// RegistryDescriptor waits for the runtime to be registered and then returns its registry
+	// descriptor.
+	RegistryDescriptor(ctx context.Context) (*Runtime, error)
 }

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -632,6 +632,33 @@ func testRegistryRuntime(t *testing.T, backend api.Backend, consensus consensusA
 			false,
 			false,
 		},
+		// Runtime with zero minimum storage write replication.
+		{
+			"WithZeroStorageMinWriteReplication",
+			func(rt *api.Runtime) {
+				rt.Storage.MinWriteReplication = 0
+			},
+			false,
+			false,
+		},
+		// Runtime with too high storage write replication.
+		{
+			"WithTooHighStorageMinWriteReplication",
+			func(rt *api.Runtime) {
+				rt.Storage.MinWriteReplication = rt.Storage.GroupSize + 1
+			},
+			false,
+			false,
+		},
+		// Runtime with valid, but not equal to group size storage write replication.
+		{
+			"WithValidStorageMinWriteReplication",
+			func(rt *api.Runtime) {
+				rt.Storage.MinWriteReplication = rt.Storage.GroupSize - 1
+			},
+			false,
+			true,
+		},
 	}
 
 	rtMap := make(map[common.Namespace]*api.Runtime)
@@ -1472,6 +1499,7 @@ func NewTestRuntime(seed []byte, ent *TestEntity, isKeyManager bool) (*TestRunti
 		},
 		Storage: api.StorageParameters{
 			GroupSize:               3,
+			MinWriteReplication:     3,
 			MaxApplyWriteLogEntries: 100_000,
 			MaxApplyOps:             2,
 			MaxMergeRoots:           8,

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -237,7 +237,7 @@ func (s *runtimeState) testSuccessfulRound(t *testing.T, backend api.Backend, co
 	var ns common.Namespace
 	copy(ns[:], rt.Runtime.ID[:])
 
-	storageBackend, err := storage.New(context.Background(), dataDir, ns, identity, consensus.Scheduler(), consensus.Registry())
+	storageBackend, err := storage.New(context.Background(), dataDir, ns, identity)
 	require.NoError(err, "storage.New")
 	defer storageBackend.Cleanup()
 

--- a/go/scheduler/tests/tester.go
+++ b/go/scheduler/tests/tester.go
@@ -133,6 +133,7 @@ func SchedulerImplementationTests(t *testing.T, name string, backend api.Backend
 	rt.Runtime.Executor.GroupSize = 2
 	rt.Runtime.Executor.GroupBackupSize = 1
 	rt.Runtime.Storage.GroupSize = 1
+	rt.Runtime.Storage.MinWriteReplication = 1
 	rt.MustRegister(t, consensus.Registry(), consensus)
 
 	epoch = epochtimeTests.MustAdvanceEpoch(t, epochtime, 1)

--- a/go/storage/client/init.go
+++ b/go/storage/client/init.go
@@ -22,6 +22,7 @@ func newClient(
 	namespace common.Namespace,
 	ident *identity.Identity,
 	nodes committee.NodeDescriptorLookup,
+	runtime registry.RuntimeDescriptorProvider,
 ) (api.Backend, error) {
 	committeeClient, err := committee.NewClient(ctx, nodes, committee.WithClientAuthentication(ident))
 	if err != nil {
@@ -32,6 +33,7 @@ func newClient(
 		ctx:             ctx,
 		logger:          logging.GetLogger("storage/client"),
 		committeeClient: committeeClient,
+		runtime:         runtime,
 	}
 	return b, nil
 }
@@ -43,6 +45,7 @@ func New(
 	ident *identity.Identity,
 	schedulerBackend scheduler.Backend,
 	registryBackend registry.Backend,
+	runtime registry.RuntimeDescriptorProvider,
 ) (api.Backend, error) {
 	committeeWatcher, err := committee.NewWatcher(
 		ctx,
@@ -56,7 +59,7 @@ func New(
 		return nil, fmt.Errorf("storage/client: failed to create committee watcher: %w", err)
 	}
 
-	return newClient(ctx, namespace, ident, committeeWatcher.Nodes())
+	return newClient(ctx, namespace, ident, committeeWatcher.Nodes(), runtime)
 }
 
 // NewStatic creates a new storage client that only follows a specific storage node. This is mostly
@@ -73,7 +76,7 @@ func NewStatic(
 		return nil, fmt.Errorf("storage/client: failed to create node descriptor watcher: %w", err)
 	}
 
-	client, err := newClient(ctx, namespace, ident, nw)
+	client, err := newClient(ctx, namespace, ident, nw, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go/storage/client/tests/tests.go
+++ b/go/storage/client/tests/tests.go
@@ -42,7 +42,7 @@ func ClientWorkerTests(
 	ns := rt.Runtime.ID
 
 	// Initialize storage client.
-	client, err := storageClient.New(ctx, ns, identity, consensus.Scheduler(), consensus.Registry())
+	client, err := storageClient.New(ctx, ns, identity, consensus.Scheduler(), consensus.Registry(), nil)
 	require.NoError(err, "NewStorageClient")
 
 	// Create mock root hash.

--- a/go/storage/fuzz/fuzz.go
+++ b/go/storage/fuzz/fuzz.go
@@ -41,7 +41,7 @@ func init() {
 	}
 
 	// Create the storage backend service.
-	storageBackend, err = storage.New(context.Background(), localDB, common.Namespace{}, identity, nil, nil)
+	storageBackend, err = storage.New(context.Background(), localDB, common.Namespace{}, identity)
 	if err != nil {
 		panic(err)
 	}

--- a/go/worker/compute/executor/committee/node.go
+++ b/go/worker/compute/executor/committee/node.go
@@ -247,6 +247,21 @@ func (n *Node) queueBatchBlocking(
 		)
 		return errInvalidReceipt
 	}
+	// Make sure there are enough signatures.
+	rt, err := n.commonNode.Runtime.RegistryDescriptor(ctx)
+	if err != nil {
+		n.logger.Warn("failed to fetch runtime registry descriptor",
+			"err", err,
+		)
+		return err
+	}
+	if uint64(len(storageSignatures)) < rt.Storage.MinWriteReplication {
+		n.logger.Warn("received external batch with not enough storage receipts",
+			"min_write_replication", rt.Storage.MinWriteReplication,
+			"num_receipts", len(storageSignatures),
+		)
+		return errInvalidReceipt
+	}
 
 	receiptBody := storage.ReceiptBody{
 		Version:   1,

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -228,7 +228,14 @@ func NewNode(
 	node.ctx, node.ctxCancel = context.WithCancel(context.Background())
 
 	// Create a new storage client that will be used for remote sync.
-	scl, err := client.New(node.ctx, commonNode.Runtime.ID(), node.commonNode.Identity, node.commonNode.Consensus.Scheduler(), node.commonNode.Consensus.Registry())
+	scl, err := client.New(
+		node.ctx,
+		commonNode.Runtime.ID(),
+		node.commonNode.Identity,
+		node.commonNode.Consensus.Scheduler(),
+		node.commonNode.Consensus.Registry(),
+		nil,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("storage worker: failed to create client: %w", err)
 	}

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -342,11 +342,21 @@ func (n *Node) updateExternalServicePolicyLocked(snapshot *committee.EpochSnapsh
 	// TODO: Query registry only for storage nodes after
 	// https://github.com/oasisprotocol/oasis-core/issues/1923 is implemented.
 	nodes, err := n.commonNode.Consensus.Registry().GetNodes(context.Background(), snapshot.GetGroupVersion())
-	if nodes != nil {
-		storageNodesPolicy.AddRulesForNodeRoles(&policy, nodes, node.RoleStorageWorker)
-	} else {
+	if err != nil {
 		n.logger.Error("couldn't get nodes from registry", "err", err)
 	}
+	if len(nodes) > 0 {
+		// Only include nodes for our runtime, do not include all storage nodes.
+		var rtNodes []*node.Node
+		for _, storageNode := range nodes {
+			if storageNode.GetRuntime(n.commonNode.Runtime.ID()) != nil {
+				rtNodes = append(rtNodes, storageNode)
+			}
+		}
+
+		storageNodesPolicy.AddRulesForNodeRoles(&policy, rtNodes, node.RoleStorageWorker)
+	}
+
 	// Update storage gRPC access policy for the current runtime.
 	n.grpcPolicy.SetAccessPolicy(policy, n.commonNode.Runtime.ID())
 	n.logger.Debug("set new storage gRPC access policy", "policy", policy)

--- a/go/worker/storage/committee/policy.go
+++ b/go/worker/storage/committee/policy.go
@@ -40,6 +40,8 @@ var (
 	sentryNodesPolicy = &committee.AccessPolicy{
 		Actions: []accessctl.Action{
 			accessctl.Action(api.MethodGetDiff.FullName()),
+			accessctl.Action(api.MethodGetCheckpoints.FullName()),
+			accessctl.Action(api.MethodGetCheckpointChunk.FullName()),
 			accessctl.Action(api.MethodApply.FullName()),
 			accessctl.Action(api.MethodApplyBatch.FullName()),
 			accessctl.Action(api.MethodMerge.FullName()),

--- a/tests/fixture-data/net-runner/default.json
+++ b/tests/fixture-data/net-runner/default.json
@@ -60,6 +60,7 @@
             },
             "storage": {
                 "group_size": 0,
+                "min_write_replication": 0,
                 "max_apply_write_log_entries": 0,
                 "max_apply_ops": 0,
                 "max_merge_roots": 0,
@@ -109,6 +110,7 @@
             },
             "storage": {
                 "group_size": 1,
+                "min_write_replication": 1,
                 "max_apply_write_log_entries": 100000,
                 "max_apply_ops": 2,
                 "max_merge_roots": 8,


### PR DESCRIPTION
Fixes #1821

TODO
* [x] Commitment pool tests.
* [x] Registry tests.
* [x] Update storage client to only wait for MinWriteReplication writes.
