### PR TITLE
go/worker/executor: Relay transaction that fail to be enqueued

### DIFF
--- a/.changelog/3393.trivial.md
+++ b/.changelog/3393.trivial.md
@@ -1,0 +1,1 @@
+go/worker/executor: Relay transaction that fail to be enqueued

--- a/go/runtime/scheduling/simple/incoming_queue.go
+++ b/go/runtime/scheduling/simple/incoming_queue.go
@@ -1,7 +1,6 @@
 package simple
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -9,12 +8,13 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/runtime/transaction"
+	p2pError "github.com/oasisprotocol/oasis-core/go/worker/common/p2p/error"
 )
 
 var (
-	errQueueFull         = errors.New("queue is full")
-	errCallTooLarge      = errors.New("call too large")
-	errCallAlreadyExists = errors.New("call already exists in queue")
+	errQueueFull         = fmt.Errorf("queue is full")
+	errCallTooLarge      = p2pError.Permanent(fmt.Errorf("call too large"))
+	errCallAlreadyExists = fmt.Errorf("call already exists in queue")
 )
 
 type incomingQueue struct {


### PR DESCRIPTION
Minor change to the executor worker handling of retrying P2P Tx errors: 
- retry & relay Tx messages if CheckTx error is not actually permanent (e.g. errors due to runtime being not ready)
- QueueTx failures should generally be retried and relayed  (unless it's a duplicate transaction errors then it should be just relayed)