### PR TITLE
github: Replace deprecated set-env command with environment file

### DIFF
--- a/.changelog/3522.internal.md
+++ b/.changelog/3522.internal.md
@@ -1,0 +1,1 @@
+github: Replace deprecated `set-env` workflow command with environment file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           GIT_VERSION=${GITHUB_REF#refs/tags/v}
           if [[ ! ${GIT_VERSION} =~ ^[0-9]+\.[0-9]+$ ]]; then
-            echo ::set-env name=RELEASE_BRANCH::stable/${GIT_VERSION%.*}.x
+            echo "RELEASE_BRANCH=stable/${GIT_VERSION%.*}.x" >> $GITHUB_ENV
           fi
       - name: Build and publish the next release
         run: |


### PR DESCRIPTION
The deprecated `set-env` workflow command used stdout to communicate with a GitHub Action Runner which poses a security issue with workflows that log untrusted data to stdout.

For more details, see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.