### PR TITLE
github: Unpin Go version in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go 1.15
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: "1.15.5"
+          go-version: "1.15.x"
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
       - name: Install Oasis Node prerequisites


### PR DESCRIPTION
This is no longer needed and should also enable the next release to be built with the latest 1.15.x version.

This reverts commit 73a3acbc28b00f90f76e53977cfa0acdc3eb905a.