### PR TITLE
go/worker/storage: Add StorageRPC role and change access policy

### DIFF
--- a/.changelog/3696.feature.md
+++ b/.changelog/3696.feature.md
@@ -1,0 +1,8 @@
+go/worker/storage: Add StorageRPC role and change access policy
+
+Getting checkpoints and diffs is now allowed for any connecting node,
+which eliminates a race condition and initialization difficulty in the
+storage committee node startup.
+
+State access is made gated but optionally public as before, depending on
+command line parameters.

--- a/go/common/accessctl/accessctl.go
+++ b/go/common/accessctl/accessctl.go
@@ -12,6 +12,9 @@ import (
 // Subject is an access control subject.
 type Subject string
 
+// AnySubject is a wildcard subject. When set for an action in a policy, it matches any subject.
+const AnySubject Subject = "*"
+
 // SubjectFromX509Certificate returns a Subject from the given X.509
 // certificate.
 func SubjectFromX509Certificate(cert *x509.Certificate) Subject {
@@ -57,6 +60,16 @@ func (p Policy) Allow(sub Subject, act Action) {
 	p[act][sub] = true
 }
 
+// AllowAll adds a policy rule that allows anyone to perform the given action.
+// The effect is similar as defining the action to have no access control, but is
+// better suited for configuration that depends on runtime parameters.
+func (p Policy) AllowAll(act Action) {
+	if p[act] == nil {
+		p[act] = make(map[Subject]bool)
+	}
+	p[act][AnySubject] = true
+}
+
 // Deny removes a policy rule that allows the given Subject to perform the
 // given Action.
 func (p Policy) Deny(sub Subject, act Action) {
@@ -72,7 +85,7 @@ func (p Policy) IsAllowed(sub Subject, act Action) bool {
 	if p[act] == nil {
 		return false
 	}
-	return p[act][sub]
+	return p[act][AnySubject] || p[act][sub]
 }
 
 // String returns the string representation of the policy.

--- a/go/common/accessctl/accessctl_test.go
+++ b/go/common/accessctl/accessctl_test.go
@@ -40,6 +40,19 @@ func TestPolicy(t *testing.T) {
 
 	// Remove nonexisting rule from a non-empty policy.
 	policy.Deny("anne", "write")
+
+	// Wildcard rules.
+	policy.Allow("anne", "read")
+	require.False(policy.IsAllowed("anne", "write"), "Anne should not have write access")
+	require.False(policy.IsAllowed("bob", "write"), "Bob should not have write access")
+	policy.AllowAll("write")
+	require.True(policy.IsAllowed("anne", "write"), "Anne should have write access")
+	require.True(policy.IsAllowed("bob", "write"), "Bob should have write access")
+	policy.Allow("bob", "write")
+	require.True(policy.IsAllowed("bob", "write"), "Bob should have write access")
+	policy.Deny(AnySubject, "write")
+	require.False(policy.IsAllowed("anne", "write"), "Anne should not have write access")
+	require.True(policy.IsAllowed("bob", "write"), "Bob should have write access")
 }
 
 func TestSubjectFromCertificate(t *testing.T) {

--- a/go/common/grpc/service.go
+++ b/go/common/grpc/service.go
@@ -26,6 +26,11 @@ type NamespaceExtractorFunc func(ctx context.Context, req interface{}) (common.N
 // a specific request. In case an error is returned the request is aborted.
 type AccessControlFunc func(ctx context.Context, req interface{}) (bool, error)
 
+// AccessControlAlways is a utility AccessControlFunc that enables access control for every request.
+func AccessControlAlways(ctx context.Context, req interface{}) (bool, error) {
+	return true, nil
+}
+
 // ServiceNameFromMethod extract service name from method name.
 func ServiceNameFromMethod(methodName string) ServiceName {
 	substrs := strings.Split(methodName, "/")

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -103,10 +103,12 @@ const (
 	RoleValidator RolesMask = 1 << 3
 	// RoleConsensusRPC is the public consensus RPC services worker role.
 	RoleConsensusRPC RolesMask = 1 << 4
+	// RoleStorageRPC is the public storage RPC services worker role.
+	RoleStorageRPC RolesMask = 1 << 5
 
 	// RoleReserved are all the bits of the Oasis node roles bitmask
 	// that are reserved and must not be used.
-	RoleReserved RolesMask = ((1 << 32) - 1) & ^((RoleConsensusRPC << 1) - 1)
+	RoleReserved RolesMask = ((1 << 32) - 1) & ^((RoleStorageRPC << 1) - 1)
 )
 
 // Roles returns a list of available valid roles.
@@ -117,6 +119,7 @@ func Roles() (roles []RolesMask) {
 		RoleKeyManager,
 		RoleValidator,
 		RoleConsensusRPC,
+		RoleStorageRPC,
 	}
 }
 
@@ -146,6 +149,9 @@ func (m RolesMask) String() string {
 	}
 	if m&RoleConsensusRPC != 0 {
 		ret = append(ret, "consensus-rpc")
+	}
+	if m&RoleStorageRPC != 0 {
+		ret = append(ret, "storage-rpc")
 	}
 
 	return strings.Join(ret, ",")

--- a/go/oasis-node/cmd/debug/storage/export.go
+++ b/go/oasis-node/cmd/debug/storage/export.go
@@ -173,7 +173,7 @@ func newDirectStorageBackend(dataDir string, namespace common.Namespace) (storag
 		cfg.DB = filepath.Join(cfg.DB, storageDatabase.DefaultFileName(cfg.Backend))
 		return storageDatabase.New(cfg)
 	case storageClient.BackendName:
-		return storageClient.New(context.Background(), namespace, nil, nil, nil, nil)
+		return storageClient.NewForPublicStorage(context.Background(), namespace, nil, nil, nil)
 	default:
 		return nil, fmt.Errorf("storage: unsupported backend: '%v'", cfg.Backend)
 	}

--- a/go/oasis-node/node_test.go
+++ b/go/oasis-node/node_test.go
@@ -73,6 +73,7 @@ var (
 		{runtimeRegistry.CfgRuntimeProvisioner, runtimeRegistry.RuntimeProvisionerMock},
 		{workerCommon.CfgClientPort, workerClientPort},
 		{storageWorker.CfgWorkerEnabled, true},
+		{storageWorker.CfgWorkerPublicRPCEnabled, true},
 		{executor.CfgScheduleCheckTxEnabled, false},
 		{tendermintCommon.CfgCoreListenAddress, "tcp://0.0.0.0:27565"},
 		{tendermintFull.CfgSupplementarySanityEnabled, true},

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -370,6 +370,13 @@ func (args *argBuilder) workerStorageEnabled() *argBuilder {
 	return args
 }
 
+func (args *argBuilder) workerStoragePublicRPCEnabled(enabled bool) *argBuilder {
+	if enabled {
+		args.vec = append(args.vec, "--"+workerStorage.CfgWorkerPublicRPCEnabled)
+	}
+	return args
+}
+
 func (args *argBuilder) workerStorageDebugIgnoreApplies(ignore bool) *argBuilder {
 	if ignore {
 		args.vec = append(args.vec, "--"+workerStorage.CfgWorkerDebugIgnoreApply)

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -338,6 +338,7 @@ type StorageWorkerFixture struct { // nolint: maligned
 	NoAutoStart bool `json:"no_auto_start,omitempty"`
 
 	DisableCertRotation bool `json:"disable_cert_rotation"`
+	DisablePublicRPC    bool `json:"disable_public_rpc"`
 
 	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
 
@@ -382,6 +383,7 @@ func (f *StorageWorkerFixture) Create(net *Network) (*Storage, error) {
 		// Syncing should normally be enabled, but normally disabled in tests.
 		CheckpointSyncDisabled: !f.CheckpointSyncEnabled,
 		DisableCertRotation:    f.DisableCertRotation,
+		DisablePublicRPC:       f.DisablePublicRPC,
 		Runtimes:               f.Runtimes,
 	})
 }

--- a/go/oasis-test-runner/oasis/storage.go
+++ b/go/oasis-test-runner/oasis/storage.go
@@ -24,6 +24,7 @@ type Storage struct { // nolint: maligned
 	entity  *Entity
 
 	disableCertRotation     bool
+	disablePublicRPC        bool
 	ignoreApplies           bool
 	checkpointSyncDisabled  bool
 	checkpointCheckInterval time.Duration
@@ -46,6 +47,7 @@ type StorageCfg struct { // nolint: maligned
 	Entity        *Entity
 
 	DisableCertRotation     bool
+	DisablePublicRPC        bool
 	IgnoreApplies           bool
 	CheckpointSyncDisabled  bool
 	CheckpointCheckInterval time.Duration
@@ -118,6 +120,7 @@ func (worker *Storage) startNode() error {
 		workerClientPort(worker.clientPort).
 		workerP2pPort(worker.p2pPort).
 		workerStorageEnabled().
+		workerStoragePublicRPCEnabled(!worker.disablePublicRPC).
 		workerStorageDebugIgnoreApplies(worker.ignoreApplies).
 		workerStorageDebugDisableCheckpointSync(worker.checkpointSyncDisabled).
 		workerStorageCheckpointCheckInterval(worker.checkpointCheckInterval).
@@ -204,6 +207,7 @@ func (net *Network) NewStorage(cfg *StorageCfg) (*Storage, error) {
 		entity:                  cfg.Entity,
 		sentryIndices:           cfg.SentryIndices,
 		disableCertRotation:     cfg.DisableCertRotation,
+		disablePublicRPC:        cfg.DisablePublicRPC,
 		ignoreApplies:           cfg.IgnoreApplies,
 		checkpointSyncDisabled:  cfg.CheckpointSyncDisabled,
 		checkpointCheckInterval: cfg.CheckpointCheckInterval,

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -584,6 +584,7 @@ func testRegistryRuntime(t *testing.T, backend api.Backend, consensus consensusA
 								MaxNodes: map[node.RolesMask]uint16{
 									node.RoleComputeWorker: 2,
 									node.RoleStorageWorker: 2,
+									node.RoleStorageRPC:    2,
 								},
 							},
 							nodeEntities[3].Entity.ID: {
@@ -1028,7 +1029,7 @@ func (ent *TestEntity) NewTestNodes(nCompute, nStorage int, idNonce []byte, runt
 		if i < nCompute {
 			role = node.RoleComputeWorker
 		} else {
-			role = node.RoleStorageWorker
+			role = node.RoleStorageWorker | node.RoleStorageRPC
 		}
 
 		nod.Node = &node.Node{

--- a/go/runtime/registry/registry.go
+++ b/go/runtime/registry/registry.go
@@ -257,7 +257,7 @@ func (r *runtime) finishInitialization(ctx context.Context, ident *identity.Iden
 	defer r.Unlock()
 
 	if r.storage == nil {
-		storageBackend, err := client.New(ctx, r.id, ident, r.consensus.Scheduler(), r.consensus.Registry(), r)
+		storageBackend, err := client.NewForPublicStorage(ctx, r.id, ident, r.consensus.Registry(), r)
 		if err != nil {
 			return fmt.Errorf("runtime/registry: cannot create storage for runtime %s: %w", r.id, err)
 		}

--- a/go/storage/api/grpc.go
+++ b/go/storage/api/grpc.go
@@ -21,11 +21,35 @@ var (
 	ServiceName = cmnGrpc.NewServiceName("Storage")
 
 	// MethodSyncGet is the SyncGet method.
-	MethodSyncGet = ServiceName.NewMethod("SyncGet", GetRequest{})
+	MethodSyncGet = ServiceName.NewMethod("SyncGet", GetRequest{}).
+			WithNamespaceExtractor(func(ctx context.Context, req interface{}) (common.Namespace, error) {
+			r, ok := req.(*GetRequest)
+			if !ok {
+				return common.Namespace{}, errInvalidRequestType
+			}
+			return r.Tree.Root.Namespace, nil
+		}).
+		WithAccessControl(cmnGrpc.AccessControlAlways)
 	// MethodSyncGetPrefixes is the SyncGetPrefixes method.
-	MethodSyncGetPrefixes = ServiceName.NewMethod("SyncGetPrefixes", GetPrefixesRequest{})
+	MethodSyncGetPrefixes = ServiceName.NewMethod("SyncGetPrefixes", GetPrefixesRequest{}).
+				WithNamespaceExtractor(func(ctx context.Context, req interface{}) (common.Namespace, error) {
+			r, ok := req.(*GetPrefixesRequest)
+			if !ok {
+				return common.Namespace{}, errInvalidRequestType
+			}
+			return r.Tree.Root.Namespace, nil
+		}).
+		WithAccessControl(cmnGrpc.AccessControlAlways)
 	// MethodSyncIterate is the SyncIterate method.
-	MethodSyncIterate = ServiceName.NewMethod("SyncIterate", IterateRequest{})
+	MethodSyncIterate = ServiceName.NewMethod("SyncIterate", IterateRequest{}).
+				WithNamespaceExtractor(func(ctx context.Context, req interface{}) (common.Namespace, error) {
+			r, ok := req.(*IterateRequest)
+			if !ok {
+				return common.Namespace{}, errInvalidRequestType
+			}
+			return r.Tree.Root.Namespace, nil
+		}).
+		WithAccessControl(cmnGrpc.AccessControlAlways)
 	// MethodApply is the Apply method.
 	MethodApply = ServiceName.NewMethod("Apply", ApplyRequest{}).
 			WithNamespaceExtractor(func(ctx context.Context, req interface{}) (common.Namespace, error) {
@@ -35,9 +59,7 @@ var (
 			}
 			return r.Namespace, nil
 		}).
-		WithAccessControl(func(ctx context.Context, req interface{}) (bool, error) {
-			return true, nil
-		})
+		WithAccessControl(cmnGrpc.AccessControlAlways)
 
 	// MethodApplyBatch is the ApplyBatch method.
 	MethodApplyBatch = ServiceName.NewMethod("ApplyBatch", ApplyBatchRequest{}).
@@ -48,48 +70,16 @@ var (
 			}
 			return r.Namespace, nil
 		}).
-		WithAccessControl(func(ctx context.Context, req interface{}) (bool, error) {
-			return true, nil
-		})
+		WithAccessControl(cmnGrpc.AccessControlAlways)
 
 	// MethodGetDiff is the GetDiff method.
-	MethodGetDiff = ServiceName.NewMethod("GetDiff", GetDiffRequest{}).
-			WithNamespaceExtractor(func(ctx context.Context, req interface{}) (common.Namespace, error) {
-			r, ok := req.(*GetDiffRequest)
-			if !ok {
-				return common.Namespace{}, errInvalidRequestType
-			}
-			return r.StartRoot.Namespace, nil
-		}).
-		WithAccessControl(func(ctx context.Context, req interface{}) (bool, error) {
-			return true, nil
-		})
+	MethodGetDiff = ServiceName.NewMethod("GetDiff", GetDiffRequest{})
 
 	// MethodGetCheckpoints is the GetCheckpoints method.
-	MethodGetCheckpoints = ServiceName.NewMethod("GetCheckpoints", checkpoint.GetCheckpointsRequest{}).
-				WithNamespaceExtractor(func(ctx context.Context, req interface{}) (common.Namespace, error) {
-			r, ok := req.(*checkpoint.GetCheckpointsRequest)
-			if !ok {
-				return common.Namespace{}, errInvalidRequestType
-			}
-			return r.Namespace, nil
-		}).
-		WithAccessControl(func(ctx context.Context, req interface{}) (bool, error) {
-			return true, nil
-		})
+	MethodGetCheckpoints = ServiceName.NewMethod("GetCheckpoints", checkpoint.GetCheckpointsRequest{})
 
 	// MethodGetCheckpointChunk is the GetCheckpointChunk method.
-	MethodGetCheckpointChunk = ServiceName.NewMethod("GetCheckpointChunk", checkpoint.ChunkMetadata{}).
-					WithNamespaceExtractor(func(ctx context.Context, req interface{}) (common.Namespace, error) {
-			cm, ok := req.(*checkpoint.ChunkMetadata)
-			if !ok {
-				return common.Namespace{}, errInvalidRequestType
-			}
-			return cm.Root.Namespace, nil
-		}).
-		WithAccessControl(func(ctx context.Context, req interface{}) (bool, error) {
-			return true, nil
-		})
+	MethodGetCheckpointChunk = ServiceName.NewMethod("GetCheckpointChunk", checkpoint.ChunkMetadata{})
 
 	// serviceDesc is the gRPC service descriptor.
 	serviceDesc = grpc.ServiceDesc{

--- a/go/storage/client/tests/tests.go
+++ b/go/storage/client/tests/tests.go
@@ -42,7 +42,7 @@ func ClientWorkerTests(
 	ns := rt.Runtime.ID
 
 	// Initialize storage client.
-	client, err := storageClient.New(ctx, ns, identity, consensus.Scheduler(), consensus.Registry(), nil)
+	client, err := storageClient.NewForPublicStorage(ctx, ns, identity, consensus.Registry(), nil)
 	require.NoError(err, "NewStorageClient")
 
 	// Create mock root hash.
@@ -61,7 +61,7 @@ func ClientWorkerTests(
 			Position: root.Hash,
 		},
 	})
-	require.EqualError(err, storageClient.ErrStorageNotAvailable.Error(), "storage client get before initialization")
+	require.Error(err, "storage client get before initialization")
 	require.Nil(r, "result should be nil")
 
 	// Advance the epoch.

--- a/go/worker/storage/committee/policy.go
+++ b/go/worker/storage/committee/policy.go
@@ -11,6 +11,9 @@ import (
 var (
 	executorCommitteePolicy = &committee.AccessPolicy{
 		Actions: []accessctl.Action{
+			accessctl.Action(api.MethodSyncGet.FullName()),
+			accessctl.Action(api.MethodSyncGetPrefixes.FullName()),
+			accessctl.Action(api.MethodSyncIterate.FullName()),
 			accessctl.Action(api.MethodApply.FullName()),
 			accessctl.Action(api.MethodApplyBatch.FullName()),
 		},
@@ -20,16 +23,16 @@ var (
 	// sync-up.
 	storageNodesPolicy = &committee.AccessPolicy{
 		Actions: []accessctl.Action{
-			accessctl.Action(api.MethodGetDiff.FullName()),
-			accessctl.Action(api.MethodGetCheckpoints.FullName()),
-			accessctl.Action(api.MethodGetCheckpointChunk.FullName()),
+			accessctl.Action(api.MethodSyncGet.FullName()),
+			accessctl.Action(api.MethodSyncGetPrefixes.FullName()),
+			accessctl.Action(api.MethodSyncIterate.FullName()),
 		},
 	}
 	sentryNodesPolicy = &committee.AccessPolicy{
 		Actions: []accessctl.Action{
-			accessctl.Action(api.MethodGetDiff.FullName()),
-			accessctl.Action(api.MethodGetCheckpoints.FullName()),
-			accessctl.Action(api.MethodGetCheckpointChunk.FullName()),
+			accessctl.Action(api.MethodSyncGet.FullName()),
+			accessctl.Action(api.MethodSyncGetPrefixes.FullName()),
+			accessctl.Action(api.MethodSyncIterate.FullName()),
 			accessctl.Action(api.MethodApply.FullName()),
 			accessctl.Action(api.MethodApplyBatch.FullName()),
 		},

--- a/go/worker/storage/init.go
+++ b/go/worker/storage/init.go
@@ -23,6 +23,10 @@ const (
 	CfgWorkerEnabled      = "worker.storage.enabled"
 	cfgWorkerFetcherCount = "worker.storage.fetcher_count"
 
+	// CfgWorkerPublicRPCEnabled enables storage state access for all nodes instead of just
+	// storage committee members.
+	CfgWorkerPublicRPCEnabled = "worker.storage.public_rpc.enabled"
+
 	// CfgWorkerCheckpointerDisabled disables the storage checkpointer.
 	CfgWorkerCheckpointerDisabled = "worker.storage.checkpointer.disabled"
 	// CfgWorkerCheckpointCheckInterval configures the checkpointer check interval.
@@ -100,6 +104,7 @@ func NewLocalBackend(
 func init() {
 	Flags.Bool(CfgWorkerEnabled, false, "Enable storage worker")
 	Flags.Uint(cfgWorkerFetcherCount, 4, "Number of concurrent storage diff fetchers")
+	Flags.Bool(CfgWorkerPublicRPCEnabled, false, "Enable storage RPC access for all nodes")
 	Flags.Bool(CfgWorkerCheckpointerDisabled, false, "Disable the storage checkpointer")
 	Flags.Duration(CfgWorkerCheckpointCheckInterval, 1*time.Minute, "Storage checkpointer check interval")
 	Flags.Bool(CfgWorkerCheckpointSyncDisabled, false, "Disable initial storage sync from checkpoints")

--- a/go/worker/storage/worker.go
+++ b/go/worker/storage/worker.go
@@ -117,6 +117,13 @@ func (s *Worker) registerRuntime(dataDir string, commonNode *committeeCommon.Nod
 	if err != nil {
 		return fmt.Errorf("failed to create role provider: %w", err)
 	}
+	var rpRPC registration.RoleProvider
+	if viper.GetBool(CfgWorkerPublicRPCEnabled) {
+		rpRPC, err = s.registration.NewRuntimeRoleProvider(node.RoleStorageRPC, id)
+		if err != nil {
+			return fmt.Errorf("failed to create rpc role provider: %w", err)
+		}
+	}
 
 	path, err := registry.EnsureRuntimeStateDir(dataDir, id)
 	if err != nil {
@@ -135,6 +142,7 @@ func (s *Worker) registerRuntime(dataDir string, commonNode *committeeCommon.Nod
 		s.fetchPool,
 		s.watchState,
 		rp,
+		rpRPC,
 		s.commonWorker.GetConfig(),
 		localStorage,
 		checkpointerCfg,


### PR DESCRIPTION
Getting checkpoints and diffs is now allowed for any connecting node,
which eliminates a race condition and initialization difficulty in the
storage committee node startup.

State access is made gated but optionally public as before, depending on
command line parameters.

Closes #3562 