### PR TITLE
go/consensus: Add SubmitTxNoWait method

### DIFF
--- a/.changelog/3152.feature.md
+++ b/.changelog/3152.feature.md
@@ -1,0 +1,4 @@
+go/consensus: Add SubmitTxNoWait method
+
+The new method allows submitting a transaction without waiting for it to be
+included in a block.

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -87,7 +87,8 @@ type ClientBackend interface {
 	LightClientBackend
 	TransactionAuthHandler
 
-	// SubmitTx submits a signed consensus transaction.
+	// SubmitTx submits a signed consensus transaction and waits for the transaction to be included
+	// in a block. Use SubmitTxNoWait if you only need to broadcast the transaction.
 	SubmitTx(ctx context.Context, tx *transaction.SignedTransaction) error
 
 	// StateToGenesis returns the genesis state at the specified block height.

--- a/go/consensus/api/base.go
+++ b/go/consensus/api/base.go
@@ -198,3 +198,8 @@ func (b *BaseBackend) GetParameters(ctx context.Context, height int64) (*Paramet
 func (b *BaseBackend) State() syncer.ReadSyncer {
 	panic(ErrUnsupported)
 }
+
+// Implements Backend.
+func (b *BaseBackend) SubmitTxNoWait(ctx context.Context, tx *transaction.SignedTransaction) error {
+	panic(ErrUnsupported)
+}

--- a/go/consensus/api/light.go
+++ b/go/consensus/api/light.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 
+	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/syncer"
 )
 
@@ -20,6 +21,10 @@ type LightClientBackend interface {
 	// State returns a MKVS read syncer that can be used to read consensus state from a remote node
 	// and verify it against the trusted local root.
 	State() syncer.ReadSyncer
+
+	// SubmitTxNoWait submits a signed consensus transaction, but does not wait for the transaction
+	// to be included in a block. Use SubmitTx if you need to wait for execution.
+	SubmitTxNoWait(ctx context.Context, tx *transaction.SignedTransaction) error
 
 	// TODO: Move SubmitEvidence etc. from Backend.
 }

--- a/go/consensus/tendermint/full/light.go
+++ b/go/consensus/tendermint/full/light.go
@@ -8,7 +8,9 @@ import (
 	tmrpctypes "github.com/tendermint/tendermint/rpc/core/types"
 	tmstate "github.com/tendermint/tendermint/state"
 
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	consensusAPI "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/syncer"
 )
 
@@ -78,4 +80,9 @@ func (t *fullService) GetParameters(ctx context.Context, height int64) (*consens
 // Implements LightClientBackend.
 func (t *fullService) State() syncer.ReadSyncer {
 	return t.mux.State().Storage()
+}
+
+// Implements LightClientBackend.
+func (t *fullService) SubmitTxNoWait(ctx context.Context, tx *transaction.SignedTransaction) error {
+	return t.broadcastTxRaw(cbor.Marshal(tx))
 }

--- a/go/consensus/tests/tester.go
+++ b/go/consensus/tests/tester.go
@@ -3,6 +3,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -118,6 +119,16 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.ClientBackend)
 	require.NoError(err, "GetParameters")
 	require.Equal(params.Height, blk.Height, "returned parameters height should be correct")
 	require.NotNil(params.Meta, "returned parameters should contain metadata")
+
+	err = backend.SubmitTxNoWait(ctx, &transaction.SignedTransaction{})
+	require.Error(err, "SubmitTxNoWait should fail with invalid transaction")
+
+	testTx := transaction.NewTransaction(0, nil, epochtimemock.MethodSetEpoch, epoch)
+	testSigner := memorySigner.NewTestSigner(fmt.Sprintf("consensus tests tx signer: %T", backend))
+	testSigTx, err := transaction.Sign(testSigner, testTx)
+	require.NoError(err, "transaction.Sign")
+	err = backend.SubmitTxNoWait(ctx, testSigTx)
+	require.NoError(err, "SubmitTxNoWait")
 
 	// We should be able to do remote state queries. Of course the state format is backend-specific
 	// so we simply perform some usual storage operations like fetching random keys and iterating


### PR DESCRIPTION
Fixes #3152 

The new method allows submitting a transaction without waiting for it to be
included in a block.