### PR TITLE
go/oasis-test-runner: Fix e2e/consensus-state-sync scenario

### DIFF
--- a/.changelog/3194.internal.md
+++ b/.changelog/3194.internal.md
@@ -1,0 +1,5 @@
+go/oasis-test-runner: Fix e2e/consensus-state-sync scenario
+
+Instead of terminating the validator-to-be-synced immediately and restarting
+it later, do not even start it. Early stopping could result in state that
+prevents proper state sync later.


### PR DESCRIPTION
Instead of terminating the validator-to-be-synced immediately and restarting
it later, do not even start it. Early stopping could result in state that
prevents proper state sync later.