### PR TITLE
[BACKPORT/20.12.x] Bump arc-swap and smallvec

### DIFF
--- a/.changelog/3511.internal.md
+++ b/.changelog/3511.internal.md
@@ -1,0 +1,1 @@
+rust: bump arc-swap to 0.4.8

--- a/.changelog/3604.internal.2.md
+++ b/.changelog/3604.internal.2.md
@@ -1,0 +1,1 @@
+Update smallvec to 0.6.14

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
+checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
 
 [[package]]
 name = "atty"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,9 +2026,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
 dependencies = [
  "maybe-uninit",
 ]


### PR DESCRIPTION
Backport Rust crate version bumps.