### PR TITLE
go: Fix CLI tools to not print error messages twice

### DIFF
--- a/.changelog/3230.bugfix.md
+++ b/.changelog/3230.bugfix.md
@@ -1,0 +1,1 @@
+go: Fix CLI tools to not print error messages twice

--- a/go/extra/stats/cmd/root.go
+++ b/go/extra/stats/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
@@ -38,7 +39,7 @@ func Execute() {
 	}
 
 	if err := rootCmd.Execute(); err != nil {
-		common.EarlyLogAndExit(err)
+		os.Exit(1)
 	}
 }
 

--- a/go/oasis-net-runner/cmd/root.go
+++ b/go/oasis-net-runner/cmd/root.go
@@ -57,7 +57,7 @@ func RootCmd() *cobra.Command {
 // Execute spawns the main entry point after handing the config file.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		common.EarlyLogAndExit(err)
+		os.Exit(1)
 	}
 }
 

--- a/go/oasis-node/cmd/root.go
+++ b/go/oasis-node/cmd/root.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"os"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -41,7 +42,7 @@ func Execute() {
 	syscall.Umask(0o077)
 
 	if err := rootCmd.Execute(); err != nil {
-		cmdCommon.EarlyLogAndExit(err)
+		os.Exit(1)
 	}
 }
 

--- a/go/oasis-remote-signer/cmd/root.go
+++ b/go/oasis-remote-signer/cmd/root.go
@@ -62,7 +62,7 @@ var (
 // Execute spawns the main entry point after handling the config file.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		cmdCommon.EarlyLogAndExit(err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Previously, `Execute()` called `nodeCommon.EarlyLogAndExit()` if there was an error running `rootCmd.Execute()` which in turn printed the error to stderr.

The error message is printed to stdout via [github.com/spf13/cobra's `ExecuteC()`](https://github.com/spf13/cobra/blob/a684a6d7f5e37385d954dd3b5a14fc6912c6ab9d/command.go#L959-L963) already, so this resulted in the same error message being printed twice.

This is an expansion of f5f906b3c076290d20ea6cbd298ce548c2000513 which fixed this behavior for `go/oasis-test-runner/cmd`.

Closes #3048.