### PR TITLE
Client node support for hosting runtimes

### DIFF
--- a/.buildkite/scripts/test_e2e.sh
+++ b/.buildkite/scripts/test_e2e.sh
@@ -17,12 +17,6 @@ WORKDIR=$PWD
 #################
 # Run test suite.
 #################
-# Determine correct runtime to use for SGX.
-runtime_target="default"
-if [[ "${OASIS_TEE_HARDWARE:-""}" == "intel-sgx" ]]; then
-    runtime_target="sgx/x86_64-fortanix-unknown-sgx"
-fi
-
 # We need a directory in the workdir so that Buildkite can fetch artifacts.
 if [[ "${BUILDKITE:-""}" != "" ]]; then
     mkdir -p ${TEST_BASE_DIR:-$PWD}/e2e
@@ -55,7 +49,8 @@ ${test_runner_binary} \
     --basedir.no_cleanup \
     --e2e.node.binary ${node_binary} \
     --e2e/runtime.client.binary_dir ${WORKDIR}/target/default/debug \
-    --e2e/runtime.runtime.binary_dir ${WORKDIR}/target/${runtime_target}/debug \
+    --e2e/runtime.runtime.binary_dir.default ${WORKDIR}/target/default/debug \
+    --e2e/runtime.runtime.binary_dir.intel-sgx ${WORKDIR}/target/sgx/x86_64-fortanix-unknown-sgx/debug \
     --e2e/runtime.runtime.loader ${WORKDIR}/target/default/debug/oasis-core-runtime-loader \
     --e2e/runtime.tee_hardware ${OASIS_TEE_HARDWARE:-""} \
     --e2e/runtime.ias.mock=${ias_mock} \

--- a/.changelog/3653.cfg.md
+++ b/.changelog/3653.cfg.md
@@ -1,0 +1,5 @@
+Change compute worker runtime configuration flags
+
+All the flags under `worker.runtime.*` have been moved under just
+`runtime.*`. For example the `worker.runtime.paths` flag needs to be renamed
+to `runtime.paths`.

--- a/.changelog/3653.feature.md
+++ b/.changelog/3653.feature.md
@@ -1,0 +1,1 @@
+go/runtime/client: Perform local CheckTx when a hosted runtime exists

--- a/.changelog/3653.internal.2.md
+++ b/.changelog/3653.internal.2.md
@@ -1,0 +1,4 @@
+go/runtime/host: Add helpers for common requests
+
+An additional interface `RichRuntime` is added which provides wrappers for
+common requests (currently only `CheckTx`).

--- a/.changelog/3653.internal.md
+++ b/.changelog/3653.internal.md
@@ -1,0 +1,1 @@
+go/runtime: Move host configuration to runtime registry

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -94,7 +94,9 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 				Kind:       registry.KindKeyManager,
 				Entity:     0,
 				Keymanager: -1,
-				Binaries:   viper.GetStringSlice(cfgKeymanagerBinary),
+				Binaries: map[node.TEEHardware][]string{
+					tee: viper.GetStringSlice(cfgKeymanagerBinary),
+				},
 				AdmissionPolicy: registry.RuntimeAdmissionPolicy{
 					AnyNode: &registry.AnyNodeRuntimeAdmissionPolicy{},
 				},
@@ -105,7 +107,9 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 				Kind:       registry.KindCompute,
 				Entity:     0,
 				Keymanager: 0,
-				Binaries:   viper.GetStringSlice(cfgRuntimeBinary),
+				Binaries: map[node.TEEHardware][]string{
+					tee: viper.GetStringSlice(cfgRuntimeBinary),
+				},
 				Executor: registry.ExecutorParameters{
 					GroupSize:       2,
 					GroupBackupSize: 1,

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -225,14 +225,6 @@ func (n *Node) startRuntimeServices() error {
 		)
 	})
 
-	// Initialize the node's runtime registry.
-	n.RuntimeRegistry, err = runtimeRegistry.New(n.svcMgr.Ctx, cmdCommon.DataDir(), n.Consensus, n.Identity)
-	if err != nil {
-		return err
-	}
-	n.svcMgr.RegisterCleanupOnly(n.RuntimeRegistry, "runtime registry")
-	storageAPI.RegisterService(n.grpcInternal.Server(), n.RuntimeRegistry.StorageRouter())
-
 	// Initialize runtime workers.
 	if err = n.initRuntimeWorkers(); err != nil {
 		n.logger.Error("failed to initialize workers",
@@ -305,6 +297,14 @@ func (n *Node) initRuntimeWorkers() error {
 		)
 		return err
 	}
+
+	// Initialize the node's runtime registry.
+	n.RuntimeRegistry, err = runtimeRegistry.New(n.svcMgr.Ctx, cmdCommon.DataDir(), n.Consensus, n.Identity, n.IAS)
+	if err != nil {
+		return err
+	}
+	n.svcMgr.RegisterCleanupOnly(n.RuntimeRegistry, "runtime registry")
+	storageAPI.RegisterService(n.grpcInternal.Server(), n.RuntimeRegistry.StorageRouter())
 
 	// Initialize the common worker.
 	n.CommonWorker, err = workerCommon.New(

--- a/go/oasis-node/node_test.go
+++ b/go/oasis-node/node_test.go
@@ -70,7 +70,7 @@ var (
 		{cmdCommonFlags.CfgDebugDontBlameOasis, true},
 		{storageWorker.CfgBackend, "badger"},
 		{compute.CfgWorkerEnabled, true},
-		{workerCommon.CfgRuntimeProvisioner, workerCommon.RuntimeProvisionerMock},
+		{runtimeRegistry.CfgRuntimeProvisioner, runtimeRegistry.RuntimeProvisionerMock},
 		{workerCommon.CfgClientPort, workerClientPort},
 		{storageWorker.CfgWorkerEnabled, true},
 		{executor.CfgScheduleCheckTxEnabled, false},
@@ -163,7 +163,7 @@ func newTestNode(t *testing.T) *testNode {
 	viper.Set("log.file", filepath.Join(dataDir, "test-node.log"))
 	viper.Set(runtimeRegistry.CfgSupported, testRuntimeID.String())
 	viper.Set(runtimeRegistry.CfgTagIndexerBackend, "bleve")
-	viper.Set(workerCommon.CfgRuntimePaths, map[string]string{
+	viper.Set(runtimeRegistry.CfgRuntimePaths, map[string]string{
 		testRuntimeID.String(): "mock-runtime",
 	})
 	viper.Set("worker.registration.entity", filepath.Join(dataDir, "entity.json"))

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crash"
 	commonGrpc "github.com/oasisprotocol/oasis-core/go/common/grpc"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx"
 	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint"
 	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint/abci"
@@ -534,9 +535,9 @@ func (args *argBuilder) appendRuntimePruner(p *RuntimePrunerCfg) *argBuilder {
 	return args
 }
 
-func (args *argBuilder) appendComputeNodeRuntime(rt *Runtime, binaryIdx int) *argBuilder {
+func (args *argBuilder) appendHostedRuntime(rt *Runtime, tee node.TEEHardware, binaryIdx int) *argBuilder {
 	args = args.runtimeSupported(rt.id).
-		runtimePath(rt.id, rt.binaries[binaryIdx]).
+		runtimePath(rt.id, rt.binaries[tee][binaryIdx]).
 		appendRuntimePruner(&rt.pruner)
 	return args
 }

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -275,23 +275,23 @@ func (args *argBuilder) workerP2pEnabled() *argBuilder {
 	return args
 }
 
-func (args *argBuilder) workerRuntimeProvisioner(provisioner string) *argBuilder {
+func (args *argBuilder) runtimeProvisioner(provisioner string) *argBuilder {
 	args.vec = append(args.vec, []string{
-		"--" + workerCommon.CfgRuntimeProvisioner, provisioner,
+		"--" + runtimeRegistry.CfgRuntimeProvisioner, provisioner,
 	}...)
 	return args
 }
 
-func (args *argBuilder) workerRuntimeSGXLoader(fn string) *argBuilder {
+func (args *argBuilder) runtimeSGXLoader(fn string) *argBuilder {
 	args.vec = append(args.vec, []string{
-		"--" + workerCommon.CfgRuntimeSGXLoader, fn,
+		"--" + runtimeRegistry.CfgRuntimeSGXLoader, fn,
 	}...)
 	return args
 }
 
-func (args *argBuilder) workerRuntimePath(id common.Namespace, fn string) *argBuilder {
+func (args *argBuilder) runtimePath(id common.Namespace, fn string) *argBuilder {
 	args.vec = append(args.vec, []string{
-		"--" + workerCommon.CfgRuntimePaths, id.String() + "=" + fn,
+		"--" + runtimeRegistry.CfgRuntimePaths, id.String() + "=" + fn,
 	}...)
 	return args
 }
@@ -536,7 +536,7 @@ func (args *argBuilder) appendRuntimePruner(p *RuntimePrunerCfg) *argBuilder {
 
 func (args *argBuilder) appendComputeNodeRuntime(rt *Runtime, binaryIdx int) *argBuilder {
 	args = args.runtimeSupported(rt.id).
-		workerRuntimePath(rt.id, rt.binaries[binaryIdx]).
+		runtimePath(rt.id, rt.binaries[binaryIdx]).
 		appendRuntimePruner(&rt.pruner)
 	return args
 }

--- a/go/oasis-test-runner/oasis/client.go
+++ b/go/oasis-test-runner/oasis/client.go
@@ -3,6 +3,7 @@ package oasis
 import (
 	"fmt"
 
+	"github.com/oasisprotocol/oasis-core/go/common/node"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 )
 
@@ -44,8 +45,8 @@ func (client *Client) startNode() error {
 		if v.kind != registry.KindCompute {
 			continue
 		}
-		args = args.runtimeSupported(v.id).
-			appendRuntimePruner(&v.pruner)
+		// XXX: could support configurable binary idx if ever needed.
+		args = args.appendHostedRuntime(v, node.TEEHardwareInvalid, 0)
 	}
 
 	if err := client.net.startOasisNode(&client.Node, nil, args); err != nil {

--- a/go/oasis-test-runner/oasis/compute.go
+++ b/go/oasis-test-runner/oasis/compute.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	commonWorker "github.com/oasisprotocol/oasis-core/go/worker/common"
+	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 )
 
 const (
@@ -101,8 +101,8 @@ func (worker *Compute) startNode() error {
 		workerClientPort(worker.clientPort).
 		workerP2pPort(worker.p2pPort).
 		workerComputeEnabled().
-		workerRuntimeProvisioner(worker.runtimeProvisioner).
-		workerRuntimeSGXLoader(worker.net.cfg.RuntimeSGXLoaderBinary).
+		runtimeProvisioner(worker.runtimeProvisioner).
+		runtimeSGXLoader(worker.net.cfg.RuntimeSGXLoaderBinary).
 		workerExecutorScheduleCheckTxEnabled().
 		configureDebugCrashPoints(worker.crashPointsProbability).
 		appendNetwork(worker.net).
@@ -146,7 +146,7 @@ func (net *Network) NewCompute(cfg *ComputeCfg) (*Compute, error) {
 	}
 
 	if cfg.RuntimeProvisioner == "" {
-		cfg.RuntimeProvisioner = commonWorker.RuntimeProvisionerSandboxed
+		cfg.RuntimeProvisioner = runtimeRegistry.RuntimeProvisionerSandboxed
 	}
 
 	worker := &Compute{

--- a/go/oasis-test-runner/oasis/compute.go
+++ b/go/oasis-test-runner/oasis/compute.go
@@ -112,7 +112,7 @@ func (worker *Compute) startNode() error {
 	for _, idx := range worker.runtimes {
 		v := worker.net.runtimes[idx]
 		// XXX: could support configurable binary idx if ever needed.
-		args = args.appendComputeNodeRuntime(v, 0)
+		args = args.appendHostedRuntime(v, v.teeHardware, 0)
 	}
 
 	if err := worker.net.startOasisNode(&worker.Node, nil, args); err != nil {

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -199,10 +199,10 @@ type RuntimeFixture struct { // nolint: maligned
 	Entity     int                  `json:"entity"`
 	Keymanager int                  `json:"keymanager"`
 
-	Binaries         []string         `json:"binaries"`
-	GenesisState     storage.WriteLog `json:"genesis_state,omitempty"`
-	GenesisStatePath string           `json:"genesis_state_path,omitempty"`
-	GenesisRound     uint64           `json:"genesis_round,omitempty"`
+	Binaries         map[node.TEEHardware][]string `json:"binaries"`
+	GenesisState     storage.WriteLog              `json:"genesis_state,omitempty"`
+	GenesisStatePath string                        `json:"genesis_state_path,omitempty"`
+	GenesisRound     uint64                        `json:"genesis_round,omitempty"`
 
 	Executor     registry.ExecutorParameters     `json:"executor"`
 	TxnScheduler registry.TxnSchedulerParameters `json:"txn_scheduler"`

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -275,7 +275,7 @@ func (km *Keymanager) startNode() error {
 		runtimeProvisioner(runtimeRegistry.RuntimeProvisionerSandboxed).
 		runtimeSGXLoader(km.net.cfg.RuntimeSGXLoaderBinary).
 		// XXX: could support configurable binary idx if ever needed.
-		runtimePath(km.runtime.id, km.runtime.binaries[0]).
+		runtimePath(km.runtime.id, km.runtime.binaries[km.runtime.teeHardware][0]).
 		workerKeymanagerEnabled().
 		workerKeymanagerRuntimeID(km.runtime.id).
 		configureDebugCrashPoints(km.crashPointsProbability).

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -14,7 +14,7 @@ import (
 	kmCmd "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/keymanager"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
-	workerCommon "github.com/oasisprotocol/oasis-core/go/worker/common"
+	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 )
 
 const (
@@ -272,10 +272,10 @@ func (km *Keymanager) startNode() error {
 		tendermintPrune(km.consensus.PruneNumKept).
 		tendermintRecoverCorruptedWAL(km.consensus.TendermintRecoverCorruptedWAL).
 		workerClientPort(km.workerClientPort).
-		workerRuntimeProvisioner(workerCommon.RuntimeProvisionerSandboxed).
-		workerRuntimeSGXLoader(km.net.cfg.RuntimeSGXLoaderBinary).
+		runtimeProvisioner(runtimeRegistry.RuntimeProvisionerSandboxed).
+		runtimeSGXLoader(km.net.cfg.RuntimeSGXLoaderBinary).
 		// XXX: could support configurable binary idx if ever needed.
-		workerRuntimePath(km.runtime.id, km.runtime.binaries[0]).
+		runtimePath(km.runtime.id, km.runtime.binaries[0]).
 		workerKeymanagerEnabled().
 		workerKeymanagerRuntimeID(km.runtime.id).
 		configureDebugCrashPoints(km.crashPointsProbability).

--- a/go/oasis-test-runner/oasis/runtime.go
+++ b/go/oasis-test-runner/oasis/runtime.go
@@ -31,7 +31,7 @@ type Runtime struct { // nolint: maligned
 	id   common.Namespace
 	kind registry.RuntimeKind
 
-	binaries    []string
+	binaries    map[node.TEEHardware][]string
 	teeHardware node.TEEHardware
 	mrEnclaves  []*sgx.MrEnclave
 	mrSigner    *sgx.MrSigner
@@ -52,7 +52,7 @@ type RuntimeCfg struct { // nolint: maligned
 	TEEHardware node.TEEHardware
 	MrSigner    *sgx.MrSigner
 
-	Binaries         []string
+	Binaries         map[node.TEEHardware][]string
 	GenesisState     storage.WriteLog
 	GenesisStatePath string
 	GenesisRound     uint64
@@ -162,7 +162,7 @@ func (net *Network) NewRuntime(cfg *RuntimeCfg) (*Runtime, error) {
 	var mrEnclaves []*sgx.MrEnclave
 	if cfg.TEEHardware == node.TEEHardwareIntelSGX {
 		enclaveIdentities := []sgx.EnclaveIdentity{}
-		for _, binary := range cfg.Binaries {
+		for _, binary := range cfg.Binaries[node.TEEHardwareIntelSGX] {
 			var mrEnclave *sgx.MrEnclave
 			if mrEnclave, err = deriveMrEnclave(binary); err != nil {
 				return nil, err

--- a/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
@@ -7,6 +7,7 @@ import (
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
@@ -56,13 +57,13 @@ func (sc *multipleRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
 	// Remove existing compute runtimes from fixture, remember RuntimeID and
 	// binary from the first one.
 	var id common.Namespace
-	var runtimeBinary string
+	var runtimeBinaries map[node.TEEHardware][]string
 	var rts []oasis.RuntimeFixture
 	for _, rt := range f.Runtimes {
 		if rt.Kind == registry.KindCompute {
-			if runtimeBinary == "" {
+			if runtimeBinaries == nil {
 				copy(id[:], rt.ID[:])
-				runtimeBinary = rt.Binaries[0]
+				runtimeBinaries = rt.Binaries
 			}
 		} else {
 			rts = append(rts, rt)
@@ -84,7 +85,7 @@ func (sc *multipleRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
 			Kind:       registry.KindCompute,
 			Entity:     0,
 			Keymanager: 0,
-			Binaries:   []string{runtimeBinary},
+			Binaries:   runtimeBinaries,
 			Executor: registry.ExecutorParameters{
 				GroupSize:       uint64(executorGroupSize),
 				GroupBackupSize: 0,

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_dynamic.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_dynamic.go
@@ -250,6 +250,12 @@ func (sc *runtimeDynamicImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 		}
 	}
 
+	// Perform an epoch transition to make sure all nodes are eligible. They may not be eligible
+	// if they have registered after the beacon commit phase.
+	if err := sc.epochTransition(ctx); err != nil {
+		return err
+	}
+
 	for i := 0; i < 5; i++ {
 		// Perform another epoch transition to elect compute runtime committees.
 		if err := sc.epochTransition(ctx); err != nil {
@@ -359,6 +365,12 @@ func (sc *runtimeDynamicImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 		if err = n.WaitReady(ctx); err != nil {
 			return fmt.Errorf("failed to wait for a compute worker: %w", err)
 		}
+	}
+
+	// Perform an epoch transition to make sure all nodes are eligible. They may not be eligible
+	// if they have registered after the beacon commit phase.
+	if err = sc.epochTransition(ctx); err != nil {
+		return err
 	}
 
 	// Epoch transition.

--- a/go/runtime/client/api/api.go
+++ b/go/runtime/client/api/api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
+	"github.com/oasisprotocol/oasis-core/go/common/service"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	enclaverpc "github.com/oasisprotocol/oasis-core/go/runtime/enclaverpc/api"
@@ -73,9 +74,12 @@ type RuntimeClient interface {
 
 	// WaitBlockIndexed waits for a runtime block to be indexed by the indexer.
 	WaitBlockIndexed(ctx context.Context, request *WaitBlockIndexedRequest) error
+}
 
-	// Cleanup cleans up the backend.
-	Cleanup()
+// RuntimeClientService is the runtime client service interface.
+type RuntimeClientService interface {
+	RuntimeClient
+	service.BackgroundService
 }
 
 // SubmitTxRequest is a SubmitTx request.

--- a/go/runtime/client/api/api.go
+++ b/go/runtime/client/api/api.go
@@ -29,9 +29,11 @@ var (
 	ErrInternal = errors.New(ModuleName, 2, "client: internal error")
 	// ErrTransactionExpired is an error returned when transaction expired.
 	ErrTransactionExpired = errors.New(ModuleName, 3, "client: transaction expired")
-	// ErrNotSynced is an error return if transaction is submitted before node has finished
+	// ErrNotSynced is an error returned if transaction is submitted before node has finished
 	// initial syncing.
 	ErrNotSynced = errors.New(ModuleName, 4, "client: not finished initial sync")
+	// ErrCheckTxFailed is an error returned if the local transaction check fails.
+	ErrCheckTxFailed = errors.New(ModuleName, 5, "client: transaction check failed")
 )
 
 // RuntimeClient is the runtime client interface.

--- a/go/runtime/client/api/grpc.go
+++ b/go/runtime/client/api/grpc.go
@@ -557,9 +557,6 @@ func (c *runtimeClient) WatchBlocks(ctx context.Context, runtimeID common.Namesp
 	return ch, sub, nil
 }
 
-func (c *runtimeClient) Cleanup() {
-}
-
 // NewRuntimeClient creates a new gRPC runtime client service.
 func NewRuntimeClient(c *grpc.ClientConn) RuntimeClient {
 	return &runtimeClient{

--- a/go/runtime/client/host.go
+++ b/go/runtime/client/host.go
@@ -1,0 +1,174 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	"github.com/oasisprotocol/oasis-core/go/runtime/host"
+	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
+	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
+	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/syncer"
+)
+
+var (
+	errMethodNotSupported   = errors.New("method not supported")
+	errEndpointNotSupported = errors.New("endpoint not supported")
+)
+
+type clientHost struct {
+	*runtimeRegistry.RuntimeHostNode
+
+	runtime   runtimeRegistry.Runtime
+	consensus consensus.Backend
+
+	stopCh chan struct{}
+	quitCh chan struct{}
+
+	logger *logging.Logger
+}
+
+// Start starts the client host.
+func (h *clientHost) Start() error {
+	go h.worker()
+	return nil
+}
+
+// Stop asks the client host to stop.
+func (h *clientHost) Stop() {
+	close(h.stopCh)
+}
+
+// Quit returns the channel which will signal when the client host has quit.
+func (h *clientHost) Quit() <-chan struct{} {
+	return h.quitCh
+}
+
+// Implements runtimeRegistry.RuntimeHostHandlerFactory.
+func (h *clientHost) GetRuntime() runtimeRegistry.Runtime {
+	return h.runtime
+}
+
+// Implements runtimeRegistry.RuntimeHostHandlerFactory.
+func (h *clientHost) NewRuntimeHostHandler() protocol.Handler {
+	return h
+}
+
+// Implements runtimeRegistry.RuntimeHostHandlerFactory.
+func (h *clientHost) NewNotifier(ctx context.Context, host host.Runtime) protocol.Notifier {
+	return nil
+}
+
+// Implements protocol.Handler.
+func (h *clientHost) Handle(ctx context.Context, body *protocol.Body) (*protocol.Body, error) {
+	switch {
+	// Storage.
+	case body.HostStorageSyncRequest != nil:
+		rq := body.HostStorageSyncRequest
+		span, sctx := opentracing.StartSpanFromContext(ctx, "storage.Sync")
+		defer span.Finish()
+
+		var rs syncer.ReadSyncer
+		switch rq.Endpoint {
+		case protocol.HostStorageEndpointRuntime:
+			// Runtime storage.
+			rs = h.runtime.Storage()
+		case protocol.HostStorageEndpointConsensus:
+			// Consensus state storage.
+			rs = h.consensus.State()
+		default:
+			return nil, errEndpointNotSupported
+		}
+
+		var rsp *storage.ProofResponse
+		var err error
+		switch {
+		case rq.SyncGet != nil:
+			rsp, err = rs.SyncGet(sctx, rq.SyncGet)
+		case rq.SyncGetPrefixes != nil:
+			rsp, err = rs.SyncGetPrefixes(sctx, rq.SyncGetPrefixes)
+		case rq.SyncIterate != nil:
+			rsp, err = rs.SyncIterate(sctx, rq.SyncIterate)
+		default:
+			return nil, errMethodNotSupported
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		return &protocol.Body{HostStorageSyncResponse: &protocol.HostStorageSyncResponse{ProofResponse: rsp}}, nil
+	// Local storage.
+	case body.HostLocalStorageGetRequest != nil:
+		value, err := h.runtime.LocalStorage().Get(body.HostLocalStorageGetRequest.Key)
+		if err != nil {
+			return nil, err
+		}
+		return &protocol.Body{HostLocalStorageGetResponse: &protocol.HostLocalStorageGetResponse{Value: value}}, nil
+	case body.HostLocalStorageSetRequest != nil:
+		if err := h.runtime.LocalStorage().Set(body.HostLocalStorageSetRequest.Key, body.HostLocalStorageSetRequest.Value); err != nil {
+			return nil, err
+		}
+		return &protocol.Body{HostLocalStorageSetResponse: &protocol.Empty{}}, nil
+	default:
+		return nil, errMethodNotSupported
+	}
+}
+
+func (h *clientHost) worker() {
+	defer close(h.quitCh)
+
+	// Wait for consensus sync.
+	select {
+	case <-h.consensus.Synced():
+	case <-h.stopCh:
+		return
+	}
+
+	// Start hosted runtime provisioning.
+	hrt, _, err := h.ProvisionHostedRuntime(context.Background())
+	switch {
+	case err == nil:
+	default:
+		h.logger.Error("failed to provision hosted runtime",
+			"err", err,
+		)
+		return
+	}
+
+	// Start the runtime.
+	if err = hrt.Start(); err != nil {
+		h.logger.Error("failed to start hosted runtime",
+			"err", err,
+		)
+		return
+	}
+
+	// Wait for the stop signal.
+	<-h.stopCh
+
+	// Ask the runtime to stop as well.
+	hrt.Stop()
+}
+
+func newClientHost(runtime runtimeRegistry.Runtime, consensus consensus.Backend) (*clientHost, error) {
+	host := &clientHost{
+		runtime:   runtime,
+		consensus: consensus,
+		stopCh:    make(chan struct{}),
+		quitCh:    make(chan struct{}),
+		logger:    logging.GetLogger("runtime/client/host"),
+	}
+
+	var err error
+	host.RuntimeHostNode, err = runtimeRegistry.NewRuntimeHostNode(host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create runtime host helper: %w", err)
+	}
+
+	return host, nil
+}

--- a/go/runtime/host/helpers.go
+++ b/go/runtime/host/helpers.go
@@ -12,9 +12,12 @@ import (
 )
 
 var (
+	// ErrInvalidArgument is the error returned when any of the passed method arguments is invalid.
 	ErrInvalidArgument = errors.New("runtime: invalid argument")
-	ErrInternal        = errors.New("runtime: internal error")
-	ErrCheckTxFailed   = errors.New("runtime: check tx failed")
+	// ErrCheckTxFailed is the error returned when a transaction is rejected by the runtime.
+	ErrCheckTxFailed = errors.New("runtime: check tx failed")
+	// ErrInternal is the error returned when an unspecified internal error occurs.
+	ErrInternal = errors.New("runtime: internal error")
 )
 
 // RichRuntime provides higher-level functions for talking with a runtime.

--- a/go/runtime/host/helpers.go
+++ b/go/runtime/host/helpers.go
@@ -1,0 +1,67 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
+	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
+	"github.com/oasisprotocol/oasis-core/go/runtime/transaction"
+)
+
+var (
+	ErrInvalidArgument = errors.New("runtime: invalid argument")
+	ErrInternal        = errors.New("runtime: internal error")
+	ErrCheckTxFailed   = errors.New("runtime: check tx failed")
+)
+
+// RichRuntime provides higher-level functions for talking with a runtime.
+type RichRuntime interface {
+	Runtime
+
+	// CheckTx requests the runtime to check a given transaction.
+	CheckTx(ctx context.Context, rb *block.Block, lb *consensus.LightBlock, tx []byte) error
+}
+
+type richRuntime struct {
+	Runtime
+}
+
+// Implements RichRuntime.
+func (r *richRuntime) CheckTx(ctx context.Context, rb *block.Block, lb *consensus.LightBlock, tx []byte) error {
+	if rb == nil || lb == nil {
+		return ErrInvalidArgument
+	}
+
+	resp, err := r.Call(ctx, &protocol.Body{
+		RuntimeCheckTxBatchRequest: &protocol.RuntimeCheckTxBatchRequest{
+			ConsensusBlock: *lb,
+			Inputs:         transaction.RawBatch{tx},
+			Block:          *rb,
+		},
+	})
+	switch {
+	case err != nil:
+		return fmt.Errorf("%w: %s", ErrInternal, err)
+	case resp.RuntimeCheckTxBatchResponse == nil:
+		return fmt.Errorf("%w: malformed runtime response", ErrInternal)
+	case len(resp.RuntimeCheckTxBatchResponse.Results) != 1:
+		return fmt.Errorf("%w: malformed runtime response: incorrect number of results", ErrInternal)
+	}
+
+	// Interpret CheckTx result.
+	result := resp.RuntimeCheckTxBatchResponse.Results[0]
+	if !result.IsSuccess() {
+		return fmt.Errorf("%w: %s", ErrCheckTxFailed, result.Error)
+	}
+
+	return nil
+}
+
+// NewRichRuntime creates a new higher-level wrapper for a given runtime. It provides additional
+// convenience functions for talking with a runtime.
+func NewRichRuntime(rt Runtime) RichRuntime {
+	return &richRuntime{Runtime: rt}
+}

--- a/go/runtime/host/mock/mock.go
+++ b/go/runtime/host/mock/mock.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/common/errors"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
@@ -87,6 +88,21 @@ func (r *runtime) Call(ctx context.Context, body *protocol.Body) (*protocol.Body
 				IOWriteLog: ioWriteLog,
 			},
 			// No RakSig in mock response.
+		}}, nil
+	case body.RuntimeCheckTxBatchRequest != nil:
+		rq := body.RuntimeCheckTxBatchRequest
+
+		var results []protocol.CheckTxResult
+		for range rq.Inputs {
+			results = append(results, protocol.CheckTxResult{
+				Error: protocol.Error{
+					Code: errors.CodeNoError,
+				},
+			})
+		}
+
+		return &protocol.Body{RuntimeCheckTxBatchResponse: &protocol.RuntimeCheckTxBatchResponse{
+			Results: results,
 		}}, nil
 	default:
 		return nil, fmt.Errorf("(mock) method not supported")

--- a/go/runtime/registry/config.go
+++ b/go/runtime/registry/config.go
@@ -1,20 +1,52 @@
 package registry
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	ias "github.com/oasisprotocol/oasis-core/go/ias/api"
+	cmdFlags "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	"github.com/oasisprotocol/oasis-core/go/runtime/history"
+	runtimeHost "github.com/oasisprotocol/oasis-core/go/runtime/host"
+	hostMock "github.com/oasisprotocol/oasis-core/go/runtime/host/mock"
+	hostProtocol "github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
+	hostSandbox "github.com/oasisprotocol/oasis-core/go/runtime/host/sandbox"
+	hostSgx "github.com/oasisprotocol/oasis-core/go/runtime/host/sgx"
 	"github.com/oasisprotocol/oasis-core/go/runtime/tagindexer"
 )
 
 const (
 	// CfgSupported configures a supported runtime ID.
 	CfgSupported = "runtime.supported"
+
+	// CfgRuntimeProvisioner configures the runtime provisioner.
+	//
+	// The same provisioner is used for all runtimes.
+	CfgRuntimeProvisioner = "runtime.provisioner"
+	// CfgRuntimePaths confgures the paths for supported runtimes.
+	//
+	// The value should be a map of runtime IDs to corresponding resource paths (type of the
+	// resource depends on the provisioner).
+	CfgRuntimePaths = "runtime.paths"
+	// CfgSandboxBinary configures the runtime sandbox binary location.
+	CfgSandboxBinary = "runtime.sandbox.binary"
+	// CfgRuntimeSGXLoader configures the runtime loader binary required for SGX runtimes.
+	//
+	// The same loader is used for all runtimes.
+	CfgRuntimeSGXLoader = "runtime.sgx.loader"
+	// CfgRuntimeSGXSignatures configures signatures for supported runtimes.
+	//
+	// The value should be a map of runtime IDs to corresponding resource paths.
+	CfgRuntimeSGXSignatures = "runtime.sgx.signatures"
 
 	// CfgHistoryPrunerStrategy configures the history pruner strategy.
 	CfgHistoryPrunerStrategy = "runtime.history.pruner.strategy"
@@ -31,8 +63,27 @@ const (
 // Flags has the configuration flags.
 var Flags = flag.NewFlagSet("", flag.ContinueOnError)
 
-// RuntimeConfig is a per-runtime config.
+const (
+	// RuntimeProvisionerMock is the name of the mock runtime provisioner.
+	//
+	// Use of this provisioner is only allowed if DebugDontBlameOasis flag is set.
+	RuntimeProvisionerMock = "mock"
+	// RuntimeProvisionerUnconfined is the name of the unconfined runtime provisioner that executes
+	// runtimes as regular processes without any sandboxing.
+	//
+	// Use of this provisioner is only allowed if DebugDontBlameOasis flag is set.
+	RuntimeProvisionerUnconfined = "unconfined"
+	// RuntimeProvisionerSandboxed is the name of the sandboxed runtime provisioner that executes
+	// runtimes as regular processes in a Linux namespaces/cgroups/SECCOMP sandbox.
+	RuntimeProvisionerSandboxed = "sandboxed"
+)
+
+// RuntimeConfig is the node runtime configuration.
 type RuntimeConfig struct {
+	// Host contains configuration for the runtime host. It may be nil if no runtimes are to be
+	// hosted by the current node.
+	Host *RuntimeHostConfig
+
 	// History configures the runtime history keeper.
 	History history.Config
 
@@ -40,8 +91,120 @@ type RuntimeConfig struct {
 	TagIndexer tagindexer.BackendFactory
 }
 
-func newConfig() (*RuntimeConfig, error) {
+// RuntimeHostConfig is configuration for a node that hosts runtimes.
+type RuntimeHostConfig struct {
+	// Provisioners contains a set of supported runtime provisioners, based on TEE hardware.
+	Provisioners map[node.TEEHardware]runtimeHost.Provisioner
+
+	// Runtimes contains per-runtime provisioning configuration. Some fields may be omitted as they
+	// are provided when the runtime is provisioned.
+	Runtimes map[common.Namespace]*runtimeHost.Config
+}
+
+func newConfig(consensus consensus.Backend, ias ias.Endpoint) (*RuntimeConfig, error) {
 	var cfg RuntimeConfig
+
+	// Check if any runtimes are configured to be hosted.
+	if viper.IsSet(CfgRuntimePaths) {
+		var rh RuntimeHostConfig
+
+		// Configure host environment information.
+		cs, err := consensus.GetStatus(context.Background())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get consensus layer status: %w", err)
+		}
+		hostInfo := &hostProtocol.HostInfo{
+			ConsensusBackend:         cs.Backend,
+			ConsensusProtocolVersion: cs.Version.ToU64(),
+		}
+
+		// Register provisioners based on the configured provisioner.
+		var insecureNoSandbox bool
+		sandboxBinary := viper.GetString(CfgSandboxBinary)
+		rh.Provisioners = make(map[node.TEEHardware]runtimeHost.Provisioner)
+		switch p := viper.GetString(CfgRuntimeProvisioner); p {
+		case RuntimeProvisionerMock:
+			// Mock provisioner, only supported when the runtime requires no TEE hardware.
+			if !cmdFlags.DebugDontBlameOasis() {
+				return nil, fmt.Errorf("mock provisioner requires use of unsafe debug flags")
+			}
+
+			rh.Provisioners[node.TEEHardwareInvalid] = hostMock.New()
+		case RuntimeProvisionerUnconfined:
+			// Unconfined provisioner, can be used with no TEE or with Intel SGX.
+			if !cmdFlags.DebugDontBlameOasis() {
+				return nil, fmt.Errorf("unconfined provisioner requires use of unsafe debug flags")
+			}
+
+			insecureNoSandbox = true
+
+			fallthrough
+		case RuntimeProvisionerSandboxed:
+			if !insecureNoSandbox {
+				if _, err = os.Stat(sandboxBinary); err != nil {
+					return nil, fmt.Errorf("failed to stat sandbox binary: %w", err)
+				}
+			}
+			// Sandboxed provisioner, can be used with no TEE or with Intel SGX.
+			rh.Provisioners[node.TEEHardwareInvalid], err = hostSandbox.New(hostSandbox.Config{
+				HostInfo:          hostInfo,
+				InsecureNoSandbox: insecureNoSandbox,
+				SandboxBinaryPath: sandboxBinary,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to create runtime provisioner: %w", err)
+			}
+
+			rh.Provisioners[node.TEEHardwareIntelSGX], err = hostSgx.New(hostSgx.Config{
+				HostInfo:          hostInfo,
+				LoaderPath:        viper.GetString(CfgRuntimeSGXLoader),
+				IAS:               ias,
+				SandboxBinaryPath: sandboxBinary,
+				InsecureNoSandbox: insecureNoSandbox,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to create SGX runtime provisioner: %w", err)
+			}
+		default:
+			return nil, fmt.Errorf("unsupported runtime provisioner: %s", p)
+		}
+
+		// Configure runtimes.
+		runtimeSGXSignatures := viper.GetStringMapString(CfgRuntimeSGXSignatures)
+		rh.Runtimes = make(map[common.Namespace]*runtimeHost.Config)
+		for runtimeID, path := range viper.GetStringMapString(CfgRuntimePaths) {
+			var id common.Namespace
+			if err := id.UnmarshalHex(runtimeID); err != nil {
+				return nil, fmt.Errorf("bad runtime identifier '%s': %w", runtimeID, err)
+			}
+
+			runtimeHostCfg := &runtimeHost.Config{
+				RuntimeID: id,
+				Path:      path,
+			}
+
+			// This config is SGX specific, but that's all that's supported
+			// right now that needs this anyway, the non-SGX provisioner
+			// currently ignores this.
+			if sigPath := runtimeSGXSignatures[runtimeID]; sigPath != "" {
+				runtimeHostCfg.Extra = &hostSgx.RuntimeExtra{
+					SignaturePath: sigPath,
+				}
+			} else {
+				// HACK HACK HACK: Allow dummy SIGSTRUCT generation.
+				runtimeHostCfg.Extra = &hostSgx.RuntimeExtra{
+					UnsafeDebugGenerateSigstruct: true,
+				}
+			}
+
+			rh.Runtimes[id] = runtimeHostCfg
+		}
+		if len(rh.Runtimes) == 0 {
+			return nil, fmt.Errorf("no runtimes configured")
+		}
+
+		cfg.Host = &rh
+	}
 
 	strategy := viper.GetString(CfgHistoryPrunerStrategy)
 	switch strings.ToLower(strategy) {
@@ -74,6 +237,12 @@ func newConfig() (*RuntimeConfig, error) {
 
 func init() {
 	Flags.StringSlice(CfgSupported, nil, "Add supported runtime ID (hex-encoded)")
+
+	Flags.String(CfgRuntimeProvisioner, RuntimeProvisionerSandboxed, "Runtime provisioner to use")
+	Flags.StringToString(CfgRuntimePaths, nil, "Paths to runtime resources (format: <rt1-ID>=<path>,<rt2-ID>=<path>)")
+	Flags.String(CfgSandboxBinary, "/usr/bin/bwrap", "Path to the sandbox binary (bubblewrap)")
+	Flags.String(CfgRuntimeSGXLoader, "", "(for SGX runtimes) Path to SGXS runtime loader binary")
+	Flags.StringToString(CfgRuntimeSGXSignatures, nil, "(for SGX runtimes) Paths to signatures (format: <rt1-ID>=<path>,<rt2-ID>=<path>")
 
 	Flags.String(CfgHistoryPrunerStrategy, history.PrunerStrategyNone, "History pruner strategy")
 	Flags.Duration(CfgHistoryPrunerInterval, 2*time.Minute, "History pruning interval")

--- a/go/runtime/registry/host.go
+++ b/go/runtime/registry/host.go
@@ -16,14 +16,14 @@ type RuntimeHostNode struct {
 	factory  RuntimeHostHandlerFactory
 	notifier protocol.Notifier
 
-	runtime host.Runtime
+	runtime host.RichRuntime
 }
 
 // ProvisionHostedRuntime provisions the configured runtime.
 //
 // This method may return before the runtime is fully provisioned. The returned runtime will not be
 // started automatically, you must call Start explicitly.
-func (n *RuntimeHostNode) ProvisionHostedRuntime(ctx context.Context) (host.Runtime, protocol.Notifier, error) {
+func (n *RuntimeHostNode) ProvisionHostedRuntime(ctx context.Context) (host.RichRuntime, protocol.Notifier, error) {
 	cfg, provisioner, err := n.factory.GetRuntime().Host(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get runtime host: %w", err)
@@ -36,17 +36,18 @@ func (n *RuntimeHostNode) ProvisionHostedRuntime(ctx context.Context) (host.Runt
 		return nil, nil, fmt.Errorf("failed to provision runtime: %w", err)
 	}
 	notifier := n.factory.NewNotifier(ctx, prt)
+	rr := host.NewRichRuntime(prt)
 
 	n.Lock()
-	n.runtime = prt
+	n.runtime = rr
 	n.notifier = notifier
 	n.Unlock()
 
-	return prt, notifier, nil
+	return rr, notifier, nil
 }
 
 // GetHostedRuntime returns the provisioned hosted runtime (if any).
-func (n *RuntimeHostNode) GetHostedRuntime() host.Runtime {
+func (n *RuntimeHostNode) GetHostedRuntime() host.RichRuntime {
 	n.Lock()
 	rt := n.runtime
 	n.Unlock()

--- a/go/runtime/registry/registry.go
+++ b/go/runtime/registry/registry.go
@@ -92,6 +92,9 @@ type Runtime interface {
 	// LocalStorage returns the per-runtime local storage.
 	LocalStorage() localstorage.LocalStorage
 
+	// HasHost checks whether this runtime can be hosted by the current node.
+	HasHost() bool
+
 	// Host returns the runtime host configuration and provisioner if configured.
 	Host(ctx context.Context) (runtimeHost.Config, runtimeHost.Provisioner, error)
 }
@@ -176,6 +179,10 @@ func (r *runtime) Storage() storageAPI.Backend {
 
 func (r *runtime) LocalStorage() localstorage.LocalStorage {
 	return r.localStorage
+}
+
+func (r *runtime) HasHost() bool {
+	return r.hostProvisioners != nil && r.hostConfig != nil
 }
 
 func (r *runtime) Host(ctx context.Context) (runtimeHost.Config, runtimeHost.Provisioner, error) {

--- a/go/worker/common/config.go
+++ b/go/worker/common/config.go
@@ -1,9 +1,7 @@
 package common
 
 import (
-	"context"
 	"fmt"
-	"os"
 	"time"
 
 	flag "github.com/spf13/pflag"
@@ -12,14 +10,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
-	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
-	ias "github.com/oasisprotocol/oasis-core/go/ias/api"
-	cmdFlags "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
-	runtimeHost "github.com/oasisprotocol/oasis-core/go/runtime/host"
-	hostMock "github.com/oasisprotocol/oasis-core/go/runtime/host/mock"
-	hostProtocol "github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
-	hostSandbox "github.com/oasisprotocol/oasis-core/go/runtime/host/sandbox"
-	hostSgx "github.com/oasisprotocol/oasis-core/go/runtime/host/sgx"
 	"github.com/oasisprotocol/oasis-core/go/worker/common/configparser"
 )
 
@@ -33,40 +23,10 @@ var (
 	// connect to.
 	CfgSentryAddresses = "worker.sentry.address"
 
-	// CfgRuntimeProvisioner configures the runtime provisioner.
-	CfgRuntimeProvisioner = "worker.runtime.provisioner"
-	// CfgRuntimeSGXLoader configures the runtime loader binary required for SGX runtimes. A single
-	// loader is used for all runtimes.
-	CfgRuntimeSGXLoader = "worker.runtime.sgx.loader"
-	// CfgRuntimePaths confgures the paths for supported runtimes. The value should be a map of
-	// runtime IDs to corresponding resource paths (type of the resource depends on the
-	// provisioner).
-	CfgRuntimePaths = "worker.runtime.paths"
-	// CfgRuntimeSGXSignatures configures signatures for supported runtimes.
-	// The value should be a map of runtime IDs to corresponding resource
-	// paths.
-	CfgRuntimeSGXSignatures = "worker.runtime.sgx.signatures"
-
-	cfgSandboxBinary        = "worker.runtime.sandbox_binary"
 	cfgStorageCommitTimeout = "worker.storage_commit_timeout"
 
 	// Flags has the configuration flags.
 	Flags = flag.NewFlagSet("", flag.ContinueOnError)
-)
-
-const (
-	// RuntimeProvisionerMock is the name of the mock runtime provisioner.
-	//
-	// Use of this provisioner is only allowed if DebugDontBlameOasis flag is set.
-	RuntimeProvisionerMock = "mock"
-	// RuntimeProvisionerUnconfined is the name of the unconfined runtime provisioner that executes
-	// runtimes as regular processes without any sandboxing.
-	//
-	// Use of this provisioner is only allowed if DebugDontBlameOasis flag is set.
-	RuntimeProvisionerUnconfined = "unconfined"
-	// RuntimeProvisionerSandboxed is the name of the sandboxed runtime provisioner that executes
-	// runtimes as regular processes in a Linux namespaces/cgroups/SECCOMP sandbox.
-	RuntimeProvisionerSandboxed = "sandboxed"
 )
 
 // Config contains common worker config.
@@ -75,23 +35,9 @@ type Config struct { // nolint: maligned
 	ClientAddresses []node.Address
 	SentryAddresses []node.TLSAddress
 
-	// RuntimeHost contains configuration for a worker that hosts runtimes. It may be nil if the
-	// worker is not configured to host runtimes.
-	RuntimeHost *RuntimeHostConfig
-
 	StorageCommitTimeout time.Duration
 
 	logger *logging.Logger
-}
-
-// RuntimeHostConfig is configuration for a worker that hosts runtimes.
-type RuntimeHostConfig struct {
-	// Provisioners contains a set of supported runtime provisioners, based on TEE hardware.
-	Provisioners map[node.TEEHardware]runtimeHost.Provisioner
-
-	// Runtimes contains per-runtime provisioning configuration. Some fields may be omitted as they
-	// are provided when the runtime is provisioned.
-	Runtimes map[common.Namespace]runtimeHost.Config
 }
 
 // GetNodeAddresses returns worker node addresses.
@@ -120,7 +66,7 @@ func (c *Config) GetNodeAddresses() ([]node.Address, error) {
 }
 
 // NewConfig creates a new worker config.
-func NewConfig(consensus consensus.Backend, ias ias.Endpoint) (*Config, error) {
+func NewConfig() (*Config, error) {
 	// Parse register address overrides.
 	clientAddresses, err := configparser.ParseAddressList(viper.GetStringSlice(cfgClientAddresses))
 	if err != nil {
@@ -145,108 +91,6 @@ func NewConfig(consensus consensus.Backend, ias ias.Endpoint) (*Config, error) {
 		logger:               logging.GetLogger("worker/config"),
 	}
 
-	// Check if any runtimes are configured to be hosted.
-	if viper.IsSet(CfgRuntimePaths) {
-		var rh RuntimeHostConfig
-
-		// Configure host environment information.
-		cs, err := consensus.GetStatus(context.Background())
-		if err != nil {
-			return nil, fmt.Errorf("failed to get consensus layer status: %w", err)
-		}
-		hostInfo := &hostProtocol.HostInfo{
-			ConsensusBackend:         cs.Backend,
-			ConsensusProtocolVersion: cs.Version.ToU64(),
-		}
-
-		// Register provisioners based on the configured provisioner.
-		var insecureNoSandbox bool
-		sandboxBinary := viper.GetString(cfgSandboxBinary)
-		rh.Provisioners = make(map[node.TEEHardware]runtimeHost.Provisioner)
-		switch p := viper.GetString(CfgRuntimeProvisioner); p {
-		case RuntimeProvisionerMock:
-			// Mock provisioner, only supported when the runtime requires no TEE hardware.
-			if !cmdFlags.DebugDontBlameOasis() {
-				return nil, fmt.Errorf("mock provisioner requires use of unsafe debug flags")
-			}
-
-			rh.Provisioners[node.TEEHardwareInvalid] = hostMock.New()
-		case RuntimeProvisionerUnconfined:
-			// Unconfined provisioner, can be used with no TEE or with Intel SGX.
-			if !cmdFlags.DebugDontBlameOasis() {
-				return nil, fmt.Errorf("unconfined provisioner requires use of unsafe debug flags")
-			}
-
-			insecureNoSandbox = true
-
-			fallthrough
-		case RuntimeProvisionerSandboxed:
-			if !insecureNoSandbox {
-				if _, err = os.Stat(sandboxBinary); err != nil {
-					return nil, fmt.Errorf("failed to stat sandbox binary: %w", err)
-				}
-			}
-			// Sandboxed provisioner, can be used with no TEE or with Intel SGX.
-			rh.Provisioners[node.TEEHardwareInvalid], err = hostSandbox.New(hostSandbox.Config{
-				HostInfo:          hostInfo,
-				InsecureNoSandbox: insecureNoSandbox,
-				SandboxBinaryPath: sandboxBinary,
-			})
-			if err != nil {
-				return nil, fmt.Errorf("failed to create runtime provisioner: %w", err)
-			}
-
-			rh.Provisioners[node.TEEHardwareIntelSGX], err = hostSgx.New(hostSgx.Config{
-				HostInfo:          hostInfo,
-				LoaderPath:        viper.GetString(CfgRuntimeSGXLoader),
-				IAS:               ias,
-				SandboxBinaryPath: sandboxBinary,
-				InsecureNoSandbox: insecureNoSandbox,
-			})
-			if err != nil {
-				return nil, fmt.Errorf("failed to create SGX runtime provisioner: %w", err)
-			}
-		default:
-			return nil, fmt.Errorf("unsupported runtime provisioner: %s", p)
-		}
-
-		// Configure runtimes.
-		runtimeSGXSignatures := viper.GetStringMapString(CfgRuntimeSGXSignatures)
-		rh.Runtimes = make(map[common.Namespace]runtimeHost.Config)
-		for runtimeID, path := range viper.GetStringMapString(CfgRuntimePaths) {
-			var id common.Namespace
-			if err := id.UnmarshalHex(runtimeID); err != nil {
-				return nil, fmt.Errorf("bad runtime identifier '%s': %w", runtimeID, err)
-			}
-
-			runtimeHostCfg := runtimeHost.Config{
-				RuntimeID: id,
-				Path:      path,
-			}
-
-			// This config is SGX specific, but that's all that's supported
-			// right now that needs this anyway, the non-SGX provisioner
-			// currently ignores this.
-			if sigPath := runtimeSGXSignatures[runtimeID]; sigPath != "" {
-				runtimeHostCfg.Extra = &hostSgx.RuntimeExtra{
-					SignaturePath: sigPath,
-				}
-			} else {
-				// HACK HACK HACK: Allow dummy SIGSTRUCT generation.
-				runtimeHostCfg.Extra = &hostSgx.RuntimeExtra{
-					UnsafeDebugGenerateSigstruct: true,
-				}
-			}
-
-			rh.Runtimes[id] = runtimeHostCfg
-		}
-		if len(rh.Runtimes) == 0 {
-			return nil, fmt.Errorf("no runtimes configured")
-		}
-
-		cfg.RuntimeHost = &rh
-	}
-
 	return &cfg, nil
 }
 
@@ -254,13 +98,6 @@ func init() {
 	Flags.Uint16(CfgClientPort, 9100, "Port to use for incoming gRPC client connections")
 	Flags.StringSlice(cfgClientAddresses, []string{}, "Address/port(s) to use for client connections when registering this node (if not set, all non-loopback local interfaces will be used)")
 	Flags.StringSlice(CfgSentryAddresses, []string{}, "Address(es) of sentry node(s) to connect to of the form [PubKey@]ip:port (where PubKey@ part represents base64 encoded node TLS public key)")
-
-	Flags.String(CfgRuntimeProvisioner, RuntimeProvisionerSandboxed, "Runtime provisioner to use")
-	Flags.String(CfgRuntimeSGXLoader, "", "(for SGX runtimes) Path to SGXS runtime loader binary")
-	Flags.StringToString(CfgRuntimePaths, nil, "Paths to runtime resources (format: <rt1-ID>=<path>,<rt2-ID>=<path>)")
-	Flags.StringToString(CfgRuntimeSGXSignatures, nil, "(for SGX runtimes) Paths to signatures (format: <rt1-ID>=<path>,<rt2-ID>=<path>")
-
-	Flags.String(cfgSandboxBinary, "/usr/bin/bwrap", "Path to the sandbox binary (bubblewrap)")
 
 	Flags.Duration(cfgStorageCommitTimeout, 5*time.Second, "Storage commit timeout")
 

--- a/go/worker/common/worker.go
+++ b/go/worker/common/worker.go
@@ -269,7 +269,7 @@ func New(
 	runtimeRegistry runtimeRegistry.Registry,
 	genesisDoc *genesis.Document,
 ) (*Worker, error) {
-	cfg, err := NewConfig(consensus, ias)
+	cfg, err := NewConfig()
 	if err != nil {
 		return nil, fmt.Errorf("worker/common: failed to initialize config: %w", err)
 	}

--- a/go/worker/compute/executor/committee/node.go
+++ b/go/worker/compute/executor/committee/node.go
@@ -29,6 +29,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 	"github.com/oasisprotocol/oasis-core/go/runtime/nodes"
+	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	"github.com/oasisprotocol/oasis-core/go/runtime/scheduling"
 	schedulingAPI "github.com/oasisprotocol/oasis-core/go/runtime/scheduling/api"
 	"github.com/oasisprotocol/oasis-core/go/runtime/transaction"
@@ -134,7 +135,7 @@ var (
 
 // Node is a committee node.
 type Node struct { // nolint: maligned
-	*commonWorker.RuntimeHostNode
+	*runtimeRegistry.RuntimeHostNode
 
 	runtimeVersion version.Version
 
@@ -1591,7 +1592,7 @@ func NewNode(
 	})
 
 	// Prepare the runtime host node helpers.
-	rhn, err := commonWorker.NewRuntimeHostNode(commonCfg.RuntimeHost, commonNode)
+	rhn, err := runtimeRegistry.NewRuntimeHostNode(commonNode)
 	if err != nil {
 		return nil, err
 	}

--- a/go/worker/keymanager/init.go
+++ b/go/worker/keymanager/init.go
@@ -97,7 +97,7 @@ func New(
 		w.runtimeHostHandler = newHostHandler(w, commonWorker, localStorage)
 
 		// Prepare the runtime host node helpers.
-		w.RuntimeHostNode, err = workerCommon.NewRuntimeHostNode(commonWorker.GetConfig().RuntimeHost, w)
+		w.RuntimeHostNode, err = runtimeRegistry.NewRuntimeHostNode(w)
 		if err != nil {
 			return nil, fmt.Errorf("worker/keymanager: failed to create runtime host helpers: %w", err)
 		}

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -50,7 +50,7 @@ var (
 // runtimes in order to update the access control lists.
 type Worker struct { // nolint: maligned
 	sync.RWMutex
-	*workerCommon.RuntimeHostNode
+	*runtimeRegistry.RuntimeHostNode
 
 	logger *logging.Logger
 


### PR DESCRIPTION
TODO
* [x] Move runtime host configuration to the runtime registry.
* [x] Support the client node hosting runtimes.
* [x] Support for provisioner remapping (a client node may use a non-TEE version of the runtime to perform local queries for public state against a runtime which runs in a TEE on executor nodes).
* [x] Describe all configuration changes.