### PR TITLE
 Pretty print transaction's gas amount in token units

### DIFF
--- a/.changelog/3151.feature.md
+++ b/.changelog/3151.feature.md
@@ -1,0 +1,1 @@
+go/consensus/api/transaction: Pretty-print transaction's fee amount in tokens

--- a/.changelog/3167.feature.1.md
+++ b/.changelog/3167.feature.1.md
@@ -1,0 +1,1 @@
+go/staking/api/token: Initial implementation

--- a/.changelog/3167.feature.2.md
+++ b/.changelog/3167.feature.2.md
@@ -1,0 +1,1 @@
+go/consensus/api/transaction: Implement `PrettyPrinter` interface for `Fee`

--- a/go/common/prettyprint/context.go
+++ b/go/common/prettyprint/context.go
@@ -1,7 +1,15 @@
 package prettyprint
 
-// ContextKeyGenesisHash is the key to retrieve the Genesis document's hash
-// value from a context.
-var ContextKeyGenesisHash = contextKey("genesis/hash")
+var (
+	// ContextKeyGenesisHash is the key to retrieve the Genesis document's hash
+	// value from a context.
+	ContextKeyGenesisHash = contextKey("genesis/hash")
+	// ContextKeyTokenSymbol is the key to retrieve the token's ticker symbol
+	// value from a context.
+	ContextKeyTokenSymbol = contextKey("staking/token-symbol")
+	// ContextKeyTokenValueExponent is the key to retrieve the token's value
+	// base-10 exponent from a context.
+	ContextKeyTokenValueExponent = contextKey("staking/token-value-exponent")
+)
 
 type contextKey string

--- a/go/consensus/api/transaction/gas.go
+++ b/go/consensus/api/transaction/gas.go
@@ -1,8 +1,14 @@
 package transaction
 
 import (
+	"context"
+	"fmt"
+	"io"
+
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
+	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+	"github.com/oasisprotocol/oasis-core/go/staking/api/token"
 )
 
 var (
@@ -12,6 +18,8 @@ var (
 
 	// ErrGasPriceTooLow is the error returned when the gas price is too low.
 	ErrGasPriceTooLow = errors.New(moduleName, 3, "transaction: gas price too low")
+
+	_ prettyprint.PrettyPrinter = (*Fee)(nil)
 )
 
 // Gas is the consensus gas representation.
@@ -24,6 +32,25 @@ type Fee struct {
 	Amount quantity.Quantity `json:"amount"`
 	// Gas is the maximum gas that a transaction can use.
 	Gas Gas `json:"gas"`
+}
+
+// PrettyPrint writes a pretty-printed representation of the fee to the given
+// writer.
+func (f Fee) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
+	fmt.Fprintf(w, "%sAmount: ", prefix)
+	token.PrettyPrintAmount(ctx, f.Amount, w)
+	fmt.Fprintln(w)
+
+	fmt.Fprintf(w, "%sGas limit: %d\n", prefix, f.Gas)
+	fmt.Fprintf(w, "%s(gas price: ", prefix)
+	token.PrettyPrintAmount(ctx, *f.GasPrice(), w)
+	fmt.Fprintln(w, " per gas unit)")
+}
+
+// PrettyType returns a representation of Fee that can be used for pretty
+// printing.
+func (f Fee) PrettyType() (interface{}, error) {
+	return f, nil
 }
 
 // GasPrice returns the gas price implied by the amount and gas.

--- a/go/consensus/api/transaction/transaction.go
+++ b/go/consensus/api/transaction/transaction.go
@@ -83,7 +83,8 @@ func (t Transaction) PrettyPrintBody(ctx context.Context, prefix string, w io.Wr
 func (t Transaction) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	fmt.Fprintf(w, "%sNonce:  %d\n", prefix, t.Nonce)
 	if t.Fee != nil {
-		fmt.Fprintf(w, "%sFee:    %s (gas limit: %d, gas price: %s)\n", prefix, t.Fee.Amount, t.Fee.Gas, t.Fee.GasPrice())
+		fmt.Fprintf(w, "%sFee:\n", prefix)
+		t.Fee.PrettyPrint(ctx, prefix+"  ", w)
 	} else {
 		fmt.Fprintf(w, "%sFee:   none\n", prefix)
 	}

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -30,6 +30,7 @@ import (
 	roothashAPI "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
+	"github.com/oasisprotocol/oasis-core/go/staking/api/token"
 	stakingTests "github.com/oasisprotocol/oasis-core/go/staking/tests/debug"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
 )
@@ -670,7 +671,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 	d.Staking.TokenSymbol = "foo"
 	require.EqualError(
 		d.SanityCheck(),
-		fmt.Sprintf("staking: sanity check failed: token symbol should match '%s'", staking.TokenSymbolRegexp),
+		fmt.Sprintf("staking: sanity check failed: token symbol should match '%s'", token.TokenSymbolRegexp),
 		"lower case token symbol should be rejected",
 	)
 

--- a/go/oasis-node/cmd/consensus/consensus.go
+++ b/go/oasis-node/cmd/consensus/consensus.go
@@ -21,7 +21,6 @@ import (
 	cmdConsensus "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/consensus"
 	cmdFlags "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	cmdGrpc "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/grpc"
-	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
 const (
@@ -137,8 +136,8 @@ func doShowTx(cmd *cobra.Command, args []string) {
 	genesis := cmdConsensus.InitGenesis()
 
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, staking.PrettyPrinterContextKeyTokenSymbol, genesis.Staking.TokenSymbol)
-	ctx = context.WithValue(ctx, staking.PrettyPrinterContextKeyTokenValueExponent, genesis.Staking.TokenValueExponent)
+	ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenSymbol, genesis.Staking.TokenSymbol)
+	ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenValueExponent, genesis.Staking.TokenValueExponent)
 	ctx = context.WithValue(ctx, prettyprint.ContextKeyGenesisHash, genesis.Hash())
 
 	sigTx := loadTx()

--- a/go/oasis-node/cmd/stake/stake.go
+++ b/go/oasis-node/cmd/stake/stake.go
@@ -15,12 +15,13 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	cmdFlags "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	cmdGrpc "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/grpc"
 	"github.com/oasisprotocol/oasis-core/go/staking/api"
-	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
+	"github.com/oasisprotocol/oasis-core/go/staking/api/token"
 )
 
 // CfgPublicKey configures the public key.
@@ -120,8 +121,8 @@ func doInfo(cmd *cobra.Command, args []string) {
 	exp := getTokenValueExponent(ctx, cmd, client)
 	fmt.Printf("Token's value base-10 exponent: %d\n", exp)
 
-	ctx = context.WithValue(ctx, api.PrettyPrinterContextKeyTokenSymbol, symbol)
-	ctx = context.WithValue(ctx, api.PrettyPrinterContextKeyTokenValueExponent, exp)
+	ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenSymbol, symbol)
+	ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenValueExponent, exp)
 
 	totalSupply, err := client.TotalSupply(ctx, consensus.HeightLatest)
 	if err != nil {
@@ -131,7 +132,7 @@ func doInfo(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	fmt.Print("Total supply: ")
-	api.PrettyPrintAmount(ctx, *totalSupply, os.Stdout)
+	token.PrettyPrintAmount(ctx, *totalSupply, os.Stdout)
 	fmt.Println()
 
 	commonPool, err := client.CommonPool(ctx, consensus.HeightLatest)
@@ -142,7 +143,7 @@ func doInfo(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	fmt.Print("Common pool: ")
-	api.PrettyPrintAmount(ctx, *commonPool, os.Stdout)
+	token.PrettyPrintAmount(ctx, *commonPool, os.Stdout)
 	fmt.Println()
 
 	lastBlockFees, err := client.LastBlockFees(ctx, consensus.HeightLatest)
@@ -153,7 +154,7 @@ func doInfo(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	fmt.Print("Last block fees: ")
-	api.PrettyPrintAmount(ctx, *lastBlockFees, os.Stdout)
+	token.PrettyPrintAmount(ctx, *lastBlockFees, os.Stdout)
 	fmt.Println()
 
 	thresholdsToQuery := []api.ThresholdKind{
@@ -178,7 +179,7 @@ func doInfo(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 		fmt.Printf("Staking threshold (%s): ", kind)
-		api.PrettyPrintAmount(ctx, *thres, os.Stdout)
+		token.PrettyPrintAmount(ctx, *thres, os.Stdout)
 		fmt.Println()
 	}
 }
@@ -238,7 +239,7 @@ func doPubkey2Address(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	fmt.Printf("%v\n", staking.NewAddress(pk))
+	fmt.Printf("%v\n", api.NewAddress(pk))
 }
 
 // Register registers the stake sub-command and all of it's children.

--- a/go/oasis-test-runner/scenario/e2e/stake_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/stake_cli.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/entity"
+	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	genesisTestHelpers "github.com/oasisprotocol/oasis-core/go/genesis/tests"
@@ -96,12 +97,12 @@ func contextWithTokenInfo() context.Context {
 	ctx := context.Background()
 	ctx = context.WithValue(
 		ctx,
-		api.PrettyPrinterContextKeyTokenSymbol,
+		prettyprint.ContextKeyTokenSymbol,
 		genesisTestHelpers.TestStakingTokenSymbol,
 	)
 	ctx = context.WithValue(
 		ctx,
-		api.PrettyPrinterContextKeyTokenValueExponent,
+		prettyprint.ContextKeyTokenValueExponent,
 		genesisTestHelpers.TestStakingTokenValueExponent,
 	)
 	return ctx

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	epochtime "github.com/oasisprotocol/oasis-core/go/epochtime/api"
+	"github.com/oasisprotocol/oasis-core/go/staking/api/token"
 )
 
 const (
@@ -23,13 +24,6 @@ const (
 	// LogEventGeneralAdjustment is a log event value that signals adjustment
 	// of an account's general balance due to a roothash message.
 	LogEventGeneralAdjustment = "staking/general_adjustment"
-
-	// Maximum length of the token symbol.
-	TokenSymbolMaxLength = 8
-	// Regular expression defining valid token symbol characters.
-	TokenSymbolRegexp = "^[A-Z]+$" // nolint: gosec // Not that kind of token :).
-	// Maximum value of token's value base-10 exponent.
-	TokenValueExponentMaxValue = 20
 )
 
 var (
@@ -67,10 +61,6 @@ var (
 	// ErrInvalidThreshold is the error returned when an invalid threshold kind
 	// is specified in a query.
 	ErrInvalidThreshold = errors.New(ModuleName, 6, "staking: invalid threshold")
-
-	// ErrInvalidTokenValueExponent is the error returned when an invalid
-	// token's value base-10 exponent is specified.
-	ErrInvalidTokenValueExponent = errors.New(ModuleName, 7, "staking: invalid token's value exponent")
 
 	// MethodTransfer is the method name for transfers.
 	MethodTransfer = transaction.NewMethodName(ModuleName, "Transfer", Transfer{})
@@ -249,7 +239,7 @@ func (t Transfer) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	fmt.Fprintf(w, "%sTo:     %s\n", prefix, t.To)
 
 	fmt.Fprintf(w, "%sAmount: ", prefix)
-	PrettyPrintAmount(ctx, t.Amount, w)
+	token.PrettyPrintAmount(ctx, t.Amount, w)
 	fmt.Fprintln(w)
 }
 
@@ -273,7 +263,7 @@ type Burn struct {
 // writer.
 func (b Burn) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	fmt.Fprintf(w, "%sAmount: ", prefix)
-	PrettyPrintAmount(ctx, b.Amount, w)
+	token.PrettyPrintAmount(ctx, b.Amount, w)
 	fmt.Fprintln(w)
 }
 
@@ -300,7 +290,7 @@ func (e Escrow) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	fmt.Fprintf(w, "%sAccount: %s\n", prefix, e.Account)
 
 	fmt.Fprintf(w, "%sAmount:  ", prefix)
-	PrettyPrintAmount(ctx, e.Amount, w)
+	token.PrettyPrintAmount(ctx, e.Amount, w)
 	fmt.Fprintln(w)
 }
 
@@ -374,7 +364,7 @@ type SharePool struct {
 // writer.
 func (p SharePool) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	fmt.Fprintf(w, "%sBalance:      ", prefix)
-	PrettyPrintAmount(ctx, p.Balance, w)
+	token.PrettyPrintAmount(ctx, p.Balance, w)
 	fmt.Fprintln(w)
 
 	fmt.Fprintf(w, "%sTotal Shares: %s\n", prefix, p.TotalShares)
@@ -729,7 +719,7 @@ type GeneralAccount struct {
 // given writer.
 func (ga GeneralAccount) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
 	fmt.Fprintf(w, "%sBalance: ", prefix)
-	PrettyPrintAmount(ctx, ga.Balance, w)
+	token.PrettyPrintAmount(ctx, ga.Balance, w)
 	fmt.Fprintln(w)
 
 	fmt.Fprintf(w, "%sNonce:   %d\n", prefix, ga.Nonce)

--- a/go/staking/api/prettyprint.go
+++ b/go/staking/api/prettyprint.go
@@ -1,69 +1,11 @@
 package api
 
 import (
-	"context"
 	"fmt"
-	"io"
 
 	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 )
-
-var (
-	// PrettyPrinterContextKeyTokenSymbol is the key to retrieve the token's
-	// ticker symbol value from a context.
-	PrettyPrinterContextKeyTokenSymbol = contextKey("staking/token-symbol")
-	// PrettyPrinterContextKeyTokenValueExponent is the key to retrieve the
-	// token's value base-10 exponent from a context.
-	PrettyPrinterContextKeyTokenValueExponent = contextKey("staking/token-value-exponent")
-)
-
-type contextKey string
-
-// ConvertToTokenAmount returns the given amount in base units to the
-// corresponding token amount accourding to the given token's value base-10
-// exponent.
-func ConvertToTokenAmount(amount quantity.Quantity, tokenValueExponent uint8) (string, error) {
-	if tokenValueExponent > TokenValueExponentMaxValue {
-		return "", ErrInvalidTokenValueExponent
-	}
-
-	return prettyprint.QuantityFrac(amount, tokenValueExponent), nil
-}
-
-// PrettyPrintAmount writes a pretty-printed representation of the given amount
-// to the given writer.
-//
-// If the context carries appropriate values for the token's ticker symbol and
-// token's value base-10 exponent, then the amount is printed in tokens instead
-// of base units.
-func PrettyPrintAmount(ctx context.Context, amount quantity.Quantity, w io.Writer) {
-	useBaseUnits := false
-
-	symbol, ok := ctx.Value(PrettyPrinterContextKeyTokenSymbol).(string)
-	if !ok || symbol == "" || len(symbol) > TokenSymbolMaxLength {
-		useBaseUnits = true
-	}
-	exp, ok := ctx.Value(PrettyPrinterContextKeyTokenValueExponent).(uint8)
-	if !ok {
-		useBaseUnits = true
-	}
-
-	var tokenAmount string
-	var err error
-	if !useBaseUnits {
-		tokenAmount, err = ConvertToTokenAmount(amount, exp)
-		if err != nil {
-			useBaseUnits = true
-		}
-	}
-
-	if useBaseUnits {
-		fmt.Fprintf(w, "%s base units", amount)
-	} else {
-		fmt.Fprintf(w, "%s %s", symbol, tokenAmount)
-	}
-}
 
 // PrettyPrintCommissionRatePercentage returns the string representing the
 // commission rate (bound) in percentage for the given commission rate (bound)

--- a/go/staking/api/prettyprint_test.go
+++ b/go/staking/api/prettyprint_test.go
@@ -1,94 +1,12 @@
 package api
 
 import (
-	"bytes"
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 )
-
-func TestConvertToTokenAmount(t *testing.T) {
-	require := require.New(t)
-
-	for _, t := range []struct {
-		expectedTokenAmount string
-		amount              *quantity.Quantity
-		exp                 uint8
-		valid               bool
-	}{
-		// General checks where 1 tokens equals 10^9 base units.
-		{"10000000000.0", quantity.NewFromUint64(10000000000000000000), 9, true},
-		{"100.0", quantity.NewFromUint64(100000000000), 9, true},
-		{"7999217230.11968289", quantity.NewFromUint64(7999217230119682890), 9, true},
-		{"7999217230.1196", quantity.NewFromUint64(7999217230119600000), 9, true},
-		{"7999217230.1", quantity.NewFromUint64(7999217230100000000), 9, true},
-		{"0.0", quantity.NewFromUint64(0), 9, true},
-		// Check for a too large token's value base-10 exponent.
-		{"INVALID", quantity.NewFromUint64(10000000000000000001), 21, false},
-		// Special checks for large and small token's value base-10 exponents.
-		{"10.0", quantity.NewFromUint64(10000000000000000000), 18, true},
-		{"10.000000000000000001", quantity.NewFromUint64(10000000000000000001), 18, true},
-		{"0.0000001", quantity.NewFromUint64(100000000000), 18, true},
-		{"0.0", quantity.NewFromUint64(0), 18, true},
-		{"10000000000000000000.0", quantity.NewFromUint64(10000000000000000000), 0, true},
-		{"10000000000000000001.0", quantity.NewFromUint64(10000000000000000001), 0, true},
-		{"0.0", quantity.NewFromUint64(0), 0, true},
-	} {
-		tokenAmount, err := ConvertToTokenAmount(*t.amount, t.exp)
-		if !t.valid {
-			require.Error(err, "converting base unit amount to tokens should fail")
-			continue
-		}
-		require.NoError(err, "converting base unit amount to tokens shouldn't fail")
-		require.Equal(t.expectedTokenAmount, tokenAmount,
-			"converting base unit amount to tokens didn't return the expected amount")
-	}
-}
-
-func TestPrettyPrintAmount(t *testing.T) {
-	require := require.New(t)
-
-	for _, t := range []struct { // nolint: maligned
-		expectedPrettyPrint string
-		amount              *quantity.Quantity
-		addSymbol           bool
-		symbol              string
-		addExp              bool
-		exp                 uint8
-	}{
-		{"CORE 10000000000.0", quantity.NewFromUint64(10000000000000000000), true, "CORE", true, 9},
-		{"CORE 100.0", quantity.NewFromUint64(100000000000), true, "CORE", true, 9},
-		{"CORE 7999217230.1196", quantity.NewFromUint64(7999217230119600000), true, "CORE", true, 9},
-		{"CORE 0.0", quantity.NewFromUint64(0), true, "CORE", true, 9},
-		// Check large and small token's value base-10 exponents.
-		{"BIG 10.0", quantity.NewFromUint64(10000000000000000000), true, "BIG", true, 18},
-		{"SMALL 10000000000000000001.0", quantity.NewFromUint64(10000000000000000001), true, "SMALL", true, 0},
-		// Check invalid token's value base-10 exponent.
-		{"100000000 base units", quantity.NewFromUint64(100000000), true, "TOOBIG", true, 21},
-		// Check invalid token's ticker symbol.
-		{"100000 base units", quantity.NewFromUint64(100000), true, "SOMETHINGLONG", true, 6},
-		{"100000 base units", quantity.NewFromUint64(100000), true, "", true, 6},
-		// Check missing combinations of token's symbol and value exponent.
-		{"100000 base units", quantity.NewFromUint64(100000), false, "MISSING", true, 6},
-		{"100000 base units", quantity.NewFromUint64(100000), true, "NOEXP", false, 0},
-		{"100000 base units", quantity.NewFromUint64(100000), false, "MISSING", false, 0},
-	} {
-		ctx := context.Background()
-		if t.addSymbol {
-			ctx = context.WithValue(ctx, PrettyPrinterContextKeyTokenSymbol, t.symbol)
-		}
-		if t.addExp {
-			ctx = context.WithValue(ctx, PrettyPrinterContextKeyTokenValueExponent, t.exp)
-		}
-		var actualPrettyPrint bytes.Buffer
-		PrettyPrintAmount(ctx, *t.amount, &actualPrettyPrint)
-		require.Equal(t.expectedPrettyPrint, actualPrettyPrint.String(),
-			"pretty printing stake amount didn't return the expected result")
-	}
-}
 
 func TestPrettyPrintCommissionRatePercentage(t *testing.T) {
 	require := require.New(t)

--- a/go/staking/api/sanity_check.go
+++ b/go/staking/api/sanity_check.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	epochtime "github.com/oasisprotocol/oasis-core/go/epochtime/api"
+	"github.com/oasisprotocol/oasis-core/go/staking/api/token"
 )
 
 // SanityCheck performs a sanity check on the consensus parameters.
@@ -233,15 +234,15 @@ func (g *Genesis) SanityCheck(now epochtime.EpochTime) error { // nolint: gocycl
 	if tokenSymbolLength == 0 {
 		return fmt.Errorf("staking: sanity check failed: token symbol is empty")
 	}
-	if tokenSymbolLength > TokenSymbolMaxLength {
+	if tokenSymbolLength > token.TokenSymbolMaxLength {
 		return fmt.Errorf("staking: sanity check failed: token symbol exceeds maximum length")
 	}
-	match := regexp.MustCompile(TokenSymbolRegexp).FindString(g.TokenSymbol)
+	match := regexp.MustCompile(token.TokenSymbolRegexp).FindString(g.TokenSymbol)
 	if match == "" {
-		return fmt.Errorf("staking: sanity check failed: token symbol should match '%s'", TokenSymbolRegexp)
+		return fmt.Errorf("staking: sanity check failed: token symbol should match '%s'", token.TokenSymbolRegexp)
 	}
 
-	if g.TokenValueExponent > TokenValueExponentMaxValue {
+	if g.TokenValueExponent > token.TokenValueExponentMaxValue {
 		return fmt.Errorf("staking: sanity check failed: token value exponent is invalid")
 	}
 

--- a/go/staking/api/token/prettyprint.go
+++ b/go/staking/api/token/prettyprint.go
@@ -1,0 +1,55 @@
+package token
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+)
+
+// ConvertToTokenAmount returns the given amount in base units to the
+// corresponding token amount accourding to the given token's value base-10
+// exponent.
+func ConvertToTokenAmount(amount quantity.Quantity, tokenValueExponent uint8) (string, error) {
+	if tokenValueExponent > TokenValueExponentMaxValue {
+		return "", ErrInvalidTokenValueExponent
+	}
+
+	return prettyprint.QuantityFrac(amount, tokenValueExponent), nil
+}
+
+// PrettyPrintAmount writes a pretty-printed representation of the given amount
+// to the given writer.
+//
+// If the context carries appropriate values for the token's ticker symbol and
+// token's value base-10 exponent, then the amount is printed in tokens instead
+// of base units.
+func PrettyPrintAmount(ctx context.Context, amount quantity.Quantity, w io.Writer) {
+	useBaseUnits := false
+
+	symbol, ok := ctx.Value(prettyprint.ContextKeyTokenSymbol).(string)
+	if !ok || symbol == "" || len(symbol) > TokenSymbolMaxLength {
+		useBaseUnits = true
+	}
+	exp, ok := ctx.Value(prettyprint.ContextKeyTokenValueExponent).(uint8)
+	if !ok {
+		useBaseUnits = true
+	}
+
+	var tokenAmount string
+	var err error
+	if !useBaseUnits {
+		tokenAmount, err = ConvertToTokenAmount(amount, exp)
+		if err != nil {
+			useBaseUnits = true
+		}
+	}
+
+	if useBaseUnits {
+		fmt.Fprintf(w, "%s base units", amount)
+	} else {
+		fmt.Fprintf(w, "%s %s", symbol, tokenAmount)
+	}
+}

--- a/go/staking/api/token/prettyprint_test.go
+++ b/go/staking/api/token/prettyprint_test.go
@@ -1,0 +1,92 @@
+package token
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+)
+
+func TestConvertToTokenAmount(t *testing.T) {
+	require := require.New(t)
+
+	for _, t := range []struct {
+		expectedTokenAmount string
+		amount              *quantity.Quantity
+		exp                 uint8
+		valid               bool
+	}{
+		// General checks where 1 tokens equals 10^9 base units.
+		{"10000000000.0", quantity.NewFromUint64(10000000000000000000), 9, true},
+		{"100.0", quantity.NewFromUint64(100000000000), 9, true},
+		{"7999217230.11968289", quantity.NewFromUint64(7999217230119682890), 9, true},
+		{"7999217230.1196", quantity.NewFromUint64(7999217230119600000), 9, true},
+		{"7999217230.1", quantity.NewFromUint64(7999217230100000000), 9, true},
+		{"0.0", quantity.NewFromUint64(0), 9, true},
+		// Check for a too large token's value base-10 exponent.
+		{"INVALID", quantity.NewFromUint64(10000000000000000001), 21, false},
+		// Special checks for large and small token's value base-10 exponents.
+		{"10.0", quantity.NewFromUint64(10000000000000000000), 18, true},
+		{"10.000000000000000001", quantity.NewFromUint64(10000000000000000001), 18, true},
+		{"0.0000001", quantity.NewFromUint64(100000000000), 18, true},
+		{"0.0", quantity.NewFromUint64(0), 18, true},
+		{"10000000000000000000.0", quantity.NewFromUint64(10000000000000000000), 0, true},
+		{"10000000000000000001.0", quantity.NewFromUint64(10000000000000000001), 0, true},
+		{"0.0", quantity.NewFromUint64(0), 0, true},
+	} {
+		tokenAmount, err := ConvertToTokenAmount(*t.amount, t.exp)
+		if !t.valid {
+			require.Error(err, "converting base unit amount to tokens should fail")
+			continue
+		}
+		require.NoError(err, "converting base unit amount to tokens shouldn't fail")
+		require.Equal(t.expectedTokenAmount, tokenAmount,
+			"converting base unit amount to tokens didn't return the expected amount")
+	}
+}
+
+func TestPrettyPrintAmount(t *testing.T) {
+	require := require.New(t)
+
+	for _, t := range []struct { // nolint: maligned
+		expectedPrettyPrint string
+		amount              *quantity.Quantity
+		addSymbol           bool
+		symbol              string
+		addExp              bool
+		exp                 uint8
+	}{
+		{"CORE 10000000000.0", quantity.NewFromUint64(10000000000000000000), true, "CORE", true, 9},
+		{"CORE 100.0", quantity.NewFromUint64(100000000000), true, "CORE", true, 9},
+		{"CORE 7999217230.1196", quantity.NewFromUint64(7999217230119600000), true, "CORE", true, 9},
+		{"CORE 0.0", quantity.NewFromUint64(0), true, "CORE", true, 9},
+		// Check large and small token's value base-10 exponents.
+		{"BIG 10.0", quantity.NewFromUint64(10000000000000000000), true, "BIG", true, 18},
+		{"SMALL 10000000000000000001.0", quantity.NewFromUint64(10000000000000000001), true, "SMALL", true, 0},
+		// Check invalid token's value base-10 exponent.
+		{"100000000 base units", quantity.NewFromUint64(100000000), true, "TOOBIG", true, 21},
+		// Check invalid token's ticker symbol.
+		{"100000 base units", quantity.NewFromUint64(100000), true, "SOMETHINGLONG", true, 6},
+		{"100000 base units", quantity.NewFromUint64(100000), true, "", true, 6},
+		// Check missing combinations of token's symbol and value exponent.
+		{"100000 base units", quantity.NewFromUint64(100000), false, "MISSING", true, 6},
+		{"100000 base units", quantity.NewFromUint64(100000), true, "NOEXP", false, 0},
+		{"100000 base units", quantity.NewFromUint64(100000), false, "MISSING", false, 0},
+	} {
+		ctx := context.Background()
+		if t.addSymbol {
+			ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenSymbol, t.symbol)
+		}
+		if t.addExp {
+			ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenValueExponent, t.exp)
+		}
+		var actualPrettyPrint bytes.Buffer
+		PrettyPrintAmount(ctx, *t.amount, &actualPrettyPrint)
+		require.Equal(t.expectedPrettyPrint, actualPrettyPrint.String(),
+			"pretty printing stake amount didn't return the expected result")
+	}
+}

--- a/go/staking/api/token/token.go
+++ b/go/staking/api/token/token.go
@@ -1,0 +1,20 @@
+// Package token implements the token-related parts of the staking API.
+package token
+
+import "github.com/oasisprotocol/oasis-core/go/common/errors"
+
+const (
+	// ModuleName is a unique module name for the staking/token module.
+	ModuleName = "staking/token"
+
+	// Maximum length of the token symbol.
+	TokenSymbolMaxLength = 8
+	// Regular expression defining valid token symbol characters.
+	TokenSymbolRegexp = "^[A-Z]+$" // nolint: gosec // Not that kind of token :).
+	// Maximum value of token's value base-10 exponent.
+	TokenValueExponentMaxValue = 20
+)
+
+// ErrInvalidTokenValueExponent is the error returned when an invalid token's
+// value base-10 exponent is specified.
+var ErrInvalidTokenValueExponent = errors.New(ModuleName, 1, "staking/token: invalid token's value exponent")


### PR DESCRIPTION
An example of the new output:
```
You are about to sign the following transaction:
  Nonce:  7
  Fee:
    Amount: AMBER 0.000002
    Gas limit: 1000
    (gas price: AMBER 0.000000002 per gas unit)
  Method: staking.Transfer
  Body:
    To:     oasis1qr3jc2yfhszpyy0daha2l9xjlkrxnzas0uaje4t3
    Amount: AMBER 170.0
Other info:
  Genesis document's hash: da80e19432de40911469314ee5aa02ee9ea5e5518b01b0b1eb3a13e526a8e3ca
```

TODO:
- [x] Finish `go/consensus/api/transaction.Fee`'s `PrettyPrint()`.

Closes https://github.com/oasisprotocol/oasis-core/issues/3151.