### PR TITLE
[BACKPORT/20.12.x] Bump GitHub Actions' versions

### DIFF
--- a/.changelog/3349.internal.md
+++ b/.changelog/3349.internal.md
@@ -1,0 +1,1 @@
+ci: bump actions/setup-python from v2.1.2 to v2.1.3

--- a/.changelog/3364.internal.md
+++ b/.changelog/3364.internal.md
@@ -1,0 +1,1 @@
+ci: Bump actions/setup-node from v2.1.1 to v2.1.2

--- a/.changelog/3365.internal.md
+++ b/.changelog/3365.internal.md
@@ -1,0 +1,1 @@
+ci: Bump actions/setup-go from v2.1.2 to v2.1.3

--- a/.changelog/3367.internal.md
+++ b/.changelog/3367.internal.md
@@ -1,0 +1,1 @@
+ci: Bump actions/upload-artifact from v2.1.4 to v2.2.0

--- a/.changelog/3405.internal.md
+++ b/.changelog/3405.internal.md
@@ -1,0 +1,1 @@
+ci: bump actions/setup-python from v2.1.3 to v2.1.4

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -32,7 +32,7 @@ jobs:
           # Fetch all history so gitlint can check the relevant commits.
           fetch-depth: '0'
       - name: Set up Python 3
-        uses: actions/setup-python@v2.1.3
+        uses: actions/setup-python@v2.1.4
         with:
           python-version: '3.x'
       - name: Set up Node.js 12

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           node-version: "12.x"
       - name: Set up Go 1.15
-        uses: actions/setup-go@v2.1.2
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: "1.15.x"
       - name: Install prerequisites

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -32,7 +32,7 @@ jobs:
           # Fetch all history so gitlint can check the relevant commits.
           fetch-depth: '0'
       - name: Set up Python 3
-        uses: actions/setup-python@v2.1.2
+        uses: actions/setup-python@v2.1.3
         with:
           python-version: '3.x'
       - name: Set up Node.js 12

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Set up Node.js 12
-        uses: actions/setup-node@v2.1.1
+        uses: actions/setup-node@v2.1.2
         with:
           node-version: "12.x"
       - name: Set up Go 1.15

--- a/.github/workflows/ci-reproducibility.yml
+++ b/.github/workflows/ci-reproducibility.yml
@@ -34,7 +34,7 @@ jobs:
           # supported by actions-rs/toolchain.
           cp build${{ matrix.build_number }}/rust-toolchain .
       - name: Set up Go 1.15
-        uses: actions/setup-go@v2.1.2
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: "1.15.x"
       - name: Set up Rust

--- a/.github/workflows/ci-reproducibility.yml
+++ b/.github/workflows/ci-reproducibility.yml
@@ -74,7 +74,7 @@ jobs:
           OASIS_NODE_MAKE_PATH: go/oasis-node/oasis-node
           OASIS_NODE_GORELEASER_PATH: dist/oasis-node_linux_amd64/oasis-node
       - name: Upload checksums
-        uses: actions/upload-artifact@v2.1.4
+        uses: actions/upload-artifact@v2.2.0
         with:
           name: oasis-node-SHA256SUMs-build${{ matrix.build_number }}
           path: oasis-node-SHA256SUMs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Set up Go 1.15
-        uses: actions/setup-go@v2.1.2
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: "1.15.5"
       - name: Set up Rust


### PR DESCRIPTION
The old versions of GitHub Actions that we use rely on `set-env` and `add-path` workflow commands were deprecated and disabled on November 16th.

For more details, see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.