### PR TITLE
go/common/crypto/signature/signers/ledger: Descriptive error on user reject

### DIFF
--- a/.changelog/3050.feature.md
+++ b/.changelog/3050.feature.md
@@ -1,0 +1,4 @@
+go/common/crypto/signature/signers/ledger: Descriptive error on user reject
+
+Make Ledger signer return a more descriptive error message when a user rejects
+a transaction on the Ledger device.

--- a/go/go.mod
+++ b/go/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/uber/jaeger-client-go v2.16.0+incompatible
 	github.com/uber/jaeger-lib v2.0.0+incompatible // indirect
 	github.com/whyrusleeping/go-logging v0.0.1
+	github.com/zondax/ledger-go v0.11.0
 	github.com/zondax/ledger-oasis-go v0.3.0
 	gitlab.com/yawning/dynlib.git v0.0.0-20200603163025-35fe007b0761
 	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9


### PR DESCRIPTION
Make Ledger signer return a more descriptive error message when a user rejects a transaction on the Ledger device.

For example, previously, the returned error was:
```
ts=2020-06-25T10:26:59.930888297Z level=error module=cmd/common/consensus caller=consensus.go:107 msg="failed to sign transaction" err="[APDU_CODE_COMMAND_NOT_ALLOWED] Command not allowed (no current EF)"
```

Now, it is:
```
ts=2020-06-25T10:27:24.693936203Z level=error module=cmd/common/consensus caller=consensus.go:107 msg="failed to sign transaction" err="transaction was rejected on Ledger device"
```