### PR TITLE
go: Explicitly use public key pinning for certificate verification

### DIFF
--- a/.changelog/3197.internal.1.md
+++ b/.changelog/3197.internal.1.md
@@ -1,0 +1,9 @@
+go: Explicitly use public key pinning for certificate verification
+
+While we only ever use public key pinning for authenticating TLS connections,
+some places still used the regular TLS config with a single certificate in
+the certificate pool. This causes failures on Go 1.15+ due to CommonName
+checks being deprecated, even if we never used hostnames for authentication.
+
+This changes all cases to use our explicit public key pinning credentials for
+gRPC connections.


### PR DESCRIPTION
See #3197 

While we only ever use public key pinning for authenticating TLS connections,
some places still used the regular TLS config with a single certificate in
the certificate pool. This causes failures on Go 1.15+ due to CommonName
checks being deprecated, even if we never used hostnames for authentication.

This changes all cases to use our explicit public key pinning credentials for
gRPC connections.