### PR TITLE
ci/codecov: ignore go/extra code coverage

### DIFF
--- a/.changelog/3272.trivial.md
+++ b/.changelog/3272.trivial.md
@@ -1,0 +1,1 @@
+codecov: Ignore `go/extra` code coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,13 +1,13 @@
 ignore:
   - "**/*.pb.go"
-  - "runtime/src/storage/mkvs/interop" # MKVS interoperability test helpers.
-  - "go/storage/mkvs/interop" # MKVS interoperability test helpers.
-  - "go/oasis-node/cmd/debug" # Debug and test utilities.
-  - "go/oasis-test-runner" # E2E test runner.
-  - "go/oasis-net-runner" # Test local network runner.
-  - "go/staking/gen_vectors" # Staking test vector generator.
-  - "go/registry/gen_vectors" # Registry test vector generator.
-  - "go/storage/fuzz" # Fuzz tests.
-  - "go/storage/mkvs/fuzz" # Fuzz tests.
   - "go/consensus/tendermint/fuzz" # Fuzz tests.
   - "go/extra" # Extra packages.
+  - "go/oasis-net-runner" # Test local network runner.
+  - "go/oasis-node/cmd/debug" # Debug and test utilities.
+  - "go/oasis-test-runner" # E2E test runner.
+  - "go/registry/gen_vectors" # Registry test vector generator.
+  - "go/staking/gen_vectors" # Staking test vector generator.
+  - "go/storage/fuzz" # Fuzz tests.
+  - "go/storage/mkvs/fuzz" # Fuzz tests.
+  - "go/storage/mkvs/interop" # MKVS interoperability test helpers.
+  - "runtime/src/storage/mkvs/interop" # MKVS interoperability test helpers.

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,4 @@ ignore:
   - "go/storage/fuzz" # Fuzz tests.
   - "go/storage/mkvs/fuzz" # Fuzz tests.
   - "go/consensus/tendermint/fuzz" # Fuzz tests.
+  - "go/extra" # Extra packages.


### PR DESCRIPTION
Since `extra` is for packages that are not directly part of oasis-core it makes sense skipping those for coverage checks.

Noticed when the coverage increased after removing `extra/stats`: https://github.com/oasisprotocol/oasis-core/pull/3270