### PR TITLE
go/storage: Sync from all registered nodes for runtime

### DIFF
--- a/.changelog/3454.feature.md
+++ b/.changelog/3454.feature.md
@@ -1,0 +1,5 @@
+Runtime storage sync should use any storage node
+
+Before storage node sync only used nodes from the current storage committee.
+Now it also syncs (with lower priority) from other storage nodes registered
+for the runtime.

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -101,6 +101,17 @@ const (
 	RoleReserved RolesMask = ((1 << 32) - 1) & ^((RoleConsensusRPC << 1) - 1)
 )
 
+// Roles returns a list of available valid roles.
+func Roles() (roles []RolesMask) {
+	return []RolesMask{
+		RoleComputeWorker,
+		RoleStorageWorker,
+		RoleKeyManager,
+		RoleValidator,
+		RoleConsensusRPC,
+	}
+}
+
 // IsSingleRole returns true if RolesMask encodes a single valid role.
 func (m RolesMask) IsSingleRole() bool {
 	// Ensures exactly one bit is set, and the set bit is a valid role.

--- a/go/keymanager/client/client.go
+++ b/go/keymanager/client/client.go
@@ -212,7 +212,7 @@ func New(
 	registry registry.Backend,
 	identity *identity.Identity,
 ) (*Client, error) {
-	committeeNodes, err := nodes.NewBaseVersionedNodeDescriptorWatcher(ctx, registry)
+	committeeNodes, err := nodes.NewVersionedNodeDescriptorWatcher(ctx, registry)
 	if err != nil {
 		return nil, fmt.Errorf("keymanager/client: failed to create node descriptor watcher: %w", err)
 	}

--- a/go/keymanager/client/client.go
+++ b/go/keymanager/client/client.go
@@ -19,8 +19,9 @@ import (
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	"github.com/oasisprotocol/oasis-core/go/keymanager/api"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
-	"github.com/oasisprotocol/oasis-core/go/runtime/committee"
 	enclaverpc "github.com/oasisprotocol/oasis-core/go/runtime/enclaverpc/api"
+	"github.com/oasisprotocol/oasis-core/go/runtime/nodes"
+	"github.com/oasisprotocol/oasis-core/go/runtime/nodes/grpc"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 )
 
@@ -43,8 +44,8 @@ type Client struct {
 	initCh      chan struct{}
 	initialized bool
 
-	committeeNodes  committee.NodeDescriptorWatcher
-	committeeClient committee.Client
+	committeeWatcher nodes.VersionedNodeDescriptorWatcher
+	committeeClient  grpc.NodesClient
 
 	logger *logging.Logger
 }
@@ -73,10 +74,10 @@ func (c *Client) CallRemote(ctx context.Context, data []byte) ([]byte, error) {
 			c.logger.Warn("no key manager connection for runtime")
 			return ErrKeyManagerNotAvailable
 		}
-		client := enclaverpc.NewTransportClient(conn)
+		enclaveClient := enclaverpc.NewTransportClient(conn)
 
 		var err error
-		resp, err = client.CallEnclave(ctx, &enclaverpc.CallEnclaveRequest{
+		resp, err = enclaveClient.CallEnclave(ctx, &enclaverpc.CallEnclaveRequest{
 			RuntimeID: c.runtime.ID(),
 			Endpoint:  api.EnclaveRPCEndpoint,
 			Payload:   data,
@@ -102,7 +103,7 @@ func (c *Client) CallRemote(ctx context.Context, data []byte) ([]byte, error) {
 			fallthrough
 		default:
 			// Request failed, communicate that to the node selection policy.
-			c.committeeClient.UpdateNodeSelectionPolicy(committee.NodeSelectionFeedback{Bad: err})
+			c.committeeClient.UpdateNodeSelectionPolicy(grpc.NodeSelectionFeedback{Bad: err})
 			return backoff.Permanent(err)
 		}
 		return nil
@@ -175,8 +176,8 @@ func (c *Client) updateState(status *api.Status) {
 		"id", status.ID,
 	)
 
-	c.committeeNodes.Reset()
-	defer c.committeeNodes.Freeze(0)
+	c.committeeWatcher.Reset()
+	defer c.committeeWatcher.Freeze(0)
 
 	// It's not possible to service requests for this key manager.
 	if !status.IsInitialized || len(status.Nodes) == 0 {
@@ -188,7 +189,7 @@ func (c *Client) updateState(status *api.Status) {
 	}
 
 	for _, nodeID := range status.Nodes {
-		_, err := c.committeeNodes.WatchNode(c.ctx, nodeID)
+		_, err := c.committeeWatcher.WatchNode(c.ctx, nodeID)
 		if err != nil {
 			c.logger.Warn("failed to watch node",
 				"err", err,
@@ -211,29 +212,30 @@ func New(
 	registry registry.Backend,
 	identity *identity.Identity,
 ) (*Client, error) {
-	committeeNodes, err := committee.NewNodeDescriptorWatcher(ctx, registry)
+	committeeNodes, err := nodes.NewBaseVersionedNodeDescriptorWatcher(ctx, registry)
 	if err != nil {
 		return nil, fmt.Errorf("keymanager/client: failed to create node descriptor watcher: %w", err)
 	}
 
-	var opts []committee.ClientOption
+	var opts []grpc.Option
 	if identity != nil {
-		opts = append(opts, committee.WithClientAuthentication(identity))
+		opts = append(opts, grpc.WithClientAuthentication(identity))
 	}
-	committeeClient, err := committee.NewClient(ctx, committeeNodes, opts...)
+	committeeClient, err := grpc.NewNodesClient(ctx, committeeNodes, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("keymanager/client: failed to create committee client: %w", err)
 	}
 
 	c := &Client{
-		runtime:         runtime,
-		backend:         backend,
-		registry:        registry,
-		ctx:             ctx,
-		initCh:          make(chan struct{}),
-		committeeNodes:  committeeNodes,
-		committeeClient: committeeClient,
-		logger:          logging.GetLogger("keymanager/client").With("runtime_id", runtime.ID()),
+		runtime:          runtime,
+		backend:          backend,
+		registry:         registry,
+		ctx:              ctx,
+		initCh:           make(chan struct{}),
+		committeeWatcher: committeeNodes,
+		committeeClient:  committeeClient,
+		logger: logging.GetLogger("keymanager/client").
+			With("runtime_id", runtime.ID()),
 	}
 	go c.worker()
 

--- a/go/oasis-node/node_test.go
+++ b/go/oasis-node/node_test.go
@@ -471,7 +471,7 @@ func testStorageClientWithNode(t *testing.T, node *testNode) {
 	require.NoError(t, err, "GetRuntime")
 	localBackend := rt.Storage().(storageAPI.LocalBackend)
 
-	client, err := storageClient.NewStatic(ctx, testRuntimeID, node.Identity, node.Consensus.Registry(), node.Identity.NodeSigner.Public())
+	client, err := storageClient.NewStatic(ctx, node.Identity, node.Consensus.Registry(), node.Identity.NodeSigner.Public())
 	require.NoError(t, err, "NewStatic")
 
 	// Determine the current round. This is required so that we can commit into

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -525,6 +525,7 @@ func RegisterScenarios() error {
 		ByzantineStorageFailRead,
 		// Storage sync test.
 		StorageSync,
+		StorageSyncFromRegistered,
 		// Sentry test.
 		Sentry,
 		SentryEncryption,

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_from_registered.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_from_registered.go
@@ -1,0 +1,192 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	epochtime "github.com/oasisprotocol/oasis-core/go/epochtime/api"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
+	"github.com/oasisprotocol/oasis-core/go/storage/database"
+)
+
+// StorageSyncFromRegistered is the storage sync scenario which tests syncing
+// from registered nodes not in committee.
+var StorageSyncFromRegistered scenario.Scenario = newStorageSyncFromRegisteredImpl()
+
+type storageSyncFromRegisteredImpl struct {
+	runtimeImpl
+}
+
+func newStorageSyncFromRegisteredImpl() scenario.Scenario {
+	return &storageSyncFromRegisteredImpl{
+		runtimeImpl: *newRuntimeImpl(
+			"storage-sync-registered",
+			"simple-keyvalue-enc-client",
+			nil,
+		),
+	}
+}
+
+func (sc *storageSyncFromRegisteredImpl) Clone() scenario.Scenario {
+	return &storageSyncFromRegisteredImpl{
+		runtimeImpl: *sc.runtimeImpl.Clone().(*runtimeImpl),
+	}
+}
+
+func (sc *storageSyncFromRegisteredImpl) Fixture() (*oasis.NetworkFixture, error) {
+	f, err := sc.runtimeImpl.Fixture()
+	if err != nil {
+		return nil, err
+	}
+
+	// Use mock epochtime and small group size so we can control which node will
+	// be in the committee.
+	f.Network.EpochtimeMock = true
+	f.Runtimes[1].Storage.GroupSize = 1
+	f.Runtimes[1].Storage.MinWriteReplication = 1
+
+	// Configure runtime for storage checkpointing.
+	f.Runtimes[1].Storage.CheckpointInterval = 10
+	f.Runtimes[1].Storage.CheckpointNumKept = 1
+	f.Runtimes[1].Storage.CheckpointChunkSize = 1 * 1024
+
+	// Start only a single node.
+	f.StorageWorkers = []oasis.StorageWorkerFixture{
+		{
+			Backend:                 database.BackendNameBadgerDB,
+			Entity:                  1,
+			CheckpointCheckInterval: 1 * time.Second,
+			AllowEarlyTermination:   true,
+		},
+		{
+			Backend:               database.BackendNameBadgerDB,
+			Entity:                1,
+			NoAutoStart:           true,
+			CheckpointSyncEnabled: true,
+		},
+	}
+
+	return f, nil
+}
+
+func (sc *storageSyncFromRegisteredImpl) Run(childEnv *env.Env) error {
+	ctx := context.Background()
+	var nextEpoch epochtime.EpochTime
+
+	clientErrCh, cmd, err := sc.runtimeImpl.start(childEnv)
+	if err != nil {
+		return err
+	}
+
+	fixture, err := sc.Fixture()
+	if err != nil {
+		return err
+	}
+
+	if err = sc.initialEpochTransitions(fixture); err != nil {
+		return err
+	}
+	// We're at epoch 2 after the initial transitions
+	nextEpoch = epochtime.EpochTime(3)
+
+	// Wait for the client to exit.
+	if err = sc.waitClient(childEnv, cmd, clientErrCh); err != nil {
+		return err
+	}
+
+	sc.Logger.Info("stopping storage worker 0")
+	// Shutdown the first storage worker.
+	storage0 := sc.Net.StorageWorkers()[0]
+	if err = storage0.Stop(); err != nil {
+		return fmt.Errorf("storage worker 0 shutdown: %w", err)
+	}
+
+	sc.Logger.Info("waiting for storage worker 0 to de-register")
+
+	// Do three epoch transitions so that the node de-registers.
+	if err = sc.Net.Controller().SetEpoch(ctx, nextEpoch); err != nil {
+		return fmt.Errorf("failed to set epoch %d: %w", nextEpoch, err)
+	}
+	nextEpoch++
+	if err = sc.Net.Controller().SetEpoch(ctx, nextEpoch); err != nil {
+		return fmt.Errorf("failed to set epoch %d: %w", nextEpoch, err)
+	}
+	nextEpoch++
+	if err = sc.Net.Controller().SetEpoch(ctx, nextEpoch); err != nil {
+		return fmt.Errorf("failed to set epoch %d: %w", nextEpoch, err)
+	}
+	nextEpoch++
+	if err = sc.Net.Controller().SetEpoch(ctx, nextEpoch); err != nil {
+		return fmt.Errorf("failed to set epoch %d: %w", nextEpoch, err)
+	}
+	nextEpoch++
+
+	sc.Logger.Info("ensuring no registered storage workers")
+	// Ensure there is no registered storage workers.
+	nodes, err := sc.Net.Controller().Registry.GetNodes(ctx, consensus.HeightLatest)
+	if err != nil {
+		return fmt.Errorf("failed to get nodes: %w", err)
+	}
+	for _, n := range nodes {
+		if n.HasRoles(node.RoleStorageWorker) {
+			return fmt.Errorf("expected no registered storage workers")
+		}
+	}
+
+	sc.Logger.Info("starting storage worker 1")
+	// Start the second Storage worker.
+	// XXX: currently 2nd worker will give up on syncing from checkpoints since
+	// the other node will be offline. Once this is fixed ensure it syncs from
+	// checkpoints.
+	storage1 := sc.Net.StorageWorkers()[1]
+	err = storage1.Start()
+	if err != nil {
+		return fmt.Errorf("can't start storage worker 1: %w", err)
+	}
+
+	sc.Logger.Info("waiting for storage worker 1 to register")
+	// Wait that the storage worker is registered.
+	if err = sc.Net.Controller().WaitNodesRegistered(ctx, sc.Net.NumRegisterNodes()-1); err != nil {
+		return err
+	}
+
+	sc.Logger.Info("ensuring storage worker 1 is elected in committee")
+	// Another epoch transition so node is elected into storage committee.
+	if err = sc.Net.Controller().SetEpoch(ctx, nextEpoch); err != nil {
+		return fmt.Errorf("failed to set epoch %d: %w", nextEpoch, err)
+	}
+
+	sc.Logger.Info("starting again storage worker 0")
+	// Start back the storage 0 so it registers and storage worker 1 can sync.
+	err = storage0.Start()
+	if err != nil {
+		return fmt.Errorf("can't start storage worker 0: %w", err)
+	}
+
+	// Wait that storage worker 1 syncs.
+	sc.Logger.Info("waiting for storage worker 1 to sync from storage worker 0")
+	if err = storage1.WaitReady(ctx); err != nil {
+		return fmt.Errorf("error waiting for late storage worker to become ready: %w", err)
+	}
+
+	// Run the client again.
+	sc.Logger.Info("starting a second client to check if runtime works with storage worker 1")
+	sc.runtimeImpl.clientArgs = []string{
+		"--key", "key2",
+		"--seed", "second_seed",
+	}
+	cmd, err = sc.startClient(childEnv)
+	if err != nil {
+		return err
+	}
+	client2ErrCh := make(chan error)
+	go func() {
+		client2ErrCh <- cmd.Wait()
+	}()
+	return sc.wait(childEnv, cmd, client2ErrCh)
+}

--- a/go/runtime/committee/committee.go
+++ b/go/runtime/committee/committee.go
@@ -202,7 +202,7 @@ func NewWatcher(
 	kind scheduler.CommitteeKind,
 	options ...WatcherOption,
 ) (Watcher, error) {
-	nw, err := nodes.NewBaseVersionedNodeDescriptorWatcher(ctx, registry)
+	nw, err := nodes.NewVersionedNodeDescriptorWatcher(ctx, registry)
 	if err != nil {
 		return nil, fmt.Errorf("committee: failed to create node descriptor watcher: %w", err)
 	}

--- a/go/runtime/committee/committee.go
+++ b/go/runtime/committee/committee.go
@@ -12,20 +12,21 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+	"github.com/oasisprotocol/oasis-core/go/runtime/nodes"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 )
 
 // Watcher is the committee watcher interface.
 type Watcher interface {
 	// Nodes returns a node descriptor lookup interface that watches all nodes in the committee.
-	Nodes() NodeDescriptorLookup
+	Nodes() nodes.NodeDescriptorLookup
 
 	// EpochTransition signals an epoch transition to the committee watcher.
 	EpochTransition(ctx context.Context, height int64) error
 }
 
 type committeeWatcher struct { // nolint: maligned
-	nw        NodeDescriptorWatcher
+	nw        nodes.VersionedNodeDescriptorWatcher
 	scheduler scheduler.Backend
 
 	runtimeID common.Namespace
@@ -39,7 +40,7 @@ type committeeWatcher struct { // nolint: maligned
 	logger *logging.Logger
 }
 
-func (cw *committeeWatcher) Nodes() NodeDescriptorLookup {
+func (cw *committeeWatcher) Nodes() nodes.NodeDescriptorLookup {
 	return cw.nw
 }
 
@@ -201,7 +202,7 @@ func NewWatcher(
 	kind scheduler.CommitteeKind,
 	options ...WatcherOption,
 ) (Watcher, error) {
-	nw, err := NewNodeDescriptorWatcher(ctx, registry)
+	nw, err := nodes.NewBaseVersionedNodeDescriptorWatcher(ctx, registry)
 	if err != nil {
 		return nil, fmt.Errorf("committee: failed to create node descriptor watcher: %w", err)
 	}

--- a/go/runtime/nodes/nodes.go
+++ b/go/runtime/nodes/nodes.go
@@ -1,0 +1,222 @@
+// Package nodes provides lookup and watcher utilities for groups of nodes.
+package nodes
+
+import (
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
+)
+
+// NodeUpdate is a node update.
+type NodeUpdate struct {
+	Update *node.Node
+	Delete *signature.PublicKey
+	Reset  bool
+
+	Freeze      *VersionEvent
+	BumpVersion *VersionEvent
+}
+
+// VersionEvent is a committee version event.
+type VersionEvent struct {
+	Version int64
+}
+
+// NodeDescriptorLookup is the node descriptor lookup interface.
+type NodeDescriptorLookup interface {
+	// Lookup looks up a node descriptor given its identifier.
+	Lookup(id signature.PublicKey) *node.Node
+
+	// LookupByPeerID looks up a node descriptor given its P2P peer ID.
+	LookupByPeerID(id signature.PublicKey) *node.Node
+
+	// LookupTags looks up tags for a given node.
+	LookupTags(id signature.PublicKey) []string
+
+	// GetNodes returns current list of nodes.
+	GetNodes() []*node.Node
+
+	// WatchNodeUpdates subscribes to notifications about node descriptor updates.
+	//
+	// For non-Versioned descriptor lookups there should be NO Versioned events.
+	// On subscription the current nodes will be sent immediately.
+	WatchNodeUpdates() (<-chan *NodeUpdate, pubsub.ClosableSubscription, error)
+
+	// Versioned returns true if this descriptor lookup is versioned.
+	//
+	// Versioned descriptor lookups are suitable to track versioned groups of nodes
+	// (e.g. committees versioned by the group number), while non-versioned lookups
+	// are suitable for watching non-versioned groups of nodes (e.g. all nodes,
+	// or all nodes registered for a specific runtime).
+	Versioned() bool
+}
+
+// NodeFilterFunc is a function that performs node filtering.
+type NodeFilterFunc func(*node.Node, []string) bool
+
+type filteredNodeDescriptorLookup struct {
+	filter NodeFilterFunc
+	base   NodeDescriptorLookup
+}
+
+// Implements NodeDescriptorLookup.
+func (f *filteredNodeDescriptorLookup) Lookup(id signature.PublicKey) *node.Node {
+	tags := f.base.LookupTags(id)
+	n := f.base.Lookup(id)
+	if !f.filter(n, tags) {
+		return nil
+	}
+	return n
+}
+
+// Implements NodeDescriptorLookup.
+func (f *filteredNodeDescriptorLookup) LookupByPeerID(id signature.PublicKey) *node.Node {
+	tags := f.base.LookupTags(id)
+	n := f.base.LookupByPeerID(id)
+	if !f.filter(n, tags) {
+		return nil
+	}
+	return n
+}
+
+// Implements NodeDescriptorLookup.
+func (f *filteredNodeDescriptorLookup) LookupTags(id signature.PublicKey) []string {
+	return f.base.LookupTags(id)
+}
+
+// Implements NodeDescriptorLookup.
+func (f *filteredNodeDescriptorLookup) GetNodes() (filtered []*node.Node) {
+	for _, v := range f.base.GetNodes() {
+		tags := f.base.LookupTags(v.ID)
+		if f.filter(v, tags) {
+			filtered = append(filtered, v)
+		}
+	}
+	return
+}
+
+// Implements NodeDescriptorLookup.
+func (f *filteredNodeDescriptorLookup) WatchNodeUpdates() (<-chan *NodeUpdate, pubsub.ClosableSubscription, error) {
+	filteredCh := make(chan *NodeUpdate)
+	ch, sub, err := f.base.WatchNodeUpdates()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	go func() {
+		defer close(filteredCh)
+
+		// XXX: This is needed so that we can correctly handle update & delete events.
+		prevNodes := make(map[signature.PublicKey]*node.Node)
+		prevTags := make(map[signature.PublicKey][]string)
+
+		for {
+			nu, ok := <-ch
+			if !ok {
+				return
+			}
+
+			switch {
+			case nu.Reset:
+				prevNodes = make(map[signature.PublicKey]*node.Node)
+				prevTags = make(map[signature.PublicKey][]string)
+			case nu.Update != nil:
+				oldNode, nodeExists := prevNodes[nu.Update.ID]
+				oldTags, exists := prevTags[nu.Update.ID]
+				tags := f.base.LookupTags(nu.Update.ID)
+
+				matchesBeforeUpdate := nodeExists && exists && f.filter(oldNode, oldTags)
+				matchesAfterUpdate := f.filter(nu.Update, tags)
+
+				switch matchesAfterUpdate {
+				case true:
+					// If node matches filters, locally save the node and tags.
+					prevNodes[nu.Update.ID] = nu.Update
+					prevTags[nu.Update.ID] = tags
+				case false:
+					// If node doesn't match filters anymore, it can be deleted from local maps.
+					delete(prevNodes, nu.Update.ID)
+					delete(prevTags, nu.Update.ID)
+				}
+
+				switch {
+				case matchesBeforeUpdate && !matchesAfterUpdate:
+					// Node passed filters before update, now doesn't.
+					// Send a delete event.
+					filteredCh <- &NodeUpdate{Delete: &nu.Update.ID}
+
+					continue
+				case !matchesBeforeUpdate && !matchesAfterUpdate:
+					// Node didn't pass filters before update, still doesn't.
+					// Don't send any events.
+					continue
+				default:
+					// Otherwise propagate the event.
+				}
+			case nu.Delete != nil:
+				oldNode, existsNode := prevNodes[*nu.Delete]
+				oldTags, exists := prevTags[*nu.Delete]
+				matchesBeforeDelete := existsNode && exists && f.filter(oldNode, oldTags)
+
+				// Delete stored values for the node.
+				delete(prevNodes, *nu.Delete)
+				delete(prevTags, *nu.Delete)
+
+				if !matchesBeforeDelete {
+					// If node didn't match filters before, don't propage the
+					// delete event.
+					continue
+				}
+			}
+
+			filteredCh <- nu
+		}
+	}()
+
+	return filteredCh, sub, nil
+}
+
+func (f *filteredNodeDescriptorLookup) Versioned() bool {
+	return f.base.Versioned()
+}
+
+// NewFilteredNodeLookup creates a NodeDescriptorLookup with a node filter function applied.
+func NewFilteredNodeLookup(nl NodeDescriptorLookup, f NodeFilterFunc) NodeDescriptorLookup {
+	return &filteredNodeDescriptorLookup{
+		filter: f,
+		base:   nl,
+	}
+}
+
+// IgnoreNodeFilter returns a node filter function that filters out the node with
+// the provided id.
+func IgnoreNodeFilter(id signature.PublicKey) NodeFilterFunc {
+	return func(node *node.Node, _ []string) bool {
+		return !node.ID.Equal(id)
+	}
+}
+
+// TagFilter returns a node filter function that only includes nodes with the given tag.
+func TagFilter(tag string) NodeFilterFunc {
+	return func(_ *node.Node, tags []string) bool {
+		for _, t := range tags {
+			if t == tag {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// WithAllFilters combines multiple filters into a single NodeFilterFunc that
+// only includes nodes passing all of the provided filters.
+func WithAllFilters(filters ...NodeFilterFunc) NodeFilterFunc {
+	return func(n *node.Node, tags []string) bool {
+		for _, f := range filters {
+			if !f(n, tags) {
+				return false
+			}
+		}
+		return true
+	}
+}

--- a/go/runtime/nodes/nodes_test.go
+++ b/go/runtime/nodes/nodes_test.go
@@ -1,0 +1,250 @@
+package nodes
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eapache/channels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
+)
+
+const recvTimeout = 1 * time.Second
+
+type mockDescriptorLookup struct {
+	sync.Mutex
+
+	nodes         map[signature.PublicKey]*node.Node
+	nodesByPeerID map[signature.PublicKey]*node.Node
+	tags          map[signature.PublicKey][]string
+
+	notifier *pubsub.Broker
+}
+
+func (m *mockDescriptorLookup) Lookup(id signature.PublicKey) *node.Node {
+	m.Lock()
+	defer m.Unlock()
+	return m.nodes[id]
+}
+
+func (m *mockDescriptorLookup) LookupByPeerID(id signature.PublicKey) *node.Node {
+	m.Lock()
+	defer m.Unlock()
+	return m.nodesByPeerID[id]
+}
+
+func (m *mockDescriptorLookup) LookupTags(id signature.PublicKey) []string {
+	m.Lock()
+	defer m.Unlock()
+	return m.tags[id]
+}
+
+func (m *mockDescriptorLookup) GetNodes() []*node.Node {
+	m.Lock()
+	defer m.Unlock()
+	nodes := make([]*node.Node, 0, len(m.nodes))
+	for _, n := range m.nodes {
+		nodes = append(nodes, n)
+	}
+
+	return nodes
+}
+
+func (m *mockDescriptorLookup) WatchNodeUpdates() (<-chan *NodeUpdate, pubsub.ClosableSubscription, error) {
+	sub := m.notifier.Subscribe()
+	ch := make(chan *NodeUpdate)
+	sub.Unwrap(ch)
+
+	return ch, sub, nil
+}
+
+func (m *mockDescriptorLookup) Versioned() bool {
+	return false
+}
+
+func TestFilteredNodeLookup(t *testing.T) {
+	require := require.New(t)
+
+	var pk1, pk2, pk3, pk4 signature.PublicKey
+	_ = pk1.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
+	_ = pk2.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000001")
+	_ = pk3.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000002")
+	_ = pk4.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000003")
+
+	n2 := &node.Node{ID: pk2}
+	mock := &mockDescriptorLookup{
+		nodes: map[signature.PublicKey]*node.Node{
+			pk1: {
+				ID: pk1,
+			},
+			pk2: n2,
+			pk3: {
+				ID: pk3,
+			},
+		},
+		nodesByPeerID: map[signature.PublicKey]*node.Node{
+			pk1: {
+				ID: pk1,
+			},
+			pk2: n2,
+			pk3: {
+				ID: pk3,
+			},
+		},
+		tags: map[signature.PublicKey][]string{
+			pk1: {"tag1", "tag2", "tag3"},
+			pk2: {"tag2", "tag3"},
+			pk3: {},
+		},
+	}
+	mock.notifier = pubsub.NewBrokerEx(func(ch channels.Channel) {
+		ch.In() <- &NodeUpdate{Reset: true}
+		for _, n := range mock.nodes {
+			ch.In() <- &NodeUpdate{Update: n}
+		}
+	})
+
+	filtered := NewFilteredNodeLookup(mock,
+		WithAllFilters(
+			IgnoreNodeFilter(pk1),
+			TagFilter("tag2"),
+		),
+	)
+
+	// Test GetNodes.
+	require.EqualValues([]*node.Node{n2}, filtered.GetNodes(), "GetNodes() should only return the node matching filters")
+
+	// Test Lookup.
+	require.Equal(n2, filtered.Lookup(pk2), "Lookup() should correctly return node matching filters")
+	require.Nil(filtered.Lookup(pk1), "Lookup() should not return node not matching filters")
+
+	// Test LookupByPeerID
+	require.Equal(n2, filtered.LookupByPeerID(pk2), "LookupByPeerID() should correctly return node matching filters")
+	require.Nil(filtered.LookupByPeerID(pk1), "LookupByPeerID() should not return node not matching filters")
+
+	// Test LookupTags.
+	require.EqualValues([]string{"tag2", "tag3"}, filtered.LookupTags(pk2), "LookupTags() should correctly return tags for node")
+	require.EqualValues([]string{"tag1", "tag2", "tag3"}, filtered.LookupTags(pk1), "LookupTags() should return tags for node not matching filters")
+
+	// Test WatchNodeUpdates.
+	ch, sub, err := filtered.WatchNodeUpdates()
+	require.NoError(err)
+	defer sub.Close()
+
+	// On subscribe receive the reset and n2 node update events.
+	select {
+	case ev := <-ch:
+		require.EqualValues(&NodeUpdate{Reset: true}, ev, "expected NodeUpdate.Reset event")
+	case <-time.After(recvTimeout):
+		t.Fatal("failed to receive initial reset event")
+	}
+	select {
+	case ev := <-ch:
+		require.EqualValues(&NodeUpdate{Update: n2}, ev, "expected NodeUpdate.Update event")
+	case <-time.After(recvTimeout):
+		t.Fatal("failed to receive initial reset event")
+	}
+
+	type testCase struct {
+		test          func()
+		expectedEvent *NodeUpdate
+		msg           string
+	}
+	for _, tc := range []testCase{
+		{
+			// Add pk4, matching filters -> should receive update event.
+			test: func() {
+				mock.Lock()
+				defer mock.Unlock()
+				mock.tags[pk4] = []string{"tag2"}
+				mock.notifier.Broadcast(&NodeUpdate{
+					Update: &node.Node{
+						ID: pk4,
+					},
+				})
+			},
+			expectedEvent: &NodeUpdate{
+				Update: &node.Node{
+					ID: pk4,
+				},
+			},
+			msg: "Added pk4 matching filters. Expecting update event.",
+		},
+		{
+			// Add tag to pk3 -> should receive update event.
+			test: func() {
+				mock.Lock()
+				defer mock.Unlock()
+				mock.tags[pk3] = []string{"tag2"}
+				mock.notifier.Broadcast(&NodeUpdate{
+					Update: &node.Node{
+						ID: pk3,
+					},
+				})
+			},
+			expectedEvent: &NodeUpdate{
+				Update: &node.Node{
+					ID: pk3,
+				},
+			},
+			msg: "Added matching tag to pk3. Expecting update event.",
+		},
+		{
+			// Remove tag from pk2 -> should receive delete event.
+			test: func() {
+				mock.Lock()
+				defer mock.Unlock()
+				mock.tags[pk2] = []string{}
+				mock.notifier.Broadcast(&NodeUpdate{
+					Update: &node.Node{
+						ID: pk2,
+					},
+				})
+			},
+			expectedEvent: &NodeUpdate{
+				Delete: &pk2,
+			},
+			msg: "Removed matching tag from pk2. Expecting delete event.",
+		},
+		{
+			// Update pk2 not matching filters -> should receive no event.
+			test: func() {
+				mock.Lock()
+				defer mock.Unlock()
+				mock.tags[pk2] = []string{"tag42"}
+				mock.notifier.Broadcast(&NodeUpdate{
+					Update: &node.Node{
+						ID: pk2,
+					},
+				})
+			},
+			expectedEvent: nil,
+			msg:           "Adding non-matching tag to pk2. Expecting no event.",
+		},
+	} {
+		// Run the test code.
+		tc.test()
+
+		// Assert expected event is received.
+		select {
+		case res := <-ch:
+			switch tc.expectedEvent {
+			case nil:
+				t.Fatalf("Expected no event, received event: %v, for test: '%s'", res, tc.msg)
+			default:
+				require.EqualValues(tc.expectedEvent, res, tc.msg)
+			}
+		case <-time.After(recvTimeout):
+			switch tc.expectedEvent {
+			case nil:
+				// Expected.
+			default:
+				t.Fatalf("failed to receive expected event: %v, for test: '%s'", tc.expectedEvent, tc.msg)
+			}
+		}
+	}
+}

--- a/go/runtime/nodes/runtime.go
+++ b/go/runtime/nodes/runtime.go
@@ -1,0 +1,193 @@
+package nodes
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/eapache/channels"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+)
+
+const roleTagPrefix = "role"
+
+func tagForRole(r node.RolesMask) string {
+	return fmt.Sprintf("%s-%s", roleTagPrefix, r.String())
+}
+
+// TagsForRoleMask returns node lookup tags for node roles.
+func TagsForRoleMask(nodeRoles node.RolesMask) (tags []string) {
+	for _, r := range node.Roles() {
+		if nodeRoles&r != 0 {
+			tags = append(tags, tagForRole(r))
+		}
+	}
+	return
+}
+
+type runtimeNodesWatcher struct { // nolint: maligned
+	sync.RWMutex
+
+	registry registry.Backend
+
+	runtimeID common.Namespace
+
+	nodes         map[signature.PublicKey]*node.Node
+	nodesByPeerID map[signature.PublicKey]*node.Node
+	tags          map[signature.PublicKey][]string
+
+	notifier *pubsub.Broker
+
+	logger *logging.Logger
+}
+
+// Implements NodeDescriptorLookup.
+func (rw *runtimeNodesWatcher) Lookup(id signature.PublicKey) *node.Node {
+	rw.RLock()
+	defer rw.RUnlock()
+
+	return rw.nodes[id]
+}
+
+// Implements NodeDescriptorLookup.
+func (rw *runtimeNodesWatcher) LookupByPeerID(id signature.PublicKey) *node.Node {
+	rw.RLock()
+	defer rw.RUnlock()
+
+	return rw.nodesByPeerID[id]
+}
+
+// Implements NodeDescriptorLookup.
+func (rw *runtimeNodesWatcher) LookupTags(id signature.PublicKey) []string {
+	rw.RLock()
+	defer rw.RUnlock()
+
+	return rw.tags[id]
+}
+
+// Implements NodeDescriptorLookup.
+func (rw *runtimeNodesWatcher) GetNodes() []*node.Node {
+	rw.RLock()
+	defer rw.RUnlock()
+
+	nodes := make([]*node.Node, 0, len(rw.nodes))
+	for _, n := range rw.nodes {
+		nodes = append(nodes, n)
+	}
+
+	return nodes
+}
+
+// Implements NodeDescriptorLookup.
+func (rw *runtimeNodesWatcher) WatchNodeUpdates() (<-chan *NodeUpdate, pubsub.ClosableSubscription, error) {
+	sub := rw.notifier.Subscribe()
+	ch := make(chan *NodeUpdate)
+	sub.Unwrap(ch)
+
+	return ch, sub, nil
+}
+
+// Implements NodeDescriptorLookup.
+func (rw *runtimeNodesWatcher) Versioned() bool {
+	// This is a non-versioned watcher, it will watch nodes as it gets them.
+	return false
+}
+
+func (rw *runtimeNodesWatcher) updateLocked(n *node.Node) {
+	if old := rw.nodes[n.ID]; old != nil {
+		delete(rw.nodesByPeerID, old.P2P.ID)
+	}
+	rw.nodes[n.ID] = n
+	rw.nodesByPeerID[n.P2P.ID] = n
+	rw.tags[n.ID] = TagsForRoleMask(n.Roles)
+
+	rw.notifier.Broadcast(&NodeUpdate{
+		Update: n,
+	})
+}
+
+func (rw *runtimeNodesWatcher) removeLocked(n *node.Node) {
+	old := rw.nodes[n.ID]
+	if old == nil {
+		return
+	}
+
+	delete(rw.nodesByPeerID, old.P2P.ID)
+	delete(rw.nodes, n.ID)
+	delete(rw.tags, n.ID)
+
+	rw.notifier.Broadcast(&NodeUpdate{
+		Delete: &n.ID,
+	})
+}
+
+func (rw *runtimeNodesWatcher) watchRuntimeNodeUpdates(ctx context.Context, ch <-chan *registry.NodeEvent, sub pubsub.ClosableSubscription) {
+	defer sub.Close()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev := <-ch:
+
+			if ev.Node.GetRuntime(rw.runtimeID) == nil {
+				continue
+			}
+
+			rw.Lock()
+			switch ev.IsRegistration {
+			case false:
+				rw.removeLocked(ev.Node)
+			case true:
+				rw.updateLocked(ev.Node)
+			}
+			rw.Unlock()
+		}
+	}
+}
+
+// NewRuntimeNodeLookup creates a new runtime node lookup.
+//
+// Runtime node lookup watches all registered nodes for the provided runtime.
+// Aditionally, watched nodes are tagged by node roles.
+func NewRuntimeNodeLookup(
+	ctx context.Context,
+	registry registry.Backend,
+	runtimeID common.Namespace,
+) (NodeDescriptorLookup, error) {
+	rw := &runtimeNodesWatcher{
+		registry:      registry,
+		runtimeID:     runtimeID,
+		nodes:         make(map[signature.PublicKey]*node.Node),
+		nodesByPeerID: make(map[signature.PublicKey]*node.Node),
+		tags:          make(map[signature.PublicKey][]string),
+		logger: logging.GetLogger("runtime/nodes/watcher").With(
+			"runtime_id", runtimeID,
+		),
+	}
+
+	rw.notifier = pubsub.NewBrokerEx(func(ch channels.Channel) {
+		rw.RLock()
+		defer rw.RUnlock()
+
+		ch.In() <- &NodeUpdate{Reset: true}
+		for _, n := range rw.nodes {
+			ch.In() <- &NodeUpdate{Update: n}
+		}
+	})
+
+	ch, sub, err := registry.WatchNodes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("runtime: failed to watch nodes: %w", err)
+	}
+
+	go rw.watchRuntimeNodeUpdates(ctx, ch, sub)
+
+	return rw, nil
+}

--- a/go/runtime/nodes/runtime_test.go
+++ b/go/runtime/nodes/runtime_test.go
@@ -1,0 +1,28 @@
+package nodes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+)
+
+func TestTagsForRoleMask(t *testing.T) {
+	cases := map[node.RolesMask][]string{
+		node.RoleComputeWorker: {tagForRole(node.RoleComputeWorker)},
+		node.RoleComputeWorker | node.RoleKeyManager: {
+			tagForRole(node.RoleComputeWorker),
+			tagForRole(node.RoleKeyManager),
+		},
+		node.RoleComputeWorker | node.RoleKeyManager | node.RoleConsensusRPC: {
+			tagForRole(node.RoleComputeWorker),
+			tagForRole(node.RoleKeyManager),
+			tagForRole(node.RoleConsensusRPC),
+		},
+	}
+
+	for tc, expected := range cases {
+		require.EqualValues(t, TagsForRoleMask(tc), expected)
+	}
+}

--- a/go/runtime/nodes/versioned.go
+++ b/go/runtime/nodes/versioned.go
@@ -252,12 +252,11 @@ func (nw *versionedNodeDescriptorWatcher) Versioned() bool {
 	return true
 }
 
-// NewBaseVersionedNodeDescriptorWatcher creates a new base versioned node descriptor watcher.
+// NewVersionedNodeDescriptorWatcher creates a new base versioned node descriptor watcher.
 //
-// The base watcher will only track nodes that will be explicitly marked to watch
+// This watcher will only track nodes that will be explicitly marked to watch
 // via WatchNode/WatchNodeWithTags methods.
-// TODO: better name?
-func NewBaseVersionedNodeDescriptorWatcher(ctx context.Context, registry registry.Backend) (VersionedNodeDescriptorWatcher, error) {
+func NewVersionedNodeDescriptorWatcher(ctx context.Context, registry registry.Backend) (VersionedNodeDescriptorWatcher, error) {
 	// Subscribe to node updates.
 	ch, sub, err := registry.WatchNodes(ctx)
 	if err != nil {

--- a/go/storage/api/api.go
+++ b/go/storage/api/api.go
@@ -321,7 +321,10 @@ type ClientBackend interface {
 	// GetConnectedNodes returns currently connected storage nodes.
 	GetConnectedNodes() []*node.Node
 
-	// EnsureCommitteeVersion waits for the storage committee client to be fully synced to the
-	// given version.
+	// EnsureCommitteeVersion waits for the storage committee client to be fully
+	// synced to the given version.
+	//
+	// This method will error in case the storage-client is not configured to
+	// track a specific committee.
 	EnsureCommitteeVersion(ctx context.Context, version int64) error
 }

--- a/go/storage/api/context.go
+++ b/go/storage/api/context.go
@@ -16,6 +16,19 @@ func WithNodePriorityHint(ctx context.Context, nodes []signature.PublicKey) cont
 	return context.WithValue(ctx, contextKeyNodePriorityHint, nodes)
 }
 
+// WithNodePriorityHintFromMap sets a storage node priority hint for any storage read requests using this
+// context. Only storage nodes that overlap with the configured committee will be used.
+func WithNodePriorityHintFromMap(ctx context.Context, nodes map[signature.PublicKey]bool) context.Context {
+	priority := make([]signature.PublicKey, 0, len(nodes))
+	for k, b := range nodes {
+		if b {
+			priority = append(priority, k)
+		}
+	}
+
+	return WithNodePriorityHint(ctx, priority)
+}
+
 // WithNodePriorityHintFromSignatures sets a storage node priority hint for any storage read
 // requests using this context. Only storage nodes that overlap with the configured committee will
 // be used.

--- a/go/storage/api/context_test.go
+++ b/go/storage/api/context_test.go
@@ -33,4 +33,13 @@ func TestNodePriorityHint(t *testing.T) {
 	nodes = NodePriorityHintFromContext(ctx2)
 	require.Len(nodes, 3, "all node ids must be there")
 	require.EqualValues([]signature.PublicKey{pk1, pk2, pk3}, nodes, "all node ids must be the same")
+
+	ctx3 := WithNodePriorityHintFromMap(ctx, map[signature.PublicKey]bool{
+		pk1: true,
+		pk2: false,
+		pk3: true,
+	})
+	nodes = NodePriorityHintFromContext(ctx3)
+	require.Len(nodes, 2, "node ids must be there")
+	require.ElementsMatch([]signature.PublicKey{pk1, pk3}, nodes, "node ids must be correct")
 }

--- a/go/storage/client/init.go
+++ b/go/storage/client/init.go
@@ -85,7 +85,7 @@ func NewStatic(
 	registryBackend registry.Backend,
 	nodeID signature.PublicKey,
 ) (api.Backend, error) {
-	nw, err := nodes.NewBaseVersionedNodeDescriptorWatcher(ctx, registryBackend)
+	nw, err := nodes.NewVersionedNodeDescriptorWatcher(ctx, registryBackend)
 	if err != nil {
 		return nil, fmt.Errorf("storage/client: failed to create node descriptor watcher: %w", err)
 	}

--- a/go/worker/common/committee/accessctl.go
+++ b/go/worker/common/committee/accessctl.go
@@ -5,7 +5,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
-	"github.com/oasisprotocol/oasis-core/go/runtime/committee"
+	"github.com/oasisprotocol/oasis-core/go/runtime/nodes"
 )
 
 var logger = logging.GetLogger("worker/common/committee/accessctl")
@@ -17,7 +17,7 @@ type AccessPolicy struct {
 
 // AddRulesForCommittee augments the given policy by allowing actions in the current AccessPolicy
 // for the nodes in the given committee.
-func (ap AccessPolicy) AddRulesForCommittee(policy *accessctl.Policy, committee *CommitteeInfo, nodes committee.NodeDescriptorLookup) {
+func (ap AccessPolicy) AddRulesForCommittee(policy *accessctl.Policy, committee *CommitteeInfo, nodes nodes.NodeDescriptorLookup) {
 	for id := range committee.PublicKeys {
 		node := nodes.Lookup(id)
 		if node == nil {

--- a/go/worker/common/committee/group.go
+++ b/go/worker/common/committee/group.go
@@ -558,7 +558,7 @@ func NewGroup(
 	consensus consensus.Backend,
 	p2p *p2p.P2P,
 ) (*Group, error) {
-	nw, err := nodes.NewBaseVersionedNodeDescriptorWatcher(ctx, consensus.Registry())
+	nw, err := nodes.NewVersionedNodeDescriptorWatcher(ctx, consensus.Registry())
 	if err != nil {
 		return nil, fmt.Errorf("group: failed to create node watcher: %w", err)
 	}

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -14,7 +14,7 @@ import (
 	keymanagerClient "github.com/oasisprotocol/oasis-core/go/keymanager/client"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
-	"github.com/oasisprotocol/oasis-core/go/runtime/committee"
+	"github.com/oasisprotocol/oasis-core/go/runtime/nodes"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	"github.com/oasisprotocol/oasis-core/go/worker/common/api"
 	"github.com/oasisprotocol/oasis-core/go/worker/common/p2p"
@@ -82,7 +82,7 @@ type NodeHooks interface {
 	// Guarded by CrossNode.
 	HandleNewEventLocked(*roothash.Event)
 	// Guarded by CrossNode.
-	HandleNodeUpdateLocked(*committee.NodeUpdate, *EpochSnapshot)
+	HandleNodeUpdateLocked(*nodes.NodeUpdate, *EpochSnapshot)
 }
 
 // Node is a committee node.
@@ -299,7 +299,7 @@ func (n *Node) handleNewEventLocked(ev *roothash.Event) {
 }
 
 // Guarded by n.CrossNode.
-func (n *Node) handleNodeUpdateLocked(update *committee.NodeUpdate) {
+func (n *Node) handleNodeUpdateLocked(update *nodes.NodeUpdate) {
 	epoch := n.Group.GetEpochSnapshot()
 
 	for _, hooks := range n.hooks {

--- a/go/worker/compute/executor/committee/node.go
+++ b/go/worker/compute/executor/committee/node.go
@@ -25,9 +25,9 @@ import (
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
-	runtimeCommittee "github.com/oasisprotocol/oasis-core/go/runtime/committee"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
+	"github.com/oasisprotocol/oasis-core/go/runtime/nodes"
 	"github.com/oasisprotocol/oasis-core/go/runtime/scheduling"
 	schedulingAPI "github.com/oasisprotocol/oasis-core/go/runtime/scheduling/api"
 	"github.com/oasisprotocol/oasis-core/go/runtime/transaction"
@@ -1267,7 +1267,7 @@ func (n *Node) HandleNewEventLocked(ev *roothash.Event) {
 
 // HandleNodeUpdateLocked implements NodeHooks.
 // Guarded by n.commonNode.CrossNode.
-func (n *Node) HandleNodeUpdateLocked(update *runtimeCommittee.NodeUpdate, snapshot *committee.EpochSnapshot) {
+func (n *Node) HandleNodeUpdateLocked(update *nodes.NodeUpdate, snapshot *committee.EpochSnapshot) {
 	// Nothing to do here.
 }
 

--- a/go/worker/keymanager/watcher.go
+++ b/go/worker/keymanager/watcher.go
@@ -5,7 +5,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
-	"github.com/oasisprotocol/oasis-core/go/runtime/committee"
+	"github.com/oasisprotocol/oasis-core/go/runtime/nodes"
 )
 
 type kmNodeWatcher struct {
@@ -30,7 +30,7 @@ func (knw *kmNodeWatcher) watchNodes() {
 	}
 	defer nodesSub.Close()
 
-	watcher, err := committee.NewNodeDescriptorWatcher(knw.w.ctx, knw.registry)
+	watcher, err := nodes.NewBaseVersionedNodeDescriptorWatcher(knw.w.ctx, knw.registry)
 	if err != nil {
 		knw.w.logger.Error("worker/keymanager: failed to create node desc watcher",
 			"err", err,

--- a/go/worker/keymanager/watcher.go
+++ b/go/worker/keymanager/watcher.go
@@ -30,7 +30,7 @@ func (knw *kmNodeWatcher) watchNodes() {
 	}
 	defer nodesSub.Close()
 
-	watcher, err := nodes.NewBaseVersionedNodeDescriptorWatcher(knw.w.ctx, knw.registry)
+	watcher, err := nodes.NewVersionedNodeDescriptorWatcher(knw.w.ctx, knw.registry)
 	if err != nil {
 		knw.w.logger.Error("worker/keymanager: failed to create node desc watcher",
 			"err", err,

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -23,9 +23,9 @@ import (
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
-	runtimeCommittee "github.com/oasisprotocol/oasis-core/go/runtime/committee"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
+	"github.com/oasisprotocol/oasis-core/go/runtime/nodes"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	workerCommon "github.com/oasisprotocol/oasis-core/go/worker/common"
 	committeeCommon "github.com/oasisprotocol/oasis-core/go/worker/common/committee"
@@ -693,6 +693,6 @@ func (crw *clientRuntimeWatcher) HandleNewEventLocked(*roothash.Event) {
 }
 
 // Guarded by CrossNode.
-func (crw *clientRuntimeWatcher) HandleNodeUpdateLocked(update *runtimeCommittee.NodeUpdate, snapshot *committeeCommon.EpochSnapshot) {
+func (crw *clientRuntimeWatcher) HandleNodeUpdateLocked(update *nodes.NodeUpdate, snapshot *committeeCommon.EpochSnapshot) {
 	crw.updateExternalServicePolicyLocked(snapshot)
 }

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -24,7 +24,8 @@ import (
 	registryApi "github.com/oasisprotocol/oasis-core/go/registry/api"
 	roothashApi "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
-	runtimeCommittee "github.com/oasisprotocol/oasis-core/go/runtime/committee"
+	"github.com/oasisprotocol/oasis-core/go/runtime/nodes"
+	"github.com/oasisprotocol/oasis-core/go/runtime/nodes/grpc"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 	storageApi "github.com/oasisprotocol/oasis-core/go/storage/api"
 	"github.com/oasisprotocol/oasis-core/go/storage/client"
@@ -188,8 +189,12 @@ type Node struct {
 
 	logger *logging.Logger
 
-	localStorage   storageApi.LocalBackend
-	storageClient  storageApi.ClientBackend
+	localStorage storageApi.LocalBackend
+
+	storageNodes     nodes.NodeDescriptorLookup
+	storageNodesGrpc grpc.NodesClient
+	storageClient    storageApi.ClientBackend
+
 	grpcPolicy     *policy.DynamicRuntimePolicyChecker
 	undefinedRound uint64
 
@@ -230,7 +235,7 @@ func NewNode(
 	checkpointerCfg *checkpoint.CheckpointerConfig,
 	checkpointSyncDisabled bool,
 ) (*Node, error) {
-	node := &Node{
+	n := &Node{
 		commonNode: commonNode,
 
 		roleProvider: roleProvider,
@@ -258,29 +263,53 @@ func NewNode(
 		initCh:          make(chan struct{}),
 	}
 
-	node.syncedState.LastBlock.Round = defaultUndefinedRound
+	n.syncedState.LastBlock.Round = defaultUndefinedRound
 	rtID := commonNode.Runtime.ID()
-	err := store.GetCBOR(rtID[:], &node.syncedState)
+	err := store.GetCBOR(rtID[:], &n.syncedState)
 	if err != nil && err != persistent.ErrNotFound {
 		return nil, fmt.Errorf("storage worker: failed to restore sync state: %w", err)
 	}
 
-	node.ctx, node.ctxCancel = context.WithCancel(context.Background())
+	n.ctx, n.ctxCancel = context.WithCancel(context.Background())
 
 	// Create a new storage client that will be used for remote sync.
-	scl, err := client.New(
-		node.ctx,
-		commonNode.Runtime.ID(),
-		node.commonNode.Identity,
-		node.commonNode.Consensus.Scheduler(),
-		node.commonNode.Consensus.Registry(),
-		nil,
-		runtimeCommittee.WithFilter(runtimeCommittee.IgnoreNodeFilter(commonNode.Identity.NodeSigner.Public())),
+	// This storage client connects to all registered nodes for the committee.
+	nl, err := nodes.NewRuntimeNodeLookup(
+		n.ctx,
+		n.commonNode.Consensus.Registry(),
+		rtID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("group: failed to create runtime node watcher: %w", err)
+	}
+
+	n.storageNodes = nodes.NewFilteredNodeLookup(nl,
+		nodes.WithAllFilters(
+			// Ignore self.
+			nodes.IgnoreNodeFilter(n.commonNode.Identity.NodeSigner.Public()),
+			// Only storage nodes.
+			nodes.TagFilter(nodes.TagsForRoleMask(node.RoleStorageWorker)[0]),
+		),
+	)
+	storageNodesGrpc, err := grpc.NewNodesClient(
+		n.ctx,
+		n.storageNodes,
+		grpc.WithClientAuthentication(n.commonNode.Identity),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("storage/client: failed to create nodes gRPC client: %w", err)
+	}
+	n.storageNodesGrpc = storageNodesGrpc
+
+	scl, err := client.NewForNodesClient(
+		n.ctx,
+		n.storageNodesGrpc,
+		n.commonNode.Runtime,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("storage worker: failed to create client: %w", err)
 	}
-	node.storageClient = scl.(storageApi.ClientBackend)
+	n.storageClient = scl.(storageApi.ClientBackend)
 
 	// Create a new checkpointer if enabled.
 	if checkpointerCfg != nil {
@@ -313,7 +342,12 @@ func NewNode(
 				}, nil
 			},
 		}
-		node.checkpointer, err = checkpoint.NewCheckpointer(node.ctx, localStorage.NodeDB(), localStorage.Checkpointer(), *checkpointerCfg)
+		n.checkpointer, err = checkpoint.NewCheckpointer(
+			n.ctx,
+			localStorage.NodeDB(),
+			localStorage.Checkpointer(),
+			*checkpointerCfg,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("storage worker: failed to create checkpointer: %w", err)
 		}
@@ -321,15 +355,15 @@ func NewNode(
 
 	// Register prune handler.
 	commonNode.Runtime.History().Pruner().RegisterHandler(&pruneHandler{
-		logger: node.logger,
-		node:   node,
+		logger: n.logger,
+		node:   n,
 	})
 
 	prometheusOnce.Do(func() {
 		prometheus.MustRegister(storageWorkerCollectors...)
 	})
 
-	return node, nil
+	return n, nil
 }
 
 // Service interface.
@@ -411,7 +445,7 @@ func (n *Node) HandleNewEventLocked(*roothashApi.Event) {
 }
 
 // Guarded by CrossNode.
-func (n *Node) HandleNodeUpdateLocked(update *runtimeCommittee.NodeUpdate, snapshot *committee.EpochSnapshot) {
+func (n *Node) HandleNodeUpdateLocked(update *nodes.NodeUpdate, snapshot *committee.EpochSnapshot) {
 	// Nothing to do here.
 	// Storage worker uses a separate watcher.
 }
@@ -479,7 +513,12 @@ func (n *Node) fetchDiff(round uint64, prevRoot, thisRoot *mkvsNode.Root, fetchM
 				"fetch_mask", fetchMask,
 			)
 
-			it, err := n.storageClient.GetDiff(n.ctx, &storageApi.GetDiffRequest{StartRoot: *prevRoot, EndRoot: *thisRoot})
+			// Prioritize committee nodes.
+			ctx := storageApi.WithNodePriorityHintFromMap(
+				n.ctx,
+				n.commonNode.Group.GetEpochSnapshot().GetStorageCommittee().PublicKeys,
+			)
+			it, err := n.storageClient.GetDiff(ctx, &storageApi.GetDiffRequest{StartRoot: *prevRoot, EndRoot: *thisRoot})
 			if err != nil {
 				result.err = err
 				return
@@ -588,7 +627,7 @@ func (n *Node) flushSyncedState(summary *blockSummary) uint64 {
 	return n.syncedState.LastBlock.Round
 }
 
-func (n *Node) updateExternalServicePolicy(rtComputeNodes runtimeCommittee.NodeDescriptorLookup) {
+func (n *Node) updateExternalServicePolicy(rtComputeNodes nodes.NodeDescriptorLookup) {
 	// Create new storage gRPC access policy for the current runtime.
 	policy := accessctl.NewPolicy()
 
@@ -632,11 +671,11 @@ func (n *Node) runtimeNodesWatcher() {
 
 	n.logger.Info("starting runtime nodes watcher")
 
-	committeeNodes := runtimeCommittee.NewFilteredNodeLookup(
+	committeeNodes := nodes.NewFilteredNodeLookup(
 		n.commonNode.Group.Nodes(),
-		runtimeCommittee.TagFilter(committee.TagForCommittee(scheduler.KindComputeExecutor)),
+		nodes.TagFilter(committee.TagForCommittee(scheduler.KindComputeExecutor)),
 	)
-	// Start watching node updates for the current committee.
+	// Start watching compute node updates for the current committee.
 	committeeNodeUps, committeeNodeUpsSub, err := committeeNodes.WatchNodeUpdates()
 	if err != nil {
 		n.logger.Error("failed to subscribe to node updates",
@@ -646,14 +685,15 @@ func (n *Node) runtimeNodesWatcher() {
 	}
 	defer committeeNodeUpsSub.Close()
 
-	nodeCh, nodeSub, err := n.commonNode.Consensus.Registry().WatchNodes(n.ctx)
+	// Watch registered storage node updates for the runtime.
+	storageNodeUps, storageNodeUpsSub, err := n.storageNodes.WatchNodeUpdates()
 	if err != nil {
-		n.logger.Error("worker/storage: failed to watch registry nodes",
+		n.logger.Error("failed to subscribe to node storage node updates",
 			"err", err,
 		)
 		return
 	}
-	defer nodeSub.Close()
+	defer storageNodeUpsSub.Close()
 
 	for {
 		select {
@@ -664,15 +704,8 @@ func (n *Node) runtimeNodesWatcher() {
 				continue
 			}
 			// Update policy (handled bellow).
-		case ev := <-nodeCh:
-			if !ev.IsRegistration {
-				continue
-			}
-			if ev.Node.GetRuntime(n.commonNode.Runtime.ID()) == nil {
-				continue
-			}
-			// Compute committee workers are handled by the committee watcher.
-			if !ev.Node.HasRoles(node.RoleStorageWorker) {
+		case u := <-storageNodeUps:
+			if u.Update == nil {
 				continue
 			}
 			// Update policy (handled bellow).
@@ -975,6 +1008,7 @@ mainLoop:
 					"old_root", item.prevRoot,
 					"new_root", item.thisRoot,
 					"fetch_mask", item.fetchMask,
+					"fetched", item.fetched,
 				)
 				syncingRounds[item.round].outstanding &= ^item.fetchMask
 				syncingRounds[item.round].awaitingRetry |= item.fetchMask

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -273,7 +273,7 @@ func NewNode(
 	n.ctx, n.ctxCancel = context.WithCancel(context.Background())
 
 	// Create a new storage client that will be used for remote sync.
-	// This storage client connects to all registered nodes for the committee.
+	// This storage client connects to all registered storage nodes for the runtime.
 	nl, err := nodes.NewRuntimeNodeLookup(
 		n.ctx,
 		n.commonNode.Consensus.Registry(),


### PR DESCRIPTION
Fixes: #3454

Done:
- [x] refactor `committee.NodeDescriptorWatcher` into a more general `NodeDescriptorWatcher` that doesn't assumes committees
  - now in `runtime/nodes/node.go`
  - supports both `Versioned` (suitable for watching committees) and non-`Versioned`  mode (e.g. suitable for watching all registered nodes for a runtime)
- [x] refactor `committee.Client` into more generalized `nodes.Client` (that now supports the more general `NodeDescriptorWatcher`)
- [x] address TODOs some more cleanups / minor refactorings
- [x] add a test for syncing from a out-of-committee node