### PR TITLE
go/tests/e2e: add missing Clone() override to late-start

### DIFF
--- a/.changelog/3106.internal.md
+++ b/.changelog/3106.internal.md
@@ -1,0 +1,1 @@
+go/tests/e2e: Add missing Clone() override to late-start

--- a/go/oasis-test-runner/scenario/e2e/runtime/late_start.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/late_start.go
@@ -23,6 +23,12 @@ func newLateStartImpl(name, clientBinary string, clientArgs []string) scenario.S
 	}
 }
 
+func (sc *lateStartImpl) Clone() scenario.Scenario {
+	return &lateStartImpl{
+		runtimeImpl: *sc.runtimeImpl.Clone().(*runtimeImpl),
+	}
+}
+
 func (sc *lateStartImpl) Fixture() (*oasis.NetworkFixture, error) {
 	f, err := sc.runtimeImpl.Fixture()
 	if err != nil {


### PR DESCRIPTION
Note: not overriding `Clone` in a scenario that embeds a different scenario actually causes embedded scenario test to be run (since `Clone` returns the embedded "parent" scenario).

Did check all other test scenarios and all do override the `Clone()` method.