### PR TITLE
go/roothash: Refactor runtime messages

### DIFF
--- a/.changelog/3430.breaking.md
+++ b/.changelog/3430.breaking.md
@@ -1,0 +1,6 @@
+go/roothash: Refactor runtime messages
+
+Several modifications are made to the runtime message representation and
+processing as specified by [ADR 0003].
+
+[ADR 0003]: docs/adr/0003-consensus-runtime-token-transfer.md

--- a/.changelog/3448.breaking.md
+++ b/.changelog/3448.breaking.md
@@ -1,0 +1,7 @@
+go/roothash: Renamed `FinalizedEvent` field in `roothash.Event`
+
+The `FinalizedEvent` field in the `roothash.Event` structure has been renamed
+to just `Finalized` in order to be consistent with other fields.
+
+Note that the serialization already used just `finalized` so that remains
+unchanged.

--- a/.changelog/3448.internal.1.md
+++ b/.changelog/3448.internal.1.md
@@ -1,0 +1,1 @@
+go/consensus/tendermint: Add message passing between mux applications

--- a/.changelog/3448.internal.2.md
+++ b/.changelog/3448.internal.2.md
@@ -1,0 +1,3 @@
+go/consensus/tendermint: Remove ForeignExecuteTx
+
+Use recently introduced message passing between apps instead.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,6 +1858,7 @@ name = "simple-keyvalue"
 version = "0.3.0-alpha"
 dependencies = [
  "anyhow",
+ "byteorder",
  "io-context",
  "oasis-core-client",
  "oasis-core-keymanager-api-common",

--- a/go/common/errors/errors.go
+++ b/go/common/errors/errors.go
@@ -80,7 +80,14 @@ func FromCode(module string, code uint32) error {
 //
 // In case the error is not of the correct type, default values
 // for an unknown error are returned.
+//
+// In case the error is nil, an empty module name and CodeNoError
+// are returned.
 func Code(err error) (string, uint32) {
+	if err == nil {
+		return "", CodeNoError
+	}
+
 	var ce *codedError
 	if !As(err, &ce) {
 		ce = errUnknownError.(*codedError)

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -66,7 +66,7 @@ var (
 	// the runtime.
 	//
 	// NOTE: This version must be synced with runtime/src/common/version.rs.
-	RuntimeHostProtocol = Version{Major: 1, Minor: 0, Patch: 0}
+	RuntimeHostProtocol = Version{Major: 2, Minor: 0, Patch: 0}
 
 	// RuntimeCommitteeProtocol versions the P2P protocol used by the runtime
 	// committee members.

--- a/go/consensus/tendermint/abci/messages.go
+++ b/go/consensus/tendermint/abci/messages.go
@@ -1,0 +1,36 @@
+package abci
+
+import (
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+)
+
+var _ api.MessageDispatcher = (*messageDispatcher)(nil)
+
+type messageDispatcher struct {
+	subscriptions map[interface{}][]api.MessageSubscriber
+}
+
+// Implements api.MessageDispatcher.
+func (md *messageDispatcher) Subscribe(kind interface{}, ms api.MessageSubscriber) {
+	if md.subscriptions == nil {
+		md.subscriptions = make(map[interface{}][]api.MessageSubscriber)
+	}
+	md.subscriptions[kind] = append(md.subscriptions[kind], ms)
+}
+
+// Implements api.MessageDispatcher.
+func (md *messageDispatcher) Publish(ctx *api.Context, kind, msg interface{}) error {
+	if len(md.subscriptions[kind]) == 0 {
+		return api.ErrNoSubscribers
+	}
+
+	var errs error
+	for _, ms := range md.subscriptions[kind] {
+		if err := ms.ExecuteMessage(ctx, kind, msg); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+	return errs
+}

--- a/go/consensus/tendermint/abci/messages_test.go
+++ b/go/consensus/tendermint/abci/messages_test.go
@@ -16,7 +16,6 @@ type testMessageKind uint8
 var (
 	testMessageA = testMessageKind(0)
 	testMessageB = testMessageKind(1)
-	testMessageC = testMessageKind(2)
 )
 
 type testMessage struct {

--- a/go/consensus/tendermint/abci/messages_test.go
+++ b/go/consensus/tendermint/abci/messages_test.go
@@ -1,0 +1,103 @@
+package abci
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+)
+
+type testMessageKind uint8
+
+var (
+	testMessageA = testMessageKind(0)
+	testMessageB = testMessageKind(1)
+	testMessageC = testMessageKind(2)
+)
+
+type testMessage struct {
+	foo int32
+}
+
+type errorMessage struct{}
+
+var errTest = fmt.Errorf("error")
+
+type testSubscriber struct {
+	msgs []int32
+	fail bool
+}
+
+// Implements api.MessageSubscriber.
+func (s *testSubscriber) ExecuteMessage(ctx *api.Context, kind, msg interface{}) error {
+	switch m := msg.(type) {
+	case *testMessage:
+		s.msgs = append(s.msgs, m.foo)
+		if s.fail {
+			return errTest
+		}
+		return nil
+	case *errorMessage:
+		return errTest
+	default:
+		panic("unexpected message was delivered")
+	}
+}
+
+func TestMessageDispatcher(t *testing.T) {
+	require := require.New(t)
+
+	now := time.Unix(1580461674, 0)
+	appState := api.NewMockApplicationState(&api.MockApplicationStateConfig{})
+	ctx := appState.NewContext(api.ContextBeginBlock, now)
+	defer ctx.Close()
+
+	var md messageDispatcher
+
+	// Publish without subscribers should work.
+	err := md.Publish(ctx, testMessageA, &testMessage{foo: 42})
+	require.Error(err, "Publish")
+	require.Equal(api.ErrNoSubscribers, err)
+
+	// With a subscriber.
+	var ms testSubscriber
+	md.Subscribe(testMessageA, &ms)
+	err = md.Publish(ctx, testMessageA, &testMessage{foo: 42})
+	require.NoError(err, "Publish")
+	require.EqualValues([]int32{42}, ms.msgs, "correct messages should be delivered")
+
+	err = md.Publish(ctx, testMessageA, &testMessage{foo: 43})
+	require.NoError(err, "Publish")
+	require.EqualValues([]int32{42, 43}, ms.msgs, "correct messages should be delivered")
+
+	err = md.Publish(ctx, testMessageB, &testMessage{foo: 44})
+	require.Error(err, "Publish")
+	require.Equal(api.ErrNoSubscribers, err)
+	require.EqualValues([]int32{42, 43}, ms.msgs, "correct messages should be delivered")
+
+	// Returning an error.
+	err = md.Publish(ctx, testMessageA, &errorMessage{})
+	require.Error(err, "Publish")
+	require.True(errors.Is(err, errTest), "returned error should be the correct one")
+
+	// Multiple subscribers.
+	var ms2 testSubscriber
+	md.Subscribe(testMessageA, &ms2)
+	err = md.Publish(ctx, testMessageA, &testMessage{foo: 44})
+	require.NoError(err, "Publish")
+	require.EqualValues([]int32{42, 43, 44}, ms.msgs, "correct messages should be delivered")
+	require.EqualValues([]int32{44}, ms2.msgs, "correct messages should be delivered")
+
+	// Multiple subscribers, some succeed some fail.
+	ms2.fail = true
+
+	err = md.Publish(ctx, testMessageA, &testMessage{foo: 45})
+	require.Error(err, "Publish")
+	require.True(errors.Is(err, errTest), "returned error should be the correct one")
+	require.EqualValues([]int32{42, 43, 44, 45}, ms.msgs, "correct messages should be delivered")
+	require.EqualValues([]int32{44, 45}, ms2.msgs, "correct messages should be delivered")
+}

--- a/go/consensus/tendermint/abci/mux.go
+++ b/go/consensus/tendermint/abci/mux.go
@@ -228,6 +228,8 @@ type abciMux struct {
 	// debugExpiringTxs maps transaction hashes to the time at which they were created. This is only
 	// used in case CheckTx is disabled (for debug purposes only).
 	debugExpiringTxs map[hash.Hash]time.Time
+
+	md messageDispatcher
 }
 
 type invalidatedTxSubscription struct {
@@ -1046,7 +1048,7 @@ func (mux *abciMux) doRegister(app api.Application) error {
 	}
 	mux.rebuildAppLexOrdering() // Inefficient but not a lot of apps.
 
-	app.OnRegister(mux.state)
+	app.OnRegister(mux.state, &mux.md)
 	mux.logger.Debug("Registered new application",
 		"app", app.Name(),
 	)

--- a/go/consensus/tendermint/abci/mux.go
+++ b/go/consensus/tendermint/abci/mux.go
@@ -562,18 +562,6 @@ func (mux *abciMux) processTx(ctx *api.Context, tx *transaction.Transaction, txS
 		return err
 	}
 
-	// Run ForeignDeliverTx on all other applications so they can
-	// run their post-tx hooks.
-	for _, foreignApp := range mux.appsByLexOrder {
-		if foreignApp == app {
-			continue
-		}
-
-		if err := foreignApp.ForeignExecuteTx(ctx, app, tx); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/go/consensus/tendermint/api/app.go
+++ b/go/consensus/tendermint/api/app.go
@@ -1,15 +1,39 @@
 package api
 
 import (
+	"errors"
+
 	tmabcitypes "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
 )
 
+// ErrNoSubscribers is the error returned when publishing a message that noone is subscribed to.
+var ErrNoSubscribers = errors.New("no subscribers to given message kind")
+
+// MessageSubscriber is a message subscriber interface.
+type MessageSubscriber interface {
+	// ExecuteMessage executes a given message.
+	ExecuteMessage(ctx *Context, kind, msg interface{}) error
+}
+
+// MessageDispatcher is a message dispatcher interface.
+type MessageDispatcher interface {
+	// Subscribe subscribes a given message subscriber to messages of a specific kind.
+	Subscribe(kind interface{}, ms MessageSubscriber)
+
+	// Publish publishes a message of a given kind by dispatching to all subscribers.
+	//
+	// In case there are no subscribers ErrNoSubscribers is returned.
+	Publish(ctx *Context, kind, msg interface{}) error
+}
+
 // Application is the interface implemented by multiplexed Oasis-specific
 // ABCI applications.
 type Application interface {
+	MessageSubscriber
+
 	// Name returns the name of the Application.
 	Name() string
 
@@ -37,7 +61,7 @@ type Application interface {
 
 	// OnRegister is the function that is called when the Application
 	// is registered with the multiplexer instance.
-	OnRegister(state ApplicationState)
+	OnRegister(ApplicationState, MessageDispatcher)
 
 	// OnCleanup is the function that is called when the ApplicationServer
 	// has been halted.

--- a/go/consensus/tendermint/api/app.go
+++ b/go/consensus/tendermint/api/app.go
@@ -70,13 +70,6 @@ type Application interface {
 	// ExecuteTx executes a transaction.
 	ExecuteTx(*Context, *transaction.Transaction) error
 
-	// ForeignExecuteTx delivers a transaction of another application for
-	// processing.
-	//
-	// This can be used to run post-tx hooks when dependencies exist
-	// between applications.
-	ForeignExecuteTx(*Context, Application, *transaction.Transaction) error
-
 	// InitChain initializes the blockchain with validators and other
 	// info from TendermintCore.
 	//

--- a/go/consensus/tendermint/api/app.go
+++ b/go/consensus/tendermint/api/app.go
@@ -29,6 +29,18 @@ type MessageDispatcher interface {
 	Publish(ctx *Context, kind, msg interface{}) error
 }
 
+// NoopMessageDispatcher is a no-op message dispatcher that performs no dispatch.
+type NoopMessageDispatcher struct{}
+
+// Implements MessageDispatcher.
+func (nd *NoopMessageDispatcher) Subscribe(interface{}, MessageSubscriber) {
+}
+
+// Implements MessageDispatcher.
+func (nd *NoopMessageDispatcher) Publish(*Context, interface{}, interface{}) error {
+	return nil
+}
+
 // Application is the interface implemented by multiplexed Oasis-specific
 // ABCI applications.
 type Application interface {

--- a/go/consensus/tendermint/apps/beacon/beacon.go
+++ b/go/consensus/tendermint/apps/beacon/beacon.go
@@ -46,7 +46,7 @@ func (app *beaconApplication) Dependencies() []string {
 	return nil
 }
 
-func (app *beaconApplication) OnRegister(state api.ApplicationState) {
+func (app *beaconApplication) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
 	app.state = state
 }
 
@@ -58,6 +58,10 @@ func (app *beaconApplication) BeginBlock(ctx *api.Context, req types.RequestBegi
 		return app.onBeaconEpochChange(ctx, beaconEpoch, req)
 	}
 	return nil
+}
+
+func (app *beaconApplication) ExecuteMessage(ctx *api.Context, kind, msg interface{}) error {
+	return fmt.Errorf("beacon: unexpected message")
 }
 
 func (app *beaconApplication) ExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {

--- a/go/consensus/tendermint/apps/beacon/beacon.go
+++ b/go/consensus/tendermint/apps/beacon/beacon.go
@@ -68,10 +68,6 @@ func (app *beaconApplication) ExecuteTx(ctx *api.Context, tx *transaction.Transa
 	return fmt.Errorf("beacon: unexpected transaction")
 }
 
-func (app *beaconApplication) ForeignExecuteTx(ctx *api.Context, other api.Application, tx *transaction.Transaction) error {
-	return nil
-}
-
 func (app *beaconApplication) EndBlock(ctx *api.Context, req types.RequestEndBlock) (types.ResponseEndBlock, error) {
 	return types.ResponseEndBlock{}, nil
 }

--- a/go/consensus/tendermint/apps/epochtime_mock/epochtime_mock.go
+++ b/go/consensus/tendermint/apps/epochtime_mock/epochtime_mock.go
@@ -39,7 +39,7 @@ func (app *epochTimeMockApplication) Dependencies() []string {
 	return nil
 }
 
-func (app *epochTimeMockApplication) OnRegister(state api.ApplicationState) {
+func (app *epochTimeMockApplication) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
 	app.state = state
 }
 
@@ -85,6 +85,10 @@ func (app *epochTimeMockApplication) BeginBlock(ctx *api.Context, request types.
 	ctx.EmitEvent(api.NewEventBuilder(app.Name()).Attribute(KeyEpoch, cbor.Marshal(future.Epoch)))
 
 	return nil
+}
+
+func (app *epochTimeMockApplication) ExecuteMessage(ctx *api.Context, kind, msg interface{}) error {
+	return fmt.Errorf("epochtime_mock: unexpected message")
 }
 
 func (app *epochTimeMockApplication) ExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {

--- a/go/consensus/tendermint/apps/epochtime_mock/epochtime_mock.go
+++ b/go/consensus/tendermint/apps/epochtime_mock/epochtime_mock.go
@@ -107,10 +107,6 @@ func (app *epochTimeMockApplication) ExecuteTx(ctx *api.Context, tx *transaction
 	}
 }
 
-func (app *epochTimeMockApplication) ForeignExecuteTx(ctx *api.Context, other api.Application, tx *transaction.Transaction) error {
-	return nil
-}
-
 func (app *epochTimeMockApplication) EndBlock(ctx *api.Context, request types.RequestEndBlock) (types.ResponseEndBlock, error) {
 	return types.ResponseEndBlock{}, nil
 }

--- a/go/consensus/tendermint/apps/keymanager/keymanager.go
+++ b/go/consensus/tendermint/apps/keymanager/keymanager.go
@@ -49,7 +49,7 @@ func (app *keymanagerApplication) Dependencies() []string {
 	return []string{registryapp.AppName}
 }
 
-func (app *keymanagerApplication) OnRegister(state tmapi.ApplicationState) {
+func (app *keymanagerApplication) OnRegister(state tmapi.ApplicationState, md tmapi.MessageDispatcher) {
 	app.state = state
 }
 
@@ -60,6 +60,10 @@ func (app *keymanagerApplication) BeginBlock(ctx *tmapi.Context, request types.R
 		return app.onEpochChange(ctx, epoch)
 	}
 	return nil
+}
+
+func (app *keymanagerApplication) ExecuteMessage(ctx *tmapi.Context, kind, msg interface{}) error {
+	return fmt.Errorf("keymanager: unexpected message")
 }
 
 func (app *keymanagerApplication) ExecuteTx(ctx *tmapi.Context, tx *transaction.Transaction) error {

--- a/go/consensus/tendermint/apps/keymanager/keymanager.go
+++ b/go/consensus/tendermint/apps/keymanager/keymanager.go
@@ -81,10 +81,6 @@ func (app *keymanagerApplication) ExecuteTx(ctx *tmapi.Context, tx *transaction.
 	}
 }
 
-func (app *keymanagerApplication) ForeignExecuteTx(ctx *tmapi.Context, other tmapi.Application, tx *transaction.Transaction) error {
-	return nil
-}
-
 func (app *keymanagerApplication) EndBlock(ctx *tmapi.Context, request types.RequestEndBlock) (types.ResponseEndBlock, error) {
 	return types.ResponseEndBlock{}, nil
 }

--- a/go/consensus/tendermint/apps/registry/api/api.go
+++ b/go/consensus/tendermint/apps/registry/api/api.go
@@ -1,0 +1,10 @@
+// Package api defines the registry application API for other applications.
+package api
+
+type messageKind uint8
+
+// MessageNewRuntimeRegistered is the message kind for new runtime registrations. The message is
+// the runtime descriptor of the runtime that has been registered.
+//
+// The message is not emitted for runtime descriptor updates.
+var MessageNewRuntimeRegistered = messageKind(0)

--- a/go/consensus/tendermint/apps/registry/api/api.go
+++ b/go/consensus/tendermint/apps/registry/api/api.go
@@ -3,8 +3,16 @@ package api
 
 type messageKind uint8
 
-// MessageNewRuntimeRegistered is the message kind for new runtime registrations. The message is
-// the runtime descriptor of the runtime that has been registered.
-//
-// The message is not emitted for runtime descriptor updates.
-var MessageNewRuntimeRegistered = messageKind(0)
+var (
+	// MessageNewRuntimeRegistered is the message kind for new runtime registrations. The message is
+	// the runtime descriptor of the runtime that has been registered.
+	//
+	// The message is not emitted for runtime descriptor updates.
+	MessageNewRuntimeRegistered = messageKind(0)
+
+	// MessageRuntimeUpdated is the message kind for runtime registration updates. The message is
+	// the runtime descriptor of the runtime that has been updated.
+	//
+	// The message is also emitted for new runtime registrations.
+	MessageRuntimeUpdated = messageKind(1)
+)

--- a/go/consensus/tendermint/apps/registry/api/api.go
+++ b/go/consensus/tendermint/apps/registry/api/api.go
@@ -11,8 +11,13 @@ var (
 	MessageNewRuntimeRegistered = messageKind(0)
 
 	// MessageRuntimeUpdated is the message kind for runtime registration updates. The message is
-	// the runtime descriptor of the runtime that has been updated.
+	// the runtime descriptor of the runtime that has been updated. Any errors returned from the
+	// handler will prevent the runtime update from taking place.
 	//
 	// The message is also emitted for new runtime registrations.
 	MessageRuntimeUpdated = messageKind(1)
+
+	// MessageRuntimeResumed is the message kind for suspended runtime resumptions. The message is
+	// the runtime descriptor of the runtime that has been resumed.
+	MessageRuntimeResumed = messageKind(2)
 )

--- a/go/consensus/tendermint/apps/registry/registry.go
+++ b/go/consensus/tendermint/apps/registry/registry.go
@@ -46,7 +46,7 @@ func (app *registryApplication) Dependencies() []string {
 	return []string{stakingapp.AppName}
 }
 
-func (app *registryApplication) OnRegister(state api.ApplicationState) {
+func (app *registryApplication) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
 	app.state = state
 }
 
@@ -59,6 +59,10 @@ func (app *registryApplication) BeginBlock(ctx *api.Context, request types.Reque
 		return app.onRegistryEpochChanged(ctx, registryEpoch)
 	}
 	return nil
+}
+
+func (app *registryApplication) ExecuteMessage(ctx *api.Context, kind, msg interface{}) error {
+	return registry.ErrInvalidArgument
 }
 
 func (app *registryApplication) ExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {

--- a/go/consensus/tendermint/apps/registry/registry.go
+++ b/go/consensus/tendermint/apps/registry/registry.go
@@ -24,6 +24,7 @@ var _ api.Application = (*registryApplication)(nil)
 
 type registryApplication struct {
 	state api.ApplicationState
+	md    api.MessageDispatcher
 }
 
 func (app *registryApplication) Name() string {
@@ -48,6 +49,7 @@ func (app *registryApplication) Dependencies() []string {
 
 func (app *registryApplication) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
 	app.state = state
+	app.md = md
 }
 
 func (app *registryApplication) OnCleanup() {
@@ -102,10 +104,6 @@ func (app *registryApplication) ExecuteTx(ctx *api.Context, tx *transaction.Tran
 	default:
 		return registry.ErrInvalidArgument
 	}
-}
-
-func (app *registryApplication) ForeignExecuteTx(ctx *api.Context, other api.Application, tx *transaction.Transaction) error {
-	return nil
 }
 
 func (app *registryApplication) EndBlock(ctx *api.Context, request types.RequestEndBlock) (types.ResponseEndBlock, error) {

--- a/go/consensus/tendermint/apps/registry/transactions.go
+++ b/go/consensus/tendermint/apps/registry/transactions.go
@@ -7,6 +7,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/entity"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	registryApi "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry/api"
 	registryState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry/state"
 	stakingState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/staking/state"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
@@ -398,6 +399,14 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 				"runtime_id", rt.ID,
 			)
 
+			// Notify other interested applications about the new runtime.
+			if err = app.md.Publish(ctx, registryApi.MessageNewRuntimeRegistered, rt); err != nil {
+				ctx.Logger().Error("RegisterNode: failed to dispatch runtime registration message",
+					"err", err,
+				)
+				return err
+			}
+
 			ctx.EmitEvent(api.NewEventBuilder(app.Name()).Attribute(KeyRuntimeRegistered, cbor.Marshal(rt)))
 		case registry.ErrNoSuchRuntime:
 			// Runtime was not suspended.
@@ -577,6 +586,16 @@ func (app *registryApplication) registerRuntime( // nolint: gocyclo
 				"err", err,
 				"entity", rt.EntityID,
 				"account", acctAddr,
+			)
+			return err
+		}
+	}
+
+	// Notify other interested applications about the new runtime.
+	if existingRt == nil && !suspended {
+		if err = app.md.Publish(ctx, registryApi.MessageNewRuntimeRegistered, rt); err != nil {
+			ctx.Logger().Error("RegisterRuntime: failed to dispatch message",
+				"err", err,
 			)
 			return err
 		}

--- a/go/consensus/tendermint/apps/registry/transactions.go
+++ b/go/consensus/tendermint/apps/registry/transactions.go
@@ -592,13 +592,20 @@ func (app *registryApplication) registerRuntime( // nolint: gocyclo
 	}
 
 	// Notify other interested applications about the new runtime.
-	if existingRt == nil && !suspended {
+	if existingRt == nil {
 		if err = app.md.Publish(ctx, registryApi.MessageNewRuntimeRegistered, rt); err != nil {
 			ctx.Logger().Error("RegisterRuntime: failed to dispatch message",
 				"err", err,
 			)
 			return err
 		}
+	}
+
+	if err = app.md.Publish(ctx, registryApi.MessageRuntimeUpdated, rt); err != nil {
+		ctx.Logger().Error("RegisterRuntime: failed to dispatch message",
+			"err", err,
+		)
+		return err
 	}
 
 	if err = state.SetRuntime(ctx, rt, sigRt, suspended); err != nil {

--- a/go/consensus/tendermint/apps/registry/transactions.go
+++ b/go/consensus/tendermint/apps/registry/transactions.go
@@ -399,9 +399,9 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 				"runtime_id", rt.ID,
 			)
 
-			// Notify other interested applications about the new runtime.
-			if err = app.md.Publish(ctx, registryApi.MessageNewRuntimeRegistered, rt); err != nil {
-				ctx.Logger().Error("RegisterNode: failed to dispatch runtime registration message",
+			// Notify other interested applications about the resumed runtime.
+			if err = app.md.Publish(ctx, registryApi.MessageRuntimeResumed, rt); err != nil {
+				ctx.Logger().Error("RegisterNode: failed to dispatch runtime resumption message",
 					"err", err,
 				)
 				return err

--- a/go/consensus/tendermint/apps/registry/transactions_test.go
+++ b/go/consensus/tendermint/apps/registry/transactions_test.go
@@ -29,7 +29,8 @@ func TestRegisterNode(t *testing.T) {
 	ctx := appState.NewContext(abciAPI.ContextDeliverTx, now)
 	defer ctx.Close()
 
-	app := registryApplication{appState}
+	var md abciAPI.NoopMessageDispatcher
+	app := registryApplication{appState, &md}
 	state := registryState.NewMutableState(ctx.State())
 	stakeState := stakingState.NewMutableState(ctx.State())
 

--- a/go/consensus/tendermint/apps/roothash/api.go
+++ b/go/consensus/tendermint/apps/roothash/api.go
@@ -47,6 +47,9 @@ var (
 	// KeyFinalized is an ABCI event attribute key for finalized blocks
 	// (value is a CBOR serialized ValueFinalized).
 	KeyFinalized = []byte("finalized")
+	// KeyMessage is an ABCI event attribute key for message result events
+	// (value is a CBOR serialized ValueMessage).
+	KeyMessage = []byte("message")
 )
 
 // QueryForRuntime returns a query for filtering transactions processed by the roothash application
@@ -78,4 +81,10 @@ type ValueFinalized struct {
 type ValueExecutionDiscrepancyDetected struct {
 	ID    common.Namespace                           `json:"id"`
 	Event roothash.ExecutionDiscrepancyDetectedEvent `json:"event"`
+}
+
+// ValueMessage is the value component of a KeyMessage.
+type ValueMessage struct {
+	ID    common.Namespace      `json:"id"`
+	Event roothash.MessageEvent `json:"event"`
 }

--- a/go/consensus/tendermint/apps/roothash/api/api.go
+++ b/go/consensus/tendermint/apps/roothash/api/api.go
@@ -1,0 +1,7 @@
+// Package api defines the roothash application API for other applications.
+package api
+
+type messageKind uint8
+
+// RuntimeMessageNoop is the message kind used when dispatching Noop runtime messages.
+var RuntimeMessageNoop = messageKind(0)

--- a/go/consensus/tendermint/apps/roothash/genesis.go
+++ b/go/consensus/tendermint/apps/roothash/genesis.go
@@ -12,7 +12,7 @@ import (
 	registryState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry/state"
 	roothashState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/roothash/state"
 	genesisAPI "github.com/oasisprotocol/oasis-core/go/genesis/api"
-	"github.com/oasisprotocol/oasis-core/go/registry/api"
+	registryAPI "github.com/oasisprotocol/oasis-core/go/registry/api"
 	roothashAPI "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	storageAPI "github.com/oasisprotocol/oasis-core/go/storage/api"
 )
@@ -53,14 +53,16 @@ func (rq *rootHashQuerier) Genesis(ctx context.Context) (*roothashAPI.Genesis, e
 	}
 
 	// Get per-runtime states.
-	rtStates := make(map[common.Namespace]*api.RuntimeGenesis)
+	rtStates := make(map[common.Namespace]*roothashAPI.GenesisRuntimeState)
 	for _, rt := range runtimes {
-		rtState := api.RuntimeGenesis{
-			StateRoot: rt.CurrentBlock.Header.StateRoot,
-			// State is always empty in Genesis regardless of StateRoot.
-			State:           storageAPI.WriteLog{},
-			StorageReceipts: []signature.Signature{},
-			Round:           rt.CurrentBlock.Header.Round,
+		rtState := roothashAPI.GenesisRuntimeState{
+			RuntimeGenesis: registryAPI.RuntimeGenesis{
+				StateRoot: rt.CurrentBlock.Header.StateRoot,
+				// State is always empty in Genesis regardless of StateRoot.
+				State:           storageAPI.WriteLog{},
+				StorageReceipts: []signature.Signature{},
+				Round:           rt.CurrentBlock.Header.Round,
+			},
 		}
 
 		rtStates[rt.Runtime.ID] = &rtState

--- a/go/consensus/tendermint/apps/roothash/messages.go
+++ b/go/consensus/tendermint/apps/roothash/messages.go
@@ -1,0 +1,55 @@
+package roothash
+
+import (
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/errors"
+	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	roothashApi "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/roothash/api"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
+)
+
+func (app *rootHashApplication) processRuntimeMessages(
+	ctx *tmapi.Context,
+	rtState *roothash.RuntimeState,
+	msgs []block.Message,
+) error {
+	for i, msg := range msgs {
+		var err error
+		switch {
+		case msg.Noop != nil:
+			err = app.md.Publish(ctx, roothashApi.RuntimeMessageNoop, &msg.Noop)
+		default:
+			// Unsupported message.
+			err = roothash.ErrInvalidArgument
+		}
+		if err != nil {
+			ctx.Logger().Warn("failed to process runtime message",
+				"err", err,
+				"runtime_id", rtState.Runtime.ID,
+				"msg_index", i,
+			)
+		}
+
+		// Make sure somebody actually handled the message, otherwise treat as unsupported.
+		if err == tmapi.ErrNoSubscribers {
+			err = roothash.ErrInvalidArgument
+		}
+
+		module, code := errors.Code(err)
+		evV := ValueMessage{
+			ID: rtState.Runtime.ID,
+			Event: roothash.MessageEvent{
+				Index:  uint32(i),
+				Module: module,
+				Code:   code,
+			},
+		}
+		ctx.EmitEvent(
+			tmapi.NewEventBuilder(app.Name()).
+				Attribute(KeyMessage, cbor.Marshal(evV)).
+				Attribute(KeyRuntimeID, ValueRuntimeID(evV.ID)),
+		)
+	}
+	return nil
+}

--- a/go/consensus/tendermint/apps/roothash/query.go
+++ b/go/consensus/tendermint/apps/roothash/query.go
@@ -14,6 +14,7 @@ import (
 type Query interface {
 	LatestBlock(context.Context, common.Namespace) (*block.Block, error)
 	GenesisBlock(context.Context, common.Namespace) (*block.Block, error)
+	RuntimeState(context.Context, common.Namespace) (*roothash.RuntimeState, error)
 	Genesis(context.Context) (*roothash.Genesis, error)
 }
 
@@ -49,6 +50,10 @@ func (rq *rootHashQuerier) GenesisBlock(ctx context.Context, id common.Namespace
 		return nil, err
 	}
 	return runtime.GenesisBlock, nil
+}
+
+func (rq *rootHashQuerier) RuntimeState(ctx context.Context, id common.Namespace) (*roothash.RuntimeState, error) {
+	return rq.state.RuntimeState(ctx, id)
 }
 
 func (app *rootHashApplication) QueryFactory() interface{} {

--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -55,7 +55,7 @@ func (app *rootHashApplication) Dependencies() []string {
 	return []string{schedulerapp.AppName, stakingapp.AppName}
 }
 
-func (app *rootHashApplication) OnRegister(state tmapi.ApplicationState) {
+func (app *rootHashApplication) OnRegister(state tmapi.ApplicationState, md tmapi.MessageDispatcher) {
 	app.state = state
 }
 
@@ -260,6 +260,10 @@ func (app *rootHashApplication) emitEmptyBlock(ctx *tmapi.Context, runtime *root
 			Attribute(KeyRuntimeID, ValueRuntimeID(runtime.Runtime.ID)),
 	)
 	return nil
+}
+
+func (app *rootHashApplication) ExecuteMessage(ctx *tmapi.Context, kind, msg interface{}) error {
+	return roothash.ErrInvalidArgument
 }
 
 func (app *rootHashApplication) ExecuteTx(ctx *tmapi.Context, tx *transaction.Transaction) error {

--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -3,7 +3,6 @@ package roothash
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 
 	"github.com/tendermint/tendermint/abci/types"
@@ -15,6 +14,7 @@ import (
 	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
 	registryapp "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry"
 	registryState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry/state"
+	roothashApi "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/roothash/api"
 	roothashState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/roothash/state"
 	schedulerapp "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/scheduler"
 	schedulerState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/scheduler/state"
@@ -33,6 +33,7 @@ var _ tmapi.Application = (*rootHashApplication)(nil)
 
 type rootHashApplication struct {
 	state tmapi.ApplicationState
+	md    tmapi.MessageDispatcher
 }
 
 func (app *rootHashApplication) Name() string {
@@ -57,6 +58,10 @@ func (app *rootHashApplication) Dependencies() []string {
 
 func (app *rootHashApplication) OnRegister(state tmapi.ApplicationState, md tmapi.MessageDispatcher) {
 	app.state = state
+	app.md = md
+
+	// Subscribe to messages emitted by other apps.
+	md.Subscribe(roothashApi.RuntimeMessageNoop, app)
 }
 
 func (app *rootHashApplication) OnCleanup() {
@@ -161,6 +166,7 @@ func (app *rootHashApplication) onCommitteeChanged(ctx *tmapi.Context, epoch epo
 
 			// Set the executor pool.
 			rtState.ExecutorPool = executorPool
+			rtState.ExecutorPool.Round = rtState.CurrentBlock.Header.Round
 		}
 
 		// Update the runtime descriptor to the latest per-epoch value.
@@ -238,7 +244,8 @@ func (app *rootHashApplication) emitEmptyBlock(ctx *tmapi.Context, runtime *root
 	blk := block.NewEmptyBlock(runtime.CurrentBlock, uint64(ctx.Now().Unix()), hdrType)
 
 	runtime.CurrentBlock = blk
-	runtime.CurrentBlockHeight = ctx.BlockHeight()
+	runtime.CurrentBlockHeight = ctx.BlockHeight() + 1 // Current height is ctx.BlockHeight() + 1
+	// Do not update LastNormal{Round,Height} as empty blocks are not emitted by the runtime.
 	if runtime.ExecutorPool != nil {
 		// Clear timeout if there was one scheduled.
 		if runtime.ExecutorPool.NextTimeout != commitment.TimeoutNever {
@@ -247,7 +254,7 @@ func (app *rootHashApplication) emitEmptyBlock(ctx *tmapi.Context, runtime *root
 				return fmt.Errorf("failed to clear round timeout: %w", err)
 			}
 		}
-		runtime.ExecutorPool.ResetCommitments()
+		runtime.ExecutorPool.ResetCommitments(blk.Header.Round)
 	}
 
 	tagV := ValueFinalized{
@@ -263,7 +270,13 @@ func (app *rootHashApplication) emitEmptyBlock(ctx *tmapi.Context, runtime *root
 }
 
 func (app *rootHashApplication) ExecuteMessage(ctx *tmapi.Context, kind, msg interface{}) error {
-	return roothash.ErrInvalidArgument
+	switch kind {
+	case roothashApi.RuntimeMessageNoop:
+		// Noop message always succeeds.
+		return nil
+	default:
+		return roothash.ErrInvalidArgument
+	}
 }
 
 func (app *rootHashApplication) ExecuteTx(ctx *tmapi.Context, tx *transaction.Transaction) error {
@@ -351,19 +364,39 @@ func (app *rootHashApplication) onNewRuntime(ctx *tmapi.Context, runtime *regist
 	genesisBlock.Header.StorageSignatures = runtime.Genesis.StorageReceipts
 	if ctx.IsInitChain() {
 		// NOTE: Outside InitChain the genesis argument will be nil.
-		genesisRts := genesis.RuntimeStates[runtime.ID]
-		if genesisRts != nil {
+		if genesisRts := genesis.RuntimeStates[runtime.ID]; genesisRts != nil {
 			genesisBlock.Header.Round = genesisRts.Round
 			genesisBlock.Header.StateRoot = genesisRts.StateRoot
 			genesisBlock.Header.StorageSignatures = runtime.Genesis.StorageReceipts
+
+			// Emit any message results now (will be deferred to the first block).
+			ctx.Logger().Debug("emitting message results",
+				"runtime_id", runtime.ID,
+				"num_results", len(genesisRts.MessageResults),
+			)
+
+			for _, msg := range genesisRts.MessageResults {
+				evV := ValueMessage{
+					ID:    runtime.ID,
+					Event: *msg,
+				}
+				ctx.EmitEvent(
+					tmapi.NewEventBuilder(app.Name()).
+						Attribute(KeyMessage, cbor.Marshal(evV)).
+						Attribute(KeyRuntimeID, ValueRuntimeID(evV.ID)),
+				)
+			}
 		}
 	}
 
 	// Create new state containing the genesis block.
 	err = state.SetRuntimeState(ctx, &roothash.RuntimeState{
-		Runtime:      runtime,
-		CurrentBlock: genesisBlock,
-		GenesisBlock: genesisBlock,
+		Runtime:            runtime,
+		CurrentBlock:       genesisBlock,
+		CurrentBlockHeight: ctx.BlockHeight() + 1, // Current height is ctx.BlockHeight() + 1
+		LastNormalRound:    genesisBlock.Header.Round,
+		LastNormalHeight:   ctx.BlockHeight() + 1, // Current height is ctx.BlockHeight() + 1
+		GenesisBlock:       genesisBlock,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to set runtime state: %w", err)
@@ -442,41 +475,63 @@ func (app *rootHashApplication) tryFinalizeExecutorCommits(
 	ctx *tmapi.Context,
 	rtState *roothash.RuntimeState,
 	forced bool,
-) (*block.Block, error) {
+) error {
 	runtime := rtState.Runtime
-	blockNr := rtState.CurrentBlock.Header.Round
+	round := rtState.CurrentBlock.Header.Round
 
 	commit, err := rtState.ExecutorPool.TryFinalize(ctx.BlockHeight(), runtime.Executor.RoundTimeout, forced, true)
 	switch err {
 	case nil:
 		// Round has been finalized.
 		ctx.Logger().Debug("finalized round",
-			"round", blockNr,
+			"round", round,
 		)
 
-		// Generate the final block.
-		hdr := commit.ToDDResult().(commitment.ComputeResultsHeader)
+		body := commit.ToDDResult().(*commitment.ComputeBody)
+		hdr := &body.Header
 
+		// Process any runtime messages.
+		if err = app.processRuntimeMessages(ctx, rtState, body.Messages); err != nil {
+			return fmt.Errorf("failed to process runtime messages: %w", err)
+		}
+
+		// Generate the final block.
 		blk := block.NewEmptyBlock(rtState.CurrentBlock, uint64(ctx.Now().Unix()), block.Normal)
 		blk.Header.IORoot = *hdr.IORoot
 		blk.Header.StateRoot = *hdr.StateRoot
-		// Messages omitted on purpose.
+		blk.Header.MessagesHash = *hdr.MessagesHash
 
 		// Timeout will be cleared by caller.
-		rtState.ExecutorPool.ResetCommitments()
+		rtState.ExecutorPool.ResetCommitments(blk.Header.Round)
 
-		return blk, nil
+		// All good. Hook up the new block.
+		rtState.CurrentBlock = blk
+		rtState.CurrentBlockHeight = ctx.BlockHeight() + 1 // Current height is ctx.BlockHeight() + 1
+		rtState.LastNormalRound = blk.Header.Round
+		rtState.LastNormalHeight = ctx.BlockHeight() + 1
+
+		tagV := ValueFinalized{
+			ID:    rtState.Runtime.ID,
+			Round: blk.Header.Round,
+		}
+		ctx.EmitEvent(
+			tmapi.NewEventBuilder(app.Name()).
+				Attribute(KeyFinalized, cbor.Marshal(tagV)).
+				Attribute(KeyRuntimeID, ValueRuntimeID(rtState.Runtime.ID)),
+		)
+
+		return nil
 	case commitment.ErrStillWaiting:
 		// Need more commits.
 		ctx.Logger().Debug("insufficient commitments for finality, waiting",
-			"round", blockNr,
+			"round", round,
 		)
 
-		return nil, nil
+		return nil
 	case commitment.ErrDiscrepancyDetected:
 		// Discrepancy has been detected.
 		ctx.Logger().Warn("executor discrepancy detected",
-			"round", blockNr,
+			"round", round,
 			logging.LogEvent, roothash.LogEventExecutionDiscrepancyDetected,
 		)
 
@@ -491,65 +546,21 @@ func (app *rootHashApplication) tryFinalizeExecutorCommits(
 				Attribute(KeyExecutionDiscrepancyDetected, cbor.Marshal(tagV)).
 				Attribute(KeyRuntimeID, ValueRuntimeID(runtime.ID)),
 		)
-		return nil, nil
+		return nil
 	default:
 	}
 
 	// Something else went wrong, emit empty error block.
 	ctx.Logger().Error("round failed",
-		"round", blockNr,
+		"round", round,
 		"err", err,
 		logging.LogEvent, roothash.LogEventRoundFailed,
 	)
 
 	if err := app.emitEmptyBlock(ctx, rtState, block.RoundFailed); err != nil {
-		return nil, fmt.Errorf("failed to emit empty block: %w", err)
+		return fmt.Errorf("failed to emit empty block: %w", err)
 	}
 
-	return nil, nil
-}
-
-func (app *rootHashApplication) postProcessFinalizedBlock(ctx *tmapi.Context, rtState *roothashState.RuntimeState, blk *block.Block) error {
-	sc := ctx.StartCheckpoint()
-	defer sc.Close()
-
-	for _, message := range blk.Header.Messages {
-		// Currently there are no valid roothash messages, so any message
-		// is treated as unsatisfactory. This is the place which would
-		// otherwise contain message handlers.
-		unsat := errors.New("tendermint/roothash: message is invalid")
-
-		if unsat != nil {
-			ctx.Logger().Error("handler not satisfied with message",
-				"err", unsat,
-				"message", message,
-				logging.LogEvent, roothash.LogEventMessageUnsat,
-			)
-
-			// Substitute empty block.
-			if err := app.emitEmptyBlock(ctx, rtState, block.RoundFailed); err != nil {
-				return fmt.Errorf("failed to emit empty block: %w", err)
-			}
-
-			return nil
-		}
-	}
-
-	sc.Commit()
-
-	// All good. Hook up the new block.
-	rtState.CurrentBlock = blk
-	rtState.CurrentBlockHeight = ctx.BlockHeight()
-
-	tagV := ValueFinalized{
-		ID:    rtState.Runtime.ID,
-		Round: blk.Header.Round,
-	}
-	ctx.EmitEvent(
-		tmapi.NewEventBuilder(app.Name()).
-			Attribute(KeyFinalized, cbor.Marshal(tagV)).
-			Attribute(KeyRuntimeID, ValueRuntimeID(rtState.Runtime.ID)),
-	)
 	return nil
 }
 
@@ -594,18 +605,7 @@ func (app *rootHashApplication) tryFinalizeBlock(
 		}
 	}(rtState.ExecutorPool.NextTimeout)
 
-	finalizedBlock, err := app.tryFinalizeExecutorCommits(ctx, rtState, forced)
-	if err != nil {
-		return fmt.Errorf("failed to finalize executor commits: %w", err)
-	}
-	if finalizedBlock == nil {
-		return nil
-	}
-
-	if err = app.postProcessFinalizedBlock(ctx, rtState, finalizedBlock); err != nil {
-		return fmt.Errorf("failed to post process finalized block: %w", err)
-	}
-	return nil
+	return app.tryFinalizeExecutorCommits(ctx, rtState, forced)
 }
 
 // New constructs a new roothash application instance.

--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -176,7 +176,7 @@ func (app *rootHashApplication) onCommitteeChanged(ctx *tmapi.Context, epoch epo
 
 func (app *rootHashApplication) suspendUnpaidRuntime(
 	ctx *tmapi.Context,
-	rtState *roothashState.RuntimeState,
+	rtState *roothash.RuntimeState,
 	regState *registryState.MutableState,
 ) error {
 	ctx.Logger().Warn("maintenance fees not paid for runtime or owner debonded, suspending",
@@ -201,7 +201,7 @@ func (app *rootHashApplication) suspendUnpaidRuntime(
 func (app *rootHashApplication) prepareNewCommittees(
 	ctx *tmapi.Context,
 	epoch epochtime.EpochTime,
-	rtState *roothashState.RuntimeState,
+	rtState *roothash.RuntimeState,
 	schedState *schedulerState.MutableState,
 	regState *registryState.MutableState,
 ) (
@@ -234,7 +234,7 @@ func (app *rootHashApplication) prepareNewCommittees(
 	return
 }
 
-func (app *rootHashApplication) emitEmptyBlock(ctx *tmapi.Context, runtime *roothashState.RuntimeState, hdrType block.HeaderType) error {
+func (app *rootHashApplication) emitEmptyBlock(ctx *tmapi.Context, runtime *roothash.RuntimeState, hdrType block.HeaderType) error {
 	blk := block.NewEmptyBlock(runtime.CurrentBlock, uint64(ctx.Now().Unix()), hdrType)
 
 	runtime.CurrentBlock = blk
@@ -360,7 +360,7 @@ func (app *rootHashApplication) onNewRuntime(ctx *tmapi.Context, runtime *regist
 	}
 
 	// Create new state containing the genesis block.
-	err = state.SetRuntimeState(ctx, &roothashState.RuntimeState{
+	err = state.SetRuntimeState(ctx, &roothash.RuntimeState{
 		Runtime:      runtime,
 		CurrentBlock: genesisBlock,
 		GenesisBlock: genesisBlock,
@@ -440,7 +440,7 @@ func (app *rootHashApplication) processRoundTimeout(ctx *tmapi.Context, state *r
 // The caller must take care of clearing and scheduling the round timeouts.
 func (app *rootHashApplication) tryFinalizeExecutorCommits(
 	ctx *tmapi.Context,
-	rtState *roothashState.RuntimeState,
+	rtState *roothash.RuntimeState,
 	forced bool,
 ) (*block.Block, error) {
 	runtime := rtState.Runtime
@@ -555,7 +555,7 @@ func (app *rootHashApplication) postProcessFinalizedBlock(ctx *tmapi.Context, rt
 
 func (app *rootHashApplication) tryFinalizeBlock(
 	ctx *tmapi.Context,
-	rtState *roothashState.RuntimeState,
+	rtState *roothash.RuntimeState,
 	forced bool,
 ) (err error) {
 	defer func(previousTimeout int64) {

--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -62,6 +62,7 @@ func (app *rootHashApplication) OnRegister(state tmapi.ApplicationState, md tmap
 	// Subscribe to messages emitted by other apps.
 	md.Subscribe(registryApi.MessageNewRuntimeRegistered, app)
 	md.Subscribe(registryApi.MessageRuntimeUpdated, app)
+	md.Subscribe(registryApi.MessageRuntimeResumed, app)
 	md.Subscribe(roothashApi.RuntimeMessageNoop, app)
 }
 
@@ -292,6 +293,9 @@ func (app *rootHashApplication) ExecuteMessage(ctx *tmapi.Context, kind, msg int
 			return nil
 		}
 		return app.verifyRuntimeUpdate(ctx, msg.(*registry.Runtime))
+	case registryApi.MessageRuntimeResumed:
+		// A previously suspended runtime has been resumed.
+		return nil
 	case roothashApi.RuntimeMessageNoop:
 		// Noop message always succeeds.
 		return nil

--- a/go/consensus/tendermint/apps/roothash/transactions.go
+++ b/go/consensus/tendermint/apps/roothash/transactions.go
@@ -86,7 +86,7 @@ func (app *rootHashApplication) getRuntimeState(
 	ctx *abciAPI.Context,
 	state *roothashState.MutableState,
 	id common.Namespace,
-) (*roothashState.RuntimeState, commitment.SignatureVerifier, commitment.NodeLookup, error) {
+) (*roothash.RuntimeState, commitment.SignatureVerifier, commitment.NodeLookup, error) {
 	// Fetch current runtime state.
 	rtState, err := state.RuntimeState(ctx, id)
 	if err != nil {

--- a/go/consensus/tendermint/apps/scheduler/scheduler.go
+++ b/go/consensus/tendermint/apps/scheduler/scheduler.go
@@ -67,7 +67,7 @@ func (app *schedulerApplication) Dependencies() []string {
 	return []string{beaconapp.AppName, registryapp.AppName, stakingapp.AppName}
 }
 
-func (app *schedulerApplication) OnRegister(state api.ApplicationState) {
+func (app *schedulerApplication) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
 	app.state = state
 }
 
@@ -198,6 +198,10 @@ func (app *schedulerApplication) BeginBlock(ctx *api.Context, request types.Requ
 		}
 	}
 	return nil
+}
+
+func (app *schedulerApplication) ExecuteMessage(ctx *api.Context, kind, msg interface{}) error {
+	return fmt.Errorf("scheduler: unexpected message")
 }
 
 func (app *schedulerApplication) ExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {

--- a/go/consensus/tendermint/apps/scheduler/scheduler.go
+++ b/go/consensus/tendermint/apps/scheduler/scheduler.go
@@ -208,10 +208,6 @@ func (app *schedulerApplication) ExecuteTx(ctx *api.Context, tx *transaction.Tra
 	return fmt.Errorf("tendermint/scheduler: unexpected transaction")
 }
 
-func (app *schedulerApplication) ForeignExecuteTx(ctx *api.Context, other api.Application, tx *transaction.Transaction) error {
-	return nil
-}
-
 func diffValidators(logger *logging.Logger, current, pending map[signature.PublicKey]int64) []types.ValidatorUpdate {
 	var updates []types.ValidatorUpdate
 	for v := range current {

--- a/go/consensus/tendermint/apps/staking/staking.go
+++ b/go/consensus/tendermint/apps/staking/staking.go
@@ -160,10 +160,6 @@ func (app *stakingApplication) ExecuteTx(ctx *api.Context, tx *transaction.Trans
 	}
 }
 
-func (app *stakingApplication) ForeignExecuteTx(ctx *api.Context, other api.Application, tx *transaction.Transaction) error {
-	return nil
-}
-
 func (app *stakingApplication) EndBlock(ctx *api.Context, request types.RequestEndBlock) (types.ResponseEndBlock, error) {
 	fees := stakingState.BlockFees(ctx)
 	if err := app.disburseFeesP(ctx, stakingState.NewMutableState(ctx.State()), stakingState.BlockProposer(ctx), &fees); err != nil {

--- a/go/consensus/tendermint/apps/staking/staking.go
+++ b/go/consensus/tendermint/apps/staking/staking.go
@@ -42,7 +42,7 @@ func (app *stakingApplication) Dependencies() []string {
 	return nil
 }
 
-func (app *stakingApplication) OnRegister(state api.ApplicationState) {
+func (app *stakingApplication) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
 	app.state = state
 }
 
@@ -96,6 +96,10 @@ func (app *stakingApplication) BeginBlock(ctx *api.Context, request types.Reques
 	}
 
 	return nil
+}
+
+func (app *stakingApplication) ExecuteMessage(ctx *api.Context, kind, msg interface{}) error {
+	return staking.ErrInvalidArgument
 }
 
 func (app *stakingApplication) ExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {

--- a/go/consensus/tendermint/apps/supplementarysanity/checks.go
+++ b/go/consensus/tendermint/apps/supplementarysanity/checks.go
@@ -83,7 +83,7 @@ func checkRootHash(ctx *abciAPI.Context, now epochtime.EpochTime) error {
 	}
 
 	blocks := make(map[common.Namespace]*block.Block)
-	runtimesByID := make(map[common.Namespace]*roothashState.RuntimeState)
+	runtimesByID := make(map[common.Namespace]*roothash.RuntimeState)
 	for _, rt := range runtimes {
 		blocks[rt.Runtime.ID] = rt.CurrentBlock
 		runtimesByID[rt.Runtime.ID] = rt

--- a/go/consensus/tendermint/apps/supplementarysanity/supplementarysanity.go
+++ b/go/consensus/tendermint/apps/supplementarysanity/supplementarysanity.go
@@ -70,10 +70,6 @@ func (app *supplementarySanityApplication) ExecuteTx(*api.Context, *transaction.
 	return fmt.Errorf("supplementarysanity: unexpected transaction")
 }
 
-func (app *supplementarySanityApplication) ForeignExecuteTx(*api.Context, api.Application, *transaction.Transaction) error {
-	return nil
-}
-
 func (app *supplementarySanityApplication) InitChain(*api.Context, types.RequestInitChain, *genesis.Document) error {
 	return nil
 }

--- a/go/consensus/tendermint/apps/supplementarysanity/supplementarysanity.go
+++ b/go/consensus/tendermint/apps/supplementarysanity/supplementarysanity.go
@@ -55,15 +55,19 @@ func (app *supplementarySanityApplication) QueryFactory() interface{} {
 	return nil
 }
 
-func (app *supplementarySanityApplication) OnRegister(state api.ApplicationState) {
+func (app *supplementarySanityApplication) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
 	app.state = state
 }
 
 func (app *supplementarySanityApplication) OnCleanup() {
 }
 
+func (app *supplementarySanityApplication) ExecuteMessage(ctx *api.Context, kind, msg interface{}) error {
+	return fmt.Errorf("supplementarysanity: unexpected message")
+}
+
 func (app *supplementarySanityApplication) ExecuteTx(*api.Context, *transaction.Transaction) error {
-	return fmt.Errorf("tendermint/supplementarysanity: unexpected transaction")
+	return fmt.Errorf("supplementarysanity: unexpected transaction")
 }
 
 func (app *supplementarySanityApplication) ForeignExecuteTx(*api.Context, api.Application, *transaction.Transaction) error {

--- a/go/consensus/tendermint/tests/genesis/genesis.go
+++ b/go/consensus/tendermint/tests/genesis/genesis.go
@@ -70,6 +70,7 @@ func NewTestNodeGenesisProvider(identity *identity.Identity) (genesis.Provider, 
 		RootHash: roothash.Genesis{
 			Parameters: roothash.ConsensusParameters{
 				DebugDoNotSuspendRuntimes: true,
+				MaxRuntimeMessages:        32,
 			},
 		},
 		Consensus: consensus.Genesis{

--- a/go/oasis-node/cmd/debug/byzantine/executor.go
+++ b/go/oasis-node/cmd/debug/byzantine/executor.go
@@ -277,13 +277,14 @@ func (cbc *computeBatchContext) createCommitment(id *identity.Identity, rak sign
 	for _, receipt := range cbc.storageReceipts {
 		storageSigs = append(storageSigs, receipt.Signature)
 	}
+	// TODO: allow script to set roothash messages?
+	msgsHash := block.MessagesHash(nil)
 	header := commitment.ComputeResultsHeader{
 		Round:        cbc.bd.Header.Round + 1,
 		PreviousHash: cbc.bd.Header.EncodedHash(),
 		IORoot:       &cbc.newIORoot,
 		StateRoot:    &cbc.newStateRoot,
-		// TODO: allow script to set roothash messages?
-		Messages: []*block.Message{},
+		MessagesHash: &msgsHash,
 	}
 	computeBody := &commitment.ComputeBody{
 		Header:            header,

--- a/go/oasis-node/cmd/debug/storage/export.go
+++ b/go/oasis-node/cmd/debug/storage/export.go
@@ -16,7 +16,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	cmdConsensus "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/consensus"
-	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	storageAPI "github.com/oasisprotocol/oasis-core/go/storage/api"
 	storageClient "github.com/oasisprotocol/oasis-core/go/storage/client"
@@ -83,7 +83,7 @@ func doExport(cmd *cobra.Command, args []string) {
 	ok = true
 }
 
-func exportRuntime(dataDir, destDir string, id common.Namespace, rtg *registry.RuntimeGenesis) error {
+func exportRuntime(dataDir, destDir string, id common.Namespace, rtg *roothash.GenesisRuntimeState) error {
 	dataDir = filepath.Join(dataDir, runtimeRegistry.RuntimesDir, id.String())
 
 	// Initialize the storage backend.

--- a/go/oasis-node/cmd/debug/txsource/workload/registration.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/registration.go
@@ -51,6 +51,7 @@ func getRuntime(entityID signature.PublicKey, id common.Namespace) *registry.Run
 		Executor: registry.ExecutorParameters{
 			GroupSize:    1,
 			RoundTimeout: 5,
+			MaxMessages:  32,
 		},
 		TxnScheduler: registry.TxnSchedulerParameters{
 			Algorithm:         "simple",

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -78,6 +78,7 @@ const (
 	// Roothash config flags.
 	cfgRoothashDebugDoNotSuspendRuntimes = "roothash.debug.do_not_suspend_runtimes"
 	cfgRoothashDebugBypassStake          = "roothash.debug.bypass_stake" // nolint: gosec
+	cfgRoothashMaxRuntimeMessages        = "roothash.max_runtime_messages"
 
 	// Staking config flags.
 	CfgStakingTokenSymbol        = "staking.token_symbol"
@@ -430,6 +431,7 @@ func AppendRootHashState(doc *genesis.Document, exports []string, l *logging.Log
 		Parameters: roothash.ConsensusParameters{
 			DebugDoNotSuspendRuntimes: viper.GetBool(cfgRoothashDebugDoNotSuspendRuntimes),
 			DebugBypassStake:          viper.GetBool(cfgRoothashDebugBypassStake),
+			MaxRuntimeMessages:        viper.GetUint32(cfgRoothashMaxRuntimeMessages),
 			// TODO: Make these configurable.
 			GasCosts: roothash.DefaultGasCosts,
 		},
@@ -720,6 +722,7 @@ func init() {
 	// Roothash config flags.
 	initGenesisFlags.Bool(cfgRoothashDebugDoNotSuspendRuntimes, false, "do not suspend runtimes (UNSAFE)")
 	initGenesisFlags.Bool(cfgRoothashDebugBypassStake, false, "bypass all roothash stake checks and operations (UNSAFE)")
+	initGenesisFlags.Uint32(cfgRoothashMaxRuntimeMessages, 128, "maximum number of runtime messages submitted in a round")
 	_ = initGenesisFlags.MarkHidden(cfgRoothashDebugDoNotSuspendRuntimes)
 	_ = initGenesisFlags.MarkHidden(cfgRoothashDebugBypassStake)
 

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -425,7 +425,7 @@ func AppendRegistryState(doc *genesis.Document, entities, runtimes, nodes []stri
 // exported runtime states.
 func AppendRootHashState(doc *genesis.Document, exports []string, l *logging.Logger) error {
 	rootSt := roothash.Genesis{
-		RuntimeStates: make(map[common.Namespace]*registry.RuntimeGenesis),
+		RuntimeStates: make(map[common.Namespace]*roothash.GenesisRuntimeState),
 
 		Parameters: roothash.ConsensusParameters{
 			DebugDoNotSuspendRuntimes: viper.GetBool(cfgRoothashDebugDoNotSuspendRuntimes),
@@ -445,7 +445,7 @@ func AppendRootHashState(doc *genesis.Document, exports []string, l *logging.Log
 			return err
 		}
 
-		var rtStates map[common.Namespace]*registry.RuntimeGenesis
+		var rtStates map[common.Namespace]*roothash.GenesisRuntimeState
 		if err = json.Unmarshal(b, &rtStates); err != nil {
 			l.Error("failed to parse genesis roothash runtime states",
 				"err", err,

--- a/go/oasis-node/cmd/registry/runtime/runtime.go
+++ b/go/oasis-node/cmd/registry/runtime/runtime.go
@@ -52,6 +52,7 @@ const (
 	CfgExecutorGroupBackupSize   = "runtime.executor.group_backup_size"
 	CfgExecutorAllowedStragglers = "runtime.executor.allowed_stragglers"
 	CfgExecutorRoundTimeout      = "runtime.executor.round_timeout"
+	CfgExecutorMaxMessages       = "runtime.executor.max_messages"
 
 	// Storage committee flags.
 	CfgStorageGroupSize               = "runtime.storage.group_size"
@@ -374,6 +375,7 @@ func runtimeFromFlags() (*registry.Runtime, signature.Signer, error) { // nolint
 			GroupBackupSize:   viper.GetUint64(CfgExecutorGroupBackupSize),
 			AllowedStragglers: viper.GetUint64(CfgExecutorAllowedStragglers),
 			RoundTimeout:      viper.GetInt64(CfgExecutorRoundTimeout),
+			MaxMessages:       viper.GetUint32(CfgExecutorMaxMessages),
 		},
 		TxnScheduler: registry.TxnSchedulerParameters{
 			Algorithm:         viper.GetString(CfgTxnSchedulerAlgorithm),
@@ -532,6 +534,7 @@ func init() {
 	runtimeFlags.Uint64(CfgExecutorGroupBackupSize, 0, "Number of backup workers in the runtime executor group/committee")
 	runtimeFlags.Uint64(CfgExecutorAllowedStragglers, 0, "Number of stragglers allowed per round in the runtime executor group")
 	runtimeFlags.Int64(CfgExecutorRoundTimeout, 5, "Executor committee round timeout for this runtime (in consensus blocks)")
+	runtimeFlags.Uint32(CfgExecutorMaxMessages, 32, "Maximum number of runtime messages that can be emitted in a round")
 
 	// Init Transaction scheduler flags.
 	runtimeFlags.String(CfgTxnSchedulerAlgorithm, registry.TxnSchedulerSimple, "Transaction scheduling algorithm")

--- a/go/oasis-test-runner/oasis/cli/registry.go
+++ b/go/oasis-test-runner/oasis/cli/registry.go
@@ -58,6 +58,7 @@ func (r *RegistryHelpers) runRegistryRuntimeSubcommand(
 			"--"+cmdRegRt.CfgExecutorGroupBackupSize, strconv.FormatUint(runtime.Executor.GroupBackupSize, 10),
 			"--"+cmdRegRt.CfgExecutorAllowedStragglers, strconv.FormatUint(runtime.Executor.AllowedStragglers, 10),
 			"--"+cmdRegRt.CfgExecutorRoundTimeout, strconv.FormatInt(runtime.Executor.RoundTimeout, 10),
+			"--"+cmdRegRt.CfgExecutorMaxMessages, strconv.FormatUint(uint64(runtime.Executor.MaxMessages), 10),
 			"--"+cmdRegRt.CfgStorageGroupSize, strconv.FormatUint(runtime.Storage.GroupSize, 10),
 			"--"+cmdRegRt.CfgStorageMinWriteReplication, strconv.FormatUint(runtime.Storage.MinWriteReplication, 10),
 			"--"+cmdRegRt.CfgStorageMaxApplyWriteLogEntries, strconv.FormatUint(runtime.Storage.MaxApplyWriteLogEntries, 10),

--- a/go/oasis-test-runner/scenario/e2e/runtime/dump_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/dump_restore.go
@@ -43,7 +43,9 @@ func newDumpRestoreImpl(
 		runtimeImpl: *newRuntimeImpl(
 			name,
 			"test-long-term-client",
-			[]string{"--mode", "part1"},
+			// Use -nomsg variant as this test also compares with the database dump which cannot
+			// reconstruct the emitted messages as those are not available in the state dump alone.
+			[]string{"--mode", "part1-nomsg"},
 		),
 		mapGenesisDocumentFn: mapGenesisDocumentFn,
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -165,6 +165,7 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 					GroupSize:       2,
 					GroupBackupSize: 1,
 					RoundTimeout:    20,
+					MaxMessages:     128,
 				},
 				TxnScheduler: registry.TxnSchedulerParameters{
 					Algorithm:         registry.TxnSchedulerSimple,

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -92,6 +92,10 @@ type ExecutorParameters struct {
 
 	// RoundTimeout is the round timeout in consensus blocks.
 	RoundTimeout int64 `json:"round_timeout"`
+
+	// MaxMessages is the maximum number of messages that can be emitted by the runtime in a
+	// single round.
+	MaxMessages uint32 `json:"max_messages"`
 }
 
 // ValidateBasic performs basic executor parameter validity checks.

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -759,6 +759,15 @@ func testRegistryRuntime(t *testing.T, backend api.Backend, consensus consensusA
 			false,
 			true,
 		},
+		// Runtime with too large MaxMessages parameter.
+		{
+			"TooBigMaxMessages",
+			func(rt *api.Runtime) {
+				rt.Executor.MaxMessages = 64 // MaxRuntimeMessages in these tests is 32.
+			},
+			false,
+			false,
+		},
 	}
 
 	rtMap := make(map[common.Namespace]*api.Runtime)
@@ -1612,6 +1621,7 @@ func NewTestRuntime(seed []byte, ent *TestEntity, isKeyManager bool) (*TestRunti
 			GroupBackupSize:   5,
 			AllowedStragglers: 1,
 			RoundTimeout:      10,
+			MaxMessages:       32,
 		},
 		TxnScheduler: api.TxnSchedulerParameters{
 			Algorithm:         api.TxnSchedulerSimple,

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -12,7 +12,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
-	"github.com/oasisprotocol/oasis-core/go/registry/api"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
 )
@@ -130,6 +130,19 @@ func NewRequestProposerTimeoutTx(nonce uint64, fee *transaction.Fee, runtimeID c
 	})
 }
 
+// RuntimeState is the per-runtime state.
+type RuntimeState struct {
+	Runtime   *registry.Runtime `json:"runtime"`
+	Suspended bool              `json:"suspended,omitempty"`
+
+	GenesisBlock *block.Block `json:"genesis_block"`
+
+	CurrentBlock       *block.Block `json:"current_block"`
+	CurrentBlockHeight int64        `json:"current_block_height"`
+
+	ExecutorPool *commitment.Pool `json:"executor_pool"`
+}
+
 // AnnotatedBlock is an annotated roothash block.
 type AnnotatedBlock struct {
 	// Height is the underlying roothash backend's block height that
@@ -185,7 +198,7 @@ type Genesis struct {
 	Parameters ConsensusParameters `json:"params"`
 
 	// RuntimeStates is the per-runtime map of genesis blocks.
-	RuntimeStates map[common.Namespace]*api.RuntimeGenesis `json:"runtime_states,omitempty"`
+	RuntimeStates map[common.Namespace]*registry.RuntimeGenesis `json:"runtime_states,omitempty"`
 }
 
 // ConsensusParameters are the roothash consensus parameters.

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -78,6 +78,9 @@ type Backend interface {
 	// the latest state from the storage backend.
 	GetLatestBlock(ctx context.Context, runtimeID common.Namespace, height int64) (*block.Block, error)
 
+	// GetRuntimeState returns the given runtime's state.
+	GetRuntimeState(ctx context.Context, runtimeID common.Namespace, height int64) (*RuntimeState, error)
+
 	// WatchBlocks returns a channel that produces a stream of
 	// annotated blocks.
 	//

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
@@ -53,6 +54,10 @@ var (
 
 	// ErrProposerTimeoutNotAllowed is the error returned when proposer timeout is not allowed.
 	ErrProposerTimeoutNotAllowed = errors.New(ModuleName, 6, "roothash: proposer timeout not allowed")
+
+	// ErrMaxMessagesTooBig is the error returned when the MaxMessages parameter is set to a value
+	// larger than the MaxRuntimeMessages specified in consensus parameters.
+	ErrMaxMessagesTooBig = errors.New(ModuleName, 7, "roothash: max runtime messages is too big")
 
 	// MethodExecutorCommit is the method name for executor commit submission.
 	MethodExecutorCommit = transaction.NewMethodName(ModuleName, "ExecutorCommit", ExecutorCommit{})
@@ -289,6 +294,15 @@ func (g *Genesis) SanityCheck() error {
 		if err := rtg.SanityCheck(true); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// VerifyRuntimeParameters verifies whether the runtime parameters are valid in the context of the
+// roothash service.
+func VerifyRuntimeParameters(logger *logging.Logger, rt *registry.Runtime, params *ConsensusParameters) error {
+	if rt.Executor.MaxMessages > params.MaxRuntimeMessages {
+		return ErrMaxMessagesTooBig
 	}
 	return nil
 }

--- a/go/roothash/api/block/block.go
+++ b/go/roothash/api/block/block.go
@@ -23,6 +23,7 @@ func NewGenesisBlock(id common.Namespace, timestamp uint64) *Block {
 	blk.Header.PreviousHash.Empty()
 	blk.Header.IORoot.Empty()
 	blk.Header.StateRoot.Empty()
+	blk.Header.MessagesHash.Empty()
 
 	return &blk
 }
@@ -40,6 +41,7 @@ func NewEmptyBlock(child *Block, timestamp uint64, htype HeaderType) *Block {
 	blk.Header.IORoot.Empty()
 	// State root is unchanged.
 	blk.Header.StateRoot = child.Header.StateRoot
+	blk.Header.MessagesHash.Empty()
 
 	return &blk
 }

--- a/go/roothash/api/block/header.go
+++ b/go/roothash/api/block/header.go
@@ -71,8 +71,8 @@ type Header struct { // nolint: maligned
 	// StateRoot is the state merkle root.
 	StateRoot hash.Hash `json:"state_root"`
 
-	// Messages are the roothash messages sent in this round.
-	Messages []*Message `json:"messages"`
+	// MessagesHash is the hash of emitted runtime messages.
+	MessagesHash hash.Hash `json:"messages_hash"`
 
 	// StorageSignatures are the storage receipt signatures for the merkle
 	// roots.

--- a/go/roothash/api/block/header_test.go
+++ b/go/roothash/api/block/header_test.go
@@ -15,13 +15,13 @@ import (
 func TestConsistentHash(t *testing.T) {
 	// NOTE: These hashes MUST be synced with runtime/src/common/roothash.rs.
 	var emptyHeaderHash hash.Hash
-	_ = emptyHeaderHash.UnmarshalHex("727b8c92cd436abc597df9ccbe3a02eeba8d7409cc68fcdf0ce3b577450631ac")
+	_ = emptyHeaderHash.UnmarshalHex("f7f340550630426b4962c3054cb7f21cf3662bd916642daff4efc9a00b4aab3f")
 
 	var empty Header
-	require.EqualValues(t, emptyHeaderHash, empty.EncodedHash())
+	require.EqualValues(t, emptyHeaderHash.String(), empty.EncodedHash().String())
 
 	var populatedHeaderHash hash.Hash
-	_ = populatedHeaderHash.UnmarshalHex("c39e8aefea5a1f794fb57f294a4ea8599381cd8739e67a8a9acb7763b54a630a")
+	_ = populatedHeaderHash.UnmarshalHex("e5f8d6958fdedf15e705cb8fc8e2515d870c79d80dd2fa17f35c9e307ca4215a")
 
 	var emptyRoot hash.Hash
 	emptyRoot.Empty()
@@ -44,7 +44,7 @@ func TestConsistentHash(t *testing.T) {
 		PreviousHash: emptyHeaderHash,
 		IORoot:       emptyRoot,
 		StateRoot:    emptyRoot,
-		Messages:     nil,
+		MessagesHash: emptyRoot,
 	}
 	require.EqualValues(t, populatedHeaderHash.String(), populated.EncodedHash().String())
 }

--- a/go/roothash/api/block/message.go
+++ b/go/roothash/api/block/message.go
@@ -1,6 +1,43 @@
 package block
 
-// Message is a roothash message that can be sent by a runtime.
+import (
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+)
+
+// Message is a message that can be sent by a runtime.
 type Message struct {
-	// No valid messages are currently defined.
+	Noop *NoopMessage `json:"noop,omitempty"`
+}
+
+// ValidateBasic performs basic validation of the runtime message.
+func (m *Message) ValidateBasic() error {
+	switch {
+	case m.Noop != nil:
+		return m.Noop.ValidateBasic()
+	default:
+		return fmt.Errorf("runtime message has no fields set")
+	}
+}
+
+// MessagesHash returns a hash of provided runtime messages.
+func MessagesHash(msgs []Message) (h hash.Hash) {
+	if len(msgs) == 0 {
+		// Special case if there are no messages.
+		h.Empty()
+		return
+	}
+	return hash.NewFrom(msgs)
+}
+
+// NoopMessage is a runtime message that doesn't result in any actions being performed and it always
+// returns success when delivered.
+type NoopMessage struct {
+	// Noop message has no fields.
+}
+
+// ValidateBasic performs basic validation of the runtime message.
+func (nm *NoopMessage) ValidateBasic() error {
+	return nil
 }

--- a/go/roothash/api/block/message_test.go
+++ b/go/roothash/api/block/message_test.go
@@ -1,0 +1,48 @@
+package block
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+)
+
+func TestMessageHash(t *testing.T) {
+	require := require.New(t)
+
+	for _, tc := range []struct {
+		msgs         []Message
+		expectedHash string
+	}{
+		{nil, "c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a"},
+		{[]Message{}, "c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a"},
+		{[]Message{{Noop: &NoopMessage{}}}, "c8b55f87109e30fe2ba57507ffc0e96e40df7c0d24dfef82a858632f5f8420f1"},
+	} {
+		var h hash.Hash
+		err := h.UnmarshalHex(tc.expectedHash)
+		require.NoError(err, "UnmarshalHex")
+
+		require.Equal(h.String(), MessagesHash(tc.msgs).String(), "MessageHash must return the expected hash")
+	}
+}
+
+func TestMessageValidateBasic(t *testing.T) {
+	require := require.New(t)
+
+	for _, tc := range []struct {
+		name  string
+		msg   Message
+		valid bool
+	}{
+		{"NoFieldsSet", Message{}, false},
+		{"ValidNoop", Message{Noop: &NoopMessage{}}, true},
+	} {
+		err := tc.msg.ValidateBasic()
+		if tc.valid {
+			require.NoError(err, tc.name)
+		} else {
+			require.Error(err, tc.name)
+		}
+	}
+}

--- a/go/roothash/api/commitment/executor_test.go
+++ b/go/roothash/api/commitment/executor_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 )
 
 func TestConsistentHash(t *testing.T) {
@@ -15,22 +16,22 @@ func TestConsistentHash(t *testing.T) {
 	_ = emptyHeaderHash.UnmarshalHex("57d73e02609a00fcf4ca43cbf8c9f12867c46942d246fb2b0bce42cbdb8db844")
 
 	var empty ComputeResultsHeader
-	require.EqualValues(t, emptyHeaderHash, empty.EncodedHash())
+	require.EqualValues(t, emptyHeaderHash.String(), empty.EncodedHash().String())
 
 	var emptyRoot hash.Hash
 	emptyRoot.Empty()
 
 	var populatedHeaderHash hash.Hash
-	_ = populatedHeaderHash.UnmarshalHex("374021bcba44f1014d0d9919e876a1ecd7fe5ec1a92ecf9c8b313cd4976fbc01")
+	_ = populatedHeaderHash.UnmarshalHex("430ff02fafc53fc0e5eb432ad3e8b09167842a3948e09a7ee4bdd88e83e01d5a")
 
 	populated := ComputeResultsHeader{
 		Round:        42,
 		PreviousHash: emptyHeaderHash,
 		IORoot:       &emptyRoot,
 		StateRoot:    &emptyRoot,
-		Messages:     nil,
+		MessagesHash: &emptyRoot,
 	}
-	require.EqualValues(t, populatedHeaderHash, populated.EncodedHash())
+	require.EqualValues(t, populatedHeaderHash.String(), populated.EncodedHash().String())
 }
 
 func TestValidateBasic(t *testing.T) {
@@ -46,12 +47,13 @@ func TestValidateBasic(t *testing.T) {
 			PreviousHash: emptyHeaderHash,
 			IORoot:       &emptyRoot,
 			StateRoot:    &emptyRoot,
-			Messages:     nil,
+			MessagesHash: &emptyRoot,
 		},
 		TxnSchedSig:       signature.Signature{},
 		InputRoot:         emptyRoot,
 		StorageSignatures: []signature.Signature{{}},
 		RakSig:            &signature.RawSignature{},
+		Messages:          nil,
 	}
 
 	for _, tc := range []struct {
@@ -81,6 +83,24 @@ func TestValidateBasic(t *testing.T) {
 			true,
 		},
 		{
+			"Bad MessagesHash",
+			func(b ComputeBody) ComputeBody {
+				b.Header.MessagesHash = nil
+				return b
+			},
+			true,
+		},
+		{
+			"Bad runtime messages",
+			func(b ComputeBody) ComputeBody {
+				b.Messages = []block.Message{
+					{}, // A message without any variant is invalid.
+				}
+				return b
+			},
+			true,
+		},
+		{
 			"Bad Failure",
 			func(b ComputeBody) ComputeBody {
 				b.SetFailure(10)
@@ -89,9 +109,57 @@ func TestValidateBasic(t *testing.T) {
 			true,
 		},
 		{
-			"Bad Failure",
+			"Bad Failure (multiple fields set)",
 			func(b ComputeBody) ComputeBody {
 				b.Failure = FailureStorageUnavailable
+				return b
+			},
+			true,
+		},
+		{
+			"Bad Failure (existing StorageSignatures)",
+			func(b ComputeBody) ComputeBody {
+				b.Failure = FailureStorageUnavailable
+				// b.StorageSignatures is set.
+				b.Header.IORoot = nil
+				b.Header.StateRoot = nil
+				b.Header.MessagesHash = nil
+				return b
+			},
+			true,
+		},
+		{
+			"Bad Failure (existing IORoot)",
+			func(b ComputeBody) ComputeBody {
+				b.Failure = FailureStorageUnavailable
+				b.StorageSignatures = nil
+				// b.Header.IORoot is set.
+				b.Header.StateRoot = nil
+				b.Header.MessagesHash = nil
+				return b
+			},
+			true,
+		},
+		{
+			"Bad Failure (existing StateRoot)",
+			func(b ComputeBody) ComputeBody {
+				b.Failure = FailureStorageUnavailable
+				b.StorageSignatures = nil
+				b.Header.IORoot = nil
+				// b.Header.StateRoot is set.
+				b.Header.MessagesHash = nil
+				return b
+			},
+			true,
+		},
+		{
+			"Bad Failure (existing MessagesHash)",
+			func(b ComputeBody) ComputeBody {
+				b.Failure = FailureStorageUnavailable
+				b.StorageSignatures = nil
+				b.Header.IORoot = nil
+				b.Header.StateRoot = nil
+				// b.Header.MessagesHash is set.
 				return b
 			},
 			true,

--- a/go/roothash/api/history.go
+++ b/go/roothash/api/history.go
@@ -17,7 +17,7 @@ type BlockHistory interface {
 	// Commit commits an annotated block into history.
 	//
 	// Must be called in order, sorted by round.
-	Commit(blk *AnnotatedBlock) error
+	Commit(blk *AnnotatedBlock, msgResults []*MessageEvent) error
 
 	// ConsensusCheckpoint records the last consensus height which was processed
 	// by the roothash backend.
@@ -35,4 +35,7 @@ type BlockHistory interface {
 
 	// GetLatestBlock returns the block at latest round.
 	GetLatestBlock(ctx context.Context) (*block.Block, error)
+
+	// GetMessageResults returns the message results for the given round.
+	GetMessageResults(ctx context.Context, round uint64) ([]*MessageEvent, error)
 }

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -300,6 +300,9 @@ func (s *runtimeState) generateExecutorCommitments(t *testing.T, consensus conse
 		},
 	)
 
+	var msgsHash hash.Hash
+	msgsHash.Empty()
+
 	// Generate all the executor commitments.
 	executorNodes = append([]*registryTests.TestNode{}, executorCommittee.workers...)
 	for _, node := range executorNodes {
@@ -309,6 +312,7 @@ func (s *runtimeState) generateExecutorCommitments(t *testing.T, consensus conse
 				PreviousHash: parent.Header.PreviousHash,
 				IORoot:       &parent.Header.IORoot,
 				StateRoot:    &parent.Header.StateRoot,
+				MessagesHash: &msgsHash,
 			},
 			StorageSignatures: parent.Header.StorageSignatures,
 			InputRoot:         hash.Hash{},
@@ -400,7 +404,7 @@ func (s *runtimeState) testSuccessfulRound(t *testing.T, backend api.Backend, co
 			// Executor commit event + Finalized event.
 			require.Len(evts, len(executorCommits)+1, "should have all events")
 			// First event is Finalized.
-			require.EqualValues(&api.FinalizedEvent{Round: header.Round}, evts[0].FinalizedEvent, "finalized event should have the right round")
+			require.EqualValues(&api.FinalizedEvent{Round: header.Round}, evts[0].Finalized, "finalized event should have the right round")
 			for i, ev := range evts[1:] {
 				switch {
 				case ev.ExecutorCommitted != nil:

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -60,7 +60,7 @@ func (h *nopHistory) RuntimeID() common.Namespace {
 	return h.runtimeID
 }
 
-func (h *nopHistory) Commit(blk *roothash.AnnotatedBlock) error {
+func (h *nopHistory) Commit(blk *roothash.AnnotatedBlock, msgResults []*roothash.MessageEvent) error {
 	return errNopHistory
 }
 
@@ -77,6 +77,10 @@ func (h *nopHistory) GetBlock(ctx context.Context, round uint64) (*block.Block, 
 }
 
 func (h *nopHistory) GetLatestBlock(ctx context.Context) (*block.Block, error) {
+	return nil, errNopHistory
+}
+
+func (h *nopHistory) GetMessageResults(ctx context.Context, round uint64) ([]*roothash.MessageEvent, error) {
 	return nil, errNopHistory
 }
 
@@ -114,8 +118,8 @@ func (h *runtimeHistory) RuntimeID() common.Namespace {
 	return h.runtimeID
 }
 
-func (h *runtimeHistory) Commit(blk *roothash.AnnotatedBlock) error {
-	err := h.db.commit(blk)
+func (h *runtimeHistory) Commit(blk *roothash.AnnotatedBlock, msgResults []*roothash.MessageEvent) error {
+	err := h.db.commit(blk, msgResults)
 	if err != nil {
 		return err
 	}
@@ -165,6 +169,13 @@ func (h *runtimeHistory) GetLatestBlock(ctx context.Context) (*block.Block, erro
 	}
 
 	return annBlk.Block, nil
+}
+
+func (h *runtimeHistory) GetMessageResults(ctx context.Context, round uint64) ([]*roothash.MessageEvent, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	return h.db.getMessageResults(round)
 }
 
 func (h *runtimeHistory) Pruner() Pruner {

--- a/go/runtime/history/prune.go
+++ b/go/runtime/history/prune.go
@@ -118,11 +118,15 @@ func (p *keepLastPruner) Prune(ctx context.Context, latestRound uint64) error {
 				break
 			}
 
-			if err := tx.Delete(item.KeyCopy(nil)); err != nil {
+			if err := tx.Delete(messageResultsKeyFmt.Encode(round)); err != nil {
 				if err == badger.ErrTxnTooBig {
 					// We can't prune any more rounds in this transaction.
 					break
 				}
+				return err
+			}
+
+			if err := tx.Delete(item.KeyCopy(nil)); err != nil {
 				return err
 			}
 

--- a/go/runtime/host/mock/mock.go
+++ b/go/runtime/host/mock/mock.go
@@ -71,8 +71,9 @@ func (r *runtime) Call(ctx context.Context, body *protocol.Body) (*protocol.Body
 			return nil, fmt.Errorf("(mock) failed to create I/O tree: %w", err)
 		}
 
-		var stateRoot hash.Hash
+		var stateRoot, msgsHash hash.Hash
 		stateRoot.Empty()
+		msgsHash.Empty()
 
 		return &protocol.Body{RuntimeExecuteTxBatchResponse: &protocol.RuntimeExecuteTxBatchResponse{
 			Batch: protocol.ComputedBatch{
@@ -81,6 +82,7 @@ func (r *runtime) Call(ctx context.Context, body *protocol.Body) (*protocol.Body
 					PreviousHash: rq.Block.Header.EncodedHash(),
 					IORoot:       &ioRoot,
 					StateRoot:    &stateRoot,
+					MessagesHash: &msgsHash,
 				},
 				IOWriteLog: ioWriteLog,
 			},

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -8,7 +8,8 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx/ias"
-	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api/block"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
 	"github.com/oasisprotocol/oasis-core/go/runtime/transaction"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
@@ -175,7 +176,7 @@ type RuntimeCheckTxBatchRequest struct {
 	// Batch of runtime inputs to check.
 	Inputs transaction.RawBatch `json:"inputs"`
 	// Block on which the batch check should be based.
-	Block roothash.Block `json:"block"`
+	Block block.Block `json:"block"`
 }
 
 // RuntimeCheckTxBatchResponse is a worker check tx batch response message body.
@@ -195,6 +196,8 @@ type ComputedBatch struct {
 	// If this runtime uses a TEE, then this is the signature of Header with
 	// node's RAK for this runtime.
 	RakSig signature.RawSignature `json:"rak_sig"`
+	// Messages are the emitted runtime messages.
+	Messages []block.Message `json:"messages"`
 }
 
 // String returns a string representation of a computed batch.
@@ -204,13 +207,17 @@ func (b *ComputedBatch) String() string {
 
 // RuntimeExecuteTxBatchRequest is a worker execute tx batch request message body.
 type RuntimeExecuteTxBatchRequest struct {
+	// MessageResults are the results of executing messages emitted by the
+	// runtime in the previous round.
+	MessageResults []*roothash.MessageEvent `json:"message_results,omitempty"`
+
 	// IORoot is the I/O root containing the inputs (transactions) that
 	// the compute node should use. It must match what is passed in "inputs".
 	IORoot hash.Hash `json:"io_root"`
 	// Batch of inputs (transactions).
 	Inputs transaction.RawBatch `json:"inputs"`
 	// Block on which the batch computation should be based.
-	Block roothash.Block `json:"block"`
+	Block block.Block `json:"block"`
 }
 
 // RuntimeExecuteTxBatchResponse is a worker execute tx batch response message body.

--- a/runtime/src/common/version.rs
+++ b/runtime/src/common/version.rs
@@ -54,7 +54,7 @@ impl From<u64> for Version {
 // and the runtime. This version MUST be compatible with the one supported by
 // the worker host.
 pub const PROTOCOL_VERSION: Version = Version {
-    major: 1,
+    major: 2,
     minor: 0,
     patch: 0,
 };

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -8,7 +8,7 @@ use crate::{
             hash::Hash,
             signature::{PublicKey, Signature},
         },
-        roothash::{Block, ComputeResultsHeader},
+        roothash::{self, Block, ComputeResultsHeader},
         runtime::RuntimeId,
         sgx::avr::AVR,
     },
@@ -28,6 +28,8 @@ pub struct ComputedBatch {
     /// If this runtime uses a TEE, then this is the signature of the batch's
     /// BatchSigMessage with the node's RAK for this runtime.
     pub rak_sig: Signature,
+    /// Messages emitted by the runtime.
+    pub messages: Vec<roothash::Message>,
 }
 
 /// Storage sync request.
@@ -112,6 +114,8 @@ pub enum Body {
         results: TxnBatch,
     },
     RuntimeExecuteTxBatchRequest {
+        #[serde(default)]
+        message_results: Vec<roothash::MessageEvent>,
         io_root: Hash,
         inputs: TxnBatch,
         block: Block,

--- a/tests/clients/simple-keyvalue/src/main.rs
+++ b/tests/clients/simple-keyvalue/src/main.rs
@@ -116,6 +116,9 @@ fn main() {
     assert_eq!(r, None); // key should not exist in db before
     long_kv.nonce = Some(rng.gen());
 
+    println!("Testing runtime message emission...");
+    rt.block_on(kv_client.message(rng.gen())).unwrap();
+
     println!("Getting long key...");
     let r = rt.block_on(kv_client.get(long_k.clone())).unwrap();
     match r {

--- a/tests/runtimes/simple-keyvalue/Cargo.toml
+++ b/tests/runtimes/simple-keyvalue/Cargo.toml
@@ -29,6 +29,7 @@ simple-keyvalue-api = { path = "./api" }
 
 anyhow = "1.0"
 io-context = "0.2.0"
+byteorder = "1.3.1"
 
 [build-dependencies]
 oasis-core-tools = { path = "../../../tools" }

--- a/tests/runtimes/simple-keyvalue/api/src/api.rs
+++ b/tests/runtimes/simple-keyvalue/api/src/api.rs
@@ -23,6 +23,9 @@ runtime_api! {
     //  Gets runtime ID of the runtime.
     pub fn get_runtime_id(()) -> Option<String>;
 
+    // Emit a runtime message.
+    pub fn message(u64) -> ();
+
     // Inserts key and corresponding value and returns old value, if any.
     // Both parameters are passed using a single serializable struct KeyValue.
     pub fn insert(KeyValue) -> Option<String>;


### PR DESCRIPTION
Fixes #3430 

TODO
* [x] Validation of per-runtime `MaxMessages` against global `MaxRuntimeMessages` roothash consensus parameter.
* [x] Validation of messages when submitted by transaction scheduler.
* [x] Emit message processing results.
* [x] Delivery of message results via RHP.
* [x] E2E test with a "ping/noop" message.
* [x] Use height of last successful round instead of height of last round when querying for message results.
* [x] Update runtime txsource workload to also emit messages.
* [x] Fix restore from genesis when events were emitted in the last round before dump.