### PR TITLE
go/common/crypto/signature: Add and use the plugin backed signer

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -114,6 +114,8 @@ steps:
       - cd /workdir/go/oasis-test-runner
       - buildkite-agent artifact upload oasis-test-runner
       - buildkite-agent artifact upload oasis-test-runner.test
+      - cd /workdir/go/oasis-test-runner/scenario/pluginsigner/example_signer_plugin
+      - buildkite-agent artifact upload example_signer_plugin.so
       - cd /workdir/go/oasis-net-runner
       - buildkite-agent artifact upload oasis-net-runner
       - cd /workdir/go/oasis-remote-signer

--- a/.buildkite/scripts/download_e2e_test_artifacts.sh
+++ b/.buildkite/scripts/download_e2e_test_artifacts.sh
@@ -19,6 +19,7 @@ download_artifact oasis-test-runner go/oasis-test-runner 755
 download_artifact oasis-test-runner.test go/oasis-test-runner 755
 download_artifact oasis-remote-signer go/oasis-remote-signer 755
 download_artifact oasis-core-runtime-loader target/default/debug 755
+download_artifact example_signer_plugin.so go/oasis-test-runner/scenario/pluginsigner/example_signer_plugin 755
 
 # Simple Key manager runtime.
 download_artifact simple-keymanager.sgxs target/sgx/x86_64-fortanix-unknown-sgx/debug 755

--- a/.buildkite/scripts/test_e2e.sh
+++ b/.buildkite/scripts/test_e2e.sh
@@ -30,6 +30,7 @@ fi
 
 node_binary="${WORKDIR}/go/oasis-node/oasis-node"
 test_runner_binary="${WORKDIR}/go/oasis-test-runner/oasis-test-runner"
+skip_options=""
 
 # Use e2e-coverage-wrapper.sh as node binary if we need to compute E2E
 # tests' coverage.
@@ -39,6 +40,11 @@ if [[ ${OASIS_E2E_COVERAGE:-""} != "" ]]; then
     # Use -env version of the wrapper as we can't pass additional arguments there.
     export E2E_COVERAGE_BINARY=${node_binary}.test
     node_binary="${WORKDIR}/scripts/e2e-coverage-wrapper-env.sh"
+
+    # The runtime library's "different version" detection also freaks out
+    # if build flags changes, and as far as I can tell --covermode doesn't
+    # work.
+    skip_options="--skip plugin-signer/basic"
 fi
 
 ias_mock="true"
@@ -60,7 +66,9 @@ ${test_runner_binary} \
     --e2e/runtime.tee_hardware ${OASIS_TEE_HARDWARE:-""} \
     --e2e/runtime.ias.mock=${ias_mock} \
     --remote-signer.binary ${WORKDIR}/go/oasis-remote-signer/oasis-remote-signer \
+    --plugin-signer.binary ${WORKDIR}/go/oasis-test-runner/scenario/pluginsigner/example_signer_plugin/example_signer_plugin.so \
     --log.level info \
+    ${skip_options} \
     ${BUILDKITE_PARALLEL_JOB_COUNT:+--parallel.job_count ${BUILDKITE_PARALLEL_JOB_COUNT}} \
     ${BUILDKITE_PARALLEL_JOB:+--parallel.job_index ${BUILDKITE_PARALLEL_JOB}} \
     "$@"

--- a/.changelog/3120.feature.1.md
+++ b/.changelog/3120.feature.1.md
@@ -1,0 +1,6 @@
+go/common/crypto/signature: Add a plugin backed signer implementation
+
+Bloating the repository with a ton of different HSM (etc) signing
+backends doesn't make sense, and is a maintenance burden.  Use the
+runtime's built-in DLSO support to be able to separate out the
+non-esssential implementations.

--- a/common.mk
+++ b/common.mk
@@ -101,6 +101,9 @@ GO_BUILD_CMD := env -u GOPATH $(OASIS_GO) build $(GOFLAGS)
 # Path to the MKVS interoperability test helpers binary in go/.
 GO_TEST_HELPER_MKVS_PATH := storage/mkvs/interop/mkvs-test-helpers
 
+# Path to the example signer plugin binary in go/.
+GO_EXAMPLE_PLUGIN_PATH := oasis-test-runner/scenario/pluginsigner/example_signer_plugin
+
 # Helper that ensures $(NEXT_VERSION) variable is not empty.
 define ENSURE_NEXT_VERSION =
 	if [[ -z "$(NEXT_VERSION)" ]]; then \

--- a/go/.gitignore
+++ b/go/.gitignore
@@ -5,6 +5,7 @@ oasis-node/oasis-node
 oasis-node/oasis-node.test
 oasis-test-runner/oasis-test-runner
 oasis-test-runner/oasis-test-runner.test
+oasis-test-runner/scenario/pluginsigner/example_signer_plugin/example_signer_plugin.so
 oasis-net-runner/oasis-net-runner
 oasis-remote-signer/oasis-remote-signer
 storage/mkvs/interop/mkvs-test-helpers

--- a/go/.gitignore
+++ b/go/.gitignore
@@ -9,5 +9,8 @@ oasis-net-runner/oasis-net-runner
 oasis-remote-signer/oasis-remote-signer
 storage/mkvs/interop/mkvs-test-helpers
 
+registry/gen_vectors/gen_vectors
+staking/gen_vectors/gen_vectors
+
 extra/extract-metrics/extract-metrics
 extra/stats/stats

--- a/go/.golangci.yml
+++ b/go/.golangci.yml
@@ -24,3 +24,10 @@ linters:
     - varcheck
     - govet
     - maligned
+
+run:
+  skip-dirs:
+    # golang-ci-lint requires that files compile for certain linters
+    # to run, and Go plugins do not compile unless `-buildmode=plugin`
+    # is set, which linters do not do.
+    - oasis-test-runner/scenario/pluginsigner/example_signer_plugin

--- a/go/Makefile
+++ b/go/Makefile
@@ -17,6 +17,7 @@ generate:
 # Build.
 # List of Go binaries to build.
 go-binaries := oasis-node oasis-test-runner oasis-net-runner oasis-remote-signer extra/stats extra/extract-metrics
+go-plugins := example-signer-plugin
 
 $(go-binaries):
 	@$(ECHO) "$(MAGENTA)*** Building $@...$(OFF)"
@@ -26,7 +27,12 @@ ifeq ($(GO_BUILD_E2E_COVERAGE),1)
 	@$(GO) test $(GOFLAGS) -c -tags e2ecoverage -covermode=atomic -coverpkg=./... -o ./$@/$(notdir $@).test ./$@
 endif
 
-build: $(go-binaries)
+# Example signer plugin.
+example-signer-plugin:
+	@$(ECHO) "$(MAGENTA)*** Building $@...$(OFF)"
+	@$(GO) build $(GOFLAGS) $(GO_EXTRA_FLAGS) -buildmode=plugin -o ./$(GO_EXAMPLE_PLUGIN_PATH) ./$(GO_EXAMPLE_PLUGIN_PATH)
+
+build: $(go-binaries) $(go-plugins)
 
 # Build test helpers.
 # List of test helpers to build.
@@ -134,7 +140,7 @@ clean:
 
 # List of targets that are not actual files.
 .PHONY: \
-	generate $(go-binaries) build \
+	generate $(go-binaries) $(go-plugins) build \
 	$(test-helpers) build-helpers \
 	$(test-vectors-targets) \
 	fmt lint \

--- a/go/common/crypto/signature/signers/plugin/plugin.go
+++ b/go/common/crypto/signature/signers/plugin/plugin.go
@@ -1,0 +1,61 @@
+// Package plugin implements the Go plugin signature signer.
+package plugin
+
+import (
+	"fmt"
+	"plugin"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+)
+
+const (
+	// EntryPoint is the entry point (FactoryCtor) expected to be defined
+	// in each signer plugin.
+	EntryPoint = "GetPluginCtor"
+
+	// SignerName is the name used to identify the plugin signer.
+	SignerName = "plugin"
+)
+
+// FactoryCtor is the function signature of the EntryPoint symbol
+// that is expected to be defined in each plugin.
+type FactoryCtor func() signature.SignerFactoryCtor
+
+// FactoryConfig is the plugin factory configuration.
+type FactoryConfig struct {
+	// Path is the path to the plugin dynamic shared object.
+	Path string
+
+	// Config is the plugin configuration.
+	Config string
+}
+
+// NewFactory creates a new factory backed by the specified plugin
+// and plugin configuration.
+func NewFactory(config interface{}, roles ...signature.SignerRole) (signature.SignerFactory, error) {
+	cfg, ok := config.(*FactoryConfig)
+	if !ok {
+		return nil, fmt.Errorf("signature/signer/plugin: invalid plugin signer configuration provided")
+	}
+
+	p, err := plugin.Open(cfg.Path)
+	if err != nil {
+		return nil, fmt.Errorf("signature/signer/plugin: failed to open plugin: %w", err)
+	}
+
+	ctorPtr, err := p.Lookup(EntryPoint)
+	if err != nil {
+		return nil, fmt.Errorf("signature/signer/plugin: failed to find entry point: %w", err)
+	}
+
+	// Yes, this should use `FactoryCtor` for the type assertion.
+	//
+	// `plugin.Symbol is func() signature.SignerFactoryCtor, not plugin.FactoryCtor`
+	factoryCtor := ctorPtr.(func() signature.SignerFactoryCtor)()
+	factory, err := factoryCtor(cfg.Config, roles...)
+	if err != nil {
+		return nil, fmt.Errorf("signature/signer/plugin: failed to initialize factory: %w", err)
+	}
+
+	return factory, nil
+}

--- a/go/oasis-node/cmd/common/signer/signer_test.go
+++ b/go/oasis-node/cmd/common/signer/signer_test.go
@@ -21,28 +21,25 @@ func TestCompositeCtor(t *testing.T) {
 	require.NoError(err, "TempDir")
 	defer os.RemoveAll(dataDir)
 
-	viper.Set(cfgSignerCompositeBackends, "1:ledger,2:file,4:memory")
+	viper.Set(cfgSignerCompositeBackends, "2:file,4:memory")
 	defer viper.Set(cfgSignerCompositeBackends, "")
 
 	testingAllowMemory = true
 
-	sf, err := doNewComposite(dataDir, signature.SignerEntity, signature.SignerNode, signature.SignerConsensus)
+	sf, err := doNewComposite(dataDir, signature.SignerNode, signature.SignerConsensus)
 	require.NoError(err, "doNewComposite")
 
 	err = sf.EnsureRole(signature.SignerEntity)
-	require.NoError(err, "EnsureRole: ledger")
+	require.Equal(signature.ErrRoleMismatch, err, "EnsureRole: not configured (entity)")
 
 	err = sf.EnsureRole(signature.SignerNode)
 	require.NoError(err, "EnsureRole: file")
 
 	err = sf.EnsureRole(signature.SignerP2P)
-	require.Equal(signature.ErrRoleMismatch, err, "EnsureRole: not configured")
+	require.Equal(signature.ErrRoleMismatch, err, "EnsureRole: not configured (p2p)")
 
 	err = sf.EnsureRole(signature.SignerConsensus)
 	require.NoError(err, "EnsureRole: memory")
-
-	// Can't actually generate with the ledger backend, because most systems
-	// do not have that garbage.
 
 	signer, err := sf.Generate(signature.SignerNode, rand.Reader)
 	require.NoError(err, "Generate: file")

--- a/go/oasis-test-runner/cmd/common/common.go
+++ b/go/oasis-test-runner/cmd/common/common.go
@@ -14,6 +14,7 @@ const (
 	CfgLogLevel           = "log.level"
 	CfgScenarioRegex      = "scenario"
 	CfgScenarioRegexShort = "s"
+	CfgScenarioSkipRegex  = "skip"
 
 	// ScenarioParamsMask is the form of parameters passed to specific scenario.
 	//

--- a/go/oasis-test-runner/scenario/pluginsigner/basic.go
+++ b/go/oasis-test-runner/scenario/pluginsigner/basic.go
@@ -1,0 +1,61 @@
+package pluginsigner
+
+import (
+	"crypto/rand"
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	pluginSigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/plugin"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
+	signerTests "github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario/signer"
+)
+
+// Basic is the basic test case.
+var Basic scenario.Scenario = newBasicImpl()
+
+func newBasicImpl() *basicImpl {
+	return &basicImpl{
+		pluginSignerImpl: *newPluginSignerImpl("basic"),
+	}
+}
+
+type basicImpl struct {
+	pluginSignerImpl
+}
+
+func (sc *basicImpl) Clone() scenario.Scenario {
+	return &basicImpl{
+		pluginSignerImpl: sc.pluginSignerImpl.Clone(),
+	}
+}
+
+func (sc *basicImpl) Run(childEnv *env.Env) error {
+	// Initialize the plugin signer.
+	pluginBinary, _ := sc.flags.GetString(cfgPluginBinary)
+	pluginConfig, _ := sc.flags.GetString(cfgPluginConfig)
+	sf, err := pluginSigner.NewFactory(
+		&pluginSigner.FactoryConfig{
+			Path:   pluginBinary,
+			Config: pluginConfig,
+		},
+		signature.SignerRoles...,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Generate keys using the new factory.
+	for _, v := range signature.SignerRoles {
+		if _, err = sf.Generate(v, rand.Reader); err != nil {
+			return fmt.Errorf("Generate(%v) failed: %w", v, err)
+		}
+	}
+
+	// Run basic common signer tests.
+	if err = signerTests.BasicTests(sf, sc.logger); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/go/oasis-test-runner/scenario/pluginsigner/example_signer_plugin/main.go
+++ b/go/oasis-test-runner/scenario/pluginsigner/example_signer_plugin/main.go
@@ -1,0 +1,58 @@
+// Package main implements an example oasis-node signer plugin, leveraging
+// the Go runtime library's DSO plugin support.
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
+)
+
+// GetPluginCtor is the plugin's entry point.
+func GetPluginCtor() signature.SignerFactoryCtor {
+	return newPluginFactory
+}
+
+func newPluginFactory(config interface{}, roles ...signature.SignerRole) (signature.SignerFactory, error) {
+	return &exampleFactory{
+		roles: roles,
+		inner: make(map[signature.SignerRole]signature.Signer),
+	}, nil
+}
+
+type exampleFactory struct {
+	roles []signature.SignerRole
+	inner map[signature.SignerRole]signature.Signer
+}
+
+func (fac *exampleFactory) EnsureRole(role signature.SignerRole) error {
+	for _, v := range fac.roles {
+		if v == role {
+			return nil
+		}
+	}
+	return signature.ErrRoleMismatch
+}
+
+func (fac *exampleFactory) Generate(role signature.SignerRole, rng io.Reader) (signature.Signer, error) {
+	if fac.inner[role] != nil {
+		return nil, fmt.Errorf("example: key already exists")
+	}
+
+	signer, err := memorySigner.NewSigner(rng)
+	if err != nil {
+		return nil, fmt.Errorf("example: failed to generate key: %w", err)
+	}
+
+	fac.inner[role] = signer
+	return signer, nil
+}
+
+func (fac *exampleFactory) Load(role signature.SignerRole) (signature.Signer, error) {
+	if signer := fac.inner[role]; signer != nil {
+		return signer, nil
+	}
+	return nil, signature.ErrNotExist
+}

--- a/go/oasis-test-runner/scenario/pluginsigner/pluginsigner.go
+++ b/go/oasis-test-runner/scenario/pluginsigner/pluginsigner.go
@@ -1,5 +1,5 @@
-// Package remotesigner implements the Oasis remote-signer test scenarios.
-package remotesigner
+// Package pluginsigner implements the Oasis plugin-signer test scenario.
+package pluginsigner
 
 import (
 	flag "github.com/spf13/pflag"
@@ -12,73 +12,72 @@ import (
 )
 
 const (
-	// cfgServerBinary is path to remote-signer server executable.
-	cfgServerBinary = "binary"
+	cfgPluginBinary = "binary"
+	cfgPluginConfig = "config"
 )
 
-// RemoteSignerParamsDummy is a dummy instance of remoteSignerImpl used to register global
-// remote-signer flags.
-var RemoteSignerParamsDummy *remoteSignerImpl = newRemoteSignerImpl("")
+var pluginSignerParamsDummy *pluginSignerImpl = newPluginSignerImpl("")
 
-type remoteSignerImpl struct {
+type pluginSignerImpl struct {
 	name   string
 	logger *logging.Logger
 	flags  *env.ParameterFlagSet
 }
 
-func newRemoteSignerImpl(name string) *remoteSignerImpl {
+func newPluginSignerImpl(name string) *pluginSignerImpl {
 	// Empty scenario name is used for registering global parameters only.
-	fullName := "remote-signer"
+	fullName := "plugin-signer"
 	if name != "" {
 		fullName += "/" + name
 	}
 
-	sc := &remoteSignerImpl{
+	sc := &pluginSignerImpl{
 		name:   fullName,
 		logger: logging.GetLogger("scenario/" + fullName),
 		flags:  env.NewParameterFlagSet(fullName, flag.ContinueOnError),
 	}
-	sc.flags.String(cfgServerBinary, "oasis-remote-signer", "remote signer binary")
+	sc.flags.String(cfgPluginBinary, "signer-plugin.so", "plugin binary")
+	sc.flags.String(cfgPluginConfig, "", "plugin configuration")
 
 	return sc
 }
 
-func (sc *remoteSignerImpl) Clone() remoteSignerImpl {
-	return remoteSignerImpl{
+func (sc *pluginSignerImpl) Clone() pluginSignerImpl {
+	return pluginSignerImpl{
 		name:   sc.name,
 		logger: sc.logger,
 		flags:  sc.flags.Clone(),
 	}
 }
 
-func (sc *remoteSignerImpl) Name() string {
+func (sc *pluginSignerImpl) Name() string {
 	return sc.name
 }
 
-func (sc *remoteSignerImpl) Parameters() *env.ParameterFlagSet {
+func (sc *pluginSignerImpl) Parameters() *env.ParameterFlagSet {
 	return sc.flags
 }
 
-func (sc *remoteSignerImpl) PreInit(childEnv *env.Env) error {
+func (sc *pluginSignerImpl) PreInit(childEnv *env.Env) error {
 	return nil
 }
 
-func (sc *remoteSignerImpl) Fixture() (*oasis.NetworkFixture, error) {
+func (sc *pluginSignerImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return nil, nil
 }
 
-func (sc *remoteSignerImpl) Init(childEnv *env.Env, net *oasis.Network) error {
+func (sc *pluginSignerImpl) Init(childEnv *env.Env, net *oasis.Network) error {
 	return nil
 }
 
 // RegisterScenarios registers all scenarios for remote-signer.
 func RegisterScenarios() error {
 	// Register non-scenario-specific parameters.
-	cmd.RegisterScenarioParams(RemoteSignerParamsDummy.Name(), RemoteSignerParamsDummy.Parameters())
+	cmd.RegisterScenarioParams(pluginSignerParamsDummy.Name(), pluginSignerParamsDummy.Parameters())
 
 	// Register default scenarios which are executed, if no test names provided.
 	for _, s := range []scenario.Scenario{
-		// Basic remote signer test case.
+		// Basic plugin signer test case.
 		Basic,
 	} {
 		if err := cmd.Register(s); err != nil {

--- a/go/oasis-test-runner/scenario/signer/signer.go
+++ b/go/oasis-test-runner/scenario/signer/signer.go
@@ -1,0 +1,61 @@
+// Package signer implements the common signer test cases.
+package signer
+
+import (
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+)
+
+// BasicTests ensures basic signer factory sanity.
+//
+// Note: The factory must be configured to service signature.SignerRoles.
+func BasicTests(factory signature.SignerFactory, logger *logging.Logger) error {
+	// EnsureRole()
+	logger.Info("testing EnsureRole")
+	for _, v := range signature.SignerRoles {
+		if err := factory.EnsureRole(v); err != nil {
+			return fmt.Errorf("failed to EnsureRole(%v): %w", v, err)
+		}
+	}
+
+	msg := []byte("You have my thanks, hacker. Let me show you the destruction you have brought upon the planet Earth.")
+
+	// Test each sub-key.
+	pkMap := make(map[signature.PublicKey]bool)
+	for _, v := range signature.SignerRoles {
+		// Load()
+		si, err := factory.Load(v)
+		if err != nil {
+			return fmt.Errorf("failed to Load(%v): %w", v, err)
+		}
+
+		pk := si.Public()
+		logger.Info("signer sub-key loaded",
+			"public_key", pk,
+			"descr", si.String(),
+		)
+
+		// ContextSign()
+		ctx := signature.NewContext(fmt.Sprintf("plugin test context: %v", v))
+		sig, err := si.ContextSign(ctx, msg)
+		if err != nil {
+			return fmt.Errorf("failed to Sign(%v): %w", v, err)
+		}
+
+		// Verify that the signature is sensible.
+		if !pk.Verify(ctx, msg, sig) {
+			return fmt.Errorf("failed to verify signature: %v", v)
+		}
+
+		pkMap[pk] = true
+	}
+
+	// Ensure that the signer uses unique sub-keys.
+	if len(pkMap) != len(signature.SignerRoles) {
+		return fmt.Errorf("signer not using unique public keys: %v distinct found", len(pkMap))
+	}
+
+	return nil
+}

--- a/go/oasis-test-runner/test-runner.go
+++ b/go/oasis-test-runner/test-runner.go
@@ -6,6 +6,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/cmd"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario/e2e"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario/e2e/runtime"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario/pluginsigner"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario/remotesigner"
 )
 
@@ -22,6 +23,7 @@ func main() {
 	for _, register := range []func() error{
 		e2e.RegisterScenarios,
 		runtime.RegisterScenarios,
+		pluginsigner.RegisterScenarios,
 		remotesigner.RegisterScenarios,
 	} {
 		if err := register(); err != nil {


### PR DESCRIPTION
Bloating the repository with a ton of different HSM (etc) signing backends doesn't make sense, and is a maintenance burden.  Use the runtime's built-in DLSO support to be able to separate out the non-esssential implementations.

 * [x] Add the plugin signer implementation
 * [x] Change oasis-node to instantiate the plugin signer.
 * [x] Add tests for the plugin signer.

After merge:
 * Move the ledger implementation off into a separate repository (https://github.com/oasisprotocol/oasis-core-ledger/issues/13)
 * Remove the integrated ledger signer implementation.
 * Remove the ledger oasis-node sub command.

Notes:
 * The plugin loader enforces (rather strictly) that the package versions of plugins are the same as what the loading application was built with.  This will require everything be built with `-trimpath`, but we should be doing that already anyway.  See https://github.com/golang/go/issues/27751 for more information.
 * This is undocumented because anyone that can't figure it out, has zero business writing anything that is even vaguely security critical.  That said there's tests and an example now.
 * golang-ci-lint got mad when linting the plugin because it doesn't have `main` defined, so it is skipped for now.
