### PR TITLE
go/worker/registration: Verify entity exists before node registration

### DIFF
--- a/.changelog/3286.bugfix.md
+++ b/.changelog/3286.bugfix.md
@@ -1,0 +1,4 @@
+go/worker/registration: Verify entity exists before node registration
+
+This avoids some cases of failed node registration transactions when the
+entity under which the node is being registered does not actually exist.


### PR DESCRIPTION
Fixes #3286 

This avoids some cases of failed node registration transactions when the entity
under which the node is being registered does not actually exist.