### PR TITLE
go/backoff: Update `cenkalti/backoff` to 4.1.0

### DIFF
--- a/.changelog/3390.internal.md
+++ b/.changelog/3390.internal.md
@@ -1,0 +1,1 @@
+go/backoff: Update `cenkalti/backoff` to 4.1.0

--- a/go/go.mod
+++ b/go/go.mod
@@ -19,7 +19,7 @@ replace (
 require (
 	github.com/blevesearch/bleve v1.0.12
 	github.com/btcsuite/btcutil v1.0.2
-	github.com/cenkalti/backoff/v4 v4.0.2
+	github.com/cenkalti/backoff/v4 v4.1.0
 	github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d // indirect
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 // indirect
 	github.com/cznic/strutil v0.0.0-20181122101858-275e90344537 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -102,8 +102,8 @@ github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEe
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.0.0 h1:6VeaLF9aI+MAUQ95106HwWzYZgJJpZ4stumjj6RFYAU=
 github.com/cenkalti/backoff/v4 v4.0.0/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
-github.com/cenkalti/backoff/v4 v4.0.2 h1:JIufpQLbh4DkbQoii76ItQIUFzevQSqOLZca4eamEDs=
-github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
+github.com/cenkalti/backoff/v4 v4.1.0 h1:c8LkOFQTzuO0WBM/ae5HdGQuZPfPxp7lqBRwQRm4fSc=
+github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/go/worker/common/p2p/error/error_test.go
+++ b/go/worker/common/p2p/error/error_test.go
@@ -91,6 +91,13 @@ func TestEnsurePermanent(t *testing.T) {
 			true,
 		},
 		{
+			"Relayable(Permanent(io.EOF))",
+			func() error {
+				return Relayable(Permanent(io.EOF))
+			},
+			false,
+		},
+		{
 			// This case is treated as permanent by backoff, but we treat it as
 			// a non-permanent error.
 			"Permanent(context.Canceled)",
@@ -106,23 +113,6 @@ func TestEnsurePermanent(t *testing.T) {
 				return EnsurePermanent(Permanent(context.Canceled))
 			},
 			true,
-		},
-		{
-			// This case is retried by backoff, since their permanent check
-			// doesn't unwrap the error.
-			"Relayable(Permanent(io.EOF))",
-			func() error {
-				return Relayable(Permanent(io.EOF))
-			},
-			true,
-		},
-		{
-			// This case tests EnsurePermanent on the previous test case.
-			"EnsurePermanent(Relayable(Permanent(io.EOF)))",
-			func() error {
-				return EnsurePermanent(Relayable(Permanent(io.EOF)))
-			},
-			false,
 		},
 	} {
 		ensureRetries(testCase.name, testCase.shouldRetry, testCase.testF)


### PR DESCRIPTION
Out upstream patch was accepted and released so the `EnsurePermanent` workaround can be simplified to only special case the `context.Canceled` method.