### PR TITLE
go: Add missing size checks in UnmarshalBinary

### DIFF
--- a/.changelog/3497.bugfix.md
+++ b/.changelog/3497.bugfix.md
@@ -1,0 +1,5 @@
+go: Add missing size checks in UnmarshalBinary
+
+Note that in practice these will never currently be triggered as the
+caller always checks the overall size before calling the more specific
+UnmarshalBinary method.

--- a/go/common/sgx/common.go
+++ b/go/common/sgx/common.go
@@ -225,6 +225,9 @@ func (id *EnclaveIdentity) UnmarshalText(text []byte) error {
 	if err != nil {
 		return fmt.Errorf("sgx: malformed EnclaveIdentity: %w", err)
 	}
+	if len(b) != enclaveIdentitySize {
+		return fmt.Errorf("sgx: malformed EnclaveIdentity")
+	}
 	if err := id.MrEnclave.UnmarshalBinary(b[:MrEnclaveSize]); err != nil {
 		return fmt.Errorf("sgx: malformed MrEnclave in EnclaveIdentity: %w", err)
 	}
@@ -238,8 +241,11 @@ func (id *EnclaveIdentity) UnmarshalText(text []byte) error {
 // UnmarshalHex decodes a hex marshaled EnclaveIdentity.
 func (id *EnclaveIdentity) UnmarshalHex(text string) error {
 	b, err := hex.DecodeString(text)
-	if err != nil || len(b) != enclaveIdentitySize {
+	if err != nil {
 		return fmt.Errorf("sgx: malformed EnclaveIdentity: %w", err)
+	}
+	if len(b) != enclaveIdentitySize {
+		return fmt.Errorf("sgx: malformed EnclaveIdentity")
 	}
 
 	copy(id.MrEnclave[:], b[:MrEnclaveSize])

--- a/go/common/sgx/ias/quote.go
+++ b/go/common/sgx/ias/quote.go
@@ -14,6 +14,9 @@ const (
 	// quoteBodyLen is the length of the part of the quote body that comes before the report.
 	quoteBodyLen = 48
 
+	// quoteReportLen is the length of the report in bytes.
+	quoteReportLen = 384
+
 	// offsetReportReportData is the offset into the report structure of the report_data field.
 	offsetReportReportData = 320
 )
@@ -39,6 +42,10 @@ type Body struct {
 
 // UnmarshalBinary decodes Body from byte array.
 func (b *Body) UnmarshalBinary(data []byte) error {
+	if len(data) < quoteBodyLen {
+		return fmt.Errorf("ias/quote: invalid body length")
+	}
+
 	b.Version = binary.LittleEndian.Uint16(data[0:])
 	switch b.Version {
 	case 1, 2:
@@ -126,8 +133,12 @@ func (r *Report) MarshalBinary() ([]byte, error) {
 	return rBin, nil
 }
 
-// UnmarshalBinary decodes Report from byte array
+// UnmarshalBinary decodes Report from a byte array.
 func (r *Report) UnmarshalBinary(data []byte) error {
+	if len(data) < quoteReportLen {
+		return fmt.Errorf("ias/quote: invalid report length")
+	}
+
 	copy(r.CPUSVN[:], data[0:])
 	r.MiscSelect = binary.LittleEndian.Uint32(data[16:])
 	r.Attributes.Flags = sgx.AttributesFlags(binary.LittleEndian.Uint64(data[48:]))

--- a/go/storage/mkvs/node/depth.go
+++ b/go/storage/mkvs/node/depth.go
@@ -29,8 +29,12 @@ func (dt Depth) MarshalBinary() []byte {
 	return data
 }
 
-// MarshalBinary encodes a Depth into binary form.
+// UnmarshalBinary decodes a binary marshaled depth.
 func (dt *Depth) UnmarshalBinary(data []byte) (int, error) {
+	if len(data) < DepthSize {
+		return 0, ErrMalformedNode
+	}
+
 	*dt = Depth(binary.LittleEndian.Uint16(data[0:DepthSize]))
 	return DepthSize, nil
 }


### PR DESCRIPTION
Note that in practice these will never currently be triggered as the
caller always checks the overall size before calling the more specific
UnmarshalBinary method.