### PR TITLE
runtime/storage/mkvs: Add MKVS impl for &mut T

### DIFF
--- a/.changelog/3604.internal.2.md
+++ b/.changelog/3604.internal.2.md
@@ -1,0 +1,1 @@
+Update smallvec to 0.6.14

--- a/.changelog/3604.internal.md
+++ b/.changelog/3604.internal.md
@@ -1,0 +1,1 @@
+runtime/storage/mkvs: Add MKVS impl for &mut T

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,9 +1990,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
 dependencies = [
  "maybe-uninit",
 ]

--- a/runtime/src/storage/mkvs/mod.rs
+++ b/runtime/src/storage/mkvs/mod.rs
@@ -221,7 +221,42 @@ pub trait Iterator: iter::Iterator<Item = (Vec<u8>, Vec<u8>)> {
     fn next(&mut self);
 }
 
-impl<T: FallibleMKVS> FallibleMKVS for &mut T {
+impl<T: MKVS + ?Sized> MKVS for &mut T {
+    fn get(&self, ctx: Context, key: &[u8]) -> Option<Vec<u8>> {
+        T::get(self, ctx, key)
+    }
+
+    fn cache_contains_key(&self, ctx: Context, key: &[u8]) -> bool {
+        T::cache_contains_key(self, ctx, key)
+    }
+
+    fn insert(&mut self, ctx: Context, key: &[u8], value: &[u8]) -> Option<Vec<u8>> {
+        T::insert(self, ctx, key, value)
+    }
+
+    fn remove(&mut self, ctx: Context, key: &[u8]) -> Option<Vec<u8>> {
+        T::remove(self, ctx, key)
+    }
+
+    fn prefetch_prefixes(&self, ctx: Context, prefixes: &Vec<Prefix>, limit: u16) {
+        T::prefetch_prefixes(self, ctx, prefixes, limit)
+    }
+
+    fn iter(&self, ctx: Context) -> Box<dyn Iterator + '_> {
+        T::iter(self, ctx)
+    }
+
+    fn commit(
+        &mut self,
+        ctx: Context,
+        namespace: Namespace,
+        version: u64,
+    ) -> Result<(WriteLog, Hash)> {
+        T::commit(self, ctx, namespace, version)
+    }
+}
+
+impl<T: FallibleMKVS + ?Sized> FallibleMKVS for &mut T {
     fn get(&self, ctx: Context, key: &[u8]) -> Result<Option<Vec<u8>>> {
         T::get(self, ctx, key)
     }


### PR DESCRIPTION
Trivial MKVS trait impl needed by the ParaTime SDK.