### PR TITLE
go/e2e/queries: correctly ignore UnexpectedEOF errors

### DIFF
--- a/.changelog/3372.internal.md
+++ b/.changelog/3372.internal.md
@@ -1,0 +1,1 @@
+go/e2e/queries: correctly ignore UnexpectedEOF errors

--- a/go/oasis-node/cmd/debug/txsource/workload/queries.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/queries.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
@@ -239,9 +240,11 @@ func (q *queries) doConsensusQueries(ctx context.Context, rng *rand.Rand, height
 			"txs_with_results", txsWithRes,
 			"height", height,
 			"err", err,
+			"status", cmnGrpc.GetErrorStatus(err),
 		)
-		if status := cmnGrpc.GetErrorStatus(err); status != nil {
-			if status.Err() == io.ErrUnexpectedEOF {
+		if st := cmnGrpc.GetErrorStatus(err); st != nil {
+			s, _ := status.FromError(io.ErrUnexpectedEOF)
+			if st.Err().Error() == s.Err().Error() {
 				// XXX: Connection seems to get occasionally reset with
 				// FLOW_CONTROL_ERROR in GetTransactionsWithResult during
 				// long-term tests, don't fail on this error until we


### PR DESCRIPTION
Working fix from: #3302 , now with tests