### PR TITLE
Fix storage sync after non-zero genesis

### DIFF
--- a/.changelog/3538.bugfix.md
+++ b/.changelog/3538.bugfix.md
@@ -1,0 +1,5 @@
+go/worker/storage: Force checkpoint sync when replication is needed
+
+Previously a freshly initialized storage node with no genesis state would
+fall back to incremental sync even though there was no chance of that
+succeeding.

--- a/.changelog/3538.internal.md
+++ b/.changelog/3538.internal.md
@@ -1,0 +1,6 @@
+go/storage/mkvs/checkpoint: Add initial version parameter
+
+Previously if the local database contained a version earlier than the genesis
+version, the checkpointer would attempt to create a new checkpoint at that
+earlier version (and fail). Now the version is clamped at the initial
+version.

--- a/go/oasis-node/cmd/registry/runtime/runtime.go
+++ b/go/oasis-node/cmd/registry/runtime/runtime.go
@@ -389,7 +389,7 @@ func runtimeFromFlags() (*registry.Runtime, signature.Signer, error) { // nolint
 			MaxApplyOps:             viper.GetUint64(CfgStorageMaxApplyOps),
 			CheckpointInterval:      viper.GetUint64(CfgStorageCheckpointInterval),
 			CheckpointNumKept:       viper.GetUint64(CfgStorageCheckpointNumKept),
-			CheckpointChunkSize:     viper.GetUint64(CfgStorageCheckpointChunkSize),
+			CheckpointChunkSize:     uint64(viper.GetSizeInBytes(CfgStorageCheckpointChunkSize)),
 		},
 	}
 	if teeHardware == node.TEEHardwareIntelSGX {
@@ -545,9 +545,9 @@ func init() {
 	runtimeFlags.Uint64(CfgStorageMinWriteReplication, 1, "Minimum required storage write replication")
 	runtimeFlags.Uint64(CfgStorageMaxApplyWriteLogEntries, 100_000, "Maximum number of write log entries")
 	runtimeFlags.Uint64(CfgStorageMaxApplyOps, 2, "Maximum number of apply operations in a batch")
-	runtimeFlags.Uint64(CfgStorageCheckpointInterval, 0, "Storage checkpoint interval (in rounds)")
-	runtimeFlags.Uint64(CfgStorageCheckpointNumKept, 0, "Number of storage checkpoints to keep")
-	runtimeFlags.Uint64(CfgStorageCheckpointChunkSize, 0, "Storage checkpoint chunk size")
+	runtimeFlags.Uint64(CfgStorageCheckpointInterval, 10_000, "Storage checkpoint interval (in rounds)")
+	runtimeFlags.Uint64(CfgStorageCheckpointNumKept, 2, "Number of storage checkpoints to keep")
+	runtimeFlags.String(CfgStorageCheckpointChunkSize, "8mb", "Storage checkpoint chunk size")
 
 	// Init Admission policy flags.
 	runtimeFlags.String(CfgAdmissionPolicy, "", "What type of node admission policy to have")

--- a/go/oasis-test-runner/oasis/cli/cli.go
+++ b/go/oasis-test-runner/oasis/cli/cli.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
+	cmdNode "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/node"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 )
 
@@ -47,6 +49,8 @@ func (b *helpersBase) runSubCommandWithOutput(name string, args []string) (bytes
 
 // Helpers are the oasis-node cli helpers.
 type Helpers struct {
+	*helpersBase
+
 	Consensus  *ConsensusHelpers
 	Registry   *RegistryHelpers
 	Keymanager *KeymanagerHelpers
@@ -61,10 +65,24 @@ func New(env *env.Env, factory Factory, logger *logging.Logger) *Helpers {
 	}
 
 	return &Helpers{
-		Consensus:  &ConsensusHelpers{base},
-		Registry:   &RegistryHelpers{base},
-		Keymanager: &KeymanagerHelpers{base},
+		helpersBase: base,
+		Consensus:   &ConsensusHelpers{base},
+		Registry:    &RegistryHelpers{base},
+		Keymanager:  &KeymanagerHelpers{base},
 	}
+}
+
+// UnsafeReset launches the unsafe-reset subcommand, clearing all consensus and (optionally)
+// runtime state.
+func (h *Helpers) UnsafeReset(dataDir string, preserveRuntimeStorage, preserveLocalStorage bool) error {
+	args := []string{"unsafe-reset", "--" + cmdCommon.CfgDataDir, dataDir}
+	if preserveRuntimeStorage {
+		args = append(args, "--"+cmdNode.CfgPreserveMKVSDatabase)
+	}
+	if preserveLocalStorage {
+		args = append(args, "--"+cmdNode.CfgPreserveLocalStorage)
+	}
+	return h.runSubCommand("unsafe-reset", args)
 }
 
 // StartSubCommand launches an oasis-node subcommand.

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -249,11 +249,12 @@ type NodeCfg struct { // nolint: maligned
 }
 
 // Network is a test Oasis network.
-type Network struct {
+type Network struct { // nolint: maligned
 	logger *logging.Logger
 
 	env     *env.Env
 	baseDir *env.Dir
+	running bool
 
 	entities       []*Entity
 	validators     []*Validator
@@ -496,6 +497,10 @@ func (net *Network) CheckLogWatchers() (err error) {
 
 // Start starts the network.
 func (net *Network) Start() error { // nolint: gocyclo
+	if net.running {
+		return nil
+	}
+
 	net.logger.Info("starting network")
 
 	// Figure out if the IAS proxy is needed by peeking at all the
@@ -711,6 +716,7 @@ func (net *Network) Start() error { // nolint: gocyclo
 	}
 
 	net.logger.Info("network started")
+	net.running = true
 
 	return nil
 }
@@ -718,6 +724,7 @@ func (net *Network) Start() error { // nolint: gocyclo
 // Stop stops the network.
 func (net *Network) Stop() {
 	net.env.Cleanup()
+	net.running = false
 }
 
 func (net *Network) runNodeBinary(consoleWriter io.Writer, args ...string) error {

--- a/go/oasis-test-runner/scenario/e2e/e2e.go
+++ b/go/oasis-test-runner/scenario/e2e/e2e.go
@@ -15,8 +15,6 @@ import (
 	consensusGenesis "github.com/oasisprotocol/oasis-core/go/consensus/genesis"
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
 	genesisFile "github.com/oasisprotocol/oasis-core/go/genesis/file"
-	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
-	cmdNode "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/node"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/cmd"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
@@ -121,47 +119,39 @@ func (sc *E2E) Init(childEnv *env.Env, net *oasis.Network) error {
 // ResetConsensusState removes all consensus state, preserving runtime storage and node-local
 // storage databases.
 func (sc *E2E) ResetConsensusState(childEnv *env.Env) error {
-	doClean := func(dataDir string, cleanArgs []string) error {
-		args := append([]string{
-			"unsafe-reset",
-			"--" + cmdCommon.CfgDataDir, dataDir,
-		}, cleanArgs...)
-
-		return cli.RunSubCommand(childEnv, sc.Logger, "unsafe-reset", sc.Net.Config().NodeBinary, args)
-	}
-
+	cli := cli.New(childEnv, sc.Net, sc.Logger)
 	for _, val := range sc.Net.Validators() {
-		if err := doClean(val.DataDir(), nil); err != nil {
+		if err := cli.UnsafeReset(val.DataDir(), false, false); err != nil {
 			return err
 		}
 	}
 	for _, cw := range sc.Net.ComputeWorkers() {
-		if err := doClean(cw.DataDir(), nil); err != nil {
+		if err := cli.UnsafeReset(cw.DataDir(), false, false); err != nil {
 			return err
 		}
 	}
 	for _, cl := range sc.Net.Clients() {
-		if err := doClean(cl.DataDir(), nil); err != nil {
+		if err := cli.UnsafeReset(cl.DataDir(), false, false); err != nil {
 			return err
 		}
 	}
 	for _, bz := range sc.Net.Byzantine() {
-		if err := doClean(bz.DataDir(), nil); err != nil {
+		if err := cli.UnsafeReset(bz.DataDir(), false, false); err != nil {
 			return err
 		}
 	}
 	for _, se := range sc.Net.Sentries() {
-		if err := doClean(se.DataDir(), nil); err != nil {
+		if err := cli.UnsafeReset(se.DataDir(), false, false); err != nil {
 			return err
 		}
 	}
 	for _, sw := range sc.Net.StorageWorkers() {
-		if err := doClean(sw.DataDir(), []string{"--" + cmdNode.CfgPreserveMKVSDatabase}); err != nil {
+		if err := cli.UnsafeReset(sw.DataDir(), true, false); err != nil {
 			return err
 		}
 	}
 	for _, kw := range sc.Net.Keymanagers() {
-		if err := doClean(kw.DataDir(), []string{"--" + cmdNode.CfgPreserveLocalStorage}); err != nil {
+		if err := cli.UnsafeReset(kw.DataDir(), false, true); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
* go/storage/mkvs/checkpoint: Add initial version parameter

  Previously if the local database contained a version earlier than the genesis
  version, the checkpointer would attempt to create a new checkpoint at that
  earlier version (and fail). Now the version is clamped at the initial version.
* go/worker/storage: Force checkpoint sync when replication is needed
  
  Previously a freshly initialized storage node with no genesis state would fall
  back to incremental sync even though there was no chance of that succeeding.