### PR TITLE
go/registry: Require SGX for non-test keymanager runtimes

### DIFF
--- a/.changelog/3146.breaking.md
+++ b/.changelog/3146.breaking.md
@@ -1,0 +1,4 @@
+go/registry: Require SGX for non-test keymanager runtimes
+
+Note: Existing deployments might need to alter the state dump to fix any
+existing keymanager runtimes that registered without SGX hardware.

--- a/go/consensus/tendermint/apps/registry/transactions.go
+++ b/go/consensus/tendermint/apps/registry/transactions.go
@@ -540,20 +540,6 @@ func (app *registryApplication) registerRuntime( // nolint: gocyclo
 		return registry.ErrIncorrectTxSigner
 	}
 
-	// If TEE is required, check if runtime provided at least one enclave ID.
-	if rt.TEEHardware != node.TEEHardwareInvalid {
-		switch rt.TEEHardware {
-		case node.TEEHardwareIntelSGX:
-			var vi registry.VersionInfoIntelSGX
-			if err = cbor.Unmarshal(rt.Version.TEE, &vi); err != nil {
-				return err
-			}
-			if len(vi.Enclaves) == 0 {
-				return registry.ErrNoEnclaveForRuntime
-			}
-		}
-	}
-
 	// Make sure the runtime doesn't exist yet.
 	var suspended bool
 	existingRt, err := state.Runtime(ctx, rt.ID)

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/entity"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+	"github.com/oasisprotocol/oasis-core/go/common/sgx"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/genesis"
 	tendermint "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
 	epochtime "github.com/oasisprotocol/oasis-core/go/epochtime/api"
@@ -170,10 +171,16 @@ func TestGenesisSanityCheck(t *testing.T) {
 
 	kmRuntimeID := hex2ns("4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff", false)
 	testKMRuntime := &registry.Runtime{
-		Versioned: cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
-		ID:        kmRuntimeID,
-		EntityID:  testEntity.ID,
-		Kind:      registry.KindKeyManager,
+		Versioned:   cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+		ID:          kmRuntimeID,
+		EntityID:    testEntity.ID,
+		Kind:        registry.KindKeyManager,
+		TEEHardware: node.TEEHardwareIntelSGX,
+		Version: registry.VersionInfo{
+			TEE: cbor.Marshal(registry.VersionInfoIntelSGX{
+				Enclaves: []sgx.EnclaveIdentity{{}},
+			}),
+		},
 		AdmissionPolicy: registry.RuntimeAdmissionPolicy{
 			EntityWhitelist: &registry.EntityWhitelistRuntimeAdmissionPolicy{
 				Entities: map[signature.PublicKey]bool{


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/3146