### PR TITLE
p2p topic ids: include chain ID and remove patch version

### DIFF
--- a/.changelog/3311.breaking.md
+++ b/.changelog/3311.breaking.md
@@ -1,0 +1,3 @@
+go/worker/p2p: include chain ID and remove patch version from topic IDs
+
+This is a breaking `RuntimeCommitteeProtocol` change.

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -68,7 +68,7 @@ var (
 
 	// RuntimeCommitteeProtocol versions the P2P protocol used by the runtime
 	// committee members.
-	RuntimeCommitteeProtocol = Version{Major: 1, Minor: 0, Patch: 0}
+	RuntimeCommitteeProtocol = Version{Major: 2, Minor: 0, Patch: 0}
 
 	// ConsensusProtocol versions all data structures and processing used by
 	// the epochtime, beacon, registry, roothash, etc. modules that are

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -106,6 +106,8 @@ var Versions = struct {
 }
 
 func parseSemVerStr(s string) Version {
+	// Trim potential pre-release suffix.
+	s = strings.Split(s, "-")[0]
 	split := strings.SplitN(s, ".", 4)
 
 	var semVers []uint16 = []uint16{0, 0, 0}

--- a/go/common/version/version_test.go
+++ b/go/common/version/version_test.go
@@ -1,0 +1,49 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMajorMinor(t *testing.T) {
+	require := require.New(t)
+
+	v1 := Version{1, 1, 0}
+	v2 := Version{1, 1, 5}
+	v3 := Version{1, 1, 10}
+	require.Equal(v1.MajorMinor(), v2.MajorMinor(), "version.MajorMinor() should match")
+	require.Equal(v2.MajorMinor(), v3.MajorMinor(), "version.MajorMinor() should match")
+	v4 := Version{1, 2, 0}
+	require.NotEqual(v1.MajorMinor(), v4.MajorMinor(), "version.MajorMinor() should not match")
+}
+
+func TestParseSemVer(t *testing.T) {
+	require := require.New(t)
+
+	for _, v := range []struct {
+		semver   string
+		expected Version
+	}{
+		{"1.0.0", Version{1, 0, 0}},
+		{"2.1.3", Version{2, 1, 3}},
+		{"1.0.0-alpha", Version{1, 0, 0}},
+		{"1.0.0-alpha+1.2", Version{1, 0, 0}},
+		{"1.8.2-beta.1.13", Version{1, 8, 2}},
+	} {
+		require.Equal(parseSemVerStr(v.semver), v.expected, "parseSemVerStr()")
+	}
+}
+
+func TestFromToU64(t *testing.T) {
+	require := require.New(t)
+
+	for _, v := range []Version{
+		{},
+		{0, 0, 0},
+		{1, 1, 1},
+		{10, 20, 30},
+	} {
+		require.Equal(FromU64(v.ToU64()), v, "FromU64(version.ToU64())")
+	}
+}

--- a/go/worker/common/p2p/dispatch.go
+++ b/go/worker/common/p2p/dispatch.go
@@ -223,7 +223,7 @@ func (h *topicHandler) retryWorker(m *queuedMsg) {
 }
 
 func newTopicHandler(p *P2P, runtimeID common.Namespace, handlers []Handler) (string, *topicHandler, error) {
-	topicID := runtimeIDToTopicID(runtimeID)
+	topicID := p.topicIDForRuntime(runtimeID)
 	topic, err := p.pubsub.Join(topicID) // Note: Disallows duplicates.
 	if err != nil {
 		return "", nil, fmt.Errorf("worker/common/p2p: failed to join topic '%s': %w", topicID, err)


### PR DESCRIPTION
Fixes: #3311

Note: used `MajorMinor()` since we also used that for runtime-host protocol.

This is a breaking `RuntimeCommitteeProtocol` change.