### PR TITLE
go/worker/common: Treat stale unauthorized peer error as permanent

### DIFF
--- a/.changelog/3133.bugfix.md
+++ b/.changelog/3133.bugfix.md
@@ -1,0 +1,5 @@
+go/worker/common: Treat stale unauthorized peer error as permanent
+
+If the message's group version indicates that the message is stale and an
+authorization check fails, treat the error as permanent as a stale message
+will never become valid.

--- a/go/oasis-node/cmd/debug/byzantine/p2p.go
+++ b/go/oasis-node/cmd/debug/byzantine/p2p.go
@@ -37,7 +37,7 @@ type p2pRecvHandler struct {
 }
 
 // AuthenticatePeer implements p2p Handler.
-func (h *p2pRecvHandler) AuthenticatePeer(peerID signature.PublicKey) error {
+func (h *p2pRecvHandler) AuthenticatePeer(peerID signature.PublicKey, msg *p2p.Message) error {
 	// The Byzantine node itself isn't especially robust. We assume that
 	// the other nodes are honest.
 	return nil

--- a/go/worker/common/p2p/dispatch.go
+++ b/go/worker/common/p2p/dispatch.go
@@ -28,7 +28,7 @@ type Handler interface {
 	//
 	// The message handler will be re-invoked on error with a periodic
 	// backoff unless errors are wrapped via `p2pError.Permanent`.
-	AuthenticatePeer(peerID signature.PublicKey) error
+	AuthenticatePeer(peerID signature.PublicKey, msg *Message) error
 
 	// HandlePeerMessage handles an incoming message from a peer.
 	//
@@ -153,7 +153,7 @@ func (h *topicHandler) dispatchMessage(peerID core.PeerID, m *queuedMsg, isIniti
 	// Perhaps this should reject the message, but it is possible that
 	// the local node is just behind.  This does result in stale messages
 	// getting retried though.
-	if err = h.handler.AuthenticatePeer(m.from); err != nil {
+	if err = h.handler.AuthenticatePeer(m.from, m.msg); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
If the message's group version indicates that the message is stale and an
authorization check fails, treat the error as permanent as a stale message will
never become valid.