### PR TITLE
go/common/crypto/signature: Use descriptive names for Signer roles 

### DIFF
--- a/.changelog/3225.breaking.md
+++ b/.changelog/3225.breaking.md
@@ -1,0 +1,3 @@
+go/common/crypto/signature: Remove `SignerRole.FromString()` method
+
+Use the newly added `SignerRole.UnmarshalText()` method instead.

--- a/.changelog/3225.cfg.md
+++ b/.changelog/3225.cfg.md
@@ -1,0 +1,14 @@
+go/common/crypto/signature: Use descriptive names for Signer roles
+
+The `--signer.composite.backends` CLI flag previously accepted integer-indexed
+Signer roles, e.g:
+
+```
+--signer.composite.backends 1:file,2:file,3:file,4:plugin
+```
+
+Now, it only accepts descriptive string names for Signer roles, e.g.:
+
+```
+--signer.composite.backends entity:file,node:file,p2p:file,consensus:plugin
+```

--- a/.changelog/3225.feature.md
+++ b/.changelog/3225.feature.md
@@ -1,0 +1,8 @@
+go/common/crypto/signature: Add new methods to `SignerRole` type
+
+Add `String()`, `MarshalText()` and `UnmarshalText()` methods to `SignerRole`
+type.
+
+Add `SignerEntityNode`, `SignerNodeName`, `SignerP2PName`,
+`SignerConsensusName` constants that represent the names of the corresponding
+Signer roles.

--- a/go/common/crypto/signature/signer_test.go
+++ b/go/common/crypto/signature/signer_test.go
@@ -111,3 +111,39 @@ func TestBlacklist(t *testing.T) {
 	require.True(pk2.IsBlacklisted(), "test key 2 should be blacklisted")
 	require.False(pk2.IsValid(), "test key 2 should be invalid")
 }
+
+func TestSignerRoles(t *testing.T) {
+	require := require.New(t)
+
+	// Make sure marshaling and unmarshaling works.
+	var unmarshaled SignerRole
+	for _, role := range SignerRoles {
+		text, err := role.MarshalText()
+		require.NoError(err, "marshal SignerRole")
+		err = unmarshaled.UnmarshalText(text)
+		require.NoError(err, "unmarshal previously marshaled SignerRole")
+		require.Equal(role, unmarshaled, "marshal and unmarshal should result in identity")
+	}
+
+	// Make sure invalid roles return appropriate string representation.
+	invalidRoles := []SignerRole{
+		SignerUnknown,
+		SignerRole(5),
+		SignerRole(-1),
+	}
+	for _, role := range invalidRoles {
+		require.Equal("[unknown signer role]", role.String())
+	}
+
+	// Make sure invalid role string representations can't be unmarshaled.
+	invalidRolesStr := []string{
+		SignerUnknown.String(),
+		"foo",
+		"bar",
+	}
+	for _, roleStr := range invalidRolesStr {
+		var role SignerRole
+		err := role.UnmarshalText([]byte(roleStr))
+		require.EqualError(err, "signature: invalid signer role: "+roleStr, "unmarshal invalid SignerRole should error")
+	}
+}

--- a/go/oasis-node/cmd/common/signer/signer.go
+++ b/go/oasis-node/cmd/common/signer/signer.go
@@ -2,6 +2,7 @@
 package signer
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -138,6 +139,13 @@ func doNewComposite(signerDir string, roles ...signature.SignerRole) (signature.
 
 		var role signature.SignerRole
 		if err := role.UnmarshalText([]byte(roleSigner[0])); err != nil {
+			if errors.Is(err, signature.ErrInvalidRole) {
+				var validRoles []string
+				for _, role := range signature.SignerRoles {
+					validRoles = append(validRoles, role.String())
+				}
+				return nil, fmt.Errorf("%w (valid roles are: %s)", err, strings.Join(validRoles, ", "))
+			}
 			return nil, err
 		}
 

--- a/go/oasis-node/cmd/common/signer/signer.go
+++ b/go/oasis-node/cmd/common/signer/signer.go
@@ -137,7 +137,7 @@ func doNewComposite(signerDir string, roles ...signature.SignerRole) (signature.
 		}
 
 		var role signature.SignerRole
-		if err := role.FromString(roleSigner[0]); err != nil {
+		if err := role.UnmarshalText([]byte(roleSigner[0])); err != nil {
 			return nil, err
 		}
 

--- a/go/oasis-node/cmd/common/signer/signer_test.go
+++ b/go/oasis-node/cmd/common/signer/signer_test.go
@@ -21,7 +21,7 @@ func TestCompositeCtor(t *testing.T) {
 	require.NoError(err, "TempDir")
 	defer os.RemoveAll(dataDir)
 
-	viper.Set(cfgSignerCompositeBackends, "2:file,4:memory")
+	viper.Set(cfgSignerCompositeBackends, "node:file,consensus:memory")
 	defer viper.Set(cfgSignerCompositeBackends, "")
 
 	testingAllowMemory = true


### PR DESCRIPTION
The `--signer.composite.backends` CLI flag previously accepted integer-indexed Signer roles, e.g:

```
--signer.composite.backends 1:file,2:file,3:file,4:plugin
```

Now, it only accepts descriptive string names for Signer roles, e.g.:

```
--signer.composite.backends entity:file,node:file,p2p:file,consensus:plugin
```