### PR TITLE
go/oasis-node/cmd: Show Genesis document's hash when displaying transactions

### DIFF
--- a/.changelog/2871.feature.md
+++ b/.changelog/2871.feature.md
@@ -1,0 +1,5 @@
+go/oasis-node/cmd: Show Genesis document's hash when displaying transactions
+
+Show Genesis document's hash when generating staking transactions with
+`oasis-node stake account gen_*` CLI commands and when showing transactions'
+pretty prints with the `oasis-node consensus show_tx` CLI command.

--- a/.changelog/3157.feature.md
+++ b/.changelog/3157.feature.md
@@ -1,0 +1,1 @@
+go/consensus/api/transaction: Add `PrettyPrintBody()` to `Transaction` type

--- a/go/common/prettyprint/context.go
+++ b/go/common/prettyprint/context.go
@@ -1,0 +1,7 @@
+package prettyprint
+
+// ContextKeyGenesisHash is the key to retrieve the Genesis document's hash
+// value from a context.
+var ContextKeyGenesisHash = contextKey("genesis/hash")
+
+type contextKey string

--- a/go/consensus/api/transaction/transaction.go
+++ b/go/consensus/api/transaction/transaction.go
@@ -90,6 +90,11 @@ func (t Transaction) PrettyPrint(ctx context.Context, prefix string, w io.Writer
 	fmt.Fprintf(w, "%sMethod: %s\n", prefix, t.Method)
 	fmt.Fprintf(w, "%sBody:\n", prefix)
 	t.PrettyPrintBody(ctx, prefix+"  ", w)
+
+	if genesisHash, ok := ctx.Value(prettyprint.ContextKeyGenesisHash).(hash.Hash); ok {
+		fmt.Println("Other info:")
+		fmt.Printf("  Genesis document's hash: %s\n", genesisHash)
+	}
 }
 
 // PrettyType returns a representation of the type that can be used for pretty printing.

--- a/go/oasis-node/cmd/consensus/consensus.go
+++ b/go/oasis-node/cmd/consensus/consensus.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
@@ -138,6 +139,7 @@ func doShowTx(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, staking.PrettyPrinterContextKeyTokenSymbol, genesis.Staking.TokenSymbol)
 	ctx = context.WithValue(ctx, staking.PrettyPrinterContextKeyTokenValueExponent, genesis.Staking.TokenValueExponent)
+	ctx = context.WithValue(ctx, prettyprint.ContextKeyGenesisHash, genesis.Hash())
 
 	sigTx := loadTx()
 	sigTx.PrettyPrint(ctx, "", os.Stdout)

--- a/go/oasis-node/cmd/stake/account.go
+++ b/go/oasis-node/cmd/stake/account.go
@@ -10,6 +10,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
 	genesisAPI "github.com/oasisprotocol/oasis-core/go/genesis/api"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	cmdConsensus "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/consensus"
@@ -93,12 +94,13 @@ var (
 	}
 )
 
-// getCtxWithTokenInfo returns a new context with values that contain token
-// information (ticker symbol, value base-10 exponent).
-func getCtxWithTokenInfo(genesis *genesisAPI.Document) context.Context {
+// getCtxWithInfo returns a new context with values that contain additional
+// information (ticker symbol, value base-10 exponent, genesis document's hash).
+func getCtxWithInfo(genesis *genesisAPI.Document) context.Context {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, staking.PrettyPrinterContextKeyTokenSymbol, genesis.Staking.TokenSymbol)
 	ctx = context.WithValue(ctx, staking.PrettyPrinterContextKeyTokenValueExponent, genesis.Staking.TokenValueExponent)
+	ctx = context.WithValue(ctx, prettyprint.ContextKeyGenesisHash, genesis.Hash())
 	return ctx
 }
 
@@ -152,7 +154,7 @@ func doAccountTransfer(cmd *cobra.Command, args []string) {
 	nonce, fee := cmdConsensus.GetTxNonceAndFee()
 	tx := staking.NewTransferTx(nonce, fee, &xfer)
 
-	cmdConsensus.SignAndSaveTx(getCtxWithTokenInfo(genesis), tx)
+	cmdConsensus.SignAndSaveTx(getCtxWithInfo(genesis), tx)
 }
 
 func doAccountBurn(cmd *cobra.Command, args []string) {
@@ -174,7 +176,7 @@ func doAccountBurn(cmd *cobra.Command, args []string) {
 	nonce, fee := cmdConsensus.GetTxNonceAndFee()
 	tx := staking.NewBurnTx(nonce, fee, &burn)
 
-	cmdConsensus.SignAndSaveTx(getCtxWithTokenInfo(genesis), tx)
+	cmdConsensus.SignAndSaveTx(getCtxWithInfo(genesis), tx)
 }
 
 func doAccountEscrow(cmd *cobra.Command, args []string) {
@@ -202,7 +204,7 @@ func doAccountEscrow(cmd *cobra.Command, args []string) {
 	nonce, fee := cmdConsensus.GetTxNonceAndFee()
 	tx := staking.NewAddEscrowTx(nonce, fee, &escrow)
 
-	cmdConsensus.SignAndSaveTx(getCtxWithTokenInfo(genesis), tx)
+	cmdConsensus.SignAndSaveTx(getCtxWithInfo(genesis), tx)
 }
 
 func doAccountReclaimEscrow(cmd *cobra.Command, args []string) {
@@ -230,7 +232,7 @@ func doAccountReclaimEscrow(cmd *cobra.Command, args []string) {
 	nonce, fee := cmdConsensus.GetTxNonceAndFee()
 	tx := staking.NewReclaimEscrowTx(nonce, fee, &reclaim)
 
-	cmdConsensus.SignAndSaveTx(getCtxWithTokenInfo(genesis), tx)
+	cmdConsensus.SignAndSaveTx(getCtxWithInfo(genesis), tx)
 }
 
 func scanRateStep(dst *staking.CommissionRateStep, raw string) error {
@@ -308,7 +310,7 @@ func doAccountAmendCommissionSchedule(cmd *cobra.Command, args []string) {
 	nonce, fee := cmdConsensus.GetTxNonceAndFee()
 	tx := staking.NewAmendCommissionScheduleTx(nonce, fee, &amendCommissionSchedule)
 
-	cmdConsensus.SignAndSaveTx(getCtxWithTokenInfo(genesis), tx)
+	cmdConsensus.SignAndSaveTx(getCtxWithInfo(genesis), tx)
 }
 
 func registerAccountCmd() {


### PR DESCRIPTION
Show Genesis document's hash when generating staking transactions with `oasis-node stake account gen_*` CLI commands, e.g.:

```
You are about to sign the following transaction:
  Nonce:  1
  Fee:    2000 (gas limit: 1000, gas price: 2)
  Method: staking.AddEscrow
  Body:
    Account: oasis1qpl4axynedmdrrgrg7dpw3yxc4a8crevr5dkuksl
    Amount:  AMBER 208.0
Other info:
  Genesis document's hash: 0b9ddeaa80431ff3718f928e654e4b64cbd3f956d69d64e9c923e30766706a11

You may need to review the transaction on your device if you use a hardware-based signer plugin...
```

And when showing transactions' pretty prints with the `oasis-node consensus show_tx` CLI command, e.g.:

```
Hash: 144bf255028a13ec03c2c19879658a97de44e32adb9750690ac2579a4df81518
Signer: l+cuboPsOeuY1+kYlROrpmKgiiELmXSw9xl0WEg8cWE=
        (signature: e1Zp1ttZRlBYDGBb1hBNx4wWydn7hp/tvYpBbVLUeOP7Fqn/vQm2NL1kWbgVWVbr4QaUAWhnP/MhwfI5DpmGBg==)
Content:
  Nonce:  1
  Fee:    2000 (gas limit: 1000, gas price: 2)
  Method: staking.AddEscrow
  Body:
    Account: oasis1qpl4axynedmdrrgrg7dpw3yxc4a8crevr5dkuksl
    Amount:  DOCS 208.0
Other info:
  Genesis document's hash: 0b9ddeaa80431ff3718f928e654e4b64cbd3f956d69d64e9c923e30766706a11
```

Closes (partially) #2871.