### PR TITLE
go/nancy: remove fixed 'golang.org/x/net' false positive ignores

### DIFF
--- a/.changelog/3340.internal.md
+++ b/.changelog/3340.internal.md
@@ -1,0 +1,1 @@
+go/nancy: remove `golang.org/x/net` false positive ignores

--- a/go/.nancy-ignore
+++ b/go/.nancy-ignore
@@ -1,13 +1,3 @@
-# For some reason these are false positives in the golang/golang.org/x/net, we
-# use the latest version of this package which is not vulnerable.
-# See: https://github.com/sonatype-nexus-community/nancy/issues/189
-CVE-2018-17847
-CVE-2018-17142
-CVE-2018-17846
-CVE-2018-17075
-CVE-2018-17143
-CVE-2018-17848
-
 # Beats me how and why etcd is even imported in viper.
 # https://github.com/spf13/viper/issues/956
 CVE-2020-15114


### PR DESCRIPTION
Should be fixed now: https://github.com/sonatype-nexus-community/nancy/issues/189