### PR TITLE
go/oasis-node/txsource: Fix event validation in queries workload

### DIFF
--- a/.changelog/3593.internal.md
+++ b/.changelog/3593.internal.md
@@ -1,0 +1,4 @@
+go/oasis-node/txsource: Fix event validation in queries workload
+
+A single transaction can now emit multiple identical events when performing
+runtime message execution emitting events.


### PR DESCRIPTION
There seems to be a bug in the queries workload event validation which fails in case two same events are emitted -- which seems like a perfectly valid thing that can happen now with a single transaction performing runtime message execution emitting events.

Discovered during long-term tests.