### PR TITLE
go/registry.WatchNodeList: return current node list upon subscription

### DIFF
--- a/.changelog/3379.bugfix.md
+++ b/.changelog/3379.bugfix.md
@@ -1,0 +1,1 @@
+go/registry.WatchNodeList: return current node list upon subscription

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -208,7 +208,7 @@ type Backend interface {
 
 	// WatchNodeList returns a channel that produces a stream of NodeList.
 	// Upon subscription, the node list for the current epoch will be sent
-	// immediately if available.
+	// immediately.
 	//
 	// Each node list will be sorted by node ID in lexicographically ascending
 	// order.


### PR DESCRIPTION
Related to: https://github.com/oasisprotocol/oasis-core/pull/3378
Discovered when testing: https://github.com/oasisprotocol/oasis-core/pull/3322 