### PR TITLE
go/consensus/tendermint: Bump Tendermint Core to v0.34-rc4-oasis4

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -11,7 +11,7 @@ replace (
 	// https://github.com/spf13/cobra/issues/1091
 	github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.2
 
-	github.com/tendermint/tendermint => github.com/oasisprotocol/tendermint v0.34.0-rc4-oasis3
+	github.com/tendermint/tendermint => github.com/oasisprotocol/tendermint v0.34.0-rc4-oasis4
 	golang.org/x/crypto/curve25519 => github.com/oasisprotocol/ed25519/extra/x25519 v0.0.0-20200819094954-65138ca6ec7c
 	golang.org/x/crypto/ed25519 => github.com/oasisprotocol/ed25519 v0.0.0-20200819094954-65138ca6ec7c
 )

--- a/go/go.sum
+++ b/go/go.sum
@@ -774,8 +774,8 @@ github.com/oasisprotocol/ed25519 v0.0.0-20200819094954-65138ca6ec7c h1:/Ydlzrdta
 github.com/oasisprotocol/ed25519 v0.0.0-20200819094954-65138ca6ec7c/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661 h1:MB73kGMtuMGS+6VDoU/mitzff7Cu+aZo9ta5wabuxVA=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661/go.mod h1:SwBxaVibf6Sr2IZ6M3WnUue0yp8dPLAo1riQRNQ60+g=
-github.com/oasisprotocol/tendermint v0.34.0-rc4-oasis3 h1:EzWXQpWq90ERowDw12jgcRQQK2FOAWVDBCHNuX7XG8M=
-github.com/oasisprotocol/tendermint v0.34.0-rc4-oasis3/go.mod h1:kIas9rp0S0G40yvKnYlW/mtQei8AJXQToxS8IWNZPbA=
+github.com/oasisprotocol/tendermint v0.34.0-rc4-oasis4 h1:FVMRTVVDwNlseeWyTbuQ7scwU7+Mdxze5RidlFOcqpg=
+github.com/oasisprotocol/tendermint v0.34.0-rc4-oasis4/go.mod h1:kIas9rp0S0G40yvKnYlW/mtQei8AJXQToxS8IWNZPbA=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=


### PR DESCRIPTION
Includes https://github.com/tendermint/tendermint/pull/5412.

TODO
* [x] Tag fork and update tag in `go.mod`.