### PR TITLE
go/roothash/tester: fix flaky RoundTimeoutWithEpochTransition

### DIFF
--- a/.changelog/3214.internal.md
+++ b/.changelog/3214.internal.md
@@ -1,0 +1,1 @@
+go/roothash/tester: fix flaky RoundTimeoutWithEpochTransition

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -546,8 +546,8 @@ WaitForRoundTimeoutBlocks:
 		case blk := <-ch:
 			header := blk.Block.Header
 
-			// Skip initial round.
-			if header.Round == child.Header.Round {
+			// Skip initial rounds.
+			if header.Round <= child.Header.Round {
 				continue
 			}
 


### PR DESCRIPTION
Extracted from: https://github.com/oasisprotocol/oasis-core/pull/3212