### PR TITLE
runtime node slashing (ADR 0005)

### DIFF
--- a/.changelog/3640.breaking.md
+++ b/.changelog/3640.breaking.md
@@ -1,0 +1,4 @@
+go/roothash: Support slashing runtime compute nodes
+
+Runtimes can configure whether compute nodes should be slashed for submitting
+incorrect results or equivocating.

--- a/docs/adr/0005-runtime-compute-slashing.md
+++ b/docs/adr/0005-runtime-compute-slashing.md
@@ -175,13 +175,13 @@ Any slashing instructions related to freezing nodes are currently ignored.
 This proposal introduces/updates the following consensus state in the roothash
 module:
 
-- **List of past valid evidence (`0x23`)**
+- **List of past valid evidence (`0x24`)**
 
   A hash uniquely identifying the evidence is stored for each successfully
   processed evidence that has not yet expired using the following key format:
 
   ```
-  0x23 <H(runtime-id) (hash.Hash)> <round (uint64)> <evidence-hash (hash.Hash)>
+  0x24 <H(runtime-id) (hash.Hash)> <round (uint64)> <evidence-hash (hash.Hash)>
   ```
 
   The value is empty as we only need to detect duplicate evidence.
@@ -293,7 +293,7 @@ performed to verify evidence validity:
 - Public keys of signers of both commitments are compared. If they are not the
   same, the evidence is invalid.
 
-- Signatures of both proposed batches are compared. If either is invalid, the
+- Signatures of both proposed batches are validated. If either is invalid, the
   evidence is invalid.
 
 - Otherwise the evidence is valid.

--- a/docs/adr/0005-runtime-compute-slashing.md
+++ b/docs/adr/0005-runtime-compute-slashing.md
@@ -50,6 +50,14 @@ type RuntimeStakingParameters struct {
 
     // Slashing are the per-runtime misbehavior slashing parameters.
     Slashing map[staking.SlashReason]staking.Slash `json:"slashing,omitempty"`
+
+    // RewardSlashEquvocationRuntimePercent is the percentage of the reward obtained when slashing
+    // for equivocation that is transferred to the runtime's account.
+    RewardSlashEquvocationRuntimePercent uint8 `json:"reward_equivocation,omitempty"`
+
+    // RewardSlashBadResultsRuntimePercent is the percentage of the reward obtained when slashing
+    // for incorrect results that is transferred to the runtime's account.
+    RewardSlashBadResultsRuntimePercent uint8 `json:"reward_bad_results,omitempty"`
 }
 ```
 

--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -9,6 +9,7 @@ import (
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
@@ -546,6 +547,58 @@ func (app *rootHashApplication) tryFinalizeExecutorCommits(
 		// Process any runtime messages.
 		if err = app.processRuntimeMessages(ctx, rtState, body.Messages); err != nil {
 			return fmt.Errorf("failed to process runtime messages: %w", err)
+		}
+
+		// If there was a discrepancy, slash nodes for incorrect results if configured.
+		if rtState.ExecutorPool.Discrepancy {
+			ctx.Logger().Debug("executor pool discrepancy",
+				"slashing", runtime.Staking.Slashing,
+			)
+			if penalty, ok := rtState.Runtime.Staking.Slashing[staking.SlashRuntimeIncorrectResults]; ok && !penalty.Amount.IsZero() {
+				commitments := rtState.ExecutorPool.ExecuteCommitments
+				var (
+					// Worker nodes that submitted incorrect results get slashed.
+					workersIncorrectResults []signature.PublicKey
+					// Backup worker nodes that resolved the discrepancy get rewarded.
+					backupCorrectResults []signature.PublicKey
+				)
+				for _, n := range rtState.ExecutorPool.Committee.Members {
+					c, ok := commitments[n.PublicKey]
+					if !ok || c.IsIndicatingFailure() {
+						continue
+					}
+					switch n.Role {
+					case scheduler.RoleBackupWorker:
+						// Backup workers that resolved the discrepancy.
+						if !commit.MostlyEqual(c) {
+							continue
+						}
+						ctx.Logger().Debug("backup worker resolved the discrepancy",
+							"pubkey", n.PublicKey,
+						)
+						backupCorrectResults = append(backupCorrectResults, n.PublicKey)
+					case scheduler.RoleWorker:
+						// Workers that caused the discrepancy.
+						if commit.MostlyEqual(c) {
+							continue
+						}
+						ctx.Logger().Debug("worker caused the discrepancy",
+							"pubkey", n.PublicKey,
+						)
+						workersIncorrectResults = append(workersIncorrectResults, n.PublicKey)
+					}
+				}
+				// Slash for incorrect results.
+				if err = onRuntimeIncorrectResults(
+					ctx,
+					workersIncorrectResults,
+					backupCorrectResults,
+					runtime,
+					&penalty.Amount,
+				); err != nil {
+					return fmt.Errorf("failed to slash for incorrect results: %w", err)
+				}
+			}
 		}
 
 		// Generate the final block.

--- a/go/consensus/tendermint/apps/roothash/slashing.go
+++ b/go/consensus/tendermint/apps/roothash/slashing.go
@@ -1,0 +1,54 @@
+package roothash
+
+import (
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	registryState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry/state"
+	stakingState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/staking/state"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
+	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
+)
+
+func onEvidenceRuntimeEquivocation(
+	ctx *abciAPI.Context,
+	pk signature.PublicKey,
+	runtimeID common.Namespace,
+	penaltyAmount *quantity.Quantity,
+) error {
+	regState := registryState.NewMutableState(ctx.State())
+	stakeState := stakingState.NewMutableState(ctx.State())
+
+	node, err := regState.Node(ctx, pk)
+	if err != nil {
+		// Node might not exist anymore (old evidence). Or the submitted evidence
+		// could be for a non-existing node (submitting "fake" but valid evidence).
+		ctx.Logger().Error("failed to get runtime node by signature public key",
+			"public_key", pk,
+			"err", err,
+		)
+		return fmt.Errorf("tendermint/roothash: failed to get node by id %s: %w", pk, roothash.ErrInvalidEvidence)
+	}
+
+	// Slash runtime node entity
+	entityAddr := staking.NewAddress(node.EntityID)
+	totalSlashed, err := stakeState.SlashEscrow(ctx, entityAddr, penaltyAmount)
+	if err != nil {
+		return fmt.Errorf("tendermint/roothash: error slashing account %s: %w", entityAddr, err)
+	}
+	if totalSlashed.IsZero() {
+		return fmt.Errorf("tendermint/roothash: nothing to slash from account %s", entityAddr)
+	}
+
+	// Move slashed amount to the runtime account.
+	// TODO: part of slashed amount (configurable) should be transferred to the transaction submitter.
+	runtimeAddr := staking.NewRuntimeAddress(runtimeID)
+	if _, err := stakeState.TransferFromCommon(ctx, runtimeAddr, totalSlashed); err != nil {
+		return fmt.Errorf("tendermint/roothash: failed transferring reward to runtime account %s: %w", runtimeAddr, err)
+	}
+
+	return nil
+}

--- a/go/consensus/tendermint/apps/roothash/slashing.go
+++ b/go/consensus/tendermint/apps/roothash/slashing.go
@@ -9,6 +9,7 @@ import (
 	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
 	registryState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry/state"
 	stakingState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/staking/state"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
@@ -16,7 +17,7 @@ import (
 func onEvidenceRuntimeEquivocation(
 	ctx *abciAPI.Context,
 	pk signature.PublicKey,
-	runtimeID common.Namespace,
+	runtime *registry.Runtime,
 	penaltyAmount *quantity.Quantity,
 ) error {
 	regState := registryState.NewMutableState(ctx.State())
@@ -33,21 +34,170 @@ func onEvidenceRuntimeEquivocation(
 		return fmt.Errorf("tendermint/roothash: failed to get node by id %s: %w", pk, roothash.ErrInvalidEvidence)
 	}
 
-	// Slash runtime node entity
+	// Slash runtime node entity.
 	entityAddr := staking.NewAddress(node.EntityID)
 	totalSlashed, err := stakeState.SlashEscrow(ctx, entityAddr, penaltyAmount)
 	if err != nil {
 		return fmt.Errorf("tendermint/roothash: error slashing account %s: %w", entityAddr, err)
 	}
+	// Since evidence can be submitted for past rounds, the node can be out of stake.
 	if totalSlashed.IsZero() {
-		return fmt.Errorf("tendermint/roothash: nothing to slash from account %s", entityAddr)
+		ctx.Logger().Warn("nothing to slash from entity for runtime equivocation",
+			"penalty", penaltyAmount,
+			"addr", entityAddr,
+		)
+		return nil
 	}
 
-	// Move slashed amount to the runtime account.
-	// TODO: part of slashed amount (configurable) should be transferred to the transaction submitter.
+	// If the caller is a node, distribute slashed funds to the controlling entity instead of the
+	// caller directly.
+	rewardAddr := ctx.CallerAddress()
+	callerNode, err := regState.Node(ctx, ctx.TxSigner())
+	switch err {
+	case nil:
+		// Caller is a node, replace reward address with its controlling entity.
+		rewardAddr = staking.NewAddress(callerNode.EntityID)
+	case registry.ErrNoSuchNode:
+		// Not a node, reward the caller directly.
+	default:
+		return fmt.Errorf("tendermint/roothash: failed to lookup node: %w", err)
+	}
+
+	// Distribute slashed funds to runtime and caller.
+	runtimePercentage := uint64(runtime.Staking.RewardSlashEquvocationRuntimePercent)
+	return distributeSlashedFunds(ctx, totalSlashed, runtimePercentage, runtime.ID, []staking.Address{rewardAddr})
+}
+
+func onRuntimeIncorrectResults(
+	ctx *abciAPI.Context,
+	discrepancyCausers []signature.PublicKey,
+	discrepancyResolvers []signature.PublicKey,
+	runtime *registry.Runtime,
+	penaltyAmount *quantity.Quantity,
+) error {
+	regState := registryState.NewMutableState(ctx.State())
+	stakeState := stakingState.NewMutableState(ctx.State())
+
+	var totalSlashed quantity.Quantity
+	for _, pk := range discrepancyCausers {
+		// Lookup the node entity.
+		node, err := regState.Node(ctx, pk)
+		if err == registry.ErrNoSuchNode {
+			ctx.Logger().Error("runtime node not found by commitment signature public key",
+				"public_key", pk,
+			)
+			continue
+		}
+		if err != nil {
+			ctx.Logger().Error("failed to get runtime node by commitment signature public key",
+				"public_key", pk,
+				"err", err,
+			)
+			return fmt.Errorf("tendermint/roothash: getting node %s: %w", pk, err)
+		}
+		entityAddr := staking.NewAddress(node.EntityID)
+
+		// Slash entity.
+		slashed, err := stakeState.SlashEscrow(ctx, entityAddr, penaltyAmount)
+		if err != nil {
+			return fmt.Errorf("tendermint/roothash: error slashing account %s: %w", entityAddr, err)
+		}
+		if err = totalSlashed.Add(slashed); err != nil {
+			return fmt.Errorf("tendermint/roothash: totalSlashed.Add(slashed): %w", err)
+		}
+		ctx.Logger().Debug("runtime node entity slashed for incorrect results",
+			"slashed", slashed,
+			"total_slashed", totalSlashed,
+			"addr", entityAddr,
+		)
+	}
+
+	// It can happen that nothing was slashed as nodes could be out of stake.
+	// A node can be out of stake as stake claims are only checked on epoch transitions
+	// and a node can be slashed multiple times per epoch.
+	// This should not fail the round, as otherwise a single node without stake could
+	// cause round failures until it is removed from the committee (on the next epoch transition).
+	if totalSlashed.IsZero() {
+		// Nothing more to do in this case.
+		return nil
+	}
+
+	// Determine who the backup workers' entities to reward are.
+	var rewardEntities []staking.Address
+	for _, pk := range discrepancyResolvers {
+		node, err := regState.Node(ctx, pk)
+		if err == registry.ErrNoSuchNode {
+			ctx.Logger().Error("runtime node not found by commitment signature public key",
+				"public_key", pk,
+			)
+			continue
+		}
+		if err != nil {
+			ctx.Logger().Error("failed to get runtime node by commitment signature public key",
+				"public_key", pk,
+				"err", err,
+			)
+			return fmt.Errorf("tendermint/roothash: getting node %s: %w", pk, err)
+		}
+		rewardEntities = append(rewardEntities, staking.NewAddress(node.EntityID))
+	}
+
+	// Distribute slashed funds to runtime and backup workers' entities.
+	runtimePercentage := uint64(runtime.Staking.RewardSlashBadResultsRuntimePercent)
+	return distributeSlashedFunds(ctx, &totalSlashed, runtimePercentage, runtime.ID, rewardEntities)
+}
+
+func distributeSlashedFunds(
+	ctx *abciAPI.Context,
+	totalSlashed *quantity.Quantity,
+	runtimePercentage uint64,
+	runtimeID common.Namespace,
+	otherAddresses []staking.Address,
+) error {
+	stakeState := stakingState.NewMutableState(ctx.State())
+
+	// Runtime account reward.
+	runtimeAccReward := totalSlashed.Clone()
+	if err := runtimeAccReward.Mul(quantity.NewFromUint64(runtimePercentage)); err != nil {
+		return fmt.Errorf("tendermint/roothash: runtimeAccReward.Mul: %w", err)
+	}
+	if err := runtimeAccReward.Quo(quantity.NewFromUint64(uint64(100))); err != nil {
+		return fmt.Errorf("tendermint/roothash: runtimeAccReward.Quo(100): %w", err)
+	}
 	runtimeAddr := staking.NewRuntimeAddress(runtimeID)
-	if _, err := stakeState.TransferFromCommon(ctx, runtimeAddr, totalSlashed); err != nil {
-		return fmt.Errorf("tendermint/roothash: failed transferring reward to runtime account %s: %w", runtimeAddr, err)
+	if _, err := stakeState.TransferFromCommon(ctx, runtimeAddr, runtimeAccReward, false); err != nil {
+		return fmt.Errorf("tendermint/roothash: failed transferring reward to %s: %w", runtimeAddr, err)
+	}
+	ctx.Logger().Debug("runtime account awarded slashed funds",
+		"reward", runtimeAccReward,
+		"total_slashed", totalSlashed,
+		"runtime_addr", runtimeAddr,
+	)
+
+	if len(otherAddresses) == 0 {
+		// Nothing more to do.
+		ctx.Logger().Debug("no other accounts to reward")
+		return nil
+	}
+
+	// (totalSlashed - runtimeAccReward) / n_reward_entities
+	otherReward := totalSlashed.Clone()
+	if err := otherReward.Sub(runtimeAccReward); err != nil {
+		return fmt.Errorf("tendermint/roothash: remainingReward.Sub(runtimeAccReward): %w", err)
+	}
+	if err := otherReward.Quo(quantity.NewFromUint64(uint64(len(otherAddresses)))); err != nil {
+		return fmt.Errorf("tendermint/roothash: remainingReward.Quo(len(discrepancyResolvers)): %w", err)
+	}
+
+	for _, addr := range otherAddresses {
+		if _, err := stakeState.TransferFromCommon(ctx, addr, otherReward, true); err != nil {
+			return fmt.Errorf("tendermint/roothash: failed transferring reward to %s: %w", addr, err)
+		}
+		ctx.Logger().Debug("account awarded slashed funds",
+			"reward", otherReward,
+			"total_slashed", totalSlashed,
+			"address", addr,
+		)
 	}
 
 	return nil

--- a/go/consensus/tendermint/apps/roothash/slashing_test.go
+++ b/go/consensus/tendermint/apps/roothash/slashing_test.go
@@ -1,0 +1,110 @@
+package roothash
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
+	"github.com/oasisprotocol/oasis-core/go/common/entity"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	registryState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry/state"
+	stakingState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/staking/state"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
+)
+
+func TestOnEvidenceRuntimeEquivocation(t *testing.T) {
+	require := require.New(t)
+
+	amount := quantity.NewFromUint64(100)
+
+	now := time.Unix(1580461674, 0)
+	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
+	ctx := appState.NewContext(abciAPI.ContextBeginBlock, now)
+	defer ctx.Close()
+
+	regState := registryState.NewMutableState(ctx.State())
+	stakeState := stakingState.NewMutableState(ctx.State())
+
+	runtime := registry.Runtime{}
+	testNodeSigner := memorySigner.NewTestSigner("runtime test signer")
+
+	// Signer is not known as there are no nodes.
+	err := onEvidenceRuntimeEquivocation(
+		ctx,
+		testNodeSigner.Public(),
+		runtime.ID,
+		amount,
+	)
+	require.Error(err, "should fail when evidence signer address is not known")
+
+	// Add entity.
+	ent, entitySigner, _ := entity.TestEntity()
+	sigEntity, err := entity.SignEntity(entitySigner, registry.RegisterEntitySignatureContext, ent)
+	require.NoError(err, "SignEntity")
+	err = regState.SetEntity(ctx, ent, sigEntity)
+	require.NoError(err, "SetEntity")
+	// Add node.
+	nodeSigner := memorySigner.NewTestSigner("node test signer")
+	nod := &node.Node{
+		Versioned: cbor.NewVersioned(node.LatestNodeDescriptorVersion),
+		ID:        testNodeSigner.Public(),
+		EntityID:  ent.ID,
+		Consensus: node.ConsensusInfo{},
+	}
+	sigNode, err := node.MultiSignNode([]signature.Signer{nodeSigner}, registry.RegisterNodeSignatureContext, nod)
+	require.NoError(err, "MultiSignNode")
+	err = regState.SetNode(ctx, nil, nod, sigNode)
+	require.NoError(err, "SetNode")
+
+	// Should fail if the node has no stake.
+	err = onEvidenceRuntimeEquivocation(
+		ctx,
+		testNodeSigner.Public(),
+		runtime.ID,
+		amount,
+	)
+	require.Error(err, "should fail when node has no stake")
+
+	// Give entity some stake.
+	addr := staking.NewAddress(ent.ID)
+	var balance quantity.Quantity
+	_ = balance.FromUint64(200)
+	var totalShares quantity.Quantity
+	_ = totalShares.FromUint64(200)
+	err = stakeState.SetAccount(ctx, addr, &staking.Account{
+		Escrow: staking.EscrowAccount{
+			Active: staking.SharePool{
+				Balance:     balance,
+				TotalShares: totalShares,
+			},
+		},
+	})
+	require.NoError(err, "SetAccount")
+
+	// Should slash.
+	err = onEvidenceRuntimeEquivocation(
+		ctx,
+		testNodeSigner.Public(),
+		runtime.ID,
+		amount,
+	)
+	require.NoError(err, "slashing should succeed")
+
+	// Entity stake should be slashed.
+	acct, err := stakeState.Account(ctx, addr)
+	require.NoError(err, "Account")
+	require.NoError(balance.Sub(amount))
+	require.EqualValues(balance, acct.Escrow.Active.Balance, "entity stake should be slashed")
+
+	// Runtime account should get the slashed amount.
+	rtAcc, err := stakeState.Account(ctx, staking.NewRuntimeAddress(runtime.ID))
+	require.NoError(err, "runtime Addr")
+	require.EqualValues(amount, &rtAcc.General.Balance, "runtime account should get slashed amount")
+}

--- a/go/consensus/tendermint/apps/roothash/slashing_test.go
+++ b/go/consensus/tendermint/apps/roothash/slashing_test.go
@@ -1,6 +1,7 @@
 package roothash
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -26,20 +27,24 @@ func TestOnEvidenceRuntimeEquivocation(t *testing.T) {
 
 	now := time.Unix(1580461674, 0)
 	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
-	ctx := appState.NewContext(abciAPI.ContextBeginBlock, now)
+	ctx := appState.NewContext(abciAPI.ContextDeliverTx, now)
 	defer ctx.Close()
 
 	regState := registryState.NewMutableState(ctx.State())
 	stakeState := stakingState.NewMutableState(ctx.State())
 
-	runtime := registry.Runtime{}
+	runtime := &registry.Runtime{
+		Staking: registry.RuntimeStakingParameters{
+			RewardSlashEquvocationRuntimePercent: 50,
+		},
+	}
 	testNodeSigner := memorySigner.NewTestSigner("runtime test signer")
 
 	// Signer is not known as there are no nodes.
 	err := onEvidenceRuntimeEquivocation(
 		ctx,
 		testNodeSigner.Public(),
-		runtime.ID,
+		runtime,
 		amount,
 	)
 	require.Error(err, "should fail when evidence signer address is not known")
@@ -63,26 +68,37 @@ func TestOnEvidenceRuntimeEquivocation(t *testing.T) {
 	err = regState.SetNode(ctx, nil, nod, sigNode)
 	require.NoError(err, "SetNode")
 
-	// Should fail if the node has no stake.
+	// Should not fail if the entity has no stake.
 	err = onEvidenceRuntimeEquivocation(
 		ctx,
 		testNodeSigner.Public(),
-		runtime.ID,
+		runtime,
 		amount,
 	)
-	require.Error(err, "should fail when node has no stake")
+	require.NoError(err, "should not fail when entity has no stake")
 
 	// Give entity some stake.
 	addr := staking.NewAddress(ent.ID)
 	var balance quantity.Quantity
-	_ = balance.FromUint64(200)
+	_ = balance.FromUint64(300)
 	var totalShares quantity.Quantity
-	_ = totalShares.FromUint64(200)
+	_ = totalShares.FromUint64(300)
 	err = stakeState.SetAccount(ctx, addr, &staking.Account{
 		Escrow: staking.EscrowAccount{
 			Active: staking.SharePool{
 				Balance:     balance,
 				TotalShares: totalShares,
+			},
+			CommissionSchedule: staking.CommissionSchedule{
+				Rates: []staking.CommissionRateStep{{
+					Start: 0,
+					Rate:  *quantity.NewFromUint64(20_000), // 20%
+				}},
+				Bounds: []staking.CommissionRateBoundStep{{
+					Start:   0,
+					RateMin: *quantity.NewFromUint64(0),
+					RateMax: *quantity.NewFromUint64(100_000), // 100%
+				}},
 			},
 		},
 	})
@@ -92,7 +108,7 @@ func TestOnEvidenceRuntimeEquivocation(t *testing.T) {
 	err = onEvidenceRuntimeEquivocation(
 		ctx,
 		testNodeSigner.Public(),
-		runtime.ID,
+		runtime,
 		amount,
 	)
 	require.NoError(err, "slashing should succeed")
@@ -106,5 +122,184 @@ func TestOnEvidenceRuntimeEquivocation(t *testing.T) {
 	// Runtime account should get the slashed amount.
 	rtAcc, err := stakeState.Account(ctx, staking.NewRuntimeAddress(runtime.ID))
 	require.NoError(err, "runtime Addr")
-	require.EqualValues(amount, &rtAcc.General.Balance, "runtime account should get slashed amount")
+
+	// Expected reward: (slashAmount / runtimeRewardPercentage).
+	expectedReward := amount.Clone()
+	runtimePercentage := quantity.NewFromUint64(uint64(runtime.Staking.RewardSlashEquvocationRuntimePercent))
+	require.NoError(expectedReward.Mul(runtimePercentage))
+	require.NoError(expectedReward.Quo(quantity.NewFromUint64(100)))
+	require.EqualValues(expectedReward, &rtAcc.General.Balance, "runtime account should get part of the slashed amount")
+
+	// Transaction signer should get the rest (in escrow).
+	require.NoError(amount.Sub(expectedReward))
+	callerAcc, err := stakeState.Account(ctx, ctx.CallerAddress())
+	require.NoError(err, "caller Account")
+	require.EqualValues(amount, &callerAcc.Escrow.Active.Balance, "caller account should get the rest in escrow")
+
+	// If the transaction signer is a node, the entity should get the rest.
+	expectedCallerReward := amount.Clone()
+	amount = quantity.NewFromUint64(100)
+
+	ctx.SetTxSigner(testNodeSigner.Public())
+
+	// Should slash.
+	err = onEvidenceRuntimeEquivocation(
+		ctx,
+		testNodeSigner.Public(),
+		runtime,
+		amount,
+	)
+	require.NoError(err, "slashing should succeed")
+
+	// Entity stake should be slashed, but since the same entity got slashed and also provided
+	// evidence, the entity should be rewarded as well.
+	acct, err = stakeState.Account(ctx, addr)
+	require.NoError(err, "Account")
+	require.NoError(balance.Sub(amount))               // Slashed amount.
+	require.NoError(balance.Add(expectedCallerReward)) // Earned rewards.
+	require.EqualValues(balance, acct.Escrow.Active.Balance, "entity stake should be slashed")
+}
+
+func TestOnRuntimeIncorrectResults(t *testing.T) {
+	require := require.New(t)
+
+	amount := quantity.NewFromUint64(100)
+
+	now := time.Unix(1580461674, 0)
+	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
+	ctx := appState.NewContext(abciAPI.ContextBeginBlock, now)
+	defer ctx.Close()
+
+	regState := registryState.NewMutableState(ctx.State())
+	stakeState := stakingState.NewMutableState(ctx.State())
+
+	runtime := &registry.Runtime{
+		Staking: registry.RuntimeStakingParameters{
+			RewardSlashBadResultsRuntimePercent: 50,
+		},
+	}
+	missingNodeSigner := memorySigner.NewTestSigner("TestOnRuntimeIncorrectResults missing node signer")
+
+	// Empty lists.
+	err := onRuntimeIncorrectResults(
+		ctx,
+		[]signature.PublicKey{},
+		[]signature.PublicKey{},
+		runtime,
+		amount,
+	)
+	require.NoError(err, "should not fail when there's no nodes to be slashed")
+
+	// Signer not known.
+	err = onRuntimeIncorrectResults(
+		ctx,
+		[]signature.PublicKey{missingNodeSigner.Public()},
+		[]signature.PublicKey{},
+		runtime,
+		amount,
+	)
+	require.NoError(err, "should not fail when node to be slashed cannot be found")
+
+	// Add state.
+	const numNodes, numSlashed = 20, 13
+	var testNodes []*node.Node
+	for i := 0; i < numNodes; i++ {
+		// Add entity.
+		entitySigner := memorySigner.NewTestSigner(fmt.Sprintf("TestOnRuntimeIncorrectResults entity signer: %d", i))
+		ent := &entity.Entity{
+			ID: entitySigner.Public(),
+		}
+		var sigEntity *entity.SignedEntity
+		sigEntity, err = entity.SignEntity(entitySigner, registry.RegisterEntitySignatureContext, ent)
+		require.NoError(err, "SignEntity")
+		err = regState.SetEntity(ctx, ent, sigEntity)
+		require.NoError(err, "SetEntity")
+		// Add node.
+		nodeSigner := memorySigner.NewTestSigner(fmt.Sprintf("TestOnRuntimeIncorrectResults node signer: %d", i))
+		nod := &node.Node{
+			Versioned: cbor.NewVersioned(node.LatestNodeDescriptorVersion),
+			ID:        nodeSigner.Public(),
+			EntityID:  ent.ID,
+			Consensus: node.ConsensusInfo{},
+		}
+		var sigNode *node.MultiSignedNode
+		sigNode, err = node.MultiSignNode([]signature.Signer{nodeSigner}, registry.RegisterNodeSignatureContext, nod)
+		require.NoError(err, "MultiSignNode")
+		err = regState.SetNode(ctx, nil, nod, sigNode)
+		require.NoError(err, "SetNode")
+
+		testNodes = append(testNodes, nod)
+	}
+
+	// Signers have no stake.
+	err = onRuntimeIncorrectResults(
+		ctx,
+		[]signature.PublicKey{testNodes[0].ID},
+		[]signature.PublicKey{testNodes[1].ID},
+		runtime,
+		amount,
+	)
+	require.NoError(err, "should not fail when entity to be slashed has no stake")
+
+	// Add stake.
+	initialEscrow := quantity.NewFromUint64(200)
+	for _, nod := range testNodes {
+		addr := staking.NewAddress(nod.EntityID)
+		var totalShares quantity.Quantity
+		_ = totalShares.FromUint64(200)
+		err = stakeState.SetAccount(ctx, addr, &staking.Account{
+			Escrow: staking.EscrowAccount{
+				Active: staking.SharePool{
+					Balance:     *initialEscrow,
+					TotalShares: totalShares,
+				},
+			},
+		})
+		require.NoError(err, "SetAccount")
+	}
+
+	// TODO: No reward nodes.
+
+	// Multiple slash and reward nodes.
+	var toSlash, toReward []signature.PublicKey
+	for i, nod := range testNodes {
+		if i < numSlashed {
+			toSlash = append(toSlash, nod.ID)
+		} else {
+			toReward = append(toReward, nod.ID)
+		}
+	}
+	err = onRuntimeIncorrectResults(
+		ctx,
+		toSlash,
+		toReward,
+		runtime,
+		amount,
+	)
+	require.NoError(err, "should not fail")
+	runtimePercentage := quantity.NewFromUint64(uint64(runtime.Staking.RewardSlashBadResultsRuntimePercent))
+	// Ensure nodes were slash, and rewards were distributed.
+	for i, nod := range testNodes {
+		acc, err := stakeState.Account(ctx, staking.NewAddress(nod.EntityID))
+		require.NoError(err, "stakeState.Account")
+
+		expectedEscrow := initialEscrow.Clone()
+		switch i < numSlashed {
+		case true:
+			// Should be slashed.
+			require.NoError(expectedEscrow.Sub(amount), "expectedEscrow.Sub(slashAmount)")
+			require.EqualValues(*expectedEscrow, acc.Escrow.Active.Balance, "Expected amount should be slashed")
+		case false:
+			// Expected reward: ((slashAmount * n_slashed_nodes) / runtimeRewardPercentage) / n_reward_nodes.
+			expectedReward := amount.Clone()
+			require.NoError(expectedReward.Mul(quantity.NewFromUint64(numSlashed)))
+			require.NoError(expectedReward.Mul(runtimePercentage))
+			require.NoError(expectedReward.Quo(quantity.NewFromUint64(100)))
+			require.NoError(expectedReward.Quo(quantity.NewFromUint64(numNodes - numSlashed)))
+			// Rewards are escrowed so they should add up to initial escrow.
+			require.NoError(expectedEscrow.Add(expectedReward))
+			require.EqualValues(*expectedEscrow, acc.Escrow.Active.Balance, "Expected amount should be rewarded")
+		}
+	}
+	// Ensure runtime acc got the reward.
 }

--- a/go/consensus/tendermint/apps/roothash/state/state_test.go
+++ b/go/consensus/tendermint/apps/roothash/state/state_test.go
@@ -1,0 +1,113 @@
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api"
+)
+
+func TestEvidence(t *testing.T) {
+	require := require.New(t)
+
+	now := time.Unix(1580461674, 0)
+	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
+	ctx := appState.NewContext(abciAPI.ContextBeginBlock, now)
+	defer ctx.Close()
+
+	s := NewMutableState(ctx.State())
+
+	rt1ID := common.NewTestNamespaceFromSeed([]byte("apps/roothash/state_test: runtime1"), 0)
+	rt2ID := common.NewTestNamespaceFromSeed([]byte("apps/roothash/state_test: runtime2"), 0)
+	rt3ID := common.NewTestNamespaceFromSeed([]byte("apps/roothash/state_test: runtime3"), 0)
+
+	for _, ev := range []struct {
+		ns common.Namespace
+		r  uint64
+		ev api.Evidence
+	}{
+		{
+			rt1ID,
+			0,
+			api.Evidence{
+				EquivocationExecutor: &api.EquivocationExecutorEvidence{},
+			},
+		},
+		{
+			rt1ID,
+			10,
+			api.Evidence{
+				EquivocationBatch: &api.EquivocationBatchEvidence{},
+			},
+		},
+		{
+			rt1ID,
+			20,
+			api.Evidence{
+				EquivocationExecutor: &api.EquivocationExecutorEvidence{},
+			},
+		},
+		{
+			rt2ID,
+			5,
+			api.Evidence{
+				EquivocationExecutor: &api.EquivocationExecutorEvidence{},
+			},
+		},
+		{
+			rt2ID,
+			10,
+			api.Evidence{
+				EquivocationBatch: &api.EquivocationBatchEvidence{},
+			},
+		},
+		{
+			rt2ID,
+			20,
+			api.Evidence{
+				EquivocationExecutor: &api.EquivocationExecutorEvidence{},
+			},
+		},
+	} {
+		h, err := ev.ev.Hash()
+		require.NoError(err, "ev.Hash()", ev.ev)
+		err = s.SetEvidenceHash(ctx, ev.ns, ev.r, h)
+		require.NoError(err, "SetEvidenceHash()", ev)
+		b, err := s.EvidenceHashExists(ctx, ev.ns, ev.r, h)
+		require.NoError(err, "EvidenceHashExists", ev)
+		require.True(b, "EvidenceHashExists", ev)
+	}
+
+	ev := api.Evidence{
+		EquivocationExecutor: &api.EquivocationExecutorEvidence{},
+	}
+	h, err := ev.Hash()
+	require.NoError(err, "ev.Hash()")
+	b, err := s.EvidenceHashExists(ctx, rt1ID, 5, h)
+	require.NoError(err, "EvidenceHashExists")
+	require.False(b, "Evidence hash should not exist")
+
+	b, err = s.EvidenceHashExists(ctx, rt2ID, 5, h)
+	require.NoError(err, "EvidenceHashExists")
+	require.True(b, "Evidence hash should exist")
+
+	// Expire evidence.
+	err = s.RemoveExpiredEvidence(ctx, rt1ID, 10)
+	require.NoError(err, "RemoveExpiredEvidence")
+	err = s.RemoveExpiredEvidence(ctx, rt2ID, 10)
+	require.NoError(err, "RemoveExpiredEvidence")
+	err = s.RemoveExpiredEvidence(ctx, rt3ID, 1)
+	require.NoError(err, "RemoveExpiredEvidence")
+
+	b, err = s.EvidenceHashExists(ctx, rt2ID, 5, h)
+	require.NoError(err, "EvidenceHashExists")
+	require.False(b, "Expired evidence hash should not exist anymore")
+
+	b, err = s.EvidenceHashExists(ctx, rt1ID, 20, h)
+	require.NoError(err, "EvidenceHashExists")
+	require.True(b, "Not expired evidence hash should still exist")
+}

--- a/go/consensus/tendermint/apps/roothash/transactions.go
+++ b/go/consensus/tendermint/apps/roothash/transactions.go
@@ -136,6 +136,11 @@ func (app *rootHashApplication) executorProposerTimeout(
 		return err
 	}
 
+	// Return early for simulation as we only need gas accounting.
+	if ctx.IsSimulation() {
+		return nil
+	}
+
 	rtState, sv, nl, err := app.getRuntimeState(ctx, state, rpt.ID)
 	if err != nil {
 		return err
@@ -299,6 +304,11 @@ func (app *rootHashApplication) submitEvidence(
 		return err
 	}
 
+	// Return early for simulation as we only need gas accounting.
+	if ctx.IsSimulation() {
+		return nil
+	}
+
 	rtState, _, _, err := app.getRuntimeState(ctx, state, evidence.ID)
 	if err != nil {
 		return err
@@ -351,6 +361,9 @@ func (app *rootHashApplication) submitEvidence(
 		}
 		round = batchA.Header.Round
 		pk = evidence.EquivocationBatch.BatchA.Signature.PublicKey
+	default:
+		// This should never happen due to ValidateBasic check above.
+		return roothash.ErrInvalidEvidence
 	}
 
 	// Evidence is valid. Store the evidence and slash the node.
@@ -372,7 +385,7 @@ func (app *rootHashApplication) submitEvidence(
 	if err = onEvidenceRuntimeEquivocation(
 		ctx,
 		pk,
-		rtState.Runtime.ID,
+		rtState.Runtime,
 		&slash,
 	); err != nil {
 		return fmt.Errorf("error slashing runtime node: %w", err)

--- a/go/consensus/tendermint/apps/roothash/transactions_test.go
+++ b/go/consensus/tendermint/apps/roothash/transactions_test.go
@@ -8,14 +8,20 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
 	registryState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry/state"
 	roothashApi "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/roothash/api"
 	roothashState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/roothash/state"
 	schedulerState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/scheduler/state"
+	stakingState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/staking/state"
 	genesisTestHelpers "github.com/oasisprotocol/oasis-core/go/genesis/tests"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
@@ -204,4 +210,356 @@ func TestMessagesGasEstimation(t *testing.T) {
 	err = app.executorCommit(ctx, roothashState, cc)
 	require.NoError(err, "ExecutorCommit")
 	require.EqualValues(5000, ctx.Gas().GasUsed(), "gas amount should be correct")
+}
+
+func TestEvidence(t *testing.T) {
+	require := require.New(t)
+	var err error
+
+	genesisTestHelpers.SetTestChainContext()
+
+	now := time.Unix(1580461674, 0)
+	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
+	ctx := appState.NewContext(abciAPI.ContextDeliverTx, now)
+	defer ctx.Close()
+
+	// Generate a private key for the node in this test.
+	sk, err := memorySigner.NewSigner(rand.Reader)
+	require.NoError(err, "NewSigner")
+
+	// Signer for a non-existing node.
+	nonExistingSigner, err := memorySigner.NewSigner(rand.Reader)
+	require.NoError(err, "NewSigner")
+	entitySigner := memorySigner.NewTestSigner("consensus/tendermint/apps/roothash: entity signer")
+
+	// Initialize staking state.
+	stakingState := stakingState.NewMutableState(ctx.State())
+	err = stakingState.SetConsensusParameters(ctx, &staking.ConsensusParameters{})
+	require.NoError(err, "staking.SetConsensusParameters")
+	entityEscrow := quantity.NewFromUint64(100)
+	entityAccount := staking.Account{
+		General: staking.GeneralAccount{
+			Balance: quantity.Quantity{},
+		},
+		Escrow: staking.EscrowAccount{
+			Active: staking.SharePool{
+				Balance:     *entityEscrow,
+				TotalShares: *quantity.NewFromUint64(100),
+			},
+		},
+	}
+	err = stakingState.SetAccount(ctx, staking.NewAddress(entitySigner.Public()), &entityAccount)
+	require.NoError(err, "SetAccount")
+
+	// Initialize registry state.
+	registryState := registryState.NewMutableState(ctx.State())
+
+	nod := &node.Node{
+		Versioned: cbor.NewVersioned(node.LatestNodeDescriptorVersion),
+		ID:        sk.Public(),
+		Consensus: node.ConsensusInfo{ID: sk.Public()},
+		EntityID:  entitySigner.Public(),
+	}
+	sigNode, nErr := node.MultiSignNode([]signature.Signer{sk}, registry.RegisterNodeSignatureContext, nod)
+	require.NoError(nErr, "MultiSignNode")
+	err = registryState.SetNode(ctx, nil, nod, sigNode)
+	require.NoError(err, "SetNode")
+
+	// Initialize runtimes.
+	slashAmount := quantity.NewFromUint64(40)
+	runtime := registry.Runtime{
+		Executor: registry.ExecutorParameters{
+			MaxMessages: 32,
+		},
+
+		Staking: registry.RuntimeStakingParameters{
+			Slashing: map[staking.SlashReason]staking.Slash{
+				staking.SlashRuntimeEquivocation: {Amount: *slashAmount},
+			},
+		},
+	}
+	runtimeNoSlashing := registry.Runtime{
+		ID: common.NewTestNamespaceFromSeed([]byte("tendermint/apps/roothash/transaction_test: runtime no slashing"), 0),
+	}
+	runtimeZeroSlashing := registry.Runtime{
+		ID: common.NewTestNamespaceFromSeed([]byte("tendermint/apps/roothash/transaction_test: runtime zero slashing"), 0),
+		Staking: registry.RuntimeStakingParameters{
+			Slashing: map[staking.SlashReason]staking.Slash{
+				staking.SlashRuntimeEquivocation: {},
+			},
+		},
+	}
+
+	// Initialize scheduler state.
+	schedulerState := schedulerState.NewMutableState(ctx.State())
+	executorCommittee := scheduler.Committee{
+		RuntimeID: runtime.ID,
+		Kind:      scheduler.KindComputeExecutor,
+		Members: []*scheduler.CommitteeNode{
+			{
+				Role:      scheduler.RoleWorker,
+				PublicKey: sk.Public(),
+			},
+		},
+	}
+	err = schedulerState.PutCommittee(ctx, &executorCommittee)
+	require.NoError(err, "PutCommittee")
+	storageCommittee := scheduler.Committee{
+		RuntimeID: runtime.ID,
+		Kind:      scheduler.KindStorage,
+		Members: []*scheduler.CommitteeNode{
+			{
+				Role:      scheduler.RoleWorker,
+				PublicKey: sk.Public(),
+			},
+		},
+	}
+	err = schedulerState.PutCommittee(ctx, &storageCommittee)
+	require.NoError(err, "PutCommittee")
+
+	// Initialize roothash state.
+	roothashState := roothashState.NewMutableState(ctx.State())
+	err = roothashState.SetConsensusParameters(ctx, &roothash.ConsensusParameters{
+		MaxRuntimeMessages: 32,
+		MaxEvidenceAge:     50,
+	})
+	require.NoError(err, "SetConsensusParameters")
+	blk := block.NewGenesisBlock(runtime.ID, 0)
+	blk.Header.Round = 99
+	err = roothashState.SetRuntimeState(ctx, &roothash.RuntimeState{
+		Runtime:            &runtime,
+		GenesisBlock:       blk,
+		CurrentBlock:       blk,
+		CurrentBlockHeight: 1000,
+		LastNormalRound:    99,
+		LastNormalHeight:   1000,
+		ExecutorPool: &commitment.Pool{
+			Runtime:   &runtime,
+			Committee: &executorCommittee,
+			Round:     99,
+		},
+	})
+	require.NoError(err, "SetRuntimeState")
+	err = roothashState.SetRuntimeState(ctx, &roothash.RuntimeState{
+		Runtime:            &runtimeNoSlashing,
+		GenesisBlock:       blk,
+		CurrentBlock:       blk,
+		CurrentBlockHeight: 1000,
+		LastNormalRound:    99,
+		LastNormalHeight:   1000,
+		ExecutorPool: &commitment.Pool{
+			Runtime:   &runtime,
+			Committee: &executorCommittee,
+			Round:     99,
+		},
+	})
+	require.NoError(err, "SetRuntimeState")
+	err = roothashState.SetRuntimeState(ctx, &roothash.RuntimeState{
+		Runtime:            &runtimeZeroSlashing,
+		GenesisBlock:       blk,
+		CurrentBlock:       blk,
+		CurrentBlockHeight: 1000,
+		LastNormalRound:    99,
+		LastNormalHeight:   1000,
+		ExecutorPool: &commitment.Pool{
+			Runtime:   &runtime,
+			Committee: &executorCommittee,
+			Round:     99,
+		},
+	})
+	require.NoError(err, "SetRuntimeState")
+
+	// Initialize evidence.
+	blk2 := block.NewEmptyBlock(blk, 0, block.Normal)
+
+	// Proposed batch.
+	batch1 := &commitment.ProposedBatch{
+		IORoot:            blk2.Header.IORoot,
+		StorageSignatures: []signature.Signature{},
+		Header:            blk2.Header,
+	}
+	signedBatch1, err := commitment.SignProposedBatch(sk, batch1)
+	require.NoError(err, "SignProposedBatch")
+	nonExistingSignerBatch1, err := commitment.SignProposedBatch(nonExistingSigner, batch1)
+	require.NoError(err, "SignProposedBatch")
+
+	batch2 := &commitment.ProposedBatch{
+		IORoot:            hash.NewFromBytes([]byte("invalid root")),
+		StorageSignatures: []signature.Signature{},
+		Header:            blk2.Header,
+	}
+	signedBatch2, err := commitment.SignProposedBatch(sk, batch2)
+	require.NoError(err, "SignProposedBatch")
+	nonExistingSignerBatch2, err := commitment.SignProposedBatch(nonExistingSigner, batch2)
+	require.NoError(err, "SignProposedBatch")
+
+	// Executor commit.
+	body := commitment.ComputeBody{
+		Header: commitment.ComputeResultsHeader{
+			Round:        blk.Header.Round,
+			PreviousHash: blk.Header.PreviousHash,
+			IORoot:       &blk.Header.IORoot,
+			StateRoot:    &blk.Header.StateRoot,
+			MessagesHash: &hash.Hash{},
+		},
+	}
+	signedCommitment1, err := commitment.SignExecutorCommitment(sk, &body)
+	require.NoError(err, "SignExecutorCommitment")
+	body.Header.PreviousHash = hash.NewFromBytes([]byte("invalid ioroot"))
+	signedCommitment2, err := commitment.SignExecutorCommitment(sk, &body)
+	require.NoError(err, "SignExecutorCommitment")
+
+	// Expired evidence.
+	blk2.Header.Round = 25
+	expired1 := &commitment.ProposedBatch{
+		IORoot:            blk2.Header.IORoot,
+		StorageSignatures: []signature.Signature{},
+		Header:            blk2.Header,
+	}
+	expiredB1, err := commitment.SignProposedBatch(sk, expired1)
+	require.NoError(err, "SignProposedBatch")
+	expired2 := &commitment.ProposedBatch{
+		IORoot:            hash.NewFromBytes([]byte("invalid root")),
+		StorageSignatures: []signature.Signature{},
+		Header:            blk2.Header,
+	}
+	expiredB2, err := commitment.SignProposedBatch(sk, expired2)
+	require.NoError(err, "SignProposedBatch")
+
+	expiredBody := commitment.ComputeBody{
+		Header: commitment.ComputeResultsHeader{
+			Round:        blk2.Header.Round,
+			PreviousHash: blk2.Header.PreviousHash,
+			IORoot:       &blk2.Header.IORoot,
+			StateRoot:    &blk2.Header.StateRoot,
+			MessagesHash: &hash.Hash{},
+		},
+	}
+	expiredCommitment1, err := commitment.SignExecutorCommitment(sk, &expiredBody)
+	require.NoError(err, "SignExecutorCommitment")
+	expiredBody.Header.PreviousHash = hash.NewFromBytes([]byte("invalid ioroot"))
+	expiredCommitment2, err := commitment.SignExecutorCommitment(sk, &expiredBody)
+	require.NoError(err, "SignExecutorCommitment")
+	var md testMsgDispatcher
+	app := rootHashApplication{appState, &md}
+
+	for _, ev := range []struct {
+		ev  *roothash.Evidence
+		err error
+		msg string
+	}{
+		{
+			&roothash.Evidence{},
+			roothash.ErrInvalidEvidence,
+			"invalid evidence",
+		},
+		{
+			&roothash.Evidence{
+				ID: common.NewTestNamespaceFromSeed([]byte("tendermint/apps/roothash/transaction_test: non existing runtime"), 0),
+				EquivocationBatch: &roothash.EquivocationBatchEvidence{
+					BatchA: *signedBatch1,
+					BatchB: *signedBatch2,
+				},
+			},
+			roothash.ErrInvalidRuntime,
+			"evidence for nonexisting runtime",
+		},
+		{
+			&roothash.Evidence{
+				ID: runtimeNoSlashing.ID,
+				EquivocationBatch: &roothash.EquivocationBatchEvidence{
+					BatchA: *signedBatch1,
+					BatchB: *signedBatch2,
+				},
+			},
+			roothash.ErrRuntimeDoesNotSlash,
+			"evidence for runtime without slashing",
+		},
+		{
+			&roothash.Evidence{
+				ID: runtimeZeroSlashing.ID,
+				EquivocationBatch: &roothash.EquivocationBatchEvidence{
+					BatchA: *signedBatch1,
+					BatchB: *signedBatch2,
+				},
+			},
+			roothash.ErrRuntimeDoesNotSlash,
+			"evidence for runtime with zero slashing",
+		},
+		{
+			&roothash.Evidence{
+				EquivocationExecutor: &roothash.EquivocationExecutorEvidence{
+					CommitA: *expiredCommitment1,
+					CommitB: *expiredCommitment2,
+				},
+			},
+			roothash.ErrInvalidEvidence,
+			"expired executor evidence",
+		},
+		{
+			&roothash.Evidence{
+				EquivocationBatch: &roothash.EquivocationBatchEvidence{
+					BatchA: *expiredB1,
+					BatchB: *expiredB2,
+				},
+			},
+			roothash.ErrInvalidEvidence,
+			"expired batch evidence",
+		},
+		{
+			&roothash.Evidence{
+				ID: runtime.ID,
+				EquivocationExecutor: &roothash.EquivocationExecutorEvidence{
+					CommitA: *signedCommitment1,
+					CommitB: *signedCommitment2,
+				},
+			},
+			nil,
+			"valid executor evidence",
+		},
+		{
+			&roothash.Evidence{
+				ID: runtime.ID,
+				EquivocationBatch: &roothash.EquivocationBatchEvidence{
+					BatchA: *signedBatch1,
+					BatchB: *signedBatch2,
+				},
+			},
+			nil,
+			"valid batch evidence",
+		},
+		{
+			&roothash.Evidence{
+				ID: runtime.ID,
+				EquivocationBatch: &roothash.EquivocationBatchEvidence{
+					BatchA: *signedBatch1,
+					BatchB: *signedBatch2,
+				},
+			},
+			roothash.ErrDuplicateEvidence,
+			"duplicate evidence",
+		},
+		{
+			&roothash.Evidence{
+				EquivocationBatch: &roothash.EquivocationBatchEvidence{
+					BatchA: *nonExistingSignerBatch1,
+					BatchB: *nonExistingSignerBatch2,
+				},
+			},
+			roothash.ErrInvalidEvidence,
+			"evidence for non-existing node",
+		},
+	} {
+		err = app.submitEvidence(ctx, roothashState, ev.ev)
+		require.ErrorIs(err, ev.err, ev.msg)
+	}
+
+	// Check that expected amount was slashed.
+	// Entity should be slashed two times.
+	require.NoError(entityEscrow.Sub(slashAmount))
+	require.NoError(entityEscrow.Sub(slashAmount))
+
+	entAcc, err := stakingState.Account(ctx, staking.NewAddress(nod.EntityID))
+	require.NoError(err, "Account()")
+	require.EqualValues(entityEscrow, &entAcc.Escrow.Active.Balance, "entity was slashed expected amount")
 }

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -141,7 +141,7 @@ func TestGenesisChainContext(t *testing.T) {
 
 	// Having to update this every single time the genesis structure
 	// changes isn't annoying at all.
-	require.Equal(t, "190c33831058e1f850a1528da9892259c4d86538f4524c561a93505fe41c4d83", stableDoc.ChainContext())
+	require.Equal(t, "c7ca04c2279b2df5773258fda6a7ff9e473fe648eb7616e1be6474308e9174e8", stableDoc.ChainContext())
 }
 
 func TestGenesisSanityCheck(t *testing.T) {

--- a/go/oasis-test-runner/oasis/cli/registry.go
+++ b/go/oasis-test-runner/oasis/cli/registry.go
@@ -106,6 +106,14 @@ func (r *RegistryHelpers) runRegistryRuntimeSubcommand(
 			"--"+cmdRegRt.CfgStakingThreshold, fmt.Sprintf("%s=%s", string(kindRaw), string(valueRaw)),
 		)
 	}
+	for reason, value := range runtime.Staking.Slashing {
+		reasonRaw, _ := reason.MarshalText()
+		valueRaw, _ := value.Amount.MarshalText()
+
+		args = append(args,
+			"--"+cmdRegRt.CfgStakingSlashing, fmt.Sprintf("%s=%s", string(reasonRaw), string(valueRaw)),
+		)
+	}
 
 	if out, err := r.runSubCommandWithOutput("registry-runtime-"+cmd, args); err != nil {
 		return fmt.Errorf("failed to run 'registry runtime %s': error: %w output: %s", cmd, err, out.String())

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -263,6 +263,9 @@ type RuntimeStakingParameters struct {
 	// In case a node is registered for multiple runtimes, it will need to satisfy the maximum
 	// threshold of all the runtimes.
 	Thresholds map[staking.ThresholdKind]quantity.Quantity `json:"thresholds,omitempty"`
+
+	// Slashing are the per-runtime misbehavior slashing parameters.
+	Slashing map[staking.SlashReason]staking.Slash `json:"slashing,omitempty"`
 }
 
 // ValidateBasic performs basic descriptor validity checks.

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -266,10 +266,24 @@ type RuntimeStakingParameters struct {
 
 	// Slashing are the per-runtime misbehavior slashing parameters.
 	Slashing map[staking.SlashReason]staking.Slash `json:"slashing,omitempty"`
+
+	// RewardSlashEquvocationRuntimePercent is the percentage of the reward obtained when slashing
+	// for equivocation that is transferred to the runtime's account.
+	RewardSlashEquvocationRuntimePercent uint8 `json:"reward_equivocation,omitempty"`
+
+	// RewardSlashBadResultsRuntimePercent is the percentage of the reward obtained when slashing
+	// for incorrect results that is transferred to the runtime's account.
+	RewardSlashBadResultsRuntimePercent uint8 `json:"reward_bad_results,omitempty"`
 }
 
 // ValidateBasic performs basic descriptor validity checks.
 func (s *RuntimeStakingParameters) ValidateBasic(runtimeKind RuntimeKind) error {
+	if s.RewardSlashEquvocationRuntimePercent > 100 {
+		return fmt.Errorf("runtime reward percentage from slashing for equivocation must be <= 100")
+	}
+	if s.RewardSlashBadResultsRuntimePercent > 100 {
+		return fmt.Errorf("runtime reward percentage from slashing for bad results must be <= 100")
+	}
 	for kind, q := range s.Thresholds {
 		switch kind {
 		case staking.KindNodeCompute, staking.KindNodeStorage:

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -6,6 +6,7 @@ import (
 	"crypto"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"testing"
 	"time"
@@ -1732,6 +1733,13 @@ func NewTestRuntime(seed []byte, ent *TestEntity, isKeyManager bool) (*TestRunti
 			AnyNode: &api.AnyNodeRuntimeAdmissionPolicy{},
 		},
 		GovernanceModel: api.GovernanceEntity,
+		Staking: api.RuntimeStakingParameters{
+			Slashing: map[staking.SlashReason]staking.Slash{
+				staking.SlashRuntimeEquivocation: {
+					Amount: *quantity.NewFromUint64(math.MaxInt64),
+				},
+			},
+		},
 	}
 	// TODO: Test with non-empty state root when enabled.
 	rt.Runtime.Genesis.StateRoot.Empty()

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -1739,6 +1739,7 @@ func NewTestRuntime(seed []byte, ent *TestEntity, isKeyManager bool) (*TestRunti
 					Amount: *quantity.NewFromUint64(math.MaxInt64),
 				},
 			},
+			RewardSlashEquvocationRuntimePercent: 100,
 		},
 	}
 	// TODO: Test with non-empty state root when enabled.

--- a/go/roothash/api/api_test.go
+++ b/go/roothash/api/api_test.go
@@ -1,0 +1,515 @@
+package api
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
+	genesisTestHelpers "github.com/oasisprotocol/oasis-core/go/genesis/tests"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
+)
+
+func TestEvidenceHash(t *testing.T) {
+	require := require.New(t)
+
+	genesisTestHelpers.SetTestChainContext()
+
+	// Test empty evidence.
+	ev := Evidence{}
+	_, err := ev.Hash()
+	require.Error(err, "empty evidence hash should error")
+
+	// Prepare valid evidence.
+	sk, err := memorySigner.NewSigner(rand.Reader)
+	require.NoError(err, "NewSigner")
+	sk2, err := memorySigner.NewSigner(rand.Reader)
+	require.NoError(err, "NewSigner")
+	runtimeID := common.NewTestNamespaceFromSeed([]byte("roothash/api_test/hash: runtime"), 0)
+	blk := block.NewGenesisBlock(runtimeID, 0)
+	batch1 := &commitment.ProposedBatch{
+		IORoot:            blk.Header.IORoot,
+		StorageSignatures: []signature.Signature{},
+		Header:            blk.Header,
+	}
+	signedBatch1, err := commitment.SignProposedBatch(sk, batch1)
+	require.NoError(err, "SignProposedBatch")
+	signed2Batch1, err := commitment.SignProposedBatch(sk2, batch1)
+	require.NoError(err, "SignedProposedBatch")
+
+	batch2 := &commitment.ProposedBatch{
+		IORoot:            hash.NewFromBytes([]byte("invalid root")),
+		StorageSignatures: []signature.Signature{},
+		Header:            blk.Header,
+	}
+	signedBatch2, err := commitment.SignProposedBatch(sk, batch2)
+	require.NoError(err, "SignProposedBatch")
+	signed2Batch2, err := commitment.SignProposedBatch(sk2, batch2)
+	require.NoError(err, "SignedProposedBatch")
+
+	// Executor commit.
+	body := commitment.ComputeBody{
+		Header: commitment.ComputeResultsHeader{
+			Round:        blk.Header.Round,
+			PreviousHash: blk.Header.PreviousHash,
+			IORoot:       &blk.Header.IORoot,
+			StateRoot:    &blk.Header.StateRoot,
+			MessagesHash: &hash.Hash{},
+		},
+	}
+	signedCommitment1, err := commitment.SignExecutorCommitment(sk, &body)
+	require.NoError(err, "SignExecutorCommitment")
+
+	ev = Evidence{
+		ID: runtimeID,
+		EquivocationBatch: &EquivocationBatchEvidence{
+			BatchA: *signedBatch1,
+			BatchB: *signedBatch2,
+		},
+	}
+	h1, err := ev.Hash()
+	require.NoError(err, "Hash")
+
+	ev = Evidence{
+		ID: runtimeID,
+		EquivocationExecutor: &EquivocationExecutorEvidence{
+			// Same round and same signer as above evidence, hash should match.
+			CommitA: *signedCommitment1,
+			CommitB: *signedCommitment1,
+		},
+	}
+	h2, err := ev.Hash()
+	require.NoError(err, "Hash")
+	require.EqualValues(h1, h2, "Equivocation evidence hashes for same round by same signer should match")
+
+	ev = Evidence{
+		ID: runtimeID,
+		EquivocationBatch: &EquivocationBatchEvidence{
+			BatchA: *signed2Batch1,
+			BatchB: *signed2Batch2,
+		},
+	}
+	h3, err := ev.Hash()
+	require.NoError(err, "Hash")
+	require.NotEqualValues(h1, h3, "Equivocation evidence hashes for same round by different signers shouldn't match")
+}
+
+func TestEvidenceValidateBasic(t *testing.T) {
+	require := require.New(t)
+
+	genesisTestHelpers.SetTestChainContext()
+
+	sk, err := memorySigner.NewSigner(rand.Reader)
+	require.NoError(err, "NewSigner")
+
+	rtID := common.NewTestNamespaceFromSeed([]byte("roothash/api_test: runtime1"), 0)
+	rtBlk := block.NewGenesisBlock(rtID, 0)
+	rtBatch1 := &commitment.ProposedBatch{
+		IORoot:            rtBlk.Header.IORoot,
+		StorageSignatures: []signature.Signature{},
+		Header:            rtBlk.Header,
+	}
+	signedB1, err := commitment.SignProposedBatch(sk, rtBatch1)
+	require.NoError(err, "SignProposedBatch")
+
+	rtBatch2 := &commitment.ProposedBatch{
+		IORoot:            hash.NewFromBytes([]byte("invalid root")),
+		StorageSignatures: []signature.Signature{},
+		Header:            rtBlk.Header,
+	}
+	signedB2, err := commitment.SignProposedBatch(sk, rtBatch2)
+	require.NoError(err, "SignProposedBatch")
+
+	body := commitment.ComputeBody{
+		Header: commitment.ComputeResultsHeader{
+			Round:        rtBlk.Header.Round,
+			PreviousHash: rtBlk.Header.PreviousHash,
+			IORoot:       &rtBlk.Header.IORoot,
+			StateRoot:    &rtBlk.Header.StateRoot,
+			MessagesHash: &hash.Hash{},
+		},
+	}
+	signedCommitment1, err := commitment.SignExecutorCommitment(sk, &body)
+	require.NoError(err, "SignExecutorCommitment")
+
+	body.Header.PreviousHash = hash.NewFromBytes([]byte("invalid hash"))
+	signedCommitment2, err := commitment.SignExecutorCommitment(sk, &body)
+	require.NoError(err, "SignExecutorCommitment")
+
+	for _, ev := range []struct {
+		ev        Evidence
+		shouldErr bool
+		msg       string
+	}{
+		{
+			Evidence{},
+			true,
+			"empty evidence should error",
+		},
+		{
+			Evidence{
+				ID: rtID,
+				EquivocationExecutor: &EquivocationExecutorEvidence{
+					CommitA: *signedCommitment1,
+					CommitB: *signedCommitment2,
+				},
+				EquivocationBatch: &EquivocationBatchEvidence{
+					BatchA: *signedB1,
+					BatchB: *signedB2,
+				},
+			},
+			true,
+			"evidence with multiple evidence types should error",
+		},
+		{
+			Evidence{
+				ID: rtID,
+				EquivocationExecutor: &EquivocationExecutorEvidence{
+					CommitA: *signedCommitment1,
+					CommitB: *signedCommitment2,
+				},
+			},
+			false,
+			"valid equivocation executor evidence",
+		},
+		{
+			Evidence{
+				ID: rtID,
+				EquivocationBatch: &EquivocationBatchEvidence{
+					BatchA: *signedB1,
+					BatchB: *signedB2,
+				},
+			},
+			false,
+			"valid equivocation batch evidence",
+		},
+	} {
+		err := ev.ev.ValidateBasic()
+		switch ev.shouldErr {
+		case true:
+			require.Error(err, ev.msg)
+		case false:
+			require.NoError(err, ev.msg)
+		}
+	}
+}
+
+func TestEquivocationBatchEvidenceValidateBasic(t *testing.T) {
+	require := require.New(t)
+
+	genesisTestHelpers.SetTestChainContext()
+
+	sk, err := memorySigner.NewSigner(rand.Reader)
+	require.NoError(err, "NewSigner")
+
+	sk2, err := memorySigner.NewSigner(rand.Reader)
+	require.NoError(err, "NewSigner")
+
+	rt1ID := common.NewTestNamespaceFromSeed([]byte("roothash/api_test: runtime1"), 0)
+	rt1Blk1 := block.NewGenesisBlock(rt1ID, 0)
+	rt1Blk2 := block.NewEmptyBlock(rt1Blk1, 0, block.Normal)
+
+	rt2ID := common.NewTestNamespaceFromSeed([]byte("roothash/api_test: runtime2"), 0)
+	rt2Blk1 := block.NewGenesisBlock(rt2ID, 0)
+	rt2Blk2 := block.NewEmptyBlock(rt2Blk1, 0, block.Invalid)
+
+	// Prepare test signed batches.
+	rt1Batch1 := &commitment.ProposedBatch{
+		IORoot:            rt1Blk1.Header.IORoot,
+		StorageSignatures: []signature.Signature{},
+		Header:            rt1Blk1.Header,
+	}
+	signedR1B1, err := commitment.SignProposedBatch(sk, rt1Batch1)
+	require.NoError(err, "SignProposedBatch")
+
+	rt1Batch2 := &commitment.ProposedBatch{
+		IORoot:            rt1Blk2.Header.IORoot,
+		StorageSignatures: []signature.Signature{},
+		Header:            rt1Blk2.Header,
+	}
+	signedR1B2, err := commitment.SignProposedBatch(sk, rt1Batch2)
+	require.NoError(err, "SignProposedBatch")
+
+	rt1Batch3 := &commitment.ProposedBatch{
+		IORoot:            hash.NewFromBytes([]byte("invalid root")),
+		StorageSignatures: []signature.Signature{},
+		Header:            rt1Blk1.Header,
+	}
+	signedR1B3, err := commitment.SignProposedBatch(sk, rt1Batch3)
+	require.NoError(err, "SignProposedBatch")
+
+	signed2R1B3, err := commitment.SignProposedBatch(sk2, rt1Batch3)
+	require.NoError(err, "SignProposedBatch")
+
+	rt2Batch1 := &commitment.ProposedBatch{
+		IORoot:            rt2Blk2.Header.IORoot,
+		StorageSignatures: []signature.Signature{},
+		Header:            rt2Blk2.Header,
+	}
+	signedR2B1, err := commitment.SignProposedBatch(sk, rt2Batch1)
+	require.NoError(err, "SignProposedBatch")
+
+	for _, ev := range []struct {
+		ev        EquivocationBatchEvidence
+		shouldErr bool
+		msg       string
+	}{
+		{
+			EquivocationBatchEvidence{},
+			true,
+			"empty evidence should error",
+		},
+		{
+			EquivocationBatchEvidence{
+				BatchA: *signedR1B1,
+			},
+			true,
+			"empty evidence should error",
+		},
+		{
+			EquivocationBatchEvidence{
+				BatchB: *signedR1B1,
+			},
+			true,
+			"empty evidence should error",
+		},
+		{
+			EquivocationBatchEvidence{
+				BatchA: *signedR1B1,
+				BatchB: *signedR1B1,
+			},
+			true,
+			"same signed batch is not valid evidence",
+		},
+		{
+			EquivocationBatchEvidence{
+				BatchA: *signedR1B1,
+				BatchB: *signedR1B2,
+			},
+			true,
+			"signed batches for different heights is not valid evidence",
+		},
+		{
+			EquivocationBatchEvidence{
+				BatchA: *signedR1B1,
+				BatchB: *signedR2B1,
+			},
+			true,
+			"signed batches for different runtimes is not valid evidence",
+		},
+		{
+			EquivocationBatchEvidence{
+				BatchA: *signedR1B1,
+				BatchB: *signedR1B3,
+			},
+			false,
+			"same height different IORoot is valid evidence",
+		},
+		{
+			EquivocationBatchEvidence{
+				BatchA: *signedR1B1,
+				BatchB: *signed2R1B3,
+			},
+			true,
+			"different signer is not valid evidence",
+		},
+	} {
+		err := ev.ev.ValidateBasic()
+		switch ev.shouldErr {
+		case true:
+			require.Error(err, ev.msg)
+		case false:
+			require.NoError(err, ev.msg)
+		}
+	}
+}
+
+func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
+	require := require.New(t)
+
+	genesisTestHelpers.SetTestChainContext()
+
+	sk, err := memorySigner.NewSigner(rand.Reader)
+	require.NoError(err, "NewSigner")
+
+	sk2, err := memorySigner.NewSigner(rand.Reader)
+	require.NoError(err, "NewSigner")
+
+	rt1ID := common.NewTestNamespaceFromSeed([]byte("roothash/api_test: runtime1"), 0)
+	rt1Blk1 := block.NewGenesisBlock(rt1ID, 0)
+	rt1Blk2 := block.NewEmptyBlock(rt1Blk1, 0, block.Normal)
+
+	body := commitment.ComputeBody{
+		Header: commitment.ComputeResultsHeader{
+			Round:        rt1Blk2.Header.Round,
+			PreviousHash: rt1Blk2.Header.PreviousHash,
+			IORoot:       &rt1Blk2.Header.IORoot,
+			StateRoot:    &rt1Blk2.Header.StateRoot,
+			MessagesHash: &hash.Hash{},
+		},
+	}
+	signed1Commitment, err := commitment.SignExecutorCommitment(sk, &body)
+	require.NoError(err, "SignExecutorCommitment")
+	signed2Commitment, err := commitment.SignExecutorCommitment(sk2, &body)
+	require.NoError(err, "SignExecutorCommitment")
+
+	body2 := commitment.ComputeBody{
+		Header: commitment.ComputeResultsHeader{
+			Round:        rt1Blk2.Header.Round,
+			PreviousHash: hash.NewFromBytes([]byte("invalid hash")),
+			IORoot:       &rt1Blk2.Header.IORoot,
+			StateRoot:    &rt1Blk2.Header.StateRoot,
+			MessagesHash: &hash.Hash{},
+		},
+	}
+	signed1Commitment2, err := commitment.SignExecutorCommitment(sk, &body2)
+	require.NoError(err, "SignExecutorCommitment")
+
+	// Different round.
+	body3 := commitment.ComputeBody{
+		Header: commitment.ComputeResultsHeader{
+			Round:        rt1Blk2.Header.Round + 1,
+			PreviousHash: hash.NewFromBytes([]byte("invalid hash")),
+			IORoot:       &rt1Blk2.Header.IORoot,
+			StateRoot:    &rt1Blk2.Header.StateRoot,
+			MessagesHash: &hash.Hash{},
+		},
+	}
+	signed1Commitment3, err := commitment.SignExecutorCommitment(sk, &body3)
+	require.NoError(err, "SignExecutorCommitment")
+
+	// Invalid.
+	invalidBody := commitment.ComputeBody{
+		Header: commitment.ComputeResultsHeader{
+			Round:        rt1Blk2.Header.Round,
+			PreviousHash: hash.NewFromBytes([]byte("invalid hash")),
+			IORoot:       nil,
+			StateRoot:    &rt1Blk2.Header.StateRoot,
+			MessagesHash: nil,
+		},
+	}
+	signed1Invalid, err := commitment.SignExecutorCommitment(sk, &invalidBody)
+	require.NoError(err, "SignExecutorCommitment")
+
+	// Failure indicating.
+	failureBody1 := body
+	failureBody1.SetFailure(commitment.FailureStorageUnavailable)
+	signedFailure1, err := commitment.SignExecutorCommitment(sk, &failureBody1)
+	require.NoError(err, "SignExecutorCommitment")
+
+	failureBody2 := body
+	failureBody2.SetFailure(commitment.FailureUnknown)
+	signedFailure2, err := commitment.SignExecutorCommitment(sk, &failureBody2)
+	require.NoError(err, "SignExecutorCommitment")
+
+	for _, ev := range []struct {
+		ev        EquivocationExecutorEvidence
+		shouldErr bool
+		msg       string
+	}{
+		{
+			EquivocationExecutorEvidence{},
+			true,
+			"empty evidence should error",
+		},
+		{
+			EquivocationExecutorEvidence{
+				CommitA: *signed1Commitment,
+			},
+			true,
+			"empty evidence should error",
+		},
+		{
+			EquivocationExecutorEvidence{
+				CommitB: *signed1Commitment,
+			},
+			true,
+			"empty evidence should error",
+		},
+		{
+			EquivocationExecutorEvidence{
+				CommitA: *signed1Commitment,
+				CommitB: *signed1Commitment,
+			},
+			true,
+			"same signed commitment is not valid evidence",
+		},
+		{
+			EquivocationExecutorEvidence{
+				CommitA: *signed1Commitment,
+				CommitB: *signed1Commitment3,
+			},
+			true,
+			"signed commitments for different rounds is not valid evidence",
+		},
+		{
+			EquivocationExecutorEvidence{
+				CommitA: *signed1Commitment,
+				CommitB: *signed1Invalid,
+			},
+			true,
+			"non valid commitment is not valid evidence",
+		},
+		{
+			EquivocationExecutorEvidence{
+				CommitA: *signed1Invalid,
+				CommitB: *signed1Commitment,
+			},
+			true,
+			"non valid commitment not valid evidence",
+		},
+		{
+			EquivocationExecutorEvidence{
+				CommitA: *signedFailure1,
+				CommitB: *signedFailure1,
+			},
+			true,
+			"same failure indicating is not valid evidence",
+		},
+		{
+			EquivocationExecutorEvidence{
+				CommitA: *signedFailure1,
+				CommitB: *signedFailure2,
+			},
+			false,
+			"different failure indicating reason is valid evidence",
+		},
+		{
+			EquivocationExecutorEvidence{
+				CommitA: *signed1Commitment,
+				CommitB: *signed2Commitment,
+			},
+			true,
+			"different signer is not valid evidence",
+		},
+		{
+			EquivocationExecutorEvidence{
+				CommitA: *signed1Commitment,
+				CommitB: *signed1Commitment2,
+			},
+			false,
+			"valid evidence",
+		},
+		{
+			EquivocationExecutorEvidence{
+				CommitA: *signed1Commitment,
+				CommitB: *signedFailure1,
+			},
+			false,
+			"valid evidence",
+		},
+	} {
+		err := ev.ev.ValidateBasic()
+		switch ev.shouldErr {
+		case true:
+			require.Error(err, ev.msg)
+		case false:
+			require.NoError(err, ev.msg)
+		}
+	}
+}

--- a/go/roothash/api/commitment/pool.go
+++ b/go/roothash/api/commitment/pool.go
@@ -263,6 +263,8 @@ func (p *Pool) addOpenExecutorCommitment(
 		return ErrTxnSchedSigInvalid
 	}
 
+	// TODO: Check for evidence of equivocation (oasis-core#3685).
+
 	switch openCom.IsIndicatingFailure() {
 	case true:
 	default:

--- a/go/roothash/api/commitment/txnscheduler.go
+++ b/go/roothash/api/commitment/txnscheduler.go
@@ -36,6 +36,11 @@ type SignedProposedBatch struct {
 	signature.Signed
 }
 
+// Equal compares vs another SignedProposedBatch for equality.
+func (s *SignedProposedBatch) Equal(cmp *SignedProposedBatch) bool {
+	return s.Signed.Equal(&cmp.Signed)
+}
+
 // Open first verifies the blob signature and then unmarshals the blob.
 func (s *SignedProposedBatch) Open(tsbd *ProposedBatch) error {
 	return s.Signed.Open(ProposedBatchSignatureContext, tsbd)

--- a/go/staking/api/slashing.go
+++ b/go/staking/api/slashing.go
@@ -22,6 +22,13 @@ const (
 	// SlashConsensusLightClientAttack is slashing due to light client attacks.
 	SlashConsensusLightClientAttack SlashReason = 0x04
 
+	// SlashRuntimeIncorrectResults is slashing due to submission of incorrect
+	// results in runtime executor commitments.
+	SlashRuntimeIncorrectResults SlashReason = 0x80
+	// SlashRuntimeEquivocation is slashing due to signing two different
+	// executor commits or proposed batches for the same round.
+	SlashRuntimeEquivocation SlashReason = 0x81
+
 	// SlashConsensusEquivocationName is the string representation of SlashConsensusEquivocation.
 	SlashConsensusEquivocationName = "consensus-equivocation"
 	// SlashBeaconInvalidCommitName is the string representation of SlashBeaconInvalidCommit.
@@ -32,6 +39,10 @@ const (
 	SlashBeaconNonparticipationName = "beacon-nonparticipation"
 	// SlashConsensusLightClientAttackName is the string representation of SlashConsensusLightClientAttack.
 	SlashConsensusLightClientAttackName = "consensus-light-client-attack"
+	// SlashRuntimeIncorrectResultsName is the string representation of SlashRuntimeIncorrectResultsName.
+	SlashRuntimeIncorrectResultsName = "runtime-incorrect-results"
+	// SlashRuntimeEquivocationName is the string representation of SlashRuntimeEquivocation.
+	SlashRuntimeEquivocationName = "runtime-equivocation"
 )
 
 // String returns a string representation of a SlashReason.
@@ -52,6 +63,10 @@ func (s SlashReason) checkedString() (string, error) {
 		return SlashBeaconNonparticipationName, nil
 	case SlashConsensusLightClientAttack:
 		return SlashConsensusLightClientAttackName, nil
+	case SlashRuntimeIncorrectResults:
+		return SlashRuntimeIncorrectResultsName, nil
+	case SlashRuntimeEquivocation:
+		return SlashRuntimeEquivocationName, nil
 	default:
 		return "[unknown slash reason]", fmt.Errorf("unknown slash reason: %d", s)
 	}
@@ -84,6 +99,10 @@ func (s *SlashReason) UnmarshalText(text []byte) error {
 		*s = SlashBeaconNonparticipation
 	case SlashConsensusLightClientAttackName:
 		*s = SlashConsensusLightClientAttack
+	case SlashRuntimeIncorrectResultsName:
+		*s = SlashRuntimeIncorrectResults
+	case SlashRuntimeEquivocationName:
+		*s = SlashRuntimeEquivocation
 	default:
 		return fmt.Errorf("invalid slash reason: %s", string(text))
 	}

--- a/go/staking/api/slashing_test.go
+++ b/go/staking/api/slashing_test.go
@@ -12,6 +12,8 @@ func TestSlashReason(t *testing.T) {
 	// Test valid SlashReasons.
 	for _, k := range []SlashReason{
 		SlashConsensusEquivocation,
+		SlashRuntimeIncorrectResults,
+		SlashRuntimeEquivocation,
 	} {
 		enc, err := k.MarshalText()
 		require.NoError(err, "MarshalText")

--- a/go/staking/tests/tester.go
+++ b/go/staking/tests/tester.go
@@ -73,7 +73,7 @@ var (
 
 	qtyOne = *quantity.NewFromUint64(1)
 
-	srcSigner  = debug.DebugStateSrcSigner
+	SrcSigner  = debug.DebugStateSrcSigner
 	SrcAddr    = debug.DebugStateSrcAddress
 	destSigner = debug.DebugStateDestSigner
 	DestAddr   = debug.DebugStateDestAddress
@@ -208,7 +208,7 @@ func testTransfer(t *testing.T, state *stakingTestsState, backend api.Backend, c
 		Amount: *quantity.NewFromUint64(math.MaxUint8),
 	}
 	tx := api.NewTransferTx(srcAcc.General.Nonce, nil, xfer)
-	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, srcSigner, tx)
+	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, SrcSigner, tx)
 	require.NoError(err, "Transfer")
 
 	var gotTransfer bool
@@ -276,7 +276,7 @@ TransferWaitLoop:
 	xfer.Amount = newSrcAcc.General.Balance
 
 	tx = api.NewTransferTx(newSrcAcc.General.Nonce, nil, xfer)
-	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, srcSigner, tx)
+	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, SrcSigner, tx)
 	require.Error(err, "Transfer - more than available balance")
 }
 
@@ -295,7 +295,7 @@ func testSelfTransfer(t *testing.T, state *stakingTestsState, backend api.Backen
 		Amount: *quantity.NewFromUint64(math.MaxUint8),
 	}
 	tx := api.NewTransferTx(srcAcc.General.Nonce, nil, xfer)
-	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, srcSigner, tx)
+	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, SrcSigner, tx)
 	require.NoError(err, "Transfer")
 
 	var gotTransfer bool
@@ -343,7 +343,7 @@ TransferWaitLoop:
 	xfer.Amount = newSrcAcc.General.Balance
 
 	tx = api.NewTransferTx(newSrcAcc.General.Nonce, nil, xfer)
-	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, srcSigner, tx)
+	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, SrcSigner, tx)
 	require.Error(err, "Transfer - more than available balance")
 }
 
@@ -364,7 +364,7 @@ func testBurn(t *testing.T, state *stakingTestsState, backend api.Backend, conse
 		Amount: *quantity.NewFromUint64(math.MaxUint32),
 	}
 	tx := api.NewBurnTx(srcAcc.General.Nonce, nil, burn)
-	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, srcSigner, tx)
+	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, SrcSigner, tx)
 	require.NoError(err, "Burn")
 
 	select {
@@ -407,11 +407,11 @@ func testBurn(t *testing.T, state *stakingTestsState, backend api.Backend, conse
 }
 
 func testEscrow(t *testing.T, state *stakingTestsState, backend api.Backend, consensus consensusAPI.Backend) {
-	testEscrowEx(t, state, backend, consensus, SrcAddr, srcSigner, DestAddr)
+	testEscrowEx(t, state, backend, consensus, SrcAddr, SrcSigner, DestAddr)
 }
 
 func testSelfEscrow(t *testing.T, state *stakingTestsState, backend api.Backend, consensus consensusAPI.Backend) {
-	testEscrowEx(t, state, backend, consensus, SrcAddr, srcSigner, SrcAddr)
+	testEscrowEx(t, state, backend, consensus, SrcAddr, SrcSigner, SrcAddr)
 }
 
 func testEscrowEx( // nolint: gocyclo
@@ -420,7 +420,7 @@ func testEscrowEx( // nolint: gocyclo
 	backend api.Backend,
 	consensus consensusAPI.Backend,
 	srcAddr api.Address,
-	srcSigner signature.Signer,
+	SrcSigner signature.Signer,
 	dstAddr api.Address,
 ) {
 	require := require.New(t)
@@ -454,7 +454,7 @@ func testEscrowEx( // nolint: gocyclo
 		Amount:  *quantity.NewFromUint64(math.MaxUint32),
 	}
 	tx := api.NewAddEscrowTx(srcAcc.General.Nonce, nil, escrow)
-	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, srcSigner, tx)
+	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, SrcSigner, tx)
 	require.NoError(err, "AddEscrow")
 	require.NoError(totalEscrowed.Add(&escrow.Amount))
 
@@ -521,7 +521,7 @@ func testEscrowEx( // nolint: gocyclo
 		Amount:  *quantity.NewFromUint64(math.MaxUint32),
 	}
 	tx = api.NewAddEscrowTx(srcAcc.General.Nonce, nil, escrow)
-	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, srcSigner, tx)
+	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, SrcSigner, tx)
 	require.NoError(err, "AddEscrow")
 	require.NoError(totalEscrowed.Add(&escrow.Amount))
 
@@ -592,7 +592,7 @@ func testEscrowEx( // nolint: gocyclo
 		Shares:  dstAcc.Escrow.Active.TotalShares,
 	}
 	tx = api.NewReclaimEscrowTx(srcAcc.General.Nonce, nil, reclaim)
-	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, srcSigner, tx)
+	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, SrcSigner, tx)
 	require.NoError(err, "ReclaimEscrow")
 
 	// Query debonding delegations.
@@ -666,7 +666,7 @@ func testEscrowEx( // nolint: gocyclo
 		Shares:  reclaim.Shares,
 	}
 	tx = api.NewReclaimEscrowTx(newSrcAcc.General.Nonce, nil, reclaim)
-	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, srcSigner, tx)
+	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, SrcSigner, tx)
 	require.Error(err, "ReclaimEscrow")
 
 	debs, err = backend.DebondingDelegations(context.Background(), &api.OwnerQuery{Owner: srcAddr, Height: consensusAPI.HeightLatest})
@@ -679,7 +679,7 @@ func testEscrowEx( // nolint: gocyclo
 		Amount:  *quantity.NewFromUint64(1), // Minimum is 10.
 	}
 	tx = api.NewAddEscrowTx(srcAcc.General.Nonce, nil, escrow)
-	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, srcSigner, tx)
+	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, SrcSigner, tx)
 	require.Error(err, "AddEscrow")
 }
 
@@ -701,7 +701,7 @@ func testAllowance(t *testing.T, state *stakingTestsState, backend api.Backend, 
 		AmountChange: *quantity.NewFromUint64(math.MaxUint8),
 	}
 	tx := api.NewAllowTx(srcAcc.General.Nonce, nil, allow)
-	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, srcSigner, tx)
+	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, SrcSigner, tx)
 	require.NoError(err, "Allow")
 
 	// Compute what new the total expected allowance should be.
@@ -846,7 +846,7 @@ func testSlashConsensusEquivocation(
 		Amount:  *quantity.NewFromUint64(math.MaxUint32),
 	}
 	tx := api.NewAddEscrowTx(srcAcc.General.Nonce, nil, escrow)
-	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, srcSigner, tx)
+	err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, SrcSigner, tx)
 	require.NoError(err, "AddEscrow")
 
 	// Query updated validator account state.


### PR DESCRIPTION
- [x] roothash/api: add evidence types
- [x] tendermint/roothash: add tx endpoint for submitting evidence of equivocation
- [x] roothash: add tests for the new evidence submission 
- [x] roothash/pool: slash non-majority for `SlashRuntimeIncorrectResults`
- [x] e2e tests
- [x] configurable amount of rewards should be awarded to nodes contributing evidence (or resolving discrepancies), add per runtime staking parameters
- [x] rewards to nodes should be escrowed (currently these are awarded into the general balance)