### PR TITLE
go/oasis-node/cmd: Remove retry functionality from staking CLI commands

### DIFF
--- a/.changelog/3113.breaking.md
+++ b/.changelog/3113.breaking.md
@@ -1,0 +1,4 @@
+go/oasis-node/cmd: Remove `--retry` flag from staking CLI commands
+
+Remove obsolete `--retry` flag from `oasis-node stake info`,
+`oasis-node stake list` and `oasis-node stake account info` CLI commands.

--- a/go/oasis-node/cmd/common/flags/flags.go
+++ b/go/oasis-node/cmd/common/flags/flags.go
@@ -21,7 +21,6 @@ const (
 
 	cfgVerbose = "verbose"
 	cfgForce   = "force"
-	cfgRetries = "retries"
 
 	// CfgDryRun is the flag used to specify a dry-run of an operation.
 	CfgDryRun = "dry_run"
@@ -32,8 +31,6 @@ var (
 	VerboseFlags = flag.NewFlagSet("", flag.ContinueOnError)
 	// ForceFlags has the force flag.
 	ForceFlags = flag.NewFlagSet("", flag.ContinueOnError)
-	// RetriesFlags has the retries flag.
-	RetriesFlags = flag.NewFlagSet("", flag.ContinueOnError)
 	// DebugTestEntityFlags has the test entity enable flag.
 	DebugTestEntityFlags = flag.NewFlagSet("", flag.ContinueOnError)
 
@@ -57,11 +54,6 @@ func Verbose() bool {
 // Force returns true iff the force flag is set.
 func Force() bool {
 	return viper.GetBool(cfgForce)
-}
-
-// Retries returns the retries flag value.
-func Retries() int {
-	return viper.GetInt(cfgRetries)
 }
 
 // ConsensusValidator returns true iff the node is opting in to be a consensus
@@ -95,8 +87,6 @@ func init() {
 
 	ForceFlags.Bool(cfgForce, false, "force")
 
-	RetriesFlags.Int(cfgRetries, 0, "retries (-1 = forever)")
-
 	ConsensusValidatorFlag.Bool(CfgConsensusValidator, false, "node is a consensus validator")
 
 	DebugTestEntityFlags.Bool(CfgDebugTestEntity, false, "use the test entity (UNSAFE)")
@@ -112,7 +102,6 @@ func init() {
 	for _, v := range []*flag.FlagSet{
 		VerboseFlags,
 		ForceFlags,
-		RetriesFlags,
 		DebugTestEntityFlags,
 		GenesisFileFlags,
 		ConsensusValidatorFlag,

--- a/go/oasis-node/cmd/stake/account.go
+++ b/go/oasis-node/cmd/stake/account.go
@@ -12,7 +12,6 @@ import (
 
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	cmdConsensus "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/consensus"
-	cmdFlags "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	cmdGrpc "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/grpc"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
@@ -321,7 +320,6 @@ func registerAccountCmd() {
 func init() {
 	accountInfoFlags.String(CfgAccountAddr, "", "account address")
 	_ = viper.BindPFlags(accountInfoFlags)
-	accountInfoFlags.AddFlagSet(cmdFlags.RetriesFlags)
 	accountInfoFlags.AddFlagSet(cmdGrpc.ClientFlags)
 
 	amountFlags.String(CfgAmount, "0", "amount of stake (in base units) for the transaction")


### PR DESCRIPTION
As mentioned https://github.com/oasisprotocol/oasis-core/pull/3111#discussion_r456003315, the retry functionality is not needed since the staking client waits for a response from the gRPC server.