### PR TITLE
Enable pretty-printers to print stake amounts in tokens

### DIFF
--- a/.changelog/3037.feature.1.md
+++ b/.changelog/3037.feature.1.md
@@ -1,0 +1,5 @@
+go/staking/api: Pretty-print account balances in tokens
+
+If a `PrettyPrinter`'s context carries appropriate values for the token's
+ticker symbol and token's value base-10 exponent, print the balance in
+tokens instead of base units.

--- a/.changelog/3037.feature.2.md
+++ b/.changelog/3037.feature.2.md
@@ -1,0 +1,4 @@
+go/oasis-node/cmd/stake: Support showing stake amounts in tokens
+
+The `oasis-node stake info` and `oasis-node stake account info` CLI commands
+show stake amounts (e.g. account balances, staking thresholds) in tokens.

--- a/.changelog/3111.breaking.md
+++ b/.changelog/3111.breaking.md
@@ -1,0 +1,1 @@
+go/common/prettyprint: Augment `PrettyPrinter.PrettyPrint()` with `Context`

--- a/go/common/crypto/signature/signature.go
+++ b/go/common/crypto/signature/signature.go
@@ -3,6 +3,7 @@ package signature
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding"
 	"encoding/base64"
@@ -445,7 +446,7 @@ type PrettySigned struct {
 
 // PrettyPrint writes a pretty-printed representation of the type
 // to the given writer.
-func (p PrettySigned) PrettyPrint(prefix string, w io.Writer) {
+func (p PrettySigned) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	data, err := json.MarshalIndent(p, prefix, "  ")
 	if err != nil {
 		fmt.Fprintf(w, "%s<error: %s>\n", prefix, err)
@@ -561,7 +562,7 @@ type PrettyMultiSigned struct {
 
 // PrettyPrint writes a pretty-printed representation of the type to the
 // given writer.
-func (p PrettyMultiSigned) PrettyPrint(prefix string, w io.Writer) {
+func (p PrettyMultiSigned) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	data, err := json.MarshalIndent(p, prefix, "  ")
 	if err != nil {
 		fmt.Fprintf(w, "%s<error: %s>\n", prefix, err)

--- a/go/common/entity/entity.go
+++ b/go/common/entity/entity.go
@@ -2,6 +2,7 @@
 package entity
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -188,14 +189,14 @@ func (s *SignedEntity) Open(context signature.Context, entity *Entity) error { /
 
 // PrettyPrint writes a pretty-printed representation of the type
 // to the given writer.
-func (s SignedEntity) PrettyPrint(prefix string, w io.Writer) {
+func (s SignedEntity) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	pt, err := s.PrettyType()
 	if err != nil {
 		fmt.Fprintf(w, "%s<error: %s>\n", prefix, err)
 		return
 	}
 
-	pt.(prettyprint.PrettyPrinter).PrettyPrint(prefix, w)
+	pt.(prettyprint.PrettyPrinter).PrettyPrint(ctx, prefix, w)
 }
 
 // PrettyType returns a representation of the type that can be used for pretty printing.

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -4,6 +4,7 @@
 package node
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -393,14 +394,14 @@ func (s *MultiSignedNode) Open(context signature.Context, node *Node) error {
 
 // PrettyPrint writes a pretty-printed representation of the type
 // to the given writer.
-func (s MultiSignedNode) PrettyPrint(prefix string, w io.Writer) {
+func (s MultiSignedNode) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	pt, err := s.PrettyType()
 	if err != nil {
 		fmt.Fprintf(w, "%s<error: %s>\n", prefix, err)
 		return
 	}
 
-	pt.(prettyprint.PrettyPrinter).PrettyPrint(prefix, w)
+	pt.(prettyprint.PrettyPrinter).PrettyPrint(ctx, prefix, w)
 }
 
 // PrettyType returns a representation of the type that can be used for pretty printing.

--- a/go/common/prettyprint/prettyprint.go
+++ b/go/common/prettyprint/prettyprint.go
@@ -1,13 +1,16 @@
 package prettyprint
 
-import "io"
+import (
+	"context"
+	"io"
+)
 
 // PrettyPrinter is an interface for types that know how to pretty
 // print themselves (e.g., to be displayed in a CLI).
 type PrettyPrinter interface {
 	// PrettyPrint writes a pretty-printed representation of the type
 	// to the given writer.
-	PrettyPrint(prefix string, w io.Writer)
+	PrettyPrint(ctx context.Context, prefix string, w io.Writer)
 
 	// PrettyType returns a representation of the type that can be used for pretty printing.
 	PrettyType() (interface{}, error)

--- a/go/consensus/api/transaction/transaction.go
+++ b/go/consensus/api/transaction/transaction.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -47,7 +48,7 @@ type Transaction struct {
 
 // PrettyPrint writes a pretty-printed representation of the type
 // to the given writer.
-func (t Transaction) PrettyPrint(prefix string, w io.Writer) {
+func (t Transaction) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	fmt.Fprintf(w, "%sNonce:  %d\n", prefix, t.Nonce)
 	if t.Fee != nil {
 		fmt.Fprintf(w, "%sFee:    %s (gas limit: %d, gas price: %s)\n", prefix, t.Fee.Amount, t.Fee.Gas, t.Fee.GasPrice())
@@ -73,7 +74,7 @@ func (t Transaction) PrettyPrint(prefix string, w io.Writer) {
 
 	// If the body type supports pretty printing, use that.
 	if pp, ok := v.(prettyprint.PrettyPrinter); ok {
-		pp.PrettyPrint(prefix+"  ", w)
+		pp.PrettyPrint(ctx, prefix+"  ", w)
 		return
 	}
 
@@ -158,7 +159,7 @@ func (s *SignedTransaction) Hash() hash.Hash {
 
 // PrettyPrint writes a pretty-printed representation of the type
 // to the given writer.
-func (s SignedTransaction) PrettyPrint(prefix string, w io.Writer) {
+func (s SignedTransaction) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	fmt.Fprintf(w, "%sHash: %s\n", prefix, s.Hash())
 
 	fmt.Fprintf(w, "%sSigner: %s\n", prefix, s.Signature.PublicKey)
@@ -179,7 +180,7 @@ func (s SignedTransaction) PrettyPrint(prefix string, w io.Writer) {
 		return
 	}
 
-	tx.PrettyPrint(prefix+"  ", w)
+	tx.PrettyPrint(ctx, prefix+"  ", w)
 }
 
 // PrettyType returns a representation of the type that can be used for pretty printing.

--- a/go/genesis/tests/helpers.go
+++ b/go/genesis/tests/helpers.go
@@ -6,8 +6,17 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 )
 
-// TestChainID is the chain ID that should be used in tests.
-const TestChainID = "test: oasis-core tests"
+const (
+	// TestChainID is the chain ID that should be used in tests.
+	TestChainID = "test: oasis-core tests"
+
+	// TestStakingTokenSymbol is the token's ticker symbol that should be used
+	// in tests.
+	TestStakingTokenSymbol = "TEST"
+	// TestStakingTokenValueExponent is the token's value base-10 exponent that
+	// should be used in tests.
+	TestStakingTokenValueExponent uint8 = 6
+)
 
 // TestChainContext is the chain domain separation context that should
 // be used in tests.

--- a/go/oasis-node/cmd/consensus/consensus.go
+++ b/go/oasis-node/cmd/consensus/consensus.go
@@ -135,7 +135,7 @@ func doShowTx(cmd *cobra.Command, args []string) {
 	cmdConsensus.InitGenesis()
 
 	sigTx := loadTx()
-	sigTx.PrettyPrint("", os.Stdout)
+	sigTx.PrettyPrint(context.Background(), "", os.Stdout)
 }
 
 func doEstimateGas(cmd *cobra.Command, args []string) {

--- a/go/oasis-node/cmd/stake/account.go
+++ b/go/oasis-node/cmd/stake/account.go
@@ -13,6 +13,7 @@ import (
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	cmdConsensus "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/consensus"
 	cmdGrpc "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/grpc"
+	"github.com/oasisprotocol/oasis-core/go/staking/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
@@ -107,6 +108,10 @@ func doAccountInfo(cmd *cobra.Command, args []string) {
 
 	ctx := context.Background()
 	acct := getAccount(ctx, cmd, addr, client)
+	symbol := getTokenSymbol(ctx, cmd, client)
+	exp := getTokenValueExponent(ctx, cmd, client)
+	ctx = context.WithValue(ctx, api.PrettyPrinterContextKeyTokenSymbol, symbol)
+	ctx = context.WithValue(ctx, api.PrettyPrinterContextKeyTokenValueExponent, exp)
 	acct.PrettyPrint(ctx, "", os.Stdout)
 }
 

--- a/go/oasis-node/cmd/stake/account.go
+++ b/go/oasis-node/cmd/stake/account.go
@@ -107,7 +107,7 @@ func doAccountInfo(cmd *cobra.Command, args []string) {
 
 	ctx := context.Background()
 	acct := getAccount(ctx, cmd, addr, client)
-	acct.PrettyPrint("", os.Stdout)
+	acct.PrettyPrint(ctx, "", os.Stdout)
 }
 
 func doAccountTransfer(cmd *cobra.Command, args []string) {

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -802,7 +802,9 @@ func (net *Network) makeGenesis() error {
 		"--" + genesis.CfgRegistryDebugAllowTestRuntimes, "true",
 		"--scheduler.max_validators_per_entity", strconv.Itoa(len(net.Validators())),
 		"--" + genesis.CfgConsensusGasCostsTxByte, strconv.FormatUint(net.cfg.ConsensusGasCostsTxByte, 10),
-		"--" + genesis.CfgStakingTokenSymbol, "TEST",
+		"--" + genesis.CfgStakingTokenSymbol, genesisTestHelpers.TestStakingTokenSymbol,
+		"--" + genesis.CfgStakingTokenValueExponent, strconv.FormatUint(
+			uint64(genesisTestHelpers.TestStakingTokenValueExponent), 10),
 	}
 	if net.cfg.EpochtimeMock {
 		args = append(args, "--epochtime.debug.mock_backend")

--- a/go/oasis-test-runner/scenario/e2e/stake_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/stake_cli.go
@@ -589,7 +589,7 @@ func (sc *stakeCLIImpl) checkGeneralAccount(
 	}
 
 	var b bytes.Buffer
-	expectedAccount.PrettyPrint("  ", &b)
+	expectedAccount.PrettyPrint(context.Background(), "  ", &b)
 	match := regexp.MustCompile(b.String()).FindStringSubmatch(accountInfo)
 	if match == nil {
 		return fmt.Errorf(
@@ -614,7 +614,7 @@ func (sc *stakeCLIImpl) checkEscrowAccountSharePool(
 	prefix := "  "
 	var b bytes.Buffer
 	fmt.Fprintf(&b, "%s%s:\n", prefix, sharePoolName)
-	expectedSharePool.PrettyPrint(prefix+"  ", &b)
+	expectedSharePool.PrettyPrint(context.Background(), prefix+"  ", &b)
 	match := regexp.MustCompile(b.String()).FindStringSubmatch(accountInfo)
 	if match == nil {
 		return fmt.Errorf(
@@ -638,7 +638,7 @@ func (sc *stakeCLIImpl) checkCommissionScheduleRates(
 
 	for _, expectedRate := range expectedRates {
 		var b bytes.Buffer
-		expectedRate.PrettyPrint("      ", &b)
+		expectedRate.PrettyPrint(context.Background(), "      ", &b)
 		match := regexp.MustCompile(b.String()).FindStringSubmatch(accountInfo)
 		if match == nil {
 			return fmt.Errorf(
@@ -663,7 +663,7 @@ func (sc *stakeCLIImpl) checkCommissionScheduleRateBounds(
 
 	for _, expectedBound := range expectedRateBounds {
 		var b bytes.Buffer
-		expectedBound.PrettyPrint("      ", &b)
+		expectedBound.PrettyPrint(context.Background(), "      ", &b)
 		match := regexp.MustCompile(b.String()).FindStringSubmatch(accountInfo)
 		if match == nil {
 			return fmt.Errorf(

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -316,14 +316,14 @@ func (s *SignedRuntime) Open(context signature.Context, runtime *Runtime) error 
 
 // PrettyPrint writes a pretty-printed representation of the type
 // to the given writer.
-func (s SignedRuntime) PrettyPrint(prefix string, w io.Writer) {
+func (s SignedRuntime) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	pt, err := s.PrettyType()
 	if err != nil {
 		fmt.Fprintf(w, "%s<error: %s>\n", prefix, err)
 		return
 	}
 
-	pt.(prettyprint.PrettyPrinter).PrettyPrint(prefix, w)
+	pt.(prettyprint.PrettyPrinter).PrettyPrint(ctx, prefix, w)
 }
 
 // PrettyType returns a representation of the type that can be used for pretty printing.

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -68,6 +68,10 @@ var (
 	// is specified in a query.
 	ErrInvalidThreshold = errors.New(ModuleName, 6, "staking: invalid threshold")
 
+	// ErrInvalidTokenValueExponent is the error returned when an invalid
+	// token's value base-10 exponent is specified.
+	ErrInvalidTokenValueExponent = errors.New(ModuleName, 7, "staking: invalid token's value exponent")
+
 	// MethodTransfer is the method name for transfers.
 	MethodTransfer = transaction.NewMethodName(ModuleName, "Transfer", Transfer{})
 	// MethodBurn is the method name for burns.
@@ -291,7 +295,9 @@ type SharePool struct {
 // PrettyPrint writes a pretty-printed representation of SharePool to the given
 // writer.
 func (p SharePool) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
-	fmt.Fprintf(w, "%sBalance:      %s\n", prefix, p.Balance)
+	fmt.Fprintf(w, "%sBalance: ", prefix)
+	PrettyPrintAmount(ctx, p.Balance, w)
+	fmt.Fprintln(w)
 
 	fmt.Fprintf(w, "%sTotal Shares: %s\n", prefix, p.TotalShares)
 }
@@ -644,9 +650,11 @@ type GeneralAccount struct {
 // PrettyPrint writes a pretty-printed representation of GeneralAccount to the
 // given writer.
 func (ga GeneralAccount) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
-	fmt.Fprintf(w, "%sBalance: %s\n", prefix, ga.Balance)
+	fmt.Fprintf(w, "%sBalance: ", prefix)
+	PrettyPrintAmount(ctx, ga.Balance, w)
+	fmt.Fprintln(w)
 
-	fmt.Fprintf(w, "%sNonce:   %d\n", prefix, ga.Nonce)
+	fmt.Fprintf(w, "%sNonce: %d\n", prefix, ga.Nonce)
 }
 
 // PrettyType returns a representation of GeneralAccount that can be used for

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -290,7 +290,7 @@ type SharePool struct {
 
 // PrettyPrint writes a pretty-printed representation of SharePool to the given
 // writer.
-func (p SharePool) PrettyPrint(prefix string, w io.Writer) {
+func (p SharePool) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	fmt.Fprintf(w, "%sBalance:      %s\n", prefix, p.Balance)
 
 	fmt.Fprintf(w, "%sTotal Shares: %s\n", prefix, p.TotalShares)
@@ -498,7 +498,7 @@ func (st StakeThreshold) String() string {
 
 // PrettyPrint writes a pretty-printed representation of StakeThreshold to the
 // given writer.
-func (st StakeThreshold) PrettyPrint(prefix string, w io.Writer) {
+func (st StakeThreshold) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	switch {
 	case st.Global != nil:
 		fmt.Fprintf(w, "%s- Global: %s\n", prefix, *st.Global)
@@ -567,7 +567,7 @@ type StakeAccumulator struct {
 
 // PrettyPrint writes a pretty-printed representation of StakeAccumulator to the
 // given writer.
-func (sa StakeAccumulator) PrettyPrint(prefix string, w io.Writer) {
+func (sa StakeAccumulator) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	if sa.Claims == nil {
 		fmt.Fprintf(w, "%sClaims: (none)\n", prefix)
 	} else {
@@ -576,7 +576,7 @@ func (sa StakeAccumulator) PrettyPrint(prefix string, w io.Writer) {
 			fmt.Fprintf(w, "%s  - Name: %s\n", prefix, claim)
 			for _, threshold := range thresholds {
 				fmt.Fprintf(w, "%s    Staking Thresholds:\n", prefix)
-				threshold.PrettyPrint(prefix+"      ", w)
+				threshold.PrettyPrint(ctx, prefix+"      ", w)
 			}
 		}
 	}
@@ -643,7 +643,7 @@ type GeneralAccount struct {
 
 // PrettyPrint writes a pretty-printed representation of GeneralAccount to the
 // given writer.
-func (ga GeneralAccount) PrettyPrint(prefix string, w io.Writer) {
+func (ga GeneralAccount) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	fmt.Fprintf(w, "%sBalance: %s\n", prefix, ga.Balance)
 
 	fmt.Fprintf(w, "%sNonce:   %d\n", prefix, ga.Nonce)
@@ -666,18 +666,18 @@ type EscrowAccount struct {
 
 // PrettyPrint writes a pretty-printed representation of EscrowAccount to the
 // given writer.
-func (e EscrowAccount) PrettyPrint(prefix string, w io.Writer) {
+func (e EscrowAccount) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	fmt.Fprintf(w, "%sActive:\n", prefix)
-	e.Active.PrettyPrint(prefix+"  ", w)
+	e.Active.PrettyPrint(ctx, prefix+"  ", w)
 
 	fmt.Fprintf(w, "%sDebonding:\n", prefix)
-	e.Debonding.PrettyPrint(prefix+"  ", w)
+	e.Debonding.PrettyPrint(ctx, prefix+"  ", w)
 
 	fmt.Fprintf(w, "%sCommission Schedule:\n", prefix)
-	e.CommissionSchedule.PrettyPrint(prefix+"  ", w)
+	e.CommissionSchedule.PrettyPrint(ctx, prefix+"  ", w)
 
 	fmt.Fprintf(w, "%sStake Accumulator:\n", prefix)
-	e.StakeAccumulator.PrettyPrint(prefix+"  ", w)
+	e.StakeAccumulator.PrettyPrint(ctx, prefix+"  ", w)
 }
 
 // PrettyType returns a representation of EscrowAccount that can be used for
@@ -748,11 +748,11 @@ type Account struct {
 
 // PrettyPrint writes a pretty-printed representation of Account to the given
 // writer.
-func (a Account) PrettyPrint(prefix string, w io.Writer) {
+func (a Account) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	fmt.Fprintf(w, "%sGeneral Account:\n", prefix)
-	a.General.PrettyPrint(prefix+"  ", w)
+	a.General.PrettyPrint(ctx, prefix+"  ", w)
 	fmt.Fprintf(w, "%sEscrow Account:\n", prefix)
-	a.Escrow.PrettyPrint(prefix+"  ", w)
+	a.Escrow.PrettyPrint(ctx, prefix+"  ", w)
 }
 
 // PrettyType returns a representation of Account that can be used for pretty

--- a/go/staking/api/commission.go
+++ b/go/staking/api/commission.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math/big"
@@ -55,7 +56,7 @@ type CommissionRateStep struct {
 
 // PrettyPrint writes a pretty-printed representation of CommissionRateStep to
 // the given writer.
-func (crs CommissionRateStep) PrettyPrint(prefix string, w io.Writer) {
+func (crs CommissionRateStep) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	fmt.Fprintf(w, "%s- Start: epoch %d\n", prefix, crs.Start)
 
 	fmt.Fprintf(w, "%s  Rate:  %s %%\n", prefix, CommissionRatePercentage(crs.Rate))
@@ -80,7 +81,7 @@ type CommissionRateBoundStep struct {
 
 // PrettyPrint writes a pretty-printed representation of CommissionRateBoundStep
 // to the given writer.
-func (crbs CommissionRateBoundStep) PrettyPrint(prefix string, w io.Writer) {
+func (crbs CommissionRateBoundStep) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	fmt.Fprintf(w, "%s- Start:        epoch %d\n", prefix, crbs.Start)
 
 	fmt.Fprintf(w, "%s  Minimum Rate: %s %%\n", prefix, CommissionRatePercentage(crbs.RateMin))
@@ -104,13 +105,13 @@ type CommissionSchedule struct {
 
 // PrettyPrint writes a pretty-printed representation of CommissionSchedule to
 // the given writer.
-func (cs CommissionSchedule) PrettyPrint(prefix string, w io.Writer) {
+func (cs CommissionSchedule) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	if cs.Rates == nil {
 		fmt.Fprintf(w, "%sRates: (none)\n", prefix)
 	} else {
 		fmt.Fprintf(w, "%sRates:\n", prefix)
 		for _, rate := range cs.Rates {
-			rate.PrettyPrint(prefix+"  ", w)
+			rate.PrettyPrint(ctx, prefix+"  ", w)
 		}
 	}
 
@@ -119,7 +120,7 @@ func (cs CommissionSchedule) PrettyPrint(prefix string, w io.Writer) {
 	} else {
 		fmt.Fprintf(w, "%sRate Bounds:\n", prefix)
 		for _, rateBound := range cs.Bounds {
-			rateBound.PrettyPrint(prefix+"  ", w)
+			rateBound.PrettyPrint(ctx, prefix+"  ", w)
 		}
 	}
 }

--- a/go/staking/api/prettyprint.go
+++ b/go/staking/api/prettyprint.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/big"
+	"strings"
+
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+)
+
+var (
+	// PrettyPrinterContextKeyTokenSymbol is the key to retrieve the token's
+	// ticker symbol value from a context.
+	PrettyPrinterContextKeyTokenSymbol = contextKey("staking/token-symbol")
+	// PrettyPrinterContextKeyTokenValueExponent is the key to retrieve the
+	// token's value base-10 exponent from a context.
+	PrettyPrinterContextKeyTokenValueExponent = contextKey("staking/token-value-exponent")
+)
+
+type contextKey string
+
+// ConvertToTokenAmount returns the given amount in base units to the
+// corresponding token amount accourding to the given token's value base-10
+// exponent.
+func ConvertToTokenAmount(amount quantity.Quantity, tokenValueExponent uint8) (string, error) {
+	if tokenValueExponent > TokenValueExponentMaxValue {
+		return "", ErrInvalidTokenValueExponent
+	}
+
+	divisor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(tokenValueExponent)), nil)
+
+	// NOTE: We use DivMod() and manual string construction to avoid conversion
+	// to other types and support arbitrarily large amounts.
+	var quotient, remainder *big.Int
+	quotient, remainder = new(big.Int).DivMod(amount.ToBigInt(), divisor, new(big.Int))
+
+	// Prefix the remainder with the appropriate number of zeros.
+	remainderStr := fmt.Sprintf("%0*s", tokenValueExponent, remainder)
+	// Trim trailing zeros from the remainder.
+	remainderStr = strings.TrimRight(remainderStr, "0")
+	// Ensure remainder is not empty.
+	if remainderStr == "" {
+		remainderStr = "0"
+	}
+
+	// Combine quotient and remainder to a string representing the token amount.
+	return fmt.Sprintf("%s.%s", quotient, remainderStr), nil
+}
+
+// PrettyPrintAmount writes a pretty-printed representation of the given amount
+// to the given writer.
+//
+// If the context carries appropriate values for the token's ticker symbol and
+// token's value base-10 exponent, then the amount is printed in tokens instead
+// of base units.
+func PrettyPrintAmount(ctx context.Context, amount quantity.Quantity, w io.Writer) {
+	useBaseUnits := false
+
+	symbol, ok := ctx.Value(PrettyPrinterContextKeyTokenSymbol).(string)
+	if !ok || symbol == "" || len(symbol) > TokenSymbolMaxLength {
+		useBaseUnits = true
+	}
+	exp, ok := ctx.Value(PrettyPrinterContextKeyTokenValueExponent).(uint8)
+	if !ok {
+		useBaseUnits = true
+	}
+
+	var tokenAmount string
+	var err error
+	if !useBaseUnits {
+		tokenAmount, err = ConvertToTokenAmount(amount, exp)
+		if err != nil {
+			useBaseUnits = true
+		}
+	}
+
+	if useBaseUnits {
+		fmt.Fprintf(w, "%s base units", amount)
+	} else {
+		fmt.Fprintf(w, "%s %s", symbol, tokenAmount)
+	}
+}

--- a/go/staking/api/prettyprint_test.go
+++ b/go/staking/api/prettyprint_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+)
+
+func TestConvertToTokenAmount(t *testing.T) {
+	require := require.New(t)
+
+	for _, t := range []struct {
+		expectedTokenAmount string
+		amount              *quantity.Quantity
+		exp                 uint8
+		valid               bool
+	}{
+		// General checks where 1 tokens equals 10^9 base units.
+		{"10000000000.0", quantity.NewFromUint64(10000000000000000000), 9, true},
+		{"100.0", quantity.NewFromUint64(100000000000), 9, true},
+		{"7999217230.11968289", quantity.NewFromUint64(7999217230119682890), 9, true},
+		{"7999217230.1196", quantity.NewFromUint64(7999217230119600000), 9, true},
+		{"7999217230.1", quantity.NewFromUint64(7999217230100000000), 9, true},
+		{"0.0", quantity.NewFromUint64(0), 9, true},
+		// Check for a too large token's value base-10 exponent.
+		{"INVALID", quantity.NewFromUint64(10000000000000000001), 21, false},
+		// Special checks for large and small token's value base-10 exponents.
+		{"10.0", quantity.NewFromUint64(10000000000000000000), 18, true},
+		{"10.000000000000000001", quantity.NewFromUint64(10000000000000000001), 18, true},
+		{"0.0000001", quantity.NewFromUint64(100000000000), 18, true},
+		{"0.0", quantity.NewFromUint64(0), 18, true},
+		{"10000000000000000000.0", quantity.NewFromUint64(10000000000000000000), 0, true},
+		{"10000000000000000001.0", quantity.NewFromUint64(10000000000000000001), 0, true},
+		{"0.0", quantity.NewFromUint64(0), 0, true},
+	} {
+		tokenAmount, err := ConvertToTokenAmount(*t.amount, t.exp)
+		if !t.valid {
+			require.Error(err, "converting base unit amount to tokens should fail")
+			continue
+		}
+		require.NoError(err, "converting base unit amount to tokens shouldn't fail")
+		require.Equal(t.expectedTokenAmount, tokenAmount,
+			"converting base unit amount to tokens didn't return the expected amount")
+	}
+}
+
+func TestPrettyPrintAmount(t *testing.T) {
+	require := require.New(t)
+
+	for _, t := range []struct { // nolint: maligned
+		expectedPrettyPrint string
+		amount              *quantity.Quantity
+		addSymbol           bool
+		symbol              string
+		addExp              bool
+		exp                 uint8
+	}{
+		{"CORE 10000000000.0", quantity.NewFromUint64(10000000000000000000), true, "CORE", true, 9},
+		{"CORE 100.0", quantity.NewFromUint64(100000000000), true, "CORE", true, 9},
+		{"CORE 7999217230.1196", quantity.NewFromUint64(7999217230119600000), true, "CORE", true, 9},
+		{"CORE 0.0", quantity.NewFromUint64(0), true, "CORE", true, 9},
+		// Check large and small token's value base-10 exponents.
+		{"BIG 10.0", quantity.NewFromUint64(10000000000000000000), true, "BIG", true, 18},
+		{"SMALL 10000000000000000001.0", quantity.NewFromUint64(10000000000000000001), true, "SMALL", true, 0},
+		// Check invalid token's value base-10 exponent.
+		{"100000000 base units", quantity.NewFromUint64(100000000), true, "TOOBIG", true, 21},
+		// Check invalid token's ticker symbol.
+		{"100000 base units", quantity.NewFromUint64(100000), true, "SOMETHINGLONG", true, 6},
+		{"100000 base units", quantity.NewFromUint64(100000), true, "", true, 6},
+		// Check missing combinations of token's symbol and value exponent.
+		{"100000 base units", quantity.NewFromUint64(100000), false, "MISSING", true, 6},
+		{"100000 base units", quantity.NewFromUint64(100000), true, "NOEXP", false, 0},
+		{"100000 base units", quantity.NewFromUint64(100000), false, "MISSING", false, 0},
+	} {
+		ctx := context.Background()
+		if t.addSymbol {
+			ctx = context.WithValue(ctx, PrettyPrinterContextKeyTokenSymbol, t.symbol)
+		}
+		if t.addExp {
+			ctx = context.WithValue(ctx, PrettyPrinterContextKeyTokenValueExponent, t.exp)
+		}
+		var actualPrettyPrint bytes.Buffer
+		PrettyPrintAmount(ctx, *t.amount, &actualPrettyPrint)
+		require.Equal(t.expectedPrettyPrint, actualPrettyPrint.String(),
+			"pretty printing stake amount didn't return the expected result")
+	}
+}


### PR DESCRIPTION
Closes #3037.

Example outputs of update `oasis-node stake` CLI commands:

```
[tadej@toronto staking-docs-network]$ oasis-node-dev stake info -a $ADDR
Token's ticker symbol: AMBER
Token's value base-10 exponent: 9
Total supply: AMBER 10000000000.0
Common pool: AMBER 7999217230.11968289
Last block fees: AMBER 0.0
Staking threshold (entity): AMBER 100.0
Staking threshold (node-validator): AMBER 100.0
Staking threshold (node-compute): AMBER 100.0
Staking threshold (node-storage): AMBER 100.0
Staking threshold (node-keymanager): AMBER 100.0
Staking threshold (runtime-compute): AMBER 100.0
Staking threshold (runtime-keymanager): AMBER 100.0
```

```
[tadej@toronto staking-docs-network]$ oasis-node-dev stake account info   -a $ADDR   --stake.account.address oasis1qp26ua0g6t30eus5mkxuv08fkds37jcqs5fs9tu7
General Account:
  Balance: AMBER 10000.000000001
  Nonce: 0
Escrow Account:
  Active:
    Balance: AMBER 0.0
    Total Shares: 0
  Debonding:
    Balance: AMBER 0.0
    Total Shares: 0
  Commission Schedule:
    Rates: (none)
    Rate Bounds: (none)
  Stake Accumulator:
    Claims: (none)
```