### PR TITLE
slashing: rename DoubleSigning to ConsensusEquivocation

### DIFF
--- a/.changelog/3646.breaking.1.md
+++ b/.changelog/3646.breaking.1.md
@@ -1,0 +1,1 @@
+go/slashing/api: change SlashReason type to `uint8`

--- a/.changelog/3646.breaking.2.md
+++ b/.changelog/3646.breaking.2.md
@@ -1,0 +1,1 @@
+go/staking/api: Rename DoubleSigning to ConsensusEquivocation

--- a/go/consensus/tendermint/apps/staking/slashing.go
+++ b/go/consensus/tendermint/apps/staking/slashing.go
@@ -16,7 +16,7 @@ import (
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
-func onEvidenceDoubleSign(
+func onEvidenceConsensusEquivocation(
 	ctx *abciAPI.Context,
 	addr tmcrypto.Address,
 	height int64,
@@ -66,7 +66,7 @@ func onEvidenceDoubleSign(
 		return err
 	}
 
-	penalty := st[staking.SlashDoubleSigning]
+	penalty := st[staking.SlashConsensusEquivocation]
 
 	// Freeze validator to prevent it being slashed again. This also prevents the
 	// validator from being scheduled in the next epoch.

--- a/go/consensus/tendermint/apps/staking/slashing_test.go
+++ b/go/consensus/tendermint/apps/staking/slashing_test.go
@@ -20,7 +20,7 @@ import (
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
-func TestOnEvidenceDoubleSign(t *testing.T) {
+func TestOnEvidenceConsensusEquivocation(t *testing.T) {
 	require := require.New(t)
 
 	now := time.Unix(1580461674, 0)
@@ -39,7 +39,7 @@ func TestOnEvidenceDoubleSign(t *testing.T) {
 	stakeState := stakingState.NewMutableState(ctx.State())
 
 	// Validator address is not known as there are no nodes.
-	err := onEvidenceDoubleSign(ctx, validatorAddress, 1, now, 1)
+	err := onEvidenceConsensusEquivocation(ctx, validatorAddress, 1, now, 1)
 	require.NoError(err, "should not fail when validator address is not known")
 
 	// Add entity.
@@ -64,7 +64,7 @@ func TestOnEvidenceDoubleSign(t *testing.T) {
 	require.NoError(err, "SetNode")
 
 	// Should not fail if node status is not available.
-	err = onEvidenceDoubleSign(ctx, validatorAddress, 1, now, 1)
+	err = onEvidenceConsensusEquivocation(ctx, validatorAddress, 1, now, 1)
 	require.NoError(err, "should not fail when node status is not available")
 
 	// Add node status.
@@ -72,7 +72,7 @@ func TestOnEvidenceDoubleSign(t *testing.T) {
 	require.NoError(err, "SetNodeStatus")
 
 	// Should fail if unable to get the slashing procedure.
-	err = onEvidenceDoubleSign(ctx, validatorAddress, 1, now, 1)
+	err = onEvidenceConsensusEquivocation(ctx, validatorAddress, 1, now, 1)
 	require.Error(err, "should fail when unable to get the slashing procedure")
 
 	// Add slashing procedure.
@@ -80,7 +80,7 @@ func TestOnEvidenceDoubleSign(t *testing.T) {
 	_ = slashAmount.FromUint64(100)
 	err = stakeState.SetConsensusParameters(ctx, &staking.ConsensusParameters{
 		Slashing: map[staking.SlashReason]staking.Slash{
-			staking.SlashDoubleSigning: {
+			staking.SlashConsensusEquivocation: {
 				Amount:         slashAmount,
 				FreezeInterval: registry.FreezeForever,
 			},
@@ -90,7 +90,7 @@ func TestOnEvidenceDoubleSign(t *testing.T) {
 
 	// Should fail as the validator has no stake (which is an invariant violation as a validator
 	// needs to have some stake).
-	err = onEvidenceDoubleSign(ctx, validatorAddress, 1, now, 1)
+	err = onEvidenceConsensusEquivocation(ctx, validatorAddress, 1, now, 1)
 	require.Error(err, "should fail when validator has no stake")
 
 	// Computes entity's staking address.
@@ -112,7 +112,7 @@ func TestOnEvidenceDoubleSign(t *testing.T) {
 	require.NoError(err, "SetAccount")
 
 	// Should slash.
-	err = onEvidenceDoubleSign(ctx, validatorAddress, 1, now, 1)
+	err = onEvidenceConsensusEquivocation(ctx, validatorAddress, 1, now, 1)
 	require.NoError(err, "slashing should succeed")
 
 	// Entity stake should be slashed.

--- a/go/consensus/tendermint/apps/staking/staking.go
+++ b/go/consensus/tendermint/apps/staking/staking.go
@@ -90,7 +90,7 @@ func (app *stakingApplication) BeginBlock(ctx *api.Context, request types.Reques
 	for _, evidence := range request.ByzantineValidators {
 		switch evidence.Type {
 		case types.EvidenceType_DUPLICATE_VOTE:
-			if err := onEvidenceDoubleSign(ctx, evidence.Validator.Address, evidence.Height, evidence.Time, evidence.Validator.Power); err != nil {
+			if err := onEvidenceConsensusEquivocation(ctx, evidence.Validator.Address, evidence.Height, evidence.Time, evidence.Validator.Power); err != nil {
 				return err
 			}
 		default:

--- a/go/consensus/tendermint/apps/staking/state/state_test.go
+++ b/go/consensus/tendermint/apps/staking/state/state_test.go
@@ -251,9 +251,9 @@ func TestRewardAndSlash(t *testing.T) {
 	require.NoError(err, "Account")
 	require.Equal(mustInitQuantity(t, 300), escrowAccount.Escrow.Active.Balance, "reward late epoch - escrow active escrow")
 
-	slashedNonzero, err := s.SlashEscrow(ctx, escrowAddr, mustInitQuantityP(t, 40))
+	slashed, err := s.SlashEscrow(ctx, escrowAddr, mustInitQuantityP(t, 40))
 	require.NoError(err, "slash escrow")
-	require.True(slashedNonzero, "slashed nonzero")
+	require.False(slashed.IsZero(), "slashed nonzero")
 
 	// Loss of 40 base units.
 	delegatorAccount, err = s.Account(ctx, delegatorAddr)

--- a/go/consensus/tendermint/crypto/priv_val.go
+++ b/go/consensus/tendermint/crypto/priv_val.go
@@ -261,13 +261,13 @@ func (pv *privVal) GetPubKey() (tmcrypto.PubKey, error) {
 func (pv *privVal) SignVote(chainID string, vote *tmproto.Vote) error {
 	height, round, step := vote.Height, vote.Round, voteToStep(vote)
 
-	doubleSigned, err := pv.CheckHRS(height, round, step)
+	equivocation, err := pv.CheckHRS(height, round, step)
 	if err != nil {
 		return fmt.Errorf("tendermint/crypto: failed to check vote H/R/S: %w", err)
 	}
 
 	signBytes := tmtypes.VoteSignBytes(chainID, vote)
-	if doubleSigned {
+	if equivocation {
 		if bytes.Equal(signBytes, pv.SignBytes) {
 			vote.Signature = pv.Signature
 		} else if ts, ok := checkVotesOnlyDifferByTimestamp(pv.SignBytes, signBytes); ok {
@@ -294,13 +294,13 @@ func (pv *privVal) SignVote(chainID string, vote *tmproto.Vote) error {
 func (pv *privVal) SignProposal(chainID string, proposal *tmproto.Proposal) error {
 	height, round, step := proposal.Height, proposal.Round, stepPropose
 
-	doubleSigned, err := pv.CheckHRS(height, round, step)
+	equivocation, err := pv.CheckHRS(height, round, step)
 	if err != nil {
 		return fmt.Errorf("tendermint/crypto: failed to check proposal H/R/S: %w", err)
 	}
 
 	signBytes := tmtypes.ProposalSignBytes(chainID, proposal)
-	if doubleSigned {
+	if equivocation {
 		if bytes.Equal(signBytes, pv.SignBytes) {
 			proposal.Signature = pv.Signature
 		} else if ts, ok := checkProposalsOnlyDifferByTimestamp(pv.SignBytes, signBytes); ok {

--- a/go/consensus/tendermint/tests/evidence.go
+++ b/go/consensus/tendermint/tests/evidence.go
@@ -17,8 +17,8 @@ import (
 	genesisTestHelpers "github.com/oasisprotocol/oasis-core/go/genesis/tests"
 )
 
-// MakeDoubleSignEvidence creates consensus evidence of double signing.
-func MakeDoubleSignEvidence(t *testing.T, ident *identity.Identity, blk *consensus.Block) *consensus.Evidence {
+// MakeConsensusEquivocationEvidence creates consensus evidence of equivocation.
+func MakeConsensusEquivocationEvidence(t *testing.T, ident *identity.Identity, blk *consensus.Block) *consensus.Evidence {
 	require := require.New(t)
 
 	// Create empty directory for private validator metadata.

--- a/go/staking/api/slashing.go
+++ b/go/staking/api/slashing.go
@@ -8,21 +8,21 @@ import (
 )
 
 // SlashReason is the reason why a node was slashed.
-type SlashReason int
+type SlashReason uint8
 
 const (
-	// SlashDoubleSigning is slashing due to double signing.
-	SlashDoubleSigning SlashReason = 0
+	// SlashConsensusEquivocation is slashing due to equivocation.
+	SlashConsensusEquivocation SlashReason = 0x00
 
-	// SlashDoubleSigningName is the string representation of SlashDoubleSigning.
-	SlashDoubleSigningName = "double-signing"
+	// SlashConsensusEquivocationName is the string representation of SlashConsensusEquivocation.
+	SlashConsensusEquivocationName = "consensus-equivocation"
 )
 
 // String returns a string representation of a SlashReason.
 func (s SlashReason) String() string {
 	switch s {
-	case SlashDoubleSigning:
-		return SlashDoubleSigningName
+	case SlashConsensusEquivocation:
+		return SlashConsensusEquivocationName
 	default:
 		return "[unknown slash reason]"
 	}
@@ -31,8 +31,8 @@ func (s SlashReason) String() string {
 // MarshalText encodes a SlashReason into text form.
 func (s SlashReason) MarshalText() ([]byte, error) {
 	switch s {
-	case SlashDoubleSigning:
-		return []byte(SlashDoubleSigningName), nil
+	case SlashConsensusEquivocation:
+		return []byte(SlashConsensusEquivocationName), nil
 	default:
 		return nil, fmt.Errorf("invalid slash reason: %d", s)
 	}
@@ -45,8 +45,8 @@ func (s *SlashReason) UnmarshalText(text []byte) error {
 	// genesis file loads -- remove this once mainnet is upgraded!
 	case "0":
 		fallthrough
-	case SlashDoubleSigningName:
-		*s = SlashDoubleSigning
+	case SlashConsensusEquivocationName:
+		*s = SlashConsensusEquivocation
 	default:
 		return fmt.Errorf("invalid slash reason: %s", string(text))
 	}

--- a/go/staking/api/slashing_test.go
+++ b/go/staking/api/slashing_test.go
@@ -11,7 +11,7 @@ func TestSlashReason(t *testing.T) {
 
 	// Test valid SlashReasons.
 	for _, k := range []SlashReason{
-		SlashDoubleSigning,
+		SlashConsensusEquivocation,
 	} {
 		enc, err := k.MarshalText()
 		require.NoError(err, "MarshalText")
@@ -24,7 +24,7 @@ func TestSlashReason(t *testing.T) {
 	}
 
 	// Test invalid SlashReasons.
-	sr := SlashReason(-1)
+	sr := SlashReason(0xff)
 	require.Equal("[unknown slash reason]", sr.String())
 	enc, err := sr.MarshalText()
 	require.Nil(enc, "MarshalText on invalid slash reason should be nil")

--- a/go/staking/tests/debug/debug_stake.go
+++ b/go/staking/tests/debug/debug_stake.go
@@ -36,7 +36,7 @@ func GenesisState() api.Genesis {
 				api.KindRuntimeKeyManager: *quantity.NewFromUint64(7),
 			},
 			Slashing: map[api.SlashReason]api.Slash{
-				api.SlashDoubleSigning: {
+				api.SlashConsensusEquivocation: {
 					Amount:         *quantity.NewFromUint64(math.MaxInt64), // Slash everything.
 					FreezeInterval: 1,
 				},

--- a/go/staking/tests/tester.go
+++ b/go/staking/tests/tester.go
@@ -110,9 +110,9 @@ func StakingImplementationTests(
 	}
 
 	// Separate test as it requires some arguments that others don't.
-	t.Run("SlashDoubleSigning", func(t *testing.T) {
+	t.Run("SlashConsensusEquivocation", func(t *testing.T) {
 		state := newStakingTestsState(t, backend, consensus)
-		testSlashDoubleSigning(t, state, backend, consensus, identity, entity, entitySigner, runtimeID)
+		testSlashConsensusEquivocation(t, state, backend, consensus, identity, entity, entitySigner, runtimeID)
 	})
 }
 
@@ -819,7 +819,7 @@ AllowWaitLoop:
 	require.Equal(expectedNewAllowance, *newAllowance, "Allowance should return the correct value")
 }
 
-func testSlashDoubleSigning(
+func testSlashConsensusEquivocation(
 	t *testing.T,
 	state *stakingTestsState,
 	backend api.Backend,
@@ -877,7 +877,7 @@ func testSlashDoubleSigning(
 	// consensus backend, we need to change this part.
 	blk, err := consensus.GetBlock(context.Background(), 1)
 	require.NoError(err, "GetBlock")
-	err = consensus.SubmitEvidence(context.Background(), tendermintTests.MakeDoubleSignEvidence(t, ident, blk))
+	err = consensus.SubmitEvidence(context.Background(), tendermintTests.MakeConsensusEquivocationEvidence(t, ident, blk))
 	require.NoError(err, "SubmitEvidence")
 
 	// Wait for the node to get slashed.


### PR DESCRIPTION
Extracted some general slashing changes from: https://github.com/oasisprotocol/oasis-core/pull/3640 (ADR-0005)

- rename `DoubleSigning`->`ConsensusEquivocation`
- change `SlashReason` type to `uint8`
- change `SlashEscrow` method to return slashed amount