### PR TITLE
Bump protocol versions to 1.0.0 in preparation for the Mainnet

### DIFF
--- a/.changelog/3249.breaking.md
+++ b/.changelog/3249.breaking.md
@@ -1,0 +1,9 @@
+Bump protocol versions to 1.0.0 in preparation for the Mainnet
+
+As described in our [Versioning scheme], we will bump the protocol versions
+(Consensus, Runtime Host, Runtime Committee) to version 1.0.0 when preparing
+an Oasis Core release for the Mainnet, which signifies they are ready for
+production use.
+
+[Versioning scheme]:
+  docs/versioning.md#mainnet-and-version-1.0.0

--- a/.changelog/3249.internal.md
+++ b/.changelog/3249.internal.md
@@ -1,0 +1,1 @@
+internal: Document how to include protocol versions in the Change Log

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -95,10 +95,33 @@ make changelog
 Review the staged changes and make appropriate adjustment to the Change Log
 (e.g. re-order entries, make formatting/spelling fixes, ...).
 
-After you are content with the changes, commit them, push them to the origin
-and make a pull request.
+Add a table with protocol versions just below the next version's heading:
+
+```
+| Protocol          | Version   |
+|:------------------|:---------:|
+| Consensus         | <VERSION> |
+| Runtime Host      | <VERSION> |
+| Runtime Committee | <VERSION> |
+```
+
+where `<VERSION>` strings are replaced with appropriate protocol versions as
+defined in [go/common/version/version.go][version-file] file.
+
+For example:
+
+| Protocol          | Version   |
+|:------------------|:---------:|
+| Consensus         | 1.0.0     |
+| Runtime Host      | 1.0.0     |
+| Runtime Committee | 1.0.0     |
+
+After you've made the changes, commit them, push them to the origin and make a
+pull request.
 
 Once the pull request had been reviewed and merged, proceed to the next step.
+
+[version-file]: ../go/common/version/version.go
 
 ### Tag the next release
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -43,7 +43,7 @@ where:
 The `+dirty` part is optional and is only present if there are uncommitted
 changes in the working directory.
 
-## Protocols (Runtime, Consensus, Committee)
+## Protocols (Consensus, Runtime Host, Runtime Committee)
 
 Oasis Core’s protocol versions use [SemVer] (semantic versioning) 2.0.0 with the
 following format:

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -64,11 +64,11 @@ var (
 	// the runtime.
 	//
 	// NOTE: This version must be synced with runtime/src/common/version.rs.
-	RuntimeHostProtocol = Version{Major: 0, Minor: 16, Patch: 0}
+	RuntimeHostProtocol = Version{Major: 1, Minor: 0, Patch: 0}
 
 	// RuntimeCommitteeProtocol versions the P2P protocol used by the runtime
 	// committee members.
-	RuntimeCommitteeProtocol = Version{Major: 0, Minor: 11, Patch: 0}
+	RuntimeCommitteeProtocol = Version{Major: 1, Minor: 0, Patch: 0}
 
 	// ConsensusProtocol versions all data structures and processing used by
 	// the epochtime, beacon, registry, roothash, etc. modules that are
@@ -76,7 +76,7 @@ var (
 	//
 	// NOTE: Any change in the major or minor versions are considered
 	//       breaking changes for the protocol.
-	ConsensusProtocol = Version{Major: 0, Minor: 27, Patch: 0}
+	ConsensusProtocol = Version{Major: 1, Minor: 0, Patch: 0}
 
 	// Tendermint exposes the tendermint core version.
 	Tendermint = parseSemVerStr(version.TMCoreSemVer)

--- a/runtime/src/common/version.rs
+++ b/runtime/src/common/version.rs
@@ -65,7 +65,7 @@ impl From<u64> for Version {
 // and the runtime. This version MUST be compatible with the one supported by
 // the worker host.
 pub const PROTOCOL_VERSION: Version = Version {
-    major: 0,
-    minor: 16,
+    major: 1,
+    minor: 0,
     patch: 0,
 };


### PR DESCRIPTION
Also, document how to include protocol versions in the Change Log.