### PR TITLE
go/dependencies/etcd: update etcd with replace directive

### DIFF
--- a/.changelog/3341.internal.md
+++ b/.changelog/3341.internal.md
@@ -1,0 +1,1 @@
+go/dependencies/etcd: update etcd with replace directive

--- a/go/.nancy-ignore
+++ b/go/.nancy-ignore
@@ -1,5 +1,0 @@
-# Beats me how and why etcd is even imported in viper.
-# https://github.com/spf13/viper/issues/956
-CVE-2020-15114
-CVE-2020-15136
-CVE-2020-15115

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,10 @@
 module github.com/oasisprotocol/oasis-core/go
 
 replace (
+	// Fixes vulnerabilities in etcd v3.3.{10,13} (dependencies via viper).
+	// Can be removed once there is a spf13/viper release with updated etcd.
+	// https://github.com/spf13/viper/issues/956
+	github.com/coreos/etcd => github.com/coreos/etcd v3.3.25+incompatible
 	// Updates the version used in spf13/cobra (dependency via tendermint) as
 	// there is no release yet with the fix. Remove once an updated release of
 	// spf13/cobra exists and tendermint is updated to include it.

--- a/go/go.sum
+++ b/go/go.sum
@@ -114,8 +114,7 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
-github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
-github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
+github.com/coreos/etcd v3.3.25+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=


### PR DESCRIPTION
With updated `nancy` (done in https://github.com/oasisprotocol/oasis-core/pull/3283) we now use `go list -json -m all` to get the list of dependencies, which does correctly take `replace` directive into account. Therefore we can now replace the vulnerable etcd and remove the CVE ignores.