### PR TITLE
oasis-node/cmd/unsafe-reset: fix globs for runtime files

### DIFF
--- a/.changelog/3105.bugfix.md
+++ b/.changelog/3105.bugfix.md
@@ -1,0 +1,1 @@
+oasis-node/cmd/unsafe-reset: Fix globs for runtime files

--- a/go/oasis-node/cmd/node/unsafe_reset.go
+++ b/go/oasis-node/cmd/node/unsafe_reset.go
@@ -77,12 +77,12 @@ func doUnsafeReset(cmd *cobra.Command, args []string) {
 	if viper.GetBool(CfgPreserveLocalStorage) {
 		logger.Info("preserving untrusted local storage")
 	} else {
-		globs = append(globs, filepath.Join(runtimesGlob, runtimeLocalStorageGlob))
+		globs = append(globs, runtimeLocalStorageGlob)
 	}
 	if viper.GetBool(CfgPreserveMKVSDatabase) {
 		logger.Info("preserving MKVS database")
 	} else {
-		globs = append(globs, filepath.Join(runtimesGlob, runtimeMkvsDatabaseGlob))
+		globs = append(globs, runtimeMkvsDatabaseGlob)
 	}
 
 	// Enumerate the locations to purge.


### PR DESCRIPTION
See: https://github.com/oasisprotocol/oasis-core/blob/ec03a8ec565e53f48e7f0a8bfffcd63932443b60/go/oasis-node/cmd/node/unsafe_reset.go#L47-L48