### PR TITLE
go: update to build on macOS

### DIFF
--- a/.changelog/3333.internal.md
+++ b/.changelog/3333.internal.md
@@ -1,0 +1,1 @@
+go: Update to build on macOS

--- a/go/common/crypto/signature/signers/plugin/plugin.go
+++ b/go/common/crypto/signature/signers/plugin/plugin.go
@@ -7,12 +7,12 @@ import (
 	"net/rpc"
 	"os/exec"
 	"sync"
-	"syscall"
 
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/syscall"
 )
 
 const (
@@ -94,9 +94,7 @@ func NewFactory(config interface{}, roles ...signature.SignerRole) (signature.Si
 	// We do use managed plugins so that in the graceful exit case,
 	// the cleanup will be done at least.
 	cmd := exec.Command(cfg.Path) // nolint: gosec
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: syscall.SIGKILL,
-	}
+	cmd.SysProcAttr = syscall.CmdAttrs
 
 	client := plugin.NewClient(&plugin.ClientConfig{
 		HandshakeConfig: handshakeConfigForName(cfg.Name),

--- a/go/common/syscall/syscall_darwin.go
+++ b/go/common/syscall/syscall_darwin.go
@@ -1,0 +1,12 @@
+// Package syscall defines OS-specific syscall parameters.
+package syscall
+
+import "syscall"
+
+// IoctlTermiosGetAttr is the ioctl that implements termios tcgetattr.
+const IoctlTermiosGetAttr = syscall.TIOCGETA
+
+// CmdAttrs is the SysProcAttr used for spawning child processes. It is empty
+// for Darwin as PR_SET_PDEATH_SIG is not implemented. As a consequence, child
+// processes may not be cleaned up.
+var CmdAttrs = &syscall.SysProcAttr{}

--- a/go/common/syscall/syscall_linux.go
+++ b/go/common/syscall/syscall_linux.go
@@ -1,0 +1,12 @@
+// Package syscall defines OS-specific syscall parameters.
+package syscall
+
+import "syscall"
+
+// IoctlTermiosGetAttr is the ioctl that implements termios tcgetattr.
+const IoctlTermiosGetAttr = syscall.TCGETS
+
+// CmdAttrs is the SysProcAttr that will ensure graceful cleanup (on Linux).
+var CmdAttrs = &syscall.SysProcAttr{
+	Pdeathsig: syscall.SIGKILL,
+}

--- a/go/oasis-node/cmd/common/isatty.go
+++ b/go/oasis-node/cmd/common/isatty.go
@@ -3,6 +3,8 @@ package common
 import (
 	"syscall"
 	"unsafe"
+
+	cmnSyscall "github.com/oasisprotocol/oasis-core/go/common/syscall"
 )
 
 // Isatty returns true iff the provided file descriptor is a terminal.
@@ -20,7 +22,7 @@ func Isatty(fd uintptr) bool {
 	_, _, errno := syscall.Syscall6(
 		syscall.SYS_IOCTL,
 		fd,
-		syscall.TCGETS,
+		cmnSyscall.IoctlTermiosGetAttr,
 		uintptr(unsafe.Pointer(&attrs)),
 		0,
 		0,

--- a/go/oasis-test-runner/env/env.go
+++ b/go/oasis-test-runner/env/env.go
@@ -14,16 +14,16 @@ import (
 	"time"
 
 	flag "github.com/spf13/pflag"
+
+	cmnSyscall "github.com/oasisprotocol/oasis-core/go/common/syscall"
 )
 
 // ErrEarlyTerm is the error passed over the error channel when a
 // sub-process terminates prior to the Cleanup.
 var ErrEarlyTerm = errors.New("env: sub-process exited early")
 
-// CmdAttrs is the SysProcAttr that will ensure graceful cleanup.
-var CmdAttrs = &syscall.SysProcAttr{
-	Pdeathsig: syscall.SIGKILL,
-}
+// CmdAttrs is the SysProcAttr that will ensure graceful cleanup (on Linux).
+var CmdAttrs = cmnSyscall.CmdAttrs
 
 // CleanupFn is the cleanup hook function prototype.
 type CleanupFn func()


### PR DESCRIPTION
This PR factors out some OS-specific syscall parameters for conditional compilation.

_This does not change the fact that **macOS is not officially supported by oasis-core**._