### PR TITLE
Refactor release tooling

### DIFF
--- a/.changelog/3327.doc.md
+++ b/.changelog/3327.doc.md
@@ -1,0 +1,3 @@
+Update [Release Process] documentation
+
+[Release Process]: docs/release-process.md

--- a/.changelog/3327.internal.1.md
+++ b/.changelog/3327.internal.1.md
@@ -1,0 +1,1 @@
+Make: Output messages to stderr instead of stdout

--- a/.changelog/3327.internal.2.md
+++ b/.changelog/3327.internal.2.md
@@ -1,0 +1,4 @@
+internal: Refactor project's version handling
+
+Simplify version computation logic in Make files and start using Punch's
+version file to track version.

--- a/.changelog/3327.internal.3.md
+++ b/.changelog/3327.internal.3.md
@@ -1,0 +1,6 @@
+Make: Refactor release-related targets
+
+- Rename `tag-next-release` target to `release-tag`.
+- Rename `release` target to `release-build`.
+- Add `release-stable-branch` target that creates and pushes a stable branch
+  for the current release.

--- a/.changelog/3327.internal.4.md
+++ b/.changelog/3327.internal.4.md
@@ -1,0 +1,1 @@
+Make: Refactor Change Log handling

--- a/.changelog/3327.internal.5.md
+++ b/.changelog/3327.internal.5.md
@@ -1,0 +1,1 @@
+github: Bump GoReleaser in release workflow to 0.143.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           sudo mv goreleaser /usr/local/bin
         env:
           GORELEASER_URL_PREFIX: https://github.com/goreleaser/goreleaser/releases/download/
-          GORELEASER_VERSION: 0.127.0
+          GORELEASER_VERSION: 0.143.0
           GORELEASER_TARBALL: goreleaser_Linux_x86_64.tar.gz
           CURL_CMD: curl --proto =https --tlsv1.2 -sSL
       - name: Set RELEASE_BRANCH name for stable/bugfix releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,21 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          # Fetch all history as the recommended way to fetch all tags and
+          # branches of the project.
+          # This allows the release helpers in common.mk to determine the
+          # project's version from git correctly.
+          # For more info, see:
+          # https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
+          fetch-depth: 0
       - name: Set up Go 1.15
         uses: actions/setup-go@v2.1.2
         with:
           go-version: "1.15.x"
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
-      - name: Install oasis-node prerequisites
+      - name: Install Oasis Node prerequisites
         run: |
           sudo apt-get update
           sudo apt-get install make libseccomp-dev protobuf-compiler
@@ -43,9 +51,15 @@ jobs:
           GORELEASER_VERSION: 0.127.0
           GORELEASER_TARBALL: goreleaser_Linux_x86_64.tar.gz
           CURL_CMD: curl --proto =https --tlsv1.2 -sSL
-      - name: Create release
+      - name: Set RELEASE_BRANCH name for stable/bugfix releases
         run: |
-          make release
+          GIT_VERSION=${GITHUB_REF#refs/tags/v}
+          if [[ ! ${GIT_VERSION} =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo ::set-env name=RELEASE_BRANCH::stable/${GIT_VERSION%.*}.x
+          fi
+      - name: Build and publish the next release
+        run: |
+          make release-build
         env:
           # Instruct Make to create a real release.
           OASIS_CORE_REAL_RELEASE: "true"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ builds:
       # to ldflags.
       # For more details, see: https://github.com/oasislabs/goreleaser/issues/1.
       - -buildid=
-      - -X github.com/oasisprotocol/oasis-core/go/common/version.SoftwareVersion={{.Env.VERSION}}
+      - "{{.Env.GOLDFLAGS_VERSION}}"
     goos:
       - linux
     goarch:
@@ -42,7 +42,7 @@ builds:
       # to ldflags.
       # For more details, see: https://github.com/oasislabs/goreleaser/issues/1.
       - -buildid=
-      - -X github.com/oasisprotocol/oasis-core/go/common/version.SoftwareVersion={{.Env.VERSION}}
+      - "{{.Env.GOLDFLAGS_VERSION}}"
     goos:
       - linux
     goarch:
@@ -60,7 +60,7 @@ builds:
       # to ldflags.
       # For more details, see: https://github.com/oasislabs/goreleaser/issues/1.
       - -buildid=
-      - -X github.com/oasisprotocol/oasis-core/go/common/version.SoftwareVersion={{.Env.VERSION}}
+      - "{{.Env.GOLDFLAGS_VERSION}}"
     goos:
       - linux
     goarch:

--- a/.punch_config.py
+++ b/.punch_config.py
@@ -1,7 +1,11 @@
+# Punch configuration file.
+
+# For more information, see: https://punch.readthedocs.io/.
+
 __config_version__ = 1
 
 GLOBALS = {
-    'serializer': '{{year}}.{{minor}}',
+    'serializer': '{{year}}.{{minor}}.{{micro}}',
 }
 
 # NOTE: The FILES list is not allowed to be empty, so we need to pass it at
@@ -18,7 +22,12 @@ VERSION = [
         'name': 'minor',
         'type': 'integer',
     },
+    {
+        'name': 'micro',
+        'type': 'integer',
+    },
 ]
+
 ACTIONS = {
     'custom_bump': {
         'type': 'conditional_reset',

--- a/.punch_version.py
+++ b/.punch_version.py
@@ -1,0 +1,3 @@
+year = '20'
+minor = 11
+micro = 0

--- a/Makefile
+++ b/Makefile
@@ -144,32 +144,32 @@ clean: $(clean-targets)
 # Fetch all the latest changes (including tags) from the canonical upstream git
 # repository.
 fetch-git:
-	@$(ECHO_STDERR) "Fetching the latest changes (including tags) from $(OASIS_CORE_GIT_ORIGIN_REMOTE) remote..."
+	@$(ECHO) "Fetching the latest changes (including tags) from $(OASIS_CORE_GIT_ORIGIN_REMOTE) remote..."
 	@git fetch $(OASIS_CORE_GIT_ORIGIN_REMOTE) --tags
 
 # Assemble Change log.
 changelog: fetch-git
 	@$(ENSURE_NEXT_VERSION)
-	@$(ECHO_STDERR) "Generating Change Log for version $(NEXT_VERSION)..."
+	@$(ECHO) "Generating Change Log for version $(NEXT_VERSION)..."
 	towncrier build --version $(NEXT_VERSION)
-	@$(ECHO_STDERR) "Next, review the staged changes, commit them and make a pull request."
+	@$(ECHO) "Next, review the staged changes, commit them and make a pull request."
 	@$(WARN_BREAKING_CHANGES)
 
 # Tag the next release.
 tag-next-release: fetch-git
 	@$(ENSURE_NEXT_VERSION)
-	@$(ECHO_STDERR) "Checking if we can tag version $(NEXT_VERSION) as the next release..."
+	@$(ECHO) "Checking if we can tag version $(NEXT_VERSION) as the next release..."
 	@$(ENSURE_VALID_RELEASE_BRANCH_NAME)
 	@$(ENSURE_NO_CHANGELOG_FRAGMENTS)
 	@$(ENSURE_NEXT_VERSION_IN_CHANGELOG)
-	@$(ECHO_STDERR) "All checks have passed. Proceeding with tagging the $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH)'s HEAD with tags:\n- $(RELEASE_TAG)\n- $(RELEASE_TAG_GO)"
+	@$(ECHO) "All checks have passed. Proceeding with tagging the $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH)'s HEAD with tags:\n- $(RELEASE_TAG)\n- $(RELEASE_TAG_GO)"
 	@$(CONFIRM_ACTION)
-	@$(ECHO_STDERR) "If this appears to be stuck, you might need to touch your security key for GPG sign operation."
+	@$(ECHO) "If this appears to be stuck, you might need to touch your security key for GPG sign operation."
 	@git tag --sign --message="Version $(NEXT_VERSION)" $(RELEASE_TAG) $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH)
-	@$(ECHO_STDERR) "If this appears to be stuck, you might need to touch your security key for GPG sign operation."
+	@$(ECHO) "If this appears to be stuck, you might need to touch your security key for GPG sign operation."
 	@git tag --sign --message="Version $(NEXT_VERSION)" $(RELEASE_TAG_GO) $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH)
 	@git push $(OASIS_CORE_GIT_ORIGIN_REMOTE) $(RELEASE_TAG) $(RELEASE_TAG_GO)
-	@$(ECHO_STDERR) "$(CYAN)The following tags have been successfully pushed to $(OASIS_CORE_GIT_ORIGIN_REMOTE) remote:\n- $(RELEASE_TAG)\n- $(RELEASE_TAG_GO)$(OFF)"
+	@$(ECHO) "$(CYAN)The following tags have been successfully pushed to $(OASIS_CORE_GIT_ORIGIN_REMOTE) remote:\n- $(RELEASE_TAG)\n- $(RELEASE_TAG_GO)$(OFF)"
 
 # Prepare release.
 release:

--- a/Makefile
+++ b/Makefile
@@ -80,16 +80,8 @@ lint-git: fetch-git
 lint-md:
 	@npx markdownlint-cli '**/*.md' --ignore .changelog/
 
-# NOTE: Non-zero exit status is recorded but only set at the end so that all
-# markdownlint or gitlint errors can be seen at once.
 lint-changelog:
-	@exit_status=0; \
-	npx markdownlint-cli --config .changelog/.markdownlint.yml .changelog/ || exit_status=$$?; \
-	for fragment in $(CHANGELOG_FRAGMENTS_NON_TRIVIAL); do \
-		echo "Running gitlint on $$fragment..."; \
-		gitlint --msg-filename $$fragment -c title-max-length.line-length=78 || exit_status=$$?; \
-	done; \
-	exit $$exit_status
+	@$(CHECK_CHANGELOG_FRAGMENTS)
 
 # Check whether docs are synced with source code.
 lint-docs:

--- a/common.mk
+++ b/common.mk
@@ -34,62 +34,78 @@ OASIS_CORE_GIT_ORIGIN_REMOTE ?= origin
 # Name of the branch where to tag the next release.
 RELEASE_BRANCH ?= master
 
-# Try to determine Oasis Core's version from git.
-LATEST_TAG := $(shell git describe --tags --match 'v*' --abbrev=0 2>/dev/null)
-VERSION := $(subst v,,$(LATEST_TAG))
-IS_TAG := $(shell git describe --tags --match 'v*' --exact-match 2>/dev/null && echo YES || echo NO)
-ifeq ($(and $(LATEST_TAG),$(IS_TAG)),NO)
-	# The current commit is not exactly a tag, append commit and dirty info to
-	# the version.
-	VERSION := $(VERSION)-git$(shell git describe --always --match '' --dirty=+dirty 2>/dev/null)
+# Determine project's version from git.
+GIT_VERSION_LATEST_TAG := $(shell git describe --tags --match 'v*' --abbrev=0 2>/dev/null $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH) || echo undefined)
+GIT_VERSION_FROM_TAG := $(subst v,,$(GIT_VERSION_LATEST_TAG))
+GIT_VERSION_IS_TAG := $(shell git describe --tags --match 'v*' --exact-match &>/dev/null $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH) && echo YES || echo NO)
+ifeq ($(GIT_VERSION_IS_TAG),YES)
+	GIT_VERSION := $(GIT_VERSION_FROM_TAG)
+else
+    # The current commit is not exactly a tag, append commit and dirty info to
+    # the version.
+    GIT_VERSION := $(GIT_VERSION_FROM_TAG)-git$(shell git describe --always --match '' --dirty=+dirty 2>/dev/null)
 endif
-export VERSION
 
+# Determine project's git branch.
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 
-# Try to compute the next version based on the latest tag of the origin remote
-# using the Punch tool.
-# First, all tags from the origin remote are fetched. Next, the latest tag on
-# origin's release branch is determined. It represents Oasis Core's current
-# version. Lastly, the Punch tool is used to bump the version according to the
-# configurated versioning scheme in .punch_config.py.
-#
-# NOTE: This is a little messy because Punch doesn't support the following at
-# the moment:
-#   - Passing current version as an CLI parameter.
-#   - Outputting the new version to stdout without making modifications to any
-#     files.
-_PUNCH_VERSION_FILE_PATH_PREFIX := /tmp/oasis-core
-# NOTE: The "OUTPUT = $(eval OUTPUT := $$(shell some-comand))$(OUTPUT)" syntax
-# defers simple variable expansion so that it is only computed the first time it
-# is used. For more details, see:
-# http://make.mad-scientist.net/deferred-simple-variable-expansion/.
-_PUNCH_VERSION_FILE = $(eval _PUNCH_VERSION_FILE := $$(shell \
-	mktemp $(_PUNCH_VERSION_FILE_PATH_PREFIX).XXXXX.py \
-	))$(_PUNCH_VERSION_FILE)
-NEXT_VERSION ?= $(eval NEXT_VERSION := $$(shell \
-	set -e; \
-	LATEST_TAG_ORIGIN=`git describe --tags --match 'v*' --abbrev=0 $(OASIS_CORE_GIT_ORIGIN_REMOTE)/master` \
-	python3 -c "import os; year, minor = os.environ['LATEST_TAG_ORIGIN'].lstrip('v').split('.'); \
-		print(f'year=\"{year}\"\nminor={minor}')" > $(_PUNCH_VERSION_FILE); \
-	punch --config-file .punch_config.py --version-file $(_PUNCH_VERSION_FILE) --action custom_bump --quiet; \
-	python3 -c "exec(open('$(_PUNCH_VERSION_FILE)').read()); print('{}.{}'.format(year, minor))" \
-	))$(NEXT_VERSION)
+PUNCH_CONFIG_FILE := .punch_config.py
+PUNCH_VERSION_FILE := .punch_version.py
+# Obtain project's version as tracked by the Punch tool.
+# NOTE: The Punch tool doesn't have the ability fo print project's version to
+# stdout yet.
+# For more details, see: https://github.com/lgiordani/punch/issues/42.
+PUNCH_VERSION := $(shell python3 -c "exec(open('$(PUNCH_VERSION_FILE)').read()); version = f'{year}.{minor}.{micro}' if micro > 0 else f'{year}.{minor}'; print(version)")
+
+# Helper that bumps project's version with the Punch tool.
+define PUNCH_BUMP_VERSION =
+	if [[ "$(RELEASE_BRANCH)" == master ]]; then \
+		FLAG="--action custom_bump"; \
+	elif [[ "$(RELEASE_BRANCH)" == stable/* ]]; then \
+		if [[ -n "$(CHANGELOG_FRAGMENTS_BREAKING)" ]]; then \
+	        $(ECHO) "$(RED)Error: There shouldn't be breaking changes in a release on a stable branch.$(OFF)"; \
+			$(ECHO) "List of detected breaking changes:"; \
+			for fragment in "$(CHANGELOG_FRAGMENTS_BREAKING)"; do \
+				$(ECHO) "- $$fragment"; \
+			done; \
+			exit 1; \
+		else \
+			FLAG="--part micro"; \
+		fi; \
+    else \
+	    $(ECHO) "$(RED)Error: Unsupported release branch: '$(RELEASE_BRANCH)'.$(OFF)"; \
+		exit 1; \
+	fi; \
+	punch --config-file $(PUNCH_CONFIG_FILE) --version-file $(PUNCH_VERSION_FILE) $$FLAG --quiet
+endef
+
+# Helper that ensures project's version according to the latest Git tag equals
+# project's version as tracked by the Punch tool.
+define ENSURE_GIT_VERSION_FROM_TAG_EQUALS_PUNCH_VERSION =
+	if [[ "$(GIT_VERSION_FROM_TAG)" != "$(PUNCH_VERSION)" ]]; then \
+		$(ECHO) "$(RED)Error: Project version according to the latest Git tag from \
+		    $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH) ($(GIT_VERSION)) \
+			doesn't equal project's version in $(PUNCH_VERSION_FILE) ($(PUNCH_VERSION)).$(OFF)"; \
+		exit 1; \
+	fi
+endef
+
+# Helper that ensures project's version determined from git equals project's
+# version as tracked by the Punch tool.
+define ENSURE_GIT_VERSION_EQUALS_PUNCH_VERSION =
+	if [[ "$(GIT_VERSION)" != "$(PUNCH_VERSION)" ]]; then \
+		$(ECHO) "$(RED)Error: Project's version for $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH) \
+			determined from git ($(GIT_VERSION)) doesn't equal project's version in \
+			$(PUNCH_VERSION_FILE) ($(PUNCH_VERSION)).$(OFF)"; \
+		exit 1; \
+	fi
+endef
 
 # Go binary to use for all Go commands.
 OASIS_GO ?= go
 
 # Go command prefix to use in all Go commands.
 GO := env -u GOPATH $(OASIS_GO)
-
-# NOTE: The -trimpath flag strips all host dependent filesystem paths from
-# binaries which is required for deterministic builds.
-GOFLAGS ?= -trimpath -v
-
-# Add Oasis Core's version as a linker string value definition.
-ifneq ($(VERSION),)
-	export GOLDFLAGS ?= "-X github.com/oasisprotocol/oasis-core/go/common/version.SoftwareVersion=$(VERSION) -X github.com/oasisprotocol/oasis-core/go/common/version.GitBranch=$(GIT_BRANCH)"
-endif
 
 # Go build command to use by default.
 GO_BUILD_CMD := env -u GOPATH $(OASIS_GO) build $(GOFLAGS)
@@ -100,27 +116,88 @@ GO_TEST_HELPER_MKVS_PATH := storage/mkvs/interop/mkvs-test-helpers
 # Path to the example signer plugin binary in go/.
 GO_EXAMPLE_PLUGIN_PATH := oasis-test-runner/scenario/pluginsigner/example_signer_plugin
 
-# Helper that ensures $(NEXT_VERSION) variable is not empty.
-define ENSURE_NEXT_VERSION =
-	if [[ -z "$(NEXT_VERSION)" ]]; then \
-		$(ECHO) "$(RED)Error: Could not compute project's next version.$(OFF)"; \
+# NOTE: The -trimpath flag strips all host dependent filesystem paths from
+# binaries which is required for deterministic builds.
+GOFLAGS ?= -trimpath -v
+
+# Project's version as the linker's string value definition.
+export GOLDFLAGS_VERSION := -X github.com/oasisprotocol/oasis-core/go/common/version.SoftwareVersion=$(GIT_VERSION)
+# Project's git branch as the linker's string value definition.
+GOLDFLAGS_BRANCH := -X github.com/oasisprotocol/oasis-core/go/common/version.GitBranch=$(GIT_BRANCH)
+
+# Go's linker flags.
+export GOLDFLAGS ?= "$(GOLDFLAGS_VERSION) $(GOLDFLAGS_BRANCH)"
+
+# Helper that ensures the origin's release branch's HEAD contains a Change Log
+# section for the next release.
+define ENSURE_NEXT_RELEASE_IN_CHANGELOG =
+	if ! ( git show $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH):CHANGELOG.md | \
+			grep --quiet '^## $(PUNCH_VERSION) (.*)' ); then \
+		$(ECHO) "$(RED)Error: Could not locate Change Log section for release $(PUNCH_VERSION) on $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH) branch.$(OFF)"; \
 		exit 1; \
 	fi
 endef
 
 # Git tag of the next release.
-RELEASE_TAG := v$(NEXT_VERSION)
+RELEASE_TAG := v$(PUNCH_VERSION)
 # Go Modules compatible Git tag of the next release.
-RELEASE_TAG_GO = $(eval RELEASE_TAG_GO := $$(shell \
-	python3 -c "ver_parts = '$(NEXT_VERSION)'.split('.'); \
+RELEASE_TAG_GO := $(shell \
+	python3 -c "ver_parts = '$(PUNCH_VERSION)'.split('.'); \
 		ver_parts.append(0) if len(ver_parts) == 2 else ''; \
 		print('go/v0.{}{:0>2}.{}'.format(*ver_parts))" \
-	))$(RELEASE_TAG_GO)
+	)
 
-# Helper that ensures $(RELEASE_BRANCH) variable contains a valid release branch name.
+# Helper that ensures the new release's tag doesn't already exist on the origin
+# remote.
+define ENSURE_RELEASE_TAG_EXISTS =
+	if ! git ls-remote --exit-code --tags $(OASIS_CORE_GIT_ORIGIN_REMOTE) $(RELEASE_TAG) 1>/dev/null; then \
+		$(ECHO) "$(RED)Error: Tag '$(RELEASE_TAG)' doesn't exist on $(OASIS_CORE_GIT_ORIGIN_REMOTE) remote.$(OFF)"; \
+		exit 1; \
+	fi
+endef
+
+# Helper that ensures the new release's tag doesn't already exist on the origin
+# remote.
+define ENSURE_RELEASE_TAG_DOES_NOT_EXIST =
+	if git ls-remote --exit-code --tags $(OASIS_CORE_GIT_ORIGIN_REMOTE) $(RELEASE_TAG) 1>/dev/null; then \
+		$(ECHO) "$(RED)Error: Tag '$(RELEASE_TAG)' already exists on $(OASIS_CORE_GIT_ORIGIN_REMOTE) remote.$(OFF)"; \
+		exit 1; \
+	fi; \
+	if git show-ref --quiet --tags $(RELEASE_TAG); then \
+		$(ECHO) "$(RED)Error: Tag '$(RELEASE_TAG)' already exists locally.$(OFF)"; \
+		exit 1; \
+	fi
+endef
+
+# Name of the stable release branch (if the current version is appropriate).
+STABLE_BRANCH := $(shell python3 -c "exec(open('$(PUNCH_VERSION_FILE)').read()); print(f'stable/{year}.{minor}.x') if micro == 0 else print('undefined')")
+
+# Helper that ensures the stable branch name is valid.
+define ENSURE_VALID_STABLE_BRANCH =
+	if [[ "$(STABLE_BRANCH)" == "undefined" ]]; then \
+		$(ECHO) "$(RED)Error: Cannot create a stable release branch for version $(PUNCH_VERSION).$(OFF)"; \
+		exit 1; \
+	fi
+endef
+
+# Helper that ensures the new stable branch doesn't already exist on the origin
+# remote.
+define ENSURE_STABLE_BRANCH_DOES_NOT_EXIST =
+	if git ls-remote --exit-code --heads $(OASIS_CORE_GIT_ORIGIN_REMOTE) $(STABLE_BRANCH) 1>/dev/null; then \
+		$(ECHO) "$(RED)Error: Branch '$(STABLE_BRANCH)' already exists on $(OASIS_CORE_GIT_ORIGIN_REMOTE) remote.$(OFF)"; \
+		exit 1; \
+	fi; \
+	if git show-ref --quiet --heads $(STABLE_BRANCH); then \
+		$(ECHO) "$(RED)Error: Branch '$(STABLE_BRANCH)' already exists locally.$(OFF)"; \
+		exit 1; \
+	fi
+endef
+
+# Helper that ensures $(RELEASE_BRANCH) variable contains a valid release branch
+# name.
 define ENSURE_VALID_RELEASE_BRANCH_NAME =
 	if [[ ! $(RELEASE_BRANCH) =~ ^(master|(stable/[0-9]+\.[0-9]+\.x$$)) ]]; then \
-		$(ECHO) "$(RED)Error: Invalid release branch name: $(RELEASE_BRANCH)."; \
+		$(ECHO) "$(RED)Error: Invalid release branch name: '$(RELEASE_BRANCH)'."; \
 		exit 1; \
 	fi
 endef
@@ -138,15 +215,6 @@ define ENSURE_NO_CHANGELOG_FRAGMENTS =
 	fi
 endef
 
-# Helper that ensures the origin's release branch's HEAD contains a Change Log section for the next release.
-define ENSURE_NEXT_VERSION_IN_CHANGELOG =
-	if ! ( git show $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH):CHANGELOG.md | \
-			grep --quiet '^## $(NEXT_VERSION) (.*)' ); then \
-		$(ECHO) "$(RED)Error: Could not locate Change Log section for release $(NEXT_VERSION) on $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH) branch.$(OFF)"; \
-		exit 1; \
-	fi
-endef
-
 # Auxiliary variable that defines a new line for later substitution.
 define newline
 
@@ -160,7 +228,7 @@ For a list of changes in this release, see the [Change Log].
 *NOTE: If you are upgrading from an earlier release, please **carefully review**
 the [Change Log] for **Removals and Breaking changes**.*
 
-[Change Log]: https://github.com/oasisprotocol/oasis-core/blob/v$(VERSION)/CHANGELOG.md
+[Change Log]: https://github.com/oasisprotocol/oasis-core/blob/v$(GIT_VERSION)/CHANGELOG.md
 
 endef
 
@@ -173,6 +241,16 @@ _RELEASE_NOTES_FILE := $(shell mktemp /tmp/oasis-core.XXXXX)
 _ := $(shell printf "$(subst ",\",$(subst $(newline),\n,$(RELEASE_TEXT)))" > $(_RELEASE_NOTES_FILE))
 GORELEASER_ARGS = release --release-notes $(_RELEASE_NOTES_FILE)
 endif
+
+# Manually set GoReleaser's release tag since its automatic detection fails when
+# two tags point to the same commit.
+# In our case, each release has two tags:
+# - an ordinary Git tag
+# - a Go Modules compatible Git tag
+# and hence we need to set it manually.
+# For more details, see:
+# https://goreleaser.com/customization/build/#define-build-tag
+export GORELEASER_CURRENT_TAG := $(RELEASE_TAG)
 
 # List of non-trivial Change Log fragments.
 CHANGELOG_FRAGMENTS_NON_TRIVIAL := $(filter-out $(wildcard .changelog/*trivial*.md),$(wildcard .changelog/[0-9]*.md))

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,6 +1,11 @@
 [tool.towncrier]
 filename = "CHANGELOG.md"
 directory = ".changelog"
+# Ignore certain files when running towncrier check.
+check_ignore_files = [
+  # Punch's version file.
+  ".punch_version.py",
+]
 issue_format = "[#{issue}](https://github.com/oasisprotocol/oasis-core/issues/{issue})"
 start_string = "<!-- TOWNCRIER -->\n"
 # Custom Jinja2 template for preparing a new section of the Change Log.


### PR DESCRIPTION
Among other things, this should get rid of the:
```
/bin/bash: punch: command not found error
```
error message when running Make targets without having the Punch utility installed.