### PR TITLE
go/common/encoding/bech32: Replace to-be-removed dependency

### DIFF
--- a/.changelog/3030.internal.md
+++ b/.changelog/3030.internal.md
@@ -1,0 +1,1 @@
+go/common/encoding/bech32: Replace to-be-removed dependency

--- a/go/common/encoding/bech32/bech32.go
+++ b/go/common/encoding/bech32/bech32.go
@@ -2,14 +2,32 @@
 // BIP 173: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki.
 package bech32
 
-import "github.com/tendermint/tendermint/libs/bech32"
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcutil/bech32"
+)
 
 // Encode encodes 8-bits per byte byte-slice to a Bech32-encoded string.
 func Encode(hrp string, data []byte) (string, error) {
-	return bech32.ConvertAndEncode(hrp, data)
+	// NOTE: Taken from github.com/tendermint/tendermint/libs/bech32 (licensed under Apache-2).
+	converted, err := bech32.ConvertBits(data, 8, 5, true)
+	if err != nil {
+		return "", fmt.Errorf("encoding bech32 failed: %w", err)
+	}
+	return bech32.Encode(hrp, converted)
 }
 
 // Decode decodes a Bech32-encoded string to a 8-bits per byte byte-slice.
 func Decode(text string) (string, []byte, error) {
-	return bech32.DecodeAndConvert(text)
+	// NOTE: Taken from github.com/tendermint/tendermint/libs/bech32 (licensed under Apache-2).
+	hrp, data, err := bech32.Decode(text)
+	if err != nil {
+		return "", nil, fmt.Errorf("decoding bech32 failed: %w", err)
+	}
+	converted, err := bech32.ConvertBits(data, 5, 8, false)
+	if err != nil {
+		return "", nil, fmt.Errorf("decoding bech32 failed: %w", err)
+	}
+	return hrp, converted, nil
 }

--- a/go/go.mod
+++ b/go/go.mod
@@ -14,6 +14,7 @@ replace (
 
 require (
 	github.com/blevesearch/bleve v1.0.9
+	github.com/btcsuite/btcutil v1.0.2
 	github.com/cenkalti/backoff/v4 v4.0.0
 	github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d // indirect
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 // indirect


### PR DESCRIPTION
The github.com/tendermint/tendermint/libs/bech32 module has been removed in
later Tendermint Core versions. As it only contained a small helper, we just
copy it over.