### PR TITLE
ci: Make build-fuzz failures fatal now that upstream is fixed

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -184,7 +184,6 @@ steps:
       # TODO: Consider making this a part of the development Docker image.
       - go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
       - make -C go build-fuzz
-    soft_fail: true
     retry:
       <<: *retry_agent_failure
     plugins:

--- a/.changelog/3374.internal.md
+++ b/.changelog/3374.internal.md
@@ -1,0 +1,1 @@
+ci: Make build-fuzz failures fatal now that upstream is fixed


### PR DESCRIPTION
Fix #3374 