### PR TITLE
go/oasis-node/txsource: Increase submission timeout

### DIFF
--- a/.changelog/3568.internal.md
+++ b/.changelog/3568.internal.md
@@ -1,0 +1,4 @@
+go/oasis-node/txsource: Increase submission timeout
+
+Sometimes it can take up to two minutes for a transaction to get included in a
+block due to high load.

--- a/go/oasis-node/cmd/debug/txsource/workload/workload.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/workload.go
@@ -111,8 +111,7 @@ func (bw *BaseWorkload) FundSignAndSubmitTx(ctx context.Context, caller signatur
 		"tx_caller", caller.Public(),
 	)
 
-	// Wait for a maximum of 60 seconds to submit transaction.
-	submitCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	submitCtx, cancel := context.WithTimeout(ctx, maxSubmissionRetryElapsedTime)
 	defer cancel()
 	if err := bw.sm.SignAndSubmitTx(submitCtx, caller, tx); err != nil {
 		bw.Logger.Error("failed to submit transaction",


### PR DESCRIPTION
Sometimes it can take up to two minutes for a transaction to get included in a
block due to high load.

(This was masked before #3511 as submission was retried on all errors.)