### PR TITLE
docs: add voting power description

### DIFF
--- a/docs/consensus/scheduler.md
+++ b/docs/consensus/scheduler.md
@@ -16,3 +16,17 @@ the [consensus service API documentation].
 <!-- markdownlint-enable line-length -->
 
 ## Events
+
+## Validator Committee
+
+When the committee scheduler schedules the validator committee, it additionally
+assigns each member a _voting power_, which controls (i) the weight of its
+votes in the consensus protocol and (ii) how often it serves as the proposer in
+the consensus protocol.
+
+The committee scheduler assigns a validator's voting power proportional to its
+entity's [escrow account balance].
+
+<!-- markdownlint-disable line-length -->
+[escrow account balance]: staking.md#escrow
+<!-- markdownlint-enable line-length -->


### PR DESCRIPTION
fixes #3057

Adds a section on how voting power is computed to the Consensus Scheduler doc.