### PR TITLE
[BACKPORT/20.11.x] Add ability to set initial block height at genesis

### DIFF
--- a/.changelog/3416.internal.md
+++ b/.changelog/3416.internal.md
@@ -1,0 +1,1 @@
+go: Add ability to set initial block height at genesis

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -28,6 +28,7 @@ const (
 	cfgRuntimeLoader           = "fixture.default.runtime.loader"
 	cfgSetupRuntimes           = "fixture.default.setup_runtimes"
 	cfgTEEHardware             = "fixture.default.tee_hardware"
+	cfgInitialHeight           = "fixture.default.initial_height"
 )
 
 var (
@@ -61,6 +62,7 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 				},
 			},
 			EpochtimeMock: viper.GetBool(cfgEpochtimeMock),
+			InitialHeight: viper.GetInt64(cfgInitialHeight),
 			HaltEpoch:     viper.GetUint64(cfgHaltEpoch),
 			IAS: oasis.IASCfg{
 				Mock: true,
@@ -160,6 +162,7 @@ func init() {
 	DefaultFixtureFlags.String(cfgRuntimeLoader, "oasis-core-runtime-loader", "path to the runtime loader")
 	DefaultFixtureFlags.String(cfgTEEHardware, "", "TEE hardware to use")
 	DefaultFixtureFlags.Uint64(cfgHaltEpoch, math.MaxUint64, "halt epoch height")
+	DefaultFixtureFlags.Int64(cfgInitialHeight, 1, "initial block height")
 
 	_ = viper.BindPFlags(DefaultFixtureFlags)
 

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -42,15 +42,16 @@ import (
 )
 
 const (
-	cfgEntity      = "entity"
-	cfgRuntime     = "runtime"
-	cfgNode        = "node"
-	cfgRootHash    = "roothash"
-	cfgKeyManager  = "keymanager"
-	cfgStaking     = "staking"
-	cfgBlockHeight = "height"
-	cfgChainID     = "chain.id"
-	cfgHaltEpoch   = "halt.epoch"
+	cfgEntity        = "entity"
+	cfgRuntime       = "runtime"
+	cfgNode          = "node"
+	cfgRootHash      = "roothash"
+	cfgKeyManager    = "keymanager"
+	cfgStaking       = "staking"
+	cfgBlockHeight   = "height"
+	cfgChainID       = "chain.id"
+	cfgHaltEpoch     = "halt.epoch"
+	cfgInitialHeight = "initial_height"
 
 	// Registry config flags.
 	CfgRegistryMaxNodeExpiration                      = "registry.max_node_expiration"
@@ -165,7 +166,7 @@ func doInitGenesis(cmd *cobra.Command, args []string) {
 
 	// Build the genesis state, if any.
 	doc := &genesis.Document{
-		Height:    1,
+		Height:    viper.GetInt64(cfgInitialHeight),
 		ChainID:   chainID,
 		Time:      time.Now(),
 		HaltEpoch: epochtime.EpochTime(viper.GetUint64(cfgHaltEpoch)),
@@ -684,6 +685,7 @@ func init() {
 	initGenesisFlags.StringSlice(cfgKeyManager, nil, "path to key manager genesis status file")
 	initGenesisFlags.String(cfgChainID, "", "genesis chain id")
 	initGenesisFlags.Uint64(cfgHaltEpoch, math.MaxUint64, "genesis halt epoch height")
+	initGenesisFlags.Int64(cfgInitialHeight, 1, "initial block height")
 
 	// Registry config flags.
 	initGenesisFlags.Uint64(CfgRegistryMaxNodeExpiration, 5, "maximum node registration lifespan in epochs")

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -48,6 +48,7 @@ const (
 	defaultConsensusBackend            = "tendermint"
 	defaultConsensusTimeoutCommit      = 250 * time.Millisecond
 	defaultEpochtimeTendermintInterval = 30
+	defaultInitialHeight               = 1
 	defaultHaltEpoch                   = math.MaxUint64
 
 	logNodeFile        = "node.log"
@@ -293,6 +294,9 @@ type NetworkCfg struct { // nolint: maligned
 
 	// Consensus are the network-wide consensus parameters.
 	Consensus consensusGenesis.Genesis `json:"consensus"`
+
+	// InitialHeight is the initial block height.
+	InitialHeight int64 `json:"initial_height,omitempty"`
 
 	// HaltEpoch is the halt epoch height flag.
 	HaltEpoch uint64 `json:"halt_epoch"`
@@ -862,6 +866,7 @@ func (net *Network) MakeGenesis() error {
 		"genesis", "init",
 		"--genesis.file", net.GenesisPath(),
 		"--chain.id", genesisTestHelpers.TestChainID,
+		"--initial_height", strconv.FormatInt(net.cfg.InitialHeight, 10),
 		"--halt.epoch", strconv.FormatUint(net.cfg.HaltEpoch, 10),
 		"--consensus.backend", net.cfg.Consensus.Backend,
 		"--epochtime.tendermint.interval", strconv.FormatInt(net.cfg.EpochtimeTendermintInterval, 10),
@@ -1034,6 +1039,9 @@ func New(env *env.Env, cfg *NetworkCfg) (*Network, error) {
 	}
 	if cfgCopy.EpochtimeTendermintInterval == 0 {
 		cfgCopy.EpochtimeTendermintInterval = defaultEpochtimeTendermintInterval
+	}
+	if cfgCopy.InitialHeight == 0 {
+		cfgCopy.InitialHeight = defaultInitialHeight
 	}
 	if cfgCopy.HaltEpoch == 0 {
 		cfgCopy.HaltEpoch = defaultHaltEpoch


### PR DESCRIPTION
Backport of https://github.com/oasisprotocol/oasis-core/pull/3416.