### PR TITLE
go/oasis-test-runner/cmd: Limit scenario name regex matching

### DIFF
--- a/.changelog/3103.internal.md
+++ b/.changelog/3103.internal.md
@@ -1,0 +1,5 @@
+go/oasis-test-runner/cmd: Limit scenario name regex matching
+
+Prevent oasis-test-runner to match too many scenarios for a given
+scenario name regex by ensuring the given scenario name regex matches
+the whole scenario name.


### PR DESCRIPTION
Prevent oasis-test-runner to match too many scenarios for a given scenario name regex by ensuring the given scenario name regex matches the whole scenario name.

For example, previously, using

```
oasis-test-runner --test a [... other arguments ...]
```
would match and run all the following scenarios:
```
e2e/runtime/runtime-dynamic
e2e/runtime/keymanager-replication
e2e/gas-fees/staking
e2e/runtime/byzantine/executor-straggler
e2e/runtime/gas-fees/runtimes
e2e/node-upgrade
e2e/runtime/keymanager-upgrade
e2e/runtime/runtime-upgrade
e2e/gas-fees/staking-dump-restore
e2e/early-query
e2e/stake-cli
e2e/runtime/byzantine/merge-honest
e2e/runtime/storage-sync
remote-signer/basic
e2e/runtime/byzantine/merge-wrong
e2e/runtime/byzantine/merge-straggler
e2e/runtime/byzantine/executor-honest
e2e/node-upgrade-cancel
e2e/runtime/keymanager-restart
e2e/runtime/halt-restore
e2e/runtime/late-start
e2e/runtime/byzantine/executor-wrong
```

Now, it doesn't match any scenario.

If one wants to match something like before, he needs to explicitly add wildcards, e.g.:
```
oasis-test-runner --test .*a.* [... other arguments ...]
```