### PR TITLE
[BACKPORT/20.12.x] go/common/version: Add ConvertGoModulesVersion() function

### DIFF
--- a/.changelog/3546.feature.md
+++ b/.changelog/3546.feature.md
@@ -1,0 +1,7 @@
+go/common/version: Add `ConvertGoModulesVersion()` function
+
+It can be used to convert a Go Modules compatible version defined in
+[ADR 0002] (i.e. a Go Modules compatible Git tag without the `go/` prefix) to
+the canonical Oasis Core version.
+
+[ADR 0002]: docs/adr/0002-go-modules-compatible-git-tags.md

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -3,12 +3,16 @@ package version
 
 import (
 	"fmt"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
 
 	"github.com/tendermint/tendermint/version"
 )
+
+// VersionUndefined represents an undefined version.
+const VersionUndefined = "undefined"
 
 // NOTE: This should be kept in sync with runtime/src/common/version.rs.
 
@@ -121,4 +125,28 @@ func parseSemVerStr(s string) Version {
 	}
 
 	return Version{Major: semVers[0], Minor: semVers[1], Patch: semVers[2]}
+}
+
+var goModulesVersionRegex = regexp.MustCompile(`v0.(?P<year>[0-9]{2})(?P<minor>[0-9]{2}).(?P<micro>[0-9]+)`)
+
+// Convert Go Modules compatible version to Oasis Core's canonical version.
+func ConvertGoModulesVersion(goModVersion string) string {
+	match := goModulesVersionRegex.FindStringSubmatch(goModVersion)
+	// NOTE: match[0] contains the whole matched string.
+	if len(match) != 4 {
+		return VersionUndefined
+	}
+
+	result := make(map[string]string)
+	for i, name := range goModulesVersionRegex.SubexpNames() {
+		if i != 0 && name != "" {
+			result[name] = match[i]
+		}
+	}
+
+	version := result["year"] + "." + strings.TrimPrefix(result["minor"], "0")
+	if result["micro"] != "0" {
+		version += "." + result["micro"]
+	}
+	return version
 }

--- a/go/common/version/version_test.go
+++ b/go/common/version/version_test.go
@@ -1,0 +1,50 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertGoModulesVersion(t *testing.T) {
+	require := require.New(t)
+
+	for _, tc := range []struct {
+		goModVersion    string
+		expectedVersion string
+		valid           bool
+	}{
+		{"v0.2000.0", "20.0", true},
+		{"v0.2000.1", "20.0.1", true},
+		{"v0.2000.2", "20.0.2", true},
+		{"v0.2000.3", "20.0.3", true},
+		{"v0.2001.0", "20.1", true},
+		{"v0.2001.0", "20.1", true},
+		{"v0.2001.1", "20.1.1", true},
+		{"v0.2001.2", "20.1.2", true},
+		{"v0.2010.0", "20.10", true},
+		{"v0.2010.1", "20.10.1", true},
+		{"v0.2010.2", "20.10.2", true},
+		{"v0.2100.0", "21.0", true},
+		{"v0.2100.1", "21.0.1", true},
+		{"v0.2101.0", "21.1", true},
+		{"v0.2101.1", "21.1.1", true},
+		{"v0.2101.10", "21.1.10", true},
+		{"v0.2101.100", "21.1.100", true},
+		{"v0.2199.0", "21.99", true},
+		{"v0.2199.100", "21.99.100", true},
+		{"v0.21100.0", "", false},
+		{"0.2100.0", "", false},
+		{"0.210.0", "", false},
+		{"0.21.0", "", false},
+		{"21.0", "", false},
+		{"21.0.0", "", false},
+	} {
+		version := ConvertGoModulesVersion(tc.goModVersion)
+		if tc.valid {
+			require.Equal(tc.expectedVersion, version, "Valid Go modules version doesn't match")
+		} else {
+			require.Equal(VersionUndefined, version, "Invalid Go modules version is not undefined")
+		}
+	}
+}


### PR DESCRIPTION
Backport of #3546.