### PR TITLE
go/runtime/client: Recheck failed blocks and implement max tx age

### DIFF
--- a/.changelog/3412.bugfix.md
+++ b/.changelog/3412.bugfix.md
@@ -1,0 +1,1 @@
+go/runtime/client: Runtime client should retry processing any failed blocks

--- a/.changelog/3443.bugfix.md
+++ b/.changelog/3443.bugfix.md
@@ -1,0 +1,5 @@
+go/runtime/client: Wait for initial consensus block and group version
+
+Before, the runtime client would publish invalid messages before obtaining the
+initial group version. The messages were correctly retired upon receiving the
+group version, but this resulted in needless messages.

--- a/.changelog/3443.cfg.md
+++ b/.changelog/3443.cfg.md
@@ -1,0 +1,5 @@
+go/runtime/client: Add max transaction age
+
+Added `runtime.client.max_transaction_age` flag to configure number of
+consensus blocks after which a submitted runtime transaction is considered
+expired. Expired transactions are dropped by the client.

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -774,6 +774,7 @@ func init() {
 		compute.Flags,
 		p2p.Flags,
 		registration.Flags,
+		runtimeClient.Flags,
 		executor.Flags,
 		workerCommon.Flags,
 		workerStorage.Flags,

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -25,6 +25,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/grpc"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/metrics"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/debug/byzantine"
+	runtimeClient "github.com/oasisprotocol/oasis-core/go/runtime/client"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	workerCommon "github.com/oasisprotocol/oasis-core/go/worker/common"
 	"github.com/oasisprotocol/oasis-core/go/worker/common/p2p"
@@ -223,6 +224,13 @@ func (args *argBuilder) tendermintSupplementarySanityEnabled() *argBuilder {
 func (args *argBuilder) runtimeTagIndexerBackend(backend string) *argBuilder {
 	args.vec = append(args.vec, []string{
 		"--" + runtimeRegistry.CfgTagIndexerBackend, backend,
+	}...)
+	return args
+}
+
+func (args *argBuilder) runtimeClientMaxTransactionAge(maxTxAge int64) *argBuilder {
+	args.vec = append(args.vec, []string{
+		"--" + runtimeClient.CfgMaxTransactionAge, strconv.Itoa(int(maxTxAge)),
 	}...)
 	return args
 }

--- a/go/oasis-test-runner/oasis/client.go
+++ b/go/oasis-test-runner/oasis/client.go
@@ -10,6 +10,8 @@ import (
 type Client struct {
 	Node
 
+	maxTransactionAge int64
+
 	consensusPort uint16
 	p2pPort       uint16
 }
@@ -17,6 +19,8 @@ type Client struct {
 // ClientCfg is the Oasis client node provisioning configuration.
 type ClientCfg struct {
 	NodeCfg
+
+	MaxTransactionAge int64
 }
 
 func (client *Client) startNode() error {
@@ -32,6 +36,10 @@ func (client *Client) startNode() error {
 		workerP2pPort(client.p2pPort).
 		workerP2pEnabled().
 		runtimeTagIndexerBackend("bleve")
+
+	if client.maxTransactionAge != 0 {
+		args = args.runtimeClientMaxTransactionAge(client.maxTransactionAge)
+	}
 
 	for _, v := range client.net.runtimes {
 		if v.kind != registry.KindCompute {
@@ -73,8 +81,9 @@ func (net *Network) NewClient(cfg *ClientCfg) (*Client, error) {
 			dir:       clientDir,
 			consensus: cfg.Consensus,
 		},
-		consensusPort: net.nextNodePort,
-		p2pPort:       net.nextNodePort + 1,
+		maxTransactionAge: cfg.MaxTransactionAge,
+		consensusPort:     net.nextNodePort,
+		p2pPort:           net.nextNodePort + 1,
 	}
 	client.doStartNode = client.startNode
 

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -458,6 +458,9 @@ func (f *SentryFixture) Create(net *Network) (*Sentry, error) {
 type ClientFixture struct {
 	// Consensus contains configuration for the consensus backend.
 	Consensus ConsensusFixture `json:"consensus"`
+
+	// MaxTransactionAge configures the MaxTransactionAge configuration of the client.
+	MaxTransactionAge int64 `json:"max_transaction_age"`
 }
 
 // Create instantiates the client node described by the fixture.
@@ -466,6 +469,7 @@ func (f *ClientFixture) Create(net *Network) (*Client, error) {
 		NodeCfg: NodeCfg{
 			Consensus: f.Consensus,
 		},
+		MaxTransactionAge: f.MaxTransactionAge,
 	})
 }
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/client_expire.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/client_expire.go
@@ -1,0 +1,70 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
+	"github.com/oasisprotocol/oasis-core/go/runtime/client/api"
+)
+
+// ClientExpire is the ClientExpire node scenario.
+var ClientExpire scenario.Scenario = newClientExpireImpl("client-expire", "simple-keyvalue-client", nil)
+
+type clientExpireImpl struct {
+	runtimeImpl
+}
+
+func newClientExpireImpl(name, clientBinary string, clientArgs []string) scenario.Scenario {
+	return &clientExpireImpl{
+		runtimeImpl: *newRuntimeImpl(name, clientBinary, clientArgs),
+	}
+}
+
+func (sc *clientExpireImpl) Clone() scenario.Scenario {
+	return &clientExpireImpl{
+		runtimeImpl: *sc.runtimeImpl.Clone().(*runtimeImpl),
+	}
+}
+
+func (sc *clientExpireImpl) Fixture() (*oasis.NetworkFixture, error) {
+	f, err := sc.runtimeImpl.Fixture()
+	if err != nil {
+		return nil, err
+	}
+
+	// Make client expire all transactions instantly.
+	f.Clients[0].MaxTransactionAge = 1
+
+	return f, nil
+}
+
+func (sc *clientExpireImpl) Run(childEnv *env.Env) error {
+	ctx := context.Background()
+
+	// Start the network.
+	var err error
+	if err = sc.Net.Start(); err != nil {
+		return err
+	}
+
+	// Wait for client to be ready.
+	client := sc.Net.Clients()[0]
+	nodeCtrl, err := oasis.NewController(client.SocketPath())
+	if err != nil {
+		return err
+	}
+	if err = nodeCtrl.WaitReady(ctx); err != nil {
+		return err
+	}
+
+	err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, "hello", "test")
+	if !errors.Is(err, api.ErrTransactionExpired) {
+		return fmt.Errorf("expected error: %v, got: %v", api.ErrTransactionExpired, err)
+	}
+
+	return nil
+}

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -532,6 +532,8 @@ func RegisterScenarios() error {
 		RuntimeDynamic,
 		// Transaction source test.
 		TxSourceMultiShort,
+		// ClientExpire test.
+		ClientExpire,
 		// Late start test.
 		LateStart,
 		// KeymanagerUpgrade test.

--- a/go/runtime/client/api/api.go
+++ b/go/runtime/client/api/api.go
@@ -26,6 +26,8 @@ var (
 	ErrNotFound = errors.New(ModuleName, 1, "client: not found")
 	// ErrInternal is an error returned when an unspecified internal error occurs.
 	ErrInternal = errors.New(ModuleName, 2, "client: internal error")
+	// ErrTransactionExpired is an error returned when transaction expired.
+	ErrTransactionExpired = errors.New(ModuleName, 3, "client: transaction expired")
 )
 
 // RuntimeClient is the runtime client interface.


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/3412

- runtime client remembers failed roothash blocks and rechecks them on every new received block
- additionally transactions that do not succeed in 1500 blocks are considered failed and client drops them
  - as a future improvement should the client also support `SubmitTxNoWait` operation (opened https://github.com/oasisprotocol/oasis-core/issues/3444)