### PR TITLE
go/executor/node: check if we are in correct state before publishing a message

### DIFF
--- a/.changelog/3342.trivial.md
+++ b/.changelog/3342.trivial.md
@@ -1,0 +1,1 @@
+go/executor/node: ensure correct state before publishing a message


### PR DESCRIPTION
Currently (since https://github.com/oasisprotocol/oasis-core/pull/3320) this check is made after a node publishes a message, instead this check should be made before node publishes a message to prevent proposing another batch after node starts processing a batch.
Note that `p2p.Publish` is async so this shouldn't increase the time the CrossNode.Lock is held by much.