### PR TITLE
Ptrus/feature/txsource crash points

### DIFF
--- a/.changelog/3449.internal.md
+++ b/.changelog/3449.internal.md
@@ -1,0 +1,6 @@
+go/common/crash: Improvements to the debug crash framework
+
+- threadsafe global crasher
+- ability to configure default probability for all crash points
+- fix reported caller information on crash
+- crash with a specific exit code

--- a/go/common/crash/crash.go
+++ b/go/common/crash/crash.go
@@ -5,6 +5,7 @@ package crash
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"sync"
 	"time"
@@ -26,6 +27,10 @@ const (
 
 	// CfgDefaultCrashPointProbability is the default crash point probability.
 	CfgDefaultCrashPointProbability = "debug.crash.default"
+
+	// CrashDefaultExitCode is the exit code that will be used if program is exited
+	// due to a debug crash invocation.
+	CrashDefaultExitCode = 123
 )
 
 // RandomProvider interface that provides a Float64 random.
@@ -60,7 +65,7 @@ func newDefaultRandomProvider() RandomProvider {
 }
 
 func defaultCrashMethod() {
-	runtime.Breakpoint()
+	os.Exit(CrashDefaultExitCode)
 }
 
 var crashGlobal *Crasher

--- a/go/common/crash/crash.go
+++ b/go/common/crash/crash.go
@@ -67,7 +67,10 @@ var crashGlobal *Crasher
 
 func init() {
 	crashGlobal = New(CrasherOptions{
-		CallerSkip: 1,
+		// Skip 2 stack frames to get the correct caller information.
+		// 2 since the global crasher is never invoked directly, but via the
+		// Here() function.
+		CallerSkip: 2,
 		CLIPrefix:  defaultCLIPrefix,
 	})
 }

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/crash"
 	commonGrpc "github.com/oasisprotocol/oasis-core/go/common/grpc"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx"
 	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint"
@@ -491,6 +492,13 @@ func (args *argBuilder) appendSeedNodes(seeds []*Seed) *argBuilder {
 			"--" + tendermintCommon.CfgP2PSeed, fmt.Sprintf("%s@127.0.0.1:%d", seed.tmAddress, seed.consensusPort),
 		}...)
 	}
+	return args
+}
+
+func (args *argBuilder) configureDebugCrashPoints(prob float64) *argBuilder {
+	args.vec = append(args.vec,
+		"--"+crash.CfgDefaultCrashPointProbability, fmt.Sprintf("%f", prob),
+	)
 	return args
 }
 

--- a/go/oasis-test-runner/oasis/compute.go
+++ b/go/oasis-test-runner/oasis/compute.go
@@ -104,6 +104,7 @@ func (worker *Compute) startNode() error {
 		workerRuntimeProvisioner(worker.runtimeProvisioner).
 		workerRuntimeSGXLoader(worker.net.cfg.RuntimeSGXLoaderBinary).
 		workerExecutorScheduleCheckTxEnabled().
+		configureDebugCrashPoints(worker.crashPointsProbability).
 		appendNetwork(worker.net).
 		appendSeedNodes(worker.net.seeds).
 		appendEntity(worker.entity)
@@ -155,10 +156,11 @@ func (net *Network) NewCompute(cfg *ComputeCfg) (*Compute, error) {
 			dir:                                      computeDir,
 			termEarlyOk:                              cfg.AllowEarlyTermination,
 			termErrorOk:                              cfg.AllowErrorTermination,
+			noAutoStart:                              cfg.NoAutoStart,
+			crashPointsProbability:                   cfg.CrashPointsProbability,
 			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
 			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
 			consensus:                                cfg.Consensus,
-			noAutoStart:                              cfg.NoAutoStart,
 		},
 		entity:             cfg.Entity,
 		runtimeProvisioner: cfg.RuntimeProvisioner,

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -158,6 +158,8 @@ type ValidatorFixture struct { // nolint: maligned
 
 	NoAutoStart bool `json:"no_auto_start,omitempty"`
 
+	CrashPointsProbability float64 `json:"crash_points_probability,omitempty"`
+
 	Entity int `json:"entity"`
 
 	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
@@ -186,6 +188,7 @@ func (f *ValidatorFixture) Create(net *Network) (*Validator, error) {
 			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
 			Consensus:                  f.Consensus,
 			NoAutoStart:                f.NoAutoStart,
+			CrashPointsProbability:     f.CrashPointsProbability,
 		},
 		Entity:   entity,
 		Sentries: sentries,
@@ -291,6 +294,8 @@ type KeymanagerFixture struct {
 	// Consensus contains configuration for the consensus backend.
 	Consensus ConsensusFixture `json:"consensus"`
 
+	CrashPointsProbability float64 `json:"crash_points_probability,omitempty"`
+
 	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
 }
 
@@ -314,6 +319,7 @@ func (f *KeymanagerFixture) Create(net *Network) (*Keymanager, error) {
 			AllowEarlyTermination:      f.AllowEarlyTermination,
 			AllowErrorTermination:      f.AllowErrorTermination,
 			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
+			CrashPointsProbability:     f.CrashPointsProbability,
 			Consensus:                  f.Consensus,
 			NoAutoStart:                f.NoAutoStart,
 		},
@@ -347,6 +353,8 @@ type StorageWorkerFixture struct { // nolint: maligned
 	IgnoreApplies           bool          `json:"ignore_applies,omitempty"`
 	CheckpointSyncEnabled   bool          `json:"checkpoint_sync_enabled,omitempty"`
 
+	CrashPointsProbability float64 `json:"crash_points_probability,omitempty"`
+
 	// Runtimes contains the indexes of the runtimes to enable. Leave
 	// empty or nil for the default behaviour (i.e. include all runtimes).
 	Runtimes []int `json:"runtimes,omitempty"`
@@ -363,6 +371,7 @@ func (f *StorageWorkerFixture) Create(net *Network) (*Storage, error) {
 		NodeCfg: NodeCfg{
 			AllowEarlyTermination:      f.AllowEarlyTermination,
 			AllowErrorTermination:      f.AllowErrorTermination,
+			CrashPointsProbability:     f.CrashPointsProbability,
 			NoAutoStart:                f.NoAutoStart,
 			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
 			Consensus:                  f.Consensus,
@@ -372,7 +381,7 @@ func (f *StorageWorkerFixture) Create(net *Network) (*Storage, error) {
 		SentryIndices:           f.Sentries,
 		CheckpointCheckInterval: f.CheckpointCheckInterval,
 		IgnoreApplies:           f.IgnoreApplies,
-		// The checkpoint syncing flas is intentionally flipped here.
+		// The checkpoint syncing flag is intentionally flipped here.
 		// Syncing should normally be enabled, but normally disabled in tests.
 		CheckpointSyncDisabled: !f.CheckpointSyncEnabled,
 		DisableCertRotation:    f.DisableCertRotation,
@@ -394,6 +403,8 @@ type ComputeWorkerFixture struct {
 	// Consensus contains configuration for the consensus backend.
 	Consensus ConsensusFixture `json:"consensus"`
 
+	CrashPointsProbability float64 `json:"crash_point_probability"`
+
 	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
 
 	// Runtimes contains the indexes of the runtimes to enable.
@@ -412,6 +423,7 @@ func (f *ComputeWorkerFixture) Create(net *Network) (*Compute, error) {
 			AllowEarlyTermination:      f.AllowEarlyTermination,
 			AllowErrorTermination:      f.AllowErrorTermination,
 			NoAutoStart:                f.NoAutoStart,
+			CrashPointsProbability:     f.CrashPointsProbability,
 			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
 			Consensus:                  f.Consensus,
 		},
@@ -437,6 +449,8 @@ func (f *SeedFixture) Create(net *Network) (*Seed, error) {
 type SentryFixture struct {
 	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
 
+	CrashPointsProbability float64 `json:"crash_points_probability,omitempty"`
+
 	Validators        []int `json:"validators"`
 	StorageWorkers    []int `json:"storage_workers"`
 	KeymanagerWorkers []int `json:"keymanager_workers"`
@@ -447,6 +461,7 @@ func (f *SentryFixture) Create(net *Network) (*Sentry, error) {
 	return net.NewSentry(&SentryCfg{
 		NodeCfg: NodeCfg{
 			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
+			CrashPointsProbability:     f.CrashPointsProbability,
 		},
 		ValidatorIndices:  f.Validators,
 		StorageIndices:    f.StorageWorkers,

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -278,6 +278,7 @@ func (km *Keymanager) startNode() error {
 		workerRuntimePath(km.runtime.id, km.runtime.binaries[0]).
 		workerKeymanagerEnabled().
 		workerKeymanagerRuntimeID(km.runtime.id).
+		configureDebugCrashPoints(km.crashPointsProbability).
 		appendNetwork(km.net).
 		appendEntity(km.entity)
 
@@ -342,6 +343,7 @@ func (net *Network) NewKeymanager(cfg *KeymanagerCfg) (*Keymanager, error) {
 			dir:                                      kmDir,
 			termEarlyOk:                              cfg.AllowEarlyTermination,
 			termErrorOk:                              cfg.AllowErrorTermination,
+			crashPointsProbability:                   cfg.CrashPointsProbability,
 			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
 			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
 			consensus:                                cfg.Consensus,

--- a/go/oasis-test-runner/oasis/sentry.go
+++ b/go/oasis-test-runner/oasis/sentry.go
@@ -79,6 +79,7 @@ func (sentry *Sentry) startNode() error {
 		tendermintCoreAddress(sentry.consensusPort).
 		tendermintPrune(sentry.consensus.PruneNumKept).
 		tendermintRecoverCorruptedWAL(sentry.consensus.TendermintRecoverCorruptedWAL).
+		configureDebugCrashPoints(sentry.crashPointsProbability).
 		appendNetwork(sentry.net).
 		appendSeedNodes(sentry.net.seeds).
 		internalSocketAddress(sentry.net.validators[0].SocketPath())
@@ -148,6 +149,7 @@ func (net *Network) NewSentry(cfg *SentryCfg) (*Sentry, error) {
 			Name:                                     sentryName,
 			net:                                      net,
 			dir:                                      sentryDir,
+			crashPointsProbability:                   cfg.CrashPointsProbability,
 			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
 			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
 		},

--- a/go/oasis-test-runner/oasis/storage.go
+++ b/go/oasis-test-runner/oasis/storage.go
@@ -121,6 +121,7 @@ func (worker *Storage) startNode() error {
 		workerStorageDebugIgnoreApplies(worker.ignoreApplies).
 		workerStorageDebugDisableCheckpointSync(worker.checkpointSyncDisabled).
 		workerStorageCheckpointCheckInterval(worker.checkpointCheckInterval).
+		configureDebugCrashPoints(worker.crashPointsProbability).
 		appendNetwork(worker.net).
 		appendEntity(worker.entity)
 
@@ -192,6 +193,9 @@ func (net *Network) NewStorage(cfg *StorageCfg) (*Storage, error) {
 			net:                                      net,
 			dir:                                      storageDir,
 			noAutoStart:                              cfg.NoAutoStart,
+			termEarlyOk:                              cfg.AllowEarlyTermination,
+			termErrorOk:                              cfg.AllowErrorTermination,
+			crashPointsProbability:                   cfg.CrashPointsProbability,
 			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
 			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
 			consensus:                                cfg.Consensus,

--- a/go/oasis-test-runner/oasis/validator.go
+++ b/go/oasis-test-runner/oasis/validator.go
@@ -89,6 +89,7 @@ func (val *Validator) startNode() error {
 		tendermintSubmissionGasPrice(val.consensus.SubmissionGasPrice).
 		tendermintPrune(val.consensus.PruneNumKept).
 		tendermintRecoverCorruptedWAL(val.consensus.TendermintRecoverCorruptedWAL).
+		configureDebugCrashPoints(val.crashPointsProbability).
 		appendNetwork(val.net).
 		appendEntity(val.entity)
 
@@ -134,6 +135,7 @@ func (net *Network) NewValidator(cfg *ValidatorCfg) (*Validator, error) {
 			dir:                                      valDir,
 			termEarlyOk:                              cfg.AllowEarlyTermination,
 			termErrorOk:                              cfg.AllowErrorTermination,
+			crashPointsProbability:                   cfg.CrashPointsProbability,
 			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
 			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
 			consensus:                                cfg.Consensus,


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/3409

TODO:
- [x] test a daily txsource run with crash points enabled: https://buildkite.com/oasisprotocol/oasis-core-long-tests/builds/288#e13c4fc6-83cd-4381-83be-cf1ba1fd283b
  - wtih current configuration there were 75 crashes in the above 4 hour test run, probably can reduce the probability a bit further :grin:
- [x] test run with longepochs & crash points enabled: https://buildkite.com/oasisprotocol/oasis-core-long-tests/builds/304#29a1b084-4444-4eae-83fd-62738a0f904c
  - reduced the prob. by a half from the previous run, now there's about ~10 crashes per hour