### PR TITLE
 go/tendermint/roothash: Skip pruned heights when reindexing

### DIFF
--- a/.changelog/3127.bugfix.md
+++ b/.changelog/3127.bugfix.md
@@ -1,0 +1,1 @@
+go/tendermint/roothash: Skip pruned heights when reindexing

--- a/.changelog/3127.internal.md
+++ b/.changelog/3127.internal.md
@@ -1,0 +1,1 @@
+go/tests/e2e/history_reindex: Scenario that triggers roothash reindexing

--- a/go/consensus/tendermint/abci/prune.go
+++ b/go/consensus/tendermint/abci/prune.go
@@ -16,10 +16,13 @@ const (
 
 	pruneNone  = "none"
 	pruneKeepN = "keep_n"
+
+	// LogEventABCIPruneDelete is a log event value that signals an ABCI pruning
+	// delete event.
+	LogEventABCIPruneDelete = "tendermint/abci/prune"
 )
 
-// PruneStrategy is the strategy to use when pruning the ABCI mux iAVL
-// state.
+// PruneStrategy is the strategy to use when pruning the ABCI mux state.
 type PruneStrategy int
 
 const (
@@ -151,6 +154,7 @@ func (p *genericPruner) doPrune(ctx context.Context, latestVersion uint64) error
 		p.logger.Debug("Prune: Delete",
 			"latest_version", latestVersion,
 			"pruned_version", i,
+			logging.LogEvent, LogEventABCIPruneDelete,
 		)
 
 		err := p.ndb.Prune(ctx, i)

--- a/go/consensus/tendermint/abci/state.go
+++ b/go/consensus/tendermint/abci/state.go
@@ -106,6 +106,10 @@ func (s *applicationState) NewContext(mode api.ContextMode, now time.Time) *api.
 	)
 }
 
+func (s *applicationState) LastRetainedVersion() (int64, error) {
+	return int64(s.statePruner.GetLastRetainedVersion()), nil
+}
+
 func (s *applicationState) Storage() storage.LocalBackend {
 	return s.storage
 }

--- a/go/consensus/tendermint/api/api.go
+++ b/go/consensus/tendermint/api/api.go
@@ -199,6 +199,10 @@ type Backend interface {
 	// WatchTendermintBlocks returns a stream of Tendermint blocks as they are
 	// returned via the `EventDataNewBlock` query.
 	WatchTendermintBlocks() (<-chan *tmtypes.Block, *pubsub.Subscription)
+
+	// GetLastRetainedVersion returns the earliest retained version the ABCI
+	// state.
+	GetLastRetainedVersion(ctx context.Context) (int64, error)
 }
 
 // TransactionAuthHandler is the interface for ABCI applications that handle

--- a/go/consensus/tendermint/api/state.go
+++ b/go/consensus/tendermint/api/state.go
@@ -75,6 +75,10 @@ type ApplicationQueryState interface {
 
 	// GetEpoch returns epoch at block height.
 	GetEpoch(ctx context.Context, blockHeight int64) (epochtime.EpochTime, error)
+
+	// LastRetainedVersion returns the earliest retained version the ABCI
+	// state.
+	LastRetainedVersion() (int64, error)
 }
 
 // MockApplicationStateConfig is the configuration for the mock application state.
@@ -124,6 +128,10 @@ func (ms *mockApplicationState) GetBaseEpoch() (epochtime.EpochTime, error) {
 
 func (ms *mockApplicationState) GetEpoch(ctx context.Context, blockHeight int64) (epochtime.EpochTime, error) {
 	return ms.cfg.CurrentEpoch, nil
+}
+
+func (ms *mockApplicationState) LastRetainedVersion() (int64, error) {
+	return ms.cfg.Genesis.Height, nil
 }
 
 func (ms *mockApplicationState) GetCurrentEpoch(ctx context.Context) (epochtime.EpochTime, error) {

--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -1011,6 +1011,10 @@ func (t *tendermintService) initialize() error {
 	return nil
 }
 
+func (t *tendermintService) GetLastRetainedVersion(ctx context.Context) (int64, error) {
+	return t.mux.State().LastRetainedVersion()
+}
+
 func (t *tendermintService) GetTendermintBlock(ctx context.Context, height int64) (*tmtypes.Block, error) {
 	if err := t.ensureStarted(ctx); err != nil {
 		return nil, err

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -124,9 +124,9 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 			{Backend: "badger", Entity: 1},
 		},
 		ComputeWorkers: []oasis.ComputeWorkerFixture{
-			{Entity: 1},
-			{Entity: 1},
-			{Entity: 1},
+			{Entity: 1, Runtimes: []int{1}},
+			{Entity: 1, Runtimes: []int{1}},
+			{Entity: 1, Runtimes: []int{1}},
 		},
 		Clients: []oasis.ClientFixture{
 			{},

--- a/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
+++ b/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
@@ -374,6 +374,11 @@ func (qs *dumpQueryState) GetEpoch(ctx context.Context, blockHeight int64) (epoc
 	return epochtime.EpochTime(0), fmt.Errorf("dumpdb/dumpQueryState: GetEpoch not supported")
 }
 
+func (qs *dumpQueryState) LastRetainedVersion() (int64, error) {
+	// This is not required in the dump process.
+	return 0, fmt.Errorf("dumpdb/dumpQueryState: LastRetainedEpoch not supported")
+}
+
 // Register registers the dumpdb sub-commands.
 func Register(parentCmd *cobra.Command) {
 	dumpDBCmd.Flags().AddFlagSet(flags.GenesisFileFlags)

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -381,8 +381,7 @@ type ComputeWorkerFixture struct {
 
 	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
 
-	// Runtimes contains the indexes of the runtimes to enable. Leave
-	// empty or nil for the default behaviour (i.e. include all runtimes).
+	// Runtimes contains the indexes of the runtimes to enable.
 	Runtimes []int `json:"runtimes,omitempty"`
 }
 

--- a/go/oasis-test-runner/oasis/log.go
+++ b/go/oasis-test-runner/oasis/log.go
@@ -2,6 +2,7 @@ package oasis
 
 import (
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint/abci"
 	tendermint "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/log"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
@@ -78,4 +79,16 @@ func LogAssertUpgradeStartup() log.WatcherHandlerFactory {
 // handler was run based on JSON log output.
 func LogAssertUpgradeConsensus() log.WatcherHandlerFactory {
 	return LogAssertEvent(upgrade.LogEventConsensusUpgrade, "expected consensus upgrade did not run")
+}
+
+// LogEventABCIPruneDelete returns a handler which checks whether a ABCI pruning delete
+// was detected based on JSON log output.
+func LogEventABCIPruneDelete() log.WatcherHandlerFactory {
+	return LogAssertEvent(abci.LogEventABCIPruneDelete, "expected ABCI pruning to be done")
+}
+
+// LogAssertRoothashRoothashReindexing returns a handler witch checks wether roothash reindexing was
+// run based on JSON log output.
+func LogAssertRoothashRoothashReindexing() log.WatcherHandlerFactory {
+	return LogAssertEvent(roothash.LogEventHistoryReindexing, "roothash runtime reindexing not detected")
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/history_reindex.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/history_reindex.go
@@ -1,0 +1,168 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/log"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis/cli"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+)
+
+const (
+	reindexComputePruneNumKept = 50
+)
+
+// HistoryReindex is the scenario that triggers roothash history reindexing.
+var HistoryReindex scenario.Scenario = newHistoryReindexImpl()
+
+type historyReindexImpl struct {
+	runtimeImpl
+}
+
+func newHistoryReindexImpl() scenario.Scenario {
+	return &historyReindexImpl{
+		runtimeImpl: *newRuntimeImpl("history-reindex", "simple-keyvalue-enc-client", nil),
+	}
+}
+
+func (sc *historyReindexImpl) Fixture() (*oasis.NetworkFixture, error) {
+	f, err := sc.runtimeImpl.Fixture()
+	if err != nil {
+		return nil, err
+	}
+
+	// We need IAS proxy to use the registry as we are registering runtimes dynamically.
+	f.Network.IAS.UseRegistry = true
+
+	f.ComputeWorkers = []oasis.ComputeWorkerFixture{
+		{
+			Entity:   1,
+			Runtimes: []int{},
+			Consensus: oasis.ConsensusFixture{
+				PruneNumKept: reindexComputePruneNumKept,
+			},
+			LogWatcherHandlerFactories: []log.WatcherHandlerFactory{
+				// Ensure ABCI pruning happens on the node.
+				oasis.LogEventABCIPruneDelete(),
+				// Ensure re-indexing happens on the node.
+				oasis.LogAssertRoothashRoothashReindexing(),
+			},
+		},
+	}
+
+	// Assumes a single compute runtime.
+	var rtIdx int
+	for idx, rt := range f.Runtimes {
+		if rt.Kind == registry.KindCompute {
+			rtIdx = idx
+			break
+		}
+	}
+	// Compute runtime will be registered later.
+	f.Runtimes[rtIdx].ExcludeFromGenesis = true
+	// Use a single compute node.
+	f.Runtimes[rtIdx].Executor.GroupSize = 1
+	f.Runtimes[rtIdx].Executor.GroupBackupSize = 0
+	f.Runtimes[rtIdx].Merge.GroupSize = 1
+	f.Runtimes[rtIdx].Merge.GroupBackupSize = 0
+
+	return f, nil
+}
+
+func (sc *historyReindexImpl) Clone() scenario.Scenario {
+	return &historyReindexImpl{
+		runtimeImpl: *sc.runtimeImpl.Clone().(*runtimeImpl),
+	}
+}
+
+func (sc *historyReindexImpl) Run(childEnv *env.Env) error {
+	ctx := context.Background()
+	cli := cli.New(childEnv, sc.Net, sc.Logger)
+
+	// Start the network.
+	if err := sc.Net.Start(); err != nil {
+		return err
+	}
+
+	// Wait for enough block to ensure pruning on the compute node.
+	waitForHeight := int64(reindexComputePruneNumKept + 20)
+	sc.Logger.Info("waiting enough blocks to ensure pruning",
+		"compute_prune_num_kept", reindexComputePruneNumKept,
+		"wait_for_height", waitForHeight,
+	)
+
+	blockCh, blockSub, bErr := sc.Net.Controller().Consensus.WatchBlocks(ctx)
+	if bErr != nil {
+		return fmt.Errorf("failed waiting for block height: %w", bErr)
+	}
+	defer blockSub.Close()
+
+	for newBlk := range blockCh {
+		if newBlk.Height > waitForHeight {
+			break
+		}
+		sc.Logger.Debug("waiting enough blocks to ensure pruning",
+			"current_height", newBlk.Height,
+			"wait_for_height", waitForHeight,
+		)
+	}
+
+	// Restart compute worker with configured runtime.
+	compute := sc.Net.ComputeWorkers()[0]
+	sc.Logger.Info("stopping the compute worker")
+	if err := compute.Stop(); err != nil {
+		return err
+	}
+	var rtIdx int
+	for idx, rt := range sc.Net.Runtimes() {
+		if rt.Kind() == registry.KindCompute {
+			rtIdx = idx
+			break
+		}
+	}
+	// Update worker runtime configuration.
+	compute.UpdateRuntimes([]int{rtIdx})
+	sc.Logger.Info("starting the compute worker")
+	if err := compute.Start(); err != nil {
+		return err
+	}
+
+	// Register runtime.
+	compRt := sc.Net.Runtimes()[rtIdx]
+	compRtDesc := compRt.ToRuntimeDescriptor()
+	txPath := filepath.Join(childEnv.Dir(), "register_compute_runtime.json")
+	if err := cli.Registry.GenerateRegisterRuntimeTx(0, compRtDesc, txPath, compRt.GetGenesisStatePath()); err != nil {
+		return fmt.Errorf("failed to generate register compute runtime tx: %w", err)
+	}
+	if err := cli.Consensus.SubmitTx(txPath); err != nil {
+		return fmt.Errorf("failed to register compute runtime: %w", err)
+	}
+
+	// Wait for the compute worker to be ready.
+	sc.Logger.Info("waiting for the compute worker to become ready")
+	computeCtrl, err := oasis.NewController(compute.SocketPath())
+	if err != nil {
+		return err
+	}
+	if err = computeCtrl.WaitReady(context.Background()); err != nil {
+		return err
+	}
+
+	// Run client to ensure runtime works.
+	sc.Logger.Info("Starting the basic client")
+	cmd, err := sc.startClient(childEnv)
+	if err != nil {
+		return err
+	}
+	clientErrCh := make(chan error)
+	go func() {
+		clientErrCh <- cmd.Wait()
+	}()
+
+	return sc.wait(childEnv, cmd, clientErrCh)
+}

--- a/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
@@ -79,7 +79,6 @@ func (sc *multipleRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
 	for i := 1; i <= numComputeRuntimes; i++ {
 		// Increase LSB by 1.
 		id[len(id)-1]++
-
 		newRtFixture := oasis.RuntimeFixture{
 			ID:         id,
 			Kind:       registry.KindCompute,
@@ -119,11 +118,22 @@ func (sc *multipleRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
 		f.Runtimes = append(f.Runtimes, newRtFixture)
 	}
 
+	var computeRuntimes []int
+	for id, rt := range f.Runtimes {
+		if rt.Kind == registry.KindCompute {
+			computeRuntimes = append(computeRuntimes, id)
+		}
+	}
 	// Use numComputeWorkers compute worker fixtures.
 	numComputeWorkers, _ := sc.Flags.GetInt(cfgNumComputeWorkers)
 	f.ComputeWorkers = []oasis.ComputeWorkerFixture{}
 	for i := 0; i < numComputeWorkers; i++ {
-		f.ComputeWorkers = append(f.ComputeWorkers, oasis.ComputeWorkerFixture{Entity: 1})
+		f.ComputeWorkers = append(f.ComputeWorkers,
+			oasis.ComputeWorkerFixture{
+				Entity:   1,
+				Runtimes: computeRuntimes,
+			},
+		)
 	}
 
 	return f, nil

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -204,9 +204,9 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 			{Backend: database.BackendNameBadgerDB, Entity: 1},
 		},
 		ComputeWorkers: []oasis.ComputeWorkerFixture{
-			{Entity: 1},
-			{Entity: 1},
-			{Entity: 1},
+			{Entity: 1, Runtimes: []int{1}},
+			{Entity: 1, Runtimes: []int{1}},
+			{Entity: 1, Runtimes: []int{1}},
 		},
 		Sentries: []oasis.SentryFixture{},
 		Clients: []oasis.ClientFixture{
@@ -532,6 +532,8 @@ func RegisterScenarios() error {
 		KeymanagerUpgrade,
 		// RuntimeUpgrade test.
 		RuntimeUpgrade,
+		// HistoryReindex test.
+		HistoryReindex,
 	} {
 		if err := cmd.Register(s); err != nil {
 			return err

--- a/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
@@ -167,10 +167,10 @@ func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
 		{Entity: 1},
 	}
 	f.ComputeWorkers = []oasis.ComputeWorkerFixture{
-		{Entity: 1},
-		{Entity: 1},
-		{Entity: 1},
-		{Entity: 1},
+		{Entity: 1, Runtimes: []int{1}},
+		{Entity: 1, Runtimes: []int{1}},
+		{Entity: 1, Runtimes: []int{1}},
+		{Entity: 1, Runtimes: []int{1}},
 	}
 	f.Keymanagers = []oasis.KeymanagerFixture{
 		{Runtime: 0, Entity: 1},

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -33,6 +33,9 @@ const (
 	LogEventRoundFailed = "roothash/round_failed"
 	// LogEventMessageUnsat is a log event value that signals a roothash message was not satisfactory.
 	LogEventMessageUnsat = "roothash/message_unsat"
+	// LogEventHistoryReindexing is a log event value that singals a roothash runtime reindexing
+	// was run.
+	LogEventHistoryReindexing = "roothash/history_reindexing"
 )
 
 var (

--- a/tests/fixture-data/net-runner/default.json
+++ b/tests/fixture-data/net-runner/default.json
@@ -194,7 +194,10 @@
                 "disable_check_tx": false,
                 "prune_num_kept": 0,
                 "tendermint_recover_corrupted_wal": false
-            }
+            },
+            "runtimes": [
+                1
+            ]
         },
         {
             "entity": 1,
@@ -207,7 +210,10 @@
                 "disable_check_tx": false,
                 "prune_num_kept": 0,
                 "tendermint_recover_corrupted_wal": false
-            }
+            },
+            "runtimes": [
+                1
+            ]
         },
         {
             "entity": 1,
@@ -220,7 +226,10 @@
                 "disable_check_tx": false,
                 "prune_num_kept": 0,
                 "tendermint_recover_corrupted_wal": false
-            }
+            },
+            "runtimes": [
+                1
+            ]
         }
     ],
     "clients": [


### PR DESCRIPTION
* makes roothash reindexing aware of pruning
* adds a e2e/test scenario that triggers reindexing (with prunning)

TODO:
- [x] bunch of minor todo's/cleanups
