### PR TITLE
go/worker/executor: clear tx queue before becoming a worker

### DIFF
--- a/.changelog/3300.bugfix.md
+++ b/.changelog/3300.bugfix.md
@@ -4,5 +4,5 @@ Fixes a bug where an executor returning to committee would propose stale
 transactions that it received right before exiting committee in previous
 epoch, due to a race condition between adding transaction to the queue and
 clearing the queue.
-Clearing the incoming queue is now done on returning to the committee instead
-of leaving.
+Clearing the incoming queue is now done before node starts being a compute
+worker instead of after it stops being.


### PR DESCRIPTION
`BackupWorker` also doesn't follow transactions and processed batches so should also reset the queue in that case. 

Not sure how i missed this in: https://github.com/oasisprotocol/oasis-core/pull/3300