### PR TITLE
go/worker/p2p: Include new peers from received node list

### DIFF
--- a/.changelog/3378.bugfix.md
+++ b/.changelog/3378.bugfix.md
@@ -1,0 +1,1 @@
+go/worker/p2p: Correctly update peers on `WatchNodeList` events

--- a/go/worker/common/p2p/peermgmt.go
+++ b/go/worker/common/p2p/peermgmt.go
@@ -62,14 +62,17 @@ func (mgr *PeerManager) SetNodes(nodes []*node.Node) {
 		newNodes[peerID] = node
 	}
 
+	// Remove existing peers that are not in the new node list.
 	for peerID := range mgr.peers {
 		node := newNodes[peerID]
 		if node == nil {
-			// Remove existing peers that are not in the new node list.
 			mgr.removePeerLocked(peerID)
 			continue
 		}
+	}
 
+	// Update peers from the new node list.
+	for peerID, node := range newNodes {
 		mgr.updateNodeLocked(node, peerID)
 	}
 


### PR DESCRIPTION
Previously we only removed peers and updated existing peers from the received node list - therefore a node restarting in the middle of an epoch did not actually connect to all of the nodes until the next epoch transition (it only connected to the nodes that did an update mid-epoch - which triggered a `WatchNodes` event).

Discovered while testing #3322