### PR TITLE
go/consensus: Add the GetUnconfirmedTransactions method

### DIFF
--- a/.changelog/3187.feature.md
+++ b/.changelog/3187.feature.md
@@ -1,0 +1,5 @@
+go/consensus: Add the GetUnconfirmedTransactions method
+
+The new method allows the caller to query the current set of transactions in
+the mempool (e.g., known transactions which have not yet been included in a
+block).

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -121,6 +121,10 @@ type ClientBackend interface {
 	// height.
 	GetTransactionsWithResults(ctx context.Context, height int64) (*TransactionsWithResults, error)
 
+	// GetUnconfirmedTransactions returns a list of transactions currently in the local node's
+	// mempool. These have not yet been included in a block.
+	GetUnconfirmedTransactions(ctx context.Context) ([][]byte, error)
+
 	// WatchBlocks returns a channel that produces a stream of consensus
 	// blocks as they are being finalized.
 	WatchBlocks(ctx context.Context) (<-chan *Block, pubsub.ClosableSubscription, error)

--- a/go/consensus/api/base.go
+++ b/go/consensus/api/base.go
@@ -160,6 +160,11 @@ func (b *BaseBackend) GetTransactionsWithResults(ctx context.Context, height int
 }
 
 // Implements Backend.
+func (b *BaseBackend) GetUnconfirmedTransactions(ctx context.Context) ([][]byte, error) {
+	panic(ErrUnsupported)
+}
+
+// Implements Backend.
 func (b *BaseBackend) WatchBlocks(ctx context.Context) (<-chan *Block, pubsub.ClosableSubscription, error) {
 	panic(ErrUnsupported)
 }

--- a/go/consensus/api/grpc.go
+++ b/go/consensus/api/grpc.go
@@ -37,6 +37,8 @@ var (
 	methodGetTransactions = serviceName.NewMethod("GetTransactions", int64(0))
 	// methodGetTransactionsWithResults is the GetTransactionsWithResults method.
 	methodGetTransactionsWithResults = serviceName.NewMethod("GetTransactionsWithResults", int64(0))
+	// methodGetUnconfirmedTransactions is the GetUnconfirmedTransactions method.
+	methodGetUnconfirmedTransactions = serviceName.NewMethod("GetUnconfirmedTransactions", nil)
 	// methodGetGenesisDocument is the GetGenesisDocument method.
 	methodGetGenesisDocument = serviceName.NewMethod("GetGenesisDocument", nil)
 	// methodGetStatus is the GetStatus method.
@@ -102,6 +104,10 @@ var (
 			{
 				MethodName: methodGetTransactionsWithResults.ShortName(),
 				Handler:    handlerGetTransactionsWithResults,
+			},
+			{
+				MethodName: methodGetUnconfirmedTransactions.ShortName(),
+				Handler:    handlerGetUnconfirmedTransactions,
 			},
 			{
 				MethodName: methodGetGenesisDocument.ShortName(),
@@ -367,6 +373,25 @@ func handlerGetTransactionsWithResults( // nolint: golint
 		return srv.(ClientBackend).GetTransactionsWithResults(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
+}
+
+func handlerGetUnconfirmedTransactions( // nolint: golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	if interceptor == nil {
+		return srv.(ClientBackend).GetUnconfirmedTransactions(ctx)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodGetUnconfirmedTransactions.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ClientBackend).GetUnconfirmedTransactions(ctx)
+	}
+	return interceptor(ctx, nil, info, handler)
 }
 
 func handlerGetGenesisDocument( // nolint: golint
@@ -775,6 +800,14 @@ func (c *consensusClient) GetTransactionsWithResults(ctx context.Context, height
 		return nil, err
 	}
 	return &rsp, nil
+}
+
+func (c *consensusClient) GetUnconfirmedTransactions(ctx context.Context) ([][]byte, error) {
+	var rsp [][]byte
+	if err := c.conn.Invoke(ctx, methodGetUnconfirmedTransactions.FullName(), nil, &rsp); err != nil {
+		return nil, err
+	}
+	return rsp, nil
 }
 
 func (c *consensusClient) GetGenesisDocument(ctx context.Context) (*genesis.Document, error) {

--- a/go/consensus/tendermint/full/full.go
+++ b/go/consensus/tendermint/full/full.go
@@ -785,6 +785,15 @@ func (t *fullService) GetTransactionsWithResults(ctx context.Context, height int
 	return &txsWithResults, nil
 }
 
+func (t *fullService) GetUnconfirmedTransactions(ctx context.Context) ([][]byte, error) {
+	mempoolTxs := t.node.Mempool().ReapMaxTxs(-1)
+	txs := make([][]byte, 0, len(mempoolTxs))
+	for _, v := range mempoolTxs {
+		txs = append(txs, v[:])
+	}
+	return txs, nil
+}
+
 func (t *fullService) GetStatus(ctx context.Context) (*consensusAPI.Status, error) {
 	status := &consensusAPI.Status{
 		ConsensusVersion: version.ConsensusProtocol.String(),

--- a/go/consensus/tests/tester.go
+++ b/go/consensus/tests/tester.go
@@ -69,6 +69,9 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.ClientBackend)
 		"GetTransactionsWithResults.Results length missmatch",
 	)
 
+	_, err = backend.GetUnconfirmedTransactions(ctx)
+	require.NoError(err, "GetUnconfirmedTransactions")
+
 	blockCh, blockSub, err := backend.WatchBlocks(ctx)
 	require.NoError(err, "WatchBlocks")
 	defer blockSub.Close()


### PR DESCRIPTION
Fixes #3187 

The new method allows the caller to query the current set of transactions in
the mempool (e.g., known transactions which have not yet been included in a
block).