### PR TITLE
Renaming existing staking token to base unit

### DIFF
--- a/.changelog/3061.breaking.md
+++ b/.changelog/3061.breaking.md
@@ -1,0 +1,8 @@
+go: Rename existing staking token to base unit
+
+This allows introducing the concept of staking token which is defined as a
+given number of base units.
+
+Additionally, rename fields of the following `go/staking/api` types:
+`TransferEvent`, `BurnEvent`, `AddEscrowEvent`, `TakeEscrowEvent`,
+`ReclaimEscrowEvent`, `Transfer`, `Burn`, `Escrow`, `ReclaimEscrow`.

--- a/.changelog/3061.feature.1.md
+++ b/.changelog/3061.feature.1.md
@@ -1,0 +1,8 @@
+go/staking: Add `TokenSymbol` and `TokenValueExponent` fields to `Genesis`
+
+They allow denominating stake amounts in tokens (besides base units used
+internally).
+For more details, see [Staking Developer Docs].
+
+[Staking Developer Docs]:
+  docs/consensus/staking.md#tokens-and-base-units

--- a/.changelog/3061.feature.2.md
+++ b/.changelog/3061.feature.2.md
@@ -1,0 +1,5 @@
+go/oasis-node/cmd/genesis: Allow setting staking token symbol and value exp
+
+Allow setting staking token's ticker symbol and token value's base-10 exponent
+in `oasis-node genesis init` CLI command via `--staking.token_symbol` and
+`--staking.token_value_exponent` flags.

--- a/docs/consensus/staking.md
+++ b/docs/consensus/staking.md
@@ -1,8 +1,8 @@
 # Staking
 
 The staking service is responsible for managing the staking ledger in the
-consensus layer. It enables operations like transferring tokens between accounts
-and escrowing tokens for specific needs (e.g., operating nodes).
+consensus layer. It enables operations like transferring stake between accounts
+and escrowing stake for specific needs (e.g., operating nodes).
 
 The service interface definition lives in [`go/staking/api`]. It defines the
 supported queries and transactions. For more information you can also check out
@@ -68,7 +68,7 @@ transaction.
 
 ### Escrow
 
-Escrow accounts are used to hold funds delegated for specific consensus-layer
+Escrow accounts are used to hold stake delegated for specific consensus-layer
 operations (e.g., registering and running nodes).
 Their balance is subject to special delegation provisions and a debonding
 period.
@@ -89,24 +89,23 @@ claim can be satisfied.
 
 #### Delegation
 
-When a delegator wants to delegate some of amount of tokens to a staking
-account, he needs to escrow tokens using [Add Escrow method].
+When a delegator wants to delegate some of amount of stake to a staking account,
+he needs to escrow stake using [Add Escrow method].
 
-Similarly, when a delegator wants to reclaim some amount of escrowed tokens back
-to his general account, he needs to reclaim tokens using [Reclaim Escrow
-method].
+Similarly, when a delegator wants to reclaim some amount of escrowed stake back
+to his general account, he needs to reclaim stake using [Reclaim Escrow method].
 
 To simplify accounting, each escrow results in the delegator account being
-issued shares which can be converted back into staking tokens during the reclaim
-escrow operation.
+issued shares which can be converted back to stake during the reclaim escrow
+operation.
 
-When a delegator delegates some amount of tokens to an escrow account, the
+When a delegator delegates some amount of stake to an escrow account, the
 delegator receives the number of shares proportional to the current
-_share price_ (in tokens) calculated from the total number of tokens
+_share price_ (in base units) calculated from the total number of stake
 delegated to an escrow account so far and the number of shares issued so far:
 
 ```
-shares_per_token = account_issued_shares / account_delegated_tokens
+shares_per_base_unit = account_issued_shares / account_delegated_base_units
 ```
 
 For example, if an escrow account has the following state:
@@ -121,9 +120,9 @@ For example, if an escrow account has the following state:
 }
 ```
 
-then the current share price (i.e. `shares_per_token`) is 1000 / 250 = 4.
+then the current share price (i.e. `shares_per_base_unit`) is 1000 / 250 = 4.
 
-Delegating 500 tokens to this escrow account would result in 500 * 4 = 2000
+Delegating 500 base units to this escrow account would result in 500 * 4 = 2000
 newly issued shares.
 
 Thus, the escrow account would have the following state afterwards:
@@ -138,18 +137,19 @@ Thus, the escrow account would have the following state afterwards:
 }
 ```
 
-When a delegator wants to reclaim a certain number of escrowed tokens, the
-_token price_ (in shares) must be calculated based on the escrow account's
+When a delegator wants to reclaim a certain number of escrowed stake, the
+_base unit price_ (in shares) must be calculated based on the escrow account's
 current active balance and the number of issued shares:
 
 ```text
-tokens_per_share = account_delegated_tokens / account_issued_shares
+base_units_per_share = account_delegated_base_units / account_issued_shares
 ```
 
-Returning to our example escrow account, the current token price (i.e.
-`tokens_per_share`) is 750 / 3000 = 0.25.
+Returning to our example escrow account, the current base unit price (i.e.
+`base_units_per_share`) is 750 / 3000 = 0.25.
 
-Reclaiming 1200 shares would result in 1200 * 0.25 = 300 tokens being reclaimed.
+Reclaiming 1200 shares would result in 1200 * 0.25 = 300 base units being
+reclaimed.
 
 The escrow account would have the following state afterwards:
 
@@ -164,7 +164,7 @@ The escrow account would have the following state afterwards:
 ```
 
 Reclaiming escrow does not complete immediately, but may be subject to a
-debonding period during in which the tokens still remain escrowed.
+debonding period during in which the stake still remains escrowed.
 
 [Add Escrow method]: #add-escrow
 [Reclaim Escrow method]: #reclaim-escrow
@@ -206,7 +206,7 @@ make -C go staking/gen_vectors
 
 ### Transfer
 
-Transfer enables token transfer between different accounts in the staking
+Transfer enables stake transfer between different accounts in the staking
 ledger. A new transfer transaction can be generated using
 [`NewTransferTx` function].
 
@@ -220,15 +220,15 @@ staking.Transfer
 
 ```golang
 type Transfer struct {
-    To     Address           `json:"xfer_to"`
-    Tokens quantity.Quantity `json:"xfer_tokens"`
+    To     Address           `json:"to"`
+    Amount quantity.Quantity `json:"amount"`
 }
 ```
 
 **Fields:**
 
-* `xfer_to` specifies the destination account's address.
-* `xfer_tokens` specifies the amount of tokens to transfer.
+* `to` specifies the destination account's address.
+* `amount` specifies the amount of base units to transfer.
 
 The transaction signer implicitly specifies the source account.
 
@@ -239,7 +239,7 @@ The transaction signer implicitly specifies the source account.
 
 ### Burn
 
-Burn destroys some tokens in the caller's account. A new burn transaction can be
+Burn destroys some stake in the caller's account. A new burn transaction can be
 generated using [`NewBurnTx` function].
 
 **Method name:**
@@ -252,13 +252,13 @@ staking.Burn
 
 ```golang
 type Burn struct {
-    Tokens quantity.Quantity `json:"burn_tokens"`
+    Amount quantity.Quantity `json:"amount"`
 }
 ```
 
 **Fields:**
 
-* `burn_tokens` specifies the amount of tokens to burn.
+* `amount` specifies the amount of base units to burn.
 
 The transaction signer implicitly specifies the caller's account.
 
@@ -269,7 +269,7 @@ The transaction signer implicitly specifies the caller's account.
 
 ### Add Escrow
 
-Escrow transfers tokens into an escrow account.
+Escrow transfers stake into an escrow account.
 For more details, see the [Delegation section] of this document.
 A new add escrow transaction can be generated using [`NewAddEscrowTx` function].
 
@@ -283,15 +283,15 @@ staking.AddEscrow
 
 ```golang
 type Escrow struct {
-    Account Address           `json:"escrow_account"`
-    Tokens  quantity.Quantity `json:"escrow_tokens"`
+    Account Address           `json:"account"`
+    Amount  quantity.Quantity `json:"amount"`
 }
 ```
 
 **Fields:**
 
-* `escrow_account` specifies the destination escrow account's address.
-* `escrow_tokens` specifies the amount of tokens to transfer.
+* `account` specifies the destination escrow account's address.
+* `amount` specifies the amount of base units to transfer.
 
 The transaction signer implicitly specifies the source account.
 
@@ -318,15 +318,15 @@ staking.ReclaimEscrow
 
 ```golang
 type ReclaimEscrow struct {
-    Account Address           `json:"escrow_account"`
-    Shares  quantity.Quantity `json:"reclaim_shares"`
+    Account Address           `json:"account"`
+    Shares  quantity.Quantity `json:"shares"`
 }
 ```
 
 **Fields:**
 
-* `escrow_account` specifies the source escrow account's address.
-* `reclaim_shares` specifies the amount of shares to reclaim.
+* `account` specifies the source escrow account's address.
+* `shares` specifies the number of shares to reclaim.
 
 The transaction signer implicitly specifies the destination account.
 

--- a/docs/consensus/staking.md
+++ b/docs/consensus/staking.md
@@ -13,6 +13,25 @@ the [consensus service API documentation].
 [consensus service API documentation]: https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go/staking/api?tab=doc
 <!-- markdownlint-enable line-length -->
 
+## Tokens and Base Units
+
+Stake amounts can be denominated in tokens and base units.
+
+Tokens are used in user-facing scenarios (e.g. CLI commands) where the token
+amount is prefixed with the token's ticker symbol as defined by the [`Genesis`'
+`TokenSymbol` field][pkggodev-genesis].
+
+Another [`Genesis`' field, `TokenValueExponent`][pkggodev-genesis], defines the
+token's value base-10 exponent.
+For example, if `TokenValueExponent` is 6, then 1 token equals 10^6 (i.e. one
+million) base units.
+
+Internally, base units are used for all stake calculation and processing.
+
+<!-- markdownlint-disable line-length -->
+[pkggodev-genesis]: https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go/staking/api?tab=doc#Genesis
+<!-- markdownlint-enable line-length -->
+
 ## Accounts
 
 A staking account is an entry in the staking ledger. It can hold both general

--- a/docs/consensus/transactions.md
+++ b/docs/consensus/transactions.md
@@ -65,18 +65,19 @@ Different operations cost different amounts of gas as defined by the consensus
 parameters of the consensus component that implements the operation.
 
 Transactions that require fees to process will include a `fee` field to declare
-how much the caller is willing to pay for fees. Specifying an `amount` (in
-tokens) and `gas` (in gas units) implicitly defines a _gas price_ (price of one
-gas unit) as `amount / gas`. Consensus validators may refuse to process
-operations with a gas price that is too low.
+how much the caller is willing to pay for fees.
+Specifying an `amount` (in base units) and `gas` (in gas units) implicitly
+defines a _gas price_ (price of one gas unit) as `amount / gas`.
+Consensus validators may refuse to process operations with a gas price that is
+too low.
 
 The `gas` field defines the maximum amount of gas that can be used by an
 operation for which the fee has been included. In case an operation uses more
 gas, processing will be aborted and no state changes will take place.
 
 Signing a transaction which includes a fee structure implicitly grants
-permission to withdraw the given amount of tokens from the signer's account. In
-case there is not enough balance in the account, the operation will fail.
+permission to withdraw the given amount of base units from the signer's account.
+In case there is not enough balance in the account, the operation will fail.
 
 ```golang
 type Fee struct {
@@ -89,7 +90,7 @@ Fees are not refunded.
 
 Fields:
 
-* `amount` is the total fee amount to be paid.
+* `amount` is the total fee amount (in base units) to be paid.
 * `gas` is the maximum gas that an operation can use.
 
 ## Gas Estimation

--- a/go/consensus/tendermint/apps/scheduler/genesis.go
+++ b/go/consensus/tendermint/apps/scheduler/genesis.go
@@ -150,16 +150,17 @@ func (app *schedulerApplication) InitChain(ctx *abciAPI.Context, req types.Reque
 					err,
 				)
 			}
-			expectedPower, err = scheduler.VotingPowerFromTokens(&account.Escrow.Active.Balance)
+			expectedPower, err = scheduler.VotingPowerFromStake(&account.Escrow.Active.Balance)
 			if err != nil {
-				ctx.Logger().Error("computing voting power from tokens failed",
+				ctx.Logger().Error("computing voting power from stake failed",
 					"err", err,
 					"node", n.ID,
 					"entity", n.EntityID,
 					"account", acctAddr,
-					"tokens", &account.Escrow.Active.Balance,
+					"stake", &account.Escrow.Active.Balance,
 				)
-				return fmt.Errorf("scheduler: getting computing voting power from tokens (node %s entity %s account %s tokens %v): %w",
+				return fmt.Errorf(
+					"scheduler: computing voting power from stake (node %s entity %s account %s stake %v): %w",
 					n.ID,
 					n.EntityID,
 					acctAddr,
@@ -198,7 +199,7 @@ func (app *schedulerApplication) InitChain(ctx *abciAPI.Context, req types.Reque
 	}
 
 	if !doc.Scheduler.Parameters.DebugBypassStake {
-		supplyPower, err := scheduler.VotingPowerFromTokens(&doc.Staking.TotalSupply)
+		supplyPower, err := scheduler.VotingPowerFromStake(&doc.Staking.TotalSupply)
 		if err != nil {
 			return fmt.Errorf("init chain: total supply would break voting power computation: %w", err)
 		}

--- a/go/consensus/tendermint/apps/scheduler/scheduler.go
+++ b/go/consensus/tendermint/apps/scheduler/scheduler.go
@@ -628,7 +628,7 @@ electLoop:
 				if err != nil {
 					return fmt.Errorf("failed to fetch escrow balance for account %s: %w", entAddr, err)
 				}
-				power, err = scheduler.VotingPowerFromTokens(stake)
+				power, err = scheduler.VotingPowerFromStake(stake)
 				if err != nil {
 					return fmt.Errorf("computing voting power for account %s with balance %v: %w",
 						entAddr, stake, err,

--- a/go/consensus/tendermint/apps/staking/fees.go
+++ b/go/consensus/tendermint/apps/staking/fees.go
@@ -80,7 +80,7 @@ func (app *stakingApplication) disburseFeesP(
 		evt := &staking.TransferEvent{
 			From:   staking.FeeAccumulatorAddress,
 			To:     proposerAddr,
-			Tokens: *feeProposerAmt,
+			Amount: *feeProposerAmt,
 		}
 		ctx.EmitEvent(abciAPI.NewEventBuilder(app.Name()).Attribute(KeyTransfer, cbor.Marshal(evt)))
 	}
@@ -103,7 +103,7 @@ func (app *stakingApplication) disburseFeesP(
 		evt := &staking.TransferEvent{
 			From:   staking.FeeAccumulatorAddress,
 			To:     staking.CommonPoolAddress,
-			Tokens: *remaining,
+			Amount: *remaining,
 		}
 		ctx.EmitEvent(abciAPI.NewEventBuilder(app.Name()).Attribute(KeyTransfer, cbor.Marshal(evt)))
 	}
@@ -196,7 +196,7 @@ func (app *stakingApplication) disburseFeesVQ(
 		evt := &staking.TransferEvent{
 			From:   staking.FeeAccumulatorAddress,
 			To:     proposerAddr,
-			Tokens: *nextProposerTotal,
+			Amount: *nextProposerTotal,
 		}
 		ctx.EmitEvent(abciAPI.NewEventBuilder(app.Name()).Attribute(KeyTransfer, cbor.Marshal(evt)))
 	}
@@ -220,7 +220,7 @@ func (app *stakingApplication) disburseFeesVQ(
 			evt := &staking.TransferEvent{
 				From:   staking.FeeAccumulatorAddress,
 				To:     voterAddr,
-				Tokens: *shareVote,
+				Amount: *shareVote,
 			}
 			ctx.EmitEvent(abciAPI.NewEventBuilder(app.Name()).Attribute(KeyTransfer, cbor.Marshal(evt)))
 		}
@@ -244,7 +244,7 @@ func (app *stakingApplication) disburseFeesVQ(
 		evt := &staking.TransferEvent{
 			From:   staking.FeeAccumulatorAddress,
 			To:     staking.CommonPoolAddress,
-			Tokens: *remaining,
+			Amount: *remaining,
 		}
 		ctx.EmitEvent(abciAPI.NewEventBuilder(app.Name()).Attribute(KeyTransfer, cbor.Marshal(evt)))
 	}

--- a/go/consensus/tendermint/apps/staking/state/gas.go
+++ b/go/consensus/tendermint/apps/staking/state/gas.go
@@ -109,7 +109,7 @@ func AuthenticateAndPayFees(
 		ev := cbor.Marshal(&staking.TransferEvent{
 			From:   addr,
 			To:     staking.FeeAccumulatorAddress,
-			Tokens: fee.Amount,
+			Amount: fee.Amount,
 		})
 		ctx.EmitEvent(abciAPI.NewEventBuilder(AppName).Attribute(KeyTransfer, ev))
 	}

--- a/go/consensus/tendermint/apps/staking/state/state_test.go
+++ b/go/consensus/tendermint/apps/staking/state/state_test.go
@@ -219,8 +219,8 @@ func TestRewardAndSlash(t *testing.T) {
 	require.NoError(err, "Account")
 	require.Equal(mustInitQuantity(t, 200), escrowAccount.Escrow.Active.Balance, "reward first step - escrow active escrow")
 	require.Equal(mustInitQuantity(t, 100), escrowAccount.Escrow.Debonding.Balance, "reward first step - escrow debonding escrow")
-	// Reward is 100 tokens, with 80 added to the pool and 20 deposited as commission.
-	// We add to the pool first, so the delegation becomes 100 shares : 180 tokens.
+	// Reward is 100 base units, with 80 added to the pool and 20 deposited as commission.
+	// We add to the pool first, so the delegation becomes 100 shares : 180 base units.
 	// Then we deposit the 20 for commission, which comes out to 11 shares.
 	del, err = s.Delegation(ctx, delegatorAddr, escrowAddr)
 	require.NoError(err, "Delegation")
@@ -255,7 +255,7 @@ func TestRewardAndSlash(t *testing.T) {
 	require.NoError(err, "slash escrow")
 	require.True(slashedNonzero, "slashed nonzero")
 
-	// 40 token loss.
+	// Loss of 40 base units.
 	delegatorAccount, err = s.Account(ctx, delegatorAddr)
 	require.NoError(err, "Account")
 	require.Equal(mustInitQuantity(t, 100), delegatorAccount.General.Balance, "slash - delegator general")

--- a/go/consensus/tendermint/apps/staking/transactions.go
+++ b/go/consensus/tendermint/apps/staking/transactions.go
@@ -47,13 +47,13 @@ func (app *stakingApplication) transfer(ctx *api.Context, state *stakingState.Mu
 
 	if fromAddr.Equal(xfer.To) {
 		// Handle transfer to self as just a balance check.
-		if from.General.Balance.Cmp(&xfer.Tokens) < 0 {
+		if from.General.Balance.Cmp(&xfer.Amount) < 0 {
 			err = staking.ErrInsufficientBalance
 			ctx.Logger().Error("Transfer: self-transfer greater than balance",
 				"err", err,
 				"from", fromAddr,
 				"to", xfer.To,
-				"amount", xfer.Tokens,
+				"amount", xfer.Amount,
 			)
 			return err
 		}
@@ -65,12 +65,12 @@ func (app *stakingApplication) transfer(ctx *api.Context, state *stakingState.Mu
 		if err != nil {
 			return fmt.Errorf("failed to fetch account: %w", err)
 		}
-		if err = quantity.Move(&to.General.Balance, &from.General.Balance, &xfer.Tokens); err != nil {
+		if err = quantity.Move(&to.General.Balance, &from.General.Balance, &xfer.Amount); err != nil {
 			ctx.Logger().Error("Transfer: failed to move balance",
 				"err", err,
 				"from", fromAddr,
 				"to", xfer.To,
-				"amount", xfer.Tokens,
+				"amount", xfer.Amount,
 			)
 			return err
 		}
@@ -87,13 +87,13 @@ func (app *stakingApplication) transfer(ctx *api.Context, state *stakingState.Mu
 	ctx.Logger().Debug("Transfer: executed transfer",
 		"from", fromAddr,
 		"to", xfer.To,
-		"amount", xfer.Tokens,
+		"amount", xfer.Amount,
 	)
 
 	evt := &staking.TransferEvent{
 		From:   fromAddr,
 		To:     xfer.To,
-		Tokens: xfer.Tokens,
+		Amount: xfer.Amount,
 	}
 	ctx.EmitEvent(api.NewEventBuilder(app.Name()).Attribute(KeyTransfer, cbor.Marshal(evt)))
 
@@ -124,11 +124,11 @@ func (app *stakingApplication) burn(ctx *api.Context, state *stakingState.Mutabl
 		return fmt.Errorf("failed to fetch account: %w", err)
 	}
 
-	if err = from.General.Balance.Sub(&burn.Tokens); err != nil {
-		ctx.Logger().Error("Burn: failed to burn tokens",
+	if err = from.General.Balance.Sub(&burn.Amount); err != nil {
+		ctx.Logger().Error("Burn: failed to burn stake",
 			"err", err,
 			"from", fromAddr,
-			"amount", burn.Tokens,
+			"amount", burn.Amount,
 		)
 		return err
 	}
@@ -138,7 +138,7 @@ func (app *stakingApplication) burn(ctx *api.Context, state *stakingState.Mutabl
 		return fmt.Errorf("failed to fetch total supply: %w", err)
 	}
 
-	_ = totalSupply.Sub(&burn.Tokens)
+	_ = totalSupply.Sub(&burn.Amount)
 
 	if err = state.SetAccount(ctx, fromAddr, from); err != nil {
 		return fmt.Errorf("failed to set account: %w", err)
@@ -147,14 +147,14 @@ func (app *stakingApplication) burn(ctx *api.Context, state *stakingState.Mutabl
 		return fmt.Errorf("failed to set total supply: %w", err)
 	}
 
-	ctx.Logger().Debug("Burn: burnt tokens",
+	ctx.Logger().Debug("Burn: burnt stake",
 		"from", fromAddr,
-		"amount", burn.Tokens,
+		"amount", burn.Amount,
 	)
 
 	evt := &staking.BurnEvent{
 		Owner:  fromAddr,
-		Tokens: burn.Tokens,
+		Amount: burn.Amount,
 	}
 	ctx.EmitEvent(api.NewEventBuilder(app.Name()).Attribute(KeyBurn, cbor.Marshal(evt)))
 
@@ -175,8 +175,8 @@ func (app *stakingApplication) addEscrow(ctx *api.Context, state *stakingState.M
 		return err
 	}
 
-	// Check if sender provided at least a minimum amount of tokens.
-	if escrow.Tokens.Cmp(&params.MinDelegationAmount) < 0 {
+	// Check if sender provided at least a minimum amount of stake.
+	if escrow.Amount.Cmp(&params.MinDelegationAmount) < 0 {
 		return staking.ErrInvalidArgument
 	}
 
@@ -213,12 +213,12 @@ func (app *stakingApplication) addEscrow(ctx *api.Context, state *stakingState.M
 		return fmt.Errorf("failed to fetch delegation: %w", err)
 	}
 
-	if err = to.Escrow.Active.Deposit(&delegation.Shares, &from.General.Balance, &escrow.Tokens); err != nil {
-		ctx.Logger().Error("AddEscrow: failed to escrow tokens",
+	if err = to.Escrow.Active.Deposit(&delegation.Shares, &from.General.Balance, &escrow.Amount); err != nil {
+		ctx.Logger().Error("AddEscrow: failed to escrow stake",
 			"err", err,
 			"from", fromAddr,
 			"to", escrow.Account,
-			"amount", escrow.Tokens,
+			"amount", escrow.Amount,
 		)
 		return err
 	}
@@ -237,16 +237,16 @@ func (app *stakingApplication) addEscrow(ctx *api.Context, state *stakingState.M
 		return fmt.Errorf("failed to set delegation: %w", err)
 	}
 
-	ctx.Logger().Debug("AddEscrow: escrowed tokens",
+	ctx.Logger().Debug("AddEscrow: escrowed stake",
 		"from", fromAddr,
 		"to", escrow.Account,
-		"amount", escrow.Tokens,
+		"amount", escrow.Amount,
 	)
 
 	evt := &staking.AddEscrowEvent{
 		Owner:  fromAddr,
 		Escrow: escrow.Account,
-		Tokens: escrow.Tokens,
+		Amount: escrow.Amount,
 	}
 	ctx.EmitEvent(api.NewEventBuilder(app.Name()).Attribute(KeyAddEscrow, cbor.Marshal(evt)))
 
@@ -322,9 +322,9 @@ func (app *stakingApplication) reclaimEscrow(ctx *api.Context, state *stakingSta
 		DebondEndTime: epoch + debondingInterval,
 	}
 
-	var tokens quantity.Quantity
+	var baseUnits quantity.Quantity
 
-	if err = from.Escrow.Active.Withdraw(&tokens, &delegation.Shares, &reclaim.Shares); err != nil {
+	if err = from.Escrow.Active.Withdraw(&baseUnits, &delegation.Shares, &reclaim.Shares); err != nil {
 		ctx.Logger().Error("ReclaimEscrow: failed to redeem escrow shares",
 			"err", err,
 			"to", toAddr,
@@ -333,21 +333,22 @@ func (app *stakingApplication) reclaimEscrow(ctx *api.Context, state *stakingSta
 		)
 		return err
 	}
-	tokenAmount := tokens.Clone()
+	stakeAmount := baseUnits.Clone()
 
-	if err = from.Escrow.Debonding.Deposit(&deb.Shares, &tokens, tokenAmount); err != nil {
+	if err = from.Escrow.Debonding.Deposit(&deb.Shares, &baseUnits, stakeAmount); err != nil {
 		ctx.Logger().Error("ReclaimEscrow: failed to debond shares",
 			"err", err,
 			"to", toAddr,
 			"from", reclaim.Account,
 			"shares", reclaim.Shares,
+			"base_units", stakeAmount,
 		)
 		return err
 	}
 
-	if !tokens.IsZero() {
-		ctx.Logger().Error("ReclaimEscrow: inconsistency in transferring tokens from active escrow to debonding",
-			"remaining", tokens,
+	if !baseUnits.IsZero() {
+		ctx.Logger().Error("ReclaimEscrow: inconsistency in transferring stake from active escrow to debonding",
+			"remaining_base_units", baseUnits,
 		)
 		return staking.ErrInvalidArgument
 	}

--- a/go/consensus/tendermint/apps/staking/transactions_test.go
+++ b/go/consensus/tendermint/apps/staking/transactions_test.go
@@ -95,7 +95,7 @@ func TestReservedAddresses(t *testing.T) {
 	_ = q.FromInt64(1_000)
 
 	// NOTE: We need to specify escrow amount since that is checked before the check for reserved address.
-	err = app.addEscrow(ctx, stakeState, &staking.Escrow{Tokens: *q.Clone()})
+	err = app.addEscrow(ctx, stakeState, &staking.Escrow{Amount: *q.Clone()})
 	require.EqualError(err, "staking: forbidden by policy", "adding escrow for reserved address should error")
 
 	// NOTE: We need to specify reclaim escrow shares since that is checked before the check for reserved address.

--- a/go/consensus/tendermint/staking/staking.go
+++ b/go/consensus/tendermint/staking/staking.go
@@ -1,4 +1,4 @@
-// Package staking implements the tendermint backed staking token backend.
+// Package staking implements the tendermint backed staking backend.
 package staking
 
 import (

--- a/go/consensus/tendermint/staking/staking.go
+++ b/go/consensus/tendermint/staking/staking.go
@@ -38,6 +38,24 @@ type tendermintBackend struct {
 	closedCh chan struct{}
 }
 
+func (tb *tendermintBackend) TokenSymbol(ctx context.Context) (string, error) {
+	genesis, err := tb.service.GetGenesisDocument(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return genesis.Staking.TokenSymbol, nil
+}
+
+func (tb *tendermintBackend) TokenValueExponent(ctx context.Context) (uint8, error) {
+	genesis, err := tb.service.GetGenesisDocument(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	return genesis.Staking.TokenValueExponent, nil
+}
+
 func (tb *tendermintBackend) TotalSupply(ctx context.Context, height int64) (*quantity.Quantity, error) {
 	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
@@ -135,12 +153,27 @@ func (tb *tendermintBackend) WatchEscrows(ctx context.Context) (<-chan *api.Escr
 }
 
 func (tb *tendermintBackend) StateToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
+	// Query the staking genesis state.
 	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
+	genesis, err := q.Genesis(ctx)
+	if err != nil {
+		return nil, err
+	}
 
-	return q.Genesis(ctx)
+	// Add static values to the genesis document.
+	genesis.TokenSymbol, err = tb.TokenSymbol(ctx)
+	if err != nil {
+		return nil, err
+	}
+	genesis.TokenValueExponent, err = tb.TokenValueExponent(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return genesis, nil
 }
 
 func (tb *tendermintBackend) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {

--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -1328,7 +1328,7 @@ func genesisToTendermint(d *genesisAPI.Document) (*tmtypes.GenesisDoc, error) {
 				// If all balances and stuff are zero, it's permitted not to have an account in the ledger at all.
 				stake = &quantity.Quantity{}
 			}
-			power, err = schedulerAPI.VotingPowerFromTokens(stake)
+			power, err = schedulerAPI.VotingPowerFromStake(stake)
 			if err != nil {
 				return nil, fmt.Errorf("tendermint: computing voting power for entity %s with account %s and stake %v: %w",
 					openedNode.EntityID,

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -2,6 +2,7 @@ package genesis
 
 import (
 	"encoding/hex"
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -128,7 +129,7 @@ func TestGenesisChainContext(t *testing.T) {
 	//       on each run.
 	stableDoc.Staking = staking.Genesis{}
 
-	require.Equal(t, "935f38f4eba20a2391418c3c708f4a0359725e0c235821923edf5da43142e180", stableDoc.ChainContext())
+	require.Equal(t, "eb8815bbaf67dd9b08a3fe9810c5b71856d474d038188ca0adbaa4ef99b289e7", stableDoc.ChainContext())
 }
 
 func TestGenesisSanityCheck(t *testing.T) {
@@ -641,6 +642,39 @@ func TestGenesisSanityCheck(t *testing.T) {
 	require.NoError(d.SanityCheck(), "storage node with compute runtime should pass")
 
 	// Test staking genesis checks.
+
+	d = *testDoc
+	d.Staking.TokenSymbol = ""
+	require.EqualError(
+		d.SanityCheck(),
+		"staking: sanity check failed: token symbol is empty",
+		"empty token symbol should be rejected",
+	)
+
+	d = *testDoc
+	d.Staking.TokenSymbol = "foo"
+	require.EqualError(
+		d.SanityCheck(),
+		fmt.Sprintf("staking: sanity check failed: token symbol should match '%s'", staking.TokenSymbolRegexp),
+		"lower case token symbol should be rejected",
+	)
+
+	d = *testDoc
+	d.Staking.TokenSymbol = "LONGSYMBOL"
+	require.EqualError(
+		d.SanityCheck(),
+		"staking: sanity check failed: token symbol exceeds maximum length",
+		"too long token symbol should be rejected",
+	)
+
+	d = *testDoc
+	d.Staking.TokenValueExponent = 21
+	require.EqualError(
+		d.SanityCheck(),
+		"staking: sanity check failed: token value exponent is invalid",
+		"too large token value exponent should be rejected",
+	)
+
 	// NOTE: There doesn't seem to be a way to generate invalid Quantities, so
 	// we're just going to test the code that checks if things add up.
 	d = *testDoc

--- a/go/oasis-node/cmd/common/consensus/consensus.go
+++ b/go/oasis-node/cmd/common/consensus/consensus.go
@@ -23,7 +23,7 @@ const (
 	// CfgTxNonce configures the nonce.
 	CfgTxNonce = "transaction.nonce"
 
-	// CfgTxFeeAmount configures the fee amount in tokens.
+	// CfgTxFeeAmount configures the fee amount in base units.
 	CfgTxFeeAmount = "transaction.fee.amount"
 
 	// CfgTxFeeGas configures the maximum gas limit.
@@ -145,7 +145,7 @@ func init() {
 	_ = viper.BindPFlags(TxFileFlags)
 
 	TxFlags.Uint64(CfgTxNonce, 0, "nonce of the signing account")
-	TxFlags.Uint64(CfgTxFeeAmount, 0, "transaction fee in tokens")
+	TxFlags.Uint64(CfgTxFeeAmount, 0, "transaction fee in base units")
 	TxFlags.String(CfgTxFeeGas, "0", "maximum transaction gas limit")
 	TxFlags.Bool(CfgTxUnsigned, false, "generate an unsigned transaction")
 	_ = viper.BindPFlags(TxFlags)

--- a/go/oasis-node/cmd/debug/consim/xfer_workload.go
+++ b/go/oasis-node/cmd/debug/consim/xfer_workload.go
@@ -154,7 +154,7 @@ func (w *xferWorkload) worker(cancelCh <-chan struct{}, errCh chan<- error) {
 
 	numAccounts, numIterations := len(w.accounts), viper.GetInt(cfgXferIterations)
 
-	// Shuffle tokens around till bored.
+	// Shuffle stake around till bored.
 	for nBlocks := 0; nBlocks < numIterations; nBlocks++ {
 		// Check for cancelation due to errors.
 		select {
@@ -199,7 +199,7 @@ func xferGenTx(from, to *xferAccount, amount uint64) ([]byte, error) {
 	xfer := &staking.Transfer{
 		To: to.address,
 	}
-	if err := xfer.Tokens.FromUint64(amount); err != nil {
+	if err := xfer.Amount.FromUint64(amount); err != nil {
 		return nil, err
 	}
 
@@ -221,7 +221,7 @@ func xferGenTx(from, to *xferAccount, amount uint64) ([]byte, error) {
 	//
 	// Note: The Move call will break if from == to, so don't do that.
 	from.nonce++
-	if err = quantity.Move(&to.balance, &from.balance, &xfer.Tokens); err != nil {
+	if err = quantity.Move(&to.balance, &from.balance, &xfer.Amount); err != nil {
 		return nil, err
 	}
 

--- a/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
+++ b/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
@@ -182,6 +182,9 @@ func doDumpDB(cmd *cobra.Command, args []string) {
 		)
 		return
 	}
+	// Add static values to the staking genesis state.
+	stakingSt.TokenSymbol = oldDoc.Staking.TokenSymbol
+	stakingSt.TokenValueExponent = oldDoc.Staking.TokenValueExponent
 	doc.Staking = *stakingSt
 
 	// KeyManager

--- a/go/oasis-node/cmd/debug/txsource/workload/delegation.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/delegation.go
@@ -74,7 +74,7 @@ func (d *delegation) doEscrowTx(ctx context.Context, rng *rand.Rand, cnsc consen
 	escrow := &staking.Escrow{
 		Account: d.accounts[selectedIdx].delegatedTo,
 	}
-	if err = escrow.Tokens.FromInt64(delegateAmount); err != nil {
+	if err = escrow.Amount.FromInt64(delegateAmount); err != nil {
 		return fmt.Errorf("escrow amount error: %w", err)
 	}
 

--- a/go/oasis-node/cmd/debug/txsource/workload/oversized.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/oversized.go
@@ -63,11 +63,11 @@ func (oversized) Run(
 	for {
 		// Generate a big transfer transaction which is valid, but oversized.
 		type customTransfer struct {
-			To   staking.Address `json:"xfer_to"`
-			Data []byte          `json:"xfer_data"`
+			To   staking.Address `json:"to"`
+			Data []byte          `json:"data"`
 		}
 		xfer := customTransfer{
-			// Send zero tokens to self, so the transaction will be valid.
+			// Send zero stake to self, so the transaction will be valid.
 			To: txSignerAddr,
 			// Include some extra random data so we are over the MaxTxSize limit.
 			Data: make([]byte, genesisDoc.Consensus.Parameters.MaxTxSize),

--- a/go/oasis-node/cmd/debug/txsource/workload/parallel.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/parallel.go
@@ -47,8 +47,8 @@ func (parallel) Run(
 	xfer := &staking.Transfer{
 		To: staking.NewAddress(fundingAccount.Public()),
 	}
-	if err = xfer.Tokens.FromInt64(parallelTxTransferAmount); err != nil {
-		return fmt.Errorf("transfer tokens FromInt64 %d: %w", parallelTxTransferAmount, err)
+	if err = xfer.Amount.FromInt64(parallelTxTransferAmount); err != nil {
+		return fmt.Errorf("transfer base units FromInt64 %d: %w", parallelTxTransferAmount, err)
 	}
 	txGasAmount, err = cnsc.EstimateGas(ctx, &consensus.EstimateGasRequest{
 		Signer:      fundingAccount.Public(),
@@ -100,8 +100,8 @@ func (parallel) Run(
 				transfer := staking.Transfer{
 					To: addr,
 				}
-				if err = transfer.Tokens.FromInt64(parallelTxTransferAmount); err != nil {
-					errCh <- fmt.Errorf("transfer tokens FromInt64 %d: %w", parallelTxTransferAmount, err)
+				if err = transfer.Amount.FromInt64(parallelTxTransferAmount); err != nil {
+					errCh <- fmt.Errorf("transfer base units FromInt64 %d: %w", parallelTxTransferAmount, err)
 					return
 				}
 

--- a/go/oasis-node/cmd/debug/txsource/workload/workload.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/workload.go
@@ -133,8 +133,8 @@ func transferFunds(
 		transfer := staking.Transfer{
 			To: to,
 		}
-		if err = transfer.Tokens.FromInt64(transferAmount); err != nil {
-			return backoff.Permanent(fmt.Errorf("transfer tokens FromInt64 %d: %w", transferAmount, err))
+		if err = transfer.Amount.FromInt64(transferAmount); err != nil {
+			return backoff.Permanent(fmt.Errorf("transfer base units FromInt64 %d: %w", transferAmount, err))
 		}
 		logger.Debug("transfering funds", "from", from.Public(), "to", to, "amount", transferAmount, "nonce", nonce)
 

--- a/go/oasis-node/cmd/stake/account.go
+++ b/go/oasis-node/cmd/stake/account.go
@@ -21,7 +21,7 @@ const (
 	// CfgAccountAddr configures the account address.
 	CfgAccountAddr = "stake.account.address"
 
-	// CfgAmount configures the amount of tokens.
+	// CfgAmount configures the amount of stake in base units.
 	CfgAmount = "stake.amount"
 
 	// CfgShares configures the amount of shares.
@@ -126,7 +126,7 @@ func doAccountTransfer(cmd *cobra.Command, args []string) {
 		)
 		os.Exit(1)
 	}
-	if err := xfer.Tokens.UnmarshalText([]byte(viper.GetString(CfgAmount))); err != nil {
+	if err := xfer.Amount.UnmarshalText([]byte(viper.GetString(CfgAmount))); err != nil {
 		logger.Error("failed to parse transfer amount",
 			"err", err,
 		)
@@ -148,7 +148,7 @@ func doAccountBurn(cmd *cobra.Command, args []string) {
 	cmdConsensus.AssertTxFileOK()
 
 	var burn staking.Burn
-	if err := burn.Tokens.UnmarshalText([]byte(viper.GetString(CfgAmount))); err != nil {
+	if err := burn.Amount.UnmarshalText([]byte(viper.GetString(CfgAmount))); err != nil {
 		logger.Error("failed to parse burn amount",
 			"err", err,
 		)
@@ -176,7 +176,7 @@ func doAccountEscrow(cmd *cobra.Command, args []string) {
 		)
 		os.Exit(1)
 	}
-	if err := escrow.Tokens.UnmarshalText([]byte(viper.GetString(CfgAmount))); err != nil {
+	if err := escrow.Amount.UnmarshalText([]byte(viper.GetString(CfgAmount))); err != nil {
 		logger.Error("failed to parse escrow amount",
 			"err", err,
 		)
@@ -224,7 +224,7 @@ func scanRateStep(dst *staking.CommissionRateStep, raw string) error {
 		return err
 	}
 	if n != 2 {
-		return fmt.Errorf("scanned %d tokens (need 2)", n)
+		return fmt.Errorf("scanned %d values (need 2)", n)
 	}
 	if err = dst.Rate.FromBigInt(&rateBI); err != nil {
 		return fmt.Errorf("rate: %w", err)
@@ -240,7 +240,7 @@ func scanBoundStep(dst *staking.CommissionRateBoundStep, raw string) error {
 		return err
 	}
 	if n != 3 {
-		return fmt.Errorf("scanned %d tokens (need 3)", n)
+		return fmt.Errorf("scanned %d values (need 3)", n)
 	}
 	if err = dst.RateMin.FromBigInt(&rateMinBI); err != nil {
 		return fmt.Errorf("rate min: %w", err)
@@ -324,7 +324,7 @@ func init() {
 	accountInfoFlags.AddFlagSet(cmdFlags.RetriesFlags)
 	accountInfoFlags.AddFlagSet(cmdGrpc.ClientFlags)
 
-	amountFlags.String(CfgAmount, "0", "amount of tokens for the transaction")
+	amountFlags.String(CfgAmount, "0", "amount of stake (in base units) for the transaction")
 	_ = viper.BindPFlags(amountFlags)
 
 	sharesFlags.String(CfgShares, "0", "amount of shares for the transaction")

--- a/go/oasis-node/cmd/stake/stake.go
+++ b/go/oasis-node/cmd/stake/stake.go
@@ -1,4 +1,4 @@
-// Package stake implements the stake token sub-commands.
+// Package stake implements the staking sub-commands.
 package stake
 
 import (
@@ -30,12 +30,12 @@ const CfgPublicKey = "public_key"
 var (
 	stakeCmd = &cobra.Command{
 		Use:   "stake",
-		Short: "stake token backend utilities",
+		Short: "staking backend utilities",
 	}
 
 	infoCmd = &cobra.Command{
 		Use:   "info",
-		Short: "query the common token info",
+		Short: "query the common staking info",
 		Run:   doInfo,
 	}
 
@@ -100,7 +100,7 @@ func doInfo(cmd *cobra.Command, args []string) {
 
 	ctx := context.Background()
 
-	doWithRetries(cmd, "query token total supply", func() error {
+	doWithRetries(cmd, "query total supply", func() error {
 		q, err := client.TotalSupply(ctx, consensus.HeightLatest)
 		if err != nil {
 			return err
@@ -110,7 +110,7 @@ func doInfo(cmd *cobra.Command, args []string) {
 		return nil
 	})
 
-	doWithRetries(cmd, "query token common pool", func() error {
+	doWithRetries(cmd, "query common pool", func() error {
 		q, err := client.CommonPool(ctx, consensus.HeightLatest)
 		if err != nil {
 			return err

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -802,6 +802,7 @@ func (net *Network) makeGenesis() error {
 		"--" + genesis.CfgRegistryDebugAllowTestRuntimes, "true",
 		"--scheduler.max_validators_per_entity", strconv.Itoa(len(net.Validators())),
 		"--" + genesis.CfgConsensusGasCostsTxByte, strconv.FormatUint(net.cfg.ConsensusGasCostsTxByte, 10),
+		"--" + genesis.CfgStakingTokenSymbol, "TEST",
 	}
 	if net.cfg.EpochtimeMock {
 		args = append(args, "--epochtime.debug.mock_backend")

--- a/go/oasis-test-runner/scenario/e2e/debond.go
+++ b/go/oasis-test-runner/scenario/e2e/debond.go
@@ -71,7 +71,7 @@ func (s *debondImpl) Run(*env.Env) error {
 	}
 	s.Logger.Info("balance ok")
 
-	// First debonding: 500 tokens at epoch 1.
+	// First debonding: 500 base units at epoch 1.
 	s.Logger.Info("advancing to first debonding")
 	if err = s.Net.Controller().SetEpoch(ctx, 1); err != nil {
 		return fmt.Errorf("first SetEpoch: %w", err)
@@ -90,7 +90,7 @@ func (s *debondImpl) Run(*env.Env) error {
 	}
 	s.Logger.Info("balance ok")
 
-	// Second debonding: 500 more tokens at epoch 2.
+	// Second debonding: 500 more base units at epoch 2.
 	s.Logger.Info("advancing to second debonding")
 	if err = s.Net.Controller().SetEpoch(ctx, 2); err != nil {
 		return fmt.Errorf("second SetEpoch: %w", err)

--- a/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
+++ b/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
@@ -168,21 +168,21 @@ func (sc *gasFeesImpl) runTests(ctx context.Context) error {
 	}
 
 	// As of the last time this comment was updated:
-	// - total fees has 150 tokens from genesis common pool (different in dump-restore variant)
-	// - total fees has 50 tokens from genesis last block fees (different in dump-restore variant)
+	// - total fees has 150 base units from genesis common pool (different in dump-restore variant)
+	// - total fees has 50 base units from genesis last block fees (different in dump-restore variant)
 	// - for each of 12 transactions that pay for gas:
-	//   - 10 tokens paid for gas in a block on its own
-	//   - (2+2)/(1+2+2) = 80% => 8 tokens persisted for VQ share
-	//   - 10 - 8 = 2 tokens paid to P
-	//   - VQ share divided into 3 validator portions, for 2 tokens each
-	//   - (2)/(2+2) = 50% => 1 token per validator for Q
-	//   - 2 - 1 = 1 token per validator for V
-	//   - remaining 2 tokens moved to common pool
-	// - 150 + 50 + 12 * 10 = 320 tokens `total_fees` (different in dump-restore variant)
-	// - 12 * 2 = 24 tokens paid for P role
-	// - 12 * 1 * 3 = 36 tokens paid for V roles
-	// - 12 * 1 * 3 = 36 tokens paid for Q role
-	// - 24 + 36 + 36 = 96 tokens `disbursed_fees`
+	//   - 10 base units paid for gas in a block on its own
+	//   - (2+2)/(1+2+2) = 80% => 8 base units persisted for VQ share
+	//   - 10 - 8 = 2 base units paid to P
+	//   - VQ share divided into 3 validator portions, for 2 base units each
+	//   - (2)/(2+2) = 50% => 1 base unit per validator for Q
+	//   - 2 - 1 = 1 base unit per validator for V
+	//   - remaining 2 base units moved to common pool
+	// - 150 + 50 + 12 * 10 = 320 base units `total_fees` (different in dump-restore variant)
+	// - 12 * 2 = 24 base units paid for P role
+	// - 12 * 1 * 3 = 36 base units paid for V roles
+	// - 12 * 1 * 3 = 36 base units paid for Q role
+	// - 24 + 36 + 36 = 96 base units `disbursed_fees`
 	sc.Logger.Info("making sure that fees have been disbursed",
 		"total_fees", totalFees,
 		"disbursed_fees", newTotalEntityBalance,
@@ -264,7 +264,7 @@ func (sc *gasFeesImpl) testTransfer(ctx context.Context, signer signature.Signer
 		transfer := staking.Transfer{
 			To: dstAddr,
 		}
-		_ = transfer.Tokens.FromInt64(amount)
+		_ = transfer.Amount.FromInt64(amount)
 
 		tx := staking.NewTransferTx(acct.General.Nonce, &fee, &transfer)
 		sigTx, err := transaction.Sign(signer, tx)
@@ -278,7 +278,7 @@ func (sc *gasFeesImpl) testTransfer(ctx context.Context, signer signature.Signer
 func (sc *gasFeesImpl) testBurn(ctx context.Context, signer signature.Signer) (*quantity.Quantity, error) {
 	return sc.testStakingGas(ctx, signer, true, func(acct *staking.Account, fee transaction.Fee, amount int64) error {
 		var burn staking.Burn
-		_ = burn.Tokens.FromInt64(amount)
+		_ = burn.Amount.FromInt64(amount)
 
 		tx := staking.NewBurnTx(acct.General.Nonce, &fee, &burn)
 		sigTx, err := transaction.Sign(signer, tx)
@@ -294,7 +294,7 @@ func (sc *gasFeesImpl) testAddEscrow(ctx context.Context, signer signature.Signe
 		escrow := staking.Escrow{
 			Account: escrowAddr,
 		}
-		_ = escrow.Tokens.FromInt64(amount)
+		_ = escrow.Amount.FromInt64(amount)
 
 		tx := staking.NewAddEscrowTx(acct.General.Nonce, &fee, &escrow)
 		sigTx, err := transaction.Sign(signer, tx)

--- a/go/oasis-test-runner/scenario/e2e/runtime/gas_fees.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/gas_fees.go
@@ -34,7 +34,7 @@ func (sc *gasFeesRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
 
 	// Use deterministic identities as we need to allocate funds to nodes.
 	f.Network.DeterministicIdentities = true
-	// Give our nodes some tokens.
+	// Give our nodes some stake.
 	f.Network.StakingGenesis = "tests/fixture-data/gas-fees-runtimes/staking-genesis.json"
 	// Update validators to require fee payments.
 	for i := range f.Validators {

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_dynamic.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_dynamic.go
@@ -442,11 +442,11 @@ func (sc *runtimeDynamicImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 
 	// Now escrow the stake back.
 	sc.Logger.Info("escrowing stake back")
-	var enoughTokens quantity.Quantity
-	_ = enoughTokens.FromUint64(100_000)
+	var enoughStake quantity.Quantity
+	_ = enoughStake.FromUint64(100_000)
 	tx = staking.NewAddEscrowTx(nonce, &transaction.Fee{Gas: 10000}, &staking.Escrow{
 		Account: entAddr,
-		Tokens:  enoughTokens,
+		Amount:  enoughStake,
 	})
 	nonce++ // nolint: ineffassign
 	sigTx, err = transaction.Sign(entSigner, tx)

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -774,6 +774,7 @@ type DebondingDelegation struct {
 
 // Genesis is the initial staking state for use in the genesis block.
 type Genesis struct {
+	// Parameters are the staking consensus parameters.
 	Parameters ConsensusParameters `json:"params"`
 
 	// TokenSymbol is the token's ticker symbol.
@@ -783,13 +784,21 @@ type Genesis struct {
 	// 1 token = 10**TokenValueExponent base units.
 	TokenValueExponent uint8 `json:"token_value_exponent"`
 
-	TotalSupply   quantity.Quantity `json:"total_supply"`
-	CommonPool    quantity.Quantity `json:"common_pool"`
+	// TokenSupply is the network's total amount of stake in base units.
+	TotalSupply quantity.Quantity `json:"total_supply"`
+	// CommonPool is the network's common stake pool.
+	CommonPool quantity.Quantity `json:"common_pool"`
+	// LastBlockFees are the collected fees for previous block.
 	LastBlockFees quantity.Quantity `json:"last_block_fees"`
 
+	// Ledger is a map of staking accounts.
 	Ledger map[Address]*Account `json:"ledger,omitempty"`
 
-	Delegations          map[Address]map[Address]*Delegation            `json:"delegations,omitempty"`
+	// Delegations is a nested map of staking delegations of the form:
+	// DELEGATEE-ACCOUNT-ADDRESS: DELEGATOR-ACCOUNT-ADDRESS: DELEGATION.
+	Delegations map[Address]map[Address]*Delegation `json:"delegations,omitempty"`
+	// DebondingDelegations is a nested map of staking delegations of the form:
+	// DEBONDING-DELEGATEE-ACCOUNT-ADDRESS: DEBONDING-DELEGATOR-ACCOUNT-ADDRESS: list of DEBONDING-DELEGATIONs.
 	DebondingDelegations map[Address]map[Address][]*DebondingDelegation `json:"debonding_delegations,omitempty"`
 }
 

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -89,9 +89,9 @@ var (
 	_ prettyprint.PrettyPrinter = (*Account)(nil)
 )
 
-// Backend is a staking token implementation.
+// Backend is a staking implementation.
 type Backend interface {
-	// TotalSupply returns the total number of tokens.
+	// TotalSupply returns the total number of base units.
 	TotalSupply(ctx context.Context, height int64) (*quantity.Quantity, error)
 
 	// CommonPool returns the common pool balance.
@@ -128,11 +128,12 @@ type Backend interface {
 	// on all balance transfers.
 	WatchTransfers(ctx context.Context) (<-chan *TransferEvent, pubsub.ClosableSubscription, error)
 
-	// WatchBurns returns a channel of BurnEvent on token destruction.
+	// WatchBurns returns a channel that produces a stream of BurnEvent when
+	// base units destructed.
 	WatchBurns(ctx context.Context) (<-chan *BurnEvent, pubsub.ClosableSubscription, error)
 
 	// WatchEscrows returns a channel that produces a stream of EscrowEvent
-	// when entities add to their escrow balance, get tokens deducted from
+	// when entities add to their escrow balance, get base units deducted from
 	// their escrow balance, and have their escrow balance released into their
 	// general balance.
 	WatchEscrows(ctx context.Context) (<-chan *EscrowEvent, pubsub.ClosableSubscription, error)
@@ -159,18 +160,18 @@ type OwnerQuery struct {
 	Owner  Address `json:"owner"`
 }
 
-// TransferEvent is the event emitted when a balance is transfered, either by
-// a call to Transfer or Withdraw.
+// TransferEvent is the event emitted when stake is transferred, either by a
+// call to Transfer or Withdraw.
 type TransferEvent struct {
 	From   Address           `json:"from"`
 	To     Address           `json:"to"`
-	Tokens quantity.Quantity `json:"tokens"`
+	Amount quantity.Quantity `json:"amount"`
 }
 
-// BurnEvent is the event emitted when tokens are destroyed via a call to Burn.
+// BurnEvent is the event emitted when stake is destroyed via a call to Burn.
 type BurnEvent struct {
 	Owner  Address           `json:"owner"`
-	Tokens quantity.Quantity `json:"tokens"`
+	Amount quantity.Quantity `json:"amount"`
 }
 
 // EscrowEvent is an escrow event.
@@ -190,33 +191,33 @@ type Event struct {
 	Escrow   *EscrowEvent   `json:"escrow,omitempty"`
 }
 
-// AddEscrowEvent is the event emitted when a balance is transfered into
-// an escrow balance.
+// AddEscrowEvent is the event emitted when stake is transferred into an escrow
+// account.
 type AddEscrowEvent struct {
 	Owner  Address           `json:"owner"`
 	Escrow Address           `json:"escrow"`
-	Tokens quantity.Quantity `json:"tokens"`
+	Amount quantity.Quantity `json:"amount"`
 }
 
-// TakeEscrowEvent is the event emitted when balance is deducted from an
-// escrow balance (stake is slashed).
+// TakeEscrowEvent is the event emitted when stake is taken from an escrow
+// account (i.e. stake is slashed).
 type TakeEscrowEvent struct {
 	Owner  Address           `json:"owner"`
-	Tokens quantity.Quantity `json:"tokens"`
+	Amount quantity.Quantity `json:"amount"`
 }
 
-// ReclaimEscrowEvent is the event emitted when tokens are reclaimed from an
-// escrow balance back into the entity's general balance.
+// ReclaimEscrowEvent is the event emitted when stake is reclaimed from an
+// escrow account back into owner's general account.
 type ReclaimEscrowEvent struct {
 	Owner  Address           `json:"owner"`
 	Escrow Address           `json:"escrow"`
-	Tokens quantity.Quantity `json:"tokens"`
+	Amount quantity.Quantity `json:"amount"`
 }
 
-// Transfer is a token transfer.
+// Transfer is a stake transfer.
 type Transfer struct {
-	To     Address           `json:"xfer_to"`
-	Tokens quantity.Quantity `json:"xfer_tokens"`
+	To     Address           `json:"to"`
+	Amount quantity.Quantity `json:"amount"`
 }
 
 // NewTransferTx creates a new transfer transaction.
@@ -224,9 +225,9 @@ func NewTransferTx(nonce uint64, fee *transaction.Fee, xfer *Transfer) *transact
 	return transaction.NewTransaction(nonce, fee, MethodTransfer, xfer)
 }
 
-// Burn is a token burn (destruction).
+// Burn is a stake burn (destruction).
 type Burn struct {
-	Tokens quantity.Quantity `json:"burn_tokens"`
+	Amount quantity.Quantity `json:"amount"`
 }
 
 // NewBurnTx creates a new burn transaction.
@@ -234,10 +235,10 @@ func NewBurnTx(nonce uint64, fee *transaction.Fee, burn *Burn) *transaction.Tran
 	return transaction.NewTransaction(nonce, fee, MethodBurn, burn)
 }
 
-// Escrow is a token escrow.
+// Escrow is a stake escrow.
 type Escrow struct {
-	Account Address           `json:"escrow_account"`
-	Tokens  quantity.Quantity `json:"escrow_tokens"`
+	Account Address           `json:"account"`
+	Amount  quantity.Quantity `json:"amount"`
 }
 
 // NewAddEscrowTx creates a new add escrow transaction.
@@ -245,10 +246,10 @@ func NewAddEscrowTx(nonce uint64, fee *transaction.Fee, escrow *Escrow) *transac
 	return transaction.NewTransaction(nonce, fee, MethodAddEscrow, escrow)
 }
 
-// ReclaimEscrow is a token escrow reclamation.
+// ReclaimEscrow is a reclamation of stake from an escrow.
 type ReclaimEscrow struct {
-	Account Address           `json:"escrow_account"`
-	Shares  quantity.Quantity `json:"reclaim_shares"`
+	Account Address           `json:"account"`
+	Shares  quantity.Quantity `json:"shares"`
 }
 
 // NewReclaimEscrowTx creates a new reclaim escrow transaction.
@@ -287,8 +288,8 @@ func (p SharePool) PrettyType() (interface{}, error) {
 	return p, nil
 }
 
-// sharesForTokens computes the amount of shares for the given amount of tokens.
-func (p *SharePool) sharesForTokens(amount *quantity.Quantity) (*quantity.Quantity, error) {
+// sharesForStake computes the amount of shares for the given amount of base units.
+func (p *SharePool) sharesForStake(amount *quantity.Quantity) (*quantity.Quantity, error) {
 	if p.TotalShares.IsZero() {
 		// No existing shares, exchange rate is 1:1.
 		return amount.Clone(), nil
@@ -316,15 +317,15 @@ func (p *SharePool) sharesForTokens(amount *quantity.Quantity) (*quantity.Quanti
 	return q, nil
 }
 
-// Deposit moves tokens into the combined balance, raising the shares.
+// Deposit moves stake into the combined balance, raising the shares.
 // If an error occurs, the pool and affected accounts are left in an invalid state.
-func (p *SharePool) Deposit(shareDst, tokenSrc, tokenAmount *quantity.Quantity) error {
-	shares, err := p.sharesForTokens(tokenAmount)
+func (p *SharePool) Deposit(shareDst, stakeSrc, baseUnitsAmount *quantity.Quantity) error {
+	shares, err := p.sharesForStake(baseUnitsAmount)
 	if err != nil {
 		return err
 	}
 
-	if err = quantity.Move(&p.Balance, tokenSrc, tokenAmount); err != nil {
+	if err = quantity.Move(&p.Balance, stakeSrc, baseUnitsAmount); err != nil {
 		return err
 	}
 
@@ -339,16 +340,16 @@ func (p *SharePool) Deposit(shareDst, tokenSrc, tokenAmount *quantity.Quantity) 
 	return nil
 }
 
-// tokensForShares computes the amount of tokens for the given amount of shares.
-func (p *SharePool) tokensForShares(amount *quantity.Quantity) (*quantity.Quantity, error) {
+// stakeForShares computes the amount of base units for the given amount of shares.
+func (p *SharePool) stakeForShares(amount *quantity.Quantity) (*quantity.Quantity, error) {
 	if amount.IsZero() || p.Balance.IsZero() || p.TotalShares.IsZero() {
-		// No existing shares or no balance means no tokens.
+		// No existing shares or no balance means no base units.
 		return quantity.NewQuantity(), nil
 	}
 
 	// Exchange rate is based on issued shares and the total balance as:
 	//
-	//     tokens = shares * balance / total_shares
+	//     base_units = shares * balance / total_shares
 	//
 	q := amount.Clone()
 	// Multiply first.
@@ -362,10 +363,10 @@ func (p *SharePool) tokensForShares(amount *quantity.Quantity) (*quantity.Quanti
 	return q, nil
 }
 
-// Withdraw moves tokens out of the combined balance, reducing the shares.
+// Withdraw moves stake out of the combined balance, reducing the shares.
 // If an error occurs, the pool and affected accounts are left in an invalid state.
-func (p *SharePool) Withdraw(tokenDst, shareSrc, shareAmount *quantity.Quantity) error {
-	tokens, err := p.tokensForShares(shareAmount)
+func (p *SharePool) Withdraw(stakeDst, shareSrc, shareAmount *quantity.Quantity) error {
+	baseUnits, err := p.stakeForShares(shareAmount)
 	if err != nil {
 		return err
 	}
@@ -378,7 +379,7 @@ func (p *SharePool) Withdraw(tokenDst, shareSrc, shareAmount *quantity.Quantity)
 		return err
 	}
 
-	if err = quantity.Move(tokenDst, &p.Balance, tokens); err != nil {
+	if err = quantity.Move(stakeDst, &p.Balance, baseUnits); err != nil {
 		return err
 	}
 

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -23,6 +23,13 @@ const (
 	// LogEventGeneralAdjustment is a log event value that signals adjustment
 	// of an account's general balance due to a roothash message.
 	LogEventGeneralAdjustment = "staking/general_adjustment"
+
+	// Maximum length of the token symbol.
+	TokenSymbolMaxLength = 8
+	// Regular expression defining valid token symbol characters.
+	TokenSymbolRegexp = "^[A-Z]+$" // nolint: gosec // Not that kind of token :).
+	// Maximum value of token's value base-10 exponent.
+	TokenValueExponentMaxValue = 20
 )
 
 var (
@@ -91,6 +98,13 @@ var (
 
 // Backend is a staking implementation.
 type Backend interface {
+	// TokenSymbol returns the token's ticker symbol.
+	TokenSymbol(ctx context.Context) (string, error)
+
+	// TokenValueExponent is the token's value base-10 exponent, i.e.
+	// 1 token = 10**TokenValueExponent base units.
+	TokenValueExponent(ctx context.Context) (uint8, error)
+
 	// TotalSupply returns the total number of base units.
 	TotalSupply(ctx context.Context, height int64) (*quantity.Quantity, error)
 
@@ -758,10 +772,16 @@ type DebondingDelegation struct {
 	DebondEndTime epochtime.EpochTime `json:"debond_end"`
 }
 
-// Genesis is the initial ledger balances at genesis for use in the genesis
-// block and test cases.
+// Genesis is the initial staking state for use in the genesis block.
 type Genesis struct {
 	Parameters ConsensusParameters `json:"params"`
+
+	// TokenSymbol is the token's ticker symbol.
+	// Only upper case A-Z characters are allowed.
+	TokenSymbol string `json:"token_symbol"`
+	// TokenValueExponent is the token's value base-10 exponent, i.e.
+	// 1 token = 10**TokenValueExponent base units.
+	TokenValueExponent uint8 `json:"token_value_exponent"`
 
 	TotalSupply   quantity.Quantity `json:"total_supply"`
 	CommonPool    quantity.Quantity `json:"common_pool"`

--- a/go/staking/api/sanity_check.go
+++ b/go/staking/api/sanity_check.go
@@ -3,6 +3,7 @@ package api
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	epochtime "github.com/oasisprotocol/oasis-core/go/epochtime/api"
@@ -226,6 +227,22 @@ func SanityCheckAccountShares(
 func (g *Genesis) SanityCheck(now epochtime.EpochTime) error { // nolint: gocyclo
 	if err := g.Parameters.SanityCheck(); err != nil {
 		return fmt.Errorf("staking: sanity check failed: %w", err)
+	}
+
+	tokenSymbolLength := len(g.TokenSymbol)
+	if tokenSymbolLength == 0 {
+		return fmt.Errorf("staking: sanity check failed: token symbol is empty")
+	}
+	if tokenSymbolLength > TokenSymbolMaxLength {
+		return fmt.Errorf("staking: sanity check failed: token symbol exceeds maximum length")
+	}
+	match := regexp.MustCompile(TokenSymbolRegexp).FindString(g.TokenSymbol)
+	if match == "" {
+		return fmt.Errorf("staking: sanity check failed: token symbol should match '%s'", TokenSymbolRegexp)
+	}
+
+	if g.TokenValueExponent > TokenValueExponentMaxValue {
+		return fmt.Errorf("staking: sanity check failed: token value exponent is invalid")
 	}
 
 	if !g.TotalSupply.IsValid() {

--- a/go/staking/gen_vectors/main.go
+++ b/go/staking/gen_vectors/main.go
@@ -40,7 +40,7 @@ func main() {
 				for _, tx := range []*transaction.Transaction{
 					staking.NewTransferTx(nonce, fee, &staking.Transfer{
 						To:     transferDstAddr,
-						Tokens: *quantity.NewFromUint64(amt),
+						Amount: *quantity.NewFromUint64(amt),
 					}),
 				} {
 					vectors = append(vectors, testvectors.MakeTestVector("Transfer", tx))
@@ -51,7 +51,7 @@ func main() {
 			for _, amt := range []uint64{0, 1000, 10_000_000} {
 				for _, tx := range []*transaction.Transaction{
 					staking.NewBurnTx(nonce, fee, &staking.Burn{
-						Tokens: *quantity.NewFromUint64(amt),
+						Amount: *quantity.NewFromUint64(amt),
 					}),
 				} {
 					vectors = append(vectors, testvectors.MakeTestVector("Burn", tx))
@@ -65,7 +65,7 @@ func main() {
 				for _, tx := range []*transaction.Transaction{
 					staking.NewAddEscrowTx(nonce, fee, &staking.Escrow{
 						Account: escrowDstAddr,
-						Tokens:  *quantity.NewFromUint64(amt),
+						Amount:  *quantity.NewFromUint64(amt),
 					}),
 				} {
 					vectors = append(vectors, testvectors.MakeTestVector("Escrow", tx))

--- a/go/staking/tests/debug/debug_stake.go
+++ b/go/staking/tests/debug/debug_stake.go
@@ -40,6 +40,7 @@ var (
 			RewardFactorEpochSigned: QtyFromInt(1),
 			// Zero RewardFactorBlockProposed is normal.
 		},
+		TokenSymbol: "TEST",
 		TotalSupply: DebugStateTotalSupply,
 		Ledger: map[api.Address]*api.Account{
 			DebugStateSrcAddress: {

--- a/tests/fixture-data/consim/genesis.json
+++ b/tests/fixture-data/consim/genesis.json
@@ -71,6 +71,7 @@
       "reward_factor_epoch_signed": "0",
       "reward_factor_block_proposed": "0"
     },
+    "token_symbol": "TEST",
     "total_supply": "290000000000",
     "common_pool": "0",
     "last_block_fees": "0",


### PR DESCRIPTION
Introduce `TokenSymbol` and `TokenValue` staking parameters which represent the token's ticker symbol and token's value in base units.

TODO:
- [x] Add sanity checks for `TokenSymbol` and `TokenValue`.