### PR TITLE
go/worker/executor: reinsert tx batch in case round was not successful

### DIFF
--- a/.changelog/3324.bugfix.md
+++ b/.changelog/3324.bugfix.md
@@ -1,0 +1,1 @@
+go/worker/executor: reinsert tx batch in case round was not successful


### PR DESCRIPTION
Before we only reinserted the tx batch in case it failed during processing or on epoch transitions. Also reinsert the txs in case the round failed after commitment was already submitted.