### PR TITLE
beacon: Transaction handling fixes

### DIFF
--- a/.changelog/3675.internal.md
+++ b/.changelog/3675.internal.md
@@ -1,0 +1,1 @@
+go/consensus: Add support for method priority

--- a/go/beacon/api/pvss.go
+++ b/go/beacon/api/pvss.go
@@ -27,22 +27,7 @@ type PVSSParameters struct {
 	RevealInterval  int64 `json:"reveal_interval"`
 	TransitionDelay int64 `json:"transition_delay"`
 
-	GasCosts transaction.Costs `json:"gas_costs,omitempty"`
-
 	DebugForcedParticipants []signature.PublicKey `json:"debug_forced_participants,omitempty"`
-}
-
-const (
-	// GasOpPVSSCommit is the gas operation identifier for a commit.
-	GasOpPVSSCommit transaction.Op = "pvss_commit"
-	// GasOpPVSSReveal is the gas operation identifier for a reveal.
-	GasOpPVSSReveal transaction.Op = "pvss_reveal"
-)
-
-// DefaultGasCosts are the "default" gas costs for operations.
-var DefaultGasCosts = transaction.Costs{
-	GasOpPVSSCommit: 1000,
-	GasOpPVSSReveal: 1000,
 }
 
 // PVSSCommit is a PVSS commitment transaction payload.
@@ -53,12 +38,30 @@ type PVSSCommit struct {
 	Commit *pvss.Commit `json:"commit,omitempty"`
 }
 
+// Implements transaction.MethodMetadataProvider.
+func (pc PVSSCommit) MethodMetadata() transaction.MethodMetadata {
+	return transaction.MethodMetadata{
+		// Beacon transactions are critical to protocol operation. Since they can only be called
+		// by the block proposer this is safe to use.
+		Priority: transaction.MethodPriorityCritical,
+	}
+}
+
 // PVSSReveal is a PVSS reveal transaction payload.
 type PVSSReveal struct {
 	Epoch EpochTime `json:"epoch"`
 	Round uint64    `json:"round"`
 
 	Reveal *pvss.Reveal `json:"reveal,omitempty"`
+}
+
+// Implements transaction.MethodMetadataProvider.
+func (pr PVSSReveal) MethodMetadata() transaction.MethodMetadata {
+	return transaction.MethodMetadata{
+		// Beacon transactions are critical to protocol operation. Since they can only be called
+		// by the block proposer this is safe to use.
+		Priority: transaction.MethodPriorityCritical,
+	}
 }
 
 // RoundState is a PVSS round state.

--- a/go/consensus/api/transaction/transaction_test.go
+++ b/go/consensus/api/transaction/transaction_test.go
@@ -1,0 +1,28 @@
+package transaction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testMethodBodyNormal struct {
+}
+
+type testMethodBodyCritical struct {
+}
+
+func (tb testMethodBodyCritical) MethodMetadata() MethodMetadata {
+	return MethodMetadata{
+		Priority: MethodPriorityCritical,
+	}
+}
+
+func TestMethodMetadata(t *testing.T) {
+	require := require.New(t)
+
+	methodNormal := NewMethodName("test", "Normal", testMethodBodyNormal{})
+	methodCritical := NewMethodName("test", "Critical", testMethodBodyCritical{})
+	require.False(methodNormal.IsCritical())
+	require.True(methodCritical.IsCritical())
+}

--- a/go/consensus/tendermint/api/api.go
+++ b/go/consensus/tendermint/api/api.go
@@ -325,3 +325,13 @@ func (bsc *BaseServiceClient) DeliverEvent(ctx context.Context, height int64, tx
 func (bsc *BaseServiceClient) DeliverCommand(ctx context.Context, height int64, cmd interface{}) error {
 	return nil
 }
+
+// BlockProposerKey is the block context key for storing the block proposer address.
+type BlockProposerKey struct{}
+
+// NewDefault returns a new default value for the given key.
+func (bpk BlockProposerKey) NewDefault() interface{} {
+	// This should never be called as a block proposer must always be created by the application
+	// multiplexer.
+	panic("no proposer address in block context")
+}

--- a/go/consensus/tendermint/apps/beacon/backend_pvss.go
+++ b/go/consensus/tendermint/apps/beacon/backend_pvss.go
@@ -511,7 +511,7 @@ func (impl *backendPVSS) initRound(
 	// Note: Because of the +1, applied to BlockHeight, it may be required
 	// to strategically subtract 1 from one of the three interval/delay
 	// parameters (eg: Commit/Reveal/Delay set to 20/10/4 results in
-	// transitions at blocsk 35, 70, 105, ...).
+	// transitions at blocks 35, 70, 105, ...).
 
 	height := ctx.BlockHeight() + 1 // Current height is ctx.BlockHeight() + 1
 	pvssState.CommitDeadline = height + params.PVSSParameters.CommitInterval
@@ -552,8 +552,25 @@ func (impl *backendPVSS) ExecuteTx(
 		// In an ideal world, beacon tx-es shouldn't be gossiped to begin
 		// with (and be rejected if received), and each block should be
 		// limited to one beacon tx.
-		if ctx.IsCheckOnly() && !staking.NewAddress(ctx.TxSigner()).Equal(ctx.AppState().OwnTxSignerAddress()) {
-			return fmt.Errorf("beacon: rejecting non-local beacon tx: %s", ctx.TxSigner())
+		switch {
+		case ctx.IsCheckOnly():
+			// During CheckTx do the quick check and only accept own transactions.
+			if !staking.NewAddress(ctx.TxSigner()).Equal(ctx.AppState().OwnTxSignerAddress()) {
+				return fmt.Errorf("beacon: rejecting non-local beacon tx: %s", ctx.TxSigner())
+			}
+		case ctx.IsSimulation():
+			// No checks needed during local simulation.
+		default:
+			// During DeliverTx make sure that the transaction comes from the block proposer.
+			registryState := registryState.NewMutableState(ctx.State())
+			proposerAddr := ctx.BlockContext().Get(api.BlockProposerKey{}).([]byte)
+			proposerNodeID, err := registryState.NodeIDByConsensusAddress(ctx, proposerAddr)
+			if err != nil {
+				return fmt.Errorf("beacon: failed to resolve proposer node: %w", err)
+			}
+			if !ctx.TxSigner().Equal(proposerNodeID) {
+				return fmt.Errorf("beacon: rejecting beacon tx not from proposer (proposer: %s signer: %s)", proposerNodeID, ctx.TxSigner())
+			}
 		}
 		return impl.doPVSSTx(ctx, state, params, tx)
 	case MethodSetEpoch:
@@ -578,18 +595,6 @@ func (impl *backendPVSS) doPVSSTx(
 	}
 	if pvssState == nil {
 		return fmt.Errorf("beacon: no PVSS state, round not in progress")
-	}
-
-	// Charge gas for this transaction.
-	var gasOp transaction.Op
-	switch tx.Method {
-	case beacon.MethodPVSSCommit:
-		gasOp = beacon.GasOpPVSSCommit
-	case beacon.MethodPVSSReveal:
-		gasOp = beacon.GasOpPVSSReveal
-	}
-	if err = ctx.Gas().UseGas(1, gasOp, params.PVSSParameters.GasCosts); err != nil {
-		return err
 	}
 
 	// Ensure the tx is from a current valid participant.

--- a/go/oasis-node/cmd/debug/txsource/workload/queries.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/queries.go
@@ -278,18 +278,7 @@ func (q *queries) doConsensusQueries(ctx context.Context, rng *rand.Rand, height
 	}
 
 	var txEvents []*results.Event
-	for txIdx, res := range txsWithRes.Results {
-		if res.IsSuccess() {
-			// Successful transaction should always produce events.
-			if len(res.Events) == 0 {
-				q.logger.Error("GetTransactionsWithResults successful transaction without events",
-					"transaction", txsWithRes.Transactions[txIdx],
-					"result", res,
-					"height", height,
-				)
-				return fmt.Errorf("GetTransactionsWithResults successful transaction result without events")
-			}
-		}
+	for _, res := range txsWithRes.Results {
 		txEvents = append(txEvents, res.Events...)
 	}
 	if err := q.sanityCheckTransactionEvents(ctx, height, txEvents); err != nil {

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -271,7 +271,6 @@ func doInitGenesis(cmd *cobra.Command, args []string) {
 			CommitInterval:          viper.GetInt64(CfgBeaconPVSSCommitInterval),
 			RevealInterval:          viper.GetInt64(CfgBeaconPVSSRevealInterval),
 			TransitionDelay:         viper.GetInt64(CfgBeaconPVSSTransitionDelay),
-			GasCosts:                beacon.DefaultGasCosts, // TODO: Make these configurable.
 			DebugForcedParticipants: forcedParticipants,
 		}
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -209,9 +209,15 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 		},
 	}
 
-	epochInterval, _ := sc.Flags.GetInt64(cfgEpochInterval)
-	ff.Network.Beacon.InsecureParameters = &beacon.InsecureParameters{
-		Interval: epochInterval,
+	if epochInterval, _ := sc.Flags.GetInt64(cfgEpochInterval); epochInterval > 0 {
+		ff.Network.Beacon.InsecureParameters = &beacon.InsecureParameters{
+			Interval: epochInterval,
+		}
+		ff.Network.Beacon.PVSSParameters = &beacon.PVSSParameters{
+			CommitInterval:  epochInterval / 2,
+			RevealInterval:  (epochInterval / 2) - 4,
+			TransitionDelay: 4,
+		}
 	}
 
 	return ff, nil


### PR DESCRIPTION
* go/consensus: Add support for method priority
* go/beacon: Make beacon methods critical and ignore tx authentication
  
  There is no sense in handling transaction authentication and fees for beacon
  methods which can only be invoked by the block proposer.
* e2e/runtime: Also configure intervals for PVSS backend
* go/beacon: Only allow a single beacon transaction per block