### PR TITLE
Pretty print commission schedule rates and rate bounds as enumerated lists

### DIFF
--- a/.changelog/3265.feature.1.md
+++ b/.changelog/3265.feature.1.md
@@ -1,0 +1,1 @@
+go/staking/api: Add `PrettyPrintCommissionScheduleIndexInfixes()` helper

--- a/.changelog/3265.feature.2.md
+++ b/.changelog/3265.feature.2.md
@@ -1,0 +1,5 @@
+go/staking/api: Update commission schedule rate and rate bound pretty prints
+
+Pretty print rates and rate bounds as enumerated lists to enable easier
+inspection of commission schedule (amendments) in combination with a
+hardware-based signer plugin.

--- a/go/common/prettyprint/context.go
+++ b/go/common/prettyprint/context.go
@@ -10,6 +10,9 @@ var (
 	// ContextKeyTokenValueExponent is the key to retrieve the token's value
 	// base-10 exponent from a context.
 	ContextKeyTokenValueExponent = contextKey("staking/token-value-exponent")
+	// ContextKeyCommissionScheduleIndex is the key to retrieve the rate (bound)
+	// index in a commission schedule (amendment).
+	ContextKeyCommissionScheduleIndex = contextKey("staking/commission-schedule-index")
 )
 
 type contextKey string

--- a/go/oasis-test-runner/scenario/e2e/stake_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/stake_cli.go
@@ -623,7 +623,8 @@ func (sc *stakeCLIImpl) checkGeneralAccount(
 
 	var b bytes.Buffer
 	expectedAccount.PrettyPrint(ctx, "  ", &b)
-	match := regexp.MustCompile(b.String()).FindStringSubmatch(accountInfo)
+	regexPattern := regexp.QuoteMeta(b.String())
+	match := regexp.MustCompile(regexPattern).FindStringSubmatch(accountInfo)
 	if match == nil {
 		return fmt.Errorf(
 			"checkGeneralAccount: couldn't find expected general account %+v in account info", expectedAccount,
@@ -649,7 +650,8 @@ func (sc *stakeCLIImpl) checkEscrowAccountSharePool(
 	var b bytes.Buffer
 	fmt.Fprintf(&b, "%s%s:\n", prefix, sharePoolName)
 	expectedSharePool.PrettyPrint(ctx, prefix+"  ", &b)
-	match := regexp.MustCompile(b.String()).FindStringSubmatch(accountInfo)
+	regexPattern := regexp.QuoteMeta(b.String())
+	match := regexp.MustCompile(regexPattern).FindStringSubmatch(accountInfo)
 	if match == nil {
 		return fmt.Errorf(
 			"checkEscrowAccountSharePool: couldn't find expected escrow %s share pool %+v in account info",
@@ -675,7 +677,8 @@ func (sc *stakeCLIImpl) checkCommissionScheduleRates(
 		var b bytes.Buffer
 		ctx = context.WithValue(ctx, prettyprint.ContextKeyCommissionScheduleIndex, i)
 		expectedRate.PrettyPrint(ctx, "      ", &b)
-		match := regexp.MustCompile(b.String()).FindStringSubmatch(accountInfo)
+		regexPattern := regexp.QuoteMeta(b.String())
+		match := regexp.MustCompile(regexPattern).FindStringSubmatch(accountInfo)
 		if match == nil {
 			return fmt.Errorf(
 				"checkCommissionScheduleRates: couldn't find an expected commission schedule rate %+v in account info",
@@ -702,7 +705,8 @@ func (sc *stakeCLIImpl) checkCommissionScheduleRateBounds(
 		var b bytes.Buffer
 		ctx = context.WithValue(ctx, prettyprint.ContextKeyCommissionScheduleIndex, i)
 		expectedBound.PrettyPrint(ctx, "      ", &b)
-		match := regexp.MustCompile(b.String()).FindStringSubmatch(accountInfo)
+		regexPattern := regexp.QuoteMeta(b.String())
+		match := regexp.MustCompile(regexPattern).FindStringSubmatch(accountInfo)
 		if match == nil {
 			return fmt.Errorf(
 				"checkCommissionScheduleRateBounds: couldn't find an expected commission schedule rate bound %+v in account info",

--- a/go/oasis-test-runner/scenario/e2e/stake_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/stake_cli.go
@@ -671,8 +671,9 @@ func (sc *stakeCLIImpl) checkCommissionScheduleRates(
 		return err
 	}
 
-	for _, expectedRate := range expectedRates {
+	for i, expectedRate := range expectedRates {
 		var b bytes.Buffer
+		ctx = context.WithValue(ctx, prettyprint.ContextKeyCommissionScheduleIndex, i)
 		expectedRate.PrettyPrint(ctx, "      ", &b)
 		match := regexp.MustCompile(b.String()).FindStringSubmatch(accountInfo)
 		if match == nil {
@@ -697,8 +698,9 @@ func (sc *stakeCLIImpl) checkCommissionScheduleRateBounds(
 		return err
 	}
 
-	for _, expectedBound := range expectedRateBounds {
+	for i, expectedBound := range expectedRateBounds {
 		var b bytes.Buffer
+		ctx = context.WithValue(ctx, prettyprint.ContextKeyCommissionScheduleIndex, i)
 		expectedBound.PrettyPrint(ctx, "      ", &b)
 		match := regexp.MustCompile(b.String()).FindStringSubmatch(accountInfo)
 		if match == nil {

--- a/go/staking/api/commission.go
+++ b/go/staking/api/commission.go
@@ -52,9 +52,10 @@ type CommissionRateStep struct {
 // PrettyPrint writes a pretty-printed representation of CommissionRateStep to
 // the given writer.
 func (crs CommissionRateStep) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
-	fmt.Fprintf(w, "%s- Start: epoch %d\n", prefix, crs.Start)
+	indexInfix, emptyInfix := PrettyPrintCommissionScheduleIndexInfixes(ctx)
 
-	fmt.Fprintf(w, "%s  Rate:  %s\n", prefix, PrettyPrintCommissionRatePercentage(crs.Rate))
+	fmt.Fprintf(w, "%s%sstart: epoch %d\n", prefix, indexInfix, crs.Start)
+	fmt.Fprintf(w, "%s%srate:  %s\n", prefix, emptyInfix, PrettyPrintCommissionRatePercentage(crs.Rate))
 }
 
 // PrettyType returns a representation of CommissionRateStep that can be used
@@ -77,10 +78,11 @@ type CommissionRateBoundStep struct {
 // PrettyPrint writes a pretty-printed representation of CommissionRateBoundStep
 // to the given writer.
 func (crbs CommissionRateBoundStep) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
-	fmt.Fprintf(w, "%s- Start:        epoch %d\n", prefix, crbs.Start)
+	indexInfix, emptyInfix := PrettyPrintCommissionScheduleIndexInfixes(ctx)
 
-	fmt.Fprintf(w, "%s  Minimum Rate: %s\n", prefix, PrettyPrintCommissionRatePercentage(crbs.RateMin))
-	fmt.Fprintf(w, "%s  Maximum Rate: %s\n", prefix, PrettyPrintCommissionRatePercentage(crbs.RateMax))
+	fmt.Fprintf(w, "%s%sstart:        epoch %d\n", prefix, indexInfix, crbs.Start)
+	fmt.Fprintf(w, "%s%sminimum rate: %s\n", prefix, emptyInfix, PrettyPrintCommissionRatePercentage(crbs.RateMin))
+	fmt.Fprintf(w, "%s%smaximum rate: %s\n", prefix, emptyInfix, PrettyPrintCommissionRatePercentage(crbs.RateMax))
 }
 
 // PrettyType returns a representation of CommissionRateBoundStep that can be
@@ -105,7 +107,8 @@ func (cs CommissionSchedule) PrettyPrint(ctx context.Context, prefix string, w i
 		fmt.Fprintf(w, "%sRates: (none)\n", prefix)
 	} else {
 		fmt.Fprintf(w, "%sRates:\n", prefix)
-		for _, rate := range cs.Rates {
+		for i, rate := range cs.Rates {
+			ctx = context.WithValue(ctx, prettyprint.ContextKeyCommissionScheduleIndex, i)
 			rate.PrettyPrint(ctx, prefix+"  ", w)
 		}
 	}
@@ -114,7 +117,8 @@ func (cs CommissionSchedule) PrettyPrint(ctx context.Context, prefix string, w i
 		fmt.Fprintf(w, "%sRate Bounds: (none)\n", prefix)
 	} else {
 		fmt.Fprintf(w, "%sRate Bounds:\n", prefix)
-		for _, rateBound := range cs.Bounds {
+		for i, rateBound := range cs.Bounds {
+			ctx = context.WithValue(ctx, prettyprint.ContextKeyCommissionScheduleIndex, i)
 			rateBound.PrettyPrint(ctx, prefix+"  ", w)
 		}
 	}

--- a/go/staking/api/prettyprint.go
+++ b/go/staking/api/prettyprint.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"context"
 	"fmt"
+	"strings"
 
 	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
@@ -19,4 +21,18 @@ func PrettyPrintCommissionRatePercentage(rateNumerator quantity.Quantity) string
 	// value in percentage.
 	denominatorExp := commissionRateDenominatorExponent - 2
 	return fmt.Sprintf("%s%%", prettyprint.QuantityFrac(rateNumerator, denominatorExp))
+}
+
+// PrettyPrintCommissionScheduleIndexInfixes returns two infixes:
+// - indexInfix holds the infix to use to pretty print the given commission
+//   schedule rate (bound) index
+// - emptyInfix holds the infix to use to pretty print an empty string of an
+//   equivalent length
+func PrettyPrintCommissionScheduleIndexInfixes(ctx context.Context) (indexInfix, emptyInfix string) {
+	index, ok := ctx.Value(prettyprint.ContextKeyCommissionScheduleIndex).(int)
+	if ok {
+		indexInfix = fmt.Sprintf("(%d) ", index+1)
+		emptyInfix = strings.Repeat(" ", len(indexInfix))
+	}
+	return
 }

--- a/go/staking/api/prettyprint_test.go
+++ b/go/staking/api/prettyprint_test.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 )
 
@@ -27,5 +29,28 @@ func TestPrettyPrintCommissionRatePercentage(t *testing.T) {
 	} {
 		rate := PrettyPrintCommissionRatePercentage(*t.rateNumerator)
 		require.Equal(t.expectedRate, rate, "obtained pretty print didn't match expected value")
+	}
+}
+
+func TestPrettyPrintCommissionScheduleIndexInfixes(t *testing.T) {
+	require := require.New(t)
+
+	for _, t := range []struct {
+		expectedIndexInfix string
+		expectedEmptyInfix string
+		index              int
+		indexPresent       bool
+	}{
+		{"(1) ", "    ", 0, true},
+		{"(2) ", "    ", 1, true},
+		{"(10) ", "     ", 9, true},
+		{"(123) ", "      ", 122, true},
+		{"(2345678) ", "          ", 2345677, true},
+	} {
+		require.Equal(len(t.expectedIndexInfix), len(t.expectedEmptyInfix), "expected index and empty infixes should be of equal length")
+		ctx := context.WithValue(context.Background(), prettyprint.ContextKeyCommissionScheduleIndex, t.index)
+		indexInfix, emptyInfix := PrettyPrintCommissionScheduleIndexInfixes(ctx)
+		require.Equal(t.expectedIndexInfix, indexInfix, "obtained index infix didn't match expected value")
+		require.Equal(t.expectedEmptyInfix, emptyInfix, "obtained empty infix didn't match expected value")
 	}
 }


### PR DESCRIPTION
Example of an old pretty print:
```
You are about to sign the following transaction:
  Nonce:  0
  Fee:
    Amount: AMBER 0.000002
    Gas limit: 1000
    (gas price: AMBER 0.000000002 per gas unit)
  Method: staking.AmendCommissionSchedule
  Body:
    Amendment:
      Rates:
        - Start: epoch 32
          Rate:  50.0%
        - Start: epoch 40
          Rate:  40.0%
        - Start: epoch 48
          Rate:  30.0%
        - Start: epoch 56
          Rate:  25.0%
        - Start: epoch 64
          Rate:  20.0%
      Rate Bounds:
        - Start:        epoch 32
          Minimum Rate: 10.0%
          Maximum Rate: 50.0%
        - Start:        epoch 64
          Minimum Rate: 10.0%
          Maximum Rate: 30.0%
Other info:
  Genesis document's hash: d7aff9a80cf626fb49585a37c8f8e0ec99bccdec1c93c93d566accdccdb58bef
```

Same example with the new pretty print:
```
You are about to sign the following transaction:
  Nonce:  0
  Fee:
    Amount: AMBER 0.000002
    Gas limit: 1000
    (gas price: AMBER 0.000000002 per gas unit)
  Method: staking.AmendCommissionSchedule
  Body:
    Amendment:
      Rates:
        (1) start: epoch 32
            rate:  50.0%
        (2) start: epoch 40
            rate:  40.0%
        (3) start: epoch 48
            rate:  30.0%
        (4) start: epoch 56
            rate:  25.0%
        (5) start: epoch 64
            rate:  20.0%
      Rate Bounds:
        (1) start:        epoch 32
            minimum rate: 10.0%
            maximum rate: 50.0%
        (2) start:        epoch 64
            minimum rate: 10.0%
            maximum rate: 30.0%
Other info:
  Genesis document's hash: d7aff9a80cf626fb49585a37c8f8e0ec99bccdec1c93c93d566accdccdb58bef
```