### PR TITLE
go/worker/storage: Fill in additional versions when restoring state

### DIFF
--- a/.changelog/3525.bugfix.md
+++ b/.changelog/3525.bugfix.md
@@ -1,0 +1,6 @@
+go/worker/storage: Fill in additional versions when restoring state
+
+When a storage database from one network is used in a new network (e.g. when
+the consensus layer did a dump/restore upgrade) properly handle the case
+where there were additional rounds after the runtime has stopped (e.g., due
+to epoch transitions).

--- a/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
+++ b/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
@@ -128,7 +128,7 @@ func (sc *gasFeesImpl) Run(childEnv *env.Env) error {
 		if err != nil {
 			return err
 		}
-		if err := sc.DumpRestoreNetwork(childEnv, fixture, false); err != nil {
+		if err := sc.DumpRestoreNetwork(childEnv, fixture, false, nil); err != nil {
 			return err
 		}
 		if err := sc.runTests(ctx); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/runtime/dump_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/dump_restore.go
@@ -1,31 +1,54 @@
 package runtime
 
 import (
+	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
 )
 
-// DumpRestore is the dump and restore scenario.
-var DumpRestore scenario.Scenario = newDumpRestoreImpl()
+var (
+	// DumpRestore is the dump and restore scenario.
+	DumpRestore scenario.Scenario = newDumpRestoreImpl("dump-restore", nil)
+
+	// DumpRestoreRuntimeRoundAdvance is the scenario where additional rounds are simulated after
+	// the runtime stopped in the old network (so storage node state is behind).
+	DumpRestoreRuntimeRoundAdvance scenario.Scenario = newDumpRestoreImpl(
+		"dump-restore/runtime-round-advance",
+		func(doc *genesis.Document) {
+			// Make it look like there were additional rounds (e.g. from epoch transitions) after the
+			// runtime stopped in the old network.
+			for _, st := range doc.RootHash.RuntimeStates {
+				st.Round += 10
+			}
+		},
+	)
+)
 
 type dumpRestoreImpl struct {
 	runtimeImpl
+
+	mapGenesisDocumentFn func(*genesis.Document)
 }
 
-func newDumpRestoreImpl() scenario.Scenario {
+func newDumpRestoreImpl(
+	name string,
+	mapGenesisDocumentFn func(*genesis.Document),
+) scenario.Scenario {
 	sc := &dumpRestoreImpl{
 		runtimeImpl: *newRuntimeImpl(
-			"dump-restore",
+			name,
 			"test-long-term-client",
 			[]string{"--mode", "part1"},
 		),
+		mapGenesisDocumentFn: mapGenesisDocumentFn,
 	}
 	return sc
 }
 
 func (sc *dumpRestoreImpl) Clone() scenario.Scenario {
 	return &dumpRestoreImpl{
-		runtimeImpl: *sc.runtimeImpl.Clone().(*runtimeImpl),
+		runtimeImpl:          *sc.runtimeImpl.Clone().(*runtimeImpl),
+		mapGenesisDocumentFn: sc.mapGenesisDocumentFn,
 	}
 }
 
@@ -50,7 +73,7 @@ func (sc *dumpRestoreImpl) Run(childEnv *env.Env) error {
 	if err != nil {
 		return err
 	}
-	if err = sc.DumpRestoreNetwork(childEnv, fixture, true); err != nil {
+	if err = sc.DumpRestoreNetwork(childEnv, fixture, true, sc.mapGenesisDocumentFn); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -546,6 +546,7 @@ func RegisterScenarios() error {
 		KeymanagerReplicate,
 		// Dump/restore test.
 		DumpRestore,
+		DumpRestoreRuntimeRoundAdvance,
 		// Halt test.
 		HaltRestore,
 		// Multiple runtimes test.


### PR DESCRIPTION
Fixes #3525 

When a storage database from one network is used in a new network (e.g. when
the consensus layer did a dump/restore upgrade) properly handle the case where
there were additional rounds after the runtime has stopped (e.g., due to epoch
transitions).