### PR TITLE
go/worker/executor: don't hold the lock during storage requests

### DIFF
--- a/.changelog/3320.bugfix.md
+++ b/.changelog/3320.bugfix.md
@@ -1,0 +1,1 @@
+go/worker/executor: don't unnecessarily hold the lock during storage requests


### PR DESCRIPTION
Don't unnecessarily hold the lock during external requests to storage nodes, as those can take long time. 

Issue discovered in the daily tests with long restarts, when the storage node is taken offline, these requests can take up to 15 sec to timeout.