### PR TITLE
storage: Force insert of nodes when processing write logs

### DIFF
--- a/.changelog/3468.bugfix.md
+++ b/.changelog/3468.bugfix.md
@@ -1,0 +1,6 @@
+storage: Force insert of nodes when processing write logs
+
+When processing a write log item an insert should be forced (resulting in a
+node version bump) even in case where the exact same key/value existed
+before. This would make the logic consistent with the write log producer's
+intent.

--- a/go/storage/mkvs/tree.go
+++ b/go/storage/mkvs/tree.go
@@ -130,7 +130,10 @@ func (t *tree) ApplyWriteLog(ctx context.Context, wl writelog.Iterator) error {
 		if entry.Value == nil {
 			err = t.Remove(ctx, entry.Key)
 		} else {
-			err = t.Insert(ctx, entry.Key, entry.Value)
+			// Set the force flag -- if the value is present in the write log, even if it existed
+			// before, we should treat it as if it was created in this version since the write log
+			// producer certainly treated it as such (otherwise it wouldn't be included).
+			err = t.insert(ctx, entry.Key, entry.Value, true)
 		}
 		if err != nil {
 			return err

--- a/runtime/src/storage/mkvs/interop/mod.rs
+++ b/runtime/src/storage/mkvs/interop/mod.rs
@@ -17,9 +17,10 @@ pub trait Driver {
         &self,
         write_log: &WriteLog,
         existing_root: Hash,
+        existing_version: u64,
         root_hash: Hash,
-        namespace: Namespace,
         version: u64,
+        namespace: Namespace,
     );
 }
 

--- a/runtime/src/storage/mkvs/interop/protocol_server.rs
+++ b/runtime/src/storage/mkvs/interop/protocol_server.rs
@@ -86,21 +86,29 @@ impl Drop for ProtocolServer {
 
 impl Driver for ProtocolServer {
     fn apply(&self, write_log: &WriteLog, root_hash: Hash, namespace: Namespace, version: u64) {
-        self.apply_existing(write_log, Hash::empty_hash(), root_hash, namespace, version)
+        self.apply_existing(
+            write_log,
+            Hash::empty_hash(),
+            version,
+            root_hash,
+            version,
+            namespace,
+        )
     }
 
     fn apply_existing(
         &self,
         write_log: &WriteLog,
         existing_root: Hash,
+        existing_version: u64,
         root_hash: Hash,
-        namespace: Namespace,
         version: u64,
+        namespace: Namespace,
     ) {
         self.client
             .apply(&rpc::ApplyRequest {
                 namespace,
-                src_round: version,
+                src_round: existing_version,
                 src_root: existing_root,
                 dst_round: version,
                 dst_root: root_hash,


### PR DESCRIPTION
Fixes #3468 

When processing a write log item an insert should be forced (resulting in a
node version bump) even in case where the exact same key/value existed
before. This would make the logic consistent with the write log producer's
intent.