### PR TITLE
Storage checkpoint restore related fixes

### DIFF
--- a/.changelog/3329.trivial.md
+++ b/.changelog/3329.trivial.md
@@ -1,0 +1,4 @@
+go/worker/storage: Abort multipart insert after failed finalize
+
+Make sure to abort the multipart insert after a failed finalize operation as
+otherwise all normal batch operations will continue to fail.

--- a/.changelog/3330.bugfix.md
+++ b/.changelog/3330.bugfix.md
@@ -1,0 +1,1 @@
+go/storage/mkvs: Fix Finalize after checkpoint restore

--- a/go/storage/mkvs/db/badger/badger.go
+++ b/go/storage/mkvs/db/badger/badger.go
@@ -518,9 +518,9 @@ func (d *badgerNodeDB) Finalize(ctx context.Context, version uint64, roots []has
 	tx := d.db.NewTransactionAt(versionToTs(version), true)
 	defer tx.Discard()
 
-	// Make sure that the previous version has been finalized.
+	// Make sure that the previous version has been finalized (if we are not restoring).
 	lastFinalizedVersion, exists := d.meta.getLastFinalizedVersion()
-	if version > 0 && exists && lastFinalizedVersion < (version-1) {
+	if d.multipartVersion == multipartVersionNone && version > 0 && exists && lastFinalizedVersion < (version-1) {
 		return api.ErrNotFinalized
 	}
 	// Make sure that this version has not yet been finalized.

--- a/go/worker/storage/committee/checkpoint_sync.go
+++ b/go/worker/storage/committee/checkpoint_sync.go
@@ -455,6 +455,13 @@ func (n *Node) syncCheckpoints() (*blockSummary, error) {
 						"version", prevVersion,
 						"roots", doneRoots,
 					)
+					// Since finalize failed, we need to make sure to abort multipart insert
+					// otherwise all normal batch operations will continue to fail.
+					if abortErr := n.localStorage.NodeDB().AbortMultipartInsert(); abortErr != nil {
+						n.logger.Error("can't abort multipart insert after finalization failure",
+							"err", err,
+						)
+					}
 					// Likely a local problem, so just bail.
 					return nil, fmt.Errorf("can't finalize version after checkpoints restored: %w", err)
 				}


### PR DESCRIPTION
Fixes #3329 
Fixes #3330 

* go/worker/storage: Abort multipart insert after failed finalize
  
  Make sure to abort the multipart insert after a failed finalize operation as
  otherwise all normal batch operations will continue to fail.

* go/storage/mkvs: Fix Finalize after checkpoint restore