### PR TITLE
go/worker/common/committee: group version should be the epoch block

### DIFF
--- a/.changelog/3347.bugfix.md
+++ b/.changelog/3347.bugfix.md
@@ -1,0 +1,5 @@
+go/worker/common/committee: group version should be the epoch block
+
+When node is restarted, `EpochTransition` is called on the first received
+block, which is not necessary the actual epoch transition block. Therefore the
+epoch block needs to be queried to obtain the correct group version.


### PR DESCRIPTION
Discovered while testing: https://github.com/oasisprotocol/oasis-core/pull/3322

Note: in the other place where we compute current version (runtime client) we already handle this case correctly.