### PR TITLE
Ptrus/fix/storage update policy

### DIFF
--- a/.changelog/3453.bugfix.md
+++ b/.changelog/3453.bugfix.md
@@ -1,0 +1,5 @@
+Storage node should update access control policy on new node registrations
+
+Before, the storage node only updated policy when existing nodes updated
+registrations or committee changed. This missed the case when new storage
+node registered mid-epoch.

--- a/go/oasis-test-runner/scenario/e2e/runtime/byzantine.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/byzantine.go
@@ -266,7 +266,12 @@ func (sc *byzantineImpl) Run(childEnv *env.Env) error {
 		return err
 	}
 
-	if err = sc.initialEpochTransitions(); err != nil {
+	fixture, err := sc.Fixture()
+	if err != nil {
+		return err
+	}
+
+	if err = sc.initialEpochTransitions(fixture); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
@@ -137,8 +137,13 @@ func (sc *multipleRuntimesImpl) Run(childEnv *env.Env) error {
 		return err
 	}
 
+	fixture, err := sc.Fixture()
+	if err != nil {
+		return err
+	}
+
 	// Wait for the nodes.
-	if err := sc.initialEpochTransitions(); err != nil {
+	if err = sc.initialEpochTransitions(fixture); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -415,7 +415,7 @@ func (sc *runtimeImpl) waitNodesSynced() error {
 	return nil
 }
 
-func (sc *runtimeImpl) initialEpochTransitions() error {
+func (sc *runtimeImpl) initialEpochTransitions(fixture *oasis.NetworkFixture) error {
 	ctx := context.Background()
 
 	if len(sc.Net.Keymanagers()) > 0 {
@@ -424,7 +424,11 @@ func (sc *runtimeImpl) initialEpochTransitions() error {
 		sc.Logger.Info("waiting for validators to initialize",
 			"num_validators", len(sc.Net.Validators()),
 		)
-		for _, n := range sc.Net.Validators() {
+		for i, n := range sc.Net.Validators() {
+			if fixture.Validators[i].NoAutoStart {
+				// Skip nodes that don't auto start.
+				continue
+			}
 			if err := n.WaitReady(ctx); err != nil {
 				return fmt.Errorf("failed to wait for a validator: %w", err)
 			}
@@ -432,7 +436,11 @@ func (sc *runtimeImpl) initialEpochTransitions() error {
 		sc.Logger.Info("waiting for key managers to initialize",
 			"num_keymanagers", len(sc.Net.Keymanagers()),
 		)
-		for _, n := range sc.Net.Keymanagers() {
+		for i, n := range sc.Net.Keymanagers() {
+			if fixture.Keymanagers[i].NoAutoStart {
+				// Skip nodes that don't auto start.
+				continue
+			}
 			if err := n.WaitReady(ctx); err != nil {
 				return fmt.Errorf("failed to wait for a key manager: %w", err)
 			}
@@ -448,7 +456,11 @@ func (sc *runtimeImpl) initialEpochTransitions() error {
 	sc.Logger.Info("waiting for storage workers to initialize",
 		"num_storage_workers", len(sc.Net.StorageWorkers()),
 	)
-	for _, n := range sc.Net.StorageWorkers() {
+	for i, n := range sc.Net.StorageWorkers() {
+		if fixture.StorageWorkers[i].NoAutoStart {
+			// Skip nodes that don't auto start.
+			continue
+		}
 		if err := n.WaitReady(ctx); err != nil {
 			return fmt.Errorf("failed to wait for a storage worker: %w", err)
 		}
@@ -456,7 +468,11 @@ func (sc *runtimeImpl) initialEpochTransitions() error {
 	sc.Logger.Info("waiting for compute workers to initialize",
 		"num_compute_workers", len(sc.Net.ComputeWorkers()),
 	)
-	for _, n := range sc.Net.ComputeWorkers() {
+	for i, n := range sc.Net.ComputeWorkers() {
+		if fixture.ComputeWorkers[i].NoAutoStart {
+			// Skip nodes that don't auto start.
+			continue
+		}
 		if err := n.WaitReady(ctx); err != nil {
 			return fmt.Errorf("failed to wait for a compute worker: %w", err)
 		}

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_prune.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_prune.go
@@ -64,7 +64,12 @@ func (sc *runtimePruneImpl) Run(childEnv *env.Env) error {
 		return err
 	}
 
-	if err := sc.initialEpochTransitions(); err != nil {
+	fixture, err := sc.Fixture()
+	if err != nil {
+		return err
+	}
+
+	if err = sc.initialEpochTransitions(fixture); err != nil {
 		return err
 	}
 
@@ -77,7 +82,7 @@ func (sc *runtimePruneImpl) Run(childEnv *env.Env) error {
 			"seq", i,
 		)
 
-		if err := sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, "hello", fmt.Sprintf("world %d", i)); err != nil {
+		if err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, "hello", fmt.Sprintf("world %d", i)); err != nil {
 			return err
 		}
 	}

--- a/go/worker/common/committee/group.go
+++ b/go/worker/common/committee/group.go
@@ -38,7 +38,8 @@ const (
 	tagExecutor = "executor"
 )
 
-func tagForCommittee(kind scheduler.CommitteeKind) string {
+// TagForCommittee returns node lookup tag for scheduler committee kind.
+func TagForCommittee(kind scheduler.CommitteeKind) string {
 	switch kind {
 	case scheduler.KindComputeExecutor:
 		return tagExecutor
@@ -323,7 +324,7 @@ func (g *Group) EpochTransition(ctx context.Context, height int64) error {
 			}
 
 			// Start watching the member's node descriptor.
-			if _, err = g.nodes.WatchNodeWithTag(ctx, member.PublicKey, tagForCommittee(cm.Kind)); err != nil {
+			if _, err = g.nodes.WatchNodeWithTag(ctx, member.PublicKey, TagForCommittee(cm.Kind)); err != nil {
 				return fmt.Errorf("group: failed to fetch node info: %w", err)
 			}
 		}
@@ -567,7 +568,7 @@ func NewGroup(
 		ctx,
 		runtime.ID(),
 		identity,
-		committee.NewFilteredNodeLookup(nodes, committee.TagFilter(tagForCommittee(scheduler.KindStorage))),
+		committee.NewFilteredNodeLookup(nodes, committee.TagFilter(TagForCommittee(scheduler.KindStorage))),
 		runtime,
 	)
 	if err != nil {


### PR DESCRIPTION
Fixes: #3453

Also changes to storage-sync test to ensure syncing works in the same epoch in which the node registers (also confirmed that this updated test fails on old code).