### PR TITLE
dependabot: ignore tokio updates until it is manually updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,7 @@ updates:
       # version, remove it from the ignore list.
       - dependency-name: futures
       - dependency-name: grpcio
+      - dependency-name: tokio
       # Wait with update until https://github.com/Amanieu/intrusive-rs/pull/51
       # is merged and released, so we can continue using `intrusive_adapter!`
       # macro in`lru_cache.rs`.


### PR DESCRIPTION
Otherwise the dependabot will keep opening PRs (and rebasing those), hogging CI resources.

This is the issue tracking these outdated libs: https://github.com/oasisprotocol/oasis-core/issues/3245
