### PR TITLE
docs: Include 'Deploying a Runtime' in index and toc

### DIFF
--- a/.changelog/3207.doc.md
+++ b/.changelog/3207.doc.md
@@ -1,0 +1,1 @@
+docs: Include 'Deploying a Runtime' in index and TOC

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ Oasis Core components.
   * [Running Tests](setup/running-tests.md)
   * [Local Network Runner With a Simple Runtime](setup/oasis-net-runner.md)
   * [Single Validator Node Network](setup/single-validator-node-network.md)
+  * [Deploying a Runtime](setup/deploying-a-runtime.md)
 
 ## High-Level Components
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -12,6 +12,7 @@
   * [Running Tests](setup/running-tests.md)
   * [Local Network Runner With a Simple Runtime](setup/oasis-net-runner.md)
   * [Single Validator Node Network](setup/single-validator-node-network.md)
+  * [Deploying a Runtime](setup/deploying-a-runtime.md)
 
 ## High-Level Components
 


### PR DESCRIPTION
Forgot this in: #3100