### PR TITLE
Introduce the canonical form of Genesis files

### DIFF
--- a/.changelog/2757.feature.md
+++ b/.changelog/2757.feature.md
@@ -1,0 +1,15 @@
+Introduce the *canonical* form of a Genesis file
+
+This form is the pretty-printed JSON file with 2-space indents, where:
+
+- Struct fields are encoded in the order in which they are defined in the
+  corresponding struct definitions.
+- Maps have their keys converted to strings which are then encoded in
+  lexicographical order.
+
+For more details, see the [Genesis Document] documentation.
+
+The `oasis-node genesis init` and `oasis-node genesis dump` CLI commands are
+updated to output Genesis file in this canonical form.
+
+[Genesis Document]: docs/consensus/genesis.md

--- a/.changelog/3278.internal.md
+++ b/.changelog/3278.internal.md
@@ -1,0 +1,1 @@
+go/oasis-test-runner: Add `e2e/genesis-file` scenario

--- a/docs/consensus/genesis.md
+++ b/docs/consensus/genesis.md
@@ -1,0 +1,83 @@
+# Genesis Document
+
+The genesis document contains a set of parameters that outline the initial state
+of the [consensus layer] and its services.
+
+For more details about the actual genesis document's API, see
+[genesis API documentation].
+
+[consensus layer]: index.md
+[genesis API documentation]:
+  https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go/genesis/api
+
+## Chain Domain Separation
+
+The genesis document is also used for [chain domain separation][crypto-chain].
+
+The last part of [domain separation] context is computed as:
+
+```
+Base16(SHA512-256(CBOR(<genesis-document>)))
+```
+
+where:
+
+- `Base16()` represents the hex encoding function,
+- `SHA512-256()` represents the SHA-512/256 hash function as described in
+  [Cryptography][crypto-hash] documentation,
+- `CBOR()` represents the *canonical* CBOR encoding function as described in
+  [Serialization] documentation, and
+- `<genesis-document>` represents a given genesis document.
+
+[crypto-chain]: ../crypto.md#chain-domain-separation
+[domain separation]: ../crypto.md#domain-separation
+[crypto-hash]: ../crypto.md#hash-functions
+[Serialization]: ../encoding.md
+
+## Genesis File
+
+A genesis file is a JSON document corresponding to a serialized genesis
+document.
+
+{% hint style="info" %}
+For a high-level overview of the genesis file, its various sections and
+parameters and the parameter values that will be used for Oasis Network Mainnet
+launch, see: [Genesis File Overview].
+{% endhint %}
+
+[Genesis File Overview]:
+  https://docs.oasis.dev/general/pre-mainnet/genesis-file
+
+### Canonical Form
+
+The *canonical* form of a genesis file is the pretty-printed JSON file with
+2-space indents, where:
+
+- Struct fields are encoded in the order in which they are defined in the
+  corresponding struct definitions.
+
+  The genesis document is defined by the [`genesis/api.Document`] struct which
+  contains pointers to other structs defining the genesis state of all
+  [consensus layer] services.
+
+- Maps have their keys converted to strings which are then encoded in
+  lexicographical order.
+
+  This is Go's default behavior. For more details, see
+  [`encoding/json.Marshal()`]'s documentation.
+
+{% hint style="info" %}
+This should not be confused with the *canonical* CBOR encoding of the genesis
+document that is used to derive the domain separation context as described
+in the [Chain Domain Separation] section.
+{% endhint %}
+
+This form is used to enable simple diffing/patching with the standard Unix tools
+(i.e. `diff`/`patch`).
+
+[`genesis/api.Document`]:
+  https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go/genesis/api#Document
+
+[`encoding/json.Marshal()`]: https://golang.org/pkg/encoding/json/#Marshal
+
+[Chain Domain Separation]: #chain-domain-separation

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,7 @@ implementations.
     * [Committee Scheduler](consensus/scheduler.md)
     * [Root Hash](consensus/roothash.md)
     * [Key Manager](consensus/keymanager.md)
+  * [Genesis Document](consensus/genesis.md)
   * [Transaction Test Vectors](consensus/test-vectors.md)
 * [Runtime Layer](runtime/index.md)
   * [Runtimes](runtime/index.md#runtimes)

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -26,6 +26,7 @@
     * [Committee Scheduler](consensus/scheduler.md)
     * [Root Hash](consensus/roothash.md)
     * [Key Manager](consensus/keymanager.md)
+  * [Genesis Document](consensus/genesis.md)
   * [Transaction Test Vectors](consensus/test-vectors.md)
 * [Runtime Layer](runtime/index.md)
   * [Runtime Host Protocol](runtime/runtime-host-protocol.md)

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -260,7 +260,7 @@ func doInitGenesis(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	b, _ := json.Marshal(doc)
+	b, _ := json.MarshalIndent(doc, "", "  ")
 	if err := ioutil.WriteFile(f, b, 0o600); err != nil {
 		logger.Error("failed to save generated genesis document",
 			"err", err,
@@ -573,7 +573,7 @@ func doDumpGenesis(cmd *cobra.Command, args []string) {
 		defer w.Close()
 	}
 
-	data, err := json.Marshal(doc)
+	data, err := json.MarshalIndent(doc, "", "  ")
 	if err != nil {
 		logger.Error("failed to marshal genesis document into JSON",
 			"err", err,

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -486,7 +486,7 @@ func (net *Network) Start() error { // nolint: gocyclo
 
 	if net.cfg.GenesisFile == "" {
 		net.logger.Debug("provisioning genesis doc")
-		if err := net.makeGenesis(); err != nil {
+		if err := net.MakeGenesis(); err != nil {
 			net.logger.Error("failed to create genesis document",
 				"err", err,
 			)
@@ -845,7 +845,8 @@ func (net *Network) startOasisNode(
 	return nil
 }
 
-func (net *Network) makeGenesis() error {
+// MakeGenesis generates a new Genesis file.
+func (net *Network) MakeGenesis() error {
 	args := []string{
 		"genesis", "init",
 		"--genesis.file", net.GenesisPath(),

--- a/go/oasis-test-runner/scenario/e2e/e2e.go
+++ b/go/oasis-test-runner/scenario/e2e/e2e.go
@@ -321,6 +321,8 @@ func RegisterScenarios() error {
 		GasFeesStakingDumpRestore,
 		// Identity CLI test.
 		IdentityCLI,
+		// Genesis file test.
+		GenesisFile,
 		// Node upgrade tests.
 		NodeUpgrade,
 		NodeUpgradeCancel,

--- a/go/oasis-test-runner/scenario/e2e/genesis_file.go
+++ b/go/oasis-test-runner/scenario/e2e/genesis_file.go
@@ -1,0 +1,133 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	genesisFile "github.com/oasisprotocol/oasis-core/go/genesis/file"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis/cli"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
+)
+
+// GenesisFile is the scenario for testing the correctness of marshalled genesis
+// documents.
+var GenesisFile scenario.Scenario = &genesisFileImpl{
+	E2E: *NewE2E("genesis-file"),
+}
+
+type genesisFileImpl struct {
+	E2E
+}
+
+func (s *genesisFileImpl) Clone() scenario.Scenario {
+	return &genesisFileImpl{
+		E2E: s.E2E.Clone(),
+	}
+}
+
+func (s *genesisFileImpl) Fixture() (*oasis.NetworkFixture, error) {
+	f, err := s.E2E.Fixture()
+	if err != nil {
+		return nil, err
+	}
+
+	// A single validator is enough for this scenario.
+	f.Validators = []oasis.ValidatorFixture{
+		{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true}},
+	}
+
+	return f, nil
+}
+
+func (s *genesisFileImpl) Run(childEnv *env.Env) error {
+	// Manually provision genesis file.
+	s.Logger.Info("manually provisioning genesis file before starting the network")
+	if err := s.Net.MakeGenesis(); err != nil {
+		return fmt.Errorf("e2e/genesis-file: failed to create genesis file")
+	}
+	// Set this genesis file in network's configuration.
+	cfg := s.Net.Config()
+	cfg.GenesisFile = s.Net.GenesisPath()
+
+	if err := checkGenesisFile(s.Net.GenesisPath()); err != nil {
+		return fmt.Errorf("e2e/genesis-file: %w", err)
+	}
+	s.Logger.Info("manually provisioned genesis file equals canonical form")
+
+	if err := s.Net.Start(); err != nil {
+		return fmt.Errorf("e2e/genesis-file: failed to start network: %w", err)
+	}
+
+	s.Logger.Info("waiting for network to come up")
+	if err := s.Net.Controller().WaitNodesRegistered(context.Background(), 1); err != nil {
+		return fmt.Errorf("e2e/genesis-file: failed to wait for registered nodes: %w", err)
+	}
+
+	// Dump network state to a genesis file.
+	s.Logger.Info("dumping network state to genesis file")
+
+	dumpPath := filepath.Join(childEnv.Dir(), "genesis_dump.json")
+	args := []string{
+		"genesis", "dump",
+		"--height", "0",
+		"--genesis.file", dumpPath,
+		"--address", "unix:" + s.Net.Validators()[0].SocketPath(),
+	}
+	if err := cli.RunSubCommand(childEnv, s.Logger, "genesis-file", s.Net.Config().NodeBinary, args); err != nil {
+		return fmt.Errorf("e2e/genesis-file: failed to dump state: %w", err)
+	}
+	if err := checkGenesisFile(dumpPath); err != nil {
+		return fmt.Errorf("e2e/genesis-file: %w", err)
+	}
+	s.Logger.Info("genesis file from dumped network state equals canonical form")
+
+	return nil
+}
+
+// checkGenesisFile checks if the given genesis file equals the canonical form.
+func checkGenesisFile(filePath string) error {
+	// Load genesis document from the genesis file.
+	provider, err := genesisFile.NewFileProvider(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open genesis file: %w", err)
+	}
+	doc, err := provider.GetGenesisDocument()
+	if err != nil {
+		return fmt.Errorf("failed to get genesis document: %w", err)
+	}
+	// Perform sanity checks on the loaded genesis document.
+	err = doc.SanityCheck()
+	if err != nil {
+		return fmt.Errorf("genesis document sanity check failed: %w", err)
+	}
+
+	// Load raw genesis file.
+	rawFile, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read genesis file: %w", err)
+	}
+	// Create a marshalled genesis document in the canonical form with 2 space indents.
+	rawCanonical, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal genesis document: %w", err)
+	}
+	// Genesis file should equal the canonical form.
+	if !bytes.Equal(rawFile, rawCanonical) {
+		fileLines := strings.Split(string(rawFile), "\n")
+		canonicalLines := strings.Split(string(rawCanonical), "\n")
+		return fmt.Errorf(
+			"genesis document is not marshalled to the canonical form:\n"+
+				"\nActual marshalled genesis document (trimmed):\n%s\n"+
+				"\nExpected marshalled genesis document (trimmed):\n%s\n",
+			strings.Join(fileLines[:10], "\n"), strings.Join(canonicalLines[:10], "\n"),
+		)
+	}
+	return nil
+}


### PR DESCRIPTION
Update `oasis-node genesis init` and `oasis-node genesis dump` CLI commands to create pretty-printed JSON files that represent the Oasis' *canonical* Genesis file format.

This  _canonical_ form enables simple state patching with the standard Unix tools (i.e. `diff`/`patch`).

Closes #2757.