### PR TITLE
go/worker/keymanager: Ignore runtimes not in policy document

### DIFF
--- a/.changelog/3162.feature.md
+++ b/.changelog/3162.feature.md
@@ -1,0 +1,1 @@
+go/worker/keymanager: Ignore runtimes not in policy document


### PR DESCRIPTION
Fixes:
>Maybe it would be better to make sure that the key manager worker (not only the enclave) ignores any runtimes which are not in the policy document but are trying to use the key manager? This would make the key manager reject requests one layer earlier.

TODO:
- [ ] ~potentially also implement stopping clientRuntimeWatchers for runtimes that were removed from policy docs~
  - can do in future if needed