### PR TITLE
Update TLSAddressRequiredRoles and update node control API

### DIFF
--- a/.changelog/3038.breaking.md
+++ b/.changelog/3038.breaking.md
@@ -1,0 +1,1 @@
+go/registry: Make TLS address required for RoleConsensusRPC

--- a/.changelog/3038.feature.1.md
+++ b/.changelog/3038.feature.1.md
@@ -1,0 +1,5 @@
+go/control: Add registration status to node status
+
+This updates the response returned by the `GetStatus` method exposed by the
+node controller service to include a `Registration` field that contains
+information about the node's current registration.

--- a/.changelog/3038.feature.2.md
+++ b/.changelog/3038.feature.2.md
@@ -1,0 +1,1 @@
+go/consensus: Add IsValidator to reported node status

--- a/.changelog/3038.feature.3.md
+++ b/.changelog/3038.feature.3.md
@@ -1,0 +1,6 @@
+go/control: Add identity status to node status
+
+This updates the response returned by the `GetStatus` method exposed by the
+node controller service to include an `Identity` field that contains
+information about the public keys used to identify a node in different
+contexts.

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -124,6 +124,9 @@ type Status struct {
 	GenesisHeight int64 `json:"genesis_height"`
 	// GenesisHash is the hash of the genesis block.
 	GenesisHash []byte `json:"genesis_hash"`
+
+	// IsValidator returns whether the current node is part of the validator set.
+	IsValidator bool `json:"is_validator"`
 }
 
 // Backend is an interface that a consensus backend must provide.

--- a/go/control/api/api.go
+++ b/go/control/api/api.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"time"
 
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
+	"github.com/oasisprotocol/oasis-core/go/common/identity"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	epochtime "github.com/oasisprotocol/oasis-core/go/epochtime/api"
@@ -49,11 +51,30 @@ type Status struct {
 	// SoftwareVersion is the oasis-node software version.
 	SoftwareVersion string `json:"software_version"`
 
+	// Identity is the identity of the node.
+	Identity IdentityStatus `json:"identity"`
+
 	// Consensus is the status overview of the consensus layer.
 	Consensus consensus.Status `json:"consensus"`
 
 	// Registration is the node's registration status.
 	Registration RegistrationStatus `json:"registration"`
+}
+
+// IdentityStatus is the current node identity status, listing all the public keys that identify
+// this node in different contexts.
+type IdentityStatus struct {
+	// Node is the node identity public key.
+	Node signature.PublicKey `json:"node"`
+
+	// P2P is the public key used for p2p communication.
+	P2P signature.PublicKey `json:"p2p"`
+
+	// Consensus is the consensus public key.
+	Consensus signature.PublicKey `json:"consensus"`
+
+	// TLS is the public key used for TLS connections.
+	TLS signature.PublicKey `json:"tls"`
 }
 
 // RegistrationStatus is the node registration status.
@@ -74,6 +95,9 @@ type ControlledNode interface {
 
 	// Ready returns a channel that is closed once node is ready.
 	Ready() <-chan struct{}
+
+	// GetIdentity returns the node's identity.
+	GetIdentity() *identity.Identity
 
 	// GetRegistrationStatus returns the node's current registration status.
 	GetRegistrationStatus(ctx context.Context) (*RegistrationStatus, error)

--- a/go/control/api/api.go
+++ b/go/control/api/api.go
@@ -3,8 +3,10 @@ package api
 
 import (
 	"context"
+	"time"
 
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	epochtime "github.com/oasisprotocol/oasis-core/go/epochtime/api"
 	upgrade "github.com/oasisprotocol/oasis-core/go/upgrade/api"
@@ -49,15 +51,32 @@ type Status struct {
 
 	// Consensus is the status overview of the consensus layer.
 	Consensus consensus.Status `json:"consensus"`
+
+	// Registration is the node's registration status.
+	Registration RegistrationStatus `json:"registration"`
 }
 
-// ControlledNode is an interface the node presents for shutting itself down.
+// RegistrationStatus is the node registration status.
+type RegistrationStatus struct {
+	// LastRegistration is the time of the last successful registration with the consensus registry
+	// service. In case the node did not successfully register yet, it will be the zero timestamp.
+	LastRegistration time.Time `json:"last_registration"`
+
+	// Descriptor is the node descriptor that the node successfully registered with. In case the
+	// node did not successfully register yet, it will be nil.
+	Descriptor *node.Node `json:"descriptor,omitempty"`
+}
+
+// ControlledNode is an internal interface that the controlled oasis-node must provide.
 type ControlledNode interface {
 	// RequestShutdown is the method called by the control server to trigger node shutdown.
 	RequestShutdown() (<-chan struct{}, error)
 
 	// Ready returns a channel that is closed once node is ready.
 	Ready() <-chan struct{}
+
+	// GetRegistrationStatus returns the node's current registration status.
+	GetRegistrationStatus(ctx context.Context) (*RegistrationStatus, error)
 }
 
 // DebugModuleName is the module name for the debug controller service.

--- a/go/control/control.go
+++ b/go/control/control.go
@@ -92,10 +92,18 @@ func (c *nodeController) GetStatus(ctx context.Context) (*control.Status, error)
 		return nil, fmt.Errorf("failed to get registration status: %w", err)
 	}
 
+	ident := c.node.GetIdentity()
+
 	return &control.Status{
 		SoftwareVersion: version.SoftwareVersion,
-		Consensus:       *cs,
-		Registration:    *rs,
+		Identity: control.IdentityStatus{
+			Node:      ident.NodeSigner.Public(),
+			P2P:       ident.P2PSigner.Public(),
+			Consensus: ident.ConsensusSigner.Public(),
+			TLS:       ident.GetTLSSigner().Public(),
+		},
+		Consensus:    *cs,
+		Registration: *rs,
 	}, nil
 }
 

--- a/go/control/control.go
+++ b/go/control/control.go
@@ -3,6 +3,7 @@ package control
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
@@ -83,12 +84,18 @@ func (c *nodeController) CancelUpgrade(ctx context.Context) error {
 func (c *nodeController) GetStatus(ctx context.Context) (*control.Status, error) {
 	cs, err := c.consensus.GetStatus(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get consensus status: %w", err)
+	}
+
+	rs, err := c.node.GetRegistrationStatus(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get registration status: %w", err)
 	}
 
 	return &control.Status{
 		SoftwareVersion: version.SoftwareVersion,
 		Consensus:       *cs,
+		Registration:    *rs,
 	}, nil
 }
 

--- a/go/oasis-node/cmd/node/control.go
+++ b/go/oasis-node/cmd/node/control.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 
+	"github.com/oasisprotocol/oasis-core/go/common/identity"
 	control "github.com/oasisprotocol/oasis-core/go/control/api"
 )
 
@@ -23,6 +24,11 @@ func (n *Node) RequestShutdown() (<-chan struct{}, error) {
 // Implements control.ControlledNode.
 func (n *Node) Ready() <-chan struct{} {
 	return n.readyCh
+}
+
+// Implements control.ControlledNode.
+func (n *Node) GetIdentity() *identity.Identity {
+	return n.Identity
 }
 
 // Implements control.ControlledNode.

--- a/go/oasis-node/cmd/node/control.go
+++ b/go/oasis-node/cmd/node/control.go
@@ -1,0 +1,31 @@
+package node
+
+import (
+	"context"
+
+	control "github.com/oasisprotocol/oasis-core/go/control/api"
+)
+
+var _ control.ControlledNode = (*Node)(nil)
+
+// Implements control.ControlledNode.
+func (n *Node) RequestShutdown() (<-chan struct{}, error) {
+	if err := n.RegistrationWorker.RequestDeregistration(); err != nil {
+		return nil, err
+	}
+	// This returns only the registration worker's event channel,
+	// otherwise the caller (usually the control grpc server) will only
+	// get notified once everything is already torn down - perhaps
+	// including the server.
+	return n.RegistrationWorker.Quit(), nil
+}
+
+// Implements control.ControlledNode.
+func (n *Node) Ready() <-chan struct{} {
+	return n.readyCh
+}
+
+// Implements control.ControlledNode.
+func (n *Node) GetRegistrationStatus(ctx context.Context) (*control.RegistrationStatus, error) {
+	return n.RegistrationWorker.GetRegistrationStatus(ctx)
+}

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -69,12 +69,8 @@ import (
 	workerStorage "github.com/oasisprotocol/oasis-core/go/worker/storage"
 )
 
-var (
-	_ controlAPI.ControlledNode = (*Node)(nil)
-
-	// Flags has the configuration flags.
-	Flags = flag.NewFlagSet("", flag.ContinueOnError)
-)
+// Flags has the configuration flags.
+var Flags = flag.NewFlagSet("", flag.ContinueOnError)
 
 const exportsSubDir = "exports"
 
@@ -159,22 +155,6 @@ func (n *Node) Stop() {
 // call Cleanup() after wait returns.
 func (n *Node) Wait() {
 	n.svcMgr.Wait()
-}
-
-func (n *Node) RequestShutdown() (<-chan struct{}, error) {
-	if err := n.RegistrationWorker.RequestDeregistration(); err != nil {
-		return nil, err
-	}
-	// This returns only the registration worker's event channel,
-	// otherwise the caller (usually the control grpc server) will only
-	// get notified once everything is already torn down - perhaps
-	// including the server.
-	return n.RegistrationWorker.Quit(), nil
-}
-
-// Ready returns the ready channel which gets closed once the node is ready.
-func (n *Node) Ready() <-chan struct{} {
-	return n.readyCh
 }
 
 func (n *Node) waitReady(logger *logging.Logger) {

--- a/go/oasis-test-runner/scenario/e2e/early_query.go
+++ b/go/oasis-test-runner/scenario/e2e/early_query.go
@@ -76,5 +76,17 @@ func (sc *earlyQueryImpl) Run(childEnv *env.Env) error {
 		return fmt.Errorf("GetTransactions query should fail with ErrNoCommittedBlocks (got: %s)", err)
 	}
 
+	// GetStatus.
+	status, err := sc.net.Controller().GetStatus(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get status for node: %w", err)
+	}
+	if status.Consensus.LatestHeight != 0 {
+		return fmt.Errorf("node reports non-zero latest height before chain is initialized")
+	}
+	if !status.Consensus.IsValidator {
+		return fmt.Errorf("node does not report itself to be a validator at genesis")
+	}
+
 	return nil
 }

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -166,9 +166,10 @@ var (
 	ConsensusAddressRequiredRoles = node.RoleValidator
 
 	// TLSAddressRequiredRoles are the Node roles that require TLS Address.
-	TLSAddressRequiredRoles = (node.RoleComputeWorker |
+	TLSAddressRequiredRoles = node.RoleComputeWorker |
 		node.RoleStorageWorker |
-		node.RoleKeyManager)
+		node.RoleKeyManager |
+		node.RoleConsensusRPC
 
 	// P2PAddressRequiredRoles are the Node roles that require P2P Address.
 	P2PAddressRequiredRoles = node.RoleComputeWorker


### PR DESCRIPTION
* go/registry: Make TLS address required for RoleConsensusRPC
* go/control: Add registration status to node status
  
  This updates the response returned by the `GetStatus` method exposed by the
  node controller service to include a `Registration` field that contains
  information about the node's current registration.
* go/consensus: Add IsValidator to reported node status
* go/control: Add identity status to node status
  
  This updates the response returned by the `GetStatus` method exposed by the
  node controller service to include an `Identity` field that contains
  information about the public keys used to identify a node in different
  contexts.