### PR TITLE
go/oasis-test-runner/txsource: Decrease MinPoolSize for restarts

### DIFF
--- a/.changelog/3636.internal.md
+++ b/.changelog/3636.internal.md
@@ -1,0 +1,4 @@
+go/oasis-test-runner/txsource: Decrease MinPoolSize for restarts
+
+When restarts are enabled there can be one less node so we should make sure
+to decrease the MinPoolSize in this case.

--- a/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
@@ -435,6 +435,7 @@ func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
 
 		// One executor can be offline.
 		f.Runtimes[1].Executor.GroupSize--
+		f.Runtimes[1].Executor.MinPoolSize--
 
 		// Lower proposer and round timeouts as nodes are expected to go offline for longer time.
 		f.Runtimes[1].TxnScheduler.ProposerTimeout = 5


### PR DESCRIPTION
When restarts are enabled there can be one less node so we should make sure to
decrease the MinPoolSize in this case.