### PR TITLE
go/registry/metrics: Runtimes metrics: query for runtimes

### DIFF
--- a/.changelog/3161.bugfix.md
+++ b/.changelog/3161.bugfix.md
@@ -1,0 +1,5 @@
+go/registry/metrics: Fix `oasis_registry_runtimes` metric
+
+Metric was counting runtime events, which does not correctly take into account
+the case where runtime is suspended and resumed.
+The metric is now computed by querying the registry.

--- a/go/oasis-node/cmd/common/metrics/metrics.go
+++ b/go/oasis-node/cmd/common/metrics/metrics.go
@@ -265,6 +265,11 @@ func New(ctx context.Context) (service.BackgroundService, error) {
 	}
 }
 
+// Enabled returns if metrics are enabled.
+func Enabled() bool {
+	return viper.GetString(CfgMetricsMode) != MetricsModeNone
+}
+
 // EscapeLabelCharacters replaces invalid prometheus label name characters with "_".
 func EscapeLabelCharacters(l string) string {
 	return strings.Replace(l, ".", "_", -1)

--- a/go/runtime/host/protocol/connection.go
+++ b/go/runtime/host/protocol/connection.go
@@ -11,7 +11,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	opentracingExt "github.com/opentracing/opentracing-go/ext"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/spf13/viper"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
@@ -232,7 +231,7 @@ func (c *connection) Call(ctx context.Context, body *Body) (*Body, error) {
 func (c *connection) call(ctx context.Context, body *Body) (result *Body, err error) {
 	start := time.Now()
 	defer func() {
-		if viper.GetString(metrics.CfgMetricsMode) != metrics.MetricsModeNone {
+		if metrics.Enabled() {
 			rhpLatency.With(prometheus.Labels{"call": body.Type()}).Observe(time.Since(start).Seconds())
 			if err != nil {
 				rhpCallFailures.With(prometheus.Labels{"call": body.Type()}).Inc()


### PR DESCRIPTION
Runtime events are also triggered when a runtime is resumed, however we never subtract a runtime being suspended.