### PR TITLE
ci: don't automatically retry timed out jobs

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -66,8 +66,6 @@ retry: &retry_agent_failure
   automatic:
     - exit_status: 125 # ERRO[0092] error waiting for container: unexpected EOF
       limit: 2
-    - exit_status: 255 # Forced agent shutdown
-      limit: 2
 
 steps:
   ###########

--- a/.changelog/3036.internal.md
+++ b/.changelog/3036.internal.md
@@ -1,0 +1,1 @@
+ci: Don't automatically retry timed out jobs


### PR DESCRIPTION
Apparently jobs that timeout exit with status `255` and those shouldn't be automatically retried.

As noted before (https://github.com/oasisprotocol/oasis-core/pull/2900) `125` is actually the only error we want to automatically retry.