### PR TITLE
ci: extract go artifacts upload code into a script

### DIFF
--- a/.buildkite/benchmarks.pipeline.yml
+++ b/.buildkite/benchmarks.pipeline.yml
@@ -54,18 +54,7 @@ steps:
   - label: Build Go node
     command:
       - .buildkite/go/build.sh
-
-      # Upload the built artifacts.
-      - cd /workdir/go/oasis-node
-      - buildkite-agent artifact upload oasis-node
-      - buildkite-agent artifact upload oasis-node.test
-      - cd /workdir/go/oasis-test-runner
-      - buildkite-agent artifact upload oasis-test-runner
-      - buildkite-agent artifact upload oasis-test-runner.test
-      - cd /workdir/go/oasis-net-runner
-      - buildkite-agent artifact upload oasis-net-runner
-      - cd /workdir/go/oasis-remote-signer
-      - buildkite-agent artifact upload oasis-remote-signer
+      - .buildkite/go/upload_artifacts.sh
     plugins:
       <<: *docker_plugin
 

--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -106,20 +106,7 @@ steps:
   - label: Build Go node
     command:
       - .buildkite/go/build.sh
-
-      # Upload the built artifacts.
-      - cd /workdir/go/oasis-node
-      - buildkite-agent artifact upload oasis-node
-      - buildkite-agent artifact upload oasis-node.test
-      - cd /workdir/go/oasis-test-runner
-      - buildkite-agent artifact upload oasis-test-runner
-      - buildkite-agent artifact upload oasis-test-runner.test
-      - cd /workdir/go/oasis-test-runner/scenario/pluginsigner/example_signer_plugin
-      - buildkite-agent artifact upload example_signer_plugin.so
-      - cd /workdir/go/oasis-net-runner
-      - buildkite-agent artifact upload oasis-net-runner
-      - cd /workdir/go/oasis-remote-signer
-      - buildkite-agent artifact upload oasis-remote-signer
+      - .buildkite/go/upload_artifacts.sh
     retry:
       <<: *retry_agent_failure
     plugins:

--- a/.buildkite/go/upload_artifacts.sh
+++ b/.buildkite/go/upload_artifacts.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+pushd /workdir/go/oasis-node
+    buildkite-agent artifact upload oasis-node
+    buildkite-agent artifact upload oasis-node.test
+popd
+
+pushd /workdir/go/oasis-test-runner
+    buildkite-agent artifact upload oasis-test-runner
+    buildkite-agent artifact upload oasis-test-runner.test
+popd
+
+pushd /workdir/go/oasis-test-runner/scenario/pluginsigner/example_signer_plugin
+    buildkite-agent artifact upload example_signer_plugin.so
+popd
+
+pushd /workdir/go/oasis-net-runner
+    buildkite-agent artifact upload oasis-net-runner
+popd
+
+pushd /workdir/go/oasis-remote-signer
+    buildkite-agent artifact upload oasis-remote-signer
+popd

--- a/.buildkite/longtests.pipeline.yml
+++ b/.buildkite/longtests.pipeline.yml
@@ -44,18 +44,7 @@ steps:
   - label: Build Go node
     command:
       - .buildkite/go/build.sh
-
-      # Upload the built artifacts.
-      - cd /workdir/go/oasis-node
-      - buildkite-agent artifact upload oasis-node
-      - buildkite-agent artifact upload oasis-node.test
-      - cd /workdir/go/oasis-test-runner
-      - buildkite-agent artifact upload oasis-test-runner
-      - buildkite-agent artifact upload oasis-test-runner.test
-      - cd /workdir/go/oasis-net-runner
-      - buildkite-agent artifact upload oasis-net-runner
-      - cd /workdir/go/oasis-remote-signer
-      - buildkite-agent artifact upload oasis-remote-signer
+      - .buildkite/go/upload_artifacts.sh
     plugins:
       <<: *docker_plugin
 

--- a/.changelog/3125.internal.md
+++ b/.changelog/3125.internal.md
@@ -1,0 +1,1 @@
+ci: Extract go artifacts upload code into a script


### PR DESCRIPTION
Extracted from https://github.com/oasisprotocol/oasis-core/pull/3124 since otherwise the next longtest run will fail.