### PR TITLE
storage/client: Retry NodeNotFound errors

### DIFF
--- a/.changelog/3424.bugfix.md
+++ b/.changelog/3424.bugfix.md
@@ -1,0 +1,1 @@
+storage/client: Retry NodeNotFound errors on write requests

--- a/go/storage/client/client.go
+++ b/go/storage/client/client.go
@@ -117,11 +117,10 @@ func (b *storageClientBackend) writeWithClient(
 				case status.Code(rerr) == codes.PermissionDenied:
 					// Writes can fail around an epoch transition due to policy errors.
 					return rerr
-				case errors.Is(rerr, api.ErrPreviousVersionMismatch):
-					// Storage node may not have yet processed the epoch transition.
-					return rerr
-				case errors.Is(rerr, api.ErrRootNotFound):
-					// Storage node may not have yet processed the epoch transition.
+				case errors.Is(rerr, api.ErrNodeNotFound),
+					errors.Is(rerr, api.ErrPreviousVersionMismatch),
+					errors.Is(rerr, api.ErrRootNotFound):
+					// Storage node may not be completely synced yet.
 					return rerr
 				default:
 					// All other errors are permanent.


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/oasis-core/issues/3424 (and a flaky e2e storage_sync test)