### PR TITLE
go/consensus/tendermint/roothash: Fix latest block reindexing

### DIFF
--- a/.changelog/3594.bugfix.md
+++ b/.changelog/3594.bugfix.md
@@ -1,0 +1,9 @@
+go/consensus/tendermint/roothash: Fix latest block reindexing
+
+Only commit the block in case it was not already committed during reindex.
+This can happen when reindexing after a crash (e.g., the before_index crash
+point) since the initial height at which the reindex happens does not
+necessarily contain a round finalization event so reindexing up to height-1
+doesn't help.
+
+Discovered during long-term tests.

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -4,6 +4,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
@@ -21,6 +22,9 @@ import (
 const (
 	// ModuleName is a unique module name for the roothash module.
 	ModuleName = "roothash"
+
+	// RoundInvalid is a special round number that refers to an invalid round.
+	RoundInvalid uint64 = math.MaxUint64
 
 	// LogEventExecutionDiscrepancyDetected is a log event value that signals
 	// an execution discrepancy has been detected.


### PR DESCRIPTION
Only commit the block in case it was not already committed during reindex. This
can happen when reindexing after a crash (e.g., the before_index crash point)
since the initial height at which the reindex happens does not necessarily
contain a round finalization event so reindexing up to height-1 doesn't help.

Discovered during long-term tests.