### PR TITLE
go/e2e/txsource: periodically restart runtime nodes

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -210,7 +210,7 @@ steps:
   ###############
   - label: E2E tests
     parallelism: 7
-    timeout_in_minutes: 11
+    timeout_in_minutes: 12
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
       - .buildkite/scripts/test_e2e.sh

--- a/.changelog/3124.bugfix.md
+++ b/.changelog/3124.bugfix.md
@@ -1,0 +1,1 @@
+go/consensus/tendermint/roothash: Ignore non-tracked runtimes when reindexing

--- a/.changelog/3124.internal.md
+++ b/.changelog/3124.internal.md
@@ -1,0 +1,1 @@
+go/e2e/txsource: Periodically restart runtime nodes

--- a/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
@@ -148,11 +148,10 @@ func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
 	f.Network.StakingGenesis = "tests/fixture-data/txsource/staking-genesis.json"
 
 	if sc.nodeRestartInterval > 0 {
-		// If node restarts enabled, do not enable round timeouts and merge
+		// If node restarts enabled, do not enable round timeouts and
 		// discrepancy log watchers.
 		f.Network.DefaultLogWatcherHandlerFactories = []log.WatcherHandlerFactory{
 			oasis.LogAssertNoRoundFailures(),
-			oasis.LogAssertNoExecutionDiscrepancyDetected(),
 		}
 	}
 
@@ -166,6 +165,16 @@ func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
 		{Entity: 1},
 		{Entity: 1},
 		{Entity: 1},
+	}
+	f.ComputeWorkers = []oasis.ComputeWorkerFixture{
+		{Entity: 1},
+		{Entity: 1},
+		{Entity: 1},
+		{Entity: 1},
+	}
+	f.Keymanagers = []oasis.KeymanagerFixture{
+		{Runtime: 0, Entity: 1},
+		{Runtime: 0, Entity: 1},
 	}
 
 	// Update validators to require fee payments.
@@ -211,10 +220,19 @@ func (sc *txSourceImpl) manager(env *env.Env, errCh chan error) {
 
 	// Randomize node order.
 	var nodes []*oasis.Node
-	for _, v := range sc.Net.Validators() {
+	// Keep one of each types of nodes always running.
+	for _, v := range sc.Net.Validators()[1:] {
 		nodes = append(nodes, &v.Node)
 	}
-	// TODO: Consider including storage/compute workers.
+	for _, s := range sc.Net.StorageWorkers()[1:] {
+		nodes = append(nodes, &s.Node)
+	}
+	for _, c := range sc.Net.ComputeWorkers()[1:] {
+		nodes = append(nodes, &c.Node)
+	}
+	for _, k := range sc.Net.Keymanagers()[1:] {
+		nodes = append(nodes, &k.Node)
+	}
 
 	restartTicker := time.NewTicker(sc.nodeRestartInterval)
 	defer restartTicker.Stop()

--- a/tests/fixture-data/txsource/staking-genesis.json
+++ b/tests/fixture-data/txsource/staking-genesis.json
@@ -17,7 +17,7 @@
       "transfer": 10
     }
   },
-  "total_supply": "100000000000",
+  "total_supply": "120000000000",
   "ledger": {
     "oasis1qpt202cf6t0s5ugkk34p83yf0c30gpjkny92u7dh": {"general": {"balance": "10000000000"}},
     "oasis1qryg8qf3ydzcphr328l8psz007fms9dxeuy8lgzq": {"general": {"balance": "10000000000"}},
@@ -27,10 +27,12 @@
     "oasis1qp6tl30ljsrrqnw2awxxu2mtxk0qxyy2nymtsy90": {"general": {"balance": "10000000000"}},
     "oasis1qr77y0cqdzcqgz2wqkv59yz0j4vfvyryfv8vxllt": {"general": {"balance": "10000000000"}},
     "oasis1qzyw75ds6nw0af98xfmmpl3z8sgf3mdslvtzzcn6": {"general": {"balance": "10000000000"}},
+    "oasis1qrp7l53vn6h2z7p242ldtkqtttz2jf9dwsgu05aa": {"general": {"balance": "10000000000"}},
 
     "oasis1qrhp36j49ncpaac0aufwyuvtk04nfxcj2yq7y4my": {"general": {"balance": "10000000000"}},
     "oasis1qzc2fexm30puzq2cmlm832fvpnyaxrq33cx4zukj": {"general": {"balance": "10000000000"}},
 
-    "oasis1qpx0k28va6n0r25qd2j4jdh9f42n5vex6s9lp780": {"general": {"balance": "10000000000"}}
+    "oasis1qpx0k28va6n0r25qd2j4jdh9f42n5vex6s9lp780": {"general": {"balance": "10000000000"}},
+    "oasis1qz30d8mqzrsrsu7fr0e6nxk0ze7ffdkj8ur7sqp0": {"general": {"balance": "10000000000"}}
   }
 }


### PR DESCRIPTION
TODO:
- [x] setup 2 keymanagers for the long-running test and also enable restarts there
- [x] setup 4 compute nodes
- [x] keep one of each type of nodes always running (so we can observe the memory/cpu/disk usage of that node, compared to the others)
- [x] revert the `scripts/daily_txsource.sh` change before merging

Fixes:
* .buildkite/longtests.pipeline.yml missing new artifact: extracted into: #3125
* go/consensus/tendermint/roothash: ignore non tracked runtimes when reindexing