### PR TITLE
runtime: Use Namespace for runtime id, validate block namespace

### DIFF
--- a/.changelog/3633.breaking.md
+++ b/.changelog/3633.breaking.md
@@ -1,0 +1,4 @@
+runtime: Remove common::runtime::RuntimeId
+
+The Go API has been using Namespace for a while so this makes it
+consistent in the Rust runtime as well.

--- a/.changelog/3633.internal.md
+++ b/.changelog/3633.internal.md
@@ -1,0 +1,1 @@
+runtime: Validate block namespace against runtime ID

--- a/client/src/enclave_rpc/api/enclaverpc.rs
+++ b/client/src/enclave_rpc/api/enclaverpc.rs
@@ -3,13 +3,13 @@ use grpcio::{CallOption, Channel, Client, ClientUnaryReceiver, Result};
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 
-use oasis_core_runtime::common::runtime::RuntimeId;
+use oasis_core_runtime::common::namespace::Namespace;
 
 /// A call_enclave request.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CallEnclaveRequest {
     /// Runtime ID of the target runtime.
-    pub runtime_id: RuntimeId,
+    pub runtime_id: Namespace,
     /// Endpoint name.
     pub endpoint: String,
     /// EnclaveRPC payload to transport to the target runtime.

--- a/client/src/enclave_rpc/client.rs
+++ b/client/src/enclave_rpc/client.rs
@@ -21,7 +21,7 @@ use thiserror::Error;
 use tokio_executor::spawn;
 
 #[cfg(not(target_env = "sgx"))]
-use oasis_core_runtime::common::runtime::RuntimeId;
+use oasis_core_runtime::common::namespace::Namespace;
 use oasis_core_runtime::{
     common::{cbor, sgx::avr::EnclaveIdentity},
     enclave_rpc::{
@@ -140,7 +140,7 @@ impl RpcClient {
     pub fn new_grpc(
         builder: Builder,
         channel: Channel,
-        runtime_id: RuntimeId,
+        runtime_id: Namespace,
         endpoint: &str,
     ) -> Self {
         Self::new(

--- a/client/src/enclave_rpc/transport.rs
+++ b/client/src/enclave_rpc/transport.rs
@@ -6,7 +6,7 @@ use futures::Future;
 use io_context::Context;
 
 #[cfg(not(target_env = "sgx"))]
-use oasis_core_runtime::common::runtime::RuntimeId;
+use oasis_core_runtime::common::namespace::Namespace;
 use oasis_core_runtime::{common::cbor, enclave_rpc::types, protocol::Protocol, types::Body};
 
 #[cfg(not(target_env = "sgx"))]
@@ -71,7 +71,7 @@ impl Transport for RuntimeTransport {
 #[cfg(not(target_env = "sgx"))]
 pub struct GrpcTransport {
     pub grpc_client: EnclaveRPCClient,
-    pub runtime_id: RuntimeId,
+    pub runtime_id: Namespace,
     pub endpoint: String,
 }
 

--- a/client/src/transaction/api/client.rs
+++ b/client/src/transaction/api/client.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 
 use oasis_core_runtime::{
-    common::{crypto::hash::Hash, runtime::RuntimeId},
+    common::{crypto::hash::Hash, namespace::Namespace},
     consensus::roothash::{AnnotatedBlock, Block},
     transaction::types::TxnBatch,
 };
@@ -14,20 +14,20 @@ pub const ROUND_LATEST: u64 = u64::max_value();
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SubmitTxRequest {
-    pub runtime_id: RuntimeId,
+    pub runtime_id: Namespace,
     #[serde(with = "serde_bytes")]
     pub data: Vec<u8>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetBlockRequest {
-    pub runtime_id: RuntimeId,
+    pub runtime_id: Namespace,
     pub round: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetBlockByHashRequest {
-    pub runtime_id: RuntimeId,
+    pub runtime_id: Namespace,
     pub block_hash: Hash,
 }
 
@@ -44,28 +44,28 @@ pub struct TxResult {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetTxRequest {
-    pub runtime_id: RuntimeId,
+    pub runtime_id: Namespace,
     pub round: u64,
     pub index: u32,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetTxByBlockHashRequest {
-    pub runtime_id: RuntimeId,
+    pub runtime_id: Namespace,
     pub block_hash: Hash,
     pub index: u32,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetTxsRequest {
-    pub runtime_id: RuntimeId,
+    pub runtime_id: Namespace,
     pub round: u64,
     pub io_root: Hash,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct QueryTxRequest {
-    pub runtime_id: RuntimeId,
+    pub runtime_id: Namespace,
     #[serde(with = "serde_bytes")]
     pub key: Vec<u8>,
     #[serde(with = "serde_bytes")]
@@ -102,13 +102,13 @@ pub struct Query {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct QueryTxsRequest {
-    pub runtime_id: RuntimeId,
+    pub runtime_id: Namespace,
     pub query: Query,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WaitBlockIndexedRequest {
-    pub runtime_id: RuntimeId,
+    pub runtime_id: Namespace,
     pub round: u64,
 }
 
@@ -170,7 +170,7 @@ grpc_method!(
 grpc_stream!(
     METHOD_WATCH_BLOCKS,
     "/oasis-core.RuntimeClient/WatchBlocks",
-    RuntimeId,
+    Namespace,
     AnnotatedBlock
 );
 
@@ -268,7 +268,7 @@ impl RuntimeClient {
 
     pub fn watch_blocks(
         &self,
-        runtime_id: RuntimeId,
+        runtime_id: Namespace,
     ) -> Result<ClientSStreamReceiver<AnnotatedBlock>> {
         self.client
             .server_streaming(&METHOD_WATCH_BLOCKS, &runtime_id, Default::default())

--- a/client/src/transaction/client.rs
+++ b/client/src/transaction/client.rs
@@ -10,7 +10,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use thiserror::Error;
 
 use oasis_core_runtime::{
-    common::{cbor, crypto::hash::Hash, runtime::RuntimeId},
+    common::{cbor, crypto::hash::Hash, namespace::Namespace},
     transaction::types::{TxnBatch, TxnCall, TxnOutput},
 };
 
@@ -41,7 +41,7 @@ pub struct TxnClient {
     /// The underlying storage gRPC interface.
     storage_client: api::storage::StorageClient,
     /// Runtime identifier.
-    runtime_id: RuntimeId,
+    runtime_id: Namespace,
     /// RPC timeout.
     timeout: Option<Duration>,
     /// Block watcher for `get_latest_block` call.
@@ -50,7 +50,7 @@ pub struct TxnClient {
 
 impl TxnClient {
     /// Create a new transaction client.
-    pub fn new(channel: Channel, runtime_id: RuntimeId, timeout: Option<Duration>) -> Self {
+    pub fn new(channel: Channel, runtime_id: Namespace, timeout: Option<Duration>) -> Self {
         Self {
             client: api::client::RuntimeClient::new(channel.clone()),
             node_controller: api::control::NodeControllerClient::new(channel.clone()),

--- a/keymanager-api-common/src/api.rs
+++ b/keymanager-api-common/src/api.rs
@@ -12,7 +12,7 @@ use x25519_dalek;
 use oasis_core_runtime::{
     common::{
         crypto::signature::{PublicKey as OasisPublicKey, Signature, SignatureBundle},
-        runtime::RuntimeId,
+        namespace::Namespace,
         sgx::avr::EnclaveIdentity,
     },
     impl_bytes, runtime_api,
@@ -78,13 +78,13 @@ pub struct ReplicateResponse {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct RequestIds {
     /// Runtime ID.
-    pub runtime_id: RuntimeId,
+    pub runtime_id: Namespace,
     /// Key pair ID.
     pub key_pair_id: KeyPairId,
 }
 
 impl RequestIds {
-    pub fn new(runtime_id: RuntimeId, key_pair_id: KeyPairId) -> Self {
+    pub fn new(runtime_id: Namespace, key_pair_id: KeyPairId) -> Self {
         Self {
             runtime_id,
             key_pair_id,
@@ -213,14 +213,14 @@ pub enum KeyManagerError {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PolicySGX {
     pub serial: u32,
-    pub id: RuntimeId,
+    pub id: Namespace,
     pub enclaves: HashMap<EnclaveIdentity, EnclavePolicySGX>,
 }
 
 /// Per enclave key manager access control policy.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EnclavePolicySGX {
-    pub may_query: HashMap<RuntimeId, Vec<EnclaveIdentity>>,
+    pub may_query: HashMap<Namespace, Vec<EnclaveIdentity>>,
     pub may_replicate: Vec<EnclaveIdentity>,
 }
 

--- a/keymanager-client/src/client.rs
+++ b/keymanager-client/src/client.rs
@@ -15,7 +15,7 @@ use lru::LruCache;
 use oasis_core_client::{create_rpc_api_client, BoxFuture, RpcClient};
 use oasis_core_keymanager_api_common::*;
 use oasis_core_runtime::{
-    common::{cbor, runtime::RuntimeId, sgx::avr::EnclaveIdentity},
+    common::{cbor, namespace::Namespace, sgx::avr::EnclaveIdentity},
     enclave_rpc::session,
     protocol::Protocol,
     rak::RAK,
@@ -31,8 +31,8 @@ with_api! {
 const KEY_MANAGER_ENDPOINT: &'static str = "key-manager";
 
 struct Inner {
-    /// Runtime Id for which we are going to request keys.
-    runtime_id: RuntimeId,
+    /// Runtime identifier for which we are going to request keys.
+    runtime_id: Namespace,
     /// RPC client.
     rpc_client: Client,
     /// Local cache for the get_or_create_keys KeyManager endpoint.
@@ -47,7 +47,7 @@ pub struct RemoteClient {
 }
 
 impl RemoteClient {
-    fn new(runtime_id: RuntimeId, client: RpcClient, keys_cache_sizes: usize) -> Self {
+    fn new(runtime_id: Namespace, client: RpcClient, keys_cache_sizes: usize) -> Self {
         Self {
             inner: Arc::new(Inner {
                 runtime_id,
@@ -61,7 +61,7 @@ impl RemoteClient {
     /// Create a new key manager client with runtime-internal transport and explicit key manager
     /// enclave identities.
     pub fn new_runtime_with_enclave_identities(
-        runtime_id: RuntimeId,
+        runtime_id: Namespace,
         enclaves: Option<HashSet<EnclaveIdentity>>,
         protocol: Arc<Protocol>,
         rak: Arc<RAK>,
@@ -87,7 +87,7 @@ impl RemoteClient {
     /// method. In case of sgx, the session establishment will fail until the
     /// initial policies will be updated.
     pub fn new_runtime(
-        runtime_id: RuntimeId,
+        runtime_id: Namespace,
         protocol: Arc<Protocol>,
         rak: Arc<RAK>,
         keys_cache_sizes: usize,
@@ -116,7 +116,7 @@ impl RemoteClient {
     /// Create a new key manager client with gRPC transport.
     #[cfg(not(target_env = "sgx"))]
     pub fn new_grpc(
-        runtime_id: RuntimeId,
+        runtime_id: Namespace,
         enclaves: Option<HashSet<EnclaveIdentity>>,
         channel: Channel,
         keys_cache_sizes: usize,

--- a/keymanager-lib/src/context.rs
+++ b/keymanager-lib/src/context.rs
@@ -1,9 +1,9 @@
 //! Key manager enclave context.
 use std::sync::Arc;
 
-use oasis_core_runtime::{common::runtime::RuntimeId, Protocol};
+use oasis_core_runtime::{common::namespace::Namespace, Protocol};
 
 pub struct Context {
-    pub runtime_id: RuntimeId,
+    pub runtime_id: Namespace,
     pub protocol: Arc<Protocol>,
 }

--- a/keymanager-lib/src/kdf.rs
+++ b/keymanager-lib/src/kdf.rs
@@ -24,7 +24,7 @@ use oasis_core_runtime::{
             mrae::deoxysii::{DeoxysII, NONCE_SIZE, TAG_SIZE},
             signature,
         },
-        runtime::RuntimeId,
+        namespace::Namespace,
         sgx::egetkey::egetkey,
     },
     enclave_rpc::Context as RpcContext,
@@ -86,7 +86,7 @@ struct Inner {
     /// Master secret.
     master_secret: Option<MasterSecret>,
     checksum: Option<Vec<u8>>,
-    runtime_id: Option<RuntimeId>,
+    runtime_id: Option<Namespace>,
     signer: Option<Arc<dyn signature::Signer>>,
     cache: LruCache<Vec<u8>, KeyPair>,
 }
@@ -379,7 +379,7 @@ impl Kdf {
         }
     }
 
-    fn load_master_secret(runtime_id: &RuntimeId) -> Option<MasterSecret> {
+    fn load_master_secret(runtime_id: &Namespace) -> Option<MasterSecret> {
         let ciphertext = StorageContext::with_current(|_mkvs, untrusted_local| {
             untrusted_local.get(MASTER_SECRET_STORAGE_KEY.to_vec())
         })
@@ -407,7 +407,7 @@ impl Kdf {
         Some(MasterSecret::from(plaintext))
     }
 
-    fn save_master_secret(master_secret: &MasterSecret, runtime_id: &RuntimeId) {
+    fn save_master_secret(master_secret: &MasterSecret, runtime_id: &Namespace) {
         let mut rng = OsRng {};
 
         // Encrypt the master secret.
@@ -428,7 +428,7 @@ impl Kdf {
         .expect("failed to persist master secret");
     }
 
-    fn generate_master_secret(runtime_id: &RuntimeId) -> MasterSecret {
+    fn generate_master_secret(runtime_id: &Namespace) -> MasterSecret {
         let mut rng = OsRng {};
 
         // TODO: Support static keying for debugging.
@@ -441,7 +441,7 @@ impl Kdf {
         master_secret
     }
 
-    fn checksum_master_secret(master_secret: &MasterSecret, runtime_id: &RuntimeId) -> Vec<u8> {
+    fn checksum_master_secret(master_secret: &MasterSecret, runtime_id: &Namespace) -> Vec<u8> {
         let mut k = [0u8; 32];
 
         // KMAC256(master_secret, kmRuntimeID, 32, "ekiden-checksum-master-secret")

--- a/keymanager-lib/src/policy.rs
+++ b/keymanager-lib/src/policy.rs
@@ -13,7 +13,7 @@ use oasis_core_keymanager_api_common::*;
 use oasis_core_runtime::{
     common::{
         cbor,
-        runtime::RuntimeId,
+        namespace::Namespace,
         sgx::{
             avr::EnclaveIdentity,
             seal::{seal, unseal},
@@ -196,8 +196,8 @@ impl Policy {
 struct CachedPolicy {
     pub checksum: Vec<u8>,
     pub serial: u32,
-    pub runtime_id: RuntimeId,
-    pub may_query: HashMap<RuntimeId, HashSet<EnclaveIdentity>>,
+    pub runtime_id: Namespace,
+    pub may_query: HashMap<Namespace, HashSet<EnclaveIdentity>>,
     pub may_replicate: HashSet<EnclaveIdentity>,
     pub may_replicate_from: HashSet<EnclaveIdentity>,
 }
@@ -253,7 +253,7 @@ impl CachedPolicy {
         CachedPolicy {
             checksum: vec![],
             serial: 0,
-            runtime_id: RuntimeId::default(),
+            runtime_id: Namespace::default(),
             may_query: HashMap::new(),
             may_replicate: HashSet::new(),
             may_replicate_from: HashSet::new(),

--- a/runtime/src/common/mod.rs
+++ b/runtime/src/common/mod.rs
@@ -8,7 +8,6 @@ pub mod key_format;
 pub mod logger;
 pub mod namespace;
 pub mod quantity;
-pub mod runtime;
 pub mod sgx;
 pub mod time;
 pub mod version;

--- a/runtime/src/common/runtime.rs
+++ b/runtime/src/common/runtime.rs
@@ -1,3 +1,0 @@
-//! Runtime identifier.
-
-impl_bytes!(RuntimeId, 32, "A runtime identifier.");

--- a/runtime/src/dispatcher.rs
+++ b/runtime/src/dispatcher.rs
@@ -460,6 +460,16 @@ impl Dispatcher {
             "check_only" => check_only,
         );
 
+        // Verify that the runtime ID matches the block's namespace. This is a protocol violation
+        // as the compute node should never change the runtime ID.
+        if block.header.namespace != protocol.get_runtime_id() {
+            panic!(
+                "block namespace does not match runtime id (namespace: {:?} runtime ID: {:?})",
+                block.header.namespace,
+                protocol.get_runtime_id(),
+            );
+        }
+
         // Create a new context and dispatch the batch.
         let ctx = ctx.freeze();
         cache.maybe_replace(Root {

--- a/runtime/src/protocol.rs
+++ b/runtime/src/protocol.rs
@@ -16,7 +16,7 @@ use slog::Logger;
 use thiserror::Error;
 
 use crate::{
-    common::{cbor, logger::get_logger, runtime::RuntimeId, version::Version},
+    common::{cbor, logger::get_logger, namespace::Namespace, version::Version},
     dispatcher::Dispatcher,
     rak::RAK,
     storage::KeyValue,
@@ -66,7 +66,7 @@ pub struct Protocol {
     /// Pending outgoing requests.
     pending_out_requests: Mutex<HashMap<u64, channel::Sender<Body>>>,
     /// Runtime identifier.
-    runtime_id: Mutex<Option<RuntimeId>>,
+    runtime_id: Mutex<Option<Namespace>>,
     /// Runtime version.
     runtime_version: Version,
 }
@@ -99,7 +99,7 @@ impl Protocol {
     /// # Panics
     ///
     /// Panics, if the runtime identifier is not set.
-    pub fn get_runtime_id(self: &Protocol) -> RuntimeId {
+    pub fn get_runtime_id(self: &Protocol) -> Namespace {
         self.runtime_id
             .lock()
             .unwrap()

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -10,7 +10,7 @@ use crate::{
             hash::Hash,
             signature::{PublicKey, Signature},
         },
-        runtime::RuntimeId,
+        namespace::Namespace,
         sgx::avr::AVR,
     },
     consensus::roothash::{self, Block, ComputeResultsHeader},
@@ -74,7 +74,7 @@ pub enum Body {
 
     // Runtime interface.
     RuntimeInfoRequest {
-        runtime_id: RuntimeId,
+        runtime_id: Namespace,
         consensus_backend: String,
         consensus_protocol_version: u64,
     },

--- a/tests/clients/simple-keyvalue-enc/src/main.rs
+++ b/tests/clients/simple-keyvalue-enc/src/main.rs
@@ -8,7 +8,7 @@ use tokio::runtime::Runtime;
 
 use oasis_core_client::{create_txn_api_client, Node, TxnClient};
 use oasis_core_keymanager_client::{self, KeyManagerClient, KeyPairId};
-use oasis_core_runtime::common::{crypto::hash::Hash, runtime::RuntimeId};
+use oasis_core_runtime::common::{crypto::hash::Hash, namespace::Namespace};
 use simple_keyvalue_api::{with_api, Key, KeyValue, Transfer, Withdraw};
 
 with_api! {
@@ -40,7 +40,7 @@ fn main() {
         .get_matches();
 
     let node_address = matches.value_of("node-address").unwrap();
-    let runtime_id = value_t_or_exit!(matches, "runtime-id", RuntimeId);
+    let runtime_id = value_t_or_exit!(matches, "runtime-id", Namespace);
     let k = matches.value_of("key").unwrap();
     let nonce_seed = matches
         .value_of("seed")

--- a/tests/clients/simple-keyvalue-ops/src/main.rs
+++ b/tests/clients/simple-keyvalue-ops/src/main.rs
@@ -6,7 +6,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 use tokio::runtime::Runtime;
 
 use oasis_core_client::{create_txn_api_client, Node, TxnClient};
-use oasis_core_runtime::common::{crypto::hash::Hash, runtime::RuntimeId};
+use oasis_core_runtime::common::{crypto::hash::Hash, namespace::Namespace};
 use simple_keyvalue_api::{with_api, Key, KeyValue, Transfer, Withdraw};
 
 with_api! {
@@ -42,7 +42,7 @@ fn main() {
         .get_matches();
 
     let node_address = matches.value_of("node-address").unwrap();
-    let runtime_id = value_t_or_exit!(matches, "runtime-id", RuntimeId);
+    let runtime_id = value_t_or_exit!(matches, "runtime-id", Namespace);
     let nonce_seed = matches
         .value_of("seed")
         .unwrap_or("seeeeeeeeeeeeeeeeeeeeeeeeeeeeeed")

--- a/tests/clients/simple-keyvalue/src/main.rs
+++ b/tests/clients/simple-keyvalue/src/main.rs
@@ -22,7 +22,7 @@ use oasis_core_client::{
     Node, TxnClient,
 };
 use oasis_core_runtime::{
-    common::{crypto::hash::Hash, runtime::RuntimeId},
+    common::{crypto::hash::Hash, namespace::Namespace},
     storage::MKVS,
 };
 use simple_keyvalue_api::{with_api, Key, KeyValue, Transfer, Withdraw};
@@ -49,7 +49,7 @@ fn main() {
         .get_matches();
 
     let node_address = matches.value_of("node-address").unwrap();
-    let runtime_id = value_t_or_exit!(matches, "runtime-id", RuntimeId);
+    let runtime_id = value_t_or_exit!(matches, "runtime-id", Namespace);
     let nonce_seed = matches
         .value_of("seed")
         .unwrap_or("seeeeeeeeeeeeeeeeeeeeeeeeeeeeeed")

--- a/tests/clients/test-long-term/src/main.rs
+++ b/tests/clients/test-long-term/src/main.rs
@@ -6,7 +6,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 use tokio::runtime::Runtime;
 
 use oasis_core_client::{create_txn_api_client, Node, TxnClient};
-use oasis_core_runtime::common::{crypto::hash::Hash, runtime::RuntimeId};
+use oasis_core_runtime::common::{crypto::hash::Hash, namespace::Namespace};
 use simple_keyvalue_api::{with_api, Key, KeyValue, Transfer, Withdraw};
 
 with_api! {
@@ -46,7 +46,7 @@ fn main() {
         .get_matches();
 
     let node_address = matches.value_of("node-address").unwrap();
-    let runtime_id = value_t_or_exit!(matches, "runtime-id", RuntimeId);
+    let runtime_id = value_t_or_exit!(matches, "runtime-id", Namespace);
     let mode = matches.value_of("mode").unwrap();
     let nonce_seed = matches
         .value_of("seed")

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -12,7 +12,7 @@ use oasis_core_runtime::{
             mrae::deoxysii::{DeoxysII, KEY_SIZE, NONCE_SIZE, TAG_SIZE},
         },
         key_format::KeyFormat,
-        runtime::RuntimeId,
+        namespace::Namespace,
         version::Version,
     },
     consensus::roothash::{Message, StakingMessage},
@@ -59,7 +59,7 @@ impl KeyFormat for PendingMessagesKeyFormat {
 }
 
 struct Context {
-    test_runtime_id: RuntimeId,
+    test_runtime_id: Namespace,
     km_client: Arc<dyn KeyManagerClient>,
 }
 


### PR DESCRIPTION
* runtime: Remove common::runtime::RuntimeId
  
  The Go API has been using Namespace for a while so this makes it
  consistent in the Rust runtime as well.
* runtime: Validate block namespace against runtime ID