### PR TITLE
runtime: Reduce maximum RHP message size

### DIFF
--- a/.changelog/2213.bugfix.md
+++ b/.changelog/2213.bugfix.md
@@ -1,0 +1,1 @@
+runtime: Reduce maximum RHP message size to 16 MiB

--- a/.changelog/3139.bugfix.md
+++ b/.changelog/3139.bugfix.md
@@ -1,0 +1,1 @@
+go/worker/compute: Enforce maximum batch sizes from txn scheduler

--- a/docs/runtime/runtime-host-protocol.md
+++ b/docs/runtime/runtime-host-protocol.md
@@ -24,7 +24,7 @@ using [canonical CBOR]. The frames are serialized on the wire as follows:
 [4-byte message length (big endian)] [CBOR-serialized message]
 ```
 
-Maximum allowed message size is 104857600 bytes.
+Maximum allowed message size is 16 MiB.
 
 [canonical CBOR]: ../encoding.md
 

--- a/go/common/cbor/codec.go
+++ b/go/common/cbor/codec.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Maximum message size.
-const maxMessageSize = 104857600 // 100 MiB
+const maxMessageSize = 16 * 1024 * 1024 // 16 MiB
 
 var (
 	errMessageTooLarge  = errors.New("codec: message too large")

--- a/go/runtime/transaction/transaction_test.go
+++ b/go/runtime/transaction/transaction_test.go
@@ -117,13 +117,19 @@ func TestTransaction(t *testing.T) {
 	}
 
 	// Get input batch.
-	batch, err := tree.GetInputBatch(ctx)
+	batch, err := tree.GetInputBatch(ctx, 0, 0)
 	require.NoError(t, err, "GetInputBatch")
 	require.Len(t, batch, len(testTxns)+1, "batch should have the same transactions")
 	require.EqualValues(t, tx.Input, batch[0], "input batch transactions must be in correct order")
 	for idx, checkTx := range testTxns {
 		require.EqualValues(t, checkTx.Input, batch[idx+1], "input batch transactions must be in correct order")
 	}
+
+	// Get input batch with size limits.
+	_, err = tree.GetInputBatch(ctx, 5, 0)
+	require.Error(t, err, "GetInputBatch should fail with too many transactions")
+	_, err = tree.GetInputBatch(ctx, 0, 64)
+	require.Error(t, err, "GetInputBatch should fail with too large transactions")
 
 	// Commit.
 	// NOTE: This root is synced with tests in runtime/src/transaction/tree.rs.

--- a/go/worker/compute/executor/committee/batch.go
+++ b/go/worker/compute/executor/committee/batch.go
@@ -22,6 +22,9 @@ type unresolvedBatch struct {
 
 	batch   transaction.RawBatch
 	spanCtx opentracing.SpanContext
+
+	maxBatchSize      uint64
+	maxBatchSizeBytes uint64
 }
 
 func (ub *unresolvedBatch) String() string {
@@ -37,7 +40,7 @@ func (ub *unresolvedBatch) resolve(ctx context.Context, storage storage.Backend)
 	txs := transaction.NewTree(storage, ub.ioRoot)
 	defer txs.Close()
 
-	batch, err := txs.GetInputBatch(ctx)
+	batch, err := txs.GetInputBatch(ctx, ub.maxBatchSize, ub.maxBatchSizeBytes)
 	if err != nil || len(batch) == 0 {
 		return nil, fmt.Errorf("failed to fetch inputs from storage: %w", err)
 	}

--- a/go/worker/compute/executor/committee/node.go
+++ b/go/worker/compute/executor/committee/node.go
@@ -283,6 +283,8 @@ func (n *Node) queueBatchBlocking(
 		},
 		txnSchedSignature: txnSchedSig,
 		storageSignatures: storageSignatures,
+		maxBatchSize:      rt.TxnScheduler.MaxBatchSize,
+		maxBatchSizeBytes: rt.TxnScheduler.MaxBatchSizeBytes,
 	}
 	if batchSpan := opentracing.SpanFromContext(ctx); batchSpan != nil {
 		batch.spanCtx = batchSpan.Context()

--- a/runtime/src/protocol.rs
+++ b/runtime/src/protocol.rs
@@ -31,7 +31,7 @@ pub type Stream = ::std::os::unix::net::UnixStream;
 pub type Stream = ::std::net::TcpStream;
 
 /// Maximum message size.
-const MAX_MESSAGE_SIZE: usize = 104_857_600; // 100MB
+const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024; // 16MiB
 
 #[derive(Error, Debug)]
 pub enum ProtocolError {


### PR DESCRIPTION
Fixes #2213

Message size is reduced based on benchmark metrics where messages never exceeded 3 MiB even with large batches.

Also enforces maximum batch sizes at compute nodes.
