### PR TITLE
go/badger: bump to 20.07.0

### DIFF
--- a/.changelog/3182.internal.md
+++ b/.changelog/3182.internal.md
@@ -1,0 +1,1 @@
+go/badger: Bump to 20.07.0

--- a/go/go.mod
+++ b/go/go.mod
@@ -19,7 +19,8 @@ require (
 	github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d // indirect
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 // indirect
 	github.com/cznic/strutil v0.0.0-20181122101858-275e90344537 // indirect
-	github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200802072640-3e067a54e596
+	// https://github.com/dgraph-io/badger/releases/tag/v20.07.0
+	github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200811071800-b22eccb04321
 	github.com/eapache/channels v1.1.0
 	github.com/fxamacker/cbor/v2 v2.2.1-0.20200526031912-58b82b5bfc05
 	github.com/go-kit/kit v0.10.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -142,8 +142,8 @@ github.com/davidlazar/go-crypto v0.0.0-20170701192655-dcfb0a7ac018 h1:6xT9KW8zLC
 github.com/davidlazar/go-crypto v0.0.0-20170701192655-dcfb0a7ac018/go.mod h1:rQYf4tfk5sSwFsnDg3qYaBxSjsD9S8+59vW0dKUgme4=
 github.com/dgraph-io/badger v1.6.1 h1:w9pSFNSdq/JPM1N12Fz/F/bzo993Is1W+Q7HjPzi7yg=
 github.com/dgraph-io/badger v1.6.1/go.mod h1:FRmFw3uxvcpa8zG3Rxs0th+hCLIuaQg8HlNV5bjgnuU=
-github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200802072640-3e067a54e596 h1:wTPbClfpfAewm7+PdANaiThLw0oUWrh6pUG8JMC6xJQ=
-github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200802072640-3e067a54e596/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
+github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200811071800-b22eccb04321 h1:LsR9nZv2ijtDtB7kyQum3KKrae/15LazuOpuHUfAriY=
+github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200811071800-b22eccb04321/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
 github.com/dgraph-io/ristretto v0.0.2 h1:a5WaUrDa0qm0YrAAS1tUykT5El3kt62KNZZeMxQn3po=
 github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de h1:t0UHb5vdojIDUqktM6+xJAfScFBsVpXZmqC9dsgJmeA=


### PR DESCRIPTION
Note: only diff to the commit we were using before is the added changelog.