### PR TITLE
go/registry: Add support for querying suspended runtimes

### DIFF
--- a/.changelog/3093.feature.md
+++ b/.changelog/3093.feature.md
@@ -1,0 +1,6 @@
+go/registry: Add support for querying suspended runtimes
+
+Registry `GetRuntimes` method now accepts a parameter to enable querying for
+suspended runtimes.
+`WatchRuntimes` will now always include suspended runtimes in the initial
+response.

--- a/go/consensus/tendermint/apps/registry/query.go
+++ b/go/consensus/tendermint/apps/registry/query.go
@@ -22,7 +22,7 @@ type Query interface {
 	NodeStatus(context.Context, signature.PublicKey) (*registry.NodeStatus, error)
 	Nodes(context.Context) ([]*node.Node, error)
 	Runtime(context.Context, common.Namespace) (*registry.Runtime, error)
-	Runtimes(context.Context) ([]*registry.Runtime, error)
+	Runtimes(ctx context.Context, includeSuspended bool) ([]*registry.Runtime, error)
 	Genesis(context.Context) (*registry.Genesis, error)
 }
 
@@ -106,7 +106,10 @@ func (rq *registryQuerier) Runtime(ctx context.Context, id common.Namespace) (*r
 	return rq.state.Runtime(ctx, id)
 }
 
-func (rq *registryQuerier) Runtimes(ctx context.Context) ([]*registry.Runtime, error) {
+func (rq *registryQuerier) Runtimes(ctx context.Context, includeSuspended bool) ([]*registry.Runtime, error) {
+	if includeSuspended {
+		return rq.state.AllRuntimes(ctx)
+	}
 	return rq.state.Runtimes(ctx)
 }
 

--- a/go/oasis-node/cmd/debug/txsource/workload/queries.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/queries.go
@@ -390,12 +390,12 @@ func (q *queries) doRegistryQueries(ctx context.Context, rng *rand.Rand, height 
 	}
 
 	// Runtimes.
-	runtimes, err := q.registry.GetRuntimes(ctx, height)
+	runtimes, err := q.registry.GetRuntimes(ctx, &registry.GetRuntimesQuery{Height: height, IncludeSuspended: false})
 	if err != nil {
-		return fmt.Errorf("GetRuntimes error at height %d: %w", height, err)
+		return fmt.Errorf("GetRuntimes(IncludeSuspended=false) error at height %d: %w", height, err)
 	}
 	if len(runtimes) == 0 {
-		return fmt.Errorf("GetRuntimes empty response at height %d", height)
+		return fmt.Errorf("GetRuntimes(IncludeSuspended=false) empty response at height %d", height)
 	}
 	for _, rt := range runtimes {
 		var runtime *registry.Runtime
@@ -406,6 +406,13 @@ func (q *queries) doRegistryQueries(ctx context.Context, rng *rand.Rand, height 
 		if !rt.ID.Equal(&runtime.ID) {
 			return fmt.Errorf("GetRuntime mismatch, expected: %s, got: %s", rt, runtime)
 		}
+	}
+	allRuntimes, err := q.registry.GetRuntimes(ctx, &registry.GetRuntimesQuery{Height: height, IncludeSuspended: true})
+	if err != nil {
+		return fmt.Errorf("GetRuntimes(IncludeSuspended=true) error at height %d: %w", height, err)
+	}
+	if len(allRuntimes) < len(runtimes) {
+		return fmt.Errorf("GetRuntimes(IncludeSuspended=true) returned less runtimes than IncludeSuspended=false, at height %d", height)
 	}
 
 	// Events.

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -219,7 +219,7 @@ type Backend interface {
 
 	// GetRuntimes returns the registered Runtimes at the specified
 	// block height.
-	GetRuntimes(context.Context, int64) ([]*Runtime, error)
+	GetRuntimes(context.Context, *GetRuntimesQuery) ([]*Runtime, error)
 
 	// WatchRuntimes returns a stream of Runtime.  Upon subscription,
 	// all runtimes will be sent immediately.
@@ -245,6 +245,12 @@ type IDQuery struct {
 type NamespaceQuery struct {
 	Height int64            `json:"height"`
 	ID     common.Namespace `json:"id"`
+}
+
+// GetRuntimesQuery is a registry get runtimes query.
+type GetRuntimesQuery struct {
+	Height           int64 `json:"height"`
+	IncludeSuspended bool  `json:"include_suspended"`
 }
 
 // ConsensusAddressQuery is a registry query by consensus address.

--- a/go/registry/api/grpc.go
+++ b/go/registry/api/grpc.go
@@ -283,21 +283,21 @@ func handlerGetRuntimes( // nolint: golint
 	dec func(interface{}) error,
 	interceptor grpc.UnaryServerInterceptor,
 ) (interface{}, error) {
-	var height int64
-	if err := dec(&height); err != nil {
+	var query GetRuntimesQuery
+	if err := dec(&query); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Backend).GetRuntimes(ctx, height)
+		return srv.(Backend).GetRuntimes(ctx, &query)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetRuntimes.FullName(),
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(Backend).GetRuntimes(ctx, req.(int64))
+		return srv.(Backend).GetRuntimes(ctx, req.(*GetRuntimesQuery))
 	}
-	return interceptor(ctx, height, info, handler)
+	return interceptor(ctx, &query, info, handler)
 }
 
 func handlerStateToGenesis( // nolint: golint
@@ -628,9 +628,9 @@ func (c *registryClient) GetRuntime(ctx context.Context, query *NamespaceQuery) 
 	return &rsp, nil
 }
 
-func (c *registryClient) GetRuntimes(ctx context.Context, height int64) ([]*Runtime, error) {
+func (c *registryClient) GetRuntimes(ctx context.Context, query *GetRuntimesQuery) ([]*Runtime, error) {
 	var rsp []*Runtime
-	if err := c.conn.Invoke(ctx, methodGetRuntimes.FullName(), height, &rsp); err != nil {
+	if err := c.conn.Invoke(ctx, methodGetRuntimes.FullName(), query, &rsp); err != nil {
 		return nil, err
 	}
 	return rsp, nil


### PR DESCRIPTION
Fixes: #3093

TODO:
- [x] ~fix the runtime_dynamic test~ 
  - actually cannot reporduce this in the runtime dynamic test (or locally anymore), so it might have worked fine even before (even if the node fast-syncs it still get's all the events during fast syncing so it does get notified of the suspended runtimes). Nevertheless this change is still useful.