### PR TITLE
Modify runtime descriptors to support ADR 0004

### DIFF
--- a/.changelog/3450.breaking.2.md
+++ b/.changelog/3450.breaking.2.md
@@ -1,0 +1,10 @@
+Remove `SignedRuntime`
+
+As part of the work on [ADR 0004], support for signed runtime descriptors
+has been removed, since they are no longer required.
+All methods that used to take signed runtime descriptors now take
+non-signed runtime descriptors instead.
+This also affects the genesis file, use the `oasis-node debug fix-genesis`
+command to convert a genesis file from the old format to the new one.
+
+[ADR 0004]: docs/adr/0004-runtime-governance.md

--- a/.changelog/3450.breaking.md
+++ b/.changelog/3450.breaking.md
@@ -1,0 +1,6 @@
+Modify runtime descriptors to support ADR 0004
+
+As described in [ADR 0004], the runtime descriptors are modified to
+enable runtime governance.
+
+[ADR 0004]: docs/adr/0004-runtime-governance.md

--- a/.changelog/3450.internal.md
+++ b/.changelog/3450.internal.md
@@ -1,0 +1,1 @@
+Add `GetEntityNodes()` query to registry state

--- a/docs/consensus/genesis.md
+++ b/docs/consensus/genesis.md
@@ -53,7 +53,7 @@ launch, see: [Genesis File Overview].
 {% endhint %}
 
 [Genesis File Overview]:
-  https://docs.oasis.dev/general/pre-mainnet/genesis-file
+  https://docs.oasis.dev/general/mainnet/genesis-file
 
 ### Canonical Form
 

--- a/docs/consensus/registry.md
+++ b/docs/consensus/registry.md
@@ -51,12 +51,25 @@ offline and having entities as separate resources enables that.
 
 A [runtime] is effectively a replicated application with shared state. The
 registry resource describes a runtime's operational parameters, including its
-identifier, kind, admission policy, committee scheduling, storage etc. For a
-full description of the runtime descriptor see [the `Runtime` structure].
+identifier, kind, admission policy, committee scheduling, storage, governance
+model, etc. For a full description of the runtime descriptor see
+[the `Runtime` structure].
 
-Currently only the owning entity is allowed to make any modifications to the
-runtime. There are plans to enable runtimes to update their own descriptors in
-the future to enable runtimes to be self-governing.
+<!-- markdownlint-disable no-space-in-emphasis -->
+The chosen governance model indicates how the runtime descriptor can be updated
+in the future.
+
+There are currently three supported governance models:
+
+* **Entity governance** where the runtime owner is the only one who can update
+  the runtime descriptor via `registry.RegisterRuntime` method calls.
+
+* **Runtime-defined governance** where the runtime itself is the only one who
+  can update the runtime descriptor by emitting a runtime message.
+
+* **Consensus layer governance** where only the consensus layer itself can
+  update the runtime descriptor through network governance.
+<!-- markdownlint-enable no-space-in-emphasis -->
 
 <!-- markdownlint-disable line-length -->
 [runtime]: ../runtime/index.md
@@ -209,16 +222,18 @@ runtime transaction can be generated using [`NewRegisterRuntimeTx`].
 registry.RegisterRuntime
 ```
 
-The body of a register runtime transaction must be a [`SignedRuntime`]
-structure, which is a [signed envelope] containing a [`Runtime`] descriptor.
+The body of a register runtime transaction must be a [`Runtime`] descriptor.
 The signer of the transaction MUST be the owning entity key.
 
-Registering a runtime may require sufficient stake in the owning entity's
-[escrow account].
+Registering a runtime may require sufficient stake in either the owning
+entity's (when entity governance is used) or the runtime's (when runtime
+governance is used) [escrow account].
+
+Changing the governance model from entity governance to runtime governance is
+allowed. Any other governance model changes are not allowed.
 
 <!-- markdownlint-disable line-length -->
 [`NewRegisterRuntimeTx`]: https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go/registry/api?tab=doc#NewRegisterRuntimeTx
-[`SignedRuntime`]: https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go/registry/api?tab=doc#SignedRuntime
 [`Runtime`]: https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go/registry/api?tab=doc#Runtime
 <!-- markdownlint-enable line-length -->
 

--- a/go/consensus/tendermint/apps/keymanager/genesis.go
+++ b/go/consensus/tendermint/apps/keymanager/genesis.go
@@ -30,8 +30,8 @@ func (app *keymanagerApplication) InitChain(ctx *tmapi.Context, request types.Re
 	// list.
 	regSt := doc.Registry
 	rtMap := make(map[common.Namespace]*registry.Runtime)
-	for _, v := range regSt.Runtimes {
-		rt, err := registry.VerifyRegisterRuntimeArgs(&regSt.Parameters, ctx.Logger(), v, true, false)
+	for _, rt := range regSt.Runtimes {
+		err := registry.VerifyRuntime(&regSt.Parameters, ctx.Logger(), rt, true, false)
 		if err != nil {
 			ctx.Logger().Error("InitChain: Invalid runtime",
 				"err", err,

--- a/go/consensus/tendermint/apps/registry/registry.go
+++ b/go/consensus/tendermint/apps/registry/registry.go
@@ -95,12 +95,11 @@ func (app *registryApplication) ExecuteTx(ctx *api.Context, tx *transaction.Tran
 
 		return app.unfreezeNode(ctx, state, &unfreeze)
 	case registry.MethodRegisterRuntime:
-		var sigRt registry.SignedRuntime
-		if err := cbor.Unmarshal(tx.Body, &sigRt); err != nil {
+		var rt registry.Runtime
+		if err := cbor.Unmarshal(tx.Body, &rt); err != nil {
 			return err
 		}
-
-		return app.registerRuntime(ctx, state, &sigRt)
+		return app.registerRuntime(ctx, state, &rt)
 	default:
 		return registry.ErrInvalidArgument
 	}

--- a/go/consensus/tendermint/apps/registry/state/state.go
+++ b/go/consensus/tendermint/apps/registry/state/state.go
@@ -33,10 +33,10 @@ var (
 	//
 	// Value is empty.
 	signedNodeByEntityKeyFmt = keyformat.New(0x12, keyformat.H(&signature.PublicKey{}), keyformat.H(&signature.PublicKey{}))
-	// signedRuntimeKeyFmt is the key format used for signed runtimes.
+	// runtimeKeyFmt is the key format used for runtimes.
 	//
-	// Value is CBOR-serialized signed runtime.
-	signedRuntimeKeyFmt = keyformat.New(0x13, keyformat.H(&common.Namespace{}))
+	// Value is CBOR-serialized runtime.
+	runtimeKeyFmt = keyformat.New(0x13, keyformat.H(&common.Namespace{}))
 	// nodeByConsAddressKeyFmt is the key format used for the consensus address to
 	// node public key mapping.
 	//
@@ -62,13 +62,13 @@ var (
 	keyMapKeyFmt = keyformat.New(0x17, keyformat.H(&signature.PublicKey{}))
 	// suspendedRuntimeKeyFmt is the key format used for suspended runtimes.
 	//
-	// Value is CBOR-serialized signed runtime.
+	// Value is CBOR-serialized runtime.
 	suspendedRuntimeKeyFmt = keyformat.New(0x18, keyformat.H(&common.Namespace{}))
-	// signedRuntimeByEntityKeyFmt is the key format used for signed runtime by entity
+	// runtimeByEntityKeyFmt is the key format used for runtime by entity
 	// index.
 	//
 	// Value is empty.
-	signedRuntimeByEntityKeyFmt = keyformat.New(0x19, keyformat.H(&signature.PublicKey{}), keyformat.H(&common.Namespace{}))
+	runtimeByEntityKeyFmt = keyformat.New(0x19, keyformat.H(&signature.PublicKey{}), keyformat.H(&common.Namespace{}))
 )
 
 // ImmutableState is the immutable registry state wrapper.
@@ -250,7 +250,7 @@ func (s *ImmutableState) SignedNodes(ctx context.Context) ([]*node.MultiSignedNo
 	return nodes, nil
 }
 
-func (s *ImmutableState) getSignedRuntime(ctx context.Context, keyFmt *keyformat.KeyFormat, id common.Namespace) (*registry.SignedRuntime, error) {
+func (s *ImmutableState) getRuntime(ctx context.Context, keyFmt *keyformat.KeyFormat, id common.Namespace) (*registry.Runtime, error) {
 	raw, err := s.is.Get(ctx, keyFmt.Encode(&id))
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
@@ -259,20 +259,8 @@ func (s *ImmutableState) getSignedRuntime(ctx context.Context, keyFmt *keyformat
 		return nil, registry.ErrNoSuchRuntime
 	}
 
-	var signedRuntime registry.SignedRuntime
-	if err := cbor.Unmarshal(raw, &signedRuntime); err != nil {
-		return nil, abciAPI.UnavailableStateError(err)
-	}
-	return &signedRuntime, nil
-}
-
-func (s *ImmutableState) getRuntime(ctx context.Context, keyFmt *keyformat.KeyFormat, id common.Namespace) (*registry.Runtime, error) {
-	signedRuntime, err := s.getSignedRuntime(ctx, keyFmt, id)
-	if err != nil {
-		return nil, err
-	}
 	var runtime registry.Runtime
-	if err = cbor.Unmarshal(signedRuntime.Blob, &runtime); err != nil {
+	if err := cbor.Unmarshal(raw, &runtime); err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
 	return &runtime, nil
@@ -283,7 +271,7 @@ func (s *ImmutableState) getRuntime(ctx context.Context, keyFmt *keyformat.KeyFo
 // This excludes any suspended runtimes, use SuspendedRuntime to query
 // suspended runtimes only.
 func (s *ImmutableState) Runtime(ctx context.Context, id common.Namespace) (*registry.Runtime, error) {
-	return s.getRuntime(ctx, signedRuntimeKeyFmt, id)
+	return s.getRuntime(ctx, runtimeKeyFmt, id)
 }
 
 // SuspendedRuntime looks up a suspended runtime by its identifier and
@@ -301,23 +289,10 @@ func (s *ImmutableState) AnyRuntime(ctx context.Context, id common.Namespace) (r
 	return
 }
 
-// SignedRuntime looks up a (signed) runtime by its identifier and returns it.
-//
-// This excludes any suspended runtimes, use SuspendedSignedRuntime to query
-// suspended runtimes only.
-func (s *ImmutableState) SignedRuntime(ctx context.Context, id common.Namespace) (*registry.SignedRuntime, error) {
-	return s.getSignedRuntime(ctx, signedRuntimeKeyFmt, id)
-}
-
-// SignedSuspendedRuntime looks up a (signed) suspended runtime by its identifier and returns it.
-func (s *ImmutableState) SignedSuspendedRuntime(ctx context.Context, id common.Namespace) (*registry.SignedRuntime, error) {
-	return s.getSignedRuntime(ctx, suspendedRuntimeKeyFmt, id)
-}
-
 func (s *ImmutableState) iterateRuntimes(
 	ctx context.Context,
 	keyFmt *keyformat.KeyFormat,
-	cb func(*registry.SignedRuntime) error,
+	cb func(*registry.Runtime) error,
 ) error {
 	it := s.is.NewIterator(ctx)
 	defer it.Close()
@@ -327,64 +302,16 @@ func (s *ImmutableState) iterateRuntimes(
 			break
 		}
 
-		var signedRt registry.SignedRuntime
-		if err := cbor.Unmarshal(it.Value(), &signedRt); err != nil {
+		var rt registry.Runtime
+		if err := cbor.Unmarshal(it.Value(), &rt); err != nil {
 			return abciAPI.UnavailableStateError(err)
 		}
 
-		if err := cb(&signedRt); err != nil {
+		if err := cb(&rt); err != nil {
 			return err
 		}
 	}
 	return abciAPI.UnavailableStateError(it.Err())
-}
-
-// SignedRuntimes returns a list of all registered runtimes (signed).
-//
-// This excludes any suspended runtimes.
-func (s *ImmutableState) SignedRuntimes(ctx context.Context) ([]*registry.SignedRuntime, error) {
-	var runtimes []*registry.SignedRuntime
-	err := s.iterateRuntimes(ctx, signedRuntimeKeyFmt, func(rt *registry.SignedRuntime) error {
-		runtimes = append(runtimes, rt)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return runtimes, nil
-}
-
-// SuspendedRuntimes returns a list of all suspended runtimes (signed).
-func (s *ImmutableState) SuspendedRuntimes(ctx context.Context) ([]*registry.SignedRuntime, error) {
-	var runtimes []*registry.SignedRuntime
-	err := s.iterateRuntimes(ctx, suspendedRuntimeKeyFmt, func(rt *registry.SignedRuntime) error {
-		runtimes = append(runtimes, rt)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return runtimes, nil
-}
-
-// AllSignedRuntimes returns a list of all runtimes (suspended included).
-func (s *ImmutableState) AllSignedRuntimes(ctx context.Context) ([]*registry.SignedRuntime, error) {
-	var runtimes []*registry.SignedRuntime
-	err := s.iterateRuntimes(ctx, signedRuntimeKeyFmt, func(rt *registry.SignedRuntime) error {
-		runtimes = append(runtimes, rt)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	err = s.iterateRuntimes(ctx, suspendedRuntimeKeyFmt, func(rt *registry.SignedRuntime) error {
-		runtimes = append(runtimes, rt)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return runtimes, nil
 }
 
 // Runtimes returns a list of all registered runtimes.
@@ -392,12 +319,21 @@ func (s *ImmutableState) AllSignedRuntimes(ctx context.Context) ([]*registry.Sig
 // This excludes any suspended runtimes.
 func (s *ImmutableState) Runtimes(ctx context.Context) ([]*registry.Runtime, error) {
 	var runtimes []*registry.Runtime
-	err := s.iterateRuntimes(ctx, signedRuntimeKeyFmt, func(sigRt *registry.SignedRuntime) error {
-		var rt registry.Runtime
-		if err := cbor.Unmarshal(sigRt.Blob, &rt); err != nil {
-			return abciAPI.UnavailableStateError(err)
-		}
-		runtimes = append(runtimes, &rt)
+	err := s.iterateRuntimes(ctx, runtimeKeyFmt, func(rt *registry.Runtime) error {
+		runtimes = append(runtimes, rt)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return runtimes, nil
+}
+
+// SuspendedRuntimes returns a list of all suspended runtimes.
+func (s *ImmutableState) SuspendedRuntimes(ctx context.Context) ([]*registry.Runtime, error) {
+	var runtimes []*registry.Runtime
+	err := s.iterateRuntimes(ctx, suspendedRuntimeKeyFmt, func(rt *registry.Runtime) error {
+		runtimes = append(runtimes, rt)
 		return nil
 	})
 	if err != nil {
@@ -409,15 +345,11 @@ func (s *ImmutableState) Runtimes(ctx context.Context) ([]*registry.Runtime, err
 // AllRuntimes returns a list of all registered runtimes (suspended included).
 func (s *ImmutableState) AllRuntimes(ctx context.Context) ([]*registry.Runtime, error) {
 	var runtimes []*registry.Runtime
-	unpackFn := func(sigRt *registry.SignedRuntime) error {
-		var rt registry.Runtime
-		if err := cbor.Unmarshal(sigRt.Blob, &rt); err != nil {
-			return abciAPI.UnavailableStateError(err)
-		}
-		runtimes = append(runtimes, &rt)
+	unpackFn := func(rt *registry.Runtime) error {
+		runtimes = append(runtimes, rt)
 		return nil
 	}
-	if err := s.iterateRuntimes(ctx, signedRuntimeKeyFmt, unpackFn); err != nil {
+	if err := s.iterateRuntimes(ctx, runtimeKeyFmt, unpackFn); err != nil {
 		return nil, err
 	}
 	if err := s.iterateRuntimes(ctx, suspendedRuntimeKeyFmt, unpackFn); err != nil {
@@ -443,6 +375,46 @@ func (s *ImmutableState) NodeStatus(ctx context.Context, id signature.PublicKey)
 	return &status, nil
 }
 
+// GetEntityNodes returns nodes registered by given entity.
+// Note that this returns both active and expired nodes.
+func (s *ImmutableState) GetEntityNodes(ctx context.Context, id signature.PublicKey) ([]*node.Node, error) {
+	it := s.is.NewIterator(ctx)
+	defer it.Close()
+
+	hID := keyformat.PreHashed(id.Hash())
+
+	var nodes []*node.Node
+	for it.Seek(signedNodeByEntityKeyFmt.Encode(&id)); it.Valid(); it.Next() {
+		var hEntityID keyformat.PreHashed
+		var hNodeID keyformat.PreHashed
+
+		if !signedNodeByEntityKeyFmt.Decode(it.Key(), &hEntityID, &hNodeID) || !hEntityID.Equal(&hID) {
+			break
+		}
+
+		rawSignedNode, err := s.is.Get(ctx, signedNodeKeyFmt.Encode(&hNodeID))
+		if err != nil {
+			return nil, abciAPI.UnavailableStateError(err)
+		}
+		if rawSignedNode == nil {
+			return nil, abciAPI.UnavailableStateError(registry.ErrNoSuchNode)
+		}
+		var signedNode node.MultiSignedNode
+		if err = cbor.Unmarshal(rawSignedNode, &signedNode); err != nil {
+			return nil, abciAPI.UnavailableStateError(err)
+		}
+		var node node.Node
+		if err = cbor.Unmarshal(signedNode.Blob, &node); err != nil {
+			return nil, abciAPI.UnavailableStateError(err)
+		}
+
+		nodes = append(nodes, &node)
+	}
+
+	registry.SortNodeList(nodes)
+	return nodes, nil
+}
+
 // HasEntityNodes checks whether an entity has any registered nodes.
 func (s *ImmutableState) HasEntityNodes(ctx context.Context, id signature.PublicKey) (bool, error) {
 	it := s.is.NewIterator(ctx)
@@ -465,9 +437,9 @@ func (s *ImmutableState) HasEntityRuntimes(ctx context.Context, id signature.Pub
 	defer it.Close()
 
 	hID := keyformat.PreHashed(id.Hash())
-	if it.Seek(signedRuntimeByEntityKeyFmt.Encode(&id)); it.Valid() {
+	if it.Seek(runtimeByEntityKeyFmt.Encode(&id)); it.Valid() {
 		var hEntityID keyformat.PreHashed
-		if !signedRuntimeByEntityKeyFmt.Decode(it.Key(), &hEntityID) || !hEntityID.Equal(&hID) {
+		if !runtimeByEntityKeyFmt.Decode(it.Key(), &hEntityID) || !hEntityID.Equal(&hID) {
 			return false, nil
 		}
 		return true, nil
@@ -641,24 +613,24 @@ func (s *MutableState) RemoveNode(ctx context.Context, node *node.Node) error {
 	return nil
 }
 
-// SetRuntime sets a signed runtime descriptor for a registered runtime.
-func (s *MutableState) SetRuntime(ctx context.Context, rt *registry.Runtime, sigRt *registry.SignedRuntime, suspended bool) error {
-	if err := s.ms.Insert(ctx, signedRuntimeByEntityKeyFmt.Encode(&rt.EntityID, &rt.ID), []byte("")); err != nil {
+// SetRuntime sets a runtime descriptor for a registered runtime.
+func (s *MutableState) SetRuntime(ctx context.Context, rt *registry.Runtime, suspended bool) error {
+	if err := s.ms.Insert(ctx, runtimeByEntityKeyFmt.Encode(&rt.EntityID, &rt.ID), []byte("")); err != nil {
 		return abciAPI.UnavailableStateError(err)
 	}
 
 	var err error
 	if suspended {
-		err = s.ms.Insert(ctx, suspendedRuntimeKeyFmt.Encode(&rt.ID), cbor.Marshal(sigRt))
+		err = s.ms.Insert(ctx, suspendedRuntimeKeyFmt.Encode(&rt.ID), cbor.Marshal(rt))
 	} else {
-		err = s.ms.Insert(ctx, signedRuntimeKeyFmt.Encode(&rt.ID), cbor.Marshal(sigRt))
+		err = s.ms.Insert(ctx, runtimeKeyFmt.Encode(&rt.ID), cbor.Marshal(rt))
 	}
 	return abciAPI.UnavailableStateError(err)
 }
 
 // SuspendRuntime marks a runtime as suspended.
 func (s *MutableState) SuspendRuntime(ctx context.Context, id common.Namespace) error {
-	data, err := s.ms.RemoveExisting(ctx, signedRuntimeKeyFmt.Encode(&id))
+	data, err := s.ms.RemoveExisting(ctx, runtimeKeyFmt.Encode(&id))
 	if err != nil {
 		return abciAPI.UnavailableStateError(err)
 	}
@@ -678,7 +650,7 @@ func (s *MutableState) ResumeRuntime(ctx context.Context, id common.Namespace) e
 	if data == nil {
 		return registry.ErrNoSuchRuntime
 	}
-	err = s.ms.Insert(ctx, signedRuntimeKeyFmt.Encode(&id), data)
+	err = s.ms.Insert(ctx, runtimeKeyFmt.Encode(&id), data)
 	return abciAPI.UnavailableStateError(err)
 }
 

--- a/go/consensus/tendermint/apps/registry/transactions_test.go
+++ b/go/consensus/tendermint/apps/registry/transactions_test.go
@@ -121,14 +121,13 @@ func TestRegisterNode(t *testing.T) {
 			"ComputeNode",
 			func(tcd *testCaseData) {
 				// Create a new runtime.
-				rtSigner := memorySigner.NewTestSigner("consensus/tendermint/apps/registry: runtime signer: ComputeNode")
 				rt := registry.Runtime{
-					Versioned: cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
-					ID:        common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNode"), 0),
-					Kind:      registry.KindCompute,
+					Versioned:       cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+					ID:              common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNode"), 0),
+					Kind:            registry.KindCompute,
+					GovernanceModel: registry.GovernanceEntity,
 				}
-				sigRt, _ := registry.SignRuntime(rtSigner, registry.RegisterRuntimeSignatureContext, &rt)
-				_ = state.SetRuntime(ctx, &rt, sigRt, false)
+				_ = state.SetRuntime(ctx, &rt, false)
 
 				tcd.node.AddRoles(node.RoleComputeWorker)
 				tcd.node.Runtimes = []*node.Runtime{
@@ -144,7 +143,6 @@ func TestRegisterNode(t *testing.T) {
 			"ComputeNodeWithoutPerRuntimeStake",
 			func(tcd *testCaseData) {
 				// Create a new runtime.
-				rtSigner := memorySigner.NewTestSigner("consensus/tendermint/apps/registry: runtime signer: ComputeNodeWithoutPerRuntimeStake")
 				rt := registry.Runtime{
 					Versioned: cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
 					ID:        common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNodeWithoutPerRuntimeStake"), 0),
@@ -154,9 +152,9 @@ func TestRegisterNode(t *testing.T) {
 							staking.KindNodeCompute: *quantity.NewFromUint64(1000),
 						},
 					},
+					GovernanceModel: registry.GovernanceEntity,
 				}
-				sigRt, _ := registry.SignRuntime(rtSigner, registry.RegisterRuntimeSignatureContext, &rt)
-				_ = state.SetRuntime(ctx, &rt, sigRt, false)
+				_ = state.SetRuntime(ctx, &rt, false)
 
 				tcd.node.AddRoles(node.RoleComputeWorker)
 				tcd.node.Runtimes = []*node.Runtime{
@@ -172,7 +170,6 @@ func TestRegisterNode(t *testing.T) {
 			"ComputeNodeWithPerRuntimeStake",
 			func(tcd *testCaseData) {
 				// Create a new runtime.
-				rtSigner := memorySigner.NewTestSigner("consensus/tendermint/apps/registry: runtime signer: ComputeNodeWithPerRuntimeStake")
 				rt := registry.Runtime{
 					Versioned: cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
 					ID:        common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNodeWithPerRuntimeStake"), 0),
@@ -182,9 +179,9 @@ func TestRegisterNode(t *testing.T) {
 							staking.KindNodeCompute: *quantity.NewFromUint64(1000),
 						},
 					},
+					GovernanceModel: registry.GovernanceEntity,
 				}
-				sigRt, _ := registry.SignRuntime(rtSigner, registry.RegisterRuntimeSignatureContext, &rt)
-				_ = state.SetRuntime(ctx, &rt, sigRt, false)
+				_ = state.SetRuntime(ctx, &rt, false)
 
 				// Add bonded stake (hacky, without a self-delegation).
 				_ = stakeState.SetAccount(ctx, staking.NewAddress(tcd.node.EntityID), &staking.Account{
@@ -208,8 +205,6 @@ func TestRegisterNode(t *testing.T) {
 		{
 			"ComputeNodeWithoutPerRuntimeStakeMulti",
 			func(tcd *testCaseData) {
-				rtSigner := memorySigner.NewTestSigner("consensus/tendermint/apps/registry: runtime signer: ComputeNodeWithoutPerRuntimeStakeMulti")
-
 				// Create a new runtime.
 				rt1 := registry.Runtime{
 					Versioned: cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
@@ -220,15 +215,14 @@ func TestRegisterNode(t *testing.T) {
 							staking.KindNodeCompute: *quantity.NewFromUint64(1000),
 						},
 					},
+					GovernanceModel: registry.GovernanceEntity,
 				}
-				sigRt1, _ := registry.SignRuntime(rtSigner, registry.RegisterRuntimeSignatureContext, &rt1)
-				_ = state.SetRuntime(ctx, &rt1, sigRt1, false)
+				_ = state.SetRuntime(ctx, &rt1, false)
 
 				// Create another runtime with a different identifier.
 				rt2 := rt1
 				rt2.ID = common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNodeWithoutPerRuntimeStakeMulti 2"), 0)
-				sigRt2, _ := registry.SignRuntime(rtSigner, registry.RegisterRuntimeSignatureContext, &rt2)
-				_ = state.SetRuntime(ctx, &rt2, sigRt2, false)
+				_ = state.SetRuntime(ctx, &rt2, false)
 
 				// Add bonded stake (hacky, without a self-delegation).
 				_ = stakeState.SetAccount(ctx, staking.NewAddress(tcd.node.EntityID), &staking.Account{
@@ -253,22 +247,19 @@ func TestRegisterNode(t *testing.T) {
 		{
 			"ComputeNodeWithoutGlobalStakeMulti",
 			func(tcd *testCaseData) {
-				rtSigner := memorySigner.NewTestSigner("consensus/tendermint/apps/registry: runtime signer: ComputeNodeWithoutGlobalStakeMulti")
-
 				// Create a new runtime.
 				rt1 := registry.Runtime{
-					Versioned: cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
-					ID:        common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNodeWithoutGlobalStakeMulti 1"), 0),
-					Kind:      registry.KindCompute,
+					Versioned:       cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+					ID:              common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNodeWithoutGlobalStakeMulti 1"), 0),
+					Kind:            registry.KindCompute,
+					GovernanceModel: registry.GovernanceEntity,
 				}
-				sigRt1, _ := registry.SignRuntime(rtSigner, registry.RegisterRuntimeSignatureContext, &rt1)
-				_ = state.SetRuntime(ctx, &rt1, sigRt1, false)
+				_ = state.SetRuntime(ctx, &rt1, false)
 
 				// Create another runtime with a different identifier.
 				rt2 := rt1
 				rt2.ID = common.NewTestNamespaceFromSeed([]byte("consensus/tendermint/apps/registry: runtime: ComputeNodeWithoutGlobalStakeMulti 2"), 0)
-				sigRt2, _ := registry.SignRuntime(rtSigner, registry.RegisterRuntimeSignatureContext, &rt2)
-				_ = state.SetRuntime(ctx, &rt2, sigRt2, false)
+				_ = state.SetRuntime(ctx, &rt2, false)
 
 				// Add bonded stake (hacky, without a self-delegation).
 				_ = stakeState.SetAccount(ctx, staking.NewAddress(tcd.node.EntityID), &staking.Account{

--- a/go/consensus/tendermint/apps/supplementarysanity/checks.go
+++ b/go/consensus/tendermint/apps/supplementarysanity/checks.go
@@ -48,16 +48,16 @@ func checkRegistry(ctx *abciAPI.Context, now epochtime.EpochTime) error {
 	}
 
 	// Check runtimes.
-	signedRuntimes, err := st.SignedRuntimes(ctx)
+	runtimes, err := st.Runtimes(ctx)
 	if err != nil {
-		return fmt.Errorf("AllSignedRuntimes: %w", err)
+		return fmt.Errorf("Runtimes: %w", err)
 	}
 	suspendedRuntimes, err := st.SuspendedRuntimes(ctx)
 	if err != nil {
 		return fmt.Errorf("SuspendedRuntimes: %w", err)
 	}
 
-	runtimeLookup, err := registry.SanityCheckRuntimes(logger, params, signedRuntimes, suspendedRuntimes, false)
+	runtimeLookup, err := registry.SanityCheckRuntimes(logger, params, runtimes, suspendedRuntimes, false)
 	if err != nil {
 		return fmt.Errorf("SanityCheckRuntimes: %w", err)
 	}

--- a/go/consensus/tendermint/tests/genesis/genesis.go
+++ b/go/consensus/tendermint/tests/genesis/genesis.go
@@ -58,6 +58,10 @@ func NewTestNodeGenesisProvider(identity *identity.Identity) (genesis.Provider, 
 				DebugAllowTestRuntimes:                 true,
 				DebugAllowEntitySignedNodeRegistration: true,
 				DebugBypassStake:                       true,
+				EnableRuntimeGovernanceModels: map[registry.RuntimeGovernanceModel]bool{
+					registry.GovernanceEntity:  true,
+					registry.GovernanceRuntime: true,
+				},
 			},
 		},
 		Scheduler: scheduler.Genesis{

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -108,6 +108,7 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 					GroupSize:       2,
 					GroupBackupSize: 1,
 					RoundTimeout:    20,
+					MinPoolSize:     3, // GroupSize + GroupBackupSize
 				},
 				TxnScheduler: registry.TxnSchedulerParameters{
 					Algorithm:         registry.TxnSchedulerSimple,
@@ -121,6 +122,7 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 					MinWriteReplication:     1,
 					MaxApplyWriteLogEntries: 100_000,
 					MaxApplyOps:             2,
+					MinPoolSize:             1,
 				},
 				AdmissionPolicy: registry.RuntimeAdmissionPolicy{
 					AnyNode: &registry.AnyNodeRuntimeAdmissionPolicy{},

--- a/go/oasis-node/cmd/ias/auth_genesis.go
+++ b/go/oasis-node/cmd/ias/auth_genesis.go
@@ -7,7 +7,6 @@ import (
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/file"
 	ias "github.com/oasisprotocol/oasis-core/go/ias/api"
 	iasProxy "github.com/oasisprotocol/oasis-core/go/ias/proxy"
-	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 )
 
 type genesisAuthenticator struct {
@@ -51,13 +50,8 @@ func newGenesisAuthenticator() (iasProxy.Authenticator, error) {
 		logger:   logging.GetLogger("cmd/ias/proxy/auth/genesis"),
 		enclaves: newEnclaveStore(),
 	}
-	for _, v := range doc.Registry.Runtimes {
-		var rt registry.Runtime
-		if err = v.Open(registry.RegisterGenesisRuntimeSignatureContext, &rt); err != nil {
-			return nil, err
-		}
-
-		if _, err = auth.enclaves.addRuntime(&rt); err != nil {
+	for _, rt := range doc.Registry.Runtimes {
+		if _, err = auth.enclaves.addRuntime(rt); err != nil {
 			return nil, err
 		}
 	}

--- a/go/oasis-node/node_test.go
+++ b/go/oasis-node/node_test.go
@@ -90,6 +90,7 @@ var (
 			GroupSize:       1,
 			GroupBackupSize: 0,
 			RoundTimeout:    20,
+			MinPoolSize:     1,
 		},
 		TxnScheduler: registry.TxnSchedulerParameters{
 			Algorithm:         registry.TxnSchedulerSimple,
@@ -103,10 +104,12 @@ var (
 			MinWriteReplication:     1,
 			MaxApplyWriteLogEntries: 100_000,
 			MaxApplyOps:             2,
+			MinPoolSize:             1,
 		},
 		AdmissionPolicy: registry.RuntimeAdmissionPolicy{
 			AnyNode: &registry.AnyNodeRuntimeAdmissionPolicy{},
 		},
+		GovernanceModel: registry.GovernanceEntity,
 	}
 
 	testRuntimeID common.Namespace
@@ -287,9 +290,7 @@ func testRegisterEntityRuntime(t *testing.T, node *testNode) {
 	require.NoError(err, "register test entity")
 
 	// Register the test runtime.
-	signedRt, err := registry.SignRuntime(testEntitySigner, registry.RegisterRuntimeSignatureContext, testRuntime)
-	require.NoError(err, "sign runtime descriptor")
-	tx = registry.NewRegisterRuntimeTx(0, nil, signedRt)
+	tx = registry.NewRegisterRuntimeTx(0, nil, testRuntime)
 	err = consensusAPI.SignAndSubmitTx(context.Background(), node.Consensus, testEntitySigner, tx)
 	require.NoError(err, "register test entity")
 

--- a/go/oasis-test-runner/oasis/cli/registry.go
+++ b/go/oasis-test-runner/oasis/cli/registry.go
@@ -30,6 +30,7 @@ func (r *RegistryHelpers) runRegistryRuntimeSubcommand(
 		"--" + cmdRegRt.CfgTEEHardware, runtime.TEEHardware.String(),
 		"--" + cmdRegRt.CfgKind, runtime.Kind.String(),
 		"--" + cmdRegRt.CfgVersion, runtime.Version.Version.String(),
+		"--" + cmdRegRt.CfgGovernanceModel, runtime.GovernanceModel.String(),
 	}
 	args = append(args, extraArgs...)
 
@@ -59,6 +60,7 @@ func (r *RegistryHelpers) runRegistryRuntimeSubcommand(
 			"--"+cmdRegRt.CfgExecutorAllowedStragglers, strconv.FormatUint(runtime.Executor.AllowedStragglers, 10),
 			"--"+cmdRegRt.CfgExecutorRoundTimeout, strconv.FormatInt(runtime.Executor.RoundTimeout, 10),
 			"--"+cmdRegRt.CfgExecutorMaxMessages, strconv.FormatUint(uint64(runtime.Executor.MaxMessages), 10),
+			"--"+cmdRegRt.CfgExecutorMinPoolSize, strconv.FormatUint(runtime.Executor.MinPoolSize, 10),
 			"--"+cmdRegRt.CfgStorageGroupSize, strconv.FormatUint(runtime.Storage.GroupSize, 10),
 			"--"+cmdRegRt.CfgStorageMinWriteReplication, strconv.FormatUint(runtime.Storage.MinWriteReplication, 10),
 			"--"+cmdRegRt.CfgStorageMaxApplyWriteLogEntries, strconv.FormatUint(runtime.Storage.MaxApplyWriteLogEntries, 10),
@@ -66,6 +68,7 @@ func (r *RegistryHelpers) runRegistryRuntimeSubcommand(
 			"--"+cmdRegRt.CfgStorageCheckpointInterval, strconv.FormatUint(runtime.Storage.CheckpointInterval, 10),
 			"--"+cmdRegRt.CfgStorageCheckpointNumKept, strconv.FormatUint(runtime.Storage.CheckpointNumKept, 10),
 			"--"+cmdRegRt.CfgStorageCheckpointChunkSize, strconv.FormatUint(runtime.Storage.CheckpointChunkSize, 10),
+			"--"+cmdRegRt.CfgStorageMinPoolSize, strconv.FormatUint(runtime.Storage.MinPoolSize, 10),
 			"--"+cmdRegRt.CfgTxnSchedulerAlgorithm, runtime.TxnScheduler.Algorithm,
 			"--"+cmdRegRt.CfgTxnSchedulerBatchFlushTimeout, runtime.TxnScheduler.BatchFlushTimeout.String(),
 			"--"+cmdRegRt.CfgTxnSchedulerMaxBatchSize, strconv.FormatUint(runtime.TxnScheduler.MaxBatchSize, 10),

--- a/go/oasis-test-runner/oasis/runtime.go
+++ b/go/oasis-test-runner/oasis/runtime.go
@@ -131,6 +131,7 @@ func (net *Network) NewRuntime(cfg *RuntimeCfg) (*Runtime, error) {
 		Storage:         cfg.Storage,
 		AdmissionPolicy: cfg.AdmissionPolicy,
 		Staking:         cfg.Staking,
+		GovernanceModel: registry.GovernanceEntity,
 	}
 
 	rtDir, err := net.baseDir.NewSubDir("runtime-" + cfg.ID.String())

--- a/go/oasis-test-runner/scenario/e2e/registry_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/registry_cli.go
@@ -618,6 +618,7 @@ func (sc *registryCLIImpl) testRuntime(ctx context.Context, childEnv *env.Env, c
 			GroupBackupSize:   2,
 			AllowedStragglers: 1,
 			RoundTimeout:      5,
+			MinPoolSize:       3, // GroupSize + GroupBackupSize
 		},
 		TxnScheduler: registry.TxnSchedulerParameters{
 			Algorithm:         registry.TxnSchedulerSimple,
@@ -631,11 +632,12 @@ func (sc *registryCLIImpl) testRuntime(ctx context.Context, childEnv *env.Env, c
 			MinWriteReplication:     9,
 			MaxApplyWriteLogEntries: 10,
 			MaxApplyOps:             11,
+			MinPoolSize:             9,
 		},
 		AdmissionPolicy: registry.RuntimeAdmissionPolicy{
 			EntityWhitelist: &registry.EntityWhitelistRuntimeAdmissionPolicy{
-				Entities: map[signature.PublicKey]bool{
-					testEntity.ID: true,
+				Entities: map[signature.PublicKey]registry.EntityWhitelistConfig{
+					testEntity.ID: {},
 				},
 			},
 		},
@@ -645,6 +647,7 @@ func (sc *registryCLIImpl) testRuntime(ctx context.Context, childEnv *env.Env, c
 				staking.KindNodeStorage: q,
 			},
 		},
+		GovernanceModel: registry.GovernanceEntity,
 	}
 	// Runtime ID 0x0 is for simple-keyvalue, 0xf... is for the keymanager. Let's use 0x1.
 	_ = testRuntime.ID.UnmarshalHex("8000000000000000000000000000000000000000000000000000000000000001")

--- a/go/oasis-test-runner/scenario/e2e/runtime/history_reindex.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/history_reindex.go
@@ -68,6 +68,7 @@ func (sc *historyReindexImpl) Fixture() (*oasis.NetworkFixture, error) {
 	// Use a single compute node.
 	f.Runtimes[rtIdx].Executor.GroupSize = 1
 	f.Runtimes[rtIdx].Executor.GroupBackupSize = 0
+	f.Runtimes[rtIdx].Executor.MinPoolSize = f.Runtimes[rtIdx].Executor.GroupSize + f.Runtimes[rtIdx].Executor.GroupBackupSize
 
 	return f, nil
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
@@ -89,6 +89,7 @@ func (sc *multipleRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
 				GroupSize:       uint64(executorGroupSize),
 				GroupBackupSize: 0,
 				RoundTimeout:    20,
+				MinPoolSize:     uint64(executorGroupSize),
 			},
 			TxnScheduler: registry.TxnSchedulerParameters{
 				Algorithm:         registry.TxnSchedulerSimple,
@@ -102,6 +103,7 @@ func (sc *multipleRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
 				MinWriteReplication:     1,
 				MaxApplyWriteLogEntries: 100_000,
 				MaxApplyOps:             2,
+				MinPoolSize:             1,
 			},
 			AdmissionPolicy: registry.RuntimeAdmissionPolicy{
 				AnyNode: &registry.AnyNodeRuntimeAdmissionPolicy{},

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -166,6 +166,7 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 					GroupBackupSize: 1,
 					RoundTimeout:    20,
 					MaxMessages:     128,
+					MinPoolSize:     3, // GroupSize + GroupBackupSize
 				},
 				TxnScheduler: registry.TxnSchedulerParameters{
 					Algorithm:         registry.TxnSchedulerSimple,
@@ -179,6 +180,7 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 					MinWriteReplication:     2,
 					MaxApplyWriteLogEntries: 100_000,
 					MaxApplyOps:             2,
+					MinPoolSize:             2,
 				},
 				AdmissionPolicy: registry.RuntimeAdmissionPolicy{
 					AnyNode: &registry.AnyNodeRuntimeAdmissionPolicy{},

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_from_registered.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_from_registered.go
@@ -48,6 +48,7 @@ func (sc *storageSyncFromRegisteredImpl) Fixture() (*oasis.NetworkFixture, error
 	// be in the committee.
 	f.Network.EpochtimeMock = true
 	f.Runtimes[1].Storage.GroupSize = 1
+	f.Runtimes[1].Storage.MinPoolSize = f.Runtimes[1].Storage.GroupSize
 	f.Runtimes[1].Storage.MinWriteReplication = 1
 
 	// Configure runtime for storage checkpointing.

--- a/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
@@ -418,12 +418,14 @@ func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
 
 	// Storage committee.
 	f.Runtimes[1].Storage.GroupSize = uint64(sc.numStorageNodes)
+	f.Runtimes[1].Storage.MinPoolSize = f.Runtimes[1].Storage.GroupSize
 	f.Runtimes[1].Storage.MinWriteReplication = f.Runtimes[1].Storage.GroupSize
 
 	// Executor committee.
 	f.Runtimes[1].Executor.GroupBackupSize = 1
 	f.Runtimes[1].Executor.GroupSize = uint64(sc.numComputeNodes) -
 		f.Runtimes[1].Executor.GroupBackupSize
+	f.Runtimes[1].Executor.MinPoolSize = uint64(sc.numComputeNodes)
 
 	if sc.nodeLongRestartInterval > 0 {
 		// One storage node could be offline.

--- a/go/registry/api/sanity_check.go
+++ b/go/registry/api/sanity_check.go
@@ -106,24 +106,22 @@ func SanityCheckEntities(logger *logging.Logger, entities []*entity.SignedEntity
 func SanityCheckRuntimes(
 	logger *logging.Logger,
 	params *ConsensusParameters,
-	runtimes []*SignedRuntime,
-	suspendedRuntimes []*SignedRuntime,
+	runtimes []*Runtime,
+	suspendedRuntimes []*Runtime,
 	isGenesis bool,
 ) (RuntimeLookup, error) {
 	// First go through all runtimes and perform general sanity checks.
 	seenRuntimes := []*Runtime{}
-	for _, signedRt := range runtimes {
-		rt, err := VerifyRegisterRuntimeArgs(params, logger, signedRt, isGenesis, true)
-		if err != nil {
+	for _, rt := range runtimes {
+		if err := VerifyRuntime(params, logger, rt, isGenesis, true); err != nil {
 			return nil, fmt.Errorf("runtime sanity check failed: %w", err)
 		}
 		seenRuntimes = append(seenRuntimes, rt)
 	}
 
 	seenSuspendedRuntimes := []*Runtime{}
-	for _, signedRt := range suspendedRuntimes {
-		rt, err := VerifyRegisterRuntimeArgs(params, logger, signedRt, isGenesis, true)
-		if err != nil {
+	for _, rt := range suspendedRuntimes {
+		if err := VerifyRuntime(params, logger, rt, isGenesis, true); err != nil {
 			return nil, fmt.Errorf("runtime sanity check failed: %w", err)
 		}
 		seenSuspendedRuntimes = append(seenSuspendedRuntimes, rt)

--- a/go/roothash/api/commitment/pool_test.go
+++ b/go/roothash/api/commitment/pool_test.go
@@ -132,10 +132,12 @@ func TestPoolSingleCommitment(t *testing.T) {
 		Storage: registry.StorageParameters{
 			GroupSize:           1,
 			MinWriteReplication: 1,
+			MinPoolSize:         1,
 		},
 		Executor: registry.ExecutorParameters{
 			MaxMessages: 32,
 		},
+		GovernanceModel: registry.GovernanceEntity,
 	}
 
 	// Generate a commitment signing key.
@@ -286,10 +288,11 @@ func TestPoolSingleCommitmentTEE(t *testing.T) {
 	_ = rtID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
 
 	rt := &registry.Runtime{
-		Versioned:   cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
-		ID:          rtID,
-		Kind:        registry.KindCompute,
-		TEEHardware: node.TEEHardwareIntelSGX,
+		Versioned:       cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+		ID:              rtID,
+		Kind:            registry.KindCompute,
+		TEEHardware:     node.TEEHardwareIntelSGX,
+		GovernanceModel: registry.GovernanceEntity,
 	}
 
 	// Generate a commitment signing key.
@@ -377,12 +380,15 @@ func TestPoolStragglers(t *testing.T) {
 		Storage: registry.StorageParameters{
 			GroupSize:           1,
 			MinWriteReplication: 1,
+			MinPoolSize:         1,
 		},
 		Executor: registry.ExecutorParameters{
 			GroupSize:         2,
 			GroupBackupSize:   1,
 			AllowedStragglers: 1,
+			MinPoolSize:       3, // GroupSize + GroupBackupSize
 		},
+		GovernanceModel: registry.GovernanceEntity,
 	})
 	sk1 := sks[0]
 	sk2 := sks[1]
@@ -694,10 +700,11 @@ func TestPoolSerialization(t *testing.T) {
 	_ = rtID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
 
 	rt := &registry.Runtime{
-		Versioned:   cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
-		ID:          rtID,
-		Kind:        registry.KindCompute,
-		TEEHardware: node.TEEHardwareInvalid,
+		Versioned:       cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+		ID:              rtID,
+		Kind:            registry.KindCompute,
+		TEEHardware:     node.TEEHardwareInvalid,
+		GovernanceModel: registry.GovernanceEntity,
 	}
 
 	// Generate a commitment signing key.
@@ -968,11 +975,14 @@ func generateMockCommittee(t *testing.T, rtTemplate *registry.Runtime) (
 			Storage: registry.StorageParameters{
 				GroupSize:           1,
 				MinWriteReplication: 1,
+				MinPoolSize:         1,
 			},
 			Executor: registry.ExecutorParameters{
 				GroupSize:       2,
 				GroupBackupSize: 1,
+				MinPoolSize:     3, // GroupSize + GroupBackupSize
 			},
+			GovernanceModel: registry.GovernanceEntity,
 		}
 	default:
 		// Use the provided runtime descriptor template.

--- a/go/scheduler/tests/tester.go
+++ b/go/scheduler/tests/tester.go
@@ -118,7 +118,9 @@ func SchedulerImplementationTests(t *testing.T, name string, backend api.Backend
 	// Re-register the runtime with less nodes.
 	rt.Runtime.Executor.GroupSize = 2
 	rt.Runtime.Executor.GroupBackupSize = 1
+	rt.Runtime.Executor.MinPoolSize = 3
 	rt.Runtime.Storage.GroupSize = 1
+	rt.Runtime.Storage.MinPoolSize = 1
 	rt.Runtime.Storage.MinWriteReplication = 1
 	rt.MustRegister(t, consensus.Registry(), consensus)
 

--- a/go/staking/api/slashing.go
+++ b/go/staking/api/slashing.go
@@ -41,6 +41,10 @@ func (s SlashReason) MarshalText() ([]byte, error) {
 // UnmarshalText decodes a text slice into a SlashReason.
 func (s *SlashReason) UnmarshalText(text []byte) error {
 	switch string(text) {
+	// XXX: The "0" case is only for backward compatibility, so that the old
+	// genesis file loads -- remove this once mainnet is upgraded!
+	case "0":
+		fallthrough
 	case SlashDoubleSigningName:
 		*s = SlashDoubleSigning
 	default:


### PR DESCRIPTION
Closes #3450.

TODO:
- [x] fix e2e tests.
- [x] fix unit tests.
- [x] remove `SignedRuntime` entirely.
- [x] double-check that `oasis-node debug fix-genesis` command does the right thing.
- [x] write a few changelog fragments.
- [x] when 3511 is merged, fix the TODO in `go/consensus/tendermint/apps/registry/transactions.go`.
- [x] update docs.
- [x] add `enable_runtime_governance_models` consensus parameter & tests for it.
- [x] add more tests.

In a separate PR:
- add `update_runtime` runtime message support & e2e tests.