### PR TITLE
go/staking: Remove WatchTransfers/Burns/Escrows in favor of WatchEvents

### DIFF
--- a/.changelog/3080.breaking.md
+++ b/.changelog/3080.breaking.md
@@ -1,0 +1,6 @@
+go/staking: Remove WatchTransfers/Burns/Escrows in favor of WatchEvents
+
+The separate WatchTransfers/Burns/Escrows methods provided less information
+than the more general WatchEvents, namely they were missing the height and tx
+hash. There is no good reason to maintain both as the individual methods can
+be easily replaced with WatchEvents.

--- a/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
+++ b/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
@@ -351,7 +351,7 @@ func (sc *gasFeesImpl) testReclaimEscrow(ctx context.Context, signer signature.S
 			return fmt.Errorf("failed to reclaim escrow: %w", err)
 		}
 
-		ch, sub, err := sc.Net.Controller().Staking.WatchEscrows(ctx)
+		ch, sub, err := sc.Net.Controller().Staking.WatchEvents(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to watch escrows: %w", err)
 		}
@@ -365,7 +365,7 @@ func (sc *gasFeesImpl) testReclaimEscrow(ctx context.Context, signer signature.S
 		for {
 			select {
 			case ev := <-ch:
-				if ev.Reclaim != nil {
+				if ev.Escrow != nil && ev.Escrow.Reclaim != nil {
 					return nil
 				}
 			case <-ctx.Done():

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -137,20 +137,6 @@ type Backend interface {
 	// Paremeters returns the staking consensus parameters.
 	ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error)
 
-	// WatchTransfers returns a channel that produces a stream of TranserEvent
-	// on all balance transfers.
-	WatchTransfers(ctx context.Context) (<-chan *TransferEvent, pubsub.ClosableSubscription, error)
-
-	// WatchBurns returns a channel that produces a stream of BurnEvent when
-	// base units destructed.
-	WatchBurns(ctx context.Context) (<-chan *BurnEvent, pubsub.ClosableSubscription, error)
-
-	// WatchEscrows returns a channel that produces a stream of EscrowEvent
-	// when entities add to their escrow balance, get base units deducted from
-	// their escrow balance, and have their escrow balance released into their
-	// general balance.
-	WatchEscrows(ctx context.Context) (<-chan *EscrowEvent, pubsub.ClosableSubscription, error)
-
 	// GetEvents returns the events at specified block height.
 	GetEvents(ctx context.Context, height int64) ([]*Event, error)
 


### PR DESCRIPTION
Fixes #3080 

The separate WatchTransfers/Burns/Escrows methods provided less information
than the more general WatchEvents, namely they were missing the height and tx
hash. There is no good reason to maintain both as the individual methods can
be easily replaced with WatchEvents.