### PR TITLE
runtime/dispatcher: Break recv loop on abort request

### DIFF
--- a/.changelog/3023.bugfix.md
+++ b/.changelog/3023.bugfix.md
@@ -1,0 +1,1 @@
+runtime/dispatcher: Break recv loop on abort request

--- a/runtime/src/protocol.rs
+++ b/runtime/src/protocol.rs
@@ -268,10 +268,10 @@ impl Protocol {
                 info!(self.logger, "Received worker shutdown request");
                 Err(ProtocolError::MethodNotSupported.into())
             }
-            Body::RuntimeAbortRequest {} => {
+            req @ Body::RuntimeAbortRequest {} => {
                 info!(self.logger, "Received worker abort request");
                 self.can_handle_runtime_requests()?;
-                self.dispatcher.abort_and_wait()?;
+                self.dispatcher.abort_and_wait(ctx, id, req)?;
                 info!(self.logger, "Handled worker abort request");
                 Ok(Some(Body::RuntimeAbortResponse {}))
             }


### PR DESCRIPTION
Ideally this should be caught by: 
https://github.com/oasisprotocol/oasis-core/blob/b7b2c4201e91d06fb5f5bae84e35a3af51444926/go/runtime/host/tests/tester.go#L180-L196

But the problem is that the `Abort` request makes it to the dispatcher before the first iteration of the dispatch loop, therefore the request is handled before the dispatcher is stuck in the `recv` loop. 
 Updated the test to do another abort which also handles the case where dispatcher is stuck in the `recv` loop.