### PR TITLE
[BACKPORT/20.12.x] go/genesis: Fix epoch-based sanity checks

### DIFF
--- a/.changelog/3477.bugfix.md
+++ b/.changelog/3477.bugfix.md
@@ -1,0 +1,1 @@
+go/genesis: Fix epoch-based sanity checks

--- a/go/consensus/tendermint/abci/mux.go
+++ b/go/consensus/tendermint/abci/mux.go
@@ -4,10 +4,8 @@ package abci
 import (
 	"bytes"
 	"context"
-	"crypto/sha512"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"math"
 	"sort"
@@ -286,28 +284,20 @@ func (mux *abciMux) InitChain(req types.RequestInitChain) types.ResponseInitChai
 		panic("mux: invalid genesis application state")
 	}
 
-	b, _ := json.Marshal(st)
-	mux.logger.Debug("Genesis ABCI application state",
-		"state", string(b),
-	)
-
 	mux.currentTime = st.Time
 
 	if st.Height != req.InitialHeight || uint64(st.Height) != mux.state.initialHeight {
 		panic(fmt.Errorf("mux: inconsistent initial height (genesis: %d abci: %d state: %d)", st.Height, req.InitialHeight, mux.state.initialHeight))
 	}
 
-	// Stick the digest of the genesis block (the RequestInitChain) into
-	// the state.
+	// Stick the digest of the genesis document into the state.
 	//
 	// This serves to keep bad things from happening if absolutely
 	// nothing writes to the state till the Commit() call, along with
 	// clearly separating chain instances based on the initialization
 	// state, forever.
-	tmp := bytes.NewBuffer(nil)
-	_ = types.WriteMessage(&req, tmp)
-	genesisDigest := sha512.Sum512_256(tmp.Bytes())
-	err = mux.state.deliverTxTree.Insert(mux.state.ctx, []byte(stateKeyGenesisDigest), genesisDigest[:])
+	chainContext := st.ChainContext()
+	err = mux.state.deliverTxTree.Insert(mux.state.ctx, []byte(stateKeyGenesisDigest), []byte(chainContext))
 	if err != nil {
 		panic(err)
 	}

--- a/go/consensus/tendermint/abci/state.go
+++ b/go/consensus/tendermint/abci/state.go
@@ -79,9 +79,12 @@ func (s *applicationState) NewContext(mode api.ContextMode, now time.Time) *api.
 
 	var blockCtx *api.BlockContext
 	var state mkvs.Tree
+	blockHeight := int64(s.stateRoot.Version)
 	switch mode {
 	case api.ContextInitChain:
 		state = s.deliverTxTree
+		// Configure block height so that current height will be correctly computed.
+		blockHeight = int64(s.initialHeight) - 1
 	case api.ContextCheckTx:
 		state = s.checkTxTree
 	case api.ContextDeliverTx, api.ContextBeginBlock, api.ContextEndBlock:
@@ -103,7 +106,7 @@ func (s *applicationState) NewContext(mode api.ContextMode, now time.Time) *api.
 		api.NewNopGasAccountant(),
 		s,
 		state,
-		int64(s.stateRoot.Version),
+		blockHeight,
 		blockCtx,
 		int64(s.initialHeight),
 	)

--- a/go/epochtime/api/api.go
+++ b/go/epochtime/api/api.go
@@ -76,6 +76,15 @@ type ConsensusParameters struct {
 	DebugMockBackend bool `json:"debug_mock_backend,omitempty"`
 }
 
+// GetInitialEpoch returns the initial epoch based on the given genesis document.
+func (g *Genesis) GetInitialEpoch(height int64) EpochTime {
+	if g.Parameters.DebugMockBackend {
+		// Mock backend always starts with zero.
+		return 0
+	}
+	return g.Base + EpochTime(height/g.Parameters.Interval)
+}
+
 // SanityCheck does basic sanity checking on the genesis state.
 func (g *Genesis) SanityCheck() error {
 	unsafeFlags := g.Parameters.DebugMockBackend

--- a/go/genesis/api/sanity_check.go
+++ b/go/genesis/api/sanity_check.go
@@ -28,13 +28,15 @@ func (d *Document) SanityCheck() error {
 	if err := d.EpochTime.SanityCheck(); err != nil {
 		return err
 	}
-	if err := d.Registry.SanityCheck(d.EpochTime.Base, d.Staking.Ledger, d.Staking.Parameters.Thresholds, pkBlacklist); err != nil {
+	epoch := d.EpochTime.GetInitialEpoch(d.Height)
+
+	if err := d.Registry.SanityCheck(epoch, d.Staking.Ledger, d.Staking.Parameters.Thresholds, pkBlacklist); err != nil {
 		return err
 	}
 	if err := d.RootHash.SanityCheck(); err != nil {
 		return err
 	}
-	if err := d.Staking.SanityCheck(d.EpochTime.Base); err != nil {
+	if err := d.Staking.SanityCheck(epoch); err != nil {
 		return err
 	}
 	if err := d.KeyManager.SanityCheck(); err != nil {
@@ -47,7 +49,7 @@ func (d *Document) SanityCheck() error {
 		return err
 	}
 
-	if d.HaltEpoch < d.EpochTime.Base {
+	if d.HaltEpoch < epoch {
 		return fmt.Errorf("genesis: sanity check failed: halt epoch is in the past")
 	}
 

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -273,6 +273,8 @@ func TestGenesisSanityCheck(t *testing.T) {
 	require.Error(d.SanityCheck(), "empty chain ID should be invalid")
 
 	d = *testDoc
+	d.EpochTime.Parameters.DebugMockBackend = false
+	d.EpochTime.Parameters.Interval = 600
 	d.EpochTime.Base = 10
 	d.HaltEpoch = 5
 	require.Error(d.SanityCheck(), "halt epoch in the past should be invalid")


### PR DESCRIPTION
Backport of #3477.