### PR TITLE
failure indicating commitments

### DIFF
--- a/.changelog/3391.breaking.md
+++ b/.changelog/3391.breaking.md
@@ -1,0 +1,8 @@
+roothash: Add support for failure indicating commitments
+
+Failure-indicating executor commits are introduced in order to give the
+compute nodes a possibility to vote for failure when they cannot execute the
+given batch (e.g., due to unavailability of storage). Such commits will always
+trigger a discrepancy during discrepancy detection and will vote for failing
+the round in discrepancy resolution phase.
+<!--- Once ADR 0005 is merged, can add a link to it here. -->

--- a/.changelog/3391.internal.md
+++ b/.changelog/3391.internal.md
@@ -1,0 +1,1 @@
+roothash: Add consistent hash test for ComputeResultsHeader

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -82,7 +82,7 @@ var (
 	// checked in Oasis Core.
 	// It is converted to TendermintAppVersion whose compatibility is checked
 	// via Tendermint's version checks.
-	ConsensusProtocol = Version{Major: 1, Minor: 0, Patch: 0}
+	ConsensusProtocol = Version{Major: 2, Minor: 0, Patch: 0}
 
 	// TendermintAppVersion is Tendermint ABCI application's version computed by
 	// masking non-major consensus protocol version segments to 0 to be

--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -454,8 +454,8 @@ func (app *rootHashApplication) tryFinalizeExecutorCommits(
 		hdr := commit.ToDDResult().(commitment.ComputeResultsHeader)
 
 		blk := block.NewEmptyBlock(rtState.CurrentBlock, uint64(ctx.Now().Unix()), block.Normal)
-		blk.Header.IORoot = hdr.IORoot
-		blk.Header.StateRoot = hdr.StateRoot
+		blk.Header.IORoot = *hdr.IORoot
+		blk.Header.StateRoot = *hdr.StateRoot
 		// Messages omitted on purpose.
 
 		// Timeout will be cleared by caller.

--- a/go/oasis-node/cmd/debug/byzantine/executor.go
+++ b/go/oasis-node/cmd/debug/byzantine/executor.go
@@ -260,8 +260,8 @@ func (cbc *computeBatchContext) createCommitment(id *identity.Identity, rak sign
 	header := commitment.ComputeResultsHeader{
 		Round:        cbc.bd.Header.Round + 1,
 		PreviousHash: cbc.bd.Header.EncodedHash(),
-		IORoot:       cbc.newIORoot,
-		StateRoot:    cbc.newStateRoot,
+		IORoot:       &cbc.newIORoot,
+		StateRoot:    &cbc.newStateRoot,
 		// TODO: allow script to set roothash messages?
 		Messages: []*block.Message{},
 	}
@@ -278,7 +278,7 @@ func (cbc *computeBatchContext) createCommitment(id *identity.Identity, rak sign
 			return fmt.Errorf("signature Sign RAK: %w", err)
 		}
 
-		computeBody.RakSig = rakSig.Signature
+		computeBody.RakSig = &rakSig.Signature
 	}
 	var err error
 	cbc.commit, err = commitment.SignExecutorCommitment(id.NodeSigner, computeBody)
@@ -291,7 +291,7 @@ func (cbc *computeBatchContext) createCommitment(id *identity.Identity, rak sign
 
 func (cbc *computeBatchContext) publishToChain(svc consensus.Backend, id *identity.Identity, runtimeID common.Namespace) error {
 	if err := roothashExecutorCommit(svc, id, runtimeID, []commitment.ExecutorCommitment{*cbc.commit}); err != nil {
-		return fmt.Errorf("roothash merge commentment: %w", err)
+		return fmt.Errorf("roothash merge commitment: %w", err)
 	}
 
 	return nil

--- a/go/roothash/api/commitment/commitment.go
+++ b/go/roothash/api/commitment/commitment.go
@@ -13,6 +13,9 @@ type OpenCommitment interface {
 	// type.
 	MostlyEqual(OpenCommitment) bool
 
+	// IsIndicatingFailure returns true if this commitment indicates a failure.
+	IsIndicatingFailure() bool
+
 	// ToVote returns a hash that represents a vote for this commitment as
 	// per discrepancy resolution criteria.
 	ToVote() hash.Hash

--- a/go/roothash/api/commitment/executor.go
+++ b/go/roothash/api/commitment/executor.go
@@ -126,7 +126,7 @@ func (m *ComputeBody) RootsForStorageReceipt() []hash.Hash {
 	}
 }
 
-// ValidateBasic performs basic compute body commitment parameters checks.
+// ValidateBasic performs basic executor commitment validity checks.
 func (m *ComputeBody) ValidateBasic() error {
 	header := &m.Header
 	switch m.Failure {

--- a/go/roothash/api/commitment/executor_test.go
+++ b/go/roothash/api/commitment/executor_test.go
@@ -1,0 +1,93 @@
+package commitment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+)
+
+func TestValidateBasic(t *testing.T) {
+	var emptyRoot hash.Hash
+	emptyRoot.Empty()
+
+	var emptyHeaderHash hash.Hash
+	_ = emptyHeaderHash.UnmarshalHex("57d73e02609a00fcf4ca43cbf8c9f12867c46942d246fb2b0bce42cbdb8db844")
+
+	body := ComputeBody{
+		Header: ComputeResultsHeader{
+			Round:        42,
+			PreviousHash: emptyHeaderHash,
+			IORoot:       &emptyRoot,
+			StateRoot:    &emptyRoot,
+			Messages:     nil,
+		},
+		TxnSchedSig:       signature.Signature{},
+		InputRoot:         emptyRoot,
+		StorageSignatures: []signature.Signature{{}},
+		RakSig:            &signature.RawSignature{},
+	}
+
+	for _, tc := range []struct {
+		name      string
+		fn        func(ComputeBody) ComputeBody
+		shouldErr bool
+	}{
+		{
+			"Ok",
+			func(b ComputeBody) ComputeBody { return b },
+			false,
+		},
+		{
+			"Bad IORoot",
+			func(b ComputeBody) ComputeBody {
+				b.Header.IORoot = nil
+				return b
+			},
+			true,
+		},
+		{
+			"Bad StateRoot",
+			func(b ComputeBody) ComputeBody {
+				b.Header.StateRoot = nil
+				return b
+			},
+			true,
+		},
+		{
+			"Bad Failure",
+			func(b ComputeBody) ComputeBody {
+				b.SetFailure(10)
+				return b
+			},
+			true,
+		},
+		{
+			"Bad Failure",
+			func(b ComputeBody) ComputeBody {
+				b.Failure = FailureStorageUnavailable
+				return b
+			},
+			true,
+		},
+		{
+			"Ok Failure",
+			func(b ComputeBody) ComputeBody {
+				b.SetFailure(FailureStorageUnavailable)
+				return b
+			},
+			false,
+		},
+	} {
+		b := tc.fn(body)
+		err := b.ValidateBasic()
+		switch tc.shouldErr {
+		case true:
+			require.Error(t, err, "ValidateBasic(%s)", tc.name)
+		case false:
+			require.NoError(t, err, "ValidateBasic(%s)", tc.name)
+		}
+	}
+}

--- a/go/roothash/api/commitment/executor_test.go
+++ b/go/roothash/api/commitment/executor_test.go
@@ -9,6 +9,30 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 )
 
+func TestConsistentHash(t *testing.T) {
+	// NOTE: These hashes MUST be synced with runtime/src/common/roothash.rs.
+	var emptyHeaderHash hash.Hash
+	_ = emptyHeaderHash.UnmarshalHex("57d73e02609a00fcf4ca43cbf8c9f12867c46942d246fb2b0bce42cbdb8db844")
+
+	var empty ComputeResultsHeader
+	require.EqualValues(t, emptyHeaderHash, empty.EncodedHash())
+
+	var emptyRoot hash.Hash
+	emptyRoot.Empty()
+
+	var populatedHeaderHash hash.Hash
+	_ = populatedHeaderHash.UnmarshalHex("374021bcba44f1014d0d9919e876a1ecd7fe5ec1a92ecf9c8b313cd4976fbc01")
+
+	populated := ComputeResultsHeader{
+		Round:        42,
+		PreviousHash: emptyHeaderHash,
+		IORoot:       &emptyRoot,
+		StateRoot:    &emptyRoot,
+		Messages:     nil,
+	}
+	require.EqualValues(t, populatedHeaderHash, populated.EncodedHash())
+}
+
 func TestValidateBasic(t *testing.T) {
 	var emptyRoot hash.Hash
 	emptyRoot.Empty()

--- a/go/roothash/api/commitment/pool.go
+++ b/go/roothash/api/commitment/pool.go
@@ -227,6 +227,14 @@ func (p *Pool) addOpenExecutorCommitment(
 		return ErrNotBasedOnCorrectBlock
 	}
 
+	if err := body.ValidateBasic(); err != nil {
+		logger.Debug("executor commitment validate basic error",
+			"body", body,
+			"err", err,
+		)
+		return ErrBadExecutorCommitment
+	}
+
 	if err := sv.VerifyTxnSchedulerSignature(body.TxnSchedSig, blk.Header.Round); err != nil {
 		logger.Debug("executor commitment has bad transaction scheduler signer",
 			"node_id", id,
@@ -237,15 +245,6 @@ func (p *Pool) addOpenExecutorCommitment(
 	}
 	if ok := body.VerifyTxnSchedSignature(blk.Header); !ok {
 		return ErrTxnSchedSigInvalid
-	}
-
-	// Validate basic.
-	if err := body.ValidateBasic(); err != nil {
-		logger.Debug("executor commitment validate basic error",
-			"body", body,
-			"err", err,
-		)
-		return ErrBadExecutorCommitment
 	}
 
 	switch openCom.IsIndicatingFailure() {

--- a/go/roothash/api/commitment/pool.go
+++ b/go/roothash/api/commitment/pool.go
@@ -29,12 +29,13 @@ var (
 	ErrDiscrepancyDetected    = errors.New(moduleName, 8, "roothash/commitment: discrepancy detected")
 	ErrStillWaiting           = errors.New(moduleName, 9, "roothash/commitment: still waiting for commits")
 	ErrInsufficientVotes      = errors.New(moduleName, 10, "roothash/commitment: insufficient votes to finalize discrepancy resolution round")
-	ErrBadExecutorCommits     = errors.New(moduleName, 11, "roothash/commitment: bad executor commitments")
+	ErrBadExecutorCommitment  = errors.New(moduleName, 11, "roothash/commitment: bad executor commitment")
 	ErrTxnSchedSigInvalid     = p2pError.Permanent(errors.New(moduleName, 12, "roothash/commitment: txn scheduler signature invalid"))
 	ErrInvalidMessages        = p2pError.Permanent(errors.New(moduleName, 13, "roothash/commitment: invalid messages"))
 	ErrBadStorageReceipts     = errors.New(moduleName, 14, "roothash/commitment: bad storage receipts")
 	ErrTimeoutNotCorrectRound = errors.New(moduleName, 15, "roothash/commitment: timeout not for correct round")
 	ErrNodeIsScheduler        = errors.New(moduleName, 16, "roothash/commitment: node is scheduler")
+	ErrMajorityFailure        = errors.New(moduleName, 17, "roothash/commitment: majority commitments indicated failure")
 )
 
 const (
@@ -226,35 +227,6 @@ func (p *Pool) addOpenExecutorCommitment(
 		return ErrNotBasedOnCorrectBlock
 	}
 
-	// Verify RAK-attestation.
-	if p.Runtime.TEEHardware != node.TEEHardwareInvalid {
-		n, err := nl.Node(ctx, id)
-		if err != nil {
-			// This should never happen as nodes cannot disappear mid-epoch.
-			logger.Warn("unable to fetch node descriptor to verify RAK-attestation",
-				"err", err,
-				"node_id", id,
-			)
-			return ErrNotInCommittee
-		}
-
-		rt := n.GetRuntime(p.Runtime.ID)
-		if rt == nil {
-			// We currently prevent this case throughout the rest of the system.
-			// Still, it's prudent to check.
-			logger.Warn("committee member not registered with this runtime",
-				"runtime_id", p.Runtime.ID,
-				"node_id", id,
-			)
-			return ErrNotInCommittee
-		}
-
-		rak := rt.Capabilities.TEE.RAK
-		if !rak.Verify(ComputeResultsHeaderSignatureContext, cbor.Marshal(header), body.RakSig[:]) {
-			return ErrRakSigInvalid
-		}
-	}
-
 	if err := sv.VerifyTxnSchedulerSignature(body.TxnSchedSig, blk.Header.Round); err != nil {
 		logger.Debug("executor commitment has bad transaction scheduler signer",
 			"node_id", id,
@@ -267,28 +239,74 @@ func (p *Pool) addOpenExecutorCommitment(
 		return ErrTxnSchedSigInvalid
 	}
 
-	// Check if the header refers to merkle roots in storage.
-	if uint64(len(body.StorageSignatures)) < p.Runtime.Storage.MinWriteReplication {
-		logger.Debug("executor commitment doesn't have enough storage receipts",
-			"node_id", id,
-			"min_write_replication", p.Runtime.Storage.MinWriteReplication,
-			"num_receipts", len(body.StorageSignatures),
-		)
-		return ErrBadStorageReceipts
-	}
-	if err := sv.VerifyCommitteeSignatures(scheduler.KindStorage, body.StorageSignatures); err != nil {
-		logger.Debug("executor commitment has bad storage receipt signers",
-			"node_id", id,
+	// Validate basic.
+	if err := body.ValidateBasic(); err != nil {
+		logger.Debug("executor commitment validate basic error",
+			"body", body,
 			"err", err,
 		)
-		return err
+		return ErrBadExecutorCommitment
 	}
-	if err := body.VerifyStorageReceiptSignatures(blk.Header.Namespace); err != nil {
-		logger.Debug("executor commitment has bad storage receipt signatures",
-			"node_id", id,
-			"err", err,
-		)
-		return p2pError.Permanent(err)
+
+	switch openCom.IsIndicatingFailure() {
+	case true:
+	default:
+		// Verify RAK-attestation.
+		if p.Runtime.TEEHardware != node.TEEHardwareInvalid {
+			n, err := nl.Node(ctx, id)
+			if err != nil {
+				// This should never happen as nodes cannot disappear mid-epoch.
+				logger.Warn("unable to fetch node descriptor to verify RAK-attestation",
+					"err", err,
+					"node_id", id,
+				)
+				return ErrNotInCommittee
+			}
+
+			rt := n.GetRuntime(p.Runtime.ID)
+			if rt == nil {
+				// We currently prevent this case throughout the rest of the system.
+				// Still, it's prudent to check.
+				logger.Warn("committee member not registered with this runtime",
+					"runtime_id", p.Runtime.ID,
+					"node_id", id,
+				)
+				return ErrNotInCommittee
+			}
+
+			rak := rt.Capabilities.TEE.RAK
+			var rakSig signature.RawSignature
+			if body.RakSig != nil {
+				rakSig = *body.RakSig
+			}
+			if !rak.Verify(ComputeResultsHeaderSignatureContext, cbor.Marshal(header), rakSig[:]) {
+				return ErrRakSigInvalid
+			}
+		}
+
+		// Check if the header refers to merkle roots in storage.
+		if uint64(len(body.StorageSignatures)) < p.Runtime.Storage.MinWriteReplication {
+			logger.Debug("executor commitment doesn't have enough storage receipts",
+				"node_id", id,
+				"min_write_replication", p.Runtime.Storage.MinWriteReplication,
+				"num_receipts", len(body.StorageSignatures),
+			)
+			return ErrBadStorageReceipts
+		}
+		if err := sv.VerifyCommitteeSignatures(scheduler.KindStorage, body.StorageSignatures); err != nil {
+			logger.Debug("executor commitment has bad storage receipt signers",
+				"node_id", id,
+				"err", err,
+			)
+			return err
+		}
+		if err := body.VerifyStorageReceiptSignatures(blk.Header.Namespace); err != nil {
+			logger.Debug("executor commitment has bad storage receipt signatures",
+				"node_id", id,
+				"err", err,
+			)
+			return p2pError.Permanent(err)
+		}
 	}
 
 	if p.ExecuteCommitments == nil {
@@ -431,8 +449,15 @@ func (p *Pool) DetectDiscrepancy() (OpenCommitment, error) {
 		if commit == nil {
 			commit = c
 		}
+
+		if c.IsIndicatingFailure() {
+			discrepancyDetected = true
+			continue
+		}
+
 		if !commit.MostlyEqual(c) {
 			discrepancyDetected = true
+			continue
 		}
 	}
 
@@ -455,11 +480,12 @@ func (p *Pool) ResolveDiscrepancy() (OpenCommitment, error) {
 
 	type voteEnt struct {
 		commit OpenCommitment
-		tally  int
+		tally  uint64
 	}
 
 	votes := make(map[hash.Hash]*voteEnt)
-	var backupNodes int
+	var failuresTally uint64
+	var backupNodes uint64
 	for _, n := range p.Committee.Members {
 		if n.Role != scheduler.RoleBackupWorker {
 			continue
@@ -468,6 +494,11 @@ func (p *Pool) ResolveDiscrepancy() (OpenCommitment, error) {
 
 		c, ok := p.getCommitment(n.PublicKey)
 		if !ok {
+			continue
+		}
+
+		if c.IsIndicatingFailure() {
+			failuresTally++
 			continue
 		}
 
@@ -483,6 +514,9 @@ func (p *Pool) ResolveDiscrepancy() (OpenCommitment, error) {
 	}
 
 	minVotes := (backupNodes / 2) + 1
+	if failuresTally >= minVotes {
+		return nil, ErrMajorityFailure
+	}
 	for _, ent := range votes {
 		if ent.tally >= minVotes {
 			return ent.commit, nil

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -307,8 +307,8 @@ func (s *runtimeState) generateExecutorCommitments(t *testing.T, consensus conse
 			Header: commitment.ComputeResultsHeader{
 				Round:        parent.Header.Round,
 				PreviousHash: parent.Header.PreviousHash,
-				IORoot:       parent.Header.IORoot,
-				StateRoot:    parent.Header.StateRoot,
+				IORoot:       &parent.Header.IORoot,
+				StateRoot:    &parent.Header.StateRoot,
 			},
 			StorageSignatures: parent.Header.StorageSignatures,
 			InputRoot:         hash.Hash{},

--- a/go/runtime/host/mock/mock.go
+++ b/go/runtime/host/mock/mock.go
@@ -79,8 +79,8 @@ func (r *runtime) Call(ctx context.Context, body *protocol.Body) (*protocol.Body
 				Header: commitment.ComputeResultsHeader{
 					Round:        rq.Block.Header.Round + 1,
 					PreviousHash: rq.Block.Header.EncodedHash(),
-					IORoot:       ioRoot,
-					StateRoot:    stateRoot,
+					IORoot:       &ioRoot,
+					StateRoot:    &stateRoot,
 				},
 				IOWriteLog: ioWriteLog,
 			},

--- a/runtime/src/dispatcher.rs
+++ b/runtime/src/dispatcher.rs
@@ -406,8 +406,8 @@ impl Dispatcher {
                     let header = ComputeResultsHeader {
                         round: block.header.round + 1,
                         previous_hash: block.header.encoded_hash(),
-                        io_root,
-                        state_root: new_state_root,
+                        io_root: Some(io_root),
+                        state_root: Some(new_state_root),
                         messages,
                     };
 


### PR DESCRIPTION
The E2E tests with increased epoch times (#3322) discovered a failure edge case that can happen if the storage committee becomes unavailable after proposer already proposes a batch, but before any of the nodes submit a commitment. In that case the nodes currently abort the processing and wait for a round failure. Since there is no submitted commitments the round failure only happens at the next epoch transition.

This PR adds support for failure indicating commitments (which were first proposed as part of the [ADR 0005](https://github.com/oasisprotocol/oasis-core/blob/cbf413b788e3fd0a0bc20b8193cc3570f99880b9/docs/adr/0005-runtime-compute-slashing.md)), which solve the above mentioned issue since compute nodes can now submit a failure indicating commitment and with it trigger a round failure. 

NOTE: only the subset (support for failure indicating commitments) of the mentioned ADR is implemented here.

TODO:
- [x] probably some more tests
- [x] check for other scenarios where a failure indicating commitment should be submitted by an executor node (currently only the mentioned failure scenario was fixed)