### PR TITLE
go/oasis-node/cmd/common: ExportEntity should use the entity ctor

### DIFF
--- a/.changelog/3117.bugfix.md
+++ b/.changelog/3117.bugfix.md
@@ -1,0 +1,5 @@
+go/oasis-node/cmd/common: ExportEntity should use the entity ctor
+
+Instead of using an entity populated with the zero values and a manually
+filled in public key, use the entity constructor that can fill in
+sensible values for things like the version.

--- a/go/oasis-node/cmd/common/common.go
+++ b/go/oasis-node/cmd/common/common.go
@@ -272,7 +272,7 @@ func ExportEntity(signerBackend, entityDir string) error {
 	if err != nil {
 		return err
 	}
-	var entity entity.Entity
-	entity.ID = signer.Public()
-	return entity.Save(entityDir)
+
+	_, err = entity.GenerateWithSigner(entityDir, signer, nil)
+	return err
 }


### PR DESCRIPTION
Instead of using an entity populated with the zero values and a manually
filled in public key, use the entity constructor that can fill in
sensible values for things like the version.

Rescued from #3094