### PR TITLE
go/scheduler: Check runtime versions for node eligibility

### DIFF
--- a/.changelog/3611.breaking.md
+++ b/.changelog/3611.breaking.md
@@ -1,0 +1,1 @@
+go/scheduler: Check runtime versions for node eligibility

--- a/go/common/sgx/common.go
+++ b/go/common/sgx/common.go
@@ -258,3 +258,9 @@ func (id *EnclaveIdentity) UnmarshalHex(text string) error {
 func (id EnclaveIdentity) String() string {
 	return hex.EncodeToString(id.MrEnclave[:]) + hex.EncodeToString(id.MrSigner[:])
 }
+
+// Constraints are the Intel SGX TEE constraints.
+type Constraints struct {
+	// Enclaves is the allowed MRENCLAVE/MRSIGNER pairs.
+	Enclaves []EnclaveIdentity `json:"enclaves"`
+}

--- a/go/consensus/tendermint/apps/scheduler/scheduler.go
+++ b/go/consensus/tendermint/apps/scheduler/scheduler.go
@@ -292,6 +292,9 @@ func (app *schedulerApplication) isSuitableExecutorWorker(ctx *api.Context, n *n
 		if !nrt.ID.Equal(&rt.ID) {
 			continue
 		}
+		if nrt.Version.MaskNonMajor() != rt.Version.Version.MaskNonMajor() {
+			return false
+		}
 		switch rt.TEEHardware {
 		case node.TEEHardwareInvalid:
 			if nrt.Capabilities.TEE != nil {
@@ -305,7 +308,7 @@ func (app *schedulerApplication) isSuitableExecutorWorker(ctx *api.Context, n *n
 			if nrt.Capabilities.TEE.Hardware != rt.TEEHardware {
 				return false
 			}
-			if err := nrt.Capabilities.TEE.Verify(ctx.Now()); err != nil {
+			if err := nrt.Capabilities.TEE.Verify(ctx.Now(), rt.Version.TEE); err != nil {
 				ctx.Logger().Warn("failed to verify node TEE attestaion",
 					"err", err,
 					"node", n,

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -187,7 +187,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 		Kind:        registry.KindKeyManager,
 		TEEHardware: node.TEEHardwareIntelSGX,
 		Version: registry.VersionInfo{
-			TEE: cbor.Marshal(registry.VersionInfoIntelSGX{
+			TEE: cbor.Marshal(sgx.Constraints{
 				Enclaves: []sgx.EnclaveIdentity{{}},
 			}),
 		},
@@ -232,7 +232,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 		},
 		TEEHardware: node.TEEHardwareIntelSGX,
 		Version: registry.VersionInfo{
-			TEE: cbor.Marshal(registry.VersionInfoIntelSGX{
+			TEE: cbor.Marshal(sgx.Constraints{
 				Enclaves: []sgx.EnclaveIdentity{{}},
 			}),
 		},

--- a/go/oasis-node/cmd/debug/byzantine/steps_test.go
+++ b/go/oasis-node/cmd/debug/byzantine/steps_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/sgx"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx/ias"
 )
 
@@ -13,7 +15,11 @@ func TestFakeCapabilitySGX(t *testing.T) {
 	_, fakeCapabilitiesSGX, err := initFakeCapabilitiesSGX()
 	require.NoError(t, err, "initFakeCapabilitiesSGX failed")
 
+	cs := cbor.Marshal(sgx.Constraints{
+		Enclaves: []sgx.EnclaveIdentity{{}},
+	})
+
 	ias.SetSkipVerify()
 	ias.SetAllowDebugEnclaves()
-	require.NoError(t, fakeCapabilitiesSGX.TEE.Verify(time.Now()), "fakeCapabilitiesSGX not valid")
+	require.NoError(t, fakeCapabilitiesSGX.TEE.Verify(time.Now(), cs), "fakeCapabilitiesSGX not valid")
 }

--- a/go/oasis-node/cmd/ias/auth.go
+++ b/go/oasis-node/cmd/ias/auth.go
@@ -55,12 +55,12 @@ func (st *enclaveStore) addRuntime(runtime *registry.Runtime) (int, error) {
 		return len(st.enclaves), nil
 	}
 
-	var vi registry.VersionInfoIntelSGX
-	if err := cbor.Unmarshal(runtime.Version.TEE, &vi); err != nil {
+	var cs sgx.Constraints
+	if err := cbor.Unmarshal(runtime.Version.TEE, &cs); err != nil {
 		return len(st.enclaves), err
 	}
 
-	st.enclaves[runtime.ID] = vi.Enclaves
+	st.enclaves[runtime.ID] = cs.Enclaves
 
 	return len(st.enclaves), nil
 }

--- a/go/oasis-node/cmd/registry/runtime/runtime.go
+++ b/go/oasis-node/cmd/registry/runtime/runtime.go
@@ -388,7 +388,7 @@ func runtimeFromFlags() (*registry.Runtime, error) { // nolint: gocyclo
 		GovernanceModel: govModel,
 	}
 	if teeHardware == node.TEEHardwareIntelSGX {
-		var vi registry.VersionInfoIntelSGX
+		var cs sgx.Constraints
 		for _, v := range viper.GetStringSlice(CfgVersionEnclave) {
 			var enclaveID sgx.EnclaveIdentity
 			if err = enclaveID.UnmarshalHex(v); err != nil {
@@ -397,9 +397,9 @@ func runtimeFromFlags() (*registry.Runtime, error) { // nolint: gocyclo
 				)
 				return nil, err
 			}
-			vi.Enclaves = append(vi.Enclaves, enclaveID)
+			cs.Enclaves = append(cs.Enclaves, enclaveID)
 		}
-		rt.Version.TEE = cbor.Marshal(vi)
+		rt.Version.TEE = cbor.Marshal(cs)
 	}
 	switch sap := viper.GetString(CfgAdmissionPolicy); sap {
 	case AdmissionPolicyNameAnyNode:

--- a/go/oasis-test-runner/oasis/cli/registry.go
+++ b/go/oasis-test-runner/oasis/cli/registry.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/sgx"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/consensus"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
@@ -37,12 +38,12 @@ func (r *RegistryHelpers) runRegistryRuntimeSubcommand(
 	switch runtime.TEEHardware {
 	case node.TEEHardwareInvalid:
 	case node.TEEHardwareIntelSGX:
-		var versionIntelSGX registry.VersionInfoIntelSGX
-		if err := cbor.Unmarshal(runtime.Version.TEE, &versionIntelSGX); err != nil {
+		var cs sgx.Constraints
+		if err := cbor.Unmarshal(runtime.Version.TEE, &cs); err != nil {
 			return fmt.Errorf("failed to unmarshal Intel SGX TEE version: %w", err)
 		}
 
-		for _, e := range versionIntelSGX.Enclaves {
+		for _, e := range cs.Enclaves {
 			args = append(args,
 				"--"+cmdRegRt.CfgVersionEnclave, e.String(),
 			)

--- a/go/oasis-test-runner/oasis/runtime.go
+++ b/go/oasis-test-runner/oasis/runtime.go
@@ -170,7 +170,7 @@ func (net *Network) NewRuntime(cfg *RuntimeCfg) (*Runtime, error) {
 			enclaveIdentities = append(enclaveIdentities, sgx.EnclaveIdentity{MrEnclave: *mrEnclave, MrSigner: *cfg.MrSigner})
 			mrEnclaves = append(mrEnclaves, mrEnclave)
 		}
-		descriptor.Version.TEE = cbor.Marshal(registry.VersionInfoIntelSGX{
+		descriptor.Version.TEE = cbor.Marshal(sgx.Constraints{
 			Enclaves: enclaveIdentities,
 		})
 	}

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -13,7 +13,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
-	"github.com/oasisprotocol/oasis-core/go/common/sgx"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
@@ -490,12 +489,6 @@ type VersionInfo struct {
 	// TEE is the enclave version information, in an enclave provider specific
 	// format if any.
 	TEE []byte `json:"tee,omitempty"`
-}
-
-// VersionInfoIntelSGX is the SGX TEE version information.
-type VersionInfoIntelSGX struct {
-	// Enclaves is the allowed MRENCLAVE/MRSIGNER pairs.
-	Enclaves []sgx.EnclaveIdentity `json:"enclaves"`
 }
 
 // RuntimeGenesis is the runtime genesis information that is used to

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -687,10 +687,10 @@ func testRegistryRuntime(t *testing.T, backend api.Backend, consensus consensusA
 				rt.Kind = api.KindKeyManager
 				rt.TEEHardware = node.TEEHardwareIntelSGX
 
-				vi := api.VersionInfoIntelSGX{
+				cs := sgx.Constraints{
 					Enclaves: []sgx.EnclaveIdentity{{}},
 				}
-				rt.Version.TEE = cbor.Marshal(vi)
+				rt.Version.TEE = cbor.Marshal(cs)
 				// Set non-test runtime.
 				rt.ID = newNamespaceFromSeed([]byte("SGXKeyManager"), common.NamespaceKeyManager)
 			},
@@ -724,10 +724,10 @@ func testRegistryRuntime(t *testing.T, backend api.Backend, consensus consensusA
 				rt.KeyManager = &rtMapByName["KeyManager"].ID
 				rt.TEEHardware = node.TEEHardwareIntelSGX
 
-				vi := api.VersionInfoIntelSGX{
+				cs := sgx.Constraints{
 					Enclaves: []sgx.EnclaveIdentity{{}},
 				}
-				rt.Version.TEE = cbor.Marshal(vi)
+				rt.Version.TEE = cbor.Marshal(cs)
 				// Set non-test runtime.
 				rt.ID = newNamespaceFromSeed([]byte("SGXWithKM"), 0)
 			},


### PR DESCRIPTION
Fixes #3611 