### PR TITLE
go/common/cbor: Bump fxamacker/cbor to 58b1cf4afc2b

### DIFF
--- a/.changelog/3204.breaking.md
+++ b/.changelog/3204.breaking.md
@@ -1,0 +1,4 @@
+go/common/cbor: Bump fxamacker/cbor to bafca87fa6db
+
+This should result in some smaller payloads as omitempty should work better
+for our use cases now.

--- a/go/common/cbor/versioned.go
+++ b/go/common/cbor/versioned.go
@@ -49,8 +49,7 @@ func NewVersioned(v uint16) Versioned {
 
 func init() {
 	// Use the untrusted decode options, but ignore unknown fields.
-	// FIXME: https://github.com/fxamacker/cbor/issues/240
-	decOptionsVersioned.ExtraReturnErrors = int(cbor.ExtraDecErrorNone)
+	decOptionsVersioned.ExtraReturnErrors = cbor.ExtraDecErrorNone
 
 	var err error
 	if decModeVersioned, err = decOptionsVersioned.DecMode(); err != nil {

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -134,7 +134,7 @@ func TestGenesisChainContext(t *testing.T) {
 	//       on each run.
 	stableDoc.Staking = staking.Genesis{}
 
-	require.Equal(t, "df6289d7d46e98ec8facbd3a9efebee2ad81136200217819b5aeabf08b3431bc", stableDoc.ChainContext())
+	require.Equal(t, "abfb77523d8ce18470143c9b4159ceaf8f1542e7b1cbc15d934e8b21de220378", stableDoc.ChainContext())
 }
 
 func TestGenesisSanityCheck(t *testing.T) {

--- a/go/go.mod
+++ b/go/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/cznic/strutil v0.0.0-20181122101858-275e90344537 // indirect
 	github.com/dgraph-io/badger/v2 v2.2007.1
 	github.com/eapache/channels v1.1.0
-	github.com/fxamacker/cbor/v2 v2.2.1-0.20200526031912-58b82b5bfc05
+	github.com/fxamacker/cbor/v2 v2.2.1-0.20200820021930-bafca87fa6db
 	github.com/go-kit/kit v0.10.0
 	github.com/golang/protobuf v1.4.2
 	github.com/golang/snappy v0.0.1

--- a/go/go.sum
+++ b/go/go.sum
@@ -182,8 +182,8 @@ github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVB
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fxamacker/cbor/v2 v2.2.1-0.20200526031912-58b82b5bfc05 h1:yLgDT1nOw+JVlRVeMPkqzQZUu3Jgz0lN+1PeuS9TCaQ=
-github.com/fxamacker/cbor/v2 v2.2.1-0.20200526031912-58b82b5bfc05/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/fxamacker/cbor/v2 v2.2.1-0.20200820021930-bafca87fa6db h1:JCjUE9xYakEXU8BtIZ2T6z10RJBgYZCC3q9lZhAaTms=
+github.com/fxamacker/cbor/v2 v2.2.1-0.20200820021930-bafca87fa6db/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/glycerine/go-unsnap-stream v0.0.0-20181221182339-f9677308dec2 h1:Ujru1hufTHVb++eG6OuNDKMxZnGIvF6o/u8q/8h2+I4=
 github.com/glycerine/go-unsnap-stream v0.0.0-20181221182339-f9677308dec2/go.mod h1:/20jfyN9Y5QPEAprSgKAUr+glWDY39ZiUEAYOEv5dsE=


### PR DESCRIPTION
This should result in some smaller payloads as omitempty should work better for
our use cases now.