### PR TITLE
go/worker/common: Use group-synced storage client

### DIFF
--- a/.changelog/3253.bugfix.md
+++ b/.changelog/3253.bugfix.md
@@ -1,0 +1,5 @@
+go/worker/common: Use group-synced storage client
+
+Previously the runtime worker(s) used the common storage client which was not
+synced with any particular committee version. This could cause an executor
+node to use a stale storage node for storing updates.

--- a/.changelog/3253.internal.md
+++ b/.changelog/3253.internal.md
@@ -1,0 +1,1 @@
+go/runtime/committee: Support filtering nodes by tags

--- a/go/storage/api/api.go
+++ b/go/storage/api/api.go
@@ -320,4 +320,8 @@ type ClientBackend interface {
 
 	// GetConnectedNodes returns currently connected storage nodes.
 	GetConnectedNodes() []*node.Node
+
+	// EnsureCommitteeVersion waits for the storage committee client to be fully synced to the
+	// given version.
+	EnsureCommitteeVersion(ctx context.Context, version int64) error
 }

--- a/go/storage/client/client.go
+++ b/go/storage/client/client.go
@@ -51,14 +51,18 @@ type storageClientBackend struct {
 	runtime         registry.RuntimeDescriptorProvider
 }
 
-// GetConnectedNodes returns registry node information about all connected
-// storage nodes.
+// Implements api.StorageClient.
 func (b *storageClientBackend) GetConnectedNodes() []*node.Node {
 	var nodes []*node.Node
 	for _, conn := range b.committeeClient.GetConnectionsWithMeta() {
 		nodes = append(nodes, conn.Node)
 	}
 	return nodes
+}
+
+// Implements api.StorageClient.
+func (b *storageClientBackend) EnsureCommitteeVersion(ctx context.Context, version int64) error {
+	return b.committeeClient.EnsureVersion(ctx, version)
 }
 
 type grpcResponse struct {

--- a/go/storage/client/init.go
+++ b/go/storage/client/init.go
@@ -17,7 +17,8 @@ import (
 // BackendName is the name of this implementation.
 const BackendName = "client"
 
-func newClient(
+// NewForCommittee creates a new storage client that tracks the specified committee.
+func NewForCommittee(
 	ctx context.Context,
 	namespace common.Namespace,
 	ident *identity.Identity,
@@ -59,7 +60,7 @@ func New(
 		return nil, fmt.Errorf("storage/client: failed to create committee watcher: %w", err)
 	}
 
-	return newClient(ctx, namespace, ident, committeeWatcher.Nodes(), runtime)
+	return NewForCommittee(ctx, namespace, ident, committeeWatcher.Nodes(), runtime)
 }
 
 // NewStatic creates a new storage client that only follows a specific storage node. This is mostly
@@ -76,7 +77,7 @@ func NewStatic(
 		return nil, fmt.Errorf("storage/client: failed to create node descriptor watcher: %w", err)
 	}
 
-	client, err := newClient(ctx, namespace, ident, nw, nil)
+	client, err := NewForCommittee(ctx, namespace, ident, nw, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go/storage/metrics.go
+++ b/go/storage/metrics.go
@@ -72,6 +72,13 @@ func (w *metricsWrapper) GetConnectedNodes() []*node.Node {
 	return []*node.Node{}
 }
 
+func (w *metricsWrapper) EnsureCommitteeVersion(ctx context.Context, version int64) error {
+	if clientBackend, ok := w.Backend.(api.ClientBackend); ok {
+		return clientBackend.EnsureCommitteeVersion(ctx, version)
+	}
+	return api.ErrUnsupported
+}
+
 func (w *metricsWrapper) Apply(ctx context.Context, request *api.ApplyRequest) ([]*api.Receipt, error) {
 	start := time.Now()
 	receipts, err := w.Backend.Apply(ctx, request)

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -16,7 +16,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	"github.com/oasisprotocol/oasis-core/go/runtime/committee"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
-	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
 	"github.com/oasisprotocol/oasis-core/go/worker/common/api"
 	"github.com/oasisprotocol/oasis-core/go/worker/common/p2p"
 	p2pError "github.com/oasisprotocol/oasis-core/go/worker/common/p2p/error"
@@ -93,8 +92,8 @@ type Node struct {
 	Identity         *identity.Identity
 	KeyManager       keymanagerApi.Backend
 	KeyManagerClient *keymanagerClient.Client
-	Storage          storage.Backend
 	Consensus        consensus.Backend
+	Group            *Group
 
 	ctx       context.Context
 	cancelCtx context.CancelFunc
@@ -102,8 +101,6 @@ type Node struct {
 	stopOnce  sync.Once
 	quitCh    chan struct{}
 	initCh    chan struct{}
-
-	Group *Group
 
 	hooks []NodeHooks
 
@@ -452,7 +449,6 @@ func NewNode(
 		Runtime:    runtime,
 		Identity:   identity,
 		KeyManager: keymanager,
-		Storage:    runtime.Storage(),
 		Consensus:  consensus,
 		ctx:        ctx,
 		cancelCtx:  cancel,
@@ -462,7 +458,7 @@ func NewNode(
 		logger:     logging.GetLogger("worker/common/committee").With("runtime_id", runtime.ID()),
 	}
 
-	group, err := NewGroup(ctx, identity, runtime.ID(), n, consensus, p2p)
+	group, err := NewGroup(ctx, identity, runtime, n, consensus, p2p)
 	if err != nil {
 		return nil, err
 	}

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -223,7 +223,7 @@ func NewNode(
 	workerCommonCfg workerCommon.Config,
 	checkpointerCfg checkpoint.CheckpointerConfig,
 ) (*Node, error) {
-	localStorage, ok := commonNode.Storage.(storageApi.LocalBackend)
+	localStorage, ok := commonNode.Runtime.Storage().(storageApi.LocalBackend)
 	if !ok {
 		return nil, ErrNonLocalBackend
 	}


### PR DESCRIPTION
Previously the runtime worker(s) used the common storage client which was not
synced with any particular committee version. This could cause an executor
node to use a stale storage node for storing updates.

TODO
* [x] Support multiple tags per node
* [x] Test