### PR TITLE
go/common/version: Bump consensus protocol version to 2.0.0

### DIFF
--- a/.changelog/3470.breaking.md
+++ b/.changelog/3470.breaking.md
@@ -1,0 +1,1 @@
+go/common/crypto: Bump ed25519 version

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -76,7 +76,7 @@ var (
 	//
 	// NOTE: Any change in the major or minor versions are considered
 	//       breaking changes for the protocol.
-	ConsensusProtocol = Version{Major: 1, Minor: 1, Patch: 0}
+	ConsensusProtocol = Version{Major: 2, Minor: 0, Patch: 0}
 
 	// Tendermint exposes the tendermint core version.
 	Tendermint = parseSemVerStr(version.TMCoreSemVer)


### PR DESCRIPTION
Since https://github.com/oasisprotocol/oasis-core/pull/3360 has been merged, we stated that from now onwards, only a change in a protocol's major version signifies a backward-incompatible change.

The change in https://github.com/oasisprotocol/oasis-core/pull/3458/ is a breaking change, hence we should bump the consensus protocol's major version.