### PR TITLE
go tendermint: status peers and validator only after started

### DIFF
--- a/.changelog/3534.bugfix.md
+++ b/.changelog/3534.bugfix.md
@@ -1,0 +1,5 @@
+go/consensus/tendermint: status peers and validator only after started
+
+When accessing the node status in very early stages of initialization when a
+Tendermint node structure is not available, the status RPC would make the node
+panic. Leave the peers and validator status blank instead.

--- a/go/consensus/tendermint/full/full.go
+++ b/go/consensus/tendermint/full/full.go
@@ -803,29 +803,29 @@ func (t *fullService) GetStatus(ctx context.Context) (*consensusAPI.Status, erro
 		default:
 			return nil, fmt.Errorf("failed to fetch current block: %w", err)
 		}
-	}
 
-	// List of consensus peers.
-	tmpeers := t.node.Switch().Peers().List()
-	peers := make([]string, 0, len(tmpeers))
-	for _, tmpeer := range tmpeers {
-		p := string(tmpeer.ID()) + "@" + tmpeer.RemoteAddr().String()
-		peers = append(peers, p)
-	}
-	status.NodePeers = peers
+		// List of consensus peers.
+		tmpeers := t.node.Switch().Peers().List()
+		peers := make([]string, 0, len(tmpeers))
+		for _, tmpeer := range tmpeers {
+			p := string(tmpeer.ID()) + "@" + tmpeer.RemoteAddr().String()
+			peers = append(peers, p)
+		}
+		status.NodePeers = peers
 
-	// Check if the local node is in the validator set for the latest (uncommitted) block.
-	valSetHeight := status.LatestHeight + 1
-	if valSetHeight < status.GenesisHeight {
-		valSetHeight = status.GenesisHeight
+		// Check if the local node is in the validator set for the latest (uncommitted) block.
+		valSetHeight := status.LatestHeight + 1
+		if valSetHeight < status.GenesisHeight {
+			valSetHeight = status.GenesisHeight
+		}
+		vals, err := t.stateStore.LoadValidators(valSetHeight)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load validator set: %w", err)
+		}
+		consensusPk := t.identity.ConsensusSigner.Public()
+		consensusAddr := []byte(crypto.PublicKeyToTendermint(&consensusPk).Address())
+		status.IsValidator = vals.HasAddress(consensusAddr)
 	}
-	vals, err := t.stateStore.LoadValidators(valSetHeight)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load validator set: %w", err)
-	}
-	consensusPk := t.identity.ConsensusSigner.Public()
-	consensusAddr := []byte(crypto.PublicKeyToTendermint(&consensusPk).Address())
-	status.IsValidator = vals.HasAddress(consensusAddr)
 
 	return status, nil
 }


### PR DESCRIPTION
Otherwise we won't have `t.node` available.