### PR TITLE
go/oasis-test-runner: governance workload

### DIFF
--- a/.changelog/3603.internal.md
+++ b/.changelog/3603.internal.md
@@ -1,0 +1,1 @@
+go/oasis-test-runner/txsource: Add governance workload

--- a/docs/adr/0006-consensus-governance.md
+++ b/docs/adr/0006-consensus-governance.md
@@ -2,6 +2,7 @@
 
 ## Changelog
 
+- 2021-01-06: Update API to include Proposals() method
 - 2020-12-08: Updates to match the actual implementation
 - 2020-10-27: Voting period in epochs, min upgrade cancellation difference,
   failed proposal state
@@ -365,6 +366,9 @@ This proposal introduces the following query methods in the governance module:
 type Backend interface {
     // ActiveProposals returns a list of all proposals that have not yet closed.
     ActiveProposals(ctx context.Context, height int64) ([]*Proposal, error)
+
+    // Proposals returns a list of all proposals.
+    Proposals(ctx context.Context, height int64) ([]*Proposal, error)
 
     // Proposal looks up a specific proposal.
     Proposal(ctx context.Context, query *ProposalQuery) (*Proposal, error)

--- a/go/consensus/tendermint/apps/governance/query.go
+++ b/go/consensus/tendermint/apps/governance/query.go
@@ -12,6 +12,7 @@ import (
 // Query is the governance query interface.
 type Query interface {
 	ActiveProposals(context.Context) ([]*governance.Proposal, error)
+	Proposals(context.Context) ([]*governance.Proposal, error)
 	Proposal(context.Context, uint64) (*governance.Proposal, error)
 	Votes(context.Context, uint64) ([]*governance.VoteEntry, error)
 	PendingUpgrades(context.Context) ([]*upgrade.Descriptor, error)
@@ -39,6 +40,10 @@ type governanceQuerier struct {
 
 func (gq *governanceQuerier) ActiveProposals(ctx context.Context) ([]*governance.Proposal, error) {
 	return gq.state.ActiveProposals(ctx)
+}
+
+func (gq *governanceQuerier) Proposals(ctx context.Context) ([]*governance.Proposal, error) {
+	return gq.state.Proposals(ctx)
 }
 
 func (gq *governanceQuerier) Proposal(ctx context.Context, id uint64) (*governance.Proposal, error) {

--- a/go/consensus/tendermint/apps/governance/transactions.go
+++ b/go/consensus/tendermint/apps/governance/transactions.go
@@ -111,7 +111,7 @@ func (app *governanceApplication) submitProposal(
 		switch err {
 		case nil:
 		case governance.ErrNoSuchUpgrade:
-			ctx.Logger().Error("governance: cancel upgrade for a non existing upgrade proposal",
+			ctx.Logger().Error("governance: cancel upgrade for a non existing pending upgrade",
 				"proposal_id", cancelUpgrade.ProposalID,
 				"err", err,
 			)

--- a/go/consensus/tendermint/governance/governance.go
+++ b/go/consensus/tendermint/governance/governance.go
@@ -48,6 +48,15 @@ func (sc *serviceClient) ActiveProposals(ctx context.Context, height int64) ([]*
 	return q.ActiveProposals(ctx)
 }
 
+func (sc *serviceClient) Proposals(ctx context.Context, height int64) ([]*api.Proposal, error) {
+	q, err := sc.querier.QueryAt(ctx, height)
+	if err != nil {
+		return nil, err
+	}
+
+	return q.Proposals(ctx)
+}
+
 func (sc *serviceClient) Proposal(ctx context.Context, query *api.ProposalQuery) (*api.Proposal, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {

--- a/go/governance/api/api.go
+++ b/go/governance/api/api.go
@@ -106,6 +106,9 @@ type Backend interface {
 	// ActiveProposals returns a list of all proposals that have not yet closed.
 	ActiveProposals(ctx context.Context, height int64) ([]*Proposal, error)
 
+	// Proposals returns a list of all proposals.
+	Proposals(ctx context.Context, height int64) ([]*Proposal, error)
+
 	// Proposal looks up a specific proposal.
 	Proposal(ctx context.Context, query *ProposalQuery) (*Proposal, error)
 

--- a/go/governance/api/proposal.go
+++ b/go/governance/api/proposal.go
@@ -97,7 +97,6 @@ type Proposal struct {
 	ClosesAt epochtime.EpochTime `json:"closes_at"`
 	// Results are the final tallied results after the voting period has
 	// ended.
-
 	Results map[Vote]quantity.Quantity `json:"results,omitempty"`
 	// InvalidVotes is the number of invalid votes after tallying.
 	InvalidVotes uint64 `json:"invalid_votes,omitempty"`

--- a/go/governance/tests/tester.go
+++ b/go/governance/tests/tester.go
@@ -424,6 +424,10 @@ WaitForSubmittedVote:
 			assertAccountBalance(t, consensus, staking.GovernanceDepositsAddress, consensusAPI.HeightLatest, quantity.NewQuantity())
 			assertAccountBalance(t, consensus, submitterAddr, ev.Height, testState.submitterBalance)
 
+			// Test proposals query.
+			proposals, err := backend.Proposals(ctx, consensusAPI.HeightLatest)
+			require.NoError(err, "Proposals query")
+			require.True(len(proposals) > 1, "At least two proposals should exist")
 			return
 		case <-time.After(recvTimeout):
 			t.Fatalf("failed to receive event")

--- a/go/oasis-node/cmd/debug/txsource/txsource.go
+++ b/go/oasis-node/cmd/debug/txsource/txsource.go
@@ -5,6 +5,7 @@ import (
 	"crypto"
 	"fmt"
 	"math/rand"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
@@ -13,6 +14,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/drbg"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/mathrand"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	fileSigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/file"
 	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
@@ -25,10 +27,11 @@ import (
 )
 
 const (
-	CfgWorkload  = "workload"
-	CfgSeed      = "seed"
-	CfgTimeLimit = "time_limit"
-	CfgGasPrice  = "gas_price"
+	CfgWorkload        = "workload"
+	CfgSeed            = "seed"
+	CfgTimeLimit       = "time_limit"
+	CfgGasPrice        = "gas_price"
+	CfgValidatorEntity = "validator_entity"
 )
 
 var (
@@ -123,8 +126,25 @@ func doRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Load the validator entity paths if provided, some workloads need to make
+	// transactions as the validator entity.
+	var validatorEntities []signature.Signer
+	for _, p := range viper.GetStringSlice(CfgValidatorEntity) {
+		var fact signature.SignerFactory
+		fact, err = fileSigner.NewFactory(filepath.Dir(p), signature.SignerEntity)
+		if err != nil {
+			return fmt.Errorf("loading validator entity factory: %w", err)
+		}
+		var validatorEntity signature.Signer
+		validatorEntity, err = fact.Load(signature.SignerEntity)
+		if err != nil {
+			return fmt.Errorf("loading validator entity: %w", err)
+		}
+		validatorEntities = append(validatorEntities, validatorEntity)
+	}
+
 	logger.Debug("entering workload", "name", name)
-	if err = w.Run(ctx, rng, conn, cnsc, sm, fundingAccount); err != nil {
+	if err = w.Run(ctx, rng, conn, cnsc, sm, fundingAccount, validatorEntities); err != nil {
 		logger.Error("workload error", "err", err)
 		return fmt.Errorf("workload %s: %w", name, err)
 	}
@@ -144,6 +164,7 @@ func init() {
 	fs.String(CfgSeed, "seeeeeeeeeeeeeeeeeeeeeeeeeeeeeed", "Seed to use for randomized workloads")
 	fs.Duration(CfgTimeLimit, 0, "Exit successfully after this long, or 0 to run forever")
 	fs.Uint64(CfgGasPrice, 0, "Gas price to use for consensus transactions")
+	fs.StringSlice(CfgValidatorEntity, nil, "Paths to validator entities")
 	_ = viper.BindPFlags(fs)
 	txsourceCmd.Flags().AddFlagSet(fs)
 

--- a/go/oasis-node/cmd/debug/txsource/workload/commission.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/commission.go
@@ -345,6 +345,7 @@ func (c *commission) Run(
 	cnsc consensus.ClientBackend,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
+	validatorEntities []signature.Signer,
 ) error {
 	// Initialize base workload.
 	c.BaseWorkload.Init(cnsc, sm, fundingAccount)

--- a/go/oasis-node/cmd/debug/txsource/workload/delegation.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/delegation.go
@@ -188,6 +188,7 @@ func (d *delegation) Run(
 	cnsc consensus.ClientBackend,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
+	validatorEntities []signature.Signer,
 ) error {
 	// Initialize base workload.
 	d.BaseWorkload.Init(cnsc, sm, fundingAccount)

--- a/go/oasis-node/cmd/debug/txsource/workload/governance.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/governance.go
@@ -1,0 +1,462 @@
+package workload
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"google.golang.org/grpc"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	epochtime "github.com/oasisprotocol/oasis-core/go/epochtime/api"
+	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
+	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
+	upgrade "github.com/oasisprotocol/oasis-core/go/upgrade/api"
+)
+
+// NameGovernance is the name of the governance workload.
+const NameGovernance = "governance"
+
+var errUnexpectedGovTxResult = fmt.Errorf("unexpected governance tx result")
+
+// Governance is the governance workload.
+var Governance = &governanceWorkload{
+	BaseWorkload: NewBaseWorkload(NameGovernance),
+}
+
+var numProposerAccounts = 10
+
+// How likely voters should vote YES for the proposal made by i'th proposer.
+var proposersVoteYesRate = []uint8{
+	100,
+	99,
+	98,
+	95,
+	92,
+	90,
+	80,
+	70,
+	50,
+	0,
+}
+
+type governanceWorkload struct {
+	BaseWorkload
+
+	ctx context.Context
+	rng *rand.Rand
+
+	currentEpoch epochtime.EpochTime
+	parameters   *governance.ConsensusParameters
+
+	consensus  consensus.ClientBackend
+	governance governance.Backend
+
+	proposerAccounts []*struct {
+		signer  signature.Signer
+		address staking.Address
+		nonce   uint64
+	}
+	ensureYesVote map[uint64]bool
+
+	validatorEntities []signature.Signer
+}
+
+func (g *governanceWorkload) ensureUpgradeCanceled(upgrade *upgrade.Descriptor) error {
+	proposalID, err := g.submitCancelUpgradeProposal(upgrade, false)
+	if err != nil {
+		return fmt.Errorf("submitting cancel upgrade proposal: %w", err)
+	}
+	g.ensureYesVote[proposalID] = true
+	// Vote for the submitted proposal.
+	for _, v := range g.validatorEntities {
+		if err := g.submitVote(v, proposalID, governance.VoteYes); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *governanceWorkload) submitProposalContent(pc *governance.ProposalContent, shouldFail bool) (uint64, error) {
+	proposerAcc := g.proposerAccounts[g.rng.Intn(len(g.proposerAccounts))]
+
+	// Submit proposal.
+	tx := governance.NewSubmitProposalTx(proposerAcc.nonce, nil, pc)
+	proposerAcc.nonce++
+	err := g.FundSignAndSubmitTx(g.ctx, proposerAcc.signer, tx)
+	switch shouldFail {
+	case true:
+		if err == nil {
+			g.Logger.Error("expected proposal submission to fail",
+				"tx", tx,
+				"proposal_content", pc,
+			)
+			return 0, fmt.Errorf("%w: expected proposal submission to fail", errUnexpectedGovTxResult)
+		}
+		g.Logger.Debug("proposal submission failed (expected)",
+			"err", err,
+		)
+		return 0, nil
+	case false:
+		if err != nil {
+			g.Logger.Error("failed to sign and submit proposal transaction",
+				"tx", tx,
+				"signer", proposerAcc.signer.Public(),
+				"proposal_content", pc,
+			)
+			return 0, fmt.Errorf("%w: failed to sign and submit tx: %v", errUnexpectedGovTxResult, err)
+		}
+	}
+
+	g.Logger.Debug("proposal submitted",
+		"proposal_content", pc,
+	)
+	// Ensure proposal exists.
+	aps, err := g.governance.ActiveProposals(g.ctx, consensus.HeightLatest)
+	if err != nil {
+		return 0, fmt.Errorf("failed to query active proposals: %w", err)
+	}
+	var proposal *governance.Proposal
+	for _, ap := range aps {
+		if ap.Content.Equals(pc) {
+			proposal = ap
+			break
+		}
+	}
+
+	return proposal.ID, nil
+}
+
+func (g *governanceWorkload) doUpgradeProposal() error {
+	// Generate proposal content.
+	h, err := upgrade.OwnHash()
+	if err != nil {
+		return err
+	}
+	minUpgradeEpoch := int64(g.currentEpoch + g.parameters.UpgradeMinEpochDiff)
+	maxUpgradeEpoch := minUpgradeEpoch + int64(3*g.parameters.UpgradeMinEpochDiff)
+	// [minUpgradeEpoch, maxUpgradeEpoch]
+	upgradeEpoch := epochtime.EpochTime(g.rng.Int63n(maxUpgradeEpoch-minUpgradeEpoch+1) + minUpgradeEpoch)
+	nameSuffix := make([]byte, 20)
+	if _, err = g.rng.Read(nameSuffix); err != nil {
+		return err
+	}
+	proposalContent := &governance.ProposalContent{
+		Upgrade: &governance.UpgradeProposal{
+			Descriptor: upgrade.Descriptor{
+				Name:       fmt.Sprintf("test-upgrade_%s", hex.EncodeToString(nameSuffix)),
+				Method:     upgrade.UpgradeMethodInternal,
+				Identifier: hex.EncodeToString(h[:]),
+				Epoch:      upgradeEpoch,
+			},
+		},
+	}
+
+	// Check if upgrade submission is expected to succeed. It should fail in case
+	// there is a pending upgrade already scheduled minUpgradeEpoch before/after the
+	// proposed upgrade epoch.
+	var shouldFail bool
+	pendingUpgrades, err := g.governance.PendingUpgrades(g.ctx, consensus.HeightLatest)
+	if err != nil {
+		return fmt.Errorf("governance.PendingUpgrades: %w", err)
+	}
+	for _, pu := range pendingUpgrades {
+		if pu.Epoch.AbsDiff(proposalContent.Upgrade.Epoch) < g.parameters.UpgradeMinEpochDiff {
+			shouldFail = true
+			break
+		}
+	}
+
+	_, err = g.submitProposalContent(proposalContent, shouldFail)
+	switch {
+	case errors.Is(err, errUnexpectedGovTxResult):
+		// Unexpected gov tx results can happen on epoch transitions:
+		// - pending upgrade just being canceled by a different proposal
+		// - new pending upgrade could have just been accepted
+		if b, _ := g.checkEpochTransition(); b {
+			// The error is probably be related to the epoch transition:
+			g.Logger.Error("cancel upgrade proposal error on epoch transition", "err", err)
+			return nil
+		}
+		return err
+	default:
+		return err
+	}
+}
+
+func (g *governanceWorkload) submitCancelUpgradeProposal(descriptor *upgrade.Descriptor, shouldFail bool) (uint64, error) {
+	// Find proposal matching the pending upgrade.
+	ps, err := g.governance.Proposals(g.ctx, consensus.HeightLatest)
+	if err != nil {
+		return 0, fmt.Errorf("querying proposals: %w", err)
+	}
+	var proposal *governance.Proposal
+	for _, p := range ps {
+		if p.Content.Upgrade != nil && p.Content.Upgrade.Equals(descriptor) {
+			proposal = p
+			break
+		}
+	}
+	if proposal == nil {
+		g.Logger.Error("proposal for descriptor not found",
+			"proposals", ps,
+			"descriptor", descriptor,
+		)
+		return 0, fmt.Errorf("proposal for pending upgrade not found")
+	}
+
+	return g.submitProposalContent(
+		&governance.ProposalContent{
+			CancelUpgrade: &governance.CancelUpgradeProposal{
+				ProposalID: proposal.ID,
+			},
+		}, shouldFail)
+}
+
+func (g *governanceWorkload) doCancelUpgradeProposal() error {
+	pendingUpgrades, err := g.governance.PendingUpgrades(g.ctx, consensus.HeightLatest)
+	if err != nil {
+		return fmt.Errorf("governance.PendingUpgrades: %w", err)
+	}
+
+	// Pick a random eligible pending upgrade.
+	var pendingUpgrade *upgrade.Descriptor
+	var shouldFail bool
+OUTER:
+	for _, i := range rand.Perm(len(pendingUpgrades)) {
+		pu := pendingUpgrades[i]
+
+		d := pu.Epoch.AbsDiff(g.currentEpoch)
+		switch {
+		case d < g.parameters.UpgradeCancelMinEpochDiff:
+			pendingUpgrade = pu
+			shouldFail = true
+			break OUTER
+		case d > g.parameters.UpgradeCancelMinEpochDiff+2:
+			pendingUpgrade = pu
+			shouldFail = false
+			break OUTER
+		default:
+			// Skip pending upgrades that are about to be closed, as the main
+			// workload loop makes sure those will get canceled.
+		}
+	}
+	if pendingUpgrade == nil {
+		g.Logger.Debug("no eligible pending upgrade for submitting cancel upgrade proposal, skipping",
+			"pending_upgrades", pendingUpgrades,
+		)
+		return nil
+	}
+
+	_, err = g.submitCancelUpgradeProposal(pendingUpgrade, shouldFail)
+	switch {
+	case errors.Is(err, errUnexpectedGovTxResult):
+		// Unexpected gov tx results can happen on epoch transitions:
+		// - pending upgrade just being canceled by a different proposal
+		if b, _ := g.checkEpochTransition(); b {
+			// The error is probably related to the epoch transition:
+			g.Logger.Error("cancel upgrade proposal error on epoch transition", "err", err)
+			return nil
+		}
+		return err
+	default:
+		return err
+	}
+}
+
+func (g *governanceWorkload) submitVote(voter signature.Signer, proposalID uint64, vote governance.Vote) error {
+	tx := governance.NewCastVoteTx(0, nil, &governance.ProposalVote{
+		ID:   proposalID,
+		Vote: vote,
+	})
+	if err := g.FundSignAndSubmitTx(g.ctx, voter, tx); err != nil {
+		return fmt.Errorf("failed to sign and submit cast vote transaction: %w", err)
+	}
+
+	g.Logger.Debug("proposal vote cast", "vote", vote, "voter", voter.Public(), "proposal_id", proposalID)
+
+	return nil
+}
+
+func (g *governanceWorkload) doGovernanceVote() error {
+	activeProposals, err := g.governance.ActiveProposals(g.ctx, consensus.HeightLatest)
+	if err != nil {
+		return fmt.Errorf("governance.ActiveProposals(): %w", err)
+	}
+	if len(activeProposals) == 0 {
+		g.Logger.Debug("no active proposals, skipping submit vote")
+		return nil
+	}
+
+	var proposal *governance.Proposal
+	for _, idx := range rand.Perm(len(activeProposals)) {
+		p := activeProposals[idx]
+		// Avoid voting for proposals that could close during this iteration.
+		if p.ClosesAt <= g.currentEpoch+1 {
+			continue
+		}
+		proposal = p
+		break
+	}
+
+	// Select vote based on the proposer.
+	proposerIdx := -1
+	for i, p := range g.proposerAccounts {
+		if p.address.Equal(proposal.Submitter) {
+			proposerIdx = i
+			break
+		}
+	}
+	if proposerIdx == -1 {
+		return fmt.Errorf("invalid propopsal submitter: %v", proposal.Submitter)
+	}
+	var vote governance.Vote
+	switch {
+	case g.ensureYesVote[proposal.ID],
+		uint8(g.rng.Intn(100)) < proposersVoteYesRate[proposerIdx]:
+		vote = governance.VoteYes
+	case g.rng.Intn(100) < 50:
+		vote = governance.VoteNo
+	default:
+		vote = governance.VoteAbstain
+	}
+
+	return g.submitVote(g.validatorEntities[g.rng.Intn(len(g.validatorEntities))], proposal.ID, vote)
+}
+
+func (g *governanceWorkload) checkEpochTransition() (bool, error) {
+	epoch, err := g.consensus.GetEpoch(g.ctx, consensus.HeightLatest)
+	if err != nil {
+		return false, fmt.Errorf("querying epoch: %w", err)
+	}
+
+	return epoch > g.currentEpoch, nil
+}
+
+// Implements Workload.
+func (g *governanceWorkload) NeedsFunds() bool {
+	return true
+}
+
+// Implements Workload.
+func (g *governanceWorkload) Run(
+	gracefulExit context.Context,
+	rng *rand.Rand,
+	conn *grpc.ClientConn,
+	cnsc consensus.ClientBackend,
+	sm consensus.SubmissionManager,
+	fundingAccount signature.Signer,
+	validatorEntities []signature.Signer,
+) error {
+	var err error
+
+	// Initialize state.
+	g.BaseWorkload.Init(cnsc, sm, fundingAccount)
+	g.rng = rng
+	g.ctx = context.Background()
+
+	g.parameters, err = cnsc.Governance().ConsensusParameters(g.ctx, consensus.HeightLatest)
+	if err != nil {
+		return fmt.Errorf("error querying governance consensus parameters: %w", err)
+	}
+
+	g.consensus = cnsc
+	g.governance = cnsc.Governance()
+
+	g.validatorEntities = validatorEntities
+	if len(g.validatorEntities) == 0 {
+		return fmt.Errorf("workload requires validator entities")
+	}
+
+	g.proposerAccounts = make([]*struct {
+		signer  signature.Signer
+		address staking.Address
+		nonce   uint64
+	}, numProposerAccounts)
+	fac := memorySigner.NewFactory()
+	for i := range g.proposerAccounts {
+		var signer signature.Signer
+		signer, err = fac.Generate(signature.SignerEntity, rng)
+		if err != nil {
+			return fmt.Errorf("memory signer factory Generate account %d: %w", i, err)
+		}
+		g.proposerAccounts[i] = &struct {
+			signer  signature.Signer
+			address staking.Address
+			nonce   uint64
+		}{
+			signer:  signer,
+			address: staking.NewAddress(signer.Public()),
+		}
+		if err = g.TransferFunds(
+			g.ctx,
+			fundingAccount,
+			g.proposerAccounts[i].address,
+			g.parameters.MinProposalDeposit.ToBigInt().Uint64()*1000,
+		); err != nil {
+			return fmt.Errorf("account funding failure: %w", err)
+		}
+	}
+
+	g.ensureYesVote = make(map[uint64]bool)
+
+	// Main workload loop.
+	for {
+		select {
+		case <-time.After(1 * time.Second):
+		case <-gracefulExit.Done():
+			g.Logger.Debug("time's up")
+			return nil
+		}
+
+		var epoch epochtime.EpochTime
+		epoch, err = cnsc.GetEpoch(g.ctx, consensus.HeightLatest)
+		if err != nil {
+			return fmt.Errorf("querying epoch: %w", err)
+		}
+
+		// Epoch transition - update the local state accordingly.
+		if epoch > g.currentEpoch {
+			g.currentEpoch = epoch
+
+			// Make sure no pending upgrade will go through.
+			// XXX: this makes sure that any pending upgrades that are about to be executed are
+			// canceled. When txsource suite supports handling upgrades mid-run, remove this part.
+			var upgrades []*upgrade.Descriptor
+			upgrades, err = g.governance.PendingUpgrades(g.ctx, consensus.HeightLatest)
+			if err != nil {
+				return fmt.Errorf("querying penging upgrades: %w", err)
+			}
+			for _, up := range upgrades {
+				if up.Epoch.AbsDiff(g.currentEpoch) != g.parameters.UpgradeCancelMinEpochDiff+2 {
+					continue
+				}
+				if err = g.ensureUpgradeCanceled(up); err != nil {
+					return fmt.Errorf("ensuring upgrade canceled: %w", err)
+				}
+			}
+		}
+
+		switch rng.Intn(3) {
+		case 0:
+			if err = g.doUpgradeProposal(); err != nil {
+				return fmt.Errorf("submitting governance proposal: %w", err)
+			}
+		case 1:
+			if err = g.doCancelUpgradeProposal(); err != nil {
+				return fmt.Errorf("submitting cancel governance upgrade proposal: %w", err)
+			}
+		case 2:
+			if err = g.doGovernanceVote(); err != nil {
+				return fmt.Errorf("submitting governance vote: %w", err)
+			}
+		default:
+			return fmt.Errorf("unimplemented")
+		}
+	}
+}

--- a/go/oasis-node/cmd/debug/txsource/workload/oversized.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/oversized.go
@@ -45,6 +45,7 @@ func (o *oversized) Run(
 	cnsc consensus.ClientBackend,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
+	validatorEntities []signature.Signer,
 ) error {
 	// Initialize base workload.
 	o.BaseWorkload.Init(cnsc, sm, fundingAccount)

--- a/go/oasis-node/cmd/debug/txsource/workload/parallel.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/parallel.go
@@ -52,6 +52,7 @@ func (p *parallel) Run(
 	cnsc consensus.ClientBackend,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
+	validatorEntities []signature.Signer,
 ) error {
 	// Initialize base workload.
 	p.BaseWorkload.Init(cnsc, sm, fundingAccount)

--- a/go/oasis-node/cmd/debug/txsource/workload/registration.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/registration.go
@@ -160,6 +160,7 @@ func (r *registration) Run( // nolint: gocyclo
 	cnsc consensus.ClientBackend,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
+	validatorEntities []signature.Signer,
 ) error {
 	// Initialize base workload.
 	r.BaseWorkload.Init(cnsc, sm, fundingAccount)

--- a/go/oasis-node/cmd/debug/txsource/workload/runtime.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/runtime.go
@@ -523,6 +523,7 @@ func (r *runtime) Run(
 	cnsc consensus.ClientBackend,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
+	validatorEntities []signature.Signer,
 ) error {
 	// Initialize base workload.
 	r.BaseWorkload.Init(cnsc, sm, fundingAccount)

--- a/go/oasis-node/cmd/debug/txsource/workload/transfer.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/transfer.go
@@ -251,6 +251,7 @@ func (t *transfer) Run(
 	cnsc consensus.ClientBackend,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
+	validatorEntities []signature.Signer,
 ) error {
 	// Initialize base workload.
 	t.BaseWorkload.Init(cnsc, sm, fundingAccount)

--- a/go/oasis-node/cmd/debug/txsource/workload/workload.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/workload.go
@@ -34,6 +34,7 @@ var ByName = map[string]Workload{
 	NameRegistration: Registration,
 	NameRuntime:      Runtime,
 	NameTransfer:     Transfer,
+	NameGovernance:   Governance,
 }
 
 // Flags has the workload flags.
@@ -91,15 +92,6 @@ func (bw *BaseWorkload) GasPrice() uint64 {
 	// NOTE: This cannot fail as workloads use static price discovery.
 	gasPrice, _ := bw.sm.PriceDiscovery().GasPrice(context.Background())
 	return gasPrice.ToBigInt().Uint64()
-}
-
-// LoadNonce returns the current nonce for the provided address.
-func (bw *BaseWorkload) LoadNonce(ctx context.Context, addr staking.Address) (uint64, error) {
-	acc, err := bw.cc.Staking().Account(ctx, &staking.OwnerQuery{Height: consensus.HeightLatest, Owner: addr})
-	if err != nil {
-		return 0, fmt.Errorf("failed to query account info: %w", err)
-	}
-	return acc.General.Nonce, nil
 }
 
 // FundSignAndSubmitTx funds the caller to cover transaction fees, signs the transaction and submits

--- a/go/oasis-node/cmd/debug/txsource/workload/workload.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/workload.go
@@ -55,6 +55,7 @@ type Workload interface {
 		cnsc consensus.ClientBackend,
 		sm consensus.SubmissionManager,
 		fundingAccount signature.Signer,
+		validatorEntities []signature.Signer,
 	) error
 }
 
@@ -90,6 +91,15 @@ func (bw *BaseWorkload) GasPrice() uint64 {
 	// NOTE: This cannot fail as workloads use static price discovery.
 	gasPrice, _ := bw.sm.PriceDiscovery().GasPrice(context.Background())
 	return gasPrice.ToBigInt().Uint64()
+}
+
+// LoadNonce returns the current nonce for the provided address.
+func (bw *BaseWorkload) LoadNonce(ctx context.Context, addr staking.Address) (uint64, error) {
+	acc, err := bw.cc.Staking().Account(ctx, &staking.OwnerQuery{Height: consensus.HeightLatest, Owner: addr})
+	if err != nil {
+		return 0, fmt.Errorf("failed to query account info: %w", err)
+	}
+	return acc.General.Nonce, nil
 }
 
 // FundSignAndSubmitTx funds the caller to cover transaction fees, signs the transaction and submits

--- a/go/oasis-test-runner/scenario/e2e/debond.go
+++ b/go/oasis-test-runner/scenario/e2e/debond.go
@@ -48,7 +48,7 @@ func (s *debondImpl) Fixture() (*oasis.NetworkFixture, error) {
 		},
 		TotalSupply: *quantity.NewFromUint64(1000),
 		Ledger: map[staking.Address]*staking.Account{
-			EntityAccount: {
+			TestEntityAccount: {
 				Escrow: staking.EscrowAccount{
 					Debonding: staking.SharePool{
 						Balance:     *quantity.NewFromUint64(1000),
@@ -58,7 +58,7 @@ func (s *debondImpl) Fixture() (*oasis.NetworkFixture, error) {
 			},
 		},
 		DebondingDelegations: map[staking.Address]map[staking.Address][]*staking.DebondingDelegation{
-			EntityAccount: {
+			TestEntityAccount: {
 				DeterministicValidator0: {
 					{
 						Shares:        *quantity.NewFromUint64(500),

--- a/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
+++ b/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
@@ -83,7 +83,7 @@ func (sc *gasFeesImpl) Fixture() (*oasis.NetworkFixture, error) {
 				CommonPool:    *quantity.NewFromUint64(150),
 				LastBlockFees: *quantity.NewFromUint64(50),
 				Ledger: map[staking.Address]*staking.Account{
-					EntityAccount: {
+					TestEntityAccount: {
 						General: staking.GeneralAccount{
 							Balance: *quantity.NewFromUint64(1000),
 						},

--- a/go/oasis-test-runner/scenario/e2e/runtime/dump_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/dump_restore.go
@@ -124,6 +124,10 @@ func (sc *dumpRestoreImpl) Run(childEnv *env.Env) error {
 	}
 
 	// Check that everything works with restored state.
-	sc.runtimeImpl.clientArgs = []string{"--mode", "part2"}
+	sc.runtimeImpl.clientArgs = []string{
+		"--mode", "part2",
+		// Use a different nonce seed.
+		"--seed", "second_seed",
+	}
 	return sc.runtimeImpl.Run(childEnv)
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/governance_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/governance_upgrade.go
@@ -487,6 +487,10 @@ func (sc *governanceConsensusUpgradeImpl) Run(childEnv *env.Env) error { // noli
 	}
 
 	// Check that runtime still works after the upgrade.
-	sc.runtimeImpl.clientArgs = []string{"--mode", "part2"}
+	sc.runtimeImpl.clientArgs = []string{
+		"--mode", "part2",
+		// Use a different nonce seed.
+		"--seed", "second_seed",
+	}
 	return sc.runtimeImpl.Run(childEnv)
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/governance_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/governance_upgrade.go
@@ -113,7 +113,7 @@ func (sc *governanceConsensusUpgradeImpl) Fixture() (*oasis.NetworkFixture, erro
 		CommonPool:  *quantity.NewFromUint64(100),
 		Ledger: map[staking.Address]*staking.Account{
 			// Fund entity account so we'll be able to submit the proposal.
-			e2e.Entity1Account: {
+			e2e.DeterministicEntity1: {
 				General: staking.GeneralAccount{
 					Balance: *quantity.NewFromUint64(1000),
 				},
@@ -126,8 +126,8 @@ func (sc *governanceConsensusUpgradeImpl) Fixture() (*oasis.NetworkFixture, erro
 			},
 		},
 		Delegations: map[staking.Address]map[staking.Address]*staking.Delegation{
-			e2e.Entity1Account: {
-				e2e.Entity1Account: &staking.Delegation{
+			e2e.DeterministicEntity1: {
+				e2e.DeterministicEntity1: &staking.Delegation{
 					Shares: *quantity.NewFromUint64(100),
 				},
 			},
@@ -333,7 +333,7 @@ func (sc *governanceConsensusUpgradeImpl) Run(childEnv *env.Env) error { // noli
 	entityAcc, err := sc.Net.Controller().Staking.Account(sc.ctx,
 		&staking.OwnerQuery{
 			Height: consensus.HeightLatest,
-			Owner:  e2e.Entity1Account,
+			Owner:  e2e.DeterministicEntity1,
 		},
 	)
 	if err != nil {

--- a/go/oasis-test-runner/scenario/e2e/runtime/halt_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/halt_restore.go
@@ -144,6 +144,10 @@ func (sc *haltRestoreImpl) Run(childEnv *env.Env) error {
 	// socket path length.
 	sc.Net.Config().UseShortGrpcSocketPaths = true
 
-	sc.runtimeImpl.clientArgs = []string{"--mode", "part2"}
+	sc.runtimeImpl.clientArgs = []string{
+		"--mode", "part2",
+		// Use a different nonce seed.
+		"--seed", "second_seed",
+	}
 	return sc.runtimeImpl.Run(childEnv)
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
+	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/debug/txsource"
@@ -230,6 +231,14 @@ func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
 	}
 	// Use deterministic identities as we need to allocate funds to nodes.
 	f.Network.DeterministicIdentities = true
+	f.Network.GovernanceParameters = &governance.ConsensusParameters{
+		VotingPeriod:              10,
+		MinProposalDeposit:        *quantity.NewFromUint64(300),
+		Quorum:                    90,
+		Threshold:                 90,
+		UpgradeMinEpochDiff:       40,
+		UpgradeCancelMinEpochDiff: 20,
+	}
 	f.Network.StakingGenesis = &staking.Genesis{
 		Parameters: staking.ConsensusParameters{
 			CommissionScheduleRules: staking.CommissionScheduleRules{

--- a/go/oasis-test-runner/scenario/e2e/test_accounts.go
+++ b/go/oasis-test-runner/scenario/e2e/test_accounts.go
@@ -4,8 +4,11 @@ import stakingTests "github.com/oasisprotocol/oasis-core/go/staking/tests/debug"
 
 // Deterministic Test Accounts.
 var (
-	EntityAccount  = stakingTests.AddressFromString("oasis1qq7us2p22udg2t24u6ry4m29wzql005pjsske8gt")
-	Entity1Account = stakingTests.AddressFromString("oasis1qqncl383h8458mr9cytatygctzwsx02n4c5f8ed7")
+	TestEntityAccount    = stakingTests.AddressFromString("oasis1qq7us2p22udg2t24u6ry4m29wzql005pjsske8gt")
+	DeterministicEntity1 = stakingTests.AddressFromString("oasis1qqncl383h8458mr9cytatygctzwsx02n4c5f8ed7")
+	DeterministicEntity2 = stakingTests.AddressFromString("oasis1qznshq4ttrgh83d9wqvgmsuq3pfsndg3tus7lx98")
+	DeterministicEntity3 = stakingTests.AddressFromString("oasis1qrz6kjp9lu6vc6snhlszq3p2nlx76qasaqr2auqk")
+	DeterministicEntity4 = stakingTests.AddressFromString("oasis1qqw3ka3eeuy5qaytyhesxtj4fe5pp0xkdy954uwk")
 
 	DeterministicValidator0 = stakingTests.AddressFromString("oasis1qpt202cf6t0s5ugkk34p83yf0c30gpjkny92u7dh")
 	DeterministicValidator1 = stakingTests.AddressFromString("oasis1qryg8qf3ydzcphr328l8psz007fms9dxeuy8lgzq")


### PR DESCRIPTION
- Adds the governance workload. Governance workload does the following:
  - continuously submits proposals (both upgrade & cancel pending upgrade)
  - votes for proposals (makes sure some proposals get rejected and some pass) 
  - cancels any pending upgrades (via submitting a proposal and making sure it passes) `UpgradeCancelMinEpochDiff` before execution, to ensure no upgrades actually happen during the txsource test. In future we could/should probably also support this in the txsource test. 
- queries workload is updated with governance queries
- use multiple entities for txsrouce validators

TODO:
- [x] add governance queries to queries workload