### PR TITLE
go/worker: Defer various processing

### DIFF
--- a/.changelog/3049.internal.1.md
+++ b/.changelog/3049.internal.1.md
@@ -1,0 +1,5 @@
+go/worker/compute/executor: Defer fetching the batch from storage
+
+There is no need to attempt to fetch the batch immediately, we can defer it to
+when we actually need to start processing the batch. This makes fetching not
+block P2P dispatch.

--- a/.changelog/3049.internal.2.md
+++ b/.changelog/3049.internal.2.md
@@ -1,0 +1,5 @@
+go/worker/compute/merge: Defer finalization attempt
+
+There is no need for the finalization attempt to block handling of an incoming
+commitment as any errors from that are not propagated. This avoids blocking
+P2P relaying as well.

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -18,6 +18,7 @@ import (
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
 	"github.com/oasisprotocol/oasis-core/go/worker/common/p2p"
+	p2pError "github.com/oasisprotocol/oasis-core/go/worker/common/p2p/error"
 )
 
 var (
@@ -167,7 +168,7 @@ func (n *Node) HandlePeerMessage(ctx context.Context, message *p2p.Message) erro
 			return nil
 		}
 	}
-	return errors.New("unknown message type")
+	return p2pError.Permanent(errors.New("unknown message type"))
 }
 
 // Guarded by n.CrossNode.

--- a/go/worker/compute/executor/committee/batch.go
+++ b/go/worker/compute/executor/committee/batch.go
@@ -1,0 +1,48 @@
+package committee
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/runtime/transaction"
+	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
+)
+
+// unresolvedBatch is a batch that may still need to be resolved (fetched from storage).
+type unresolvedBatch struct {
+	// ioRoot is the I/O root from the transaction scheduler containing the inputs.
+	ioRoot storage.Root
+	// txnSchedSignatures is the transaction scheduler signature of the dispatched batch.
+	txnSchedSignature signature.Signature
+	// storageSignatures are the storage node signatures of storage receipts for the I/O root.
+	storageSignatures []signature.Signature
+
+	batch   transaction.RawBatch
+	spanCtx opentracing.SpanContext
+}
+
+func (ub *unresolvedBatch) String() string {
+	return fmt.Sprintf("UnresolvedBatch{ioRoot: %s}", ub.ioRoot)
+}
+
+func (ub *unresolvedBatch) resolve(ctx context.Context, storage storage.Backend) (transaction.RawBatch, error) {
+	if ub.batch != nil {
+		// In case we already have a resolved batch, just return it.
+		return ub.batch, nil
+	}
+
+	txs := transaction.NewTree(storage, ub.ioRoot)
+	defer txs.Close()
+
+	batch, err := txs.GetInputBatch(ctx)
+	if err != nil || len(batch) == 0 {
+		return nil, fmt.Errorf("failed to fetch inputs from storage: %w", err)
+	}
+	if len(batch) == 0 {
+		return nil, fmt.Errorf("failed to fetch inputs from storage: batch is empty")
+	}
+	return batch, nil
+}

--- a/go/worker/compute/executor/committee/state.go
+++ b/go/worker/compute/executor/committee/state.go
@@ -4,14 +4,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/opentracing/opentracing-go"
-
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
-	"github.com/oasisprotocol/oasis-core/go/runtime/transaction"
 )
 
 // StateName is a symbolic state without the attached values.
@@ -131,18 +126,10 @@ func (s StateWaitingForBatch) String() string {
 
 // StateWaitingForBlock is the waiting for block state.
 type StateWaitingForBlock struct {
-	// I/O root from the transaction scheduler containing the inputs.
-	ioRoot hash.Hash
 	// Batch that is waiting to be processed.
-	batch transaction.RawBatch
-	// Tracing for this batch.
-	batchSpanCtx opentracing.SpanContext
+	batch *unresolvedBatch
 	// Header of the block we are waiting for.
 	header *block.Header
-	// Transaction scheduler's signature.
-	txnSchedSig signature.Signature
-	// Storage signatures for the I/O root containing the inputs.
-	inputStorageSigs []signature.Signature
 }
 
 // Name returns the name of the state.
@@ -157,16 +144,8 @@ func (s StateWaitingForBlock) String() string {
 
 // StateWaitingForEvent is the waiting for event state.
 type StateWaitingForEvent struct {
-	// I/O root from the transaction scheduler containing the inputs.
-	ioRoot hash.Hash
 	// Batch that is being processed.
-	batch transaction.RawBatch
-	// Tracing for this batch.
-	batchSpanCtx opentracing.SpanContext
-	// Transaction scheduler's signature.
-	txnSchedSig signature.Signature
-	// Storage signatures for the I/O root containing the inputs.
-	inputStorageSigs []signature.Signature
+	batch *unresolvedBatch
 }
 
 // Name returns the name of the state.
@@ -181,22 +160,14 @@ func (s StateWaitingForEvent) String() string {
 
 // StateProcessingBatch is the processing batch state.
 type StateProcessingBatch struct {
-	// I/O root from the transaction scheduler containing the inputs.
-	ioRoot hash.Hash
 	// Batch that is being processed.
-	batch transaction.RawBatch
-	// Tracing for this batch.
-	batchSpanCtx opentracing.SpanContext
+	batch *unresolvedBatch
 	// Timing for this batch.
 	batchStartTime time.Time
 	// Function for cancelling batch processing.
 	cancelFn context.CancelFunc
 	// Channel which will provide the result.
 	done chan *protocol.ComputedBatch
-	// Transaction scheduler's signature.
-	txnSchedSig signature.Signature
-	// Storage signatures for the I/O root containing the inputs.
-	inputStorageSigs []signature.Signature
 }
 
 // Name returns the name of the state.


### PR DESCRIPTION
* go/worker/compute/executor: Defer fetching the batch from storage
  
  There is no need to attempt to fetch the batch immediately, we can defer it to
  when we actually need to start processing the batch. This makes fetching not
  block P2P dispatch.
* go/worker/compute/merge: Defer finalization attempt
  
  There is no need for the finalization attempt to block handling of an incoming
  commitment as any errors from that are not propagated. This avoids blocking
  P2P relaying as well.
* go/worker/common: Treat unknown P2P message type as a permanent error