### PR TITLE
go/consensus/tendermint: Sync state database before discarding versions

### DIFF
--- a/.changelog/3173.bugfix.md
+++ b/.changelog/3173.bugfix.md
@@ -1,0 +1,7 @@
+go/consensus/tendermint: Sync state database before discarding versions
+
+Otherwise a crash can cause the state database to be rolled back to a version
+that has already been discarded from Tendermint's state stores which would
+prevent replay on restart.
+
+Discovered during long-term tests.

--- a/go/consensus/tendermint/abci/prune.go
+++ b/go/consensus/tendermint/abci/prune.go
@@ -170,6 +170,12 @@ func (p *genericPruner) doPrune(ctx context.Context, latestVersion uint64) error
 		}
 	}
 
+	// Make sure to sync the underlying database before updating what can be discarded. Otherwise
+	// things can be pruned and in case of a crash replay will not be possible.
+	if err := p.ndb.Sync(); err != nil {
+		return fmt.Errorf("failed to sync state database: %w", err)
+	}
+
 	// We can discard everything below the earliest version.
 	p.Lock()
 	p.lastRetainedVersion = p.earliestVersion

--- a/go/storage/mkvs/db/api/api.go
+++ b/go/storage/mkvs/db/api/api.go
@@ -112,6 +112,10 @@ type NodeDB interface {
 	// Size returns the size of the database in bytes.
 	Size() (int64, error)
 
+	// Sync syncs the database to disk. This is useful if the NoFsync option is used to explicitly
+	// perform a sync.
+	Sync() error
+
 	// Close closes the database.
 	Close()
 }
@@ -219,6 +223,10 @@ func (d *nopNodeDB) Prune(ctx context.Context, version uint64) error {
 
 func (d *nopNodeDB) Size() (int64, error) {
 	return 0, nil
+}
+
+func (d *nopNodeDB) Sync() error {
+	return nil
 }
 
 func (d *nopNodeDB) Close() {

--- a/go/storage/mkvs/db/badger/badger.go
+++ b/go/storage/mkvs/db/badger/badger.go
@@ -693,6 +693,10 @@ func (d *badgerNodeDB) Size() (int64, error) {
 	return lsm + vlog, nil
 }
 
+func (d *badgerNodeDB) Sync() error {
+	return d.db.Sync()
+}
+
 func (d *badgerNodeDB) Close() {
 	d.closeOnce.Do(func() {
 		d.gc.Close()


### PR DESCRIPTION
Otherwise a crash can cause the state database to be rolled back to a version
that has already been discarded from Tendermint's state stores which would
prevent replay on restart.

Discovered during long-term tests.