### PR TITLE
go/worker/p2p: Skip peer authentication for our own messages

### DIFF
--- a/.changelog/3319.bugfix.md
+++ b/.changelog/3319.bugfix.md
@@ -1,0 +1,5 @@
+go/worker/p2p: Skip peer authentication for our own messages
+
+In practice this fixes a bug in a setup where executor nodes are used to
+submit runtime transactions. The executor nodes that are not part of the
+active committee, would end up self-rejecting transaction messages.

--- a/go/worker/common/p2p/dispatch.go
+++ b/go/worker/common/p2p/dispatch.go
@@ -164,12 +164,15 @@ func (h *topicHandler) dispatchMessage(peerID core.PeerID, m *queuedMsg, isIniti
 	h.handlersLock.RLock()
 	defer h.handlersLock.RUnlock()
 
-	for _, handler := range h.handlers {
-		// Perhaps this should reject the message, but it is possible that
-		// the local node is just behind.  This does result in stale messages
-		// getting retried though.
-		if err = handler.AuthenticatePeer(m.from, m.msg); err != nil {
-			return err
+	// Authenticate the peer if it's not us.
+	if m.peerID != h.p2p.host.ID() {
+		for _, handler := range h.handlers {
+			// Perhaps this should reject the message, but it is possible that
+			// the local node is just behind.  This does result in stale messages
+			// getting retried though.
+			if err = handler.AuthenticatePeer(m.from, m.msg); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/3318