### PR TITLE
go/worker/common/committee: check if active epoch exists

### DIFF
--- a/.changelog/3432.bugfix.md
+++ b/.changelog/3432.bugfix.md
@@ -1,0 +1,4 @@
+go/worker/common: check if active epoch exists in HandlePeerMsg
+
+Fixes nil pointer dereference that can happen if the executor node tries to
+publish a message before it is synced

--- a/go/worker/common/committee/group.go
+++ b/go/worker/common/committee/group.go
@@ -467,6 +467,10 @@ func (g *Group) HandlePeerMessage(unusedPeerID signature.PublicKey, msg *p2p.Mes
 		g.RLock()
 		defer g.RUnlock()
 
+		if g.activeEpoch == nil {
+			return fmt.Errorf("group: no active epoch")
+		}
+
 		// Ensure that both peers have the same view of the current group. If this
 		// is not the case, this means that one of the nodes processed an epoch
 		// transition and the other one didn't.


### PR DESCRIPTION
Fixes nil ptr defer that can happen if the executor node tries to publish a message before it's synced