### PR TITLE
go/runtime/client: Reject transactions before node completes initial sync

### DIFF
--- a/.changelog/3452.feature.md
+++ b/.changelog/3452.feature.md
@@ -1,0 +1,1 @@
+Runtime client should fail `SubmitTx` calls until consensus is synced

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -268,9 +268,20 @@ func (sc *runtimeImpl) resolveDefaultKeyManagerBinary() (string, error) {
 }
 
 func (sc *runtimeImpl) startClient(childEnv *env.Env) (*exec.Cmd, error) {
+	ctx := context.Background()
+
 	clients := sc.Net.Clients()
 	if len(clients) == 0 {
 		return nil, fmt.Errorf("scenario/e2e: network has no client nodes")
+	}
+
+	sc.Logger.Info("ensuring client node is synced")
+	ctrl, err := oasis.NewController(clients[0].SocketPath())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create controller for client: %w", err)
+	}
+	if err = ctrl.WaitSync(ctx); err != nil {
+		return nil, fmt.Errorf("client-0 failed to sync: %w", err)
 	}
 
 	d, err := childEnv.NewSubDir("client")

--- a/go/runtime/client/api/api.go
+++ b/go/runtime/client/api/api.go
@@ -28,6 +28,9 @@ var (
 	ErrInternal = errors.New(ModuleName, 2, "client: internal error")
 	// ErrTransactionExpired is an error returned when transaction expired.
 	ErrTransactionExpired = errors.New(ModuleName, 3, "client: transaction expired")
+	// ErrNotSynced is an error return if transaction is submitted before node has finished
+	// initial syncing.
+	ErrNotSynced = errors.New(ModuleName, 4, "client: not finished initial sync")
 )
 
 // RuntimeClient is the runtime client interface.

--- a/go/runtime/client/client.go
+++ b/go/runtime/client/client.go
@@ -83,6 +83,14 @@ func (c *runtimeClient) SubmitTx(ctx context.Context, request *api.SubmitTxReque
 		return nil, fmt.Errorf("client: cannot submit transaction, p2p disabled")
 	}
 
+	select {
+	case <-c.common.consensus.Synced():
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		return nil, api.ErrNotSynced
+	}
+
 	var watcher *blockWatcher
 	var ok bool
 	var err error


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/3452