### PR TITLE
docs: Fix wrong indentation of Ubuntu system packages install command

### DIFF
--- a/docs/setup/prerequisites.md
+++ b/docs/setup/prerequisites.md
@@ -29,7 +29,7 @@ Core:
   On Ubuntu 18.10+ (18.04 LTS provides overly-old `bubblewrap`), you can install
   all the above with:
 
-<!-- markdownlint-disable line-length -->
+  <!-- markdownlint-disable line-length -->
   ```
   sudo apt install bubblewrap gcc g++ protobuf-compiler make cmake libssl-dev libseccomp-dev pkg-config
   ```


### PR DESCRIPTION
Here is how it looks like before this change:
![Screenshot from 2020-09-11 14-47-43](https://user-images.githubusercontent.com/2518544/92927421-ddd30d00-f43d-11ea-8539-55f035c50cbc.png)
