### PR TITLE
go/storage/mkvs/checkpoint: Fix handling of non-zero earliest version

### DIFF
--- a/.changelog/3480.bugfix.md
+++ b/.changelog/3480.bugfix.md
@@ -1,0 +1,1 @@
+go/storage/mkvs/checkpoint: Fix handling of non-zero earliest version


### PR DESCRIPTION
Fixes #3480 