### PR TITLE
go/storage/mkvs/checkpoint: Remove empty version directories

### DIFF
--- a/.changelog/3160.bugfix.md
+++ b/.changelog/3160.bugfix.md
@@ -1,0 +1,4 @@
+go/storage/mkvs/checkpoint: Remove empty version directories
+
+When all root checkpoints are removed for a specific version, the version dir
+itself should also be removed.

--- a/go/storage/mkvs/checkpoint/checkpoint.go
+++ b/go/storage/mkvs/checkpoint/checkpoint.go
@@ -64,22 +64,10 @@ type Creator interface {
 	CreateCheckpoint(ctx context.Context, root node.Root, chunkSize uint64) (*Metadata, error)
 
 	// GetCheckpoint retrieves checkpoint metadata for a specific checkpoint.
-	GetCheckpoint(ctx context.Context, request *GetCheckpointRequest) (*Metadata, error)
+	GetCheckpoint(ctx context.Context, version uint16, root node.Root) (*Metadata, error)
 
 	// DeleteCheckpoint deletes a specific checkpoint.
-	DeleteCheckpoint(ctx context.Context, request *DeleteCheckpointRequest) error
-}
-
-// GetCheckpointRequest is a GetCheckpoint request.
-type GetCheckpointRequest struct {
-	Version uint16    `json:"version"`
-	Root    node.Root `json:"root"`
-}
-
-// DeleteCheckpointRequest is a DeleteCheckpoint request.
-type DeleteCheckpointRequest struct {
-	Version uint16    `json:"version"`
-	Root    node.Root `json:"root"`
+	DeleteCheckpoint(ctx context.Context, version uint16, root node.Root) error
 }
 
 // Restorer is a checkpoint restorer.

--- a/go/storage/mkvs/checkpoint/checkpoint_test.go
+++ b/go/storage/mkvs/checkpoint/checkpoint_test.go
@@ -235,6 +235,10 @@ func TestFileCheckpointCreator(t *testing.T) {
 	require.NoError(err, "GetCheckpoints")
 	require.Len(cps, 0, "there should be no checkpoints")
 
+	// Make sure there are no empty directories.
+	_, err = os.Stat(filepath.Join(dir, "checkpoints", strconv.FormatUint(root.Version, 10)))
+	require.True(os.IsNotExist(err), "there should be no empty directories after deletion")
+
 	_, err = fc.GetCheckpoint(ctx, &GetCheckpointRequest{Version: 1, Root: root})
 	require.Error(err, "GetCheckpoint should fail with non-existent checkpoint")
 

--- a/go/storage/mkvs/checkpoint/checkpoint_test.go
+++ b/go/storage/mkvs/checkpoint/checkpoint_test.go
@@ -63,7 +63,7 @@ func TestFileCheckpointCreator(t *testing.T) {
 	require.NoError(err, "GetCheckpoints")
 	require.Len(cps, 0)
 
-	_, err = fc.GetCheckpoint(ctx, &GetCheckpointRequest{Root: root})
+	_, err = fc.GetCheckpoint(ctx, 1, root)
 	require.Error(err, "GetCheckpoint should fail with non-existent checkpoint")
 
 	// Create a checkpoint and check that it has been created correctly.
@@ -91,7 +91,7 @@ func TestFileCheckpointCreator(t *testing.T) {
 	require.Len(cps, 1, "there should be one checkpoint")
 	require.Equal(cp, cps[0], "checkpoint returned by GetCheckpoint should be correct")
 
-	gcp, err := fc.GetCheckpoint(ctx, &GetCheckpointRequest{Version: 1, Root: root})
+	gcp, err := fc.GetCheckpoint(ctx, 1, root)
 	require.NoError(err, "GetCheckpoint")
 	require.Equal(cp, gcp)
 
@@ -133,7 +133,7 @@ func TestFileCheckpointCreator(t *testing.T) {
 	require.True(errors.Is(err, ErrNoRestoreInProgress))
 
 	// Generate a bogus manifest which does not verify by corrupting chunk at index 1.
-	bogusCp, err := fc.GetCheckpoint(ctx, &GetCheckpointRequest{Version: 1, Root: root})
+	bogusCp, err := fc.GetCheckpoint(ctx, 1, root)
 	require.NoError(err, "GetCheckpoint")
 	require.Equal(cp, bogusCp)
 
@@ -227,7 +227,7 @@ func TestFileCheckpointCreator(t *testing.T) {
 	}
 
 	// Deleting a checkpoint should work.
-	err = fc.DeleteCheckpoint(ctx, &DeleteCheckpointRequest{Version: 1, Root: root})
+	err = fc.DeleteCheckpoint(ctx, 1, root)
 	require.NoError(err, "DeleteCheckpoint")
 
 	// There should now be no checkpoints.
@@ -239,11 +239,11 @@ func TestFileCheckpointCreator(t *testing.T) {
 	_, err = os.Stat(filepath.Join(dir, "checkpoints", strconv.FormatUint(root.Version, 10)))
 	require.True(os.IsNotExist(err), "there should be no empty directories after deletion")
 
-	_, err = fc.GetCheckpoint(ctx, &GetCheckpointRequest{Version: 1, Root: root})
+	_, err = fc.GetCheckpoint(ctx, 1, root)
 	require.Error(err, "GetCheckpoint should fail with non-existent checkpoint")
 
 	// Deleting a non-existent checkpoint should fail.
-	err = fc.DeleteCheckpoint(ctx, &DeleteCheckpointRequest{Version: 1, Root: root})
+	err = fc.DeleteCheckpoint(ctx, 1, root)
 	require.Error(err, "DeleteCheckpoint on a non-existent checkpoint should fail")
 
 	// Fetching a non-existent chunk should fail.

--- a/go/storage/mkvs/checkpoint/checkpointer.go
+++ b/go/storage/mkvs/checkpoint/checkpointer.go
@@ -109,7 +109,7 @@ func (c *checkpointer) checkpoint(ctx context.Context, version uint64, params *C
 
 		// If there is an error, make sure to remove any created checkpoints.
 		for _, root := range roots {
-			_ = c.creator.DeleteCheckpoint(ctx, &DeleteCheckpointRequest{Version: checkpointVersion, Root: root})
+			_ = c.creator.DeleteCheckpoint(ctx, checkpointVersion, root)
 		}
 	}()
 
@@ -181,10 +181,7 @@ func (c *checkpointer) maybeCheckpoint(ctx context.Context, version uint64, para
 
 		for _, version := range cpVersions[:len(cpVersions)-int(params.NumKept)] {
 			for _, root := range cpsByVersion[version] {
-				if err = c.creator.DeleteCheckpoint(ctx, &DeleteCheckpointRequest{
-					Version: checkpointVersion,
-					Root:    root,
-				}); err != nil {
+				if err = c.creator.DeleteCheckpoint(ctx, checkpointVersion, root); err != nil {
 					c.logger.Warn("failed to garbage collect checkpoint",
 						"root", root,
 						"err", err,

--- a/go/storage/mkvs/checkpoint/checkpointer_test.go
+++ b/go/storage/mkvs/checkpoint/checkpointer_test.go
@@ -1,0 +1,96 @@
+package checkpoint
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs"
+	db "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
+	badgerDb "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/badger"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/node"
+)
+
+const (
+	testCheckInterval = 50 * time.Millisecond
+	testNumKept       = 2
+)
+
+func TestCheckpointer(t *testing.T) {
+	require := require.New(t)
+
+	// Initialize a database.
+	dir, err := ioutil.TempDir("", "mkvs.checkpointer")
+	require.NoError(err, "TempDir")
+	defer os.RemoveAll(dir)
+
+	ndb, err := badgerDb.New(&db.Config{
+		DB:           filepath.Join(dir, "db"),
+		Namespace:    testNs,
+		MaxCacheSize: 16 * 1024 * 1024,
+	})
+	require.NoError(err, "New")
+
+	// Create a file-based checkpoint creator.
+	fc, err := NewFileCreator(filepath.Join(dir, "checkpoints"), ndb)
+	require.NoError(err, "NewFileCreator")
+
+	// Create a checkpointer.
+	ctx := context.Background()
+	cp, err := NewCheckpointer(ctx, ndb, fc, CheckpointerConfig{
+		Name:            "test",
+		Namespace:       testNs,
+		CheckInterval:   testCheckInterval,
+		RootsPerVersion: 1,
+		Parameters: &CreationParameters{
+			Interval:  1,
+			NumKept:   testNumKept,
+			ChunkSize: 16 * 1024,
+		},
+	})
+	require.NoError(err, "NewCheckpointer")
+
+	// Finalize a few rounds.
+	var root node.Root
+	root.Empty()
+	root.Namespace = testNs
+
+	for round := uint64(0); round < 10; round++ {
+		tree := mkvs.NewWithRoot(nil, ndb, root)
+		err = tree.Insert(ctx, []byte(fmt.Sprintf("round %d", round)), []byte(fmt.Sprintf("value %d", round)))
+		require.NoError(err, "Insert")
+
+		_, rootHash, err := tree.Commit(ctx, testNs, round)
+		require.NoError(err, "Commit")
+
+		root.Version = round
+		root.Hash = rootHash
+
+		err = ndb.Finalize(ctx, root.Version, []hash.Hash{root.Hash})
+		require.NoError(err, "Finalize")
+		cp.NotifyNewVersion(round)
+
+		select {
+		case <-cp.(*checkpointer).statusCh:
+		case <-time.After(2 * testCheckInterval):
+			t.Fatalf("failed to wait for checkpointer to checkpoint")
+		}
+
+		// Make sure that there are always the correct number of checkpoints.
+		if round > testNumKept+1 {
+			cps, err := fc.GetCheckpoints(ctx, &GetCheckpointsRequest{
+				Version:   checkpointVersion,
+				Namespace: testNs,
+			})
+			require.NoError(err, "GetCheckpoints")
+			require.Len(cps, testNumKept+1, "incorrect number of live checkpoints")
+		}
+	}
+}

--- a/go/storage/mkvs/checkpoint/file.go
+++ b/go/storage/mkvs/checkpoint/file.go
@@ -170,7 +170,8 @@ func (fc *fileCreator) DeleteCheckpoint(ctx context.Context, version uint16, roo
 
 	versionDir := filepath.Join(fc.dataDir, strconv.FormatUint(root.Version, 10))
 	checkpointDir := filepath.Join(versionDir, root.Hash.String())
-	if _, err := os.Stat(checkpointDir); err != nil {
+	checkpointFilename := filepath.Join(checkpointDir, checkpointMetadataFile)
+	if err := os.Remove(checkpointFilename); err != nil {
 		return ErrCheckpointNotFound
 	}
 


### PR DESCRIPTION
When all root checkpoints are removed for a specific version, the version dir
itself should also be removed.