### PR TITLE
go/e2e/governance-upgrade: wait for compute nodes to be ready

### DIFF
--- a/.changelog/3618.internal.md
+++ b/.changelog/3618.internal.md
@@ -1,0 +1,1 @@
+go/e2e/governance-upgrade: wait for compute nodes to be ready

--- a/go/oasis-test-runner/scenario/e2e/runtime/governance_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/governance_upgrade.go
@@ -12,7 +12,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
-	epoch "github.com/oasisprotocol/oasis-core/go/epochtime/api"
 	epochtime "github.com/oasisprotocol/oasis-core/go/epochtime/api"
 	"github.com/oasisprotocol/oasis-core/go/governance/api"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
@@ -41,7 +40,7 @@ var (
 type governanceConsensusUpgradeImpl struct {
 	runtimeImpl
 
-	currentEpoch epoch.EpochTime
+	currentEpoch epochtime.EpochTime
 	entityNonce  uint64
 
 	correctBinaryHash   bool
@@ -478,6 +477,14 @@ func (sc *governanceConsensusUpgradeImpl) Run(childEnv *env.Env) error { // noli
 		_, err = sc.Net.Controller().Registry.GetEntity(sc.ctx, idQuery)
 		if err != nil {
 			return fmt.Errorf("can't get registered test entity: %w", err)
+		}
+
+		// Wait for compute nodes to be ready.
+		sc.Logger.Info("waiting for compute nodes to be ready")
+		for _, n := range sc.Net.ComputeWorkers() {
+			if err = n.WaitReady(sc.ctx); err != nil {
+				return fmt.Errorf("failed to wait for a compute node: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
This should help with the governance-upgrade test flakiness where the runtime client request would be sent before the compute nodes were ready (related to: https://github.com/oasisprotocol/oasis-core/pull/3599 as compute nodes take a bit more time to get initialized after a restart now).