### PR TITLE
go/oasis-node/cmd/common: Add LoadEntitySigner() helper

### DIFF
--- a/.changelog/3556.internal.md
+++ b/.changelog/3556.internal.md
@@ -1,0 +1,5 @@
+go/oasis-node/cmd/common: Add `LoadEntitySigner()` helper
+
+Replace `LoadEntity()` helper with `LoadEntitySigner()` that requires no
+arguments and loads the entity directory and obtains the signer backend by
+itself.

--- a/go/oasis-node/cmd/common/common.go
+++ b/go/oasis-node/cmd/common/common.go
@@ -249,15 +249,19 @@ func GetInputReader(cmd *cobra.Command, cfg string) (io.ReadCloser, bool, error)
 	return r, true, err
 }
 
-// LoadEntity loads the entity and it's signer.
-func LoadEntity(signerBackend, entityDir string) (*entity.Entity, signature.Signer, error) {
+// LoadEntitySigner loads the entity and its signer.
+func LoadEntitySigner() (*entity.Entity, signature.Signer, error) {
 	if flags.DebugTestEntity() {
 		return entity.TestEntity()
 	}
-
-	factory, err := cmdSigner.NewFactory(signerBackend, entityDir, signature.SignerEntity)
+	entityDir, err := cmdSigner.CLIDirOrPwd()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to retrieve entity dir: %w", err)
+	}
+
+	factory, err := cmdSigner.NewFactory(cmdSigner.Backend(), entityDir, signature.SignerEntity)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create signer factory for %s: %w", cmdSigner.Backend(), err)
 	}
 
 	return entity.Load(entityDir, factory)

--- a/go/oasis-node/cmd/common/consensus/consensus.go
+++ b/go/oasis-node/cmd/common/consensus/consensus.go
@@ -106,17 +106,9 @@ func SignAndSaveTx(ctx context.Context, tx *transaction.Transaction, signer sign
 		return
 	}
 
-	var err error
-	var entityDir string
 	if signer == nil {
-		entityDir, err = cmdSigner.CLIDirOrPwd()
-		if err != nil {
-			logger.Error("failed to retrieve entity dir",
-				"err", err,
-			)
-			os.Exit(1)
-		}
-		_, signer, err = cmdCommon.LoadEntity(cmdSigner.Backend(), entityDir)
+		var err error
+		_, signer, err = cmdCommon.LoadEntitySigner()
 		if err != nil {
 			logger.Error("failed to load signer",
 				"err", err,

--- a/go/oasis-node/cmd/registry/entity/entity.go
+++ b/go/oasis-node/cmd/registry/entity/entity.go
@@ -285,17 +285,9 @@ func doGenRegister(cmd *cobra.Command, args []string) {
 	cmdConsensus.InitGenesis()
 	cmdConsensus.AssertTxFileOK()
 
-	entityDir, err := cmdSigner.CLIDirOrPwd()
+	ent, signer, err := cmdCommon.LoadEntitySigner()
 	if err != nil {
-		logger.Error("failed to retrieve entity dir",
-			"err", err,
-		)
-		os.Exit(1)
-	}
-
-	ent, signer, err := cmdCommon.LoadEntity(cmdSigner.Backend(), entityDir)
-	if err != nil {
-		logger.Error("failed to load entity",
+		logger.Error("failed to load entity and its signer",
 			"err", err,
 		)
 		os.Exit(1)

--- a/go/oasis-node/cmd/registry/node/node.go
+++ b/go/oasis-node/cmd/registry/node/node.go
@@ -108,8 +108,7 @@ func doInit(cmd *cobra.Command, args []string) { // nolint: gocyclo
 
 	// Get the entity ID or entity.
 	var (
-		entityDir string
-		entityID  signature.PublicKey
+		entityID signature.PublicKey
 
 		entity       *entity.Entity
 		entitySigner signature.Signer
@@ -128,16 +127,9 @@ func doInit(cmd *cobra.Command, args []string) { // nolint: gocyclo
 
 		isSelfSigned = true
 	} else {
-		entityDir, err = cmdSigner.CLIDirOrPwd()
+		entity, entitySigner, err = cmdCommon.LoadEntitySigner()
 		if err != nil {
-			logger.Error("failed to retrieve entity dir",
-				"err", err,
-			)
-			os.Exit(1)
-		}
-		entity, entitySigner, err = cmdCommon.LoadEntity(cmdSigner.Backend(), entityDir)
-		if err != nil {
-			logger.Error("failed to load entity",
+			logger.Error("failed to load entity and its signer",
 				"err", err,
 			)
 			os.Exit(1)

--- a/go/oasis-node/cmd/registry/runtime/runtime.go
+++ b/go/oasis-node/cmd/registry/runtime/runtime.go
@@ -249,16 +249,9 @@ func runtimeFromFlags() (*registry.Runtime, signature.Signer, error) { // nolint
 		return nil, nil, fmt.Errorf("invalid TEE hardware")
 	}
 
-	entityDir, err := cmdSigner.CLIDirOrPwd()
+	_, signer, err := cmdCommon.LoadEntitySigner()
 	if err != nil {
-		logger.Error("failed to retrieve signer dir",
-			"err", err,
-		)
-		return nil, nil, fmt.Errorf("failed to retrieve signer dir")
-	}
-	_, signer, err := cmdCommon.LoadEntity(cmdSigner.Backend(), entityDir)
-	if err != nil {
-		logger.Error("failed to load owning entity",
+		logger.Error("failed to load owning entity's signer",
 			"err", err,
 		)
 		return nil, nil, err


### PR DESCRIPTION
Replace `LoadEntity()` helper with `LoadEntitySigner()` that requires no arguments and loads the entity directory and obtains the signer backend by itself.

Remove entity directory loading boilerplate code by using this new helper.