### PR TITLE
go/upgrade: use ProtocolVersions as internal upgrade identifier

### DIFF
--- a/.changelog/3579.breaking.md
+++ b/.changelog/3579.breaking.md
@@ -1,0 +1,5 @@
+go/upgrade: Use ProtocolVersions as internal upgrade identifier
+
+Before this change the Internal upgrades used node binary hashes to ensure
+upgrade version compatibility. To make it more practical use software versions
+instead.

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -99,13 +99,16 @@ var (
 	Toolchain = parseSemVerStr(strings.TrimPrefix(runtime.Version(), "go"))
 )
 
-// Versions contains all known protocol versions.
-var Versions = struct {
-	RuntimeHostProtocol      Version
-	RuntimeCommitteeProtocol Version
-	ConsensusProtocol        Version
-	Toolchain                Version
-}{
+// ProtocolVersions are the protocol versions.
+type ProtocolVersions struct {
+	RuntimeHostProtocol      Version `json:"runtime_host_protocol"`
+	RuntimeCommitteeProtocol Version `json:"runtime_committee_protocol"`
+	ConsensusProtocol        Version `json:"consensus_protocol"`
+	Toolchain                Version `json:"toolchain"`
+}
+
+// Versions are current protocol versions.
+var Versions = ProtocolVersions{
 	RuntimeHostProtocol,
 	RuntimeCommitteeProtocol,
 	ConsensusProtocol,

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -107,6 +107,23 @@ type ProtocolVersions struct {
 	Toolchain                Version `json:"toolchain"`
 }
 
+// Compatible returns if the two protocol versions are compatible.
+func (pv *ProtocolVersions) Compatible(other ProtocolVersions) bool {
+	if pv.RuntimeHostProtocol.MaskNonMajor() != other.RuntimeHostProtocol.MaskNonMajor() {
+		return false
+	}
+	if pv.RuntimeCommitteeProtocol.MaskNonMajor() != other.RuntimeCommitteeProtocol.MaskNonMajor() {
+		return false
+	}
+	if pv.ConsensusProtocol.MaskNonMajor() != other.ConsensusProtocol.MaskNonMajor() {
+		return false
+	}
+	if pv.Toolchain.MaskNonMajor() != other.Toolchain.MaskNonMajor() {
+		return false
+	}
+	return true
+}
+
 // Versions are current protocol versions.
 var Versions = ProtocolVersions{
 	RuntimeHostProtocol,

--- a/go/common/version/version_test.go
+++ b/go/common/version/version_test.go
@@ -90,3 +90,68 @@ func TestConvertGoModulesVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestProtocolVersionCompatible(t *testing.T) {
+	for _, v := range []struct {
+		versions     func() ProtocolVersions
+		isCompatible bool
+		msg          string
+	}{
+		{
+			func() ProtocolVersions {
+				v := Versions
+				v.ConsensusProtocol.Patch++
+				return v
+			},
+			true,
+			"patch version change is compatible",
+		},
+		{
+			func() ProtocolVersions {
+				v := Versions
+				v.ConsensusProtocol.Minor++
+				return v
+			},
+			true,
+			"minor version change is compatible",
+		},
+		{
+			func() ProtocolVersions {
+				v := Versions
+				v.ConsensusProtocol.Major++
+				return v
+			},
+			false,
+			"consensus protocol major version change is not compatible",
+		},
+		{
+			func() ProtocolVersions {
+				v := Versions
+				v.Toolchain.Major++
+				return v
+			},
+			false,
+			"toolchain major version change is not compatible",
+		},
+		{
+			func() ProtocolVersions {
+				v := Versions
+				v.RuntimeCommitteeProtocol.Major++
+				return v
+			},
+			false,
+			"runtime committee protocol major version change is not compatible",
+		},
+		{
+			func() ProtocolVersions {
+				v := Versions
+				v.RuntimeHostProtocol.Major++
+				return v
+			},
+			false,
+			"runtime host protocol major version change is not compatible",
+		},
+	} {
+		require.Equal(t, v.isCompatible, Versions.Compatible(v.versions()), v.msg)
+	}
+}

--- a/go/consensus/tendermint/apps/governance/genesis_test.go
+++ b/go/consensus/tendermint/apps/governance/genesis_test.go
@@ -1,7 +1,6 @@
 package governance
 
 import (
-	"encoding/hex"
 	"fmt"
 	"testing"
 	"time"
@@ -9,9 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/abci/types"
 
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
 	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
 	governanceState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/governance/state"
 	epochtime "github.com/oasisprotocol/oasis-core/go/epochtime/api"
@@ -21,10 +21,7 @@ import (
 	upgrade "github.com/oasisprotocol/oasis-core/go/upgrade/api"
 )
 
-var (
-	emptyHash    hash.Hash
-	emptyHashHex = hex.EncodeToString(emptyHash[:])
-)
+var identifier = cbor.Marshal(version.ProtocolVersions{ConsensusProtocol: version.FromU64(42)})
 
 func TestInitChain(t *testing.T) {
 	require := require.New(t)
@@ -107,7 +104,7 @@ func TestInitChain(t *testing.T) {
 						ClosesAt:     20,
 						State:        governance.StatePassed,
 						InvalidVotes: 0,
-						Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: emptyHashHex, Epoch: 30}}},
+						Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: identifier, Epoch: 30}}},
 						CreatedAt:    10,
 						Deposit:      *quantity.NewFromUint64(10),
 						Submitter:    addresses[1],
@@ -135,7 +132,7 @@ func TestInitChain(t *testing.T) {
 						ClosesAt:     100,
 						State:        governance.StateActive,
 						InvalidVotes: 0,
-						Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: emptyHashHex, Epoch: 10000}}},
+						Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: identifier, Epoch: 10000}}},
 						CreatedAt:    20,
 						Deposit:      *quantity.NewFromUint64(10),
 						Submitter:    addresses[3],
@@ -146,7 +143,7 @@ func TestInitChain(t *testing.T) {
 						ClosesAt:     70,
 						State:        governance.StatePassed,
 						InvalidVotes: 0,
-						Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: emptyHashHex, Epoch: 1000}}},
+						Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: identifier, Epoch: 1000}}},
 						CreatedAt:    20,
 						Deposit:      *quantity.NewFromUint64(10),
 						Submitter:    addresses[4],
@@ -160,7 +157,7 @@ func TestInitChain(t *testing.T) {
 						ClosesAt:     70,
 						State:        governance.StatePassed,
 						InvalidVotes: 0,
-						Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: emptyHashHex, Epoch: 2000}}},
+						Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: identifier, Epoch: 2000}}},
 						CreatedAt:    60,
 						Deposit:      *quantity.NewFromUint64(10),
 						Submitter:    addresses[4],
@@ -174,7 +171,7 @@ func TestInitChain(t *testing.T) {
 						ClosesAt:     70,
 						State:        governance.StatePassed,
 						InvalidVotes: 0,
-						Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: emptyHashHex, Epoch: 2000}}},
+						Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: identifier, Epoch: 2000}}},
 						CreatedAt:    60,
 						Deposit:      *quantity.NewFromUint64(10),
 						Submitter:    addresses[4],
@@ -287,7 +284,7 @@ func TestGenesis(t *testing.T) {
 			ClosesAt:     20,
 			State:        governance.StateRejected,
 			InvalidVotes: 3,
-			Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: emptyHashHex, Epoch: 30}}},
+			Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: identifier, Epoch: 30}}},
 			CreatedAt:    10,
 			Deposit:      *quantity.NewFromUint64(10),
 			Submitter:    addresses[0],
@@ -301,7 +298,7 @@ func TestGenesis(t *testing.T) {
 			ClosesAt:     20,
 			State:        governance.StatePassed,
 			InvalidVotes: 0,
-			Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: emptyHashHex, Epoch: 30}}},
+			Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: identifier, Epoch: 30}}},
 			CreatedAt:    10,
 			Deposit:      *quantity.NewFromUint64(10),
 			Submitter:    addresses[1],
@@ -329,7 +326,7 @@ func TestGenesis(t *testing.T) {
 			ClosesAt:     100,
 			State:        governance.StateActive,
 			InvalidVotes: 0,
-			Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: emptyHashHex, Epoch: 10000}}},
+			Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: identifier, Epoch: 10000}}},
 			CreatedAt:    20,
 			Deposit:      *quantity.NewFromUint64(10),
 			Submitter:    addresses[3],
@@ -340,7 +337,7 @@ func TestGenesis(t *testing.T) {
 			ClosesAt:     100,
 			State:        governance.StatePassed,
 			InvalidVotes: 0,
-			Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: emptyHashHex, Epoch: 1000}}},
+			Content:      governance.ProposalContent{Upgrade: &governance.UpgradeProposal{Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Identifier: identifier, Epoch: 1000}}},
 			CreatedAt:    20,
 			Deposit:      *quantity.NewFromUint64(10),
 			Submitter:    addresses[4],

--- a/go/consensus/tendermint/apps/governance/governance_test.go
+++ b/go/consensus/tendermint/apps/governance/governance_test.go
@@ -2,7 +2,6 @@ package governance
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"testing"
@@ -17,6 +16,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/entity"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
 	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
 	governanceState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/governance/state"
 	registryState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry/state"
@@ -328,12 +328,10 @@ func TestExecuteProposal(t *testing.T) {
 	ctx := appState.NewContext(abciAPI.ContextDeliverTx, now)
 	defer ctx.Close()
 
-	ownHash, err := upgrade.OwnHash()
-	require.NoError(err, "upgrade.OwnHash()")
 	defaultUpgradeProposal := &governance.UpgradeProposal{
 		Descriptor: upgrade.Descriptor{
 			Method:     upgrade.UpgradeMethodInternal,
-			Identifier: hex.EncodeToString(ownHash[:]),
+			Identifier: cbor.Marshal(version.Versions),
 			Epoch:      20,
 		},
 	}
@@ -434,7 +432,7 @@ func TestExecuteProposal(t *testing.T) {
 						Name:       "test-upgrade",
 						Method:     upgrade.UpgradeMethodInternal,
 						Epoch:      22, // Already scheduled upgrade is at epoch 20.
-						Identifier: emptyHashHex,
+						Identifier: identifier,
 					},
 				}},
 			},
@@ -517,14 +515,12 @@ func TestBeginBlock(t *testing.T) {
 		state: appState,
 	}
 
-	ownHash, err := upgrade.OwnHash()
-	require.NoError(err, "upgrade.OwnHash()")
 	// Prepare some pending upgrades.
 	upgrade11 := &governance.UpgradeProposal{
-		Descriptor: upgrade.Descriptor{Epoch: 11, Method: upgrade.UpgradeMethodInternal, Identifier: hex.EncodeToString(ownHash[:])},
+		Descriptor: upgrade.Descriptor{Epoch: 11, Method: upgrade.UpgradeMethodInternal, Identifier: cbor.Marshal(version.Versions)},
 	}
 	upgrade12 := &governance.UpgradeProposal{
-		Descriptor: upgrade.Descriptor{Epoch: 12, Method: upgrade.UpgradeMethodInternal, Identifier: hex.EncodeToString(ownHash[:])},
+		Descriptor: upgrade.Descriptor{Epoch: 12, Method: upgrade.UpgradeMethodInternal, Identifier: cbor.Marshal(version.Versions)},
 	}
 	err = state.SetProposal(ctx, &governance.Proposal{ID: 1, Content: governance.ProposalContent{Upgrade: upgrade11}})
 	require.NoError(err, "SetProposal")

--- a/go/consensus/tendermint/apps/governance/state/state_test.go
+++ b/go/consensus/tendermint/apps/governance/state/state_test.go
@@ -7,9 +7,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
 	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
 	epochtime "github.com/oasisprotocol/oasis-core/go/epochtime/api"
 	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
@@ -34,7 +36,7 @@ func initProposals(require *require.Assertions, ctx *abciAPI.Context, s *Mutable
 				Upgrade: &governance.UpgradeProposal{
 					Descriptor: upgrade.Descriptor{
 						Name:       "test",
-						Identifier: "1",
+						Identifier: cbor.Marshal(version.ProtocolVersions{ConsensusProtocol: version.FromU64(1)}),
 						Epoch:      epochtime.EpochTime(100),
 					},
 				},
@@ -50,7 +52,7 @@ func initProposals(require *require.Assertions, ctx *abciAPI.Context, s *Mutable
 				Upgrade: &governance.UpgradeProposal{
 					Descriptor: upgrade.Descriptor{
 						Name:       "test2",
-						Identifier: "12",
+						Identifier: cbor.Marshal(version.ProtocolVersions{ConsensusProtocol: version.FromU64(2)}),
 						Epoch:      epochtime.EpochTime(200),
 					},
 				},
@@ -66,7 +68,7 @@ func initProposals(require *require.Assertions, ctx *abciAPI.Context, s *Mutable
 				Upgrade: &governance.UpgradeProposal{
 					Descriptor: upgrade.Descriptor{
 						Name:       "test3",
-						Identifier: "123",
+						Identifier: cbor.Marshal(version.ProtocolVersions{ConsensusProtocol: version.FromU64(3)}),
 						Epoch:      epochtime.EpochTime(300),
 					},
 				},
@@ -82,7 +84,7 @@ func initProposals(require *require.Assertions, ctx *abciAPI.Context, s *Mutable
 				Upgrade: &governance.UpgradeProposal{
 					Descriptor: upgrade.Descriptor{
 						Name:       "test4",
-						Identifier: "1234",
+						Identifier: cbor.Marshal(version.ProtocolVersions{ConsensusProtocol: version.FromU64(4)}),
 						Epoch:      epochtime.EpochTime(300),
 					},
 				},

--- a/go/consensus/tendermint/apps/governance/transactions_test.go
+++ b/go/consensus/tendermint/apps/governance/transactions_test.go
@@ -86,7 +86,7 @@ func TestSubmitProposal(t *testing.T) {
 				Descriptor: upgrade.Descriptor{
 					Method:     upgrade.UpgradeMethodInternal,
 					Epoch:      10,
-					Identifier: emptyHashHex,
+					Identifier: identifier,
 				},
 			}},
 			func() {},
@@ -100,7 +100,7 @@ func TestSubmitProposal(t *testing.T) {
 				Descriptor: upgrade.Descriptor{
 					Method:     upgrade.UpgradeMethodInternal,
 					Epoch:      10,
-					Identifier: emptyHashHex,
+					Identifier: identifier,
 				},
 			}},
 			func() {},
@@ -122,7 +122,7 @@ func TestSubmitProposal(t *testing.T) {
 				Descriptor: upgrade.Descriptor{
 					Method:     upgrade.UpgradeMethodInternal,
 					Epoch:      10,
-					Identifier: emptyHashHex,
+					Identifier: identifier,
 				},
 			}},
 			func() {},
@@ -149,7 +149,7 @@ func TestSubmitProposal(t *testing.T) {
 				upgrade := upgrade.Descriptor{
 					Method:     upgrade.UpgradeMethodInternal,
 					Epoch:      10,
-					Identifier: emptyHashHex,
+					Identifier: identifier,
 				}
 				err = state.SetPendingUpgrade(ctx, 10, &upgrade)
 				require.NoError(err, "SetPendingUpgrade()")
@@ -173,7 +173,7 @@ func TestSubmitProposal(t *testing.T) {
 				Descriptor: upgrade.Descriptor{
 					Method:     upgrade.UpgradeMethodInternal,
 					Epoch:      200,
-					Identifier: emptyHashHex,
+					Identifier: identifier,
 				},
 			}},
 			func() {},
@@ -230,7 +230,7 @@ func TestSubmitProposal(t *testing.T) {
 			&governance.ProposalContent{Upgrade: &governance.UpgradeProposal{
 				Descriptor: upgrade.Descriptor{
 					Method:     upgrade.UpgradeMethodInternal,
-					Identifier: emptyHashHex,
+					Identifier: identifier,
 					Epoch:      210,
 				},
 			}},
@@ -238,7 +238,7 @@ func TestSubmitProposal(t *testing.T) {
 				upgrade := upgrade.Descriptor{
 					Method:     upgrade.UpgradeMethodInternal,
 					Epoch:      200,
-					Identifier: emptyHashHex,
+					Identifier: identifier,
 				}
 				err = state.SetPendingUpgrade(ctx, 10, &upgrade)
 				require.NoError(err, "SetPendingUpgrade()")

--- a/go/consensus/tests/tester.go
+++ b/go/consensus/tests/tester.go
@@ -63,12 +63,12 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.ClientBackend)
 	require.Len(
 		txsWithResults.Transactions,
 		len(txs),
-		"GetTransactionsWithResults.Transactions length missmatch",
+		"GetTransactionsWithResults.Transactions length mismatch",
 	)
 	require.Len(
 		txsWithResults.Results,
 		len(txsWithResults.Transactions),
-		"GetTransactionsWithResults.Results length missmatch",
+		"GetTransactionsWithResults.Results length mismatch",
 	)
 
 	_, err = backend.GetUnconfirmedTransactions(ctx)

--- a/go/control/api/api.go
+++ b/go/control/api/api.go
@@ -46,8 +46,7 @@ type NodeController interface {
 	UpgradeBinary(ctx context.Context, descriptor *upgrade.Descriptor) error
 
 	// CancelUpgrade cancels the specific pending upgrade, unless it is already in progress.
-	// TODO: currently pending upgrade name uniqueness is not enforced.
-	CancelUpgrade(ctx context.Context, name string) error
+	CancelUpgrade(ctx context.Context, descriptor *upgrade.Descriptor) error
 
 	// GetStatus returns the current status overview of the node.
 	GetStatus(ctx context.Context) (*Status, error)

--- a/go/control/api/grpc.go
+++ b/go/control/api/grpc.go
@@ -200,21 +200,21 @@ func handlerCancelUpgrade( // nolint: golint
 	dec func(interface{}) error,
 	interceptor grpc.UnaryServerInterceptor,
 ) (interface{}, error) {
-	var name string
-	if err := dec(&name); err != nil {
+	var descriptor upgradeApi.Descriptor
+	if err := dec(&descriptor); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return nil, srv.(NodeController).CancelUpgrade(ctx, name)
+		return nil, srv.(NodeController).CancelUpgrade(ctx, &descriptor)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodCancelUpgrade.FullName(),
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return nil, srv.(NodeController).CancelUpgrade(ctx, req.(string))
+		return nil, srv.(NodeController).CancelUpgrade(ctx, req.(*upgradeApi.Descriptor))
 	}
-	return interceptor(ctx, name, info, handler)
+	return interceptor(ctx, &descriptor, info, handler)
 }
 
 func handlerGetStatus( // nolint: golint
@@ -277,8 +277,8 @@ func (c *nodeControllerClient) UpgradeBinary(ctx context.Context, descriptor *up
 	return c.conn.Invoke(ctx, methodUpgradeBinary.FullName(), descriptor, nil)
 }
 
-func (c *nodeControllerClient) CancelUpgrade(ctx context.Context, name string) error {
-	return c.conn.Invoke(ctx, methodCancelUpgrade.FullName(), name, nil)
+func (c *nodeControllerClient) CancelUpgrade(ctx context.Context, descriptor *upgradeApi.Descriptor) error {
+	return c.conn.Invoke(ctx, methodCancelUpgrade.FullName(), descriptor, nil)
 }
 
 func (c *nodeControllerClient) GetStatus(ctx context.Context) (*Status, error) {

--- a/go/control/control.go
+++ b/go/control/control.go
@@ -77,8 +77,8 @@ func (c *nodeController) UpgradeBinary(ctx context.Context, descriptor *upgrade.
 	return c.upgrader.SubmitDescriptor(ctx, descriptor)
 }
 
-func (c *nodeController) CancelUpgrade(ctx context.Context, name string) error {
-	return c.upgrader.CancelUpgrade(ctx, name)
+func (c *nodeController) CancelUpgrade(ctx context.Context, descriptor *upgrade.Descriptor) error {
+	return c.upgrader.CancelUpgrade(ctx, descriptor)
 }
 
 func (c *nodeController) GetStatus(ctx context.Context) (*control.Status, error) {

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/genesis"
 	tendermint "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
 	epochtime "github.com/oasisprotocol/oasis-core/go/epochtime/api"
@@ -840,8 +841,6 @@ func TestGenesisSanityCheck(t *testing.T) {
 	d.Governance.Parameters.UpgradeMinEpochDiff = 50
 	require.Error(d.SanityCheck(), "upgrade_min_epoch_diff < voting_period should be rejected")
 
-	ownHash, err := upgrade.OwnHash()
-	require.NoError(err, "upgrade.OwnHash()")
 	validTestProposals := func() []*governance.Proposal {
 		return []*governance.Proposal{
 			{
@@ -850,7 +849,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 				Submitter: stakingTests.DebugStateDestAddress,
 				Content: governance.ProposalContent{
 					Upgrade: &governance.UpgradeProposal{
-						Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Epoch: 500, Identifier: hex.EncodeToString(ownHash[:])},
+						Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Epoch: 500, Identifier: cbor.Marshal(version.Versions)},
 					},
 				},
 				State: governance.StateActive,
@@ -891,7 +890,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 	require.Error(d.SanityCheck(), "proposal invalid content")
 
 	d.Governance.Proposals = validTestProposals()
-	d.Governance.Proposals[0].Content.Upgrade.Identifier = "abc"
+	d.Governance.Proposals[0].Content.Upgrade.Identifier = cbor.Marshal("abc")
 	require.Error(d.SanityCheck(), "proposal upgrade invalid identifier")
 
 	d.Governance.Proposals = validTestProposals()
@@ -945,7 +944,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 			Submitter: stakingTests.DebugStateDestAddress,
 			Content: governance.ProposalContent{
 				Upgrade: &governance.UpgradeProposal{
-					Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Epoch: 400, Identifier: hex.EncodeToString(ownHash[:])},
+					Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Epoch: 400, Identifier: cbor.Marshal(version.Versions)},
 				},
 			},
 			State: governance.StatePassed,
@@ -960,7 +959,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 		Submitter: stakingTests.DebugStateDestAddress,
 		Content: governance.ProposalContent{
 			Upgrade: &governance.UpgradeProposal{
-				Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Epoch: 710, Identifier: hex.EncodeToString(ownHash[:])},
+				Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Epoch: 710, Identifier: cbor.Marshal(version.Versions)},
 			},
 		},
 		State: governance.StatePassed,
@@ -974,7 +973,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 		Submitter: stakingTests.DebugStateDestAddress,
 		Content: governance.ProposalContent{
 			Upgrade: &governance.UpgradeProposal{
-				Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Epoch: 410, Identifier: hex.EncodeToString(ownHash[:])},
+				Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Epoch: 410, Identifier: cbor.Marshal(version.Versions)},
 			},
 		},
 		State: governance.StatePassed,

--- a/go/governance/api/api_test.go
+++ b/go/governance/api/api_test.go
@@ -1,18 +1,16 @@
 package api
 
 import (
-	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/upgrade/api"
 )
 
 func TestValidateBasic(t *testing.T) {
-	hh, err := api.OwnHash()
-	require.NoError(t, err, "OwnHash()")
-	h := hex.EncodeToString(hh[:])
 	for _, tc := range []struct {
 		msg       string
 		p         *ProposalContent
@@ -45,7 +43,7 @@ func TestValidateBasic(t *testing.T) {
 					Descriptor: api.Descriptor{
 						Method:     api.UpgradeMethodInternal,
 						Epoch:      42,
-						Identifier: h,
+						Identifier: cbor.Marshal(version.Versions),
 					},
 				},
 			},

--- a/go/oasis-node/cmd/control/control.go
+++ b/go/oasis-node/cmd/control/control.go
@@ -177,11 +177,27 @@ func doCancelUpgrade(cmd *cobra.Command, args []string) {
 	defer conn.Close()
 
 	if len(args) == 0 {
-		logger.Error("expected descriptor name")
+		logger.Error("expected descriptor path")
 		os.Exit(1)
 	}
 
-	err := client.CancelUpgrade(context.Background(), args[0])
+	descriptorBytes, err := ioutil.ReadFile(args[0])
+	if err != nil {
+		logger.Error("failed to read upgrade descriptor",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+
+	var desc upgrade.Descriptor
+	if err = json.Unmarshal(descriptorBytes, &desc); err != nil {
+		logger.Error("can't parse upgrade descriptor",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+
+	err = client.CancelUpgrade(context.Background(), &desc)
 	if err != nil {
 		logger.Error("failed to send upgrade cancellation request",
 			"err", err,

--- a/go/oasis-node/cmd/debug/txsource/workload/queries.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/queries.go
@@ -255,24 +255,24 @@ func (q *queries) doConsensusQueries(ctx context.Context, rng *rand.Rand, height
 		return fmt.Errorf("GetTransactionsWithResults at height %d: %w", height, err)
 	}
 	if len(txs) != len(txsWithRes.Transactions) {
-		q.logger.Error("GetTransactionsWithResults transactions length missmatch",
+		q.logger.Error("GetTransactionsWithResults transactions length mismatch",
 			"txs", txs,
 			"txs_with_results", txsWithRes,
 			"height", height,
 		)
 		return fmt.Errorf(
-			"GetTransactionsWithResults transactions length missmatch, expected: %d, got: %d",
+			"GetTransactionsWithResults transactions length mismatch, expected: %d, got: %d",
 			len(txs), len(txsWithRes.Transactions),
 		)
 	}
 	if len(txsWithRes.Transactions) != len(txsWithRes.Results) {
-		q.logger.Error("GetTransactionsWithResults results length missmatch",
+		q.logger.Error("GetTransactionsWithResults results length mismatch",
 			"txs", txs,
 			"txs_with_results", txsWithRes,
 			"height", height,
 		)
 		return fmt.Errorf(
-			"GetTransactionsWithResults results length missmatch, expected: %d, got: %d",
+			"GetTransactionsWithResults results length mismatch, expected: %d, got: %d",
 			len(txsWithRes.Transactions), len(txsWithRes.Results),
 		)
 	}
@@ -722,7 +722,7 @@ func (q *queries) doRuntimeQueries(ctx context.Context, rng *rand.Rand) error {
 		return fmt.Errorf("runtimeClient.GetBlockByHash, hash: %s: %w", block.Header.EncodedHash(), err)
 	}
 	if block.Header.EncodedHash() != block2.Header.EncodedHash() {
-		q.logger.Error("runtime block header hash missmatch",
+		q.logger.Error("runtime block header hash mismatch",
 			"round", round,
 			"latest_round", latestRound,
 			"round_hash", block.Header.EncodedHash(),

--- a/go/upgrade/api/api_test.go
+++ b/go/upgrade/api/api_test.go
@@ -1,12 +1,12 @@
 package api
 
 import (
-	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
 )
 
 func TestUpgradeMethod(t *testing.T) {
@@ -39,10 +39,6 @@ func TestUpgradeMethod(t *testing.T) {
 }
 
 func TestValidateBasic(t *testing.T) {
-	hh, err := OwnHash()
-	require.NoError(t, err, "OwnHash()")
-	h := hex.EncodeToString(hh[:])
-
 	for _, tc := range []struct {
 		msg       string
 		d         *Descriptor
@@ -58,7 +54,7 @@ func TestValidateBasic(t *testing.T) {
 			d: &Descriptor{
 				Method:     42,
 				Epoch:      100,
-				Identifier: h,
+				Identifier: cbor.Marshal(version.Versions),
 			},
 			shouldErr: true,
 		},
@@ -67,7 +63,7 @@ func TestValidateBasic(t *testing.T) {
 			d: &Descriptor{
 				Method:     UpgradeMethodInternal,
 				Epoch:      0,
-				Identifier: h,
+				Identifier: cbor.Marshal(version.Versions),
 			},
 			shouldErr: true,
 		},
@@ -76,7 +72,7 @@ func TestValidateBasic(t *testing.T) {
 			d: &Descriptor{
 				Method:     UpgradeMethodInternal,
 				Epoch:      42,
-				Identifier: "invalid",
+				Identifier: cbor.Marshal("invalid"),
 			},
 			shouldErr: true,
 		},
@@ -85,7 +81,7 @@ func TestValidateBasic(t *testing.T) {
 			d: &Descriptor{
 				Method:     UpgradeMethodInternal,
 				Epoch:      42,
-				Identifier: h,
+				Identifier: cbor.Marshal(version.Versions),
 			},
 			shouldErr: false,
 		},
@@ -100,10 +96,6 @@ func TestValidateBasic(t *testing.T) {
 }
 
 func TestEquals(t *testing.T) {
-	hh, err := OwnHash()
-	require.NoError(t, err, "OwnHash()")
-	h := hex.EncodeToString(hh[:])
-
 	for _, tc := range []struct {
 		msg    string
 		d1     *Descriptor
@@ -147,7 +139,7 @@ func TestEquals(t *testing.T) {
 		{
 			msg: "different identifier should not be equal",
 			d1: &Descriptor{
-				Identifier: h,
+				Identifier: cbor.Marshal(version.Versions),
 			},
 			d2:     &Descriptor{},
 			equals: false,
@@ -158,13 +150,13 @@ func TestEquals(t *testing.T) {
 				Name:       "d",
 				Method:     UpgradeMethodInternal,
 				Epoch:      42,
-				Identifier: h,
+				Identifier: cbor.Marshal(version.Versions),
 			},
 			d2: &Descriptor{
 				Name:       "d",
 				Method:     UpgradeMethodInternal,
 				Epoch:      42,
-				Identifier: h,
+				Identifier: cbor.Marshal(version.Versions),
 			},
 			equals: true,
 		},
@@ -174,13 +166,6 @@ func TestEquals(t *testing.T) {
 }
 
 func TestEnsureCompatible(t *testing.T) {
-	hh, err := OwnHash()
-	require.NoError(t, err, "OwnHash()")
-	h := hex.EncodeToString(hh[:])
-
-	var emptyHash hash.Hash
-	emptyH := hex.EncodeToString(emptyHash[:])
-
 	for _, tc := range []struct {
 		msg       string
 		d         *Descriptor
@@ -196,7 +181,7 @@ func TestEnsureCompatible(t *testing.T) {
 			d: &Descriptor{
 				Method:     UpgradeMethodInternal,
 				Epoch:      100,
-				Identifier: emptyH,
+				Identifier: cbor.Marshal(version.ProtocolVersions{RuntimeHostProtocol: version.FromU64(42)}),
 			},
 			shouldErr: true,
 		},
@@ -205,7 +190,7 @@ func TestEnsureCompatible(t *testing.T) {
 			d: &Descriptor{
 				Method:     UpgradeMethodInternal,
 				Epoch:      42,
-				Identifier: h,
+				Identifier: cbor.Marshal(version.Versions),
 			},
 			shouldErr: false,
 		},

--- a/go/upgrade/dummy.go
+++ b/go/upgrade/dummy.go
@@ -19,7 +19,7 @@ func (u *dummyUpgradeManager) PendingUpgrades(ctx context.Context) ([]*api.Pendi
 	return nil, nil
 }
 
-func (u *dummyUpgradeManager) CancelUpgrade(ctx context.Context, name string) error {
+func (u *dummyUpgradeManager) CancelUpgrade(ctx context.Context, descriptor *api.Descriptor) error {
 	return nil
 }
 

--- a/go/upgrade/upgrade.go
+++ b/go/upgrade/upgrade.go
@@ -72,7 +72,7 @@ func (u *upgradeManager) PendingUpgrades(ctx context.Context) ([]*api.PendingUpg
 	return u.pending, nil
 }
 
-func (u *upgradeManager) CancelUpgrade(ctx context.Context, name string) error {
+func (u *upgradeManager) CancelUpgrade(ctx context.Context, descriptor *api.Descriptor) error {
 	u.lock.Lock()
 	defer u.lock.Unlock()
 
@@ -83,7 +83,7 @@ func (u *upgradeManager) CancelUpgrade(ctx context.Context, name string) error {
 
 	var pending []*api.PendingUpgrade
 	for _, pu := range u.pending {
-		if pu.Descriptor.Name != name {
+		if !pu.Descriptor.Equals(descriptor) {
 			pending = append(pending, pu)
 			continue
 		}


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/3579

TODO:
- [x] ~enforce upgrade descriptor name uniqueness~ actually instead of the proposed change, the `CancelUpgrade` method (the only place where this was problematic) was updated to require passing in the whole descriptor to be canceled.

NOTE: this also introduces a minor change the governance submit proposal transaction format (see governance/gen_vectors change).