### PR TITLE
beacon: Add a minimal gRPC service

### DIFF
--- a/.changelog/3666.internal.md
+++ b/.changelog/3666.internal.md
@@ -1,0 +1,4 @@
+beacon: Add a minimal gRPC service
+
+I would put something more descriptive in here, but the change log
+fragment CI linter continues to terrorize me.

--- a/go/beacon/api/api.go
+++ b/go/beacon/api/api.go
@@ -58,11 +58,18 @@ type Backend interface {
 	// epoch.
 	GetEpochBlock(context.Context, EpochTime) (int64, error)
 
+	// WaitEpoch waits for a specific epoch.
+	//
+	// Note that an epoch is considered reached even if any epoch greater
+	// than the one specified is reached (e.g., that the current epoch
+	// is already in the future).
+	WaitEpoch(ctx context.Context, epoch EpochTime) error
+
 	// WatchEpochs returns a channel that produces a stream of messages
 	// on epoch transitions.
 	//
 	// Upon subscription the current epoch is sent immediately.
-	WatchEpochs() (<-chan EpochTime, *pubsub.Subscription)
+	WatchEpochs(ctx context.Context) (<-chan EpochTime, pubsub.ClosableSubscription, error)
 
 	// WatchLatestEpoch returns a channel that produces a stream of
 	// messages on epoch transitions. If an epoch transition happens
@@ -70,7 +77,7 @@ type Backend interface {
 	// epochs are overwritten.
 	//
 	// Upon subscription the current epoch is sent immediately.
-	WatchLatestEpoch() (<-chan EpochTime, *pubsub.Subscription)
+	WatchLatestEpoch(ctx context.Context) (<-chan EpochTime, pubsub.ClosableSubscription, error)
 
 	// GetBeacon gets the beacon for the provided block height.
 	// Calling this method with height `consensus.HeightLatest` should

--- a/go/beacon/api/grpc.go
+++ b/go/beacon/api/grpc.go
@@ -1,0 +1,372 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc"
+
+	cmnGrpc "github.com/oasisprotocol/oasis-core/go/common/grpc"
+	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
+)
+
+var (
+	// serviceName is the gRPC service name.
+	serviceName = cmnGrpc.NewServiceName("Beacon")
+
+	// methodGetBaseEpoch is the GetBaseEpoch method.
+	methodGetBaseEpoch = serviceName.NewMethod("GetBaseEpoch", nil)
+	// methodGetpoch is the GetEpoch method.
+	methodGetEpoch = serviceName.NewMethod("GetEpoch", int64(0))
+	// methodGetEpochBlock is the GetEpochBlock method.
+	methodGetEpochBlock = serviceName.NewMethod("GetEpochBlock", EpochTime(0))
+	// methodWaitEpoch is the WaitEpoch method.
+	methodWaitEpoch = serviceName.NewMethod("WaitEpoch", EpochTime(0))
+	// methodGetBeacon is the GetBeacon method.
+	methodGetBeacon = serviceName.NewMethod("GetBeacon", int64(0))
+	// methodStateToGenesis is the StateToGenesis method.
+	methodStateToGenesis = serviceName.NewMethod("StateToGenesis", int64(0))
+	// methodConsensusParameters is the ConsensusParameters method.
+	methodConsensusParameters = serviceName.NewMethod("ConsensusParameters", int64(0))
+
+	// methodWatchEpochs is the WatchEpochs method.
+	methodWatchEpochs = serviceName.NewMethod("WatchEpochs", nil)
+
+	// serviceDesc is the gRCP service descriptor.
+	serviceDesc = grpc.ServiceDesc{
+		ServiceName: string(serviceName),
+		HandlerType: (*Backend)(nil),
+		Methods: []grpc.MethodDesc{
+			{
+				MethodName: methodGetBaseEpoch.ShortName(),
+				Handler:    handlerGetBaseEpoch,
+			},
+			{
+				MethodName: methodGetEpoch.ShortName(),
+				Handler:    handlerGetEpoch,
+			},
+			{
+				MethodName: methodWaitEpoch.ShortName(),
+				Handler:    handlerWaitEpoch,
+			},
+			{
+				MethodName: methodGetEpochBlock.ShortName(),
+				Handler:    handlerGetEpochBlock,
+			},
+			{
+				MethodName: methodGetBeacon.ShortName(),
+				Handler:    handlerGetBeacon,
+			},
+			{
+				MethodName: methodStateToGenesis.ShortName(),
+				Handler:    handlerStateToGenesis,
+			},
+			{
+				MethodName: methodConsensusParameters.ShortName(),
+				Handler:    handlerConsensusParameters,
+			},
+		},
+		Streams: []grpc.StreamDesc{
+			{
+				StreamName:    methodWatchEpochs.ShortName(),
+				Handler:       handlerWatchEpochs,
+				ServerStreams: true,
+			},
+		},
+	}
+)
+
+func handlerGetBaseEpoch( //nolint:golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	if interceptor == nil {
+		return srv.(Backend).GetBaseEpoch(ctx)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodGetBaseEpoch.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).GetBaseEpoch(ctx)
+	}
+	return interceptor(ctx, nil, info, handler)
+}
+
+func handlerGetEpoch( //nolint:golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var height int64
+	if err := dec(&height); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(Backend).GetEpoch(ctx, height)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodGetEpoch.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).GetEpoch(ctx, req.(int64))
+	}
+	return interceptor(ctx, height, info, handler)
+}
+
+func handlerWaitEpoch( // nolint: golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var epoch EpochTime
+	if err := dec(&epoch); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return nil, srv.(Backend).WaitEpoch(ctx, epoch)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodWaitEpoch.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, srv.(Backend).WaitEpoch(ctx, req.(EpochTime))
+	}
+	return interceptor(ctx, epoch, info, handler)
+}
+
+func handlerGetEpochBlock( //nolint:golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var epoch EpochTime
+	if err := dec(&epoch); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(Backend).GetEpochBlock(ctx, epoch)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodGetEpochBlock.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).GetEpochBlock(ctx, req.(EpochTime))
+	}
+	return interceptor(ctx, epoch, info, handler)
+}
+
+func handlerGetBeacon( //nolint:golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var height int64
+	if err := dec(&height); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(Backend).GetBeacon(ctx, height)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodGetBeacon.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).GetBeacon(ctx, req.(int64))
+	}
+	return interceptor(ctx, height, info, handler)
+}
+
+func handlerStateToGenesis( // nolint: golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var height int64
+	if err := dec(&height); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(Backend).StateToGenesis(ctx, height)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodStateToGenesis.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).StateToGenesis(ctx, req.(int64))
+	}
+	return interceptor(ctx, height, info, handler)
+}
+
+func handlerConsensusParameters( //nolint:golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var height int64
+	if err := dec(&height); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(Backend).ConsensusParameters(ctx, height)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodConsensusParameters.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).ConsensusParameters(ctx, req.(int64))
+	}
+	return interceptor(ctx, height, info, handler)
+}
+
+func handlerWatchEpochs(srv interface{}, stream grpc.ServerStream) error {
+	if err := stream.RecvMsg(nil); err != nil {
+		return err
+	}
+
+	ctx := stream.Context()
+	ch, sub, err := srv.(Backend).WatchEpochs(ctx)
+	if err != nil {
+		return err
+	}
+	defer sub.Close()
+
+	for {
+		select {
+		case epoch, ok := <-ch:
+			if !ok {
+				return nil
+			}
+
+			if err := stream.SendMsg(epoch); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// RegisterService registers a new beacon service with the given gRPC server.
+func RegisterService(server *grpc.Server, service Backend) {
+	server.RegisterService(&serviceDesc, service)
+}
+
+type beaconClient struct {
+	conn *grpc.ClientConn
+}
+
+func (c *beaconClient) GetBaseEpoch(ctx context.Context) (EpochTime, error) {
+	var rsp EpochTime
+	if err := c.conn.Invoke(ctx, methodGetBaseEpoch.FullName(), nil, &rsp); err != nil {
+		return 0, err
+	}
+	return rsp, nil
+}
+
+func (c *beaconClient) GetEpoch(ctx context.Context, height int64) (EpochTime, error) {
+	var rsp EpochTime
+	if err := c.conn.Invoke(ctx, methodGetEpoch.FullName(), height, &rsp); err != nil {
+		return 0, err
+	}
+	return rsp, nil
+}
+
+func (c *beaconClient) GetEpochBlock(ctx context.Context, epoch EpochTime) (int64, error) {
+	var rsp int64
+	if err := c.conn.Invoke(ctx, methodGetEpochBlock.FullName(), epoch, &rsp); err != nil {
+		return 0, err
+	}
+	return rsp, nil
+}
+
+func (c *beaconClient) WaitEpoch(ctx context.Context, epoch EpochTime) error {
+	return c.conn.Invoke(ctx, methodWaitEpoch.FullName(), epoch, nil)
+}
+
+func (c *beaconClient) WatchEpochs(ctx context.Context) (<-chan EpochTime, pubsub.ClosableSubscription, error) {
+	ctx, sub := pubsub.NewContextSubscription(ctx)
+
+	stream, err := c.conn.NewStream(ctx, &serviceDesc.Streams[0], methodWatchEpochs.FullName())
+	if err != nil {
+		return nil, nil, err
+	}
+	if err = stream.SendMsg(nil); err != nil {
+		return nil, nil, err
+	}
+	if err = stream.CloseSend(); err != nil {
+		return nil, nil, err
+	}
+
+	ch := make(chan EpochTime)
+	go func() {
+		defer close(ch)
+
+		for {
+			var epoch EpochTime
+			if serr := stream.RecvMsg(&epoch); serr != nil {
+				return
+			}
+
+			select {
+			case ch <- epoch:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return ch, sub, nil
+}
+
+func (c *beaconClient) WatchLatestEpoch(ctx context.Context) (<-chan EpochTime, pubsub.ClosableSubscription, error) {
+	// The only thing that uses this is the registration worker, and it
+	// is not over gRPC.
+	return nil, nil, fmt.Errorf("beacon: gRPC method not implemented")
+}
+
+func (c *beaconClient) GetBeacon(ctx context.Context, height int64) ([]byte, error) {
+	var rsp []byte
+	if err := c.conn.Invoke(ctx, methodGetBeacon.FullName(), height, &rsp); err != nil {
+		return nil, err
+	}
+	return rsp, nil
+}
+
+func (c *beaconClient) StateToGenesis(ctx context.Context, height int64) (*Genesis, error) {
+	var rsp Genesis
+	if err := c.conn.Invoke(ctx, methodStateToGenesis.FullName(), height, &rsp); err != nil {
+		return nil, err
+	}
+	return &rsp, nil
+}
+
+func (c *beaconClient) ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error) {
+	var rsp ConsensusParameters
+	if err := c.conn.Invoke(ctx, methodConsensusParameters.FullName(), height, &rsp); err != nil {
+		return nil, err
+	}
+	return &rsp, nil
+}
+
+func (c *beaconClient) Cleanup() {
+}
+
+// NewBeaconClient creates a new gRPC scheduler client service.
+func NewBeaconClient(c *grpc.ClientConn) Backend {
+	return &beaconClient{c}
+}

--- a/go/beacon/tests/tester.go
+++ b/go/beacon/tests/tester.go
@@ -49,7 +49,8 @@ func EpochtimeSetableImplementationTest(t *testing.T, backend api.Backend) {
 
 	var e api.EpochTime
 
-	ch, sub := timeSource.WatchEpochs()
+	ch, sub, err := timeSource.WatchEpochs(context.Background())
+	require.NoError(err, "WatchEpochs")
 	defer sub.Close()
 	select {
 	case e = <-ch:
@@ -58,7 +59,8 @@ func EpochtimeSetableImplementationTest(t *testing.T, backend api.Backend) {
 		t.Fatalf("failed to receive current epoch on WatchEpochs")
 	}
 
-	latestCh, subCh := timeSource.WatchLatestEpoch()
+	latestCh, subCh, err := timeSource.WatchLatestEpoch(context.Background())
+	require.NoError(err, "WatchLatestEpoch")
 	defer subCh.Close()
 	select {
 	case e = <-latestCh:

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -104,19 +104,6 @@ type ClientBackend interface {
 	// EstimateGas calculates the amount of gas required to execute the given transaction.
 	EstimateGas(ctx context.Context, req *EstimateGasRequest) (transaction.Gas, error)
 
-	// WaitEpoch waits for consensus to reach an epoch.
-	//
-	// Note that an epoch is considered reached even if any epoch greater than
-	// the one specified is reached (e.g., that the current epoch is already
-	// in the future).
-	WaitEpoch(ctx context.Context, epoch beacon.EpochTime) error
-
-	// GetEpoch returns the current epoch.
-	GetEpoch(ctx context.Context, height int64) (beacon.EpochTime, error)
-
-	// BeaconConsensusParameters returns the beacon consensus parameters.
-	BeaconConsensusParameters(ctx context.Context, height int64) (*beacon.ConsensusParameters, error)
-
 	// GetBlock returns a consensus block at a specific height.
 	GetBlock(ctx context.Context, height int64) (*Block, error)
 
@@ -144,6 +131,9 @@ type ClientBackend interface {
 
 	// GetStatus returns the current status overview.
 	GetStatus(ctx context.Context) (*Status, error)
+
+	// Beacon returns the beacon backend.
+	Beacon() beacon.Backend
 
 	// Registry returns the registry backend.
 	Registry() registry.Backend
@@ -242,9 +232,6 @@ type ServicesBackend interface {
 
 	// SubmissionManager returns the transaction submission manager.
 	SubmissionManager() SubmissionManager
-
-	// Beacon returns the beacon backend.
-	Beacon() beacon.Backend
 
 	// KeyManager returns the keymanager backend.
 	KeyManager() keymanager.Backend

--- a/go/consensus/tendermint/full/full.go
+++ b/go/consensus/tendermint/full/full.go
@@ -618,43 +618,6 @@ func (t *fullService) Governance() governanceAPI.Backend {
 	return t.governance
 }
 
-func (t *fullService) GetEpoch(ctx context.Context, height int64) (beaconAPI.EpochTime, error) {
-	if t.beacon == nil {
-		return beaconAPI.EpochInvalid, consensusAPI.ErrUnsupported
-	}
-	return t.beacon.GetEpoch(ctx, height)
-}
-
-func (t *fullService) WaitEpoch(ctx context.Context, epoch beaconAPI.EpochTime) error {
-	if t.beacon == nil {
-		return consensusAPI.ErrUnsupported
-	}
-
-	ch, sub := t.beacon.WatchEpochs()
-	defer sub.Close()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case e, ok := <-ch:
-			if !ok {
-				return context.Canceled
-			}
-			if e >= epoch {
-				return nil
-			}
-		}
-	}
-}
-
-func (t *fullService) BeaconConsensusParameters(ctx context.Context, height int64) (*beaconAPI.ConsensusParameters, error) {
-	if t.beacon == nil {
-		return nil, consensusAPI.ErrUnsupported
-	}
-	return t.beacon.ConsensusParameters(ctx, height)
-}
-
 func (t *fullService) GetBlock(ctx context.Context, height int64) (*consensusAPI.Block, error) {
 	blk, err := t.GetTendermintBlock(ctx, height)
 	if err != nil {

--- a/go/consensus/tendermint/seed/seed.go
+++ b/go/consensus/tendermint/seed/seed.go
@@ -189,21 +189,6 @@ func (srv *seedService) EstimateGas(ctx context.Context, req *consensus.Estimate
 }
 
 // Implements Backend.
-func (srv *seedService) WaitEpoch(ctx context.Context, epoch beacon.EpochTime) error {
-	return consensus.ErrUnsupported
-}
-
-// Implements Backend.
-func (srv *seedService) GetEpoch(ctx context.Context, height int64) (beacon.EpochTime, error) {
-	return 0, consensus.ErrUnsupported
-}
-
-// Implements Backend.
-func (srv *seedService) BeaconConsensusParameters(ctx context.Context, height int64) (*beacon.ConsensusParameters, error) {
-	return nil, consensus.ErrUnsupported
-}
-
-// Implements Backend.
 func (srv *seedService) GetBlock(ctx context.Context, height int64) (*consensus.Block, error) {
 	return nil, consensus.ErrUnsupported
 }

--- a/go/consensus/tests/tester.go
+++ b/go/consensus/tests/tester.go
@@ -90,10 +90,6 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.ClientBackend)
 		}
 	}
 
-	epoch, err := backend.GetEpoch(ctx, consensus.HeightLatest)
-	require.NoError(err, "GetEpoch")
-	require.True(epoch > 0, "epoch height should be greater than zero")
-
 	_, err = backend.EstimateGas(ctx, &consensus.EstimateGasRequest{})
 	require.ErrorIs(err, consensus.ErrInvalidArgument, "EstimateGas with nil transaction should fail")
 

--- a/go/oasis-node/cmd/debug/byzantine/node.go
+++ b/go/oasis-node/cmd/debug/byzantine/node.go
@@ -210,7 +210,10 @@ func initializeAndRegisterByzantineNode(
 }
 
 func waitForEpoch(svc consensus.Backend, epoch beacon.EpochTime) error {
-	ch, sub := svc.Beacon().WatchEpochs()
+	ch, sub, err := svc.Beacon().WatchEpochs(context.Background())
+	if err != nil {
+		return err
+	}
 	defer sub.Close()
 
 	for {

--- a/go/oasis-node/cmd/debug/consim/timesource.go
+++ b/go/oasis-node/cmd/debug/consim/timesource.go
@@ -33,11 +33,15 @@ func (b *simTimeSource) GetEpochBlock(ctx context.Context, epoch api.EpochTime) 
 	return height, nil
 }
 
-func (b *simTimeSource) WatchEpochs() (<-chan api.EpochTime, *pubsub.Subscription) {
+func (b *simTimeSource) WaitEpoch(ctx context.Context, epoch api.EpochTime) error {
+	panic("consim/epochtime: WaitEpoch not supported")
+}
+
+func (b *simTimeSource) WatchEpochs(ctx context.Context) (<-chan api.EpochTime, pubsub.ClosableSubscription, error) {
 	panic("consim/epochtime: WatchEpochs not supported")
 }
 
-func (b *simTimeSource) WatchLatestEpoch() (<-chan api.EpochTime, *pubsub.Subscription) {
+func (b *simTimeSource) WatchLatestEpoch(ctx context.Context) (<-chan api.EpochTime, pubsub.ClosableSubscription, error) {
 	panic("consim/epochtime: WatchLatestEpoch not supported")
 }
 

--- a/go/oasis-node/cmd/debug/txsource/workload/commission.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/commission.go
@@ -128,11 +128,11 @@ func findNextExclusiveBound(bounds []staking.CommissionRateBoundStep, currentBou
 	return nil
 }
 
-func (c *commission) doAmendCommissionSchedule(ctx context.Context, rng *rand.Rand, cnsc consensus.ClientBackend, stakingClient staking.Backend) error {
+func (c *commission) doAmendCommissionSchedule(ctx context.Context, rng *rand.Rand, stakingClient staking.Backend) error {
 	c.Logger.Debug("amend commission schedule")
 
 	// Get current epoch.
-	currentEpoch, err := cnsc.GetEpoch(ctx, consensus.HeightLatest)
+	currentEpoch, err := c.Consensus().Beacon().GetEpoch(ctx, consensus.HeightLatest)
 	if err != nil {
 		return fmt.Errorf("GetEpoch: %w", err)
 	}
@@ -369,7 +369,7 @@ func (c *commission) Run(
 	c.rules = params.CommissionScheduleRules
 
 	for {
-		if err = c.doAmendCommissionSchedule(ctx, rng, cnsc, stakingClient); err != nil {
+		if err = c.doAmendCommissionSchedule(ctx, rng, stakingClient); err != nil {
 			return err
 		}
 

--- a/go/oasis-node/cmd/debug/txsource/workload/delegation.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/delegation.go
@@ -39,11 +39,11 @@ type delegation struct {
 	}
 }
 
-func (d *delegation) doEscrowTx(ctx context.Context, rng *rand.Rand, cnsc consensus.ClientBackend) error {
+func (d *delegation) doEscrowTx(ctx context.Context, rng *rand.Rand) error {
 	d.Logger.Debug("escrow tx flow")
 
 	// Get current epoch.
-	epoch, err := cnsc.GetEpoch(ctx, consensus.HeightLatest)
+	epoch, err := d.Consensus().Beacon().GetEpoch(ctx, consensus.HeightLatest)
 	if err != nil {
 		return fmt.Errorf("GetEpoch: %w", err)
 	}
@@ -95,7 +95,7 @@ func (d *delegation) doEscrowTx(ctx context.Context, rng *rand.Rand, cnsc consen
 	return nil
 }
 
-func (d *delegation) doReclaimEscrowTx(ctx context.Context, rng *rand.Rand, cnsc consensus.ClientBackend, stakingClient staking.Backend) error {
+func (d *delegation) doReclaimEscrowTx(ctx context.Context, rng *rand.Rand, stakingClient staking.Backend) error {
 	d.Logger.Debug("reclaim escrow tx")
 
 	// Select an account that has active delegation.
@@ -224,11 +224,11 @@ func (d *delegation) Run(
 	for {
 		switch rng.Intn(2) {
 		case 0:
-			if err := d.doEscrowTx(ctx, rng, cnsc); err != nil {
+			if err := d.doEscrowTx(ctx, rng); err != nil {
 				return err
 			}
 		case 1:
-			if err := d.doReclaimEscrowTx(ctx, rng, cnsc, stakingClient); err != nil {
+			if err := d.doReclaimEscrowTx(ctx, rng, stakingClient); err != nil {
 				return err
 			}
 		default:

--- a/go/oasis-node/cmd/debug/txsource/workload/governance.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/governance.go
@@ -333,7 +333,7 @@ func (g *governanceWorkload) doGovernanceVote() error {
 }
 
 func (g *governanceWorkload) checkEpochTransition() (bool, error) {
-	epoch, err := g.consensus.GetEpoch(g.ctx, consensus.HeightLatest)
+	epoch, err := g.Consensus().Beacon().GetEpoch(g.ctx, consensus.HeightLatest)
 	if err != nil {
 		return false, fmt.Errorf("querying epoch: %w", err)
 	}
@@ -418,7 +418,7 @@ func (g *governanceWorkload) Run(
 		}
 
 		var epoch beacon.EpochTime
-		epoch, err = cnsc.GetEpoch(g.ctx, consensus.HeightLatest)
+		epoch, err = g.Consensus().Beacon().GetEpoch(g.ctx, consensus.HeightLatest)
 		if err != nil {
 			return fmt.Errorf("querying epoch: %w", err)
 		}

--- a/go/oasis-node/cmd/debug/txsource/workload/registration.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/registration.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 
+	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
@@ -168,6 +169,7 @@ func (r *registration) Run( // nolint: gocyclo
 	// Initialize base workload.
 	r.BaseWorkload.Init(cnsc, sm, fundingAccount)
 
+	beacon := beacon.NewBeaconClient(conn)
 	ctx := context.Background()
 	var err error
 
@@ -288,7 +290,7 @@ func (r *registration) Run( // nolint: gocyclo
 		selectedNode := selectedAcc.nodeIdentities[rng.Intn(registryNumNodesPerEntity)]
 
 		// Current epoch.
-		epoch, err := cnsc.GetEpoch(ctx, consensus.HeightLatest)
+		epoch, err := beacon.GetEpoch(ctx, consensus.HeightLatest)
 		if err != nil {
 			return fmt.Errorf("failed to get current epoch: %w", err)
 		}

--- a/go/oasis-node/cmd/debug/txsource/workload/runtime.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/runtime.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 
+	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
@@ -528,6 +529,7 @@ func (r *runtime) Run(
 	// Initialize base workload.
 	r.BaseWorkload.Init(cnsc, sm, fundingAccount)
 
+	beacon := beacon.NewBeaconClient(conn)
 	ctx := context.Background()
 
 	// Simple-keyvalue runtime.
@@ -551,7 +553,7 @@ func (r *runtime) Run(
 
 	// Wait for 2nd epoch, so that runtimes are up and running.
 	r.Logger.Info("waiting for 2nd epoch")
-	if err := cnsc.WaitEpoch(ctx, 2); err != nil {
+	if err := beacon.WaitEpoch(ctx, 2); err != nil {
 		return fmt.Errorf("failed waiting for 2nd epoch: %w", err)
 	}
 

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -201,6 +201,7 @@ func (n *Node) startRuntimeServices() error {
 
 	// Initialize and register the internal gRPC services.
 	grpcSrv := n.grpcInternal.Server()
+	beacon.RegisterService(grpcSrv, n.Consensus.Beacon())
 	scheduler.RegisterService(grpcSrv, n.Consensus.Scheduler())
 	registryAPI.RegisterService(grpcSrv, n.Consensus.Registry())
 	stakingAPI.RegisterService(grpcSrv, n.Consensus.Staking())

--- a/go/oasis-test-runner/oasis/controller.go
+++ b/go/oasis-test-runner/oasis/controller.go
@@ -3,6 +3,7 @@ package oasis
 import (
 	"google.golang.org/grpc"
 
+	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	cmnGrpc "github.com/oasisprotocol/oasis-core/go/common/grpc"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	control "github.com/oasisprotocol/oasis-core/go/control/api"
@@ -20,6 +21,7 @@ type Controller struct {
 	control.DebugController
 	control.NodeController
 
+	Beacon        beacon.Backend
 	Consensus     consensus.ClientBackend
 	Staking       staking.Backend
 	Governance    governance.Backend
@@ -51,6 +53,7 @@ func NewController(socketPath string) (*Controller, error) {
 	return &Controller{
 		DebugController: control.NewDebugControllerClient(conn),
 		NodeController:  control.NewNodeControllerClient(conn),
+		Beacon:          beacon.NewBeaconClient(conn),
 		Consensus:       consensus.NewConsensusClient(conn),
 		Staking:         staking.NewStakingClient(conn),
 		Governance:      governance.NewGovernanceClient(conn),

--- a/go/oasis-test-runner/scenario/e2e/runtime/halt_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/halt_restore.go
@@ -68,7 +68,7 @@ func (sc *haltRestoreImpl) Run(childEnv *env.Env) error {
 	ctx := context.Background()
 	sc.Logger.Info("waiting for halt epoch")
 	// Wait for halt epoch.
-	err = sc.Net.Controller().Consensus.WaitEpoch(ctx, haltEpoch)
+	err = sc.Net.Controller().Beacon.WaitEpoch(ctx, haltEpoch)
 	if err != nil {
 		return fmt.Errorf("failed waiting for halt epoch: %w", err)
 	}

--- a/go/oasis-test-runner/scenario/e2e/seed_api.go
+++ b/go/oasis-test-runner/scenario/e2e/seed_api.go
@@ -147,18 +147,6 @@ func (sc *seedAPI) Run(childEnv *env.Env) error { // nolint: gocyclo
 		return fmt.Errorf("seed node EstimateGas should fail with unsupported")
 	}
 
-	sc.Logger.Info("testing WaitEpoch")
-	err = seedCtrl.Consensus.WaitEpoch(ctx, 0)
-	if err != consensusAPI.ErrUnsupported {
-		return fmt.Errorf("seed node WaitEpoch should fail with unsupported")
-	}
-
-	sc.Logger.Info("testing GetEpoch")
-	_, err = seedCtrl.Consensus.GetEpoch(ctx, 0)
-	if err != consensusAPI.ErrUnsupported {
-		return fmt.Errorf("seed node GetEpoch should fail with unsupported")
-	}
-
 	sc.Logger.Info("testing GetBlock")
 	_, err = seedCtrl.Consensus.GetBlock(ctx, consensusAPI.HeightLatest)
 	if err != consensusAPI.ErrUnsupported {

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -223,7 +223,13 @@ func (w *Worker) registrationLoop() { // nolint: gocyclo
 	// (re-)register the node on each epoch transition. This doesn't
 	// need to be strict block-epoch time, since it just serves to
 	// extend the node's expiration.
-	ch, sub := w.beacon.WatchLatestEpoch()
+	ch, sub, err := w.beacon.WatchLatestEpoch(w.ctx)
+	if err != nil {
+		w.logger.Error("failed to watch epochs",
+			"err", err,
+		)
+		return
+	}
 	defer sub.Close()
 
 	regFn := func(epoch beacon.EpochTime, hook RegisterNodeHook, retry bool) error {

--- a/go/worker/upgrade/worker.go
+++ b/go/worker/upgrade/worker.go
@@ -31,7 +31,13 @@ func (w *Worker) doWatchGovernanceUpgrades() {
 
 	w.logger.Info("staring governance update worker")
 
-	epochCh, sub := w.beacon.WatchEpochs()
+	epochCh, sub, err := w.beacon.WatchEpochs(w.ctx)
+	if err != nil {
+		w.logger.Error("error watching epochs",
+			"err", err,
+		)
+		return
+	}
 	defer sub.Close()
 
 	// Wait for first block to be synced so that initial queries won't fail.


### PR DESCRIPTION
beacon: Add a minimal gRPC service

This moves the following calls to the new beacon gRPC service:
 * `Consensus.GetEpoch`
 * `Consensus.WaitEpoch`
 * `Consensus.BeaconConsensusParameters` -> `Beacon.ConsensusParameters`

At some point someone that cares can move the `SetEpoch` call from the debug endpoint, and add support for streams.

Fixes #3666