### PR TITLE
go staking: increase reward amount denominator

### DIFF
--- a/.changelog/3065.breaking.md
+++ b/.changelog/3065.breaking.md
@@ -1,0 +1,17 @@
+go/staking: Increase reward amount denominator
+
+This allows the genesis block writer to specify finer reward rates.
+
+Associated genesis controls analysis:
+
+```
+RewardAmountDenominator
+|- AddRewards
+|  |- RewardFactorEpochElectionAny
+|  '- RewardFactorEpochSigned
+'- AddRewardSingleAttenuated
+   '- RewardFactorBlockProposed
+```
+
+Note to the genesis block writer: scale rewards factors **up** by a
+factor of **1,000**.

--- a/go/consensus/tendermint/apps/staking/state/state_test.go
+++ b/go/consensus/tendermint/apps/staking/state/state_test.go
@@ -209,7 +209,7 @@ func TestRewardAndSlash(t *testing.T) {
 	require.NoError(err, "SetDebondingDelegation")
 
 	// Epoch 10 is during the first step.
-	require.NoError(s.AddRewards(ctx, 10, mustInitQuantityP(t, 100), escrowAddrAsList), "add rewards epoch 10")
+	require.NoError(s.AddRewards(ctx, 10, mustInitQuantityP(t, 100_000), escrowAddrAsList), "add rewards epoch 10")
 
 	// 100% gain.
 	delegatorAccount, err = s.Account(ctx, delegatorAddr)
@@ -233,7 +233,7 @@ func TestRewardAndSlash(t *testing.T) {
 	require.Equal(mustInitQuantityP(t, 9900), commonPool, "reward first step - common pool")
 
 	// Epoch 30 is in the second step.
-	require.NoError(s.AddRewards(ctx, 30, mustInitQuantityP(t, 100), escrowAddrAsList), "add rewards epoch 30")
+	require.NoError(s.AddRewards(ctx, 30, mustInitQuantityP(t, 100_000), escrowAddrAsList), "add rewards epoch 30")
 
 	// 50% gain.
 	escrowAccount, err = s.Account(ctx, escrowAddr)
@@ -244,7 +244,7 @@ func TestRewardAndSlash(t *testing.T) {
 	require.Equal(mustInitQuantityP(t, 9800), commonPool, "reward first step - common pool")
 
 	// Epoch 99 is after the end of the schedule
-	require.NoError(s.AddRewards(ctx, 99, mustInitQuantityP(t, 100), escrowAddrAsList), "add rewards epoch 99")
+	require.NoError(s.AddRewards(ctx, 99, mustInitQuantityP(t, 100_000), escrowAddrAsList), "add rewards epoch 99")
 
 	// No change.
 	escrowAccount, err = s.Account(ctx, escrowAddr)
@@ -268,7 +268,7 @@ func TestRewardAndSlash(t *testing.T) {
 	require.Equal(mustInitQuantityP(t, 9840), commonPool, "slash - common pool")
 
 	// Epoch 10 is during the first step.
-	require.NoError(s.AddRewardSingleAttenuated(ctx, 10, mustInitQuantityP(t, 10), 5, 10, escrowAddr), "add attenuated rewards epoch 30")
+	require.NoError(s.AddRewardSingleAttenuated(ctx, 10, mustInitQuantityP(t, 10_000), 5, 10, escrowAddr), "add attenuated rewards epoch 30")
 
 	// 5% gain.
 	escrowAccount, err = s.Account(ctx, escrowAddr)

--- a/go/staking/api/rewards.go
+++ b/go/staking/api/rewards.go
@@ -17,9 +17,9 @@ type RewardStep struct {
 }
 
 func init() {
-	// Denominated in 1000th of a percent.
+	// Denominated in one millionth of a percent.
 	RewardAmountDenominator = quantity.NewQuantity()
-	err := RewardAmountDenominator.FromBigInt(big.NewInt(100_000))
+	err := RewardAmountDenominator.FromBigInt(big.NewInt(100_000_000))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The denominator turned out not to be fine enough. This PR increases it. To keep the same reward rate, the numerators from the genesis block would need to be increased too. cc @bennetyee 