### PR TITLE
rust update tiny-keccak, hmac, sha2 dependencies

### DIFF
--- a/.changelog/3260.internal.md
+++ b/.changelog/3260.internal.md
@@ -1,0 +1,1 @@
+rust: Update tiny-keccak, hmac, sha2 dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,4 +66,3 @@ updates:
       - dependency-name: serde_cbor
       - dependency-name: sha2
       - dependency-name: snow
-      - dependency-name: tiny-keccak

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,12 +57,10 @@ updates:
       # version, remove it from the ignore list.
       - dependency-name: futures
       - dependency-name: grpcio
-      - dependency-name: hmac
       - dependency-name: intrusive-collections
       - dependency-name: rustracing
       - dependency-name: rustracing_jaeger
       - dependency-name: serde
       - dependency-name: serde_bytes
       - dependency-name: serde_cbor
-      - dependency-name: sha2
       - dependency-name: snow

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,12 +406,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
 dependencies = [
- "generic-array 0.12.3",
- "subtle 1.0.0",
+ "generic-array 0.14.4",
+ "subtle",
 ]
 
 [[package]]
@@ -423,7 +423,7 @@ dependencies = [
  "byteorder",
  "digest 0.8.1",
  "rand_core",
- "subtle 2.2.3",
+ "subtle",
  "zeroize 1.1.0",
 ]
 
@@ -436,7 +436,7 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core",
- "subtle 2.2.3",
+ "subtle",
  "zeroize 1.1.0",
 ]
 
@@ -445,7 +445,7 @@ name = "deoxysii"
 version = "0.2.1"
 source = "git+https://github.com/oasisprotocol/deoxysii-rust#32d107103fbed459226a7c0e52a3b947cb77ef33"
 dependencies = [
- "subtle 2.2.3",
+ "subtle",
  "thiserror",
  "zeroize 0.6.0",
 ]
@@ -792,12 +792,12 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
+checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
 dependencies = [
  "crypto-mac",
- "digest 0.8.1",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1214,7 +1214,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "sgx-isa",
- "sha2 0.8.2",
+ "sha2 0.9.1",
  "slog",
  "slog-json",
  "slog-scope",
@@ -1936,7 +1936,7 @@ dependencies = [
  "ring",
  "rustc_version",
  "sha2 0.8.2",
- "subtle 2.2.3",
+ "subtle",
  "x25519-dalek 0.6.0",
 ]
 
@@ -1973,12 +1973,6 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,7 +1177,7 @@ dependencies = [
  "rand",
  "sgx-isa",
  "sp800-185",
- "tiny-keccak",
+ "tiny-keccak 2.0.2",
  "x25519-dalek 1.1.0",
  "zeroize 1.1.0",
 ]
@@ -1223,7 +1223,7 @@ dependencies = [
  "sp800-185",
  "tempfile",
  "thiserror",
- "tiny-keccak",
+ "tiny-keccak 2.0.2",
  "tokio-current-thread",
  "tokio-executor",
  "untrusted",
@@ -1959,7 +1959,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b18e3b1ddbf090b195425aca6edf8efb8e9b1fd42708131adf0f882db24fc9"
 dependencies = [
  "byteorder",
- "tiny-keccak",
+ "tiny-keccak 1.5.0",
 ]
 
 [[package]]
@@ -2110,6 +2110,15 @@ name = "tiny-keccak"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
 ]

--- a/keymanager-lib/Cargo.toml
+++ b/keymanager-lib/Cargo.toml
@@ -16,6 +16,6 @@ io-context = "0.2.0"
 rand = "0.7.3"
 sgx-isa = { version = "0.3.2", features = ["sgxstd"] }
 sp800-185 = "0.2.0"
-tiny-keccak = "1.4.2"
+tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 x25519-dalek = "1.1.0"
 zeroize = "1.1"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -39,7 +39,7 @@ io-context = "0.2.0"
 x25519-dalek = "1.1.0"
 ed25519-dalek = "1.0.0-pre.3"
 deoxysii = { git = "https://github.com/oasisprotocol/deoxysii-rust" }
-tiny-keccak = "1.4.2"
+tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 sp800-185 = "0.2.0"
 zeroize = "1.1"
 intrusive-collections = "0.8"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -43,8 +43,8 @@ tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 sp800-185 = "0.2.0"
 zeroize = "1.1"
 intrusive-collections = "0.8"
-sha2 = "0.8.1"
-hmac = "0.7.1"
+sha2 = "0.9.1"
+hmac = "0.9.0"
 honggfuzz = "0.5.47"
 arbitrary = { version = "0.4.1", features = ["derive"] }
 

--- a/runtime/src/common/crypto/hash.rs
+++ b/runtime/src/common/crypto/hash.rs
@@ -16,11 +16,11 @@ impl Hash {
     pub fn digest_bytes_list(data: &[&[u8]]) -> Hash {
         let mut ctx = Sha512Trunc256::new();
         for datum in data {
-            ctx.input(datum);
+            ctx.update(datum);
         }
 
         let mut result = [0u8; 32];
-        result[..].copy_from_slice(ctx.result().as_ref());
+        result[..].copy_from_slice(ctx.finalize().as_ref());
 
         Hash(result)
     }

--- a/runtime/src/common/crypto/mrae/deoxysii.rs
+++ b/runtime/src/common/crypto/mrae/deoxysii.rs
@@ -3,7 +3,7 @@
 pub use super::deoxysii_rust::{DeoxysII, KEY_SIZE, NONCE_SIZE, TAG_SIZE};
 
 use super::{
-    hmac::{Hmac, Mac},
+    hmac::{Hmac, Mac, NewMac},
     sha2::Sha512Trunc256,
     x25519_dalek,
 };
@@ -22,12 +22,12 @@ fn derive_symmetric_key(public: &[u8; 32], private: &[u8; 32]) -> [u8; KEY_SIZE]
     let pmk = private.diffie_hellman(&public);
 
     let mut kdf = Kdf::new_varkey(b"MRAE_Box_Deoxys-II-256-128").expect("Hmac::new_varkey");
-    kdf.input(pmk.as_bytes());
+    kdf.update(pmk.as_bytes());
     drop(pmk);
 
     let mut derived_key = [0u8; KEY_SIZE];
-    let digest = kdf.result();
-    derived_key.copy_from_slice(&digest.code().as_ref()[..KEY_SIZE]);
+    let digest = kdf.finalize();
+    derived_key.copy_from_slice(&digest.into_bytes()[..KEY_SIZE]);
 
     derived_key
 }


### PR DESCRIPTION
Part of #3245

