### PR TITLE
go/consensus/tendermint: Use P2P key for Tendermint P2P

### DIFF
--- a/.changelog/3101.breaking.md
+++ b/.changelog/3101.breaking.md
@@ -1,0 +1,5 @@
+go/consensus/tendermint: Use P2P key for Tendermint P2P
+
+Previously the Tendermint consensus backend used the node's identity key for
+Tendermint P2P connections. This has now been changed to use the node's P2P
+key instead as that can be made ephemeral in the future.

--- a/go/consensus/tendermint/seed.go
+++ b/go/consensus/tendermint/seed.go
@@ -103,7 +103,7 @@ func NewSeed(dataDir string, identity *identity.Identity, genesisProvider genesi
 	cfg.AddrBookStrict = !viper.GetBool(CfgDebugP2PAddrBookLenient)
 	// MaxNumInboundPeers/MaxNumOutboundPeers
 
-	nodeKey := &p2p.NodeKey{PrivKey: crypto.SignerToTendermint(identity.NodeSigner)}
+	nodeKey := &p2p.NodeKey{PrivKey: crypto.SignerToTendermint(identity.P2PSigner)}
 
 	doc, err := genesisProvider.GetGenesisDocument()
 	if err != nil {
@@ -121,7 +121,7 @@ func NewSeed(dataDir string, identity *identity.Identity, genesisProvider genesi
 		Network:       doc.ChainContext()[:types.MaxChainIDLen],
 		Version:       "0.0.1",
 		Channels:      []byte{pex.PexChannel},
-		Moniker:       "oasis-seed-" + identity.NodeSigner.Public().String(),
+		Moniker:       "oasis-seed-" + identity.P2PSigner.Public().String(),
 	}
 
 	// Carve out all of the services.

--- a/go/oasis-node/cmd/debug/txsource/workload/registration.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/registration.go
@@ -122,7 +122,7 @@ func getNodeDesc(rng *rand.Rand, nodeIdentity *identity.Identity, entityID signa
 			ID: nodeIdentity.ConsensusSigner.Public(),
 			Addresses: []node.ConsensusAddress{
 				{
-					ID:      nodeIdentity.ConsensusSigner.Public(),
+					ID:      nodeIdentity.P2PSigner.Public(),
 					Address: nodeAddr,
 				},
 			},

--- a/go/oasis-node/cmd/identity/tendermint/tendermint.go
+++ b/go/oasis-node/cmd/identity/tendermint/tendermint.go
@@ -70,7 +70,7 @@ func printTmAddress(desc, keyFile string) {
 
 func showNodeAddress(cmd *cobra.Command, args []string) {
 	desc := strings.TrimPrefix(cmd.Short, "outputs ")
-	printTmAddress(desc, identity.NodeKeyPubFilename)
+	printTmAddress(desc, identity.P2PKeyPubFilename)
 }
 
 func showConsensusAddress(cmd *cobra.Command, args []string) {

--- a/go/oasis-node/cmd/registry/node/node.go
+++ b/go/oasis-node/cmd/registry/node/node.go
@@ -268,7 +268,7 @@ func doInit(cmd *cobra.Command, args []string) { // nolint: gocyclo
 					)
 					os.Exit(1)
 				}
-				consensusAddr.ID = n.ID
+				consensusAddr.ID = n.P2P.ID
 			}
 			n.Consensus.Addresses = append(n.Consensus.Addresses, consensusAddr)
 		}

--- a/go/oasis-test-runner/oasis/byzantine.go
+++ b/go/oasis-test-runner/oasis/byzantine.go
@@ -81,11 +81,11 @@ func (net *Network) NewByzantine(cfg *ByzantineCfg) (*Byzantine, error) {
 	}
 
 	// Pre-provision the node identity so that we can update the entity.
-	publicKey, _, err := net.provisionNodeIdentity(byzantineDir, cfg.IdentitySeed, false)
+	nodeKey, _, _, err := net.provisionNodeIdentity(byzantineDir, cfg.IdentitySeed, false)
 	if err != nil {
 		return nil, fmt.Errorf("oasis/byzantine: failed to provision node identity: %w", err)
 	}
-	if err := cfg.Entity.addNode(publicKey); err != nil {
+	if err := cfg.Entity.addNode(nodeKey); err != nil {
 		return nil, err
 	}
 
@@ -106,7 +106,7 @@ func (net *Network) NewByzantine(cfg *ByzantineCfg) (*Byzantine, error) {
 		activationEpoch: cfg.ActivationEpoch,
 	}
 	worker.doStartNode = worker.startNode
-	copy(worker.NodeID[:], publicKey[:])
+	copy(worker.NodeID[:], nodeKey[:])
 
 	net.byzantine = append(net.byzantine, worker)
 	net.nextNodePort += 2

--- a/go/oasis-test-runner/oasis/compute.go
+++ b/go/oasis-test-runner/oasis/compute.go
@@ -134,11 +134,11 @@ func (net *Network) NewCompute(cfg *ComputeCfg) (*Compute, error) {
 
 	// Pre-provision the node identity so that we can update the entity.
 	seed := fmt.Sprintf(computeIdentitySeedTemplate, len(net.computeWorkers))
-	publicKey, _, err := net.provisionNodeIdentity(computeDir, seed, false)
+	nodeKey, _, _, err := net.provisionNodeIdentity(computeDir, seed, false)
 	if err != nil {
 		return nil, fmt.Errorf("oasis/compute: failed to provision node identity: %w", err)
 	}
-	if err := cfg.Entity.addNode(publicKey); err != nil {
+	if err := cfg.Entity.addNode(nodeKey); err != nil {
 		return nil, err
 	}
 
@@ -166,7 +166,7 @@ func (net *Network) NewCompute(cfg *ComputeCfg) (*Compute, error) {
 		runtimes:           cfg.Runtimes,
 	}
 	worker.doStartNode = worker.startNode
-	copy(worker.NodeID[:], publicKey[:])
+	copy(worker.NodeID[:], nodeKey[:])
 
 	net.computeWorkers = append(net.computeWorkers, worker)
 	net.nextNodePort += 3

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -317,11 +317,11 @@ func (net *Network) NewKeymanager(cfg *KeymanagerCfg) (*Keymanager, error) {
 
 	// Pre-provision the node identity so that we can update the entity.
 	seed := fmt.Sprintf(keymanagerIdentitySeedTemplate, len(net.keymanagers))
-	publicKey, sentryClientCert, err := net.provisionNodeIdentity(kmDir, seed, false)
+	nodeKey, p2pKey, sentryClientCert, err := net.provisionNodeIdentity(kmDir, seed, false)
 	if err != nil {
 		return nil, fmt.Errorf("oasis/keymanager: failed to provision node identity: %w", err)
 	}
-	if err := cfg.Entity.addNode(publicKey); err != nil {
+	if err := cfg.Entity.addNode(nodeKey); err != nil {
 		return nil, err
 	}
 	// Sentry client cert.
@@ -350,14 +350,14 @@ func (net *Network) NewKeymanager(cfg *KeymanagerCfg) (*Keymanager, error) {
 		entity:           cfg.Entity,
 		policy:           cfg.Policy,
 		sentryIndices:    cfg.SentryIndices,
-		tmAddress:        crypto.PublicKeyToTendermint(&publicKey).Address().String(),
+		tmAddress:        crypto.PublicKeyToTendermint(&p2pKey).Address().String(),
 		sentryPubKey:     sentryPubKey,
 		consensusPort:    net.nextNodePort,
 		workerClientPort: net.nextNodePort + 1,
 		mayGenerate:      len(net.keymanagers) == 0,
 	}
 	km.doStartNode = km.startNode
-	copy(km.NodeID[:], publicKey[:])
+	copy(km.NodeID[:], nodeKey[:])
 
 	net.keymanagers = append(net.keymanagers, km)
 	net.nextNodePort += 2

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -888,26 +888,26 @@ func (net *Network) GetCLIConfig() cli.Config {
 	return cfg
 }
 
-func (net *Network) provisionNodeIdentity(dataDir *env.Dir, seed string, persistTLS bool) (signature.PublicKey, *x509.Certificate, error) {
+func (net *Network) provisionNodeIdentity(dataDir *env.Dir, seed string, persistTLS bool) (signature.PublicKey, signature.PublicKey, *x509.Certificate, error) {
 	if net.cfg.DeterministicIdentities {
 		if err := net.generateDeterministicNodeIdentity(dataDir, seed); err != nil {
-			return signature.PublicKey{}, nil, fmt.Errorf("oasis: failed to generate deterministic identity: %w", err)
+			return signature.PublicKey{}, signature.PublicKey{}, nil, fmt.Errorf("oasis: failed to generate deterministic identity: %w", err)
 		}
 	}
 
 	signerFactory, err := fileSigner.NewFactory(dataDir.String(), signature.SignerNode, signature.SignerP2P, signature.SignerConsensus)
 	if err != nil {
-		return signature.PublicKey{}, nil, fmt.Errorf("oasis: failed to create node file signer factory: %w", err)
+		return signature.PublicKey{}, signature.PublicKey{}, nil, fmt.Errorf("oasis: failed to create node file signer factory: %w", err)
 	}
 	nodeIdentity, err := identity.LoadOrGenerate(dataDir.String(), signerFactory, persistTLS)
 	if err != nil {
-		return signature.PublicKey{}, nil, fmt.Errorf("oasis: failed to provision node identity: %w", err)
+		return signature.PublicKey{}, signature.PublicKey{}, nil, fmt.Errorf("oasis: failed to provision node identity: %w", err)
 	}
 	sentryCert, err := x509.ParseCertificate(nodeIdentity.TLSSentryClientCertificate.Certificate[0])
 	if err != nil {
-		return signature.PublicKey{}, nil, fmt.Errorf("oasis: failed to parse sentry client certificate: %w", err)
+		return signature.PublicKey{}, signature.PublicKey{}, nil, fmt.Errorf("oasis: failed to parse sentry client certificate: %w", err)
 	}
-	return nodeIdentity.NodeSigner.Public(), sentryCert, nil
+	return nodeIdentity.NodeSigner.Public(), nodeIdentity.P2PSigner.Public(), sentryCert, nil
 }
 
 // New creates a new test Oasis network.

--- a/go/oasis-test-runner/oasis/seed.go
+++ b/go/oasis-test-runner/oasis/seed.go
@@ -60,7 +60,7 @@ func (net *Network) newSeedNode() (*seedNode, error) {
 	if err != nil {
 		return nil, fmt.Errorf("oasis/seed: failed to provision seed identity: %w", err)
 	}
-	seedPublicKey := seedIdentity.NodeSigner.Public()
+	seedP2PPublicKey := seedIdentity.P2PSigner.Public()
 
 	seedNode := &seedNode{
 		Node: Node{
@@ -68,7 +68,7 @@ func (net *Network) newSeedNode() (*seedNode, error) {
 			net:  net,
 			dir:  seedDir,
 		},
-		tmAddress:     crypto.PublicKeyToTendermint(&seedPublicKey).Address().String(),
+		tmAddress:     crypto.PublicKeyToTendermint(&seedP2PPublicKey).Address().String(),
 		consensusPort: net.nextNodePort,
 	}
 	seedNode.doStartNode = seedNode.startNode

--- a/go/oasis-test-runner/oasis/sentry.go
+++ b/go/oasis-test-runner/oasis/sentry.go
@@ -17,7 +17,7 @@ type Sentry struct {
 	storageIndices    []int
 	keymanagerIndices []int
 
-	publicKey     signature.PublicKey
+	p2pPublicKey  signature.PublicKey
 	tlsPublicKey  signature.PublicKey
 	tmAddress     string
 	consensusPort uint16
@@ -139,7 +139,7 @@ func (net *Network) NewSentry(cfg *SentryCfg) (*Sentry, error) {
 		)
 		return nil, fmt.Errorf("oasis/sentry: failed to provision sentry identity: %w", err)
 	}
-	sentryPublicKey := sentryIdentity.NodeSigner.Public()
+	sentryP2PPublicKey := sentryIdentity.P2PSigner.Public()
 	sentryTLSPublicKey := sentryIdentity.GetTLSSigner().Public()
 
 	sentry := &Sentry{
@@ -153,9 +153,9 @@ func (net *Network) NewSentry(cfg *SentryCfg) (*Sentry, error) {
 		validatorIndices:  cfg.ValidatorIndices,
 		storageIndices:    cfg.StorageIndices,
 		keymanagerIndices: cfg.KeymanagerIndices,
-		publicKey:         sentryPublicKey,
+		p2pPublicKey:      sentryP2PPublicKey,
 		tlsPublicKey:      sentryTLSPublicKey,
-		tmAddress:         crypto.PublicKeyToTendermint(&sentryPublicKey).Address().String(),
+		tmAddress:         crypto.PublicKeyToTendermint(&sentryP2PPublicKey).Address().String(),
 		consensusPort:     net.nextNodePort,
 		controlPort:       net.nextNodePort + 1,
 		sentryPort:        net.nextNodePort + 2,

--- a/go/oasis-test-runner/oasis/storage.go
+++ b/go/oasis-test-runner/oasis/storage.go
@@ -164,11 +164,11 @@ func (net *Network) NewStorage(cfg *StorageCfg) (*Storage, error) {
 
 	// Pre-provision the node identity so that we can update the entity.
 	seed := fmt.Sprintf(storageIdentitySeedTemplate, len(net.storageWorkers))
-	publicKey, sentryClientCert, err := net.provisionNodeIdentity(storageDir, seed, cfg.DisableCertRotation)
+	nodeKey, p2pKey, sentryClientCert, err := net.provisionNodeIdentity(storageDir, seed, cfg.DisableCertRotation)
 	if err != nil {
 		return nil, fmt.Errorf("oasis/storage: failed to provision node identity: %w", err)
 	}
-	if err := cfg.Entity.addNode(publicKey); err != nil {
+	if err := cfg.Entity.addNode(nodeKey); err != nil {
 		return nil, err
 	}
 	// Sentry client cert.
@@ -197,14 +197,14 @@ func (net *Network) NewStorage(cfg *StorageCfg) (*Storage, error) {
 		ignoreApplies:           cfg.IgnoreApplies,
 		checkpointCheckInterval: cfg.CheckpointCheckInterval,
 		sentryPubKey:            sentryPubKey,
-		tmAddress:               crypto.PublicKeyToTendermint(&publicKey).Address().String(),
+		tmAddress:               crypto.PublicKeyToTendermint(&p2pKey).Address().String(),
 		consensusPort:           net.nextNodePort,
 		clientPort:              net.nextNodePort + 1,
 		p2pPort:                 net.nextNodePort + 2,
 		runtimes:                cfg.Runtimes,
 	}
 	worker.doStartNode = worker.startNode
-	copy(worker.NodeID[:], publicKey[:])
+	copy(worker.NodeID[:], nodeKey[:])
 
 	net.storageWorkers = append(net.storageWorkers, worker)
 	net.nextNodePort += 3

--- a/go/oasis-test-runner/oasis/validator.go
+++ b/go/oasis-test-runner/oasis/validator.go
@@ -152,7 +152,7 @@ func (net *Network) NewValidator(cfg *ValidatorCfg) (*Validator, error) {
 	if len(val.sentries) > 0 {
 		for _, sentry := range val.sentries {
 			var consensusAddr node.ConsensusAddress
-			consensusAddr.ID = sentry.publicKey
+			consensusAddr.ID = sentry.p2pPublicKey
 			if err = consensusAddr.Address.FromIP(localhost, sentry.consensusPort); err != nil {
 				return nil, fmt.Errorf("oasis/validator: failed to parse IP address: %w", err)
 			}
@@ -169,12 +169,12 @@ func (net *Network) NewValidator(cfg *ValidatorCfg) (*Validator, error) {
 	// Load node's identity, so that we can pass the validator's Tendermint
 	// address to sentry node(s) to configure it as a private peer.
 	seed := fmt.Sprintf(validatorIdentitySeedTemplate, len(net.validators))
-	valPublicKey, sentryClientCert, err := net.provisionNodeIdentity(valDir, seed, false)
+	valNodeKey, valP2PKey, sentryClientCert, err := net.provisionNodeIdentity(valDir, seed, false)
 	if err != nil {
 		return nil, fmt.Errorf("oasis/validator: failed to provision node identity: %w", err)
 	}
-	copy(val.NodeID[:], valPublicKey[:])
-	val.tmAddress = crypto.PublicKeyToTendermint(&val.NodeID).Address().String()
+	copy(val.NodeID[:], valNodeKey[:])
+	val.tmAddress = crypto.PublicKeyToTendermint(&valP2PKey).Address().String()
 	if err = cfg.Entity.addNode(val.NodeID); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #3101 

Previously the Tendermint consensus backend used the node's identity key for
Tendermint P2P connections. This has now been changed to use the node's P2P
key instead as that can be made ephemeral in the future.