### PR TITLE
go/oasis-test-runner: Fix e2e/consensus-state-sync scenario (take two)

### DIFF
--- a/.changelog/3369.internal.md
+++ b/.changelog/3369.internal.md
@@ -1,0 +1,4 @@
+go/oasis-test-runner: Fix e2e/consensus-state-sync scenario (take two)
+
+Previous "fix" actually made the test silently skip actually performing state
+sync because it used the wrong validator index.

--- a/go/consensus/tendermint/abci/mux.go
+++ b/go/consensus/tendermint/abci/mux.go
@@ -43,6 +43,10 @@ const (
 
 	// debugTxLifetime is the transaction mempool lifetime when CheckTx is disabled (debug only).
 	debugTxLifetime = 1 * time.Minute
+
+	// LogEventABCIStateSyncComplete is a log event value that signals an ABCI state syncing
+	// completed event.
+	LogEventABCIStateSyncComplete = "tendermint/abci/state_sync_complete"
 )
 
 var (
@@ -1008,6 +1012,7 @@ func (mux *abciMux) ApplySnapshotChunk(req types.RequestApplySnapshotChunk) type
 
 		mux.logger.Info("successfully synced state",
 			"root", cp.Root,
+			logging.LogEvent, LogEventABCIStateSyncComplete,
 		)
 	}
 

--- a/go/oasis-test-runner/oasis/log.go
+++ b/go/oasis-test-runner/oasis/log.go
@@ -82,6 +82,12 @@ func LogEventABCIPruneDelete() log.WatcherHandlerFactory {
 	return LogAssertEvent(abci.LogEventABCIPruneDelete, "expected ABCI pruning to be done")
 }
 
+// LogEventABCIStateSyncComplete returns a handler which checks whether an ABCI state sync
+// completion was detected based on JSON log output.
+func LogEventABCIStateSyncComplete() log.WatcherHandlerFactory {
+	return LogAssertEvent(abci.LogEventABCIStateSyncComplete, "expected ABCI state sync to complete")
+}
+
 // LogAssertRoothashRoothashReindexing returns a handler which checks whether roothash reindexing was
 // run based on JSON log output.
 func LogAssertRoothashRoothashReindexing() log.WatcherHandlerFactory {


### PR DESCRIPTION
Previous "fix" (see #3194) actually made the test silently skip actually performing state sync because it used the wrong validator index.