### PR TITLE
go/consensus/tendermint: Refactor internal event handling

### DIFF
--- a/.changelog/3091.internal.md
+++ b/.changelog/3091.internal.md
@@ -1,0 +1,6 @@
+go/consensus/tendermint: Refactor internal event handling
+
+Previously each consensus service client implemented its own event processing
+loop. All service clients now have a unified event loop implementation (each
+still runs in its own goroutine) that takes care of query subscriptions and
+event dispatch.

--- a/go/consensus/tendermint/api/api_test.go
+++ b/go/consensus/tendermint/api/api_test.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
+	tmquery "github.com/tendermint/tendermint/libs/pubsub/query"
+)
+
+func TestServiceDescriptor(t *testing.T) {
+	require := require.New(t)
+
+	q1 := tmquery.MustParse("a='b'")
+
+	sd := NewStaticServiceDescriptor("test", "test-type", []tmpubsub.Query{q1})
+	require.Equal("test", sd.Name())
+	require.Equal("test-type", sd.EventType())
+	recvQ1 := <-sd.Queries()
+	require.EqualValues(q1, recvQ1, "received query should be correct")
+	_, ok := <-sd.Queries()
+	require.False(ok, "query channel must be closed")
+}

--- a/go/consensus/tendermint/apps/epochtime_mock/epochtime_mock.go
+++ b/go/consensus/tendermint/apps/epochtime_mock/epochtime_mock.go
@@ -62,7 +62,7 @@ func (app *epochTimeMockApplication) BeginBlock(ctx *api.Context, request types.
 		return nil
 	}
 
-	height := ctx.BlockHeight()
+	height := ctx.BlockHeight() + 1
 	if future.Height != height {
 		ctx.Logger().Error("BeginBlock: height mismatch in defered set",
 			"height", height,
@@ -121,7 +121,7 @@ func (app *epochTimeMockApplication) setEpoch(
 	state *mutableState,
 	epoch epochtime.EpochTime,
 ) error {
-	height := ctx.BlockHeight()
+	height := ctx.BlockHeight() + 1
 
 	ctx.Logger().Info("scheduling epoch transition",
 		"epoch", epoch,

--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -320,7 +320,7 @@ func (app *rootHashApplication) emitEmptyBlock(ctx *tmapi.Context, runtime *root
 	ctx.EmitEvent(
 		tmapi.NewEventBuilder(app.Name()).
 			Attribute(KeyFinalized, cbor.Marshal(tagV)).
-			Attribute(KeyRuntimeID, cbor.Marshal(runtime.Runtime.ID)),
+			Attribute(KeyRuntimeID, ValueRuntimeID(runtime.Runtime.ID)),
 	)
 }
 
@@ -441,7 +441,7 @@ func (app *rootHashApplication) onNewRuntime(ctx *tmapi.Context, runtime *regist
 	ctx.EmitEvent(
 		tmapi.NewEventBuilder(app.Name()).
 			Attribute(KeyFinalized, cbor.Marshal(tagV)).
-			Attribute(KeyRuntimeID, cbor.Marshal(runtime.ID)),
+			Attribute(KeyRuntimeID, ValueRuntimeID(runtime.ID)),
 	)
 	return nil
 }
@@ -598,7 +598,7 @@ func (app *rootHashApplication) tryFinalizeExecute(
 		ctx.EmitEvent(
 			tmapi.NewEventBuilder(app.Name()).
 				Attribute(KeyExecutionDiscrepancyDetected, cbor.Marshal(tagV)).
-				Attribute(KeyRuntimeID, cbor.Marshal(runtime.ID)),
+				Attribute(KeyRuntimeID, ValueRuntimeID(runtime.ID)),
 		)
 		return
 	default:
@@ -674,7 +674,7 @@ func (app *rootHashApplication) tryFinalizeMerge(
 		ctx.EmitEvent(
 			tmapi.NewEventBuilder(app.Name()).
 				Attribute(KeyMergeDiscrepancyDetected, cbor.Marshal(tagV)).
-				Attribute(KeyRuntimeID, cbor.Marshal(runtime.ID)),
+				Attribute(KeyRuntimeID, ValueRuntimeID(runtime.ID)),
 		)
 		return nil
 	default:
@@ -728,7 +728,7 @@ func (app *rootHashApplication) postProcessFinalizedBlock(ctx *tmapi.Context, rt
 	ctx.EmitEvent(
 		tmapi.NewEventBuilder(app.Name()).
 			Attribute(KeyFinalized, cbor.Marshal(tagV)).
-			Attribute(KeyRuntimeID, cbor.Marshal(rtState.Runtime.ID)),
+			Attribute(KeyRuntimeID, ValueRuntimeID(rtState.Runtime.ID)),
 	)
 	return nil
 }

--- a/go/consensus/tendermint/apps/roothash/transactions.go
+++ b/go/consensus/tendermint/apps/roothash/transactions.go
@@ -157,7 +157,7 @@ func (app *rootHashApplication) executorCommit(
 		ctx.EmitEvent(
 			tmapi.NewEventBuilder(app.Name()).
 				Attribute(KeyExecutorCommitted, cbor.Marshal(evV)).
-				Attribute(KeyRuntimeID, cbor.Marshal(cc.ID)),
+				Attribute(KeyRuntimeID, ValueRuntimeID(cc.ID)),
 		)
 	}
 
@@ -225,7 +225,7 @@ func (app *rootHashApplication) mergeCommit(
 		ctx.EmitEvent(
 			tmapi.NewEventBuilder(app.Name()).
 				Attribute(KeyMergeCommitted, cbor.Marshal(evV)).
-				Attribute(KeyRuntimeID, cbor.Marshal(mc.ID)),
+				Attribute(KeyRuntimeID, ValueRuntimeID(mc.ID)),
 		)
 	}
 

--- a/go/consensus/tendermint/roothash/roothash.go
+++ b/go/consensus/tendermint/roothash/roothash.go
@@ -11,6 +11,7 @@ import (
 	"github.com/eapache/channels"
 	"github.com/hashicorp/go-multierror"
 	tmabcitypes "github.com/tendermint/tendermint/abci/types"
+	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
 	tmrpctypes "github.com/tendermint/tendermint/rpc/core/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 
@@ -20,7 +21,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
-	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
 	app "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/roothash"
 	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint/service"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api"
@@ -30,7 +31,11 @@ import (
 
 const crashPointBlockBeforeIndex = "roothash.before_index"
 
-var _ api.Backend = (*tendermintBackend)(nil)
+// ServiceClient is the roothash service client interface.
+type ServiceClient interface {
+	api.Backend
+	tmapi.ServiceClient
+}
 
 type runtimeBrokers struct {
 	sync.Mutex
@@ -42,37 +47,49 @@ type runtimeBrokers struct {
 	lastBlock       *block.Block
 }
 
-type tendermintBackend struct {
+type trackedRuntime struct {
+	runtimeID common.Namespace
+
+	height       int64
+	blockHistory api.BlockHistory
+	reindexDone  bool
+}
+
+type cmdTrackRuntime struct {
+	runtimeID    common.Namespace
+	blockHistory api.BlockHistory
+}
+
+type serviceClient struct {
+	tmapi.BaseServiceClient
 	sync.RWMutex
 
 	ctx    context.Context
 	logger *logging.Logger
 
-	service         service.TendermintService
-	querier         *app.QueryFactory
-	lastBlockHeight int64
+	service service.TendermintService
+	querier *app.QueryFactory
 
 	allBlockNotifier *pubsub.Broker
 	runtimeNotifiers map[common.Namespace]*runtimeBrokers
 	genesisBlocks    map[common.Namespace]*block.Block
 
-	closeOnce      sync.Once
-	closedCh       chan struct{}
-	initCh         chan struct{}
-	blockHistoryCh chan api.BlockHistory
+	queryCh        chan tmpubsub.Query
+	cmdCh          chan interface{}
+	trackedRuntime map[common.Namespace]*trackedRuntime
 }
 
-func (tb *tendermintBackend) GetGenesisBlock(ctx context.Context, id common.Namespace, height int64) (*block.Block, error) {
+func (sc *serviceClient) GetGenesisBlock(ctx context.Context, id common.Namespace, height int64) (*block.Block, error) {
 	// First check if we have the genesis blocks cached. They are immutable so easy
 	// to cache to avoid repeated requests to the Tendermint app.
-	tb.RLock()
-	if blk := tb.genesisBlocks[id]; blk != nil {
-		tb.RUnlock()
+	sc.RLock()
+	if blk := sc.genesisBlocks[id]; blk != nil {
+		sc.RUnlock()
 		return blk, nil
 	}
-	tb.RUnlock()
+	sc.RUnlock()
 
-	q, err := tb.querier.QueryAt(ctx, height)
+	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -83,19 +100,19 @@ func (tb *tendermintBackend) GetGenesisBlock(ctx context.Context, id common.Name
 	}
 
 	// Update the genesis block cache.
-	tb.Lock()
-	tb.genesisBlocks[id] = blk
-	tb.Unlock()
+	sc.Lock()
+	sc.genesisBlocks[id] = blk
+	sc.Unlock()
 
 	return blk, nil
 }
 
-func (tb *tendermintBackend) GetLatestBlock(ctx context.Context, id common.Namespace, height int64) (*block.Block, error) {
-	return tb.getLatestBlockAt(ctx, id, height)
+func (sc *serviceClient) GetLatestBlock(ctx context.Context, id common.Namespace, height int64) (*block.Block, error) {
+	return sc.getLatestBlockAt(ctx, id, height)
 }
 
-func (tb *tendermintBackend) getLatestBlockAt(ctx context.Context, id common.Namespace, height int64) (*block.Block, error) {
-	q, err := tb.querier.QueryAt(ctx, height)
+func (sc *serviceClient) getLatestBlockAt(ctx context.Context, id common.Namespace, height int64) (*block.Block, error) {
+	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -103,8 +120,8 @@ func (tb *tendermintBackend) getLatestBlockAt(ctx context.Context, id common.Nam
 	return q.LatestBlock(ctx, id)
 }
 
-func (tb *tendermintBackend) WatchBlocks(id common.Namespace) (<-chan *api.AnnotatedBlock, *pubsub.Subscription, error) {
-	notifiers := tb.getRuntimeNotifiers(id)
+func (sc *serviceClient) WatchBlocks(id common.Namespace) (<-chan *api.AnnotatedBlock, *pubsub.Subscription, error) {
+	notifiers := sc.getRuntimeNotifiers(id)
 
 	sub := notifiers.blockNotifier.SubscribeEx(-1, func(ch channels.Channel) {
 		// Replay the latest block if it exists.
@@ -142,37 +159,58 @@ func (tb *tendermintBackend) WatchBlocks(id common.Namespace) (<-chan *api.Annot
 		}
 	}()
 
+	// Start tracking this runtime if we are not tracking it yet.
+	if err := sc.trackRuntime(sc.ctx, id, nil); err != nil {
+		sub.Close()
+		return nil, nil, err
+	}
+
 	return monotonicCh, sub, nil
 }
 
-func (tb *tendermintBackend) WatchAllBlocks() (<-chan *block.Block, *pubsub.Subscription) {
-	sub := tb.allBlockNotifier.Subscribe()
+func (sc *serviceClient) WatchAllBlocks() (<-chan *block.Block, *pubsub.Subscription) {
+	sub := sc.allBlockNotifier.Subscribe()
 	ch := make(chan *block.Block)
 	sub.Unwrap(ch)
 
 	return ch, sub
 }
 
-func (tb *tendermintBackend) WatchEvents(id common.Namespace) (<-chan *api.Event, *pubsub.Subscription, error) {
-	notifiers := tb.getRuntimeNotifiers(id)
+func (sc *serviceClient) WatchEvents(id common.Namespace) (<-chan *api.Event, *pubsub.Subscription, error) {
+	notifiers := sc.getRuntimeNotifiers(id)
 	sub := notifiers.eventNotifier.Subscribe()
 	ch := make(chan *api.Event)
 	sub.Unwrap(ch)
 
+	// Start tracking this runtime if we are not tracking it yet.
+	if err := sc.trackRuntime(sc.ctx, id, nil); err != nil {
+		sub.Close()
+		return nil, nil, err
+	}
+
 	return ch, sub, nil
 }
 
-func (tb *tendermintBackend) TrackRuntime(ctx context.Context, history api.BlockHistory) error {
+func (sc *serviceClient) TrackRuntime(ctx context.Context, history api.BlockHistory) error {
+	return sc.trackRuntime(ctx, history.RuntimeID(), history)
+}
+
+func (sc *serviceClient) trackRuntime(ctx context.Context, id common.Namespace, history api.BlockHistory) error {
+	cmd := &cmdTrackRuntime{
+		runtimeID:    id,
+		blockHistory: history,
+	}
+
 	select {
-	case tb.blockHistoryCh <- history:
+	case sc.cmdCh <- cmd:
 	case <-ctx.Done():
 		return ctx.Err()
 	}
 	return nil
 }
 
-func (tb *tendermintBackend) StateToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
-	q, err := tb.querier.QueryAt(ctx, height)
+func (sc *serviceClient) StateToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
+	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -180,12 +218,12 @@ func (tb *tendermintBackend) StateToGenesis(ctx context.Context, height int64) (
 	return q.Genesis(ctx)
 }
 
-func (tb *tendermintBackend) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
+func (sc *serviceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
 	var results *tmrpctypes.ResultBlockResults
-	results, err := tb.service.GetBlockResults(height)
+	results, err := sc.service.GetBlockResults(height)
 	if err != nil {
-		tb.logger.Error("failed to get tendermint block results",
+		sc.logger.Error("failed to get tendermint block results",
 			"err", err,
 			"height", height,
 		)
@@ -193,9 +231,9 @@ func (tb *tendermintBackend) GetEvents(ctx context.Context, height int64) ([]*ap
 	}
 
 	// Get transactions at given height.
-	txns, err := tb.service.GetTransactions(ctx, height)
+	txns, err := sc.service.GetTransactions(ctx, height)
 	if err != nil {
-		tb.logger.Error("failed to get tendermint transactions",
+		sc.logger.Error("failed to get tendermint transactions",
 			"err", err,
 			"height", height,
 		)
@@ -231,69 +269,57 @@ func (tb *tendermintBackend) GetEvents(ctx context.Context, height int64) ([]*ap
 	return events, nil
 }
 
-func (tb *tendermintBackend) Cleanup() {
-	tb.closeOnce.Do(func() {
-		<-tb.closedCh
-	})
+func (sc *serviceClient) Cleanup() {
 }
 
-func (tb *tendermintBackend) getRuntimeNotifiers(id common.Namespace) *runtimeBrokers {
-	tb.Lock()
-	defer tb.Unlock()
+func (sc *serviceClient) getRuntimeNotifiers(id common.Namespace) *runtimeBrokers {
+	sc.Lock()
+	defer sc.Unlock()
 
-	notifiers := tb.runtimeNotifiers[id]
+	notifiers := sc.runtimeNotifiers[id]
 	if notifiers == nil {
 		notifiers = &runtimeBrokers{
 			blockNotifier: pubsub.NewBroker(false),
 			eventNotifier: pubsub.NewBroker(false),
 		}
-		tb.runtimeNotifiers[id] = notifiers
+		sc.runtimeNotifiers[id] = notifiers
 	}
 
 	return notifiers
 }
 
-func (tb *tendermintBackend) reindexBlocks(bh api.BlockHistory) error {
-	var err error
-	var lastHeight int64
-	if lastHeight, err = bh.LastConsensusHeight(); err != nil {
-		tb.logger.Error("failed to get last indexed height",
-			"err", err,
-		)
-		return err
-	}
-
-	// Scan all blocks between last indexed height and current height. Note that
-	// we can safely snapshot the current height as we have already subscribed
-	// to new blocks.
-	var currentBlk *tmtypes.Block
-	if currentBlk, err = tb.service.GetTendermintBlock(tb.ctx, consensus.HeightLatest); err != nil {
-		tb.logger.Error("failed to get latest block",
-			"err", err,
-		)
-		return err
-	}
-
-	// There may not be a current block yet if we need to initialize from genesis.
-	if currentBlk == nil {
+func (sc *serviceClient) reindexBlocks(currentHeight int64, bh api.BlockHistory) error {
+	if currentHeight <= 0 {
 		return nil
 	}
 
-	tb.logger.Debug("reindexing blocks",
+	logger := sc.logger.With("runtime_id", bh.RuntimeID())
+
+	var err error
+	var lastHeight int64
+	if lastHeight, err = bh.LastConsensusHeight(); err != nil {
+		sc.logger.Error("failed to get last indexed height",
+			"err", err,
+		)
+		return fmt.Errorf("failed to get last indexed height: %w", err)
+	}
+
+	// Scan all blocks between last indexed height and current height.
+	logger.Debug("reindexing blocks",
 		"last_indexed_height", lastHeight,
-		"current_height", currentBlk.Height,
+		"current_height", currentHeight,
 	)
 
 	// TODO: Take prune strategy into account (e.g., skip heights).
-	for height := lastHeight + 1; height <= currentBlk.Height; height++ {
+	for height := lastHeight + 1; height <= currentHeight; height++ {
 		var results *tmrpctypes.ResultBlockResults
-		results, err = tb.service.GetBlockResults(height)
+		results, err = sc.service.GetBlockResults(height)
 		if err != nil {
-			tb.logger.Error("failed to get tendermint block",
+			logger.Error("failed to get tendermint block results",
 				"err", err,
 				"height", height,
 			)
-			return err
+			return fmt.Errorf("failed to get tendermint block results: %w", err)
 		}
 
 		// Index block.
@@ -309,198 +335,195 @@ func (tb *tendermintBackend) reindexBlocks(bh api.BlockHistory) error {
 			for _, pair := range tmEv.GetAttributes() {
 				if bytes.Equal(pair.GetKey(), app.KeyFinalized) {
 					var value app.ValueFinalized
-					if err := cbor.Unmarshal(pair.GetValue(), &value); err != nil {
-						tb.logger.Error("failed to unamrshal finalized event",
+					if err = cbor.Unmarshal(pair.GetValue(), &value); err != nil {
+						logger.Error("failed to unmarshal finalized event",
 							"err", err,
 							"height", height,
 						)
-						continue
+						return fmt.Errorf("failed to unmarshal finalized event: %w", err)
 					}
 
-					blk, err := tb.getLatestBlockAt(tb.ctx, value.ID, height)
-					if err != nil {
-						tb.logger.Error("failed to fetch latest block",
-							"err", err,
-							"height", height,
-							"runtime_id", value.ID,
-						)
-						continue
-					}
-					if blk.Header.Round != value.Round {
-						tb.logger.Error("worker: finalized event/query round mismatch",
-							"block", blk,
-							"event", value,
-						)
-						continue
-					}
-
-					annBlk := &api.AnnotatedBlock{
-						Height: height,
-						Block:  blk,
-					}
-					if err = bh.Commit(annBlk); err != nil {
-						tb.logger.Error("failed to commit block to block history",
-							"err", err,
-							"height", height,
-							"round", blk.Header.Round,
-						)
-						return err
+					if err = sc.processFinalizedEvent(sc.ctx, height, value.ID, &value.Round, false); err != nil {
+						return fmt.Errorf("failed to process finalized event: %w", err)
 					}
 				}
 			}
 		}
 	}
 
-	tb.logger.Debug("block reindex complete")
+	sc.logger.Debug("block reindex complete")
 
 	return nil
 }
 
-func (tb *tendermintBackend) worker(ctx context.Context) { // nolint: gocyclo
-	defer close(tb.closedCh)
+// Implements api.ServiceClient.
+func (sc *serviceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
+	return tmapi.NewServiceDescriptor(api.ModuleName, app.EventType, sc.queryCh, sc.cmdCh)
+}
 
-	// Subscribe to transactions which modify state.
-	sub, err := tb.service.Subscribe("roothash-worker", app.QueryApp)
-	if err != nil {
-		tb.logger.Error("failed to subscribe",
-			"err", err,
-		)
-		return
-	}
-	defer tb.service.Unsubscribe("roothash-worker", app.QueryApp) // nolint: errcheck
-
-	close(tb.initCh)
-
-	// Initialize block history keepers.
-	blockHistory := make(map[common.Namespace]api.BlockHistory)
-
-	// Process transactions and emit notifications for our subscribers.
-	for {
-		var event interface{}
-
-		select {
-		case msg := <-sub.Out():
-			event = msg.Data()
-		case <-sub.Cancelled():
-			tb.logger.Debug("terminating, subscription closed")
-			return
-		case bh := <-tb.blockHistoryCh:
-			// We need to start watching a new block history.
-			blockHistory[bh.RuntimeID()] = bh
-			// Perform reindex if required.
-			if err = tb.reindexBlocks(bh); err != nil {
-				tb.logger.Error("failed to reindex blocks",
-					"err", err,
-					"runtime_id", bh.RuntimeID(),
-				)
-
-				panic("roothash: failed to reindex blocks")
+// Implements api.ServiceClient.
+func (sc *serviceClient) DeliverCommand(ctx context.Context, height int64, cmd interface{}) error {
+	switch c := cmd.(type) {
+	case *cmdTrackRuntime:
+		// Request to track a new runtime.
+		etr := sc.trackedRuntime[c.runtimeID]
+		if etr != nil {
+			// Ignore duplicate runtime tracking requests unless this updates the block history.
+			if etr.blockHistory != nil || c.blockHistory == nil {
+				break
 			}
-			continue
-		case <-ctx.Done():
-			return
+		} else {
+			sc.logger.Debug("tracking new runtime",
+				"runtime_id", c.runtimeID,
+				"height", height,
+			)
 		}
 
-		switch ev := event.(type) {
-		case tmtypes.EventDataNewBlock:
-			tb.Lock()
-			tb.lastBlockHeight = ev.Block.Header.Height
-			tb.Unlock()
-
-			tb.onEventDataNewBlock(ctx, ev, blockHistory)
-		case tmtypes.EventDataTx:
-			tb.onEventDataTx(ctx, ev, blockHistory)
-		default:
+		// We need to start watching a new block history.
+		tr := &trackedRuntime{
+			runtimeID:    c.runtimeID,
+			blockHistory: c.blockHistory,
 		}
+		sc.trackedRuntime[c.runtimeID] = tr
+		// Request subscription to events for this runtime.
+		sc.queryCh <- app.QueryForRuntime(tr.runtimeID)
+
+		// Emit latest block.
+		if err := sc.processFinalizedEvent(ctx, height, tr.runtimeID, nil, true); err != nil {
+			sc.logger.Warn("failed to emit latest block",
+				"err", err,
+				"runtime_id", c.runtimeID,
+				"height", height,
+			)
+		}
+		// Make sure we reindex again when receiving the first event.
+		tr.reindexDone = false
+	default:
+		return fmt.Errorf("roothash: unknown command: %T", cmd)
 	}
+	return nil
 }
 
-func (tb *tendermintBackend) onEventDataNewBlock(
-	ctx context.Context,
-	ev tmtypes.EventDataNewBlock,
-	blockHistory map[common.Namespace]api.BlockHistory,
-) {
-	tmEvents := append([]tmabcitypes.Event{}, ev.ResultBeginBlock.GetEvents()...)
-	tmEvents = append(tmEvents, ev.ResultEndBlock.GetEvents()...)
-	events, err := EventsFromTendermint(nil, ev.Block.Header.Height, tmEvents)
+// Implements api.ServiceClient.
+func (sc *serviceClient) DeliverEvent(ctx context.Context, height int64, tx tmtypes.Tx, ev *tmabcitypes.Event) error {
+	events, err := EventsFromTendermint(tx, height, []tmabcitypes.Event{*ev})
 	if err != nil {
-		tb.logger.Error("error processing tendermint roothash events", "err", err)
+		return fmt.Errorf("roothash: failed to process tendermint events: %w", err)
 	}
-	tb.processEvents(ctx, events, blockHistory)
-}
 
-func (tb *tendermintBackend) onEventDataTx(
-	ctx context.Context,
-	ev tmtypes.EventDataTx,
-	blockHistory map[common.Namespace]api.BlockHistory,
-) {
-	events, err := EventsFromTendermint(ev.Tx, ev.Height, ev.Result.Events)
-	if err != nil {
-		tb.logger.Error("error processing tendermint roothash events", "err", err)
-	}
-	tb.processEvents(ctx, events, blockHistory)
-}
-
-func (tb *tendermintBackend) processEvents(ctx context.Context, events []*api.Event, blockHistory map[common.Namespace]api.BlockHistory) {
 	for _, ev := range events {
 		// Notify non-finalized events.
 		if ev.FinalizedEvent == nil {
-			notifiers := tb.getRuntimeNotifiers(ev.RuntimeID)
+			notifiers := sc.getRuntimeNotifiers(ev.RuntimeID)
 			notifiers.eventNotifier.Broadcast(ev)
 			continue
 		}
 
-		// Process finalized event.
-		blk, err := tb.getLatestBlockAt(ctx, ev.RuntimeID, ev.Height)
-		if err != nil {
-			tb.logger.Error("worker: failed to fetch latest block",
-				"err", err,
-				"height", ev.Height,
-				"runtime_id", ev.RuntimeID,
-			)
-			continue
+		if err = sc.processFinalizedEvent(ctx, height, ev.RuntimeID, &ev.FinalizedEvent.Round, true); err != nil {
+			return fmt.Errorf("roothash: failed to process finalized event: %w", err)
 		}
-		if blk.Header.Round != ev.FinalizedEvent.Round {
-			tb.logger.Error("worker: finalized event/query round mismatch",
-				"block", blk,
-				"event", ev,
-			)
-			continue
-		}
-
-		notifiers := tb.getRuntimeNotifiers(ev.RuntimeID)
-		// Ensure latest block is set.
-		notifiers.Lock()
-		notifiers.lastBlock = blk
-		notifiers.lastBlockHeight = ev.Height
-		notifiers.Unlock()
-
-		annBlk := &api.AnnotatedBlock{
-			Height: ev.Height,
-			Block:  blk,
-		}
-		// Commit the block to history if needed.
-		if bh, ok := blockHistory[ev.RuntimeID]; ok {
-			crash.Here(crashPointBlockBeforeIndex)
-
-			err = bh.Commit(annBlk)
-			if err != nil {
-				tb.logger.Error("failed to commit block to history keeper",
-					"err", err,
-					"runtime_id", ev.RuntimeID,
-					"height", ev.Height,
-					"round", blk.Header.Round,
-				)
-				// Panic as otherwise the history would become out of sync with
-				// what was emitted from the roothash backend. The only reason
-				// why something like this could happen is a problem with the
-				// history database.
-				panic("roothash: failed to index block")
-			}
-		}
-		tb.allBlockNotifier.Broadcast(blk)
-		notifiers.blockNotifier.Broadcast(annBlk)
 	}
+
+	return nil
+}
+
+func (sc *serviceClient) processFinalizedEvent(
+	ctx context.Context,
+	height int64,
+	runtimeID common.Namespace,
+	round *uint64,
+	reindex bool,
+) (err error) {
+	tr := sc.trackedRuntime[runtimeID]
+	defer func() {
+		// If there was an error, flag the tracked runtime for reindex.
+		if err == nil {
+			return
+		}
+
+		tr.reindexDone = false
+	}()
+
+	if height <= tr.height {
+		return nil
+	}
+
+	// Process finalized event.
+	var blk *block.Block
+	if blk, err = sc.getLatestBlockAt(ctx, runtimeID, height); err != nil {
+		sc.logger.Error("failed to fetch latest block",
+			"err", err,
+			"height", height,
+			"runtime_id", runtimeID,
+		)
+		return fmt.Errorf("roothash: failed to fetch latest block: %w", err)
+	}
+	if round != nil && blk.Header.Round != *round {
+		sc.logger.Error("finalized event/query round mismatch",
+			"block_round", blk.Header.Round,
+			"event_round", *round,
+		)
+		return fmt.Errorf("roothash: finalized event/query round mismatch")
+	}
+
+	annBlk := &api.AnnotatedBlock{
+		Height: height,
+		Block:  blk,
+	}
+
+	// Commit the block to history if needed.
+	if tr.blockHistory != nil {
+		crash.Here(crashPointBlockBeforeIndex)
+
+		// Perform reindex if required.
+		if reindex && !tr.reindexDone {
+			// Note that we need to reindex up to the previous height as the current height is
+			// already being processed right now.
+			if err = sc.reindexBlocks(height-1, tr.blockHistory); err != nil {
+				sc.logger.Error("failed to reindex blocks",
+					"err", err,
+					"runtime_id", runtimeID,
+				)
+				return fmt.Errorf("failed to reindex blocks: %w", err)
+			}
+			tr.reindexDone = true
+		}
+
+		sc.logger.Debug("commit block",
+			"runtime_id", runtimeID,
+			"height", height,
+			"round", blk.Header.Round,
+		)
+
+		err = tr.blockHistory.Commit(annBlk)
+		if err != nil {
+			sc.logger.Error("failed to commit block to history keeper",
+				"err", err,
+				"runtime_id", runtimeID,
+				"height", height,
+				"round", blk.Header.Round,
+			)
+			return fmt.Errorf("failed to commit block to history keeper: %w", err)
+		}
+	}
+
+	// Skip emitting events if we are reindexing.
+	if !reindex {
+		return nil
+	}
+
+	notifiers := sc.getRuntimeNotifiers(runtimeID)
+	// Ensure latest block is set.
+	notifiers.Lock()
+	notifiers.lastBlock = blk
+	notifiers.lastBlockHeight = height
+	notifiers.Unlock()
+
+	sc.allBlockNotifier.Broadcast(blk)
+	notifiers.blockNotifier.Broadcast(annBlk)
+	tr.height = height
+
+	return nil
 }
 
 // EventsFromTendermint extracts staking events from tendermint events.
@@ -581,8 +604,7 @@ func EventsFromTendermint(
 				ev := &api.Event{RuntimeID: value.ID, Height: height, TxHash: txHash, MergeCommitted: &value.Event}
 				events = append(events, ev)
 			case bytes.Equal(key, app.KeyRuntimeID):
-				// Runtime ID attribute.
-				// Not used currently.
+				// Runtime ID attribute (Base64-encoded to allow queries).
 			default:
 				errs = multierror.Append(errs, fmt.Errorf("roothash: unknown event type: key: %s, val: %s", key, val))
 			}
@@ -596,14 +618,14 @@ func New(
 	ctx context.Context,
 	dataDir string,
 	service service.TendermintService,
-) (api.Backend, error) {
+) (ServiceClient, error) {
 	// Initialize and register the tendermint service component.
 	a := app.New()
 	if err := service.RegisterApplication(a); err != nil {
 		return nil, err
 	}
 
-	tb := &tendermintBackend{
+	return &serviceClient{
 		ctx:              ctx,
 		logger:           logging.GetLogger("roothash/tendermint"),
 		service:          service,
@@ -611,14 +633,10 @@ func New(
 		allBlockNotifier: pubsub.NewBroker(false),
 		runtimeNotifiers: make(map[common.Namespace]*runtimeBrokers),
 		genesisBlocks:    make(map[common.Namespace]*block.Block),
-		closedCh:         make(chan struct{}),
-		initCh:           make(chan struct{}),
-		blockHistoryCh:   make(chan api.BlockHistory, runtimeRegistry.MaxRuntimeCount),
-	}
-
-	go tb.worker(ctx)
-
-	return tb, nil
+		queryCh:          make(chan tmpubsub.Query, runtimeRegistry.MaxRuntimeCount),
+		cmdCh:            make(chan interface{}, runtimeRegistry.MaxRuntimeCount),
+		trackedRuntime:   make(map[common.Namespace]*trackedRuntime),
+	}, nil
 }
 
 func init() {

--- a/go/consensus/tendermint/seed.go
+++ b/go/consensus/tendermint/seed.go
@@ -21,7 +21,7 @@ import (
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 )
 
-var logger = logging.GetLogger("consensus/tendermint/seed")
+var seedLogger = logging.GetLogger("consensus/tendermint/seed")
 
 // SeedService is a Tendermint seed service.
 type SeedService struct {
@@ -170,7 +170,7 @@ func populateAddrBookFromGenesis(addrBook p2p.AddrBook, doc *genesis.Document, o
 		var tmvAddr *p2p.NetAddress
 		tmvAddr, err := api.NodeToP2PAddr(&openedNode)
 		if err != nil {
-			logger.Error("failed to reformat genesis validator address",
+			seedLogger.Error("failed to reformat genesis validator address",
 				"err", err,
 			)
 			continue
@@ -187,7 +187,7 @@ func populateAddrBookFromGenesis(addrBook p2p.AddrBook, doc *genesis.Document, o
 		addrBook.RemoveAddress(v)
 
 		if err := addrBook.AddAddress(v, ourAddr); err != nil {
-			logger.Error("failed to add genesis validator to address book",
+			seedLogger.Error("failed to add genesis validator to address book",
 				"err", err,
 			)
 		}

--- a/go/consensus/tendermint/service/service.go
+++ b/go/consensus/tendermint/service/service.go
@@ -4,7 +4,6 @@ package service
 import (
 	"context"
 
-	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
 	tmrpctypes "github.com/tendermint/tendermint/rpc/core/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 
@@ -45,12 +44,6 @@ type TendermintService interface {
 	// WatchTendermintBlocks returns a stream of Tendermint blocks as they are
 	// returned via the `EventDataNewBlock` query.
 	WatchTendermintBlocks() (<-chan *tmtypes.Block, *pubsub.Subscription)
-
-	// Subscribe subscribes to tendermint events.
-	Subscribe(subscriber string, query tmpubsub.Query) (tmtypes.Subscription, error)
-
-	// Unsubscribe unsubscribes from tendermint events.
-	Unsubscribe(subscriber string, query tmpubsub.Query) error
 }
 
 // GenesisProvider is a tendermint specific genesis document provider.

--- a/go/consensus/tendermint/services.go
+++ b/go/consensus/tendermint/services.go
@@ -1,0 +1,200 @@
+package tendermint
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/eapache/channels"
+	tmabcitypes "github.com/tendermint/tendermint/abci/types"
+	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
+	tmtypes "github.com/tendermint/tendermint/types"
+
+	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+)
+
+// serviceClientWorker manages block and event notifications for all service clients.
+func (t *tendermintService) serviceClientWorker(ctx context.Context, svc api.ServiceClient) {
+	defer t.serviceClientsWg.Done()
+
+	sd := svc.ServiceDescriptor()
+
+	logger := t.Logger.With("service", sd.Name())
+	logger.Info("starting event dispatcher")
+
+	var (
+		cases   []reflect.SelectCase
+		queries []tmpubsub.Query
+	)
+	// Context cancellation.
+	const indexCtx = 0
+	cases = append(cases, reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(ctx.Done()),
+	})
+	queries = append(queries, nil)
+	// General query for new block headers.
+	newBlockCh, newBlockSub := t.WatchTendermintBlocks()
+	defer newBlockSub.Close()
+
+	const indexNewBlock = 1
+	cases = append(cases, reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(newBlockCh),
+	})
+	queries = append(queries, nil)
+	// Query update.
+	const indexQueries = 2
+	cases = append(cases, reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(sd.Queries()),
+	})
+	queries = append(queries, nil)
+	// Commands.
+	const indexCommands = 3
+	cases = append(cases, reflect.SelectCase{
+		Dir: reflect.SelectRecv,
+		// Initially, start with a nil channel and only start looking into commands after we see a
+		// block from the consensus backend.
+		Chan: reflect.ValueOf(nil),
+	})
+	queries = append(queries, nil)
+
+	// Service client event loop.
+	var height int64
+	for {
+		chosen, recv, recvOk := reflect.Select(cases)
+		if !recvOk {
+			// Replace closed channels with nil to avoid needless wakeups.
+			cases[chosen].Chan = reflect.ValueOf(nil)
+			if chosen != indexCtx {
+				continue
+			}
+		}
+		switch chosen {
+		case indexCtx:
+			return
+		case indexQueries:
+			// Subscribe to new query.
+			query := recv.Interface().(tmpubsub.Query)
+
+			logger.Debug("subscribing to new query",
+				"query", query,
+			)
+
+			sub, err := t.node.EventBus().SubscribeUnbuffered(ctx, tmSubscriberID, query)
+			if err != nil {
+				logger.Error("failed to subscribe to service events",
+					"err", err,
+				)
+				continue
+			}
+			// Oh yes, this can actually return a nil subscription even though the error was also
+			// nil if the node is just shutting down.
+			if sub == (*tmpubsub.Subscription)(nil) {
+				continue
+			}
+
+			// Transform events.
+			buffer := channels.NewInfiniteChannel()
+			go func() {
+				defer t.node.EventBus().Unsubscribe(ctx, tmSubscriberID, query) // nolint: errcheck
+				defer buffer.Close()
+
+				for {
+					select {
+					// Should not return on ctx.Done() as that could lead to a deadlock.
+					case <-sub.Cancelled():
+						// Subscription cancelled.
+						return
+					case v := <-sub.Out():
+						// Received an event.
+						switch ev := v.Data().(type) {
+						case tmtypes.EventDataNewBlockHeader:
+							buffer.In() <- &api.ServiceEvent{Block: &ev}
+						case tmtypes.EventDataTx:
+							buffer.In() <- &api.ServiceEvent{Tx: &ev}
+						default:
+						}
+					}
+				}
+			}()
+
+			cases = append(cases, reflect.SelectCase{
+				Dir:  reflect.SelectRecv,
+				Chan: reflect.ValueOf(buffer.Out()),
+			})
+			queries = append(queries, query)
+		case indexCommands:
+			// New command.
+			if err := svc.DeliverCommand(ctx, height, recv.Interface()); err != nil {
+				logger.Error("failed to deliver command to service client",
+					"err", err,
+				)
+				continue
+			}
+		case indexNewBlock:
+			// New block.
+			if height == 0 {
+				// Seen a block, now we are ready to process commands.
+				cases[indexCommands].Chan = reflect.ValueOf(sd.Commands())
+			}
+			height = recv.Interface().(*tmtypes.Block).Header.Height
+
+			if err := svc.DeliverBlock(ctx, height); err != nil {
+				logger.Error("failed to deliver block notification to service client",
+					"err", err,
+				)
+				continue
+			}
+		default:
+			// New service client event.
+			ev := recv.Interface().(*api.ServiceEvent)
+			var (
+				tx       tmtypes.Tx
+				tmEvents []tmabcitypes.Event
+			)
+			switch {
+			case ev.Block != nil:
+				height = ev.Block.Header.Height
+				tmEvents = append([]tmabcitypes.Event{}, ev.Block.ResultBeginBlock.GetEvents()...)
+				tmEvents = append(tmEvents, ev.Block.ResultEndBlock.GetEvents()...)
+			case ev.Tx != nil:
+				height = ev.Tx.Height
+				tx = ev.Tx.Tx
+				tmEvents = ev.Tx.Result.Events
+			default:
+				logger.Warn("unknown event",
+					"ev", fmt.Sprintf("%+v", ev),
+				)
+				continue
+			}
+
+			// Deliver all events.
+			query := queries[chosen]
+			for i, tmEv := range tmEvents {
+				// Skip all events not from the target service.
+				if tmEv.GetType() != sd.EventType() {
+					continue
+				}
+				// Skip all events not matching the initial query. This is required as we get all
+				// events not only those matching the query so we need to do a separate pass.
+				tagMap := make(map[string][]string)
+				for _, attr := range tmEv.Attributes {
+					compositeTag := fmt.Sprintf("%s.%s", tmEv.Type, string(attr.Key))
+					tagMap[compositeTag] = append(tagMap[compositeTag], string(attr.Value))
+				}
+				if matches, _ := query.Matches(tagMap); !matches {
+					continue
+				}
+
+				if err := svc.DeliverEvent(ctx, height, tx, &tmEvents[i]); err != nil {
+					logger.Error("failed to deliver event to service client",
+						"err", err,
+					)
+					continue
+				}
+			}
+		}
+	}
+}

--- a/go/epochtime/api/api.go
+++ b/go/epochtime/api/api.go
@@ -9,6 +9,9 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 )
 
+// ModuleName is a unique module name for the epochtime module.
+const ModuleName = "epochtime"
+
 // EpochTime is the number of intervals (epochs) since a fixed instant
 // in time (epoch date).
 type EpochTime uint64

--- a/go/oasis-node/cmd/debug/byzantine/byzantine.go
+++ b/go/oasis-node/cmd/debug/byzantine/byzantine.go
@@ -111,7 +111,8 @@ func doExecutorHonest(cmd *cobra.Command, args []string) {
 		}
 	}()
 
-	if err = epochtimeWaitForEpoch(ht.service, epochtime.EpochTime(viper.GetUint64(CfgActivationEpoch))); err != nil {
+	activationEpoch := epochtime.EpochTime(viper.GetUint64(CfgActivationEpoch))
+	if err = epochtimeWaitForEpoch(ht.service, activationEpoch); err != nil {
 		panic(fmt.Sprintf("epochtimeWaitForEpoch: %+v", err))
 	}
 
@@ -126,13 +127,13 @@ func doExecutorHonest(cmd *cobra.Command, args []string) {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 
-	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindComputeExecutor)
+	electionHeight, err := schedulerNextElectionHeight(ht.service, activationEpoch+1)
 	if err != nil {
 		panic(fmt.Sprintf("scheduler next election height failed: %+v", err))
 	}
 	executorCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeExecutor, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeExecutor, err))
+		panic(fmt.Sprintf("scheduler get committee %s at height %d failed: %+v", scheduler.KindComputeExecutor, electionHeight, err))
 	}
 	if err = schedulerCheckScheduled(executorCommittee, defaultIdentity.NodeSigner.Public(), scheduler.Worker); err != nil {
 		panic(fmt.Sprintf("scheduler check scheduled failed: %+v", err))
@@ -243,7 +244,8 @@ func doExecutorWrong(cmd *cobra.Command, args []string) {
 		}
 	}()
 
-	if err = epochtimeWaitForEpoch(ht.service, epochtime.EpochTime(viper.GetUint64(CfgActivationEpoch))); err != nil {
+	activationEpoch := epochtime.EpochTime(viper.GetUint64(CfgActivationEpoch))
+	if err = epochtimeWaitForEpoch(ht.service, activationEpoch); err != nil {
 		panic(fmt.Sprintf("epochtimeWaitForEpoch: %+v", err))
 	}
 
@@ -258,13 +260,13 @@ func doExecutorWrong(cmd *cobra.Command, args []string) {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 
-	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindComputeExecutor)
+	electionHeight, err := schedulerNextElectionHeight(ht.service, activationEpoch+1)
 	if err != nil {
 		panic(fmt.Sprintf("scheduler next election height failed: %+v", err))
 	}
 	executorCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeExecutor, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeExecutor, err))
+		panic(fmt.Sprintf("scheduler get committee %s at height %d failed: %+v", scheduler.KindComputeExecutor, electionHeight, err))
 	}
 	if err = schedulerCheckScheduled(executorCommittee, defaultIdentity.NodeSigner.Public(), scheduler.Worker); err != nil {
 		panic(fmt.Sprintf("scheduler check scheduled failed: %+v", err))
@@ -375,7 +377,8 @@ func doExecutorStraggler(cmd *cobra.Command, args []string) {
 		}
 	}()
 
-	if err = epochtimeWaitForEpoch(ht.service, epochtime.EpochTime(viper.GetUint64(CfgActivationEpoch))); err != nil {
+	activationEpoch := epochtime.EpochTime(viper.GetUint64(CfgActivationEpoch))
+	if err = epochtimeWaitForEpoch(ht.service, activationEpoch); err != nil {
 		panic(fmt.Sprintf("epochtimeWaitForEpoch: %+v", err))
 	}
 
@@ -389,13 +392,13 @@ func doExecutorStraggler(cmd *cobra.Command, args []string) {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 
-	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindComputeExecutor)
+	electionHeight, err := schedulerNextElectionHeight(ht.service, activationEpoch+1)
 	if err != nil {
 		panic(fmt.Sprintf("scheduler next election height failed: %+v", err))
 	}
 	executorCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeExecutor, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeExecutor, err))
+		panic(fmt.Sprintf("scheduler get committee %s at height %d failed: %+v", scheduler.KindComputeExecutor, electionHeight, err))
 	}
 	if err = schedulerCheckScheduled(executorCommittee, defaultIdentity.NodeSigner.Public(), scheduler.Worker); err != nil {
 		panic(fmt.Sprintf("scheduler check scheduled failed: %+v", err))
@@ -456,7 +459,8 @@ func doMergeHonest(cmd *cobra.Command, args []string) {
 		}
 	}()
 
-	if err = epochtimeWaitForEpoch(ht.service, epochtime.EpochTime(viper.GetUint64(CfgActivationEpoch))); err != nil {
+	activationEpoch := epochtime.EpochTime(viper.GetUint64(CfgActivationEpoch))
+	if err = epochtimeWaitForEpoch(ht.service, activationEpoch); err != nil {
 		panic(fmt.Sprintf("epochtimeWaitForEpoch: %+v", err))
 	}
 
@@ -464,13 +468,13 @@ func doMergeHonest(cmd *cobra.Command, args []string) {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 
-	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindComputeExecutor)
+	electionHeight, err := schedulerNextElectionHeight(ht.service, activationEpoch+1)
 	if err != nil {
 		panic(fmt.Sprintf("scheduler next election height failed: %+v", err))
 	}
 	mergeCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeMerge, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeMerge, err))
+		panic(fmt.Sprintf("scheduler get committee %s at height %d failed: %+v", scheduler.KindComputeMerge, electionHeight, err))
 	}
 	if err = schedulerCheckScheduled(mergeCommittee, defaultIdentity.NodeSigner.Public(), scheduler.Worker); err != nil {
 		panic(fmt.Sprintf("scheduler check scheduled failed: %+v", err))
@@ -564,7 +568,8 @@ func doMergeWrong(cmd *cobra.Command, args []string) {
 		}
 	}()
 
-	if err = epochtimeWaitForEpoch(ht.service, epochtime.EpochTime(viper.GetUint64(CfgActivationEpoch))); err != nil {
+	activationEpoch := epochtime.EpochTime(viper.GetUint64(CfgActivationEpoch))
+	if err = epochtimeWaitForEpoch(ht.service, activationEpoch); err != nil {
 		panic(fmt.Sprintf("epochtimeWaitForEpoch: %+v", err))
 	}
 
@@ -572,13 +577,13 @@ func doMergeWrong(cmd *cobra.Command, args []string) {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 
-	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindComputeExecutor)
+	electionHeight, err := schedulerNextElectionHeight(ht.service, activationEpoch+1)
 	if err != nil {
 		panic(fmt.Sprintf("scheduler next election height failed: %+v", err))
 	}
 	mergeCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeMerge, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeMerge, err))
+		panic(fmt.Sprintf("scheduler get committee %s at height %d failed: %+v", scheduler.KindComputeMerge, electionHeight, err))
 	}
 	if err = schedulerCheckScheduled(mergeCommittee, defaultIdentity.NodeSigner.Public(), scheduler.Worker); err != nil {
 		panic(fmt.Sprintf("scheduler check scheduled failed: %+v", err))
@@ -696,7 +701,8 @@ func doMergeStraggler(cmd *cobra.Command, args []string) {
 		}
 	}()
 
-	if err = epochtimeWaitForEpoch(ht.service, epochtime.EpochTime(viper.GetUint64(CfgActivationEpoch))); err != nil {
+	activationEpoch := epochtime.EpochTime(viper.GetUint64(CfgActivationEpoch))
+	if err = epochtimeWaitForEpoch(ht.service, activationEpoch); err != nil {
 		panic(fmt.Sprintf("epochtimeWaitForEpoch: %+v", err))
 	}
 
@@ -704,13 +710,13 @@ func doMergeStraggler(cmd *cobra.Command, args []string) {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 
-	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindComputeExecutor)
+	electionHeight, err := schedulerNextElectionHeight(ht.service, activationEpoch+1)
 	if err != nil {
 		panic(fmt.Sprintf("scheduler next election height failed: %+v", err))
 	}
 	mergeCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeMerge, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeMerge, err))
+		panic(fmt.Sprintf("scheduler get committee %s at height %d failed: %+v", scheduler.KindComputeMerge, electionHeight, err))
 	}
 	if err = schedulerCheckScheduled(mergeCommittee, defaultIdentity.NodeSigner.Public(), scheduler.Worker); err != nil {
 		panic(fmt.Sprintf("scheduler check scheduled failed: %+v", err))

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_sync.go
@@ -41,6 +41,9 @@ func (sc *storageSyncImpl) Fixture() (*oasis.NetworkFixture, error) {
 
 	// Make the first storage worker check for checkpoints more often.
 	f.StorageWorkers[0].CheckpointCheckInterval = 1 * time.Second
+	// Configure runtime to allow a smaller replication factor as otherwise execution may fail when
+	// the bad node is in the storage committee.
+	f.Runtimes[1].Storage.MinWriteReplication = 1
 	// Configure runtime for storage checkpointing.
 	f.Runtimes[1].Storage.CheckpointInterval = 10
 	f.Runtimes[1].Storage.CheckpointNumKept = 1

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -186,7 +186,7 @@ type Event struct {
 type MetricsMonitorable interface {
 	// WatchAllBlocks returns a channel that produces a stream of blocks.
 	//
-	// All blocks from all runtimes will be pushed into the stream
+	// All blocks from all tracked runtimes will be pushed into the stream
 	// immediately as they are finalized.
 	WatchAllBlocks() (<-chan *block.Block, *pubsub.Subscription)
 }

--- a/go/scheduler/api/api.go
+++ b/go/scheduler/api/api.go
@@ -16,6 +16,9 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 )
 
+// ModuleName is a unique module name for the scheduler module.
+const ModuleName = "scheduler"
+
 // Role is the role a given node plays in a committee.
 type Role uint8
 


### PR DESCRIPTION
TODO
* [X] Remove Subscribe/Unsubscribe from internal Tendermint backend APIs.
* [X] Cleanup.