### PR TITLE
go/oasis-test-runner/cmd: Sort scenarios for correct parallel execution

### DIFF
--- a/.changelog/3104.bugfix.md
+++ b/.changelog/3104.bugfix.md
@@ -1,0 +1,1 @@
+go/oasis-test-runner/cmd: Sort scenarios for correct parallel execution

--- a/go/oasis-test-runner/cmd/root.go
+++ b/go/oasis-test-runner/cmd/root.go
@@ -305,6 +305,10 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Sort requested scenarios to enable consistent partitioning for parallel
+	// job execution.
+	sort.Slice(toRun, func(i, j int) bool { return toRun[i].Name() < toRun[j].Name() })
+
 	excludeMap := make(map[string]bool)
 	if excludeEnv := os.Getenv("OASIS_EXCLUDE_E2E"); excludeEnv != "" {
 		for _, v := range strings.Split(excludeEnv, ",") {

--- a/go/oasis-test-runner/cmd/root.go
+++ b/go/oasis-test-runner/cmd/root.go
@@ -316,9 +316,15 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Run the required test scenarios.
+	// Get parallel job execution parameters.
 	parallelJobCount := viper.GetInt(cfgParallelJobCount)
 	parallelJobIndex := viper.GetInt(cfgParallelJobIndex)
+	if parallelJobIndex < 0 || parallelJobIndex >= parallelJobCount {
+		return fmt.Errorf(
+			"root: invalid value of %s flag: %d (should be in range [0, %d))",
+			cfgParallelJobIndex, parallelJobIndex, parallelJobCount,
+		)
+	}
 
 	// Parse test parameters passed by CLI.
 	var toRunExploded map[string][]scenario.Scenario


### PR DESCRIPTION
Fixes: #3104.