### PR TITLE
go/registry/runtimes: Add AllowedComputeRuntimes to keymanager runtimes

### DIFF
--- a/.changelog/3145.breaking.md
+++ b/.changelog/3145.breaking.md
@@ -1,0 +1,7 @@
+go/registry/runtimes: Add AllowedComputeRuntimes to keymanager runtimes
+
+Keymanager runtimes now need to specify compute runtime IDs that are allowed
+to use it as a key manager. By default, no runtimes are allowed.
+
+NOTE: Keymanager runtimes exported from existing deployments will default to
+not allowing any compute runtimes, so exported state might need to be altered.

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -169,6 +169,8 @@ func TestGenesisSanityCheck(t *testing.T) {
 	}
 	signedTestEntity := signEntityOrDie(signer, testEntity)
 
+	testRuntimeID := hex2ns("0000000000000000000000000000000000000000000000000000000000000001", false)
+
 	kmRuntimeID := hex2ns("4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff", false)
 	testKMRuntime := &registry.Runtime{
 		Versioned:   cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
@@ -188,10 +190,14 @@ func TestGenesisSanityCheck(t *testing.T) {
 				},
 			},
 		},
+		KeyManagerParameters: registry.KeyManagerParameters{
+			AllowedComputeRuntimes: map[common.Namespace]bool{
+				testRuntimeID: true,
+			},
+		},
 	}
 	signedTestKMRuntime := signRuntimeOrDie(signer, testKMRuntime)
 
-	testRuntimeID := hex2ns("0000000000000000000000000000000000000000000000000000000000000001", false)
 	testRuntime := &registry.Runtime{
 		Versioned:  cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
 		ID:         testRuntimeID,

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -71,6 +71,11 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 				AdmissionPolicy: registry.RuntimeAdmissionPolicy{
 					AnyNode: &registry.AnyNodeRuntimeAdmissionPolicy{},
 				},
+				KeyManagerParameters: registry.KeyManagerParameters{
+					AllowedComputeRuntimes: map[common.Namespace]bool{
+						runtimeID: true,
+					},
+				},
 			},
 			// Compute runtime.
 			{

--- a/go/oasis-test-runner/oasis/cli/registry.go
+++ b/go/oasis-test-runner/oasis/cli/registry.go
@@ -99,6 +99,12 @@ func (r *RegistryHelpers) runRegistryRuntimeSubcommand(
 		return fmt.Errorf("invalid admission policy")
 	}
 
+	for rtID := range runtime.KeyManagerParameters.AllowedComputeRuntimes {
+		args = append(args,
+			"--"+cmdRegRt.CfgKeyManagerAllowedComputeRuntimes, rtID.String(),
+		)
+	}
+
 	for kind, value := range runtime.Staking.Thresholds {
 		kindRaw, _ := kind.MarshalText()
 		valueRaw, _ := value.MarshalText()

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -197,10 +197,11 @@ type RuntimeFixture struct { // nolint: maligned
 	GenesisStatePath string           `json:"genesis_state_path,omitempty"`
 	GenesisRound     uint64           `json:"genesis_round,omitempty"`
 
-	Executor     registry.ExecutorParameters     `json:"executor"`
-	Merge        registry.MergeParameters        `json:"merge"`
-	TxnScheduler registry.TxnSchedulerParameters `json:"txn_scheduler"`
-	Storage      registry.StorageParameters      `json:"storage"`
+	Executor             registry.ExecutorParameters     `json:"executor"`
+	Merge                registry.MergeParameters        `json:"merge"`
+	TxnScheduler         registry.TxnSchedulerParameters `json:"txn_scheduler"`
+	Storage              registry.StorageParameters      `json:"storage"`
+	KeyManagerParameters registry.KeyManagerParameters   `json:"key_manager_parameters"`
 
 	AdmissionPolicy registry.RuntimeAdmissionPolicy   `json:"admission_policy"`
 	Staking         registry.RuntimeStakingParameters `json:"staking,omitempty"`
@@ -230,24 +231,25 @@ func (f *RuntimeFixture) Create(netFixture *NetworkFixture, net *Network) (*Runt
 	}
 
 	return net.NewRuntime(&RuntimeCfg{
-		ID:                 f.ID,
-		Kind:               f.Kind,
-		Entity:             entity,
-		Keymanager:         km,
-		TEEHardware:        netFixture.TEE.Hardware,
-		MrSigner:           netFixture.TEE.MrSigner,
-		Executor:           f.Executor,
-		Merge:              f.Merge,
-		TxnScheduler:       f.TxnScheduler,
-		Storage:            f.Storage,
-		AdmissionPolicy:    f.AdmissionPolicy,
-		Staking:            f.Staking,
-		Binaries:           f.Binaries,
-		GenesisState:       f.GenesisState,
-		GenesisStatePath:   f.GenesisStatePath,
-		GenesisRound:       f.GenesisRound,
-		Pruner:             f.Pruner,
-		ExcludeFromGenesis: f.ExcludeFromGenesis,
+		ID:                   f.ID,
+		Kind:                 f.Kind,
+		Entity:               entity,
+		Keymanager:           km,
+		TEEHardware:          netFixture.TEE.Hardware,
+		MrSigner:             netFixture.TEE.MrSigner,
+		Executor:             f.Executor,
+		Merge:                f.Merge,
+		TxnScheduler:         f.TxnScheduler,
+		Storage:              f.Storage,
+		KeyManagerParameters: f.KeyManagerParameters,
+		AdmissionPolicy:      f.AdmissionPolicy,
+		Staking:              f.Staking,
+		Binaries:             f.Binaries,
+		GenesisState:         f.GenesisState,
+		GenesisStatePath:     f.GenesisStatePath,
+		GenesisRound:         f.GenesisRound,
+		Pruner:               f.Pruner,
+		ExcludeFromGenesis:   f.ExcludeFromGenesis,
 	})
 }
 

--- a/go/oasis-test-runner/oasis/runtime.go
+++ b/go/oasis-test-runner/oasis/runtime.go
@@ -57,10 +57,11 @@ type RuntimeCfg struct { // nolint: maligned
 	GenesisStatePath string
 	GenesisRound     uint64
 
-	Executor     registry.ExecutorParameters
-	Merge        registry.MergeParameters
-	TxnScheduler registry.TxnSchedulerParameters
-	Storage      registry.StorageParameters
+	Executor             registry.ExecutorParameters
+	Merge                registry.MergeParameters
+	TxnScheduler         registry.TxnSchedulerParameters
+	Storage              registry.StorageParameters
+	KeyManagerParameters registry.KeyManagerParameters
 
 	AdmissionPolicy registry.RuntimeAdmissionPolicy
 	Staking         registry.RuntimeStakingParameters
@@ -122,17 +123,18 @@ func (rt *Runtime) GetGenesisStatePath() string {
 // NewRuntime provisions a new runtime and adds it to the network.
 func (net *Network) NewRuntime(cfg *RuntimeCfg) (*Runtime, error) {
 	descriptor := registry.Runtime{
-		Versioned:       cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
-		ID:              cfg.ID,
-		EntityID:        cfg.Entity.entity.ID,
-		Kind:            cfg.Kind,
-		TEEHardware:     cfg.TEEHardware,
-		Executor:        cfg.Executor,
-		Merge:           cfg.Merge,
-		TxnScheduler:    cfg.TxnScheduler,
-		Storage:         cfg.Storage,
-		AdmissionPolicy: cfg.AdmissionPolicy,
-		Staking:         cfg.Staking,
+		Versioned:            cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+		ID:                   cfg.ID,
+		EntityID:             cfg.Entity.entity.ID,
+		Kind:                 cfg.Kind,
+		TEEHardware:          cfg.TEEHardware,
+		Executor:             cfg.Executor,
+		Merge:                cfg.Merge,
+		TxnScheduler:         cfg.TxnScheduler,
+		Storage:              cfg.Storage,
+		KeyManagerParameters: cfg.KeyManagerParameters,
+		AdmissionPolicy:      cfg.AdmissionPolicy,
+		Staking:              cfg.Staking,
 	}
 
 	rtDir, err := net.baseDir.NewSubDir("runtime-" + cfg.ID.String())

--- a/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
@@ -118,12 +118,16 @@ func (sc *multipleRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
 		f.Runtimes = append(f.Runtimes, newRtFixture)
 	}
 
+	kmRuntime := f.Runtimes[0]
 	var computeRuntimes []int
 	for id, rt := range f.Runtimes {
 		if rt.Kind == registry.KindCompute {
 			computeRuntimes = append(computeRuntimes, id)
+			kmRuntime.KeyManagerParameters.AllowedComputeRuntimes[rt.ID] = true
 		}
 	}
+	// Update keymanager runtime.
+	f.Runtimes[0] = kmRuntime
 	// Use numComputeWorkers compute worker fixtures.
 	numComputeWorkers, _ := sc.Flags.GetInt(cfgNumComputeWorkers)
 	f.ComputeWorkers = []oasis.ComputeWorkerFixture{}

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -150,6 +150,11 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 					AnyNode: &registry.AnyNodeRuntimeAdmissionPolicy{},
 				},
 				Binaries: []string{keyManagerBinary},
+				KeyManagerParameters: registry.KeyManagerParameters{
+					AllowedComputeRuntimes: map[common.Namespace]bool{
+						runtimeID: true,
+					},
+				},
 			},
 			// Compute runtime.
 			{

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -1247,6 +1247,15 @@ func VerifyRegisterComputeRuntimeArgs(ctx context.Context, logger *logging.Logge
 			)
 			return ErrInvalidArgument
 		}
+
+		// Key manager runtime should allow this runtime.
+		if _, ok := km.KeyManagerParameters.AllowedComputeRuntimes[rt.ID]; !ok {
+			logger.Error("RegisterRuntime: runtime not in provided key manager allowlist",
+				"runtime", rt.ID,
+				"key_manager", km.ID,
+			)
+			return ErrInvalidArgument
+		}
 	}
 
 	return nil

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -208,6 +208,13 @@ func (s *RuntimeStakingParameters) ValidateBasic(runtimeKind RuntimeKind) error 
 	return nil
 }
 
+// KeyManagerParameters are the parameters specific to key manager runtimes.
+type KeyManagerParameters struct {
+	// AllowedComputeRuntimes sets which compute runtimes are allowed to
+	// register with this key manager runtime.
+	AllowedComputeRuntimes map[common.Namespace]bool `json:"allowed_compute_runtimes"`
+}
+
 const (
 	// LatestRuntimeDescriptorVersion is the latest entity descriptor version that should be used
 	// for all new descriptors. Using earlier versions may be rejected.
@@ -255,6 +262,9 @@ type Runtime struct { // nolint: maligned
 
 	// Storage stores parameters of the storage committee.
 	Storage StorageParameters `json:"storage,omitempty"`
+
+	// KeyManager parameters stores paratemers specific to keymanager runtime.
+	KeyManagerParameters KeyManagerParameters `json:"key_manager_parameters,omitempty"`
 
 	// AdmissionPolicy sets which nodes are allowed to register for this runtime.
 	// This policy applies to all roles.

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -680,6 +680,12 @@ func testRegistryRuntime(t *testing.T, backend api.Backend, consensus consensusA
 			"KeyManager",
 			func(rt *api.Runtime) {
 				rt.Kind = api.KindKeyManager
+				// Allow compute runtime from the following test case.
+				compRt, rErr := NewTestRuntime([]byte("WithKM"), entity, false)
+				require.NoError(rErr, "NewTestRuntime (%s)", "WithKM")
+				rt.KeyManagerParameters.AllowedComputeRuntimes = map[common.Namespace]bool{
+					compRt.Runtime.ID: true,
+				}
 			},
 			true,
 			true,
@@ -692,6 +698,15 @@ func testRegistryRuntime(t *testing.T, backend api.Backend, consensus consensusA
 			},
 			false,
 			true,
+		},
+		// Runtime with not allowed key manager.
+		{
+			"WithNotAllowedKM",
+			func(rt *api.Runtime) {
+				rt.KeyManager = &rtMapByName["KeyManager"].ID
+			},
+			false,
+			false,
 		},
 		// Runtime with bad key manager.
 		{


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/3145