### PR TITLE
go/oasis-node: add consensus estimate_gas

### DIFF
--- a/.changelog/2723.feature.md
+++ b/.changelog/2723.feature.md
@@ -1,0 +1,5 @@
+go oasis-node: Add CLI command for estimating gas cost of a transaction
+
+This adds `oasis-node consensus estimate_gas`.
+
+This adds `--transaction.unsigned`.

--- a/go/oasis-test-runner/oasis/cli/consensus.go
+++ b/go/oasis-test-runner/oasis/cli/consensus.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
@@ -49,12 +48,12 @@ func (c *ConsensusHelpers) EstimateGas(txPath string, signerPub signature.Public
 	}
 	out, err := c.runSubCommandWithOutput("consensus-estimate_gas", args)
 	if err != nil {
-		return 0, fmt.Errorf("failed to estimate gas: %w stderr [%s]", err, out.String())
+		return 0, fmt.Errorf("failed to estimate gas: error: %w output: %s", err, out.String())
 	}
 	gasS := out.String()
-	gasU, err := strconv.ParseUint(gasS, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse output %s: %w", gasS, err)
+	var gas transaction.Gas
+	if _, err = fmt.Sscan(gasS, &gas); err != nil {
+		return 0, fmt.Errorf("failed to parse output: error: %w output: %s", err, gasS)
 	}
-	return transaction.Gas(gasU), nil
+	return gas, nil
 }

--- a/go/oasis-test-runner/scenario/e2e/stake_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/stake_cli.go
@@ -240,8 +240,9 @@ func (sc *stakeCLIImpl) testTransfer(childEnv *env.Env, cli *cli.Helpers, src ap
 	if err != nil {
 		return fmt.Errorf("estimate gas on unsigned transfer tx: %w", err)
 	}
-	// TODO: replace with comparison to expected value
-	fmt.Printf("gas %d, reference %d\n", gas, 10000)
+	if gas != 272 {
+		return fmt.Errorf("wrong gas estimate: expected %d, got %d", 272, gas)
+	}
 
 	transferTxPath := filepath.Join(childEnv.Dir(), "stake_transfer.json")
 	if err = sc.genTransferTx(childEnv, transferAmount, 0, dst, transferTxPath); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/stake_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/stake_cli.go
@@ -241,6 +241,13 @@ func (sc *stakeCLIImpl) testTransfer(childEnv *env.Env, cli *cli.Helpers, src ap
 		return err
 	}
 
+	gas, err := cli.Consensus.EstimateGas(transferTxPath)
+	if err != nil {
+		return err
+	}
+	// TODO: replace with comparison to expected value
+	fmt.Printf("gas %d, reference %d\n", gas, 10000)
+
 	if err := cli.Consensus.SubmitTx(transferTxPath); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/stake_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/stake_cli.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/entity"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/consensus"
@@ -227,35 +228,43 @@ func (sc *stakeCLIImpl) testPubkey2Address(childEnv *env.Env, publicKeyText stri
 
 // testTransfer tests transfer of transferAmount tokens from src to dst.
 func (sc *stakeCLIImpl) testTransfer(childEnv *env.Env, cli *cli.Helpers, src api.Address, dst api.Address) error {
-	transferTxPath := filepath.Join(childEnv.Dir(), "stake_transfer.json")
-	if err := sc.genTransferTx(childEnv, transferAmount, 0, dst, transferTxPath); err != nil {
-		return err
+	unsignedTransferTxPath := filepath.Join(childEnv.Dir(), "stake_transfer_unsigned.cbor")
+	if err := sc.genUnsignedTransferTx(childEnv, transferAmount, 0, dst, unsignedTransferTxPath); err != nil {
+		return fmt.Errorf("genUnsignedTransferTx: %w", err)
 	}
-	if err := sc.showTx(childEnv, transferTxPath); err != nil {
-		return err
-	}
-	if err := sc.checkBalance(childEnv, src, initBalance); err != nil {
-		return err
-	}
-	if err := sc.checkBalance(childEnv, dst, 0); err != nil {
-		return err
-	}
-
-	gas, err := cli.Consensus.EstimateGas(transferTxPath)
+	_, teSigner, err := entity.TestEntity()
 	if err != nil {
-		return err
+		return fmt.Errorf("obtain test entity: %w", err)
+	}
+	gas, err := cli.Consensus.EstimateGas(unsignedTransferTxPath, teSigner.Public())
+	if err != nil {
+		return fmt.Errorf("estimate gas on unsigned transfer tx: %w", err)
 	}
 	// TODO: replace with comparison to expected value
 	fmt.Printf("gas %d, reference %d\n", gas, 10000)
 
-	if err := cli.Consensus.SubmitTx(transferTxPath); err != nil {
+	transferTxPath := filepath.Join(childEnv.Dir(), "stake_transfer.json")
+	if err = sc.genTransferTx(childEnv, transferAmount, 0, dst, transferTxPath); err != nil {
+		return err
+	}
+	if err = sc.showTx(childEnv, transferTxPath); err != nil {
+		return err
+	}
+	if err = sc.checkBalance(childEnv, src, initBalance); err != nil {
+		return err
+	}
+	if err = sc.checkBalance(childEnv, dst, 0); err != nil {
 		return err
 	}
 
-	if err := sc.checkBalance(childEnv, src, initBalance-transferAmount-feeAmount); err != nil {
+	if err = cli.Consensus.SubmitTx(transferTxPath); err != nil {
 		return err
 	}
-	if err := sc.checkBalance(childEnv, dst, transferAmount); err != nil {
+
+	if err = sc.checkBalance(childEnv, src, initBalance-transferAmount-feeAmount); err != nil {
+		return err
+	}
+	if err = sc.checkBalance(childEnv, dst, transferAmount); err != nil {
 		return err
 	}
 	accounts, err := sc.listAccountAddresses(childEnv)
@@ -518,6 +527,28 @@ func (sc *stakeCLIImpl) showTx(childEnv *env.Env, txPath string) error {
 	}
 	if out, err := cli.RunSubCommandWithOutput(childEnv, sc.Logger, "show_tx", sc.Net.Config().NodeBinary, args); err != nil {
 		return fmt.Errorf("showTx: failed to show tx: error: %w, output: %s", err, out.String())
+	}
+	return nil
+}
+
+func (sc *stakeCLIImpl) genUnsignedTransferTx(childEnv *env.Env, amount int, nonce int, dst api.Address, txPath string) error {
+	sc.Logger.Info("generating unsigned stake transfer tx", stake.CfgTransferDestination, dst)
+
+	args := []string{
+		"stake", "account", "gen_transfer",
+		"--" + stake.CfgAmount, strconv.Itoa(amount),
+		"--" + consensus.CfgTxNonce, strconv.Itoa(nonce),
+		"--" + consensus.CfgTxFile, txPath,
+		"--" + stake.CfgTransferDestination, dst.String(),
+		"--" + consensus.CfgTxFeeAmount, strconv.Itoa(feeAmount),
+		"--" + consensus.CfgTxFeeGas, strconv.Itoa(feeGas),
+		"--" + consensus.CfgTxUnsigned,
+		"--" + flags.CfgDebugDontBlameOasis,
+		"--" + common.CfgDebugAllowTestKeys,
+		"--" + flags.CfgGenesisFile, sc.Net.GenesisPath(),
+	}
+	if out, err := cli.RunSubCommandWithOutput(childEnv, sc.Logger, "gen_transfer", sc.Net.Config().NodeBinary, args); err != nil {
+		return fmt.Errorf("genUnsignedTransferTx: failed to generate transfer tx: error: %w output: %s", err, out.String())
 	}
 	return nil
 }


### PR DESCRIPTION
fixes #2723 

> We just need to expose it via CLI.

in fact this is made even easier now that the command is further exposed over consensus ClientBackend

~~doesn't exactly live up to the original request though, because you'd still have to set a gas and sign it first before you would run the signed transaction through this file~~