### PR TITLE
ci/ci-reproducibility: fix output path

### DIFF
--- a/.github/workflows/ci-reproducibility.yml
+++ b/.github/workflows/ci-reproducibility.yml
@@ -90,10 +90,12 @@ jobs:
         uses: actions/download-artifact@v2.0.5
         with:
           name: oasis-node-SHA256SUMs-build1
+          path: oasis-node-SHA256SUMs-build1
       - name: Download checksum for build 2
         uses: actions/download-artifact@v2.0.5
         with:
           name: oasis-node-SHA256SUMs-build2
+          path: oasis-node-SHA256SUMs-build2
       - name: Check if checksums are the same
         shell: bash
         run: |


### PR DESCRIPTION
This matches the behavior from actions/download-artifact@v1 (ref: https://github.com/actions/download-artifact#compatibility-between-v1-and-v2)