### PR TITLE
queries workload eof

### DIFF
--- a/.changelog/3302.internal.md
+++ b/.changelog/3302.internal.md
@@ -1,0 +1,5 @@
+ci: Daily longterm test minor fixes
+
+- Don't fail on UnexpectedEOF during `GetTransactionsWithResults`.
+
+- Enable `"RecoverCorruptedWAL"` for all nodes.

--- a/go/common/grpc/errors.go
+++ b/go/common/grpc/errors.go
@@ -15,15 +15,25 @@ import (
 
 // IsErrorCode returns true if the given error represents a specific gRPC error code.
 func IsErrorCode(err error, code codes.Code) bool {
+	status := GetErrorStatus(err)
+	if status == nil {
+		return false
+	}
+
+	return status.Code() == code
+}
+
+// GetErrorStatus returns gRPC status from error.
+func GetErrorStatus(err error) *status.Status {
 	var grpcError interface {
 		error
 		GRPCStatus() *status.Status
 	}
 	if !errors.As(err, &grpcError) {
-		return false
+		return nil
 	}
 
-	return grpcError.GRPCStatus().Code() == code
+	return grpcError.GRPCStatus()
 }
 
 // grpcError is a serializable error.

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_sync.go
@@ -190,7 +190,7 @@ func (sc *storageSyncImpl) Run(childEnv *env.Env) error {
 		return fmt.Errorf("can't start last storage worker: %w", err)
 	}
 	if err := lateWorker.WaitReady(ctx); err != nil {
-		return fmt.Errorf("erorr waiting for late storage worker to become ready: %w", err)
+		return fmt.Errorf("error waiting for late storage worker to become ready: %w", err)
 	}
 	// Wait a bit to give the logger in the node time to sync; the message has already been
 	// logged by this point, it just might not be on disk yet.

--- a/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
@@ -314,6 +314,7 @@ func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
 	for i := range f.Validators {
 		f.Validators[i].Consensus.MinGasPrice = txSourceGasPrice
 		f.Validators[i].Consensus.SubmissionGasPrice = txSourceGasPrice
+		// Enable recovery from corrupted WAL.
 		f.Validators[i].Consensus.TendermintRecoverCorruptedWAL = sc.tendermintRecoverCorruptedWAL
 		// Ensure validator-0 does not have pruning enabled, so nodes taken down
 		// for long period can sync from it.
@@ -323,10 +324,14 @@ func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
 	// Update all other nodes to use a specific gas price.
 	for i := range f.Keymanagers {
 		f.Keymanagers[i].Consensus.SubmissionGasPrice = txSourceGasPrice
+		// Enable recovery from corrupted WAL.
+		f.Keymanagers[i].Consensus.TendermintRecoverCorruptedWAL = sc.tendermintRecoverCorruptedWAL
 		sc.generateConsensusFixture(&f.Keymanagers[i].Consensus, false)
 	}
 	for i := range f.StorageWorkers {
 		f.StorageWorkers[i].Consensus.SubmissionGasPrice = txSourceGasPrice
+		// Enable recovery from corrupted WAL.
+		f.StorageWorkers[i].Consensus.TendermintRecoverCorruptedWAL = sc.tendermintRecoverCorruptedWAL
 		sc.generateConsensusFixture(&f.StorageWorkers[i].Consensus, false)
 		if i > 0 {
 			f.StorageWorkers[i].CheckpointSyncEnabled = true
@@ -334,6 +339,8 @@ func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
 	}
 	for i := range f.ComputeWorkers {
 		f.ComputeWorkers[i].Consensus.SubmissionGasPrice = txSourceGasPrice
+		// Enable recovery from corrupted WAL.
+		f.ComputeWorkers[i].Consensus.TendermintRecoverCorruptedWAL = sc.tendermintRecoverCorruptedWAL
 		sc.generateConsensusFixture(&f.ComputeWorkers[i].Consensus, false)
 	}
 	for i := range f.ByzantineNodes {


### PR DESCRIPTION
- don't fail on `EOF` on `GetTransactionsWithResults`
- enable `TendermintRecoverCorruptedWAL` also for non-validators since the upstream recovery doesn't seem to work all that well