### PR TITLE
go/worker/common/p2p: Don't treat context cancellation as permanent

### DIFF
--- a/.changelog/3075.bugfix.md
+++ b/.changelog/3075.bugfix.md
@@ -1,0 +1,5 @@
+go/worker/common/p2p: Don't treat context cancellation as permanent
+
+Context cancellation errors should not count as permanent for P2P dispatch as
+the cancelled context may be due to the round advancing in which case
+dispatch should actually be retried.

--- a/go/worker/common/p2p/error/error.go
+++ b/go/worker/common/p2p/error/error.go
@@ -1,7 +1,12 @@
 // Package error exists only to break an import loop.
 package error
 
-import "github.com/cenkalti/backoff/v4"
+import (
+	"context"
+	"errors"
+
+	"github.com/cenkalti/backoff/v4"
+)
 
 // Permanent wraps an error returned by various handler functions to
 // suppress retry.
@@ -12,6 +17,12 @@ func Permanent(err error) error {
 // IsPermanent returns true iff the error is a permanent p2p message
 // handler error.
 func IsPermanent(err error) bool {
+	if errors.Is(err, context.Canceled) {
+		// Context cancellation errors should not count as permanent for P2P dispatch. This is
+		// because the cancelled context may be due to the round advancing in which case dispatch
+		// should actually be retried.
+		return false
+	}
 	_, ok := (err).(*backoff.PermanentError)
 	return ok
 }


### PR DESCRIPTION
Context cancellation errors should not count as permanent for P2P dispatch as
the cancelled context may be due to the round advancing in which case dispatch
should actually be retried.