### PR TITLE
runtime/committee/client: reduce gRPC max backoff timeout

### DIFF
--- a/.changelog/3035.bugfix.md
+++ b/.changelog/3035.bugfix.md
@@ -1,0 +1,4 @@
+runtime/committee/client: Reduce gRPC max backoff timeout
+
+Committee nodes are expected to be available and this timeout is more in line
+with timeouts used in the clients using these connections.


### PR DESCRIPTION
Reduces the gRPC backoff MaxDelay in committee client. Committee nodes are expected to be available and this timeout is more in line with timeouts we use in the clients using these connections (e.g. storage client retries for 15 secs). 

This was causing spurious `runtime_dynamic` E2E test failures, where the nodes are restarted in the test. In case the storage node restart took to long, the connection retry delay got greater than the retry timeout in storage client, causing failures.