### PR TITLE
go/genesis: Remove time sanity check

### DIFF
--- a/.changelog/3178.bugfix.md
+++ b/.changelog/3178.bugfix.md
@@ -1,0 +1,6 @@
+go/genesis: Remove time sanity check
+
+Previously the genesis document sanity check rejected genesis documents with
+future timestamps which made it awkward to prepare the node in advance. Since
+the only supported consensus backend (Tendermint) can handle future
+timestamps by delaying the consensus process, allow such genesis documents.

--- a/go/genesis/api/sanity_check.go
+++ b/go/genesis/api/sanity_check.go
@@ -3,7 +3,6 @@ package api
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 )
@@ -12,10 +11,6 @@ import (
 func (d *Document) SanityCheck() error {
 	if d.Height < 0 {
 		return fmt.Errorf("genesis: sanity check failed: height must be >= 0")
-	}
-
-	if d.Time.After(time.Now()) {
-		return fmt.Errorf("genesis: sanity check failed: time of genesis document is in the future")
 	}
 
 	if strings.TrimSpace(d.ChainID) == "" {

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -271,10 +271,6 @@ func TestGenesisSanityCheck(t *testing.T) {
 	require.Error(d.SanityCheck(), "height < 0 should be invalid")
 
 	d = *testDoc
-	d.Time = time.Now().Add(time.Minute * 2)
-	require.Error(d.SanityCheck(), "future time of genesis doc should be invalid")
-
-	d = *testDoc
 	d.ChainID = "   \t"
 	require.Error(d.SanityCheck(), "empty chain ID should be invalid")
 


### PR DESCRIPTION
Fixes #3178 

Previously the genesis document sanity check rejected genesis documents with
future timestamps which made it awkward to prepare the node in advance. Since
the only supported consensus backend (Tendermint) can handle future
timestamps by delaying the consensus process, allow such genesis documents.