### PR TITLE
go/runtime/scheduling: Consumer should pull from scheduler

### DIFF
--- a/.changelog/3569.bugfix.md
+++ b/.changelog/3569.bugfix.md
@@ -1,0 +1,6 @@
+go/runtime/scheduling: Consumer should pull from scheduler
+
+Previously the scheduler would push batches to the consumer (e.g. compute
+node) which makes no sense as the consumer knows when it's ready to accept
+new batches. This changes the model so that the consumer pulls batches from
+the scheduler.

--- a/go/runtime/scheduling/api/api.go
+++ b/go/runtime/scheduling/api/api.go
@@ -4,7 +4,6 @@ package api
 import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
-	"github.com/oasisprotocol/oasis-core/go/runtime/transaction"
 )
 
 // Scheduler defines an algorithm for scheduling incoming transactions.
@@ -12,20 +11,8 @@ type Scheduler interface {
 	// Name is the scheduler algorithm name.
 	Name() string
 
-	// Initialize initializes the internal scheduler state.
-	// Scheduler should use the provided transaction dispatcher to dispatch
-	// transactions.
-	Initialize(td TransactionDispatcher) error
-
-	// IsInitialized returns true, if the scheduler has been initialized.
-	IsInitialized() bool
-
-	// ScheduleTx attempts to schedule a transaction.
-	//
-	// The scheduling algorithm may peek into the transaction to extract
-	// metadata needed for scheduling. In this case, the transaction bytes
-	// must correspond to a transaction.TxnCall structure.
-	ScheduleTx(tx []byte) error
+	// QueueTx queues a transaction for scheduling.
+	QueueTx(tx []byte) error
 
 	// AppendTxBatch appends a transaction batch for scheduling.
 	//
@@ -36,8 +23,8 @@ type Scheduler interface {
 	// RemoveTxBatch removes a transaction batch.
 	RemoveTxBatch(tx [][]byte) error
 
-	// Flush flushes queued transactions.
-	Flush(force bool) error
+	// GetBatch returns a batch of scheduled transactions (if any is available).
+	GetBatch(force bool) [][]byte
 
 	// UnscheduledSize returns number of unscheduled items.
 	UnscheduledSize() uint64
@@ -50,10 +37,4 @@ type Scheduler interface {
 
 	// Clear clears the transaction queue.
 	Clear()
-}
-
-// TransactionDispatcher dispatches transactions to a scheduled executor committee.
-type TransactionDispatcher interface {
-	// Dispatch attempts to dispatch a batch to a executor committee.
-	Dispatch(batch transaction.RawBatch) error
 }

--- a/go/runtime/scheduling/simple/simple.go
+++ b/go/runtime/scheduling/simple/simple.go
@@ -3,7 +3,6 @@ package simple
 
 import (
 	"fmt"
-	"sync/atomic"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
@@ -23,53 +22,22 @@ type scheduler struct {
 
 	txPool        txpool.TxPool
 	maxTxPoolSize uint64
-
-	dispatcher         api.TransactionDispatcher
-	dispatchInProgress uint32
 }
 
-func (s *scheduler) scheduleBatch(force bool) error {
-	if !atomic.CompareAndSwapUint32(&s.dispatchInProgress, 0, 1) {
-		// Dispatch already in progress.
+func (s *scheduler) QueueTx(tx []byte) error {
+	switch err := s.txPool.Add(tx); err {
+	case nil:
 		return nil
-	}
-	defer atomic.StoreUint32(&s.dispatchInProgress, 0)
-
-	batch := s.txPool.GetBatch(force)
-	if len(batch) > 0 {
-		// Try to dispatch batch.
-		if err := s.dispatcher.Dispatch(batch); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (s *scheduler) ScheduleTx(tx []byte) error {
-	if err := s.txPool.Add(tx); err != nil {
+	case txpool.ErrCallAlreadyExists:
 		// Return success in case of duplicate calls to avoid the client
 		// mistaking this for an actual error.
-		if err == txpool.ErrCallAlreadyExists {
-			s.logger.Warn("ignoring duplicate call",
-				"batch", tx,
-			)
-		} else {
-			return err
-		}
-	}
-
-	// Try scheduling a batch.
-	if err := s.scheduleBatch(false); err != nil {
-		// XXX: Log a warning here as the expected common failures are
-		// whenever we try dispatching a batch and we are not the scheduler,
-		// or when another batch is being processed.
-		s.logger.Warn("failed scheduling a batch",
-			"err", err,
+		s.logger.Warn("ignoring duplicate call",
+			"batch", tx,
 		)
+		return nil
+	default:
+		return err
 	}
-
-	return nil
 }
 
 // AppendTxBatch appends a batch of transactions.
@@ -88,19 +56,8 @@ func (s *scheduler) RemoveTxBatch(tx [][]byte) error {
 	return s.txPool.RemoveBatch(tx)
 }
 
-func (s *scheduler) Flush(force bool) error {
-	// Schedule a batch.
-	if err := s.scheduleBatch(force); err != nil {
-		// XXX: Log a warning here as the expected common failures are
-		// whenever we try dispatching a batch and we are not the scheduler,
-		// or when another batch is being processed.
-		s.logger.Warn("failed scheduling a batch",
-			"err", err,
-		)
-		return err
-	}
-
-	return nil
+func (s *scheduler) GetBatch(force bool) [][]byte {
+	return s.txPool.GetBatch(force)
 }
 
 func (s *scheduler) UnscheduledSize() uint64 {
@@ -113,16 +70,6 @@ func (s *scheduler) IsQueued(id hash.Hash) bool {
 
 func (s *scheduler) Clear() {
 	s.txPool.Clear()
-}
-
-func (s *scheduler) Initialize(td api.TransactionDispatcher) error {
-	s.dispatcher = td
-
-	return nil
-}
-
-func (s *scheduler) IsInitialized() bool {
-	return s.dispatcher != nil
 }
 
 func (s *scheduler) UpdateParameters(params registry.TxnSchedulerParameters) error {

--- a/go/runtime/scheduling/simple/txpool/orderedmap/ordered_map.go
+++ b/go/runtime/scheduling/simple/txpool/orderedmap/ordered_map.go
@@ -188,12 +188,13 @@ func (q *orderedMap) UpdateConfig(cfg api.Config) error {
 		if current == nil {
 			break
 		}
-		if cfg.MaxPoolSize > uint64(newQueue.Len()) {
+		if uint64(newQueue.Len()) >= cfg.MaxPoolSize {
 			break
 		}
 		el := current.Value.(*pair)
 		txSize := uint64(len(el.Value))
 		if txSize > cfg.MaxBatchSizeBytes {
+			current = current.Prev()
 			continue
 		}
 		newQueue.PushFront(el)


### PR DESCRIPTION
Previously the scheduler would push batches to the consumer (e.g. compute
node) which makes no sense as the consumer knows when it's ready to accept
new batches. This changes the model so that the consumer pulls batches from
the scheduler.