### PR TITLE
go/e2e/workload-queries: allow historical `QueryTxs` to fail few times

### DIFF
--- a/.changelog/3338.internal.md
+++ b/.changelog/3338.internal.md
@@ -1,0 +1,1 @@
+go/e2e/workload-queries: allow historical `QueryTxs` to fail few times


### PR DESCRIPTION
A `QueryTxs` in the daily E2E tests will fail in case it's done for a height for which active storage nodes are missing historical state due to restoring from snapshots (https://github.com/oasisprotocol/oasis-core/issues/3337). Note: for this to happen also the `storage-0` needs to not be in the committee for the epoch (since `storage-0` is never restarted it has all the state), and the other storage node (which likely has the state) is down (e.g. due to just being restarted), therefore this should happen rarely.
This makes the E2E test not fail in those cases.