### PR TITLE
go/oasis-node: Omit existing entity check for non-file signers

### DIFF
--- a/.changelog/3215.bugfix.md
+++ b/.changelog/3215.bugfix.md
@@ -1,0 +1,9 @@
+go/oasis-node: Omit existing entity check for non-file signers
+
+The "registry entity init" subcommand previously always performed a check
+whether an entity already exists. It did that by creating an additional
+signer factory to perform this check.
+
+Some signers assign exclusive access to an underlying resource (e.g., HSM) to
+the given factory. In that case, all operations on the second signer factory
+would fail. Thus we now omit the existing entity check for non-file signers.


### PR DESCRIPTION
Fixes #3215 

The "registry entity init" subcommand previously always performed a check
whether an entity already exists. It did that by creating an additional signer
factory to perform this check.

Some signers assign exclusive access to an underlying resource (e.g., HSM) to
the given factory. In that case, all operations on the second signer factory
would fail. Thus we now omit the existing entity check for non-file signers.