### PR TITLE
go: Use `cbor.Versioned` for descriptor versioning

### DIFF
--- a/.changelog/3119.internal.md
+++ b/.changelog/3119.internal.md
@@ -1,0 +1,1 @@
+go: Use `cbor.Versioned` for descriptor versioning

--- a/go/common/cbor/versioned.go
+++ b/go/common/cbor/versioned.go
@@ -39,6 +39,14 @@ func GetVersion(data []byte) (uint16, error) {
 	return vblob.V, nil
 }
 
+// NewVersioned creates a new Versioned structure with the specified version.
+func NewVersioned(v uint16) Versioned {
+	if v == invalidVersion {
+		panic("cbor: invalid version specified")
+	}
+	return Versioned{V: v}
+}
+
 func init() {
 	// Use the untrusted decode options, but ignore unknown fields.
 	// FIXME: https://github.com/fxamacker/cbor/issues/240

--- a/go/common/cbor/versioned_test.go
+++ b/go/common/cbor/versioned_test.go
@@ -26,9 +26,7 @@ func TestVersioned(t *testing.T) {
 
 	const testVersion uint16 = 451
 	raw = Marshal(&b{
-		Versioned: Versioned{
-			V: testVersion,
-		},
+		Versioned: NewVersioned(testVersion),
 		a: a{
 			A: "Empty are still many sites for lone ones and twain ones",
 		},

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -46,10 +46,7 @@ const (
 
 // Node represents public connectivity information about an Oasis node.
 type Node struct { // nolint: maligned
-	// DescriptorVersion is the node descriptor version.
-	//
-	// It should be bumped whenever breaking changes are made to the descriptor.
-	DescriptorVersion uint16 `json:"v,omitempty"`
+	cbor.Versioned
 
 	// ID is the public key identifying the node.
 	ID signature.PublicKey `json:"id"`
@@ -131,18 +128,19 @@ func (m RolesMask) String() string {
 
 // ValidateBasic performs basic descriptor validity checks.
 func (n *Node) ValidateBasic(strictVersion bool) error {
+	v := n.Versioned.V
 	switch strictVersion {
 	case true:
 		// Only the latest version is allowed.
-		if n.DescriptorVersion != LatestNodeDescriptorVersion {
+		if v != LatestNodeDescriptorVersion {
 			return fmt.Errorf("invalid node descriptor version (expected: %d got: %d)",
 				LatestNodeDescriptorVersion,
-				n.DescriptorVersion,
+				v,
 			)
 		}
 	case false:
 		// A range of versions is allowed.
-		if n.DescriptorVersion < minNodeDescriptorVersion || n.DescriptorVersion > maxNodeDescriptorVersion {
+		if v < minNodeDescriptorVersion || v > maxNodeDescriptorVersion {
 			return fmt.Errorf("invalid node descriptor version (min: %d max: %d)",
 				minNodeDescriptorVersion,
 				maxNodeDescriptorVersion,

--- a/go/consensus/tendermint/apps/registry/state/state_test.go
+++ b/go/consensus/tendermint/apps/registry/state/state_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
@@ -42,8 +43,8 @@ func TestNodeUpdate(t *testing.T) {
 
 	// Create a new node.
 	n := node.Node{
-		DescriptorVersion: node.LatestNodeDescriptorVersion,
-		ID:                nodeSigner.Public(),
+		Versioned: cbor.NewVersioned(node.LatestNodeDescriptorVersion),
+		ID:        nodeSigner.Public(),
 		P2P: node.P2PInfo{
 			ID: p2pSigner1.Public(),
 		},

--- a/go/consensus/tendermint/apps/registry/transactions_test.go
+++ b/go/consensus/tendermint/apps/registry/transactions_test.go
@@ -7,6 +7,7 @@ import (
 	requirePkg "github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
 	"github.com/oasisprotocol/oasis-core/go/common/entity"
@@ -121,9 +122,9 @@ func TestRegisterNode(t *testing.T) {
 				// Create a new runtime.
 				rtSigner := memorySigner.NewTestSigner("consensus/tendermint/apps/registry: runtime signer: ComputeNode")
 				rt := registry.Runtime{
-					DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
-					ID:                common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNode"), 0),
-					Kind:              registry.KindCompute,
+					Versioned: cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+					ID:        common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNode"), 0),
+					Kind:      registry.KindCompute,
 				}
 				sigRt, _ := registry.SignRuntime(rtSigner, registry.RegisterRuntimeSignatureContext, &rt)
 				_ = state.SetRuntime(ctx, &rt, sigRt, false)
@@ -144,9 +145,9 @@ func TestRegisterNode(t *testing.T) {
 				// Create a new runtime.
 				rtSigner := memorySigner.NewTestSigner("consensus/tendermint/apps/registry: runtime signer: ComputeNodeWithoutPerRuntimeStake")
 				rt := registry.Runtime{
-					DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
-					ID:                common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNodeWithoutPerRuntimeStake"), 0),
-					Kind:              registry.KindCompute,
+					Versioned: cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+					ID:        common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNodeWithoutPerRuntimeStake"), 0),
+					Kind:      registry.KindCompute,
 					Staking: registry.RuntimeStakingParameters{
 						Thresholds: map[staking.ThresholdKind]quantity.Quantity{
 							staking.KindNodeCompute: *quantity.NewFromUint64(1000),
@@ -172,9 +173,9 @@ func TestRegisterNode(t *testing.T) {
 				// Create a new runtime.
 				rtSigner := memorySigner.NewTestSigner("consensus/tendermint/apps/registry: runtime signer: ComputeNodeWithPerRuntimeStake")
 				rt := registry.Runtime{
-					DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
-					ID:                common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNodeWithPerRuntimeStake"), 0),
-					Kind:              registry.KindCompute,
+					Versioned: cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+					ID:        common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNodeWithPerRuntimeStake"), 0),
+					Kind:      registry.KindCompute,
 					Staking: registry.RuntimeStakingParameters{
 						Thresholds: map[staking.ThresholdKind]quantity.Quantity{
 							staking.KindNodeCompute: *quantity.NewFromUint64(1000),
@@ -210,9 +211,9 @@ func TestRegisterNode(t *testing.T) {
 
 				// Create a new runtime.
 				rt1 := registry.Runtime{
-					DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
-					ID:                common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNodeWithoutPerRuntimeStakeMulti 1"), 0),
-					Kind:              registry.KindCompute,
+					Versioned: cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+					ID:        common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNodeWithoutPerRuntimeStakeMulti 1"), 0),
+					Kind:      registry.KindCompute,
 					Staking: registry.RuntimeStakingParameters{
 						Thresholds: map[staking.ThresholdKind]quantity.Quantity{
 							staking.KindNodeCompute: *quantity.NewFromUint64(1000),
@@ -255,9 +256,9 @@ func TestRegisterNode(t *testing.T) {
 
 				// Create a new runtime.
 				rt1 := registry.Runtime{
-					DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
-					ID:                common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNodeWithoutGlobalStakeMulti 1"), 0),
-					Kind:              registry.KindCompute,
+					Versioned: cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+					ID:        common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNodeWithoutGlobalStakeMulti 1"), 0),
+					Kind:      registry.KindCompute,
 				}
 				sigRt1, _ := registry.SignRuntime(rtSigner, registry.RegisterRuntimeSignatureContext, &rt1)
 				_ = state.SetRuntime(ctx, &rt1, sigRt1, false)
@@ -368,9 +369,9 @@ func TestRegisterNode(t *testing.T) {
 
 			// Prepare a test entity that owns the nodes.
 			ent := entity.Entity{
-				DescriptorVersion: entity.LatestEntityDescriptorVersion,
-				ID:                tcd.entitySigner.Public(),
-				Nodes:             []signature.PublicKey{tcd.nodeSigner.Public()},
+				Versioned: cbor.NewVersioned(entity.LatestEntityDescriptorVersion),
+				ID:        tcd.entitySigner.Public(),
+				Nodes:     []signature.PublicKey{tcd.nodeSigner.Public()},
 			}
 			sigEnt, err := entity.SignEntity(tcd.entitySigner, registry.RegisterEntitySignatureContext, &ent)
 			require.NoError(err, "SignEntity")
@@ -383,10 +384,10 @@ func TestRegisterNode(t *testing.T) {
 			require.NoError(err, "address.UnmarshalText")
 
 			tcd.node = node.Node{
-				DescriptorVersion: node.LatestNodeDescriptorVersion,
-				ID:                tcd.nodeSigner.Public(),
-				EntityID:          ent.ID,
-				Expiration:        3,
+				Versioned:  cbor.NewVersioned(node.LatestNodeDescriptorVersion),
+				ID:         tcd.nodeSigner.Public(),
+				EntityID:   ent.ID,
+				Expiration: 3,
 				P2P: node.P2PInfo{
 					ID:        tcd.p2pSigner.Public(),
 					Addresses: []node.Address{address},

--- a/go/consensus/tendermint/apps/staking/slashing_test.go
+++ b/go/consensus/tendermint/apps/staking/slashing_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
 	"github.com/oasisprotocol/oasis-core/go/common/entity"
@@ -50,9 +51,9 @@ func TestOnEvidenceDoubleSign(t *testing.T) {
 	// Add node.
 	nodeSigner := memorySigner.NewTestSigner("node test signer")
 	nod := &node.Node{
-		DescriptorVersion: node.LatestNodeDescriptorVersion,
-		ID:                nodeSigner.Public(),
-		EntityID:          ent.ID,
+		Versioned: cbor.NewVersioned(node.LatestNodeDescriptorVersion),
+		ID:        nodeSigner.Public(),
+		EntityID:  ent.ID,
 		Consensus: node.ConsensusInfo{
 			ID: consensusID,
 		},

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
@@ -160,7 +161,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 	// Note that this test entity has no nodes by design, those will be added
 	// later by various tests.
 	testEntity := &entity.Entity{
-		DescriptorVersion:      entity.LatestEntityDescriptorVersion,
+		Versioned:              cbor.NewVersioned(entity.LatestEntityDescriptorVersion),
 		ID:                     validPK,
 		AllowEntitySignedNodes: true,
 	}
@@ -168,10 +169,10 @@ func TestGenesisSanityCheck(t *testing.T) {
 
 	kmRuntimeID := hex2ns("4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff", false)
 	testKMRuntime := &registry.Runtime{
-		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
-		ID:                kmRuntimeID,
-		EntityID:          testEntity.ID,
-		Kind:              registry.KindKeyManager,
+		Versioned: cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+		ID:        kmRuntimeID,
+		EntityID:  testEntity.ID,
+		Kind:      registry.KindKeyManager,
 		AdmissionPolicy: registry.RuntimeAdmissionPolicy{
 			EntityWhitelist: &registry.EntityWhitelistRuntimeAdmissionPolicy{
 				Entities: map[signature.PublicKey]bool{
@@ -184,11 +185,11 @@ func TestGenesisSanityCheck(t *testing.T) {
 
 	testRuntimeID := hex2ns("0000000000000000000000000000000000000000000000000000000000000001", false)
 	testRuntime := &registry.Runtime{
-		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
-		ID:                testRuntimeID,
-		EntityID:          testEntity.ID,
-		Kind:              registry.KindCompute,
-		KeyManager:        &testKMRuntime.ID,
+		Versioned:  cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+		ID:         testRuntimeID,
+		EntityID:   testEntity.ID,
+		Kind:       registry.KindCompute,
+		KeyManager: &testKMRuntime.ID,
 		Executor: registry.ExecutorParameters{
 			GroupSize:    1,
 			RoundTimeout: 1 * time.Second,
@@ -223,11 +224,11 @@ func TestGenesisSanityCheck(t *testing.T) {
 	var testAddress node.Address
 	_ = testAddress.UnmarshalText([]byte("127.0.0.1:1234"))
 	testNode := &node.Node{
-		DescriptorVersion: node.LatestNodeDescriptorVersion,
-		ID:                nodeSigner.Public(),
-		EntityID:          testEntity.ID,
-		Expiration:        10,
-		Roles:             node.RoleValidator,
+		Versioned:  cbor.NewVersioned(node.LatestNodeDescriptorVersion),
+		ID:         nodeSigner.Public(),
+		EntityID:   testEntity.ID,
+		Expiration: 10,
+		Roles:      node.RoleValidator,
 		TLS: node.TLSInfo{
 			PubKey: nodeTLSSigner.Public(),
 			Addresses: []node.TLSAddress{

--- a/go/oasis-node/cmd/debug/byzantine/registry.go
+++ b/go/oasis-node/cmd/debug/byzantine/registry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
@@ -42,10 +43,10 @@ func registryRegisterNode(svc service.TendermintService, id *identity.Identity, 
 	}
 
 	nodeDesc := &node.Node{
-		DescriptorVersion: node.LatestNodeDescriptorVersion,
-		ID:                id.NodeSigner.Public(),
-		EntityID:          entityID,
-		Expiration:        1000,
+		Versioned:  cbor.NewVersioned(node.LatestNodeDescriptorVersion),
+		ID:         id.NodeSigner.Public(),
+		EntityID:   entityID,
+		Expiration: 1000,
 		TLS: node.TLSInfo{
 			PubKey:    id.GetTLSSigner().Public(),
 			Addresses: tlsAddresses,

--- a/go/oasis-node/cmd/debug/txsource/workload/registration.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/registration.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
 	"github.com/oasisprotocol/oasis-core/go/common/entity"
@@ -43,10 +44,10 @@ type registration struct {
 
 func getRuntime(entityID signature.PublicKey, id common.Namespace) *registry.Runtime {
 	rt := &registry.Runtime{
-		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
-		ID:                id,
-		EntityID:          entityID,
-		Kind:              registry.KindCompute,
+		Versioned: cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+		ID:        id,
+		EntityID:  entityID,
+		Kind:      registry.KindCompute,
 		Executor: registry.ExecutorParameters{
 			GroupSize:    1,
 			RoundTimeout: 1 * time.Second,
@@ -97,11 +98,11 @@ func getNodeDesc(rng *rand.Rand, nodeIdentity *identity.Identity, entityID signa
 	}
 
 	nodeDesc := node.Node{
-		DescriptorVersion: node.LatestNodeDescriptorVersion,
-		ID:                nodeIdentity.NodeSigner.Public(),
-		EntityID:          entityID,
-		Expiration:        0,
-		Roles:             availableRoles[rng.Intn(len(availableRoles))],
+		Versioned:  cbor.NewVersioned(node.LatestNodeDescriptorVersion),
+		ID:         nodeIdentity.NodeSigner.Public(),
+		EntityID:   entityID,
+		Expiration: 0,
+		Roles:      availableRoles[rng.Intn(len(availableRoles))],
 		TLS: node.TLSInfo{
 			PubKey: nodeIdentity.GetTLSSigner().Public(),
 			Addresses: []node.TLSAddress{
@@ -211,8 +212,8 @@ func (r *registration) Run( // nolint: gocyclo
 		}
 
 		ent := &entity.Entity{
-			DescriptorVersion: entity.LatestEntityDescriptorVersion,
-			ID:                entityAccs[i].signer.Public(),
+			Versioned: cbor.NewVersioned(entity.LatestEntityDescriptorVersion),
+			ID:        entityAccs[i].signer.Public(),
 		}
 
 		// Generate entity node identities.

--- a/go/oasis-node/cmd/registry/entity/entity.go
+++ b/go/oasis-node/cmd/registry/entity/entity.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/entity"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
@@ -375,7 +376,7 @@ func loadOrGenerateEntity(dataDir string, generate bool) (*entity.Entity, signat
 
 	if generate {
 		template := &entity.Entity{
-			DescriptorVersion:      entity.LatestEntityDescriptorVersion,
+			Versioned:              cbor.NewVersioned(entity.LatestEntityDescriptorVersion),
 			AllowEntitySignedNodes: viper.GetBool(cfgAllowEntitySignedNodes),
 		}
 

--- a/go/oasis-node/cmd/registry/node/node.go
+++ b/go/oasis-node/cmd/registry/node/node.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	fileSigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/file"
 	"github.com/oasisprotocol/oasis-core/go/common/entity"
@@ -182,10 +183,10 @@ func doInit(cmd *cobra.Command, args []string) { // nolint: gocyclo
 	}
 
 	n := &node.Node{
-		DescriptorVersion: node.LatestNodeDescriptorVersion,
-		ID:                nodeIdentity.NodeSigner.Public(),
-		EntityID:          entityID,
-		Expiration:        viper.GetUint64(CfgExpiration),
+		Versioned:  cbor.NewVersioned(node.LatestNodeDescriptorVersion),
+		ID:         nodeIdentity.NodeSigner.Public(),
+		EntityID:   entityID,
+		Expiration: viper.GetUint64(CfgExpiration),
 		TLS: node.TLSInfo{
 			PubKey:     nodeIdentity.GetTLSSigner().Public(),
 			NextPubKey: nextPubKey,

--- a/go/oasis-node/cmd/registry/runtime/runtime.go
+++ b/go/oasis-node/cmd/registry/runtime/runtime.go
@@ -367,12 +367,12 @@ func runtimeFromFlags() (*registry.Runtime, signature.Signer, error) { // nolint
 	}
 
 	rt := &registry.Runtime{
-		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
-		ID:                id,
-		EntityID:          signer.Public(),
-		Genesis:           gen,
-		Kind:              kind,
-		TEEHardware:       teeHardware,
+		Versioned:   cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+		ID:          id,
+		EntityID:    signer.Public(),
+		Genesis:     gen,
+		Kind:        kind,
+		TEEHardware: teeHardware,
 		Version: registry.VersionInfo{
 			Version: version.FromU64(viper.GetUint64(CfgVersion)),
 		},

--- a/go/oasis-node/node_test.go
+++ b/go/oasis-node/node_test.go
@@ -15,6 +15,7 @@ import (
 
 	beaconTests "github.com/oasisprotocol/oasis-core/go/beacon/tests"
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	fileSigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/file"
 	"github.com/oasisprotocol/oasis-core/go/common/entity"
@@ -79,7 +80,7 @@ var (
 	}
 
 	testRuntime = &registry.Runtime{
-		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
+		Versioned: cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
 		// ID: default value,
 		// EntityID: test entity,
 		Kind: registry.KindCompute,

--- a/go/oasis-test-runner/oasis/runtime.go
+++ b/go/oasis-test-runner/oasis/runtime.go
@@ -115,17 +115,17 @@ func (rt *Runtime) GetGenesisStatePath() string {
 // NewRuntime provisions a new runtime and adds it to the network.
 func (net *Network) NewRuntime(cfg *RuntimeCfg) (*Runtime, error) {
 	descriptor := registry.Runtime{
-		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
-		ID:                cfg.ID,
-		EntityID:          cfg.Entity.entity.ID,
-		Kind:              cfg.Kind,
-		TEEHardware:       cfg.TEEHardware,
-		Executor:          cfg.Executor,
-		Merge:             cfg.Merge,
-		TxnScheduler:      cfg.TxnScheduler,
-		Storage:           cfg.Storage,
-		AdmissionPolicy:   cfg.AdmissionPolicy,
-		Staking:           cfg.Staking,
+		Versioned:       cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+		ID:              cfg.ID,
+		EntityID:        cfg.Entity.entity.ID,
+		Kind:            cfg.Kind,
+		TEEHardware:     cfg.TEEHardware,
+		Executor:        cfg.Executor,
+		Merge:           cfg.Merge,
+		TxnScheduler:    cfg.TxnScheduler,
+		Storage:         cfg.Storage,
+		AdmissionPolicy: cfg.AdmissionPolicy,
+		Staking:         cfg.Staking,
 	}
 
 	rtDir, err := net.baseDir.NewSubDir("runtime-" + cfg.ID.String())

--- a/go/oasis-test-runner/scenario/e2e/registry_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/registry_cli.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	fileSigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/file"
 	"github.com/oasisprotocol/oasis-core/go/common/entity"
@@ -403,10 +404,10 @@ func (sc *registryCLIImpl) newTestNode(entityID signature.PublicKey) (*node.Node
 	}
 
 	testNode := node.Node{
-		DescriptorVersion: node.LatestNodeDescriptorVersion,
-		ID:                signature.PublicKey{}, // ID is generated afterwards.
-		EntityID:          entityID,
-		Expiration:        42,
+		Versioned:  cbor.NewVersioned(node.LatestNodeDescriptorVersion),
+		ID:         signature.PublicKey{}, // ID is generated afterwards.
+		EntityID:   entityID,
+		Expiration: 42,
 		TLS: node.TLSInfo{
 			PubKey:    signature.PublicKey{}, // Public key is generated afterwards.
 			Addresses: testTLSAddresses,
@@ -609,9 +610,9 @@ func (sc *registryCLIImpl) testRuntime(ctx context.Context, childEnv *env.Env, c
 	var q quantity.Quantity
 	_ = q.FromUint64(100)
 	testRuntime := registry.Runtime{
-		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
-		EntityID:          testEntity.ID,
-		Kind:              registry.KindCompute,
+		Versioned: cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+		EntityID:  testEntity.ID,
+		Kind:      registry.KindCompute,
 		Executor: registry.ExecutorParameters{
 			GroupSize:         1,
 			GroupBackupSize:   2,

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -220,10 +220,7 @@ const (
 
 // Runtime represents a runtime.
 type Runtime struct { // nolint: maligned
-	// DescriptorVersion is the runtime descriptor version.
-	//
-	// It should be bumped whenever breaking changes are made to the descriptor.
-	DescriptorVersion uint16 `json:"v,omitempty"`
+	cbor.Versioned
 
 	// ID is a globally unique long term identifier of the runtime.
 	ID common.Namespace `json:"id"`
@@ -269,18 +266,19 @@ type Runtime struct { // nolint: maligned
 
 // ValidateBasic performs basic descriptor validity checks.
 func (r *Runtime) ValidateBasic(strictVersion bool) error {
+	v := r.Versioned.V
 	switch strictVersion {
 	case true:
 		// Only the latest version is allowed.
-		if r.DescriptorVersion != LatestRuntimeDescriptorVersion {
+		if v != LatestRuntimeDescriptorVersion {
 			return fmt.Errorf("invalid runtime descriptor version (expected: %d got: %d)",
 				LatestRuntimeDescriptorVersion,
-				r.DescriptorVersion,
+				v,
 			)
 		}
 	case false:
 		// A range of versions is allowed.
-		if r.DescriptorVersion < minRuntimeDescriptorVersion || r.DescriptorVersion > maxRuntimeDescriptorVersion {
+		if v < minRuntimeDescriptorVersion || v > maxRuntimeDescriptorVersion {
 			return fmt.Errorf("invalid runtime descriptor version (min: %d max: %d)",
 				minRuntimeDescriptorVersion,
 				maxRuntimeDescriptorVersion,

--- a/go/registry/gen_vectors/main.go
+++ b/go/registry/gen_vectors/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
@@ -37,8 +38,8 @@ func main() {
 			entitySigner := memorySigner.NewTestSigner("oasis-core registry test vectors: RegisterEntity signer")
 			for _, numNodes := range []int{0, 1, 2, 5} {
 				ent := entity.Entity{
-					DescriptorVersion: entity.LatestEntityDescriptorVersion,
-					ID:                entitySigner.Public(),
+					Versioned: cbor.NewVersioned(entity.LatestEntityDescriptorVersion),
+					ID:        entitySigner.Public(),
 				}
 				for i := 0; i < numNodes; i++ {
 					nodeSigner := memorySigner.NewTestSigner(fmt.Sprintf("oasis core registry test vectors: node signer %d", i))

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/drbg"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
@@ -855,12 +856,12 @@ func (ent *TestEntity) NewTestNodes(nCompute, nStorage int, idNonce []byte, runt
 		}
 
 		nod.Node = &node.Node{
-			DescriptorVersion: node.LatestNodeDescriptorVersion,
-			ID:                nod.Signer.Public(),
-			EntityID:          ent.Entity.ID,
-			Expiration:        uint64(expiration),
-			Runtimes:          runtimes,
-			Roles:             role,
+			Versioned:  cbor.NewVersioned(node.LatestNodeDescriptorVersion),
+			ID:         nod.Signer.Public(),
+			EntityID:   ent.Entity.ID,
+			Expiration: uint64(expiration),
+			Runtimes:   runtimes,
+			Roles:      role,
 		}
 		addr := node.Address{
 			TCPAddr: net.TCPAddr{
@@ -1139,12 +1140,12 @@ func (ent *TestEntity) NewTestNodes(nCompute, nStorage int, idNonce []byte, runt
 			panic("should find one additional compute runtime")
 		}
 		nod.UpdatedNode = &node.Node{
-			DescriptorVersion: node.LatestNodeDescriptorVersion,
-			ID:                nod.Signer.Public(),
-			EntityID:          ent.Entity.ID,
-			Expiration:        uint64(expiration),
-			Runtimes:          moreRuntimes,
-			Roles:             role,
+			Versioned:  cbor.NewVersioned(node.LatestNodeDescriptorVersion),
+			ID:         nod.Signer.Public(),
+			EntityID:   ent.Entity.ID,
+			Expiration: uint64(expiration),
+			Runtimes:   moreRuntimes,
+			Roles:      role,
 		}
 		addr = node.Address{
 			TCPAddr: net.TCPAddr{
@@ -1171,14 +1172,14 @@ func (ent *TestEntity) NewTestNodes(nCompute, nStorage int, idNonce []byte, runt
 			{ID: publicKeyToNamespace(testRuntimeSigner.Public(), false)},
 		}
 		newNode := &node.Node{
-			DescriptorVersion: node.LatestNodeDescriptorVersion,
-			ID:                nod.Signer.Public(),
-			EntityID:          ent.Entity.ID,
-			Expiration:        uint64(expiration),
-			Runtimes:          newRuntimes,
-			Roles:             role,
-			P2P:               nod.Node.P2P,
-			TLS:               nod.Node.TLS,
+			Versioned:  cbor.NewVersioned(node.LatestNodeDescriptorVersion),
+			ID:         nod.Signer.Public(),
+			EntityID:   ent.Entity.ID,
+			Expiration: uint64(expiration),
+			Runtimes:   newRuntimes,
+			Roles:      role,
+			P2P:        nod.Node.P2P,
+			TLS:        nod.Node.TLS,
 		}
 		newNode.P2P.ID = invalidIdentity.P2PSigner.Public()
 		newNode.Consensus.ID = invalidIdentity.ConsensusSigner.Public()
@@ -1204,7 +1205,7 @@ func (ent *TestEntity) NewTestNodes(nCompute, nStorage int, idNonce []byte, runt
 			descr: "Registering with an old descriptor should fail",
 		}
 		invNode15 := *nod.Node
-		invNode15.DescriptorVersion = 0
+		invNode15.Versioned.V = 0
 		invalid15.signed, err = node.MultiSignNode(
 			[]signature.Signer{
 				nodeIdentity.NodeSigner,
@@ -1242,7 +1243,7 @@ func NewTestEntities(seed []byte, n int) ([]*TestEntity, error) {
 			return nil, err
 		}
 		ent.Entity = &entity.Entity{
-			DescriptorVersion:      entity.LatestEntityDescriptorVersion,
+			Versioned:              cbor.NewVersioned(entity.LatestEntityDescriptorVersion),
 			ID:                     ent.Signer.Public(),
 			AllowEntitySignedNodes: true,
 		}
@@ -1257,7 +1258,7 @@ func NewTestEntities(seed []byte, n int) ([]*TestEntity, error) {
 			descr: "Registering with an old descriptor should fail",
 		}
 		invEnt1 := *ent.Entity
-		invEnt1.DescriptorVersion = 0
+		invEnt1.Versioned.V = 0
 		invalid1.signed, err = entity.SignEntity(ent.Signer, api.RegisterEntitySignatureContext, &invEnt1)
 		if err != nil {
 			return nil, err
@@ -1529,10 +1530,10 @@ func NewTestRuntime(seed []byte, ent *TestEntity, isKeyManager bool) (*TestRunti
 	var rt TestRuntime
 	rt.Signer = ent.Signer
 	rt.Runtime = &api.Runtime{
-		DescriptorVersion: api.LatestRuntimeDescriptorVersion,
-		ID:                id,
-		EntityID:          ent.Entity.ID,
-		Kind:              api.KindCompute,
+		Versioned: cbor.NewVersioned(api.LatestRuntimeDescriptorVersion),
+		ID:        id,
+		EntityID:  ent.Entity.ID,
+		Kind:      api.KindCompute,
 		Executor: api.ExecutorParameters{
 			GroupSize:         3,
 			GroupBackupSize:   5,

--- a/go/roothash/api/commitment/pool_test.go
+++ b/go/roothash/api/commitment/pool_test.go
@@ -61,9 +61,9 @@ type staticNodeLookup struct {
 
 func (n *staticNodeLookup) Node(ctx context.Context, id signature.PublicKey) (*node.Node, error) {
 	return &node.Node{
-		DescriptorVersion: node.LatestNodeDescriptorVersion,
-		ID:                id,
-		Runtimes:          []*node.Runtime{n.runtime},
+		Versioned: cbor.NewVersioned(node.LatestNodeDescriptorVersion),
+		ID:        id,
+		Runtimes:  []*node.Runtime{n.runtime},
 	}, nil
 }
 
@@ -110,10 +110,10 @@ func TestPoolSingleCommitment(t *testing.T) {
 	_ = rtID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
 
 	rt := &registry.Runtime{
-		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
-		ID:                rtID,
-		Kind:              registry.KindCompute,
-		TEEHardware:       node.TEEHardwareInvalid,
+		Versioned:   cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+		ID:          rtID,
+		Kind:        registry.KindCompute,
+		TEEHardware: node.TEEHardwareInvalid,
 		Storage: registry.StorageParameters{
 			GroupSize:           1,
 			MinWriteReplication: 1,
@@ -226,10 +226,10 @@ func TestPoolSingleCommitmentTEE(t *testing.T) {
 	_ = rtID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
 
 	rt := &registry.Runtime{
-		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
-		ID:                rtID,
-		Kind:              registry.KindCompute,
-		TEEHardware:       node.TEEHardwareIntelSGX,
+		Versioned:   cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+		ID:          rtID,
+		Kind:        registry.KindCompute,
+		TEEHardware: node.TEEHardwareIntelSGX,
 	}
 
 	// Generate a commitment signing key.
@@ -458,10 +458,10 @@ func TestPoolSerialization(t *testing.T) {
 	_ = rtID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
 
 	rt := &registry.Runtime{
-		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
-		ID:                rtID,
-		Kind:              registry.KindCompute,
-		TEEHardware:       node.TEEHardwareInvalid,
+		Versioned:   cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+		ID:          rtID,
+		Kind:        registry.KindCompute,
+		TEEHardware: node.TEEHardwareInvalid,
 	}
 
 	// Generate a commitment signing key.
@@ -1114,10 +1114,10 @@ func generateMockCommittee(t *testing.T) (
 	_ = rtID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
 
 	rt = &registry.Runtime{
-		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
-		ID:                rtID,
-		Kind:              registry.KindCompute,
-		TEEHardware:       node.TEEHardwareInvalid,
+		Versioned:   cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+		ID:          rtID,
+		Kind:        registry.KindCompute,
+		TEEHardware: node.TEEHardwareInvalid,
 		Storage: registry.StorageParameters{
 			GroupSize:           1,
 			MinWriteReplication: 1,

--- a/go/upgrade/migrations/dummy.go
+++ b/go/upgrade/migrations/dummy.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"fmt"
 
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
 	"github.com/oasisprotocol/oasis-core/go/common/entity"
@@ -30,7 +31,7 @@ var (
 
 func init() {
 	entitySigner = memory.NewTestSigner(testSigningSeed)
-	TestEntity.DescriptorVersion = entity.LatestEntityDescriptorVersion
+	TestEntity.Versioned = cbor.NewVersioned(entity.LatestEntityDescriptorVersion)
 	TestEntity.ID = entitySigner.Public()
 }
 

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/accessctl"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	fileSigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/file"
 	"github.com/oasisprotocol/oasis-core/go/common/entity"
@@ -630,10 +631,10 @@ func (w *Worker) registerNode(epoch epochtime.EpochTime, hook RegisterNodeHook) 
 	}
 
 	nodeDesc := node.Node{
-		DescriptorVersion: node.LatestNodeDescriptorVersion,
-		ID:                identityPublic,
-		EntityID:          w.entityID,
-		Expiration:        uint64(epoch) + 2,
+		Versioned:  cbor.NewVersioned(node.LatestNodeDescriptorVersion),
+		ID:         identityPublic,
+		EntityID:   w.entityID,
+		Expiration: uint64(epoch) + 2,
 		TLS: node.TLSInfo{
 			PubKey:     w.identity.GetTLSSigner().Public(),
 			NextPubKey: nextPubKey,


### PR DESCRIPTION
 * [x] Entity
 * [x] Node
 * [x] Runtime

Fixes #3119