### PR TITLE
go/registry/api: Add `GetNodeByConsensusAddress` method

### DIFF
--- a/.changelog/2961.feature.md
+++ b/.changelog/2961.feature.md
@@ -1,0 +1,4 @@
+go/registry/api: Add `GetNodeByConsensusAddress` method
+
+`GetNodeByConsensusAddress` can be used to query nodes by their Consensus
+address.

--- a/.changelog/3067.breaking.md
+++ b/.changelog/3067.breaking.md
@@ -1,0 +1,4 @@
+go/registry/api: Remove `GetNodeList` method
+
+The `GetNodeList` method was unused and is therefore removed. Any code using
+this method can be migrated to use `GetNodes` instead.

--- a/go/consensus/tendermint/apps/registry/query.go
+++ b/go/consensus/tendermint/apps/registry/query.go
@@ -18,6 +18,7 @@ type Query interface {
 	Entity(context.Context, signature.PublicKey) (*entity.Entity, error)
 	Entities(context.Context) ([]*entity.Entity, error)
 	Node(context.Context, signature.PublicKey) (*node.Node, error)
+	NodeByConsensusAddress(context.Context, []byte) (*node.Node, error)
 	NodeStatus(context.Context, signature.PublicKey) (*registry.NodeStatus, error)
 	Nodes(context.Context) ([]*node.Node, error)
 	Runtime(context.Context, common.Namespace) (*registry.Runtime, error)
@@ -69,6 +70,10 @@ func (rq *registryQuerier) Node(ctx context.Context, id signature.PublicKey) (*n
 		return nil, registry.ErrNoSuchNode
 	}
 	return node, nil
+}
+
+func (rq *registryQuerier) NodeByConsensusAddress(ctx context.Context, address []byte) (*node.Node, error) {
+	return rq.state.NodeByConsensusAddress(ctx, address)
 }
 
 func (rq *registryQuerier) NodeStatus(ctx context.Context, id signature.PublicKey) (*registry.NodeStatus, error) {

--- a/go/consensus/tendermint/registry/registry.go
+++ b/go/consensus/tendermint/registry/registry.go
@@ -94,6 +94,15 @@ func (tb *tendermintBackend) GetNodes(ctx context.Context, height int64) ([]*nod
 	return q.Nodes(ctx)
 }
 
+func (tb *tendermintBackend) GetNodeByConsensusAddress(ctx context.Context, query *api.ConsensusAddressQuery) (*node.Node, error) {
+	q, err := tb.querier.QueryAt(ctx, query.Height)
+	if err != nil {
+		return nil, err
+	}
+
+	return q.NodeByConsensusAddress(ctx, query.Address)
+}
+
 func (tb *tendermintBackend) WatchNodes(ctx context.Context) (<-chan *api.NodeEvent, pubsub.ClosableSubscription, error) {
 	typedCh := make(chan *api.NodeEvent)
 	sub := tb.nodeNotifier.Subscribe()

--- a/go/consensus/tendermint/registry/registry.go
+++ b/go/consensus/tendermint/registry/registry.go
@@ -127,10 +127,6 @@ func (tb *tendermintBackend) WatchRuntimes(ctx context.Context) (<-chan *api.Run
 	return typedCh, sub, nil
 }
 
-func (tb *tendermintBackend) GetNodeList(ctx context.Context, height int64) (*api.NodeList, error) {
-	return tb.getNodeList(ctx, height)
-}
-
 func (tb *tendermintBackend) Cleanup() {
 }
 

--- a/go/oasis-node/cmd/debug/txsource/workload/queries.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/queries.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	tmcrypto "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/crypto"
 	control "github.com/oasisprotocol/oasis-core/go/control/api"
 	epochtime "github.com/oasisprotocol/oasis-core/go/epochtime/api"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
@@ -212,6 +213,17 @@ func (q *queries) doRegistryQueries(ctx context.Context, rng *rand.Rand, height 
 		_, err = q.registry.GetNodeStatus(ctx, &registry.IDQuery{ID: nod.ID, Height: height})
 		if err != nil {
 			return fmt.Errorf("GetNodeStatus error at height %d: %w", height, err)
+		}
+		node, err = q.registry.GetNodeByConsensusAddress(
+			ctx,
+			&registry.ConsensusAddressQuery{
+				Address: []byte(tmcrypto.PublicKeyToTendermint(&nod.Consensus.ID).Address()), Height: height},
+		)
+		if err != nil {
+			return fmt.Errorf("GetNodeByConsensusAddress error at height %d: %w", height, err)
+		}
+		if !nod.ID.Equal(node.ID) {
+			return fmt.Errorf("GetNodeByConsensusAddress mismatch, expected: %s, got: %s", nod, node)
 		}
 	}
 

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -215,9 +215,6 @@ type Backend interface {
 	// block height.
 	GetRuntimes(context.Context, int64) ([]*Runtime, error)
 
-	// GetNodeList returns the NodeList at the specified block height.
-	GetNodeList(context.Context, int64) (*NodeList, error)
-
 	// WatchRuntimes returns a stream of Runtime.  Upon subscription,
 	// all runtimes will be sent immediately.
 	WatchRuntimes(context.Context) (<-chan *Runtime, pubsub.ClosableSubscription, error)

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -196,6 +196,11 @@ type Backend interface {
 	// GetNodes gets a list of all registered nodes.
 	GetNodes(context.Context, int64) ([]*node.Node, error)
 
+	// GetNodeByConsensusAddress looks up a node by its consensus address at the
+	// specified block height. The nature and format of the consensus address depends
+	// on the specific consensus backend implementation used.
+	GetNodeByConsensusAddress(context.Context, *ConsensusAddressQuery) (*node.Node, error)
+
 	// WatchNodes returns a channel that produces a stream of
 	// NodeEvent on node registration changes.
 	WatchNodes(context.Context) (<-chan *NodeEvent, pubsub.ClosableSubscription, error)
@@ -204,7 +209,7 @@ type Backend interface {
 	// Upon subscription, the node list for the current epoch will be sent
 	// immediately if available.
 	//
-	// Each node list will be sorted by node ID in lexographically ascending
+	// Each node list will be sorted by node ID in lexicographically ascending
 	// order.
 	WatchNodeList(context.Context) (<-chan *NodeList, pubsub.ClosableSubscription, error)
 
@@ -239,6 +244,14 @@ type IDQuery struct {
 type NamespaceQuery struct {
 	Height int64            `json:"height"`
 	ID     common.Namespace `json:"id"`
+}
+
+// ConsensusAddressQuery is a registry query by consensus address.
+// The nature and format of the consensus address depends on the specific
+// consensus backend implementation used.
+type ConsensusAddressQuery struct {
+	Height  int64  `json:"height"`
+	Address []byte `json:"address"`
 }
 
 // NewRegisterEntityTx creates a new register entity transaction.

--- a/go/registry/api/grpc.go
+++ b/go/registry/api/grpc.go
@@ -29,8 +29,6 @@ var (
 	methodGetRuntime = serviceName.NewMethod("GetRuntime", NamespaceQuery{})
 	// methodGetRuntimes is the GetRuntimes method.
 	methodGetRuntimes = serviceName.NewMethod("GetRuntimes", int64(0))
-	// methodGetNodeList is the GetNodeList method.
-	methodGetNodeList = serviceName.NewMethod("GetNodeList", int64(0))
 	// methodStateToGenesis is the StateToGenesis method.
 	methodStateToGenesis = serviceName.NewMethod("StateToGenesis", int64(0))
 	// methodGetEvents is the GetEvents method.
@@ -77,10 +75,6 @@ var (
 			{
 				MethodName: methodGetRuntimes.ShortName(),
 				Handler:    handlerGetRuntimes,
-			},
-			{
-				MethodName: methodGetNodeList.ShortName(),
-				Handler:    handlerGetNodeList,
 			},
 			{
 				MethodName: methodStateToGenesis.ShortName(),
@@ -273,29 +267,6 @@ func handlerGetRuntimes( // nolint: golint
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(Backend).GetRuntimes(ctx, req.(int64))
-	}
-	return interceptor(ctx, height, info, handler)
-}
-
-func handlerGetNodeList( // nolint: golint
-	srv interface{},
-	ctx context.Context,
-	dec func(interface{}) error,
-	interceptor grpc.UnaryServerInterceptor,
-) (interface{}, error) {
-	var height int64
-	if err := dec(&height); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(Backend).GetNodeList(ctx, height)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: methodGetNodeList.FullName(),
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(Backend).GetNodeList(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -626,14 +597,6 @@ func (c *registryClient) GetRuntimes(ctx context.Context, height int64) ([]*Runt
 		return nil, err
 	}
 	return rsp, nil
-}
-
-func (c *registryClient) GetNodeList(ctx context.Context, height int64) (*NodeList, error) {
-	var rsp NodeList
-	if err := c.conn.Invoke(ctx, methodGetNodeList.FullName(), height, &rsp); err != nil {
-		return nil, err
-	}
-	return &rsp, nil
 }
 
 func (c *registryClient) WatchRuntimes(ctx context.Context) (<-chan *Runtime, pubsub.ClosableSubscription, error) {

--- a/go/worker/common/p2p/peermgmt.go
+++ b/go/worker/common/p2p/peermgmt.go
@@ -144,7 +144,7 @@ func (mgr *PeerManager) watchRegistryNodes(consensus consensus.Backend) {
 
 	nodeCh, nSub, err := consensus.Registry().WatchNodes(mgr.ctx)
 	if err != nil {
-		mgr.logger.Error("failed to watch registery for node changes",
+		mgr.logger.Error("failed to watch registry for node changes",
 			"err", err,
 		)
 		return


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/2961