### PR TITLE
go/consensus: Move SubmitEvidence to LightClientBackend

### DIFF
--- a/.changelog/3169.feature.md
+++ b/.changelog/3169.feature.md
@@ -1,0 +1,3 @@
+go/consensus: Move SubmitEvidence to LightClientBackend
+
+This allows light clients to submit evidence of Byzantine behavior.

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -209,9 +209,6 @@ type ServicesBackend interface {
 	// consensus Halt epoch height is reached.
 	RegisterHaltHook(func(ctx context.Context, blockHeight int64, epoch epochtime.EpochTime))
 
-	// SubmitEvidence submits evidence of misbehavior.
-	SubmitEvidence(ctx context.Context, evidence Evidence) error
-
 	// SubmissionManager returns the transaction submission manager.
 	SubmissionManager() SubmissionManager
 
@@ -243,56 +240,6 @@ type TransactionAuthHandler interface {
 	// GetSignerNonce returns the nonce that should be used by the given
 	// signer for transmitting the next transaction.
 	GetSignerNonce(ctx context.Context, req *GetSignerNonceRequest) (uint64, error)
-}
-
-// EvidenceKind is kind of evindence of a node misbehaving.
-type EvidenceKind int
-
-const (
-	// EvidenceKindConsensus is consensus-layer specific evidence.
-	EvidenceKindConsensus EvidenceKind = 0
-
-	EvidenceKindMax = EvidenceKindConsensus
-)
-
-// String returns a string representation of an EvidenceKind.
-func (k EvidenceKind) String() string {
-	switch k {
-	case EvidenceKindConsensus:
-		return "consensus"
-	default:
-		return "[unknown evidence kind]"
-	}
-}
-
-// Evidence is evidence of a node misbehaving.
-type Evidence interface {
-	// Kind returns the evidence kind.
-	Kind() EvidenceKind
-	// Unwrap returns the unwrapped evidence (if any).
-	Unwrap() interface{}
-}
-
-// ConsensusEvidence is consensus backend-specific evidence.
-type ConsensusEvidence struct {
-	inner interface{}
-}
-
-var _ Evidence = (*ConsensusEvidence)(nil)
-
-// Kind returns the evidence kind.
-func (ce ConsensusEvidence) Kind() EvidenceKind {
-	return EvidenceKindConsensus
-}
-
-// Unwrap returns the unwrapped evidence (if any).
-func (ce ConsensusEvidence) Unwrap() interface{} {
-	return ce.inner
-}
-
-// NewConsensusEvidence creates new consensus backend-specific evidence.
-func NewConsensusEvidence(inner interface{}) ConsensusEvidence {
-	return ConsensusEvidence{inner: inner}
 }
 
 // EstimateGasRequest is a EstimateGas request.

--- a/go/consensus/api/base.go
+++ b/go/consensus/api/base.go
@@ -75,7 +75,7 @@ func (b *BaseBackend) RegisterHaltHook(func(ctx context.Context, blockHeight int
 }
 
 // Implements Backend.
-func (b *BaseBackend) SubmitEvidence(ctx context.Context, evidence Evidence) error {
+func (b *BaseBackend) SubmitEvidence(ctx context.Context, evidence *Evidence) error {
 	panic(ErrUnsupported)
 }
 

--- a/go/consensus/api/light.go
+++ b/go/consensus/api/light.go
@@ -26,7 +26,8 @@ type LightClientBackend interface {
 	// to be included in a block. Use SubmitTx if you need to wait for execution.
 	SubmitTxNoWait(ctx context.Context, tx *transaction.SignedTransaction) error
 
-	// TODO: Move SubmitEvidence etc. from Backend.
+	// SubmitEvidence submits evidence of misbehavior.
+	SubmitEvidence(ctx context.Context, evidence *Evidence) error
 }
 
 // SignedHeader is a signed consensus block header.
@@ -53,4 +54,10 @@ type Parameters struct {
 	Meta []byte `json:"meta"`
 
 	// TODO: Consider also including consensus/genesis.Parameters which are backend-agnostic.
+}
+
+// Evidence is evidence of a node's Byzantine behavior.
+type Evidence struct {
+	// Meta contains the consensus backend specific evidence.
+	Meta []byte `json:"meta"`
 }

--- a/go/consensus/tendermint/tests/evidence.go
+++ b/go/consensus/tendermint/tests/evidence.go
@@ -18,7 +18,7 @@ import (
 )
 
 // MakeDoubleSignEvidence creates consensus evidence of double signing.
-func MakeDoubleSignEvidence(t *testing.T, ident *identity.Identity) consensus.Evidence {
+func MakeDoubleSignEvidence(t *testing.T, ident *identity.Identity) *consensus.Evidence {
 	require := require.New(t)
 
 	// Create empty directory for private validator metadata.
@@ -64,7 +64,13 @@ func MakeDoubleSignEvidence(t *testing.T, ident *identity.Identity) consensus.Ev
 		VoteA: makeVote(pv1, genesisTestHelpers.TestChainID, 0, 1, 2, 1, blockID1, now),
 		VoteB: makeVote(pv2, genesisTestHelpers.TestChainID, 0, 1, 2, 1, blockID2, now),
 	}
-	return consensus.NewConsensusEvidence(ev)
+
+	proto, err := tmtypes.EvidenceToProto(ev)
+	require.NoError(err, "EvidenceToProto")
+	meta, err := proto.Marshal()
+	require.NoError(err, "proto.Marshal")
+
+	return &consensus.Evidence{Meta: meta}
 }
 
 // makeVote copied from Tendermint test suite.

--- a/go/consensus/tests/tester.go
+++ b/go/consensus/tests/tester.go
@@ -130,6 +130,9 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.ClientBackend)
 	err = backend.SubmitTxNoWait(ctx, testSigTx)
 	require.NoError(err, "SubmitTxNoWait")
 
+	err = backend.SubmitEvidence(ctx, &consensus.Evidence{})
+	require.Error(err, "SubmitEvidence should fail with invalid evidence")
+
 	// We should be able to do remote state queries. Of course the state format is backend-specific
 	// so we simply perform some usual storage operations like fetching random keys and iterating
 	// through everything.


### PR DESCRIPTION
Fixes #3169 

This allows light clients to submit evidence of Byzantine behavior.