### PR TITLE
go/oasis-test-runner: List all available scenarios

### DIFF
--- a/.changelog/3044.internal.md
+++ b/.changelog/3044.internal.md
@@ -1,0 +1,4 @@
+go/oasis-test-runner/cmd/common: Give verbose error when scenario is not found
+
+List all available scenarios if `oasis-test-runner` command is invoked with an
+unknown scenario.

--- a/go/oasis-test-runner/cmd/cmp/cmp.go
+++ b/go/oasis-test-runner/cmd/cmp/cmp.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
-	nodeCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/metrics"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/cmd/common"
 )
@@ -120,7 +119,7 @@ func getDuration(ctx context.Context, test string, bi *model.SampleStream) (floa
 	query := fmt.Sprintf("%s %s == 1.0", metrics.MetricUp, bi.Metric.String())
 	result, warnings, err := v1api.QueryRange(ctx, query, r)
 	if err != nil {
-		nodeCommon.EarlyLogAndExit(fmt.Errorf("error querying Prometheus: %w", err))
+		return 0, 0, fmt.Errorf("error querying Prometheus: %w", err)
 	}
 	if len(warnings) > 0 {
 		cmpLogger.Warn("warnings while querying Prometheus", "warnings", warnings)
@@ -206,7 +205,7 @@ func getSummableMetric(ctx context.Context, metric string, test string, bi *mode
 
 	result, warnings, err := v1api.Query(ctx, query, t)
 	if err != nil {
-		nodeCommon.EarlyLogAndExit(fmt.Errorf("error querying Prometheus: %w", err))
+		return 0, 0, fmt.Errorf("error querying Prometheus: %w", err)
 	}
 	if len(warnings) > 0 {
 		cmpLogger.Warn("warnings while querying Prometheus", "warnings", warnings)
@@ -256,7 +255,7 @@ func getNetwork(ctx context.Context, test string, bi *model.SampleStream) (float
 		query := fmt.Sprintf("(%s %s)", rxtx, labels.String())
 		result, warnings, err := v1api.QueryRange(ctx, query, r)
 		if err != nil {
-			nodeCommon.EarlyLogAndExit(fmt.Errorf("error querying Prometheus: %w", err))
+			return 0, 0, fmt.Errorf("error querying Prometheus: %w", err)
 		}
 		if len(warnings) > 0 {
 			cmpLogger.Warn("warnings while querying Prometheus", "warnings", warnings)

--- a/go/oasis-test-runner/cmd/common/common.go
+++ b/go/oasis-test-runner/cmd/common/common.go
@@ -3,6 +3,7 @@ package common
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
@@ -31,6 +32,15 @@ var (
 // This function *is not* thread-safe.
 func GetScenarios() map[string]scenario.Scenario {
 	return scenarios
+}
+
+// GetScenarioNames returns the names of all scenarios.
+func GetScenarioNames() (names []string) {
+	for name := range scenarios {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return
 }
 
 // GetDefaultScenarios returns all registered default scenarios.

--- a/go/oasis-test-runner/cmd/root.go
+++ b/go/oasis-test-runner/cmd/root.go
@@ -268,18 +268,20 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	defer rootEnv.Cleanup()
 	logger := logging.GetLogger("test-runner")
 
-	// Enumerate requested test cases.
+	// Enumerate requested scenarios.
 	toRun := common.GetDefaultScenarios() // Run all default scenarios if not set.
 	if vec := viper.GetStringSlice(common.CfgTest); len(vec) > 0 {
 		toRun = nil
 		for _, v := range vec {
-			n := strings.ToLower(v)
+			name := strings.ToLower(v)
 			scenario, ok := common.GetScenarios()[v]
 			if !ok {
-				logger.Error("unknown test case",
-					"test", n,
+				logger.Error("unknown scenario",
+					"scenario", name,
 				)
-				return fmt.Errorf("root: unknown test case: %s", n)
+				return fmt.Errorf("root: unknown scenario: %s\nAvailable scenarios:\n%s",
+					name, strings.Join(common.GetScenarioNames(), "\n"),
+				)
 			}
 			toRun = append(toRun, scenario)
 		}

--- a/go/oasis-test-runner/cmd/root.go
+++ b/go/oasis-test-runner/cmd/root.go
@@ -75,7 +75,7 @@ func RootCmd() *cobra.Command {
 // Execute spawns the main entry point after handing the config file.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		nodeCommon.EarlyLogAndExit(err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
List all available scenarios if command was invoked with a particular scenario that was not found.

For example, running `.buildkite/scripts/test_e2e.sh --test storage-sync` where `storage-sync` scenario doesn't exist, now returns:

```
+ WORKDIR=/home/tadej/Oasis/oasis-core
+ runtime_target=default
+ [[ '' == \i\n\t\e\l\-\s\g\x ]]
+ [[ '' != '' ]]
+ node_binary=/home/tadej/Oasis/oasis-core/go/oasis-node/oasis-node
+ test_runner_binary=/home/tadej/Oasis/oasis-core/go/oasis-test-runner/oasis-test-runner
+ [[ '' != '' ]]
+ ias_mock=true
+ set +x
+ /home/tadej/Oasis/oasis-core/go/oasis-test-runner/oasis-test-runner --basedir.no_cleanup --e2e.node.binary /home/tadej/Oasis/oasis-core/go/oasis-node/oasis-node --e2e/runtime.client.binary_dir /home/tadej/Oasis/oasis-core/target/default/debug --e2e/runtime.runtime.binary_dir /home/tadej/Oasis/oasis-core/target/default/debug --e2e/runtime.runtime.loader /home/tadej/Oasis/oasis-core/target/default/debug/oasis-core-runtime-loader --e2e/runtime.tee_hardware '' --e2e/runtime.ias.mock=true --remote-signer.binary /home/tadej/Oasis/oasis-core/go/oasis-remote-signer/oasis-remote-signer --log.level info --test storage-sync
level=error module=test-runner caller=root.go:279 ts=2020-06-24T08:07:30.560481983Z msg="unknown scenario" scenario=storage-sync
Error: root: unknown scenario: storage-sync
Available scenarios:
e2e/identity-cli
e2e/runtime/byzantine/executor-honest
e2e/runtime/byzantine/executor-straggler
e2e/runtime/byzantine/executor-wrong
e2e/runtime/byzantine/merge-honest
e2e/runtime/byzantine/merge-straggler
e2e/runtime/byzantine/merge-wrong
e2e/runtime/debond
e2e/runtime/dump-restore
e2e/runtime/early-query
e2e/runtime/gas-fees/runtimes
e2e/runtime/gas-fees/staking
e2e/runtime/gas-fees/staking-dump-restore
e2e/runtime/halt-restore
e2e/runtime/keymanager-replication
e2e/runtime/keymanager-restart
e2e/runtime/keymanager-upgrade
e2e/runtime/late-start
e2e/runtime/multiple-runtimes
e2e/runtime/node-shutdown
e2e/runtime/node-upgrade
e2e/runtime/node-upgrade-cancel
e2e/runtime/registry-cli
e2e/runtime/runtime
e2e/runtime/runtime-dynamic
e2e/runtime/runtime-encryption
e2e/runtime/runtime-prune
e2e/runtime/sentry
e2e/runtime/sentry-encryption
e2e/runtime/stake-cli
e2e/runtime/storage-sync
e2e/runtime/txsource-multi
e2e/runtime/txsource-multi-short
remote-signer/basic
```