### PR TITLE
go/common/crypto/signature/signers/plugin: Rewrite

### DIFF
--- a/.buildkite/go/upload_artifacts.sh
+++ b/.buildkite/go/upload_artifacts.sh
@@ -13,7 +13,7 @@ pushd /workdir/go/oasis-test-runner
 popd
 
 pushd /workdir/go/oasis-test-runner/scenario/pluginsigner/example_signer_plugin
-    buildkite-agent artifact upload example_signer_plugin.so
+    buildkite-agent artifact upload example_signer_plugin
 popd
 
 pushd /workdir/go/oasis-net-runner

--- a/.buildkite/scripts/download_e2e_test_artifacts.sh
+++ b/.buildkite/scripts/download_e2e_test_artifacts.sh
@@ -19,7 +19,7 @@ download_artifact oasis-test-runner go/oasis-test-runner 755
 download_artifact oasis-test-runner.test go/oasis-test-runner 755
 download_artifact oasis-remote-signer go/oasis-remote-signer 755
 download_artifact oasis-core-runtime-loader target/default/debug 755
-download_artifact example_signer_plugin.so go/oasis-test-runner/scenario/pluginsigner/example_signer_plugin 755
+download_artifact example_signer_plugin go/oasis-test-runner/scenario/pluginsigner/example_signer_plugin 755
 
 # Simple Key manager runtime.
 download_artifact simple-keymanager.sgxs target/sgx/x86_64-fortanix-unknown-sgx/debug 755

--- a/.buildkite/scripts/test_e2e.sh
+++ b/.buildkite/scripts/test_e2e.sh
@@ -30,7 +30,6 @@ fi
 
 node_binary="${WORKDIR}/go/oasis-node/oasis-node"
 test_runner_binary="${WORKDIR}/go/oasis-test-runner/oasis-test-runner"
-skip_options=""
 
 # Use e2e-coverage-wrapper.sh as node binary if we need to compute E2E
 # tests' coverage.
@@ -40,11 +39,6 @@ if [[ ${OASIS_E2E_COVERAGE:-""} != "" ]]; then
     # Use -env version of the wrapper as we can't pass additional arguments there.
     export E2E_COVERAGE_BINARY=${node_binary}.test
     node_binary="${WORKDIR}/scripts/e2e-coverage-wrapper-env.sh"
-
-    # The runtime library's "different version" detection also freaks out
-    # if build flags changes, and as far as I can tell --covermode doesn't
-    # work.
-    skip_options="--skip plugin-signer/basic"
 fi
 
 ias_mock="true"
@@ -66,9 +60,9 @@ ${test_runner_binary} \
     --e2e/runtime.tee_hardware ${OASIS_TEE_HARDWARE:-""} \
     --e2e/runtime.ias.mock=${ias_mock} \
     --remote-signer.binary ${WORKDIR}/go/oasis-remote-signer/oasis-remote-signer \
-    --plugin-signer.binary ${WORKDIR}/go/oasis-test-runner/scenario/pluginsigner/example_signer_plugin/example_signer_plugin.so \
+    --plugin-signer.name example \
+    --plugin-signer.binary ${WORKDIR}/go/oasis-test-runner/scenario/pluginsigner/example_signer_plugin/example_signer_plugin \
     --log.level info \
-    ${skip_options} \
     ${BUILDKITE_PARALLEL_JOB_COUNT:+--parallel.job_count ${BUILDKITE_PARALLEL_JOB_COUNT}} \
     ${BUILDKITE_PARALLEL_JOB:+--parallel.job_index ${BUILDKITE_PARALLEL_JOB}} \
     "$@"

--- a/.changelog/3120.feature.1.md
+++ b/.changelog/3120.feature.1.md
@@ -2,5 +2,4 @@ go/common/crypto/signature: Add a plugin backed signer implementation
 
 Bloating the repository with a ton of different HSM (etc) signing
 backends doesn't make sense, and is a maintenance burden.  Use the
-runtime's built-in DLSO support to be able to separate out the
-non-esssential implementations.
+go-plugin package to allow for externally distributed signer plugins.

--- a/go/.gitignore
+++ b/go/.gitignore
@@ -5,7 +5,7 @@ oasis-node/oasis-node
 oasis-node/oasis-node.test
 oasis-test-runner/oasis-test-runner
 oasis-test-runner/oasis-test-runner.test
-oasis-test-runner/scenario/pluginsigner/example_signer_plugin/example_signer_plugin.so
+oasis-test-runner/scenario/pluginsigner/example_signer_plugin/example_signer_plugin
 oasis-net-runner/oasis-net-runner
 oasis-remote-signer/oasis-remote-signer
 storage/mkvs/interop/mkvs-test-helpers

--- a/go/Makefile
+++ b/go/Makefile
@@ -16,8 +16,8 @@ generate:
 
 # Build.
 # List of Go binaries to build.
-go-binaries := oasis-node oasis-test-runner oasis-net-runner oasis-remote-signer extra/stats extra/extract-metrics
-go-plugins := example-signer-plugin
+go-binaries := oasis-node oasis-test-runner oasis-net-runner oasis-remote-signer \
+	extra/stats extra/extract-metrics oasis-test-runner/scenario/pluginsigner/example_signer_plugin
 
 $(go-binaries):
 	@$(ECHO) "$(MAGENTA)*** Building $@...$(OFF)"
@@ -27,12 +27,7 @@ ifeq ($(GO_BUILD_E2E_COVERAGE),1)
 	@$(GO) test $(GOFLAGS) -c -tags e2ecoverage -covermode=atomic -coverpkg=./... -o ./$@/$(notdir $@).test ./$@
 endif
 
-# Example signer plugin.
-example-signer-plugin:
-	@$(ECHO) "$(MAGENTA)*** Building $@...$(OFF)"
-	@$(GO) build $(GOFLAGS) $(GO_EXTRA_FLAGS) -buildmode=plugin -o ./$(GO_EXAMPLE_PLUGIN_PATH) ./$(GO_EXAMPLE_PLUGIN_PATH)
-
-build: $(go-binaries) $(go-plugins)
+build: $(go-binaries)
 
 # Build test helpers.
 # List of test helpers to build.

--- a/go/common/crypto/signature/signers/plugin/interface.go
+++ b/go/common/crypto/signature/signers/plugin/interface.go
@@ -1,0 +1,25 @@
+package plugin
+
+import "github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+
+// Signer is the interface that must be implemented by all signer plugins.
+type Signer interface {
+	// Initialize initializes the plugin with the provided configuration
+	// and roles.
+	Initialize(config string, roles ...signature.SignerRole) error
+
+	// Load will load the private key corresponding to the provided role,
+	// optionally generating a new keypair if requested.
+	Load(role signature.SignerRole, mustGenerate bool) error
+
+	// Public returns the public key corresponding to a given role.
+	Public(role signature.SignerRole) (signature.PublicKey, error)
+
+	// ContextSign generates a signature with the given role's private
+	// key over the context and message.
+	//
+	// Note: Unlike the real signature.Signer interface, it is assumed
+	// that the caller handles context registration and domain
+	// separation.
+	ContextSign(role signature.SignerRole, rawContext signature.Context, message []byte) ([]byte, error)
+}

--- a/go/common/crypto/signature/signers/plugin/plugin.go
+++ b/go/common/crypto/signature/signers/plugin/plugin.go
@@ -3,31 +3,66 @@ package plugin
 
 import (
 	"fmt"
-	"plugin"
+	"io"
+	"net/rpc"
+	"os/exec"
+	"sync"
+	"syscall"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-plugin"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 )
 
 const (
-	// EntryPoint is the entry point (FactoryCtor) expected to be defined
-	// in each signer plugin.
-	EntryPoint = "GetPluginCtor"
-
-	// SignerName is the name used to identify the plugin signer.
+	// SignerName is the name used to identify the plugin backed signer.
 	SignerName = "plugin"
+
+	pluginName = "oasis_core_signer"
 )
 
-// FactoryCtor is the function signature of the EntryPoint symbol
-// that is expected to be defined in each plugin.
-type FactoryCtor func() signature.SignerFactoryCtor
+var (
+	_ signature.SignerFactory = (*wrapperFactory)(nil)
+	_ signature.Signer        = (*wrapperSigner)(nil)
+	_ plugin.Plugin           = (*signerPlugin)(nil)
+
+	// Sigh, yet another logging library. :(
+	nullLogger = hclog.NewNullLogger()
+)
+
+func handshakeConfigForName(name string) plugin.HandshakeConfig {
+	return plugin.HandshakeConfig{
+		ProtocolVersion:  1,
+		MagicCookieKey:   "OASIS_CORE_SIGNER_PLUGIN",
+		MagicCookieValue: name,
+	}
+}
 
 // FactoryConfig is the plugin factory configuration.
 type FactoryConfig struct {
+	// Name is the expected human readable name of the plugin (eg: "ledger", "memory")
+	Name string
+
 	// Path is the path to the plugin dynamic shared object.
 	Path string
 
 	// Config is the plugin configuration.
 	Config string
+}
+
+// Serve instantiates and serves a concrete Signer instance as a plugin.
+// This is intended to be called from the plugin's `main()`.
+func Serve(name string, impl Signer) {
+	plugin.Serve(&plugin.ServeConfig{
+		HandshakeConfig: handshakeConfigForName(name),
+		Plugins: map[string]plugin.Plugin{
+			pluginName: &signerPlugin{
+				impl: impl,
+			},
+		},
+		Logger: nullLogger,
+	})
 }
 
 // NewFactory creates a new factory backed by the specified plugin
@@ -38,24 +73,197 @@ func NewFactory(config interface{}, roles ...signature.SignerRole) (signature.Si
 		return nil, fmt.Errorf("signature/signer/plugin: invalid plugin signer configuration provided")
 	}
 
-	p, err := plugin.Open(cfg.Path)
-	if err != nil {
-		return nil, fmt.Errorf("signature/signer/plugin: failed to open plugin: %w", err)
+	if cfg.Name == "" {
+		return nil, fmt.Errorf("signature/signer/plugin: a plugin name must be specified")
 	}
 
-	ctorPtr, err := p.Lookup(EntryPoint)
-	if err != nil {
-		return nil, fmt.Errorf("signature/signer/plugin: failed to find entry point: %w", err)
-	}
-
-	// Yes, this should use `FactoryCtor` for the type assertion.
+	// Why yes, the correct thing to do is to call `client.Kill`,
+	// when we are done with the plugin.  Alas there's no good
+	// way to do that while using `os.Exit`.
 	//
-	// `plugin.Symbol is func() signature.SignerFactoryCtor, not plugin.FactoryCtor`
-	factoryCtor := ctorPtr.(func() signature.SignerFactoryCtor)()
-	factory, err := factoryCtor(cfg.Config, roles...)
-	if err != nil {
-		return nil, fmt.Errorf("signature/signer/plugin: failed to initialize factory: %w", err)
+	// At least ensure that child processes get killed in sensible
+	// environments.  If people have a problem with this they can
+	// do one or more of:
+	//
+	//  1. Get rid of the ~180 instances of `os.Exit`
+	//  2. Complain to the Go developers to make `plugin` not suck.
+	//  3. Complain to their OS vendor to implement PR_SET_PDEATH_SIG`.
+	//  4. Complain to Docker to make Docker not suck (reaping zombies
+	//     isn't that hard).
+	//
+	// We do use managed plugins so that in the graceful exit case,
+	// the cleanup will be done at least.
+	cmd := exec.Command(cfg.Path) // nolint: gosec
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGKILL,
 	}
 
-	return factory, nil
+	client := plugin.NewClient(&plugin.ClientConfig{
+		HandshakeConfig: handshakeConfigForName(cfg.Name),
+		Plugins: map[string]plugin.Plugin{
+			pluginName: &signerPlugin{},
+		},
+		Cmd:      cmd,
+		Logger:   nullLogger,
+		Managed:  true,
+		AutoMTLS: true,
+	})
+
+	// Despite what is said above, we can at least clean up if things go
+	// wrong as part of the initialization process.
+	ok = false
+	defer func() {
+		if !ok {
+			client.Kill()
+		}
+	}()
+
+	rpcClient, err := client.Client()
+	if err != nil {
+		return nil, fmt.Errorf("signature/signer/plugin: failed to connect to plugin: %w", err)
+	}
+
+	raw, err := rpcClient.Dispense(pluginName)
+	if err != nil {
+		return nil, fmt.Errorf("signature/signer/plugin: failed to request plugin: %w", err)
+	}
+
+	pluginSigner := raw.(Signer)
+	if err = pluginSigner.Initialize(cfg.Config, roles...); err != nil {
+		return nil, fmt.Errorf("signature/signer/plugin: failed to initialize plugin: %w", err)
+	}
+
+	wf := &wrapperFactory{
+		pluginSigner: pluginSigner,
+		signers:      make(map[signature.SignerRole]*wrapperSigner),
+		name:         cfg.Name,
+	}
+	for _, v := range roles {
+		wf.signers[v] = &wrapperSigner{
+			wf:   wf,
+			role: v,
+		}
+	}
+
+	ok = true
+
+	return wf, nil
+}
+
+type wrapperFactory struct {
+	sync.Mutex
+
+	pluginSigner Signer
+	signers      map[signature.SignerRole]*wrapperSigner
+	name         string
+}
+
+func (wf *wrapperFactory) EnsureRole(role signature.SignerRole) error {
+	wf.Lock()
+	defer wf.Unlock()
+
+	if wf.signers[role] == nil {
+		return signature.ErrRoleMismatch
+	}
+	return nil
+}
+
+func (wf *wrapperFactory) Generate(role signature.SignerRole, _rng io.Reader) (signature.Signer, error) {
+	wf.Lock()
+	defer wf.Unlock()
+
+	wrapper := wf.signers[role]
+	if wrapper == nil {
+		return nil, signature.ErrRoleMismatch
+	}
+
+	if wrapper.publicKey != nil {
+		return nil, fmt.Errorf("signature/signer/plugin: refusing to overwrite existing key")
+	}
+
+	return wrapper.doLoad(true)
+}
+
+func (wf *wrapperFactory) Load(role signature.SignerRole) (signature.Signer, error) {
+	wf.Lock()
+	defer wf.Unlock()
+
+	wrapper := wf.signers[role]
+	if wrapper == nil {
+		return nil, signature.ErrRoleMismatch
+	}
+
+	if wrapper.publicKey != nil {
+		return wrapper, nil
+	}
+
+	return wrapper.doLoad(false)
+}
+
+type wrapperSigner struct {
+	wf *wrapperFactory
+
+	publicKey *signature.PublicKey
+	role      signature.SignerRole
+}
+
+func (ws *wrapperSigner) Public() signature.PublicKey {
+	return *ws.publicKey
+}
+
+func (ws *wrapperSigner) ContextSign(context signature.Context, message []byte) ([]byte, error) {
+	// Prepare the context (plugin can't handle chain separation).
+	rawCtx, err := signature.PrepareSignerContext(context)
+	if err != nil {
+		return nil, fmt.Errorf("signature/signer/plugin: failed to prepare context: %w", err)
+	}
+
+	role := ws.role
+	sig, err := ws.wf.pluginSigner.ContextSign(role, signature.Context(rawCtx), message)
+	if err != nil {
+		return nil, fmt.Errorf("signature/signer/plugin: failed to sign: %w", err)
+	}
+
+	return sig, nil
+}
+
+func (ws *wrapperSigner) String() string {
+	return fmt.Sprintf("[%s plugin signer: %s]", ws.wf.name, ws.publicKey)
+}
+
+func (ws *wrapperSigner) Reset() {
+	// Not supported for the plugin signer.
+}
+
+func (ws *wrapperSigner) doLoad(mustGenerate bool) (signature.Signer, error) {
+	role := ws.role
+	if err := ws.wf.pluginSigner.Load(role, mustGenerate); err != nil {
+		return nil, fmt.Errorf("signature/signer/plugin: failed to load/generate key: %w", err)
+	}
+	pk, err := ws.wf.pluginSigner.Public(role)
+	if err != nil {
+		return nil, fmt.Errorf("signature/signer/plugin: failed to obtain public key: %w", err)
+	}
+
+	// Cache the public key for easy re-use and to indicate that this
+	// signer is fully initialized.
+	ws.publicKey = &pk
+
+	return ws, nil
+}
+
+type signerPlugin struct {
+	impl Signer
+}
+
+func (p *signerPlugin) Server(_broker *plugin.MuxBroker) (interface{}, error) {
+	return &rpcServer{
+		impl: p.impl,
+	}, nil
+}
+
+func (signerPlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+	return &rpcClient{
+		client: c,
+	}, nil
 }

--- a/go/common/crypto/signature/signers/plugin/rpc.go
+++ b/go/common/crypto/signature/signers/plugin/rpc.go
@@ -1,0 +1,104 @@
+package plugin
+
+import (
+	"net/rpc"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+)
+
+var _ Signer = (*rpcClient)(nil)
+
+type rpcServer struct {
+	impl Signer
+}
+
+// RPCInitArgs is exposed entirely to placate `net/rpc`.
+type RPCInitArgs struct {
+	Config string
+	Roles  []signature.SignerRole
+}
+
+// RPCLoadArgs is exposed entirely to placate `net/rpc`.
+type RPCLoadArgs struct {
+	Role         signature.SignerRole
+	MustGenerate bool
+}
+
+// RPCContextSignArgs is exposed entirely to placate `net/rpc`.
+type RPCContextSignArgs struct {
+	Role       signature.SignerRole
+	RawContext signature.Context
+	Message    []byte
+}
+
+func (m *rpcServer) Initialize(args *RPCInitArgs, resp *interface{}) error {
+	return m.impl.Initialize(args.Config, args.Roles...)
+}
+
+func (m *rpcServer) Load(args *RPCLoadArgs, resp *interface{}) error {
+	return m.impl.Load(args.Role, args.MustGenerate)
+}
+
+func (m *rpcServer) Public(role signature.SignerRole, resp *signature.PublicKey) error {
+	pk, err := m.impl.Public(role)
+	*resp = pk
+	return err
+}
+
+func (m *rpcServer) ContextSign(args *RPCContextSignArgs, resp *[]byte) error {
+	sig, err := m.impl.ContextSign(args.Role, args.RawContext, args.Message)
+	*resp = sig
+	return err
+}
+
+type rpcClient struct {
+	client *rpc.Client
+}
+
+func (m *rpcClient) Initialize(config string, roles ...signature.SignerRole) error {
+	var resp interface{}
+	return m.client.Call(
+		"Plugin.Initialize",
+		&RPCInitArgs{
+			Config: config,
+			Roles:  roles,
+		},
+		&resp,
+	)
+}
+
+func (m *rpcClient) Load(role signature.SignerRole, mustGenerate bool) error {
+	var resp interface{}
+	return m.client.Call(
+		"Plugin.Load",
+		&RPCLoadArgs{
+			Role:         role,
+			MustGenerate: mustGenerate,
+		},
+		&resp,
+	)
+}
+
+func (m *rpcClient) Public(role signature.SignerRole) (signature.PublicKey, error) {
+	var resp signature.PublicKey
+	err := m.client.Call(
+		"Plugin.Public",
+		role,
+		&resp,
+	)
+	return resp, err
+}
+
+func (m *rpcClient) ContextSign(role signature.SignerRole, rawContext signature.Context, message []byte) ([]byte, error) {
+	var resp []byte
+	err := m.client.Call(
+		"Plugin.ContextSign",
+		&RPCContextSignArgs{
+			Role:       role,
+			RawContext: rawContext,
+			Message:    message,
+		},
+		&resp,
+	)
+	return resp, err
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -26,7 +26,9 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/golang/snappy v0.0.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+	github.com/hashicorp/go-hclog v0.14.1
 	github.com/hashicorp/go-multierror v1.0.0
+	github.com/hashicorp/go-plugin v1.3.0
 	github.com/hpcloud/tail v1.0.0
 	github.com/ipfs/go-log/v2 v2.1.1 // indirect
 	github.com/libp2p/go-libp2p v0.9.6

--- a/go/go.sum
+++ b/go/go.sum
@@ -198,6 +198,7 @@ github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojt
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
 github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 h1:E2s37DuLxFhQDg5gKsWoLBOB0n+ZW8s599zru8FJ2/Y=
 github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
@@ -261,6 +262,7 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
+github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
@@ -332,10 +334,15 @@ github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyN
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
+github.com/hashicorp/go-hclog v0.14.1 h1:nQcJDQwIAGnmoUWp8ubocEX40cCml/17YkF6csQLReU=
+github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-plugin v1.3.0 h1:4d/wJojzvHV1I4i/rrjVaeuyxWrLzDE1mDCyDy8fXS8=
+github.com/hashicorp/go-plugin v1.3.0/go.mod h1:F9eH4LrE/ZsRdbwhfjs9k9HoDUwAHnYtXdgmf1AVNs0=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
@@ -353,6 +360,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
+github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
@@ -422,6 +431,8 @@ github.com/jbenet/goprocess v0.1.4/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZl
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
+github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U=
 github.com/jmhodges/levigo v1.0.0/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
@@ -661,9 +672,14 @@ github.com/marten-seemann/qtls v0.9.1 h1:O0YKQxNVPaiFgMng0suWEOY2Sb4LT2sRn9Qimq3
 github.com/marten-seemann/qtls v0.9.1/go.mod h1:T1MmAdDPyISzxlK6kjRr0pcZFBVd1OZbBb/j3cvzHhk=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
+github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -688,6 +704,8 @@ github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
+github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
@@ -785,6 +803,7 @@ github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661/go.mod h1:S
 github.com/oasisprotocol/tendermint v0.33.6-oasis1 h1:mqX0cHEFO26RsJXND7bPNCo7nUGQ4ENx+omkXBS9NVk=
 github.com/oasisprotocol/tendermint v0.33.6-oasis1/go.mod h1:fMjshkHOy5okumxJQPvvz9PG3QD0F8dfiqWf1SBHsw4=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
+github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
@@ -1114,6 +1133,7 @@ golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCc
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1194,6 +1214,7 @@ golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
@@ -1267,6 +1288,7 @@ google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
+google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20181029155118-b69ba1387ce2/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
@@ -1283,6 +1305,7 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
 google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a h1:Ob5/580gVHBJZgXnff1cZDbG+xLtMVE5mDRTe+nIsX4=
 google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
+google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
@@ -1299,6 +1322,7 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.0 h1:rRYRFMVgRv6E0D70Skyfsr28tDXIuuPZyWGMPdMcnXg=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.28.1 h1:C1QC6KzgSiLyBabDi87BbjaGreoRgGUF5nOyvfrAZ1k=
 google.golang.org/grpc v1.28.1/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=

--- a/go/oasis-node/cmd/common/signer/signer.go
+++ b/go/oasis-node/cmd/common/signer/signer.go
@@ -36,6 +36,7 @@ const (
 
 	cfgSignerCompositeBackends = "signer.composite.backends"
 
+	cfgSignerPluginName   = "signer.plugin.name"
 	cfgSignerPluginPath   = "signer.plugin.path"
 	cfgSignerPluginConfig = "signer.plugin.config"
 )
@@ -114,6 +115,7 @@ func doNewFactory(signerBackend, signerDir string, roles ...signature.SignerRole
 		return remoteSigner.NewFactory(config, roles...)
 	case pluginSigner.SignerName:
 		config := &pluginSigner.FactoryConfig{
+			Name:   viper.GetString(cfgSignerPluginName),
 			Path:   viper.GetString(cfgSignerPluginPath),
 			Config: viper.GetString(cfgSignerPluginConfig),
 		}
@@ -172,7 +174,8 @@ func init() {
 	Flags.String(cfgSignerRemoteClientKey, "", "remote signer client certificate key path")
 	Flags.String(cfgSignerRemoteServerCert, "", "remote signer server certificate path")
 	Flags.String(cfgSignerCompositeBackends, "", "composite signer backends")
-	Flags.String(cfgSignerPluginPath, "", "plugin signer DSO path")
+	Flags.String(cfgSignerPluginName, "", "plugin signer backend name")
+	Flags.String(cfgSignerPluginPath, "", "plugin signer binary path")
 	Flags.String(cfgSignerPluginConfig, "", "plugin signer configuration")
 
 	_ = viper.BindPFlags(Flags)

--- a/go/oasis-node/main.go
+++ b/go/oasis-node/main.go
@@ -2,9 +2,14 @@
 package main
 
 import (
+	"github.com/hashicorp/go-plugin"
+
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd"
 )
 
 func main() {
+	// If we use go-plugin, we are supposed to clean clients up.
+	defer plugin.CleanupClients()
+
 	cmd.Execute()
 }

--- a/go/oasis-remote-signer/main.go
+++ b/go/oasis-remote-signer/main.go
@@ -2,9 +2,14 @@
 package main
 
 import (
+	"github.com/hashicorp/go-plugin"
+
 	"github.com/oasisprotocol/oasis-core/go/oasis-remote-signer/cmd"
 )
 
 func main() {
+	// If we use go-plugin, we are supposed to clean clients up.
+	defer plugin.CleanupClients()
+
 	cmd.Execute()
 }

--- a/go/oasis-test-runner/scenario/pluginsigner/basic.go
+++ b/go/oasis-test-runner/scenario/pluginsigner/basic.go
@@ -32,10 +32,12 @@ func (sc *basicImpl) Clone() scenario.Scenario {
 
 func (sc *basicImpl) Run(childEnv *env.Env) error {
 	// Initialize the plugin signer.
+	pluginName, _ := sc.flags.GetString(cfgPluginName)
 	pluginBinary, _ := sc.flags.GetString(cfgPluginBinary)
 	pluginConfig, _ := sc.flags.GetString(cfgPluginConfig)
 	sf, err := pluginSigner.NewFactory(
 		&pluginSigner.FactoryConfig{
+			Name:   pluginName,
 			Path:   pluginBinary,
 			Config: pluginConfig,
 		},

--- a/go/oasis-test-runner/scenario/pluginsigner/example_signer_plugin/main.go
+++ b/go/oasis-test-runner/scenario/pluginsigner/example_signer_plugin/main.go
@@ -1,58 +1,71 @@
-// Package main implements an example oasis-node signer plugin, leveraging
-// the Go runtime library's DSO plugin support.
+// Package main implements an example oasis-node signer plugin.
 package main
 
 import (
+	"crypto/rand"
 	"fmt"
-	"io"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
+	pluginSigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/plugin"
 )
 
-// GetPluginCtor is the plugin's entry point.
-func GetPluginCtor() signature.SignerFactoryCtor {
-	return newPluginFactory
-}
-
-func newPluginFactory(config interface{}, roles ...signature.SignerRole) (signature.SignerFactory, error) {
-	return &exampleFactory{
-		roles: roles,
-		inner: make(map[signature.SignerRole]signature.Signer),
-	}, nil
-}
-
-type exampleFactory struct {
+type examplePlugin struct {
 	roles []signature.SignerRole
 	inner map[signature.SignerRole]signature.Signer
 }
 
-func (fac *exampleFactory) EnsureRole(role signature.SignerRole) error {
-	for _, v := range fac.roles {
-		if v == role {
-			return nil
+func (pl *examplePlugin) Initialize(config string, roles ...signature.SignerRole) error {
+	// A real plugin will probably want to check to see if it has
+	// already been initialized.
+
+	pl.roles = roles
+	pl.inner = make(map[signature.SignerRole]signature.Signer)
+
+	return nil
+}
+
+func (pl *examplePlugin) Load(role signature.SignerRole, mustGenerate bool) error {
+	if signer := pl.inner[role]; signer != nil {
+		if mustGenerate {
+			return fmt.Errorf("example: key already exists")
 		}
+		return nil
 	}
-	return signature.ErrRoleMismatch
-}
-
-func (fac *exampleFactory) Generate(role signature.SignerRole, rng io.Reader) (signature.Signer, error) {
-	if fac.inner[role] != nil {
-		return nil, fmt.Errorf("example: key already exists")
+	if !mustGenerate {
+		return signature.ErrNotExist
 	}
 
-	signer, err := memorySigner.NewSigner(rng)
+	signer, err := memorySigner.NewSigner(rand.Reader)
 	if err != nil {
-		return nil, fmt.Errorf("example: failed to generate key: %w", err)
+		return fmt.Errorf("example: failed to generate key: %w", err)
 	}
 
-	fac.inner[role] = signer
-	return signer, nil
+	pl.inner[role] = signer
+
+	return nil
 }
 
-func (fac *exampleFactory) Load(role signature.SignerRole) (signature.Signer, error) {
-	if signer := fac.inner[role]; signer != nil {
-		return signer, nil
+func (pl *examplePlugin) Public(role signature.SignerRole) (signature.PublicKey, error) {
+	signer := pl.inner[role]
+	if signer == nil {
+		return signature.PublicKey{}, signature.ErrNotExist
 	}
-	return nil, signature.ErrNotExist
+	return signer.Public(), nil
+}
+
+func (pl *examplePlugin) ContextSign(role signature.SignerRole, rawContext signature.Context, message []byte) ([]byte, error) {
+	signer, ok := pl.inner[role]
+	if !ok {
+		return nil, signature.ErrNotExist
+	}
+	return signer.ContextSign(rawContext, message)
+}
+
+func main() {
+	// Signer plugins use raw contexts.
+	signature.UnsafeAllowUnregisteredContexts()
+
+	var impl examplePlugin
+	pluginSigner.Serve("example", &impl)
 }

--- a/go/oasis-test-runner/scenario/pluginsigner/pluginsigner.go
+++ b/go/oasis-test-runner/scenario/pluginsigner/pluginsigner.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	cfgPluginName   = "name"
 	cfgPluginBinary = "binary"
 	cfgPluginConfig = "config"
 )
@@ -36,7 +37,8 @@ func newPluginSignerImpl(name string) *pluginSignerImpl {
 		logger: logging.GetLogger("scenario/" + fullName),
 		flags:  env.NewParameterFlagSet(fullName, flag.ContinueOnError),
 	}
-	sc.flags.String(cfgPluginBinary, "signer-plugin.so", "plugin binary")
+	sc.flags.String(cfgPluginName, "test-signer-plugin", "plugin name")
+	sc.flags.String(cfgPluginBinary, "signer-plugin", "plugin binary")
 	sc.flags.String(cfgPluginConfig, "", "plugin configuration")
 
 	return sc

--- a/go/oasis-test-runner/test-runner.go
+++ b/go/oasis-test-runner/test-runner.go
@@ -2,6 +2,8 @@
 package main
 
 import (
+	"github.com/hashicorp/go-plugin"
+
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/cmd"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario/e2e"
@@ -11,6 +13,9 @@ import (
 )
 
 func main() {
+	// If we use go-plugin, we are supposed to clean clients up.
+	defer plugin.CleanupClients()
+
 	// The general idea is that it should be possible to reuse everything
 	// except for the main() function  and specialized test cases to write
 	// test drivers that need to exercise the Oasis network or things built


### PR DESCRIPTION
The Go runtime library's `plugin` is a steaming pile of shit.  Switch
to something that lets people write plugins that live in a separate
module, that import sub-packages from the module that is loading the
plugin.