### PR TITLE
go/consensus/tendermint: Bump Tendermint Core to v0.34-rc5-oasis1

### DIFF
--- a/.changelog/3317.internal.md
+++ b/.changelog/3317.internal.md
@@ -1,1 +1,0 @@
-go/consensus/tendermint: Bump Tendermint Core to v0.34-rc4-oasis3

--- a/.changelog/3396.breaking.md
+++ b/.changelog/3396.breaking.md
@@ -1,0 +1,1 @@
+go/consensus/tendermint: Bump Tendermint Core to v0.34-rc5-oasis1

--- a/go/consensus/genesis/genesis.go
+++ b/go/consensus/genesis/genesis.go
@@ -22,10 +22,10 @@ type Parameters struct { // nolint: maligned
 	SkipTimeoutCommit  bool          `json:"skip_timeout_commit"`
 	EmptyBlockInterval time.Duration `json:"empty_block_interval"`
 
-	MaxTxSize      uint64          `json:"max_tx_size"`
-	MaxBlockSize   uint64          `json:"max_block_size"`
-	MaxBlockGas    transaction.Gas `json:"max_block_gas"`
-	MaxEvidenceNum uint32          `json:"max_evidence_num"`
+	MaxTxSize       uint64          `json:"max_tx_size"`
+	MaxBlockSize    uint64          `json:"max_block_size"`
+	MaxBlockGas     transaction.Gas `json:"max_block_gas"`
+	MaxEvidenceSize uint64          `json:"max_evidence_size"`
 
 	// StateCheckpointInterval is the expected state checkpoint interval (in blocks).
 	StateCheckpointInterval uint64 `json:"state_checkpoint_interval"`

--- a/go/consensus/tendermint/api/genesis.go
+++ b/go/consensus/tendermint/api/genesis.go
@@ -92,7 +92,7 @@ func genesisToTendermint(d *genesis.Document) (*tmtypes.GenesisDoc, error) {
 	}
 
 	var evCfg tmproto.EvidenceParams
-	evCfg.MaxNum = d.Consensus.Parameters.MaxEvidenceNum
+	evCfg.MaxBytes = int64(d.Consensus.Parameters.MaxEvidenceSize)
 	evCfg.MaxAgeNumBlocks = debondingInterval * epochInterval
 	evCfg.MaxAgeDuration = time.Duration(evCfg.MaxAgeNumBlocks) * (d.Consensus.Parameters.TimeoutCommit + 1*time.Second)
 

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -134,7 +134,7 @@ func TestGenesisChainContext(t *testing.T) {
 	//       on each run.
 	stableDoc.Staking = staking.Genesis{}
 
-	require.Equal(t, "abfb77523d8ce18470143c9b4159ceaf8f1542e7b1cbc15d934e8b21de220378", stableDoc.ChainContext())
+	require.Equal(t, "5a67a9135f2ef388205023fd525b920852126603fafed80dbf1a20c0e41b3372", stableDoc.ChainContext())
 }
 
 func TestGenesisSanityCheck(t *testing.T) {

--- a/go/go.mod
+++ b/go/go.mod
@@ -11,7 +11,7 @@ replace (
 	// https://github.com/spf13/cobra/issues/1091
 	github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.2
 
-	github.com/tendermint/tendermint => github.com/oasisprotocol/tendermint v0.34.0-rc4-oasis4
+	github.com/tendermint/tendermint => github.com/oasisprotocol/tendermint v0.34.0-rc5-oasis1
 	golang.org/x/crypto/curve25519 => github.com/oasisprotocol/ed25519/extra/x25519 v0.0.0-20200819094954-65138ca6ec7c
 	golang.org/x/crypto/ed25519 => github.com/oasisprotocol/ed25519 v0.0.0-20200819094954-65138ca6ec7c
 )

--- a/go/go.sum
+++ b/go/go.sum
@@ -778,8 +778,8 @@ github.com/oasisprotocol/ed25519 v0.0.0-20200819094954-65138ca6ec7c h1:/Ydlzrdta
 github.com/oasisprotocol/ed25519 v0.0.0-20200819094954-65138ca6ec7c/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661 h1:MB73kGMtuMGS+6VDoU/mitzff7Cu+aZo9ta5wabuxVA=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661/go.mod h1:SwBxaVibf6Sr2IZ6M3WnUue0yp8dPLAo1riQRNQ60+g=
-github.com/oasisprotocol/tendermint v0.34.0-rc4-oasis4 h1:FVMRTVVDwNlseeWyTbuQ7scwU7+Mdxze5RidlFOcqpg=
-github.com/oasisprotocol/tendermint v0.34.0-rc4-oasis4/go.mod h1:kIas9rp0S0G40yvKnYlW/mtQei8AJXQToxS8IWNZPbA=
+github.com/oasisprotocol/tendermint v0.34.0-rc5-oasis1 h1:zwMoDjojG+KDYndOTaBCpBjEeKjk4IbES6RQPStbnc8=
+github.com/oasisprotocol/tendermint v0.34.0-rc5-oasis1/go.mod h1:kIas9rp0S0G40yvKnYlW/mtQei8AJXQToxS8IWNZPbA=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -90,7 +90,7 @@ const (
 	cfgConsensusMaxTxSizeBytes           = "consensus.tendermint.max_tx_size"
 	cfgConsensusMaxBlockSizeBytes        = "consensus.tendermint.max_block_size"
 	cfgConsensusMaxBlockGas              = "consensus.tendermint.max_block_gas"
-	cfgConsensusMaxEvidenceNum           = "consensus.tendermint.max_evidence_num"
+	cfgConsensusMaxEvidenceSizeBytes     = "consensus.tendermint.max_evidence_size"
 	CfgConsensusStateCheckpointInterval  = "consensus.state_checkpoint.interval"
 	CfgConsensusStateCheckpointNumKept   = "consensus.state_checkpoint.num_kept"
 	CfgConsensusStateCheckpointChunkSize = "consensus.state_checkpoint.chunk_size"
@@ -249,7 +249,7 @@ func doInitGenesis(cmd *cobra.Command, args []string) {
 			MaxTxSize:                uint64(viper.GetSizeInBytes(cfgConsensusMaxTxSizeBytes)),
 			MaxBlockSize:             uint64(viper.GetSizeInBytes(cfgConsensusMaxBlockSizeBytes)),
 			MaxBlockGas:              transaction.Gas(viper.GetUint64(cfgConsensusMaxBlockGas)),
-			MaxEvidenceNum:           viper.GetUint32(cfgConsensusMaxEvidenceNum),
+			MaxEvidenceSize:          uint64(viper.GetSizeInBytes(cfgConsensusMaxEvidenceSizeBytes)),
 			StateCheckpointInterval:  viper.GetUint64(CfgConsensusStateCheckpointInterval),
 			StateCheckpointNumKept:   viper.GetUint64(CfgConsensusStateCheckpointNumKept),
 			StateCheckpointChunkSize: uint64(viper.GetSizeInBytes(CfgConsensusStateCheckpointChunkSize)),
@@ -734,7 +734,7 @@ func init() {
 	initGenesisFlags.String(cfgConsensusMaxTxSizeBytes, "32kb", "tendermint maximum transaction size (in bytes)")
 	initGenesisFlags.String(cfgConsensusMaxBlockSizeBytes, "21mb", "tendermint maximum block size (in bytes)")
 	initGenesisFlags.Uint64(cfgConsensusMaxBlockGas, 0, "tendermint max gas used per block")
-	initGenesisFlags.Uint32(cfgConsensusMaxEvidenceNum, 50, "tendermint max evidence num")
+	initGenesisFlags.String(cfgConsensusMaxEvidenceSizeBytes, "1mb", "tendermint max evidence size (in bytes)")
 	initGenesisFlags.Uint64(CfgConsensusStateCheckpointInterval, 10000, "consensus state checkpoint interval (in blocks)")
 	initGenesisFlags.Uint64(CfgConsensusStateCheckpointNumKept, 2, "number of kept consensus state checkpoints")
 	initGenesisFlags.String(CfgConsensusStateCheckpointChunkSize, "8mb", "consensus state checkpoint chunk size (in bytes)")


### PR DESCRIPTION
TODO
* [x] Update to released tag.
* [x] Bump consensus version.