### PR TITLE
go/consensus: Expose read-only state via light client interface

### DIFF
--- a/.changelog/3077.feature.md
+++ b/.changelog/3077.feature.md
@@ -1,0 +1,5 @@
+go/consensus: Expose read-only state via light client interface
+
+Nodes configured as consensus RPC services workers now expose read-only
+access to consensus state via the usual MKVS ReadSyncer interface, allowing
+light clients to remotely query state while transparently verifying proofs.

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -21,6 +21,7 @@ import (
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
+	mkvsNode "github.com/oasisprotocol/oasis-core/go/storage/mkvs/node"
 )
 
 const (
@@ -105,6 +106,8 @@ type Block struct {
 	Hash []byte `json:"hash"`
 	// Time is the second-granular consensus time.
 	Time time.Time `json:"time"`
+	// StateRoot is the Merkle root of the consensus state tree.
+	StateRoot mkvsNode.Root `json:"state_root"`
 	// Meta contains the consensus backend specific block metadata.
 	Meta cbor.RawMessage `json:"meta"`
 }
@@ -125,6 +128,8 @@ type Status struct {
 	LatestHash []byte `json:"latest_hash"`
 	// LatestTime is the timestamp of the latest block.
 	LatestTime time.Time `json:"latest_time"`
+	// LatestStateRoot is the Merkle root of the consensus state tree.
+	LatestStateRoot mkvsNode.Root `json:"latest_state_root"`
 
 	// GenesisHeight is the height of the genesis block.
 	GenesisHeight int64 `json:"genesis_height"`

--- a/go/consensus/api/light.go
+++ b/go/consensus/api/light.go
@@ -1,6 +1,10 @@
 package api
 
-import "context"
+import (
+	"context"
+
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/syncer"
+)
 
 // LightClientBackend is the limited consensus interface used by light clients.
 type LightClientBackend interface {
@@ -12,6 +16,10 @@ type LightClientBackend interface {
 
 	// GetParameters returns the consensus parameters for a specific height.
 	GetParameters(ctx context.Context, height int64) (*Parameters, error)
+
+	// State returns a MKVS read syncer that can be used to read consensus state from a remote node
+	// and verify it against the trusted local root.
+	State() syncer.ReadSyncer
 
 	// TODO: Move SubmitEvidence etc. from Backend.
 }

--- a/go/consensus/tendermint/abci/mux.go
+++ b/go/consensus/tendermint/abci/mux.go
@@ -263,9 +263,9 @@ func (a *ApplicationServer) EstimateGas(caller signature.PublicKey, tx *transact
 	return a.mux.EstimateGas(caller, tx)
 }
 
-// BlockHeight returns the last committed block height.
-func (a *ApplicationServer) BlockHeight() int64 {
-	return a.mux.state.BlockHeight()
+// State returns the application state.
+func (a *ApplicationServer) State() api.ApplicationQueryState {
+	return a.mux.state
 }
 
 // NewApplicationServer returns a new ApplicationServer, using the provided

--- a/go/consensus/tendermint/full.go
+++ b/go/consensus/tendermint/full.go
@@ -9,6 +9,7 @@ import (
 	tmstate "github.com/tendermint/tendermint/state"
 
 	consensusAPI "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/syncer"
 )
 
 // We must use Tendermint's amino codec as some Tendermint's types are not easily unmarshallable.
@@ -72,4 +73,9 @@ func (t *tendermintService) GetParameters(ctx context.Context, height int64) (*c
 		Height: params.BlockHeight,
 		Meta:   aminoCodec.MustMarshalBinaryBare(params.ConsensusParams),
 	}, nil
+}
+
+// Implements LightClientBackend.
+func (t *tendermintService) State() syncer.ReadSyncer {
+	return t.mux.State().Storage()
 }

--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -818,6 +818,7 @@ func (t *tendermintService) GetStatus(ctx context.Context) (*consensusAPI.Status
 		status.LatestHeight = latestBlk.Height
 		status.LatestHash = latestBlk.Hash
 		status.LatestTime = latestBlk.Time
+		status.LatestStateRoot = latestBlk.StateRoot
 	case consensusAPI.ErrNoCommittedBlocks:
 		// No committed blocks yet.
 	default:
@@ -976,7 +977,7 @@ func (t *tendermintService) GetTendermintBlock(ctx context.Context, height int64
 		// Do not let Tendermint determine the latest height (e.g., by passing nil here) as that
 		// completely ignores ABCI processing so it can return a block for which local state does
 		// not yet exist. Use our mux notion of latest height instead.
-		tmHeight = t.mux.BlockHeight()
+		tmHeight = t.mux.State().BlockHeight()
 		if tmHeight == 0 {
 			// No committed blocks yet.
 			return nil, nil
@@ -1011,7 +1012,7 @@ func (t *tendermintService) GetBlockResults(height int64) (*tmrpctypes.ResultBlo
 	// from our mux.
 	var tmHeight int64
 	if height == consensusAPI.HeightLatest {
-		tmHeight = t.mux.BlockHeight()
+		tmHeight = t.mux.State().BlockHeight()
 		if tmHeight == 0 {
 			// No committed blocks yet.
 			return nil, consensusAPI.ErrNoCommittedBlocks


### PR DESCRIPTION
Fixes #3077 

Nodes configured as consensus RPC services workers now expose read-only
access to consensus state via the usual MKVS ReadSyncer interface, allowing
light clients to remotely query state while transparently verifying proofs.

TODO
* [x] Expose `syncer.ReadSyncer` interface into consensus state over the light client interface.
* [x] Tests.