### PR TITLE
ci: Setup daily longterm tests with longer epoch periods

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -222,7 +222,7 @@ steps:
       OASIS_E2E_COVERAGE: enable
       TEST_BASE_DIR: /tmp
       # libp2p logging.
-      IPFS_LOGGING: info
+      IPFS_LOGGING: debug
     retry:
       <<: *retry_agent_failure
     plugins:
@@ -246,7 +246,7 @@ steps:
       OASIS_EXCLUDE_E2E: e2e/runtime/txsource-multi
       TEST_BASE_DIR: /tmp
       # libp2p logging.
-      IPFS_LOGGING: info
+      IPFS_LOGGING: debug
     agents:
       queue: intel-sgx
     retry:
@@ -272,7 +272,7 @@ steps:
       OASIS_E2E_COVERAGE: enable
       TEST_BASE_DIR: /tmp
       # libp2p logging.
-      IPFS_LOGGING: info
+      IPFS_LOGGING: debug
     agents:
       queue: intel-sgx
     retry:

--- a/.buildkite/longtests.pipeline.sh
+++ b/.buildkite/longtests.pipeline.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+##
+# Dynamic Buildkite pipeline generator.
+##
+#
+# It outputs valid Buildkite pipeline in YAML format.
+#
+# To use it, define the following Steps under your Buildkite's Pipeline Settings:
+#
+# steps:
+#   - command: .buildkite/longtests.pipeline.sh
+#     label: ":pipeline: Upload"
+#
+# For more details, see:
+# https://buildkite.com/docs/pipelines/defining-steps#dynamic-pipelines.
+#
+
+set -eux
+
+epochtime_inverval="${LONGTESTS_EPOCHTIME_INTERVAL:-0}"
+
+cat .buildkite/longtests.pipeline.yml | \
+    sed "s/\${epochtime_inverval}/$epochtime_inverval/g" | \
+    buildkite-agent pipeline upload

--- a/.buildkite/longtests.pipeline.yml
+++ b/.buildkite/longtests.pipeline.yml
@@ -97,7 +97,7 @@ steps:
     env:
       TEST_BASE_DIR: /var/tmp/longtests
       # libp2p logging.
-      IPFS_LOGGING: info
+      IPFS_LOGGING: debug
     agents:
       queue: default-daily
       buildkite_agent_class: stable

--- a/.buildkite/longtests.pipeline.yml
+++ b/.buildkite/longtests.pipeline.yml
@@ -89,12 +89,11 @@ steps:
   - wait
 
   - label: Transaction source tests
-    parallelism: 1
     # Tests are set to run 12 hours + some buffer time.
-    timeout_in_minutes: 760
+    timeout_in_minutes: 800
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
-      - .buildkite/scripts/daily_txsource.sh
+      - .buildkite/scripts/daily_txsource.sh --e2e/runtime.epoch.interval=${epochtime_inverval}
     env:
       TEST_BASE_DIR: /var/tmp/longtests
       # libp2p logging.

--- a/.buildkite/scripts/daily_txsource.sh
+++ b/.buildkite/scripts/daily_txsource.sh
@@ -9,7 +9,8 @@ if [[ $BUILDKITE_RETRY_COUNT == 0 ]]; then
     ./.buildkite/scripts/test_e2e.sh \
         --metrics.address $METRICS_PUSH_ADDR \
         --metrics.labels instance=$BUILDKITE_PIPELINE_NAME-$BUILDKITE_BUILD_NUMBER \
-        --scenario e2e/runtime/txsource-multi
+        --scenario e2e/runtime/txsource-multi \
+        "$@"
 else
     curl -H "Content-Type: application/json" \
         -X POST \

--- a/.changelog/3301.internal.md
+++ b/.changelog/3301.internal.md
@@ -1,0 +1,1 @@
+ci: Setup daily longterm tests with longer epoch periods

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -30,6 +30,7 @@ const (
 	cfgRuntimeLoader    = "runtime.loader"
 	cfgTEEHardware      = "tee_hardware"
 	cfgIasMock          = "ias.mock"
+	cfgEpochInterval    = "epoch.interval"
 )
 
 var (
@@ -80,6 +81,7 @@ func newRuntimeImpl(name, clientBinary string, clientArgs []string) *runtimeImpl
 	sc.Flags.String(cfgRuntimeLoader, "oasis-core-runtime-loader", "path to the runtime loader")
 	sc.Flags.String(cfgTEEHardware, "", "TEE hardware to use")
 	sc.Flags.Bool(cfgIasMock, true, "if mock IAS service should be used")
+	sc.Flags.Int64(cfgEpochInterval, 0, "epoch interval")
 
 	return sc
 }
@@ -120,6 +122,7 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 	}
 	runtimeLoader, _ := sc.Flags.GetString(cfgRuntimeLoader)
 	iasMock, _ := sc.Flags.GetBool(cfgIasMock)
+	epochInterval, _ := sc.Flags.GetInt64(cfgEpochInterval)
 	return &oasis.NetworkFixture{
 		TEE: oasis.TEEFixture{
 			Hardware: tee,
@@ -133,6 +136,7 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 			IAS: oasis.IASCfg{
 				Mock: iasMock,
 			},
+			EpochtimeTendermintInterval: epochInterval,
 		},
 		Entities: []oasis.EntityCfg{
 			{IsDebugTestEntity: true},

--- a/go/oasis-test-runner/scenario/e2e/test_accounts.go
+++ b/go/oasis-test-runner/scenario/e2e/test_accounts.go
@@ -15,10 +15,12 @@ var (
 	DeterministicCompute1 = stakingTests.AddressFromString("oasis1qr77y0cqdzcqgz2wqkv59yz0j4vfvyryfv8vxllt")
 	DeterministicCompute2 = stakingTests.AddressFromString("oasis1qzyw75ds6nw0af98xfmmpl3z8sgf3mdslvtzzcn6")
 	DeterministicCompute3 = stakingTests.AddressFromString("oasis1qrp7l53vn6h2z7p242ldtkqtttz2jf9dwsgu05aa")
+	DeterministicCompute4 = stakingTests.AddressFromString("oasis1qzpgrrd7435s2vaxr6s7xhqxusu4muq3y5qyph7u")
 
 	DeterministicStorage0 = stakingTests.AddressFromString("oasis1qrhp36j49ncpaac0aufwyuvtk04nfxcj2yq7y4my")
 	DeterministicStorage1 = stakingTests.AddressFromString("oasis1qzc2fexm30puzq2cmlm832fvpnyaxrq33cx4zukj")
 	DeterministicStorage2 = stakingTests.AddressFromString("oasis1qq2t9c27y6kylqz4n6qmh3vn9zessh8guglsg8qc")
+	DeterministicStorage3 = stakingTests.AddressFromString("oasis1qz359ng7waf2lp7j8c6vzd6qw4g4xtelysr0hl6x")
 
 	DeterministicKeyManager0 = stakingTests.AddressFromString("oasis1qpx0k28va6n0r25qd2j4jdh9f42n5vex6s9lp780")
 	DeterministicKeyManager1 = stakingTests.AddressFromString("oasis1qz30d8mqzrsrsu7fr0e6nxk0ze7ffdkj8ur7sqp0")


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/3301

This enables configuring epochtime length for the daily txsource test run. 
To setup a daily run with longer epochs, setup another schedule in the existing pipeline and configure the epoch interval via the `LONGTESTS_EPOCHTIME_INTERVAL` env var.

TODO:
- [x] test a long run with long epochs before setting it up
- [x] Needs https://github.com/oasisprotocol/oasis-core/pull/3391 merged (as it fixes an edge case in the test)
- [x] wait for one more test run: https://buildkite.com/oasisprotocol/oasis-core-long-tests/builds/242
- [ ] update the pipeline in buildkite after this is merged

```
buildkite-agent pipeline upload .buildkite/longtests.pipeline.yml -> .buildkite/longtests.pipeline.sh
```