### PR TITLE
go/roothash: runtime domain separation in executor commitments

### DIFF
--- a/.changelog/3643.breaking.md
+++ b/.changelog/3643.breaking.md
@@ -1,0 +1,1 @@
+go/roothash: runtime domain separation context in executor commitments

--- a/go/common/crypto/signature/signer_test.go
+++ b/go/common/crypto/signature/signer_test.go
@@ -1,6 +1,7 @@
 package signature
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -11,14 +12,16 @@ func TestContext(t *testing.T) {
 	require := require.New(t)
 
 	// Make sure a context can be registered.
-	var ctx, ctx2 Context
+	var ctx, ctx2, ctx3 Context
 	require.NotPanics(func() { ctx = NewContext("test: dummy context 1") })
 	require.NotPanics(func() { ctx2 = NewContext("test: dummy context 2") })
+	require.NotPanics(func() { ctx3 = NewContext("test: dummy context 3", WithDynamicSuffix(" for test suffix ", 1)) })
 
 	// Make sure we panic if the same context is registered twice.
 	require.Panics(func() { NewContext("test: dummy context 1") })
 	// Even with different options.
 	require.Panics(func() { NewContext("test: dummy context 1", WithChainSeparation()) })
+	require.Panics(func() { NewContext("test: dummy context 3") })
 
 	// Make sure we panic if context is too long.
 	require.Panics(func() { NewContext(strings.Repeat("a", 500)) })
@@ -26,14 +29,16 @@ func TestContext(t *testing.T) {
 	// Make sure we panic if context includes the chain context separator.
 	require.Panics(func() { NewContext("test: dummy context 1 for chain blah") })
 
-	// Make sure a context with chain separation can be registered.
-	var chainCtx Context
-	require.NotPanics(func() { chainCtx = NewContext("test: dummy context 3", WithChainSeparation()) })
+	// Make sure we panic if suffix is too long.
+	require.Panics(func() { NewContext("test: dummy", WithDynamicSuffix(" for test suffix ", 500)) })
 
 	// Make sure we cannot use an unregistered context.
 	unregCtx := Context("test: unregistered")
 	_, err := PrepareSignerMessage(unregCtx, []byte("message"))
 	require.Error(err, "PrepareSignerMessage should fail with unregistered context")
+
+	_, err = unregCtx.WithSuffix("1")
+	require.Error(err, "WithSuffix should fail on unregistered context")
 
 	// Should work with registered context.
 	msg1, err := PrepareSignerMessage(ctx, []byte("message"))
@@ -42,9 +47,42 @@ func TestContext(t *testing.T) {
 	require.NoError(err, "PrepareSignerMessage should work")
 	require.NotEqual(msg1, msg2, "messages for different contexts should be different")
 
+	// Context without dynamic suffix should fail.
+	_, err = ctx2.WithSuffix("1")
+	require.Equal(err, errNoSuffixConfigured, "context suffix not configured")
+	// Suffix to big should fail.
+	_, err = ctx3.WithSuffix(strings.Repeat("a", 500))
+	require.True(errors.Is(err, errMalformedContext), "context dynamic suffix too long")
+	// Dynamic suffix without context suffix should fail
+	_, err = PrepareSignerMessage(ctx3, []byte("message"))
+	require.Equal(errNoDynamicSuffix, err, "PrepareSignerMessage should fail for dynamic context without suffix")
+
+	// Should work with different dynamic suffixes.
+	ctx3Pre1, err := ctx3.WithSuffix("1")
+	require.NoError(err, "Ctx3 WithSuffix 1")
+	ctx3Pre2, err := ctx3.WithSuffix("2")
+	require.NoError(err, "Ctx3 WithSuffix 2")
+	msg1, err = PrepareSignerMessage(ctx3Pre1, []byte("message"))
+	require.NoError(err, "PrepareSignerMessage should work")
+	msg2, err = PrepareSignerMessage(ctx3Pre2, []byte("message"))
+	require.NoError(err, "PrepareSignerMessage should work")
+	require.NotEqual(msg1, msg2, "messages for different dynamic suffixes should be different")
+
+	// Setting suffix multiple times should fail.
+	_, err = ctx3Pre1.WithSuffix("1")
+	require.Equal(err, errNoSuffixConfigured, "setting dynamic suffix multiple times should fail")
+
+	// Make sure a context with chain separation and dynamic suffix can be registered.
+	var chainCtx Context
+	require.NotPanics(func() {
+		chainCtx = NewContext("test: dummy context 4", WithChainSeparation(), WithDynamicSuffix(" for test ", 1))
+	})
+	chainCtx1, err := chainCtx.WithSuffix("1")
+	require.NoError(err, "chain context with suffix")
+
 	// Should fail with context that requires chain separation as no
 	// chain context has been set.
-	_, err = PrepareSignerMessage(chainCtx, []byte("message"))
+	_, err = PrepareSignerMessage(chainCtx1, []byte("message"))
 	require.Error(err, "PrepareSignerMessage should fail without chain context")
 
 	// Make sure we can set a chain context.
@@ -54,7 +92,10 @@ func TestContext(t *testing.T) {
 	// Make sure we can't modify a set chain context.
 	require.Panics(func() { SetChainContext("test: context change") })
 
-	msg1, err = PrepareSignerMessage(chainCtx, []byte("message"))
+	_, err = PrepareSignerMessage(chainCtx, []byte("message"))
+	require.Equal(err, errNoDynamicSuffix, "PrepareSignerMessage should fail with chain context without suffix")
+
+	msg1, err = PrepareSignerMessage(chainCtx1, []byte("message"))
 	require.NoError(err, "PrepareSignerMessage should work with chain context")
 
 	// Manually change the chain context to test that this generates different
@@ -62,18 +103,28 @@ func TestContext(t *testing.T) {
 	UnsafeResetChainContext()
 	SetChainContext("test: oasis-core tests")
 
-	msg2, err = PrepareSignerMessage(chainCtx, []byte("message"))
+	msg2, err = PrepareSignerMessage(chainCtx1, []byte("message"))
 	require.NoError(err, "PrepareSignerMessage should work with chain context")
 	require.NotEqual(msg1, msg2, "messages for different chain contexts should be different")
 
 	// Manually delete a registered context so that we can re-register with
 	// different options and check that the messages are different.
 	registeredContexts.Delete(chainCtx)
+	registeredContexts.Delete(chainCtx1)
 
-	chainCtx = NewContext("test: dummy context 3")
-	msg3, err := PrepareSignerMessage(chainCtx, []byte("message"))
+	chainCtx = NewContext("test: dummy context 4", WithDynamicSuffix(" for test ", 1))
+	chainCtx1, err = chainCtx.WithSuffix("1")
+	require.NoError(err, "chain context with suffix")
+
+	msg3, err := PrepareSignerMessage(chainCtx1, []byte("message"))
 	require.NoError(err, "PrepareSignerMessage should work")
 	require.NotEqual(msg2, msg3, "messages for different contexts should be different")
+
+	chainCtx2, err := chainCtx.WithSuffix("2")
+	require.NoError(err, "chain context with suffix")
+	msg4, err := PrepareSignerMessage(chainCtx2, []byte("message"))
+	require.NoError(err, "PrepareSignerMessage should work")
+	require.NotEqual(msg3, msg4, "messages for different contexts should be different")
 
 	// The remote signer requires bypassing the context registration checks.
 	UnsafeAllowUnregisteredContexts()

--- a/go/common/namespace.go
+++ b/go/common/namespace.go
@@ -15,6 +15,9 @@ const (
 	// NamespaceSize is the size of a chain namespace identifier in bytes.
 	NamespaceSize = 32
 
+	// NamespaceHexSize is the size of the chain namespace identifier in string format.
+	NamespaceHexSize = NamespaceSize * 2
+
 	// NamespaceIDSize is the size of the identifier component of a namespace.
 	NamespaceIDSize = NamespaceSize - 8
 

--- a/go/oasis-node/cmd/debug/byzantine/beacon.go
+++ b/go/oasis-node/cmd/debug/byzantine/beacon.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
+	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/pvss"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
@@ -68,12 +69,17 @@ func (m *BeaconMode) FromString(s string) error {
 func doBeaconScenario(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
 
+	var runtimeID common.Namespace
+	if err := runtimeID.UnmarshalHex(viper.GetString(CfgRuntimeID)); err != nil {
+		panic(fmt.Errorf("error initializing node: failed to parse runtime ID: %w", err))
+	}
+
 	var mode BeaconMode
 	if err := mode.FromString(viper.GetString(CfgBeaconMode)); err != nil {
 		panic(err)
 	}
 
-	b, err := initializeAndRegisterByzantineNode(node.RoleValidator, scheduler.RoleInvalid, scheduler.RoleInvalid, false, true)
+	b, err := initializeAndRegisterByzantineNode(runtimeID, node.RoleValidator, scheduler.RoleInvalid, scheduler.RoleInvalid, false, true)
 	if err != nil {
 		panic(fmt.Sprintf("error initializing node: %+v", err))
 	}

--- a/go/oasis-node/cmd/debug/byzantine/byzantine.go
+++ b/go/oasis-node/cmd/debug/byzantine/byzantine.go
@@ -10,6 +10,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx/ias"
@@ -27,6 +28,8 @@ import (
 const (
 	// CfgFakeSGX configures registering with SGX capability.
 	CfgFakeSGX = "fake_sgx"
+	// CfgRuntimeID configures the runtime ID Byzantine node participates in.
+	CfgRuntimeID = "runtime_id"
 	// CfgVersionFakeEnclaveID configures runtime's EnclaveIdentity.
 	CfgVersionFakeEnclaveID = "runtime.version.fake_enclave_id"
 	// CfgActivationEpoch configures the epoch at which the Byzantine node activates.
@@ -37,6 +40,8 @@ const (
 	CfgExecutorMode = "executor_mode"
 	// CfgBeaconMode configures the byzantine beacon mode.
 	CfgBeaconMode = "beacon_mode"
+
+	defaultRuntimeIDHex = "8000000000000000000000000000000000000000000000000000000000000000"
 )
 
 // ExecutorMode represents the byzantine executor mode.
@@ -121,7 +126,12 @@ func activateCommonConfig(cmd *cobra.Command, args []string) {
 }
 
 func doStorageScenario(cmd *cobra.Command, args []string) {
-	b, err := initializeAndRegisterByzantineNode(node.RoleStorageWorker, scheduler.RoleWorker, scheduler.RoleInvalid, false, false)
+	var runtimeID common.Namespace
+	if err := runtimeID.UnmarshalHex(viper.GetString(CfgRuntimeID)); err != nil {
+		panic(fmt.Errorf("error initializing node: failed to parse runtime ID: %w", err))
+	}
+
+	b, err := initializeAndRegisterByzantineNode(runtimeID, node.RoleStorageWorker, scheduler.RoleWorker, scheduler.RoleInvalid, false, false)
 	if err != nil {
 		panic(fmt.Sprintf("error initializing node: %+v", err))
 	}
@@ -136,6 +146,11 @@ func doStorageScenario(cmd *cobra.Command, args []string) {
 func doExecutorScenario(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
 
+	var runtimeID common.Namespace
+	if err := runtimeID.UnmarshalHex(viper.GetString(CfgRuntimeID)); err != nil {
+		panic(fmt.Errorf("error initializing node: failed to parse runtime ID: %w", err))
+	}
+
 	// Validate executor mode.
 	var executorMode ExecutorMode
 	if err := executorMode.FromString(viper.GetString(CfgExecutorMode)); err != nil {
@@ -143,7 +158,7 @@ func doExecutorScenario(cmd *cobra.Command, args []string) {
 	}
 
 	isTxScheduler := viper.GetBool(CfgSchedulerRoleExpected)
-	b, err := initializeAndRegisterByzantineNode(node.RoleComputeWorker, scheduler.RoleInvalid, scheduler.RoleWorker, isTxScheduler, false)
+	b, err := initializeAndRegisterByzantineNode(runtimeID, node.RoleComputeWorker, scheduler.RoleInvalid, scheduler.RoleWorker, isTxScheduler, false)
 	if err != nil {
 		panic(fmt.Sprintf("error initializing node: %+v", err))
 	}
@@ -156,7 +171,7 @@ func doExecutorScenario(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	cbc := newComputeBatchContext()
+	cbc := newComputeBatchContext(runtimeID)
 	switch isTxScheduler {
 	case true:
 		var cont bool
@@ -169,7 +184,7 @@ func doExecutorScenario(cmd *cobra.Command, args []string) {
 		}
 	case false:
 		// If we are not the scheduler, receive the proposed batch.
-		if err = cbc.receiveBatch(b.p2p, defaultRuntimeID); err != nil {
+		if err = cbc.receiveBatch(b.p2p); err != nil {
 			panic(fmt.Sprintf("compute receive batch failed: %+v", err))
 		}
 		logger.Debug("executor: received batch", "bd", cbc.bd)
@@ -226,17 +241,17 @@ func doExecutorScenario(cmd *cobra.Command, args []string) {
 	}
 	switch executorMode {
 	case ModeExecutorFailureIndicating:
-		if err = cbc.createCommitment(b.identity, defaultRuntimeID, b.rak, b.executorCommittee.EncodedMembersHash(), commitment.FailureUnknown); err != nil {
+		if err = cbc.createCommitment(b.identity, b.rak, b.executorCommittee.EncodedMembersHash(), commitment.FailureUnknown); err != nil {
 			panic(fmt.Sprintf("compute create commitment failed: %+v", err))
 		}
 	default:
-		if err = cbc.createCommitment(b.identity, defaultRuntimeID, b.rak, b.executorCommittee.EncodedMembersHash(), commitment.FailureNone); err != nil {
+		if err = cbc.createCommitment(b.identity, b.rak, b.executorCommittee.EncodedMembersHash(), commitment.FailureNone); err != nil {
 			panic(fmt.Sprintf("compute create commitment failed: %+v", err))
 		}
 
 	}
 
-	if err = cbc.publishToChain(b.tendermint.service, b.identity, defaultRuntimeID); err != nil {
+	if err = cbc.publishToChain(b.tendermint.service, b.identity); err != nil {
 		panic(fmt.Sprintf("compute publish to chain failed: %+v", err))
 	}
 	logger.Debug("executor: commitment sent")
@@ -253,6 +268,7 @@ func Register(parentCmd *cobra.Command) {
 func init() {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 	fs.Bool(CfgFakeSGX, false, "register with SGX capability")
+	fs.String(CfgRuntimeID, defaultRuntimeIDHex, "runtime ID byzantine node participates in")
 	fs.String(CfgVersionFakeEnclaveID, "", "fake runtime enclave identity")
 	fs.Uint64(CfgActivationEpoch, 0, "epoch at which the Byzantine node should activate")
 	fs.Bool(CfgSchedulerRoleExpected, false, "is executor node expected to be scheduler or not")

--- a/go/oasis-node/cmd/debug/byzantine/byzantine.go
+++ b/go/oasis-node/cmd/debug/byzantine/byzantine.go
@@ -169,7 +169,7 @@ func doExecutorScenario(cmd *cobra.Command, args []string) {
 		}
 	case false:
 		// If we are not the scheduler, receive the proposed batch.
-		if err = cbc.receiveBatch(b.p2p); err != nil {
+		if err = cbc.receiveBatch(b.p2p, defaultRuntimeID); err != nil {
 			panic(fmt.Sprintf("compute receive batch failed: %+v", err))
 		}
 		logger.Debug("executor: received batch", "bd", cbc.bd)
@@ -226,11 +226,11 @@ func doExecutorScenario(cmd *cobra.Command, args []string) {
 	}
 	switch executorMode {
 	case ModeExecutorFailureIndicating:
-		if err = cbc.createCommitment(b.identity, b.rak, b.executorCommittee.EncodedMembersHash(), commitment.FailureUnknown); err != nil {
+		if err = cbc.createCommitment(b.identity, defaultRuntimeID, b.rak, b.executorCommittee.EncodedMembersHash(), commitment.FailureUnknown); err != nil {
 			panic(fmt.Sprintf("compute create commitment failed: %+v", err))
 		}
 	default:
-		if err = cbc.createCommitment(b.identity, b.rak, b.executorCommittee.EncodedMembersHash(), commitment.FailureNone); err != nil {
+		if err = cbc.createCommitment(b.identity, defaultRuntimeID, b.rak, b.executorCommittee.EncodedMembersHash(), commitment.FailureNone); err != nil {
 			panic(fmt.Sprintf("compute create commitment failed: %+v", err))
 		}
 

--- a/go/oasis-node/cmd/debug/byzantine/node.go
+++ b/go/oasis-node/cmd/debug/byzantine/node.go
@@ -8,12 +8,13 @@ import (
 	"github.com/spf13/viper"
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
+	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
-	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
+	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
@@ -31,6 +32,7 @@ type byzantine struct {
 	storageClients []*storageClient
 	gRPC           *externalGrpc
 
+	runtimeID    common.Namespace
 	capabilities *node.Capabilities
 	rak          signature.Signer
 
@@ -60,7 +62,7 @@ func (b *byzantine) receiveAndScheduleTransactions(ctx context.Context, cbc *com
 	logger.Debug("executor: received transactions", "transactions", txs)
 	// Get latest roothash block.
 	var block *block.Block
-	block, err := getRoothashLatestBlock(ctx, b.tendermint.service, defaultRuntimeID)
+	block, err := getRoothashLatestBlock(ctx, b.tendermint.service, b.runtimeID)
 	if err != nil {
 		return false, fmt.Errorf("failed getting latest roothash block: %w", err)
 	}
@@ -75,10 +77,10 @@ func (b *byzantine) receiveAndScheduleTransactions(ctx context.Context, cbc *com
 	if mode == ModeExecutorFailureIndicating {
 		// Submit failure indicating commitment and stop.
 		logger.Debug("executor failure indicating: submitting commitment and stopping")
-		if err = cbc.createCommitment(b.identity, defaultRuntimeID, nil, b.executorCommittee.EncodedMembersHash(), commitment.FailureStorageUnavailable); err != nil {
+		if err = cbc.createCommitment(b.identity, nil, b.executorCommittee.EncodedMembersHash(), commitment.FailureStorageUnavailable); err != nil {
 			panic(fmt.Sprintf("compute create failure indicating commitment failed: %+v", err))
 		}
-		if err = cbc.publishToChain(b.tendermint.service, b.identity, defaultRuntimeID); err != nil {
+		if err = cbc.publishToChain(b.tendermint.service, b.identity); err != nil {
 			panic(fmt.Sprintf("compute publish to chain failed: %+v", err))
 		}
 		return false, nil
@@ -93,6 +95,7 @@ func (b *byzantine) receiveAndScheduleTransactions(ctx context.Context, cbc *com
 }
 
 func initializeAndRegisterByzantineNode(
+	runtimeID common.Namespace,
 	nodeRoles node.RolesMask,
 	expectedStorageRole scheduler.Role,
 	expectedExecutorRole scheduler.Role,
@@ -101,29 +104,30 @@ func initializeAndRegisterByzantineNode(
 ) (*byzantine, error) {
 	var err error
 	b := &byzantine{
-		logger: logging.GetLogger("cmd/byzantine/node"),
+		logger:    logging.GetLogger("cmd/byzantine/node"),
+		runtimeID: runtimeID,
 	}
 
 	// Initialize.
-	if err = common.Init(); err != nil {
-		common.EarlyLogAndExit(err)
+	if err = cmdCommon.Init(); err != nil {
+		cmdCommon.EarlyLogAndExit(err)
 	}
 
 	// Setup identity.
-	b.identity, err = initDefaultIdentity(common.DataDir())
+	b.identity, err = initDefaultIdentity(cmdCommon.DataDir())
 	if err != nil {
 		return nil, fmt.Errorf("init default identity failed: %w", err)
 	}
 
 	// Setup tendermint.
 	b.tendermint = newHonestTendermint()
-	if err = b.tendermint.start(b.identity, common.DataDir()); err != nil {
+	if err = b.tendermint.start(b.identity, cmdCommon.DataDir()); err != nil {
 		return nil, fmt.Errorf("node tendermint start failed: %w", err)
 	}
 
 	// Setup P2P.
 	b.p2p = newP2PHandle()
-	if err = b.p2p.start(b.tendermint, b.identity, defaultRuntimeID); err != nil {
+	if err = b.p2p.start(b.tendermint, b.identity, b.runtimeID); err != nil {
 		return nil, fmt.Errorf("P2P start failed: %w", err)
 	}
 
@@ -134,7 +138,7 @@ func initializeAndRegisterByzantineNode(
 	}
 
 	// Setup storage.
-	storage, err := newStorageNode(b.identity, defaultRuntimeID, common.DataDir())
+	storage, err := newStorageNode(b.identity, b.runtimeID, cmdCommon.DataDir())
 	if err != nil {
 		return nil, fmt.Errorf("initializing storage node failed: %w", err)
 	}
@@ -156,7 +160,7 @@ func initializeAndRegisterByzantineNode(
 			return nil, fmt.Errorf("initFakeCapabilitiesSGX: %w", err)
 		}
 	}
-	if err = registryRegisterNode(b.tendermint.service, b.identity, common.DataDir(), getGrpcAddress(), b.p2p.service.Addresses(), defaultRuntimeID, b.capabilities, nodeRoles); err != nil {
+	if err = registryRegisterNode(b.tendermint.service, b.identity, cmdCommon.DataDir(), getGrpcAddress(), b.p2p.service.Addresses(), b.runtimeID, b.capabilities, nodeRoles); err != nil {
 		return nil, fmt.Errorf("registryRegisterNode: %w", err)
 	}
 
@@ -172,7 +176,7 @@ func initializeAndRegisterByzantineNode(
 	}
 
 	// Ensure we have the expected executor worker role.
-	b.executorCommittee, err = schedulerGetCommittee(b.tendermint, b.electionHeight, scheduler.KindComputeExecutor, defaultRuntimeID)
+	b.executorCommittee, err = schedulerGetCommittee(b.tendermint, b.electionHeight, scheduler.KindComputeExecutor, b.runtimeID)
 	if err != nil {
 		return nil, fmt.Errorf("scheduler get committee %s at height %d failed: %w", scheduler.KindComputeExecutor, b.electionHeight, err)
 	}
@@ -190,7 +194,7 @@ func initializeAndRegisterByzantineNode(
 	b.logger.Debug("executor tx scheduler role ok")
 
 	// Ensure we have the expected storage worker role.
-	storageCommittee, err := schedulerGetCommittee(b.tendermint, b.electionHeight, scheduler.KindStorage, defaultRuntimeID)
+	storageCommittee, err := schedulerGetCommittee(b.tendermint, b.electionHeight, scheduler.KindStorage, b.runtimeID)
 	if err != nil {
 		return nil, fmt.Errorf("scheduler get committee %s failed: %+v", scheduler.KindStorage, err)
 	}

--- a/go/oasis-node/cmd/debug/byzantine/node.go
+++ b/go/oasis-node/cmd/debug/byzantine/node.go
@@ -75,7 +75,7 @@ func (b *byzantine) receiveAndScheduleTransactions(ctx context.Context, cbc *com
 	if mode == ModeExecutorFailureIndicating {
 		// Submit failure indicating commitment and stop.
 		logger.Debug("executor failure indicating: submitting commitment and stopping")
-		if err = cbc.createCommitment(b.identity, nil, b.executorCommittee.EncodedMembersHash(), commitment.FailureStorageUnavailable); err != nil {
+		if err = cbc.createCommitment(b.identity, defaultRuntimeID, nil, b.executorCommittee.EncodedMembersHash(), commitment.FailureStorageUnavailable); err != nil {
 			panic(fmt.Sprintf("compute create failure indicating commitment failed: %+v", err))
 		}
 		if err = cbc.publishToChain(b.tendermint.service, b.identity, defaultRuntimeID); err != nil {

--- a/go/oasis-node/cmd/debug/byzantine/steps.go
+++ b/go/oasis-node/cmd/debug/byzantine/steps.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	fileSigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/file"
@@ -18,12 +17,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/sgx"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx/ias"
 )
-
-const (
-	defaultRuntimeIDHex = "8000000000000000000000000000000000000000000000000000000000000000"
-)
-
-var defaultRuntimeID common.Namespace
 
 func initDefaultIdentity(dataDir string) (*identity.Identity, error) {
 	signerFactory, err := fileSigner.NewFactory(dataDir, signature.SignerNode, signature.SignerP2P, signature.SignerEntity, signature.SignerConsensus)
@@ -99,10 +92,4 @@ func initFakeCapabilitiesSGX() (signature.Signer, *node.Capabilities, error) {
 	}
 
 	return fr, &fc, nil
-}
-
-func init() {
-	if err := defaultRuntimeID.UnmarshalHex(defaultRuntimeIDHex); err != nil {
-		panic(fmt.Sprintf("default runtime ID UnmarshalHex: %+v", err))
-	}
 }

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -587,6 +587,11 @@ func (args *argBuilder) byzantineActivationEpoch(epoch beacon.EpochTime) *argBui
 	return args
 }
 
+func (args *argBuilder) byzantineRuntimeID(runtimeID common.Namespace) *argBuilder {
+	args.vec = append(args.vec, "--"+byzantine.CfgRuntimeID, runtimeID.String())
+	return args
+}
+
 func newArgBuilder() *argBuilder {
 	return &argBuilder{}
 }

--- a/go/oasis-test-runner/oasis/byzantine.go
+++ b/go/oasis-test-runner/oasis/byzantine.go
@@ -17,6 +17,7 @@ type Byzantine struct {
 
 	entity *Entity
 
+	runtime         int
 	consensusPort   uint16
 	p2pPort         uint16
 	activationEpoch beacon.EpochTime
@@ -33,6 +34,7 @@ type ByzantineCfg struct {
 	Entity       *Entity
 
 	ActivationEpoch beacon.EpochTime
+	Runtime         int
 }
 
 func (worker *Byzantine) startNode() error {
@@ -48,6 +50,9 @@ func (worker *Byzantine) startNode() error {
 		appendEntity(worker.entity).
 		byzantineActivationEpoch(worker.activationEpoch)
 
+	if worker.runtime > 0 {
+		args.byzantineRuntimeID(worker.net.runtimes[worker.runtime].id)
+	}
 	for _, v := range worker.net.Runtimes() {
 		if v.kind == registry.KindCompute && v.teeHardware == node.TEEHardwareIntelSGX {
 			args = args.byzantineFakeSGX()
@@ -111,6 +116,7 @@ func (net *Network) NewByzantine(cfg *ByzantineCfg) (*Byzantine, error) {
 		consensusPort:   net.nextNodePort,
 		p2pPort:         net.nextNodePort + 1,
 		activationEpoch: cfg.ActivationEpoch,
+		runtime:         cfg.Runtime,
 	}
 	worker.doStartNode = worker.startNode
 	copy(worker.NodeID[:], nodeKey[:])

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -499,6 +499,7 @@ type ByzantineFixture struct { // nolint: maligned
 	Entity       int    `json:"entity"`
 
 	ActivationEpoch beacon.EpochTime `json:"activation_epoch"`
+	Runtime         int              `json:"runtime"`
 
 	// Consensus contains configuration for the consensus backend.
 	Consensus ConsensusFixture `json:"consensus"`
@@ -525,6 +526,7 @@ func (f *ByzantineFixture) Create(net *Network) (*Byzantine, error) {
 		IdentitySeed:    f.IdentitySeed,
 		Entity:          entity,
 		ActivationEpoch: f.ActivationEpoch,
+		Runtime:         f.Runtime,
 	})
 }
 

--- a/go/oasis-test-runner/scenario/e2e/byzantine_beacon.go
+++ b/go/oasis-test-runner/scenario/e2e/byzantine_beacon.go
@@ -76,6 +76,7 @@ func (sc *byzantineBeaconImpl) Fixture() (*oasis.NetworkFixture, error) {
 			IdentitySeed:    sc.identitySeed,
 			Entity:          1,
 			ActivationEpoch: 1,
+			Runtime:         -1,
 		},
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/byzantine.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/byzantine.go
@@ -321,6 +321,7 @@ func (sc *byzantineImpl) Fixture() (*oasis.NetworkFixture, error) {
 			IdentitySeed:    sc.identitySeed,
 			Entity:          2,
 			ActivationEpoch: 1,
+			Runtime:         1,
 		},
 	}
 	return f, nil

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -193,9 +193,9 @@ func (ev *Evidence) ValidateBasic() error {
 	case ev.EquivocationExecutor != nil && ev.EquivocationBatch != nil:
 		return fmt.Errorf("evidence has multiple fields set")
 	case ev.EquivocationExecutor != nil:
-		return ev.EquivocationExecutor.ValidateBasic()
+		return ev.EquivocationExecutor.ValidateBasic(ev.ID)
 	case ev.EquivocationBatch != nil:
-		return ev.EquivocationBatch.ValidateBasic()
+		return ev.EquivocationBatch.ValidateBasic(ev.ID)
 	default:
 		return fmt.Errorf("evidence content has no fields set")
 	}
@@ -210,7 +210,7 @@ type EquivocationExecutorEvidence struct {
 // ValidateBasic performs stateless executor evidence validation checks.
 //
 // Particularly evidence is not verified to not be expired as this requires stateful checks.
-func (ev *EquivocationExecutorEvidence) ValidateBasic() error {
+func (ev *EquivocationExecutorEvidence) ValidateBasic(id common.Namespace) error {
 	if ev.CommitA.Equal(&ev.CommitB) {
 		return fmt.Errorf("commits are equal, no sign of equivocation")
 	}
@@ -219,11 +219,11 @@ func (ev *EquivocationExecutorEvidence) ValidateBasic() error {
 		return fmt.Errorf("equivocation executor evidence signature public keys don't match")
 	}
 
-	a, err := ev.CommitA.Open()
+	a, err := ev.CommitA.Open(id)
 	if err != nil {
 		return fmt.Errorf("opening CommitA: %w", err)
 	}
-	b, err := ev.CommitB.Open()
+	b, err := ev.CommitB.Open(id)
 	if err != nil {
 		return fmt.Errorf("opening CommitB: %w", err)
 	}
@@ -266,7 +266,7 @@ type EquivocationBatchEvidence struct {
 // ValidateBasic performs stateless batch evidence validation checks.
 //
 // Particularly evidence is not verified to not be expired as this requires stateful checks.
-func (ev *EquivocationBatchEvidence) ValidateBasic() error {
+func (ev *EquivocationBatchEvidence) ValidateBasic(id common.Namespace) error {
 	if ev.BatchA.Equal(&ev.BatchB) {
 		return fmt.Errorf("batches are equal, no sign of equivocation")
 	}
@@ -276,10 +276,10 @@ func (ev *EquivocationBatchEvidence) ValidateBasic() error {
 	}
 
 	var a, b commitment.ProposedBatch
-	if err := ev.BatchA.Open(&a); err != nil {
+	if err := ev.BatchA.Open(&a, id); err != nil {
 		return fmt.Errorf("opening BatchA: %w", err)
 	}
-	if err := ev.BatchB.Open(&b); err != nil {
+	if err := ev.BatchB.Open(&b, id); err != nil {
 		return fmt.Errorf("opening BatchB: %w", err)
 	}
 

--- a/go/roothash/api/api_test.go
+++ b/go/roothash/api/api_test.go
@@ -37,9 +37,9 @@ func TestEvidenceHash(t *testing.T) {
 		StorageSignatures: []signature.Signature{},
 		Header:            blk.Header,
 	}
-	signedBatch1, err := commitment.SignProposedBatch(sk, batch1)
+	signedBatch1, err := commitment.SignProposedBatch(sk, runtimeID, batch1)
 	require.NoError(err, "SignProposedBatch")
-	signed2Batch1, err := commitment.SignProposedBatch(sk2, batch1)
+	signed2Batch1, err := commitment.SignProposedBatch(sk2, runtimeID, batch1)
 	require.NoError(err, "SignedProposedBatch")
 
 	batch2 := &commitment.ProposedBatch{
@@ -47,9 +47,9 @@ func TestEvidenceHash(t *testing.T) {
 		StorageSignatures: []signature.Signature{},
 		Header:            blk.Header,
 	}
-	signedBatch2, err := commitment.SignProposedBatch(sk, batch2)
+	signedBatch2, err := commitment.SignProposedBatch(sk, runtimeID, batch2)
 	require.NoError(err, "SignProposedBatch")
-	signed2Batch2, err := commitment.SignProposedBatch(sk2, batch2)
+	signed2Batch2, err := commitment.SignProposedBatch(sk2, runtimeID, batch2)
 	require.NoError(err, "SignedProposedBatch")
 
 	// Executor commit.
@@ -62,7 +62,7 @@ func TestEvidenceHash(t *testing.T) {
 			MessagesHash: &hash.Hash{},
 		},
 	}
-	signedCommitment1, err := commitment.SignExecutorCommitment(sk, &body)
+	signedCommitment1, err := commitment.SignExecutorCommitment(sk, runtimeID, &body)
 	require.NoError(err, "SignExecutorCommitment")
 
 	ev = Evidence{
@@ -114,7 +114,7 @@ func TestEvidenceValidateBasic(t *testing.T) {
 		StorageSignatures: []signature.Signature{},
 		Header:            rtBlk.Header,
 	}
-	signedB1, err := commitment.SignProposedBatch(sk, rtBatch1)
+	signedB1, err := commitment.SignProposedBatch(sk, rtID, rtBatch1)
 	require.NoError(err, "SignProposedBatch")
 
 	rtBatch2 := &commitment.ProposedBatch{
@@ -122,7 +122,7 @@ func TestEvidenceValidateBasic(t *testing.T) {
 		StorageSignatures: []signature.Signature{},
 		Header:            rtBlk.Header,
 	}
-	signedB2, err := commitment.SignProposedBatch(sk, rtBatch2)
+	signedB2, err := commitment.SignProposedBatch(sk, rtID, rtBatch2)
 	require.NoError(err, "SignProposedBatch")
 
 	body := commitment.ComputeBody{
@@ -134,11 +134,11 @@ func TestEvidenceValidateBasic(t *testing.T) {
 			MessagesHash: &hash.Hash{},
 		},
 	}
-	signedCommitment1, err := commitment.SignExecutorCommitment(sk, &body)
+	signedCommitment1, err := commitment.SignExecutorCommitment(sk, rtID, &body)
 	require.NoError(err, "SignExecutorCommitment")
 
 	body.Header.PreviousHash = hash.NewFromBytes([]byte("invalid hash"))
-	signedCommitment2, err := commitment.SignExecutorCommitment(sk, &body)
+	signedCommitment2, err := commitment.SignExecutorCommitment(sk, rtID, &body)
 	require.NoError(err, "SignExecutorCommitment")
 
 	for _, ev := range []struct {
@@ -225,7 +225,7 @@ func TestEquivocationBatchEvidenceValidateBasic(t *testing.T) {
 		StorageSignatures: []signature.Signature{},
 		Header:            rt1Blk1.Header,
 	}
-	signedR1B1, err := commitment.SignProposedBatch(sk, rt1Batch1)
+	signedR1B1, err := commitment.SignProposedBatch(sk, rt1ID, rt1Batch1)
 	require.NoError(err, "SignProposedBatch")
 
 	rt1Batch2 := &commitment.ProposedBatch{
@@ -233,7 +233,7 @@ func TestEquivocationBatchEvidenceValidateBasic(t *testing.T) {
 		StorageSignatures: []signature.Signature{}, // Same storage signatures.
 		Header:            rt1Blk2.Header,          // Different header.
 	}
-	signedR1B2, err := commitment.SignProposedBatch(sk, rt1Batch2)
+	signedR1B2, err := commitment.SignProposedBatch(sk, rt1ID, rt1Batch2)
 	require.NoError(err, "SignProposedBatch")
 
 	rt1Batch3 := &commitment.ProposedBatch{
@@ -241,7 +241,7 @@ func TestEquivocationBatchEvidenceValidateBasic(t *testing.T) {
 		StorageSignatures: []signature.Signature{},                   // Same storage signatures.
 		Header:            rt1Blk1.Header,                            // Same header.
 	}
-	signedR1B3, err := commitment.SignProposedBatch(sk, rt1Batch3)
+	signedR1B3, err := commitment.SignProposedBatch(sk, rt1ID, rt1Batch3)
 	require.NoError(err, "SignProposedBatch")
 
 	rt1Batch4 := &commitment.ProposedBatch{
@@ -249,7 +249,7 @@ func TestEquivocationBatchEvidenceValidateBasic(t *testing.T) {
 		StorageSignatures: []signature.Signature{{}}, // Different storage signatures.
 		Header:            rt1Batch1.Header,          // Same header.
 	}
-	signedR1B4, err := commitment.SignProposedBatch(sk, rt1Batch4)
+	signedR1B4, err := commitment.SignProposedBatch(sk, rt1ID, rt1Batch4)
 	require.NoError(err, "SignProposedBatch")
 
 	rt1Batch5 := &commitment.ProposedBatch{
@@ -257,10 +257,10 @@ func TestEquivocationBatchEvidenceValidateBasic(t *testing.T) {
 		StorageSignatures: []signature.Signature{}, // Same storage signatures.
 		Header:            rt1Blk3.Header,          // Different header for same round.
 	}
-	signedR1B5, err := commitment.SignProposedBatch(sk, rt1Batch5)
+	signedR1B5, err := commitment.SignProposedBatch(sk, rt1ID, rt1Batch5)
 	require.NoError(err, "SignProposedBatch")
 
-	signed2R1B3, err := commitment.SignProposedBatch(sk2, rt1Batch3)
+	signed2R1B3, err := commitment.SignProposedBatch(sk2, rt1ID, rt1Batch3)
 	require.NoError(err, "SignProposedBatch")
 
 	rt2Batch1 := &commitment.ProposedBatch{
@@ -268,20 +268,23 @@ func TestEquivocationBatchEvidenceValidateBasic(t *testing.T) {
 		StorageSignatures: []signature.Signature{},
 		Header:            rt2Blk2.Header,
 	}
-	signedR2B1, err := commitment.SignProposedBatch(sk, rt2Batch1)
+	signedR2B1, err := commitment.SignProposedBatch(sk, rt2ID, rt2Batch1)
 	require.NoError(err, "SignProposedBatch")
 
 	for _, ev := range []struct {
+		rtID      common.Namespace
 		ev        EquivocationBatchEvidence
 		shouldErr bool
 		msg       string
 	}{
 		{
+			rt1ID,
 			EquivocationBatchEvidence{},
 			true,
 			"empty evidence should error",
 		},
 		{
+			rt1ID,
 			EquivocationBatchEvidence{
 				BatchA: *signedR1B1,
 			},
@@ -289,6 +292,7 @@ func TestEquivocationBatchEvidenceValidateBasic(t *testing.T) {
 			"empty evidence should error",
 		},
 		{
+			rt1ID,
 			EquivocationBatchEvidence{
 				BatchB: *signedR1B1,
 			},
@@ -296,6 +300,7 @@ func TestEquivocationBatchEvidenceValidateBasic(t *testing.T) {
 			"empty evidence should error",
 		},
 		{
+			rt1ID,
 			EquivocationBatchEvidence{
 				BatchA: *signedR1B1,
 				BatchB: *signedR1B1,
@@ -304,6 +309,7 @@ func TestEquivocationBatchEvidenceValidateBasic(t *testing.T) {
 			"same signed batch is not valid evidence",
 		},
 		{
+			rt1ID,
 			EquivocationBatchEvidence{
 				BatchA: *signedR1B1,
 				BatchB: *signedR1B2,
@@ -312,6 +318,7 @@ func TestEquivocationBatchEvidenceValidateBasic(t *testing.T) {
 			"signed batches for different heights is not valid evidence",
 		},
 		{
+			rt1ID,
 			EquivocationBatchEvidence{
 				BatchA: *signedR1B1,
 				BatchB: *signedR2B1,
@@ -320,6 +327,7 @@ func TestEquivocationBatchEvidenceValidateBasic(t *testing.T) {
 			"signed batches for different runtimes is not valid evidence",
 		},
 		{
+			rt1ID,
 			EquivocationBatchEvidence{
 				BatchA: *signedR1B1,
 				BatchB: *signedR1B3,
@@ -328,6 +336,7 @@ func TestEquivocationBatchEvidenceValidateBasic(t *testing.T) {
 			"same round different IORoot is valid evidence",
 		},
 		{
+			rt1ID,
 			EquivocationBatchEvidence{
 				BatchA: *signedR1B1,
 				BatchB: *signed2R1B3,
@@ -336,6 +345,7 @@ func TestEquivocationBatchEvidenceValidateBasic(t *testing.T) {
 			"different signer is not valid evidence",
 		},
 		{
+			rt1ID,
 			EquivocationBatchEvidence{
 				BatchA: *signedR1B1,
 				BatchB: *signedR1B4,
@@ -344,6 +354,7 @@ func TestEquivocationBatchEvidenceValidateBasic(t *testing.T) {
 			"same round, io root and same header is not valid evidence",
 		},
 		{
+			rt1ID,
 			EquivocationBatchEvidence{
 				BatchA: *signedR1B1,
 				BatchB: *signedR1B5,
@@ -351,8 +362,17 @@ func TestEquivocationBatchEvidenceValidateBasic(t *testing.T) {
 			false,
 			"same round and io root but different header is valid evidence",
 		},
+		{
+			rt2ID,
+			EquivocationBatchEvidence{
+				BatchA: *signedR1B1,
+				BatchB: *signedR1B5,
+			},
+			true,
+			"valid evidence for wrong runtime is invalid",
+		},
 	} {
-		err := ev.ev.ValidateBasic()
+		err := ev.ev.ValidateBasic(ev.rtID)
 		switch ev.shouldErr {
 		case true:
 			require.Error(err, ev.msg)
@@ -376,6 +396,7 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 	rt1ID := common.NewTestNamespaceFromSeed([]byte("roothash/api_test: runtime1"), 0)
 	rt1Blk1 := block.NewGenesisBlock(rt1ID, 0)
 	rt1Blk2 := block.NewEmptyBlock(rt1Blk1, 0, block.Normal)
+	rt2ID := common.NewTestNamespaceFromSeed([]byte("roothash/api_test: runtime2"), 0)
 
 	body := commitment.ComputeBody{
 		Header: commitment.ComputeResultsHeader{
@@ -386,9 +407,9 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 			MessagesHash: &hash.Hash{},
 		},
 	}
-	signed1Commitment, err := commitment.SignExecutorCommitment(sk, &body)
+	signed1Commitment, err := commitment.SignExecutorCommitment(sk, rt1ID, &body)
 	require.NoError(err, "SignExecutorCommitment")
-	signed2Commitment, err := commitment.SignExecutorCommitment(sk2, &body)
+	signed2Commitment, err := commitment.SignExecutorCommitment(sk2, rt1ID, &body)
 	require.NoError(err, "SignExecutorCommitment")
 
 	body2 := commitment.ComputeBody{
@@ -400,7 +421,7 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 			MessagesHash: &hash.Hash{},
 		},
 	}
-	signed1Commitment2, err := commitment.SignExecutorCommitment(sk, &body2)
+	signed1Commitment2, err := commitment.SignExecutorCommitment(sk, rt1ID, &body2)
 	require.NoError(err, "SignExecutorCommitment")
 
 	// Different round.
@@ -413,7 +434,7 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 			MessagesHash: &hash.Hash{},
 		},
 	}
-	signed1Commitment3, err := commitment.SignExecutorCommitment(sk, &body3)
+	signed1Commitment3, err := commitment.SignExecutorCommitment(sk, rt1ID, &body3)
 	require.NoError(err, "SignExecutorCommitment")
 
 	// Invalid.
@@ -426,31 +447,34 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 			MessagesHash: nil,
 		},
 	}
-	signed1Invalid, err := commitment.SignExecutorCommitment(sk, &invalidBody)
+	signed1Invalid, err := commitment.SignExecutorCommitment(sk, rt1ID, &invalidBody)
 	require.NoError(err, "SignExecutorCommitment")
 
 	// Failure indicating.
 	failureBody1 := body
 	failureBody1.SetFailure(commitment.FailureStorageUnavailable)
-	signedFailure1, err := commitment.SignExecutorCommitment(sk, &failureBody1)
+	signedFailure1, err := commitment.SignExecutorCommitment(sk, rt1ID, &failureBody1)
 	require.NoError(err, "SignExecutorCommitment")
 
 	failureBody2 := body
 	failureBody2.SetFailure(commitment.FailureUnknown)
-	signedFailure2, err := commitment.SignExecutorCommitment(sk, &failureBody2)
+	signedFailure2, err := commitment.SignExecutorCommitment(sk, rt1ID, &failureBody2)
 	require.NoError(err, "SignExecutorCommitment")
 
 	for _, ev := range []struct {
+		rtID      common.Namespace
 		ev        EquivocationExecutorEvidence
 		shouldErr bool
 		msg       string
 	}{
 		{
+			rt1ID,
 			EquivocationExecutorEvidence{},
 			true,
 			"empty evidence should error",
 		},
 		{
+			rt1ID,
 			EquivocationExecutorEvidence{
 				CommitA: *signed1Commitment,
 			},
@@ -458,6 +482,7 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 			"empty evidence should error",
 		},
 		{
+			rt1ID,
 			EquivocationExecutorEvidence{
 				CommitB: *signed1Commitment,
 			},
@@ -465,6 +490,7 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 			"empty evidence should error",
 		},
 		{
+			rt1ID,
 			EquivocationExecutorEvidence{
 				CommitA: *signed1Commitment,
 				CommitB: *signed1Commitment,
@@ -473,6 +499,7 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 			"same signed commitment is not valid evidence",
 		},
 		{
+			rt1ID,
 			EquivocationExecutorEvidence{
 				CommitA: *signed1Commitment,
 				CommitB: *signed1Commitment3,
@@ -481,6 +508,7 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 			"signed commitments for different rounds is not valid evidence",
 		},
 		{
+			rt1ID,
 			EquivocationExecutorEvidence{
 				CommitA: *signed1Commitment,
 				CommitB: *signed1Invalid,
@@ -489,6 +517,7 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 			"non valid commitment is not valid evidence",
 		},
 		{
+			rt1ID,
 			EquivocationExecutorEvidence{
 				CommitA: *signed1Invalid,
 				CommitB: *signed1Commitment,
@@ -497,6 +526,7 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 			"non valid commitment not valid evidence",
 		},
 		{
+			rt1ID,
 			EquivocationExecutorEvidence{
 				CommitA: *signedFailure1,
 				CommitB: *signedFailure1,
@@ -505,6 +535,7 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 			"same failure indicating is not valid evidence",
 		},
 		{
+			rt1ID,
 			EquivocationExecutorEvidence{
 				CommitA: *signedFailure1,
 				CommitB: *signedFailure2,
@@ -513,6 +544,7 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 			"different failure indicating reason is valid evidence",
 		},
 		{
+			rt1ID,
 			EquivocationExecutorEvidence{
 				CommitA: *signed1Commitment,
 				CommitB: *signed2Commitment,
@@ -521,6 +553,7 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 			"different signer is not valid evidence",
 		},
 		{
+			rt1ID,
 			EquivocationExecutorEvidence{
 				CommitA: *signed1Commitment,
 				CommitB: *signed1Commitment2,
@@ -529,6 +562,7 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 			"valid evidence",
 		},
 		{
+			rt1ID,
 			EquivocationExecutorEvidence{
 				CommitA: *signed1Commitment,
 				CommitB: *signedFailure1,
@@ -536,8 +570,17 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 			false,
 			"valid evidence",
 		},
+		{
+			rt2ID,
+			EquivocationExecutorEvidence{
+				CommitA: *signed1Commitment,
+				CommitB: *signedFailure1,
+			},
+			true,
+			"valid evidence for wrong runtime is invalid",
+		},
 	} {
-		err := ev.ev.ValidateBasic()
+		err := ev.ev.ValidateBasic(ev.rtID)
 		switch ev.shouldErr {
 		case true:
 			require.Error(err, ev.msg)

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -350,12 +350,12 @@ func (s *runtimeState) generateExecutorCommitments(t *testing.T, consensus conse
 		require.NotNil(schedulerNode, "TransactionScheduler missing in test nodes")
 
 		var signedDispatch *commitment.SignedProposedBatch
-		signedDispatch, err = commitment.SignProposedBatch(schedulerNode.Signer, dispatch)
+		signedDispatch, err = commitment.SignProposedBatch(schedulerNode.Signer, s.rt.Runtime.ID, dispatch)
 		require.NoError(err, "SignProposedBatch")
 		commitBody.TxnSchedSig = signedDispatch.Signature
 
 		// `err` shadows outside.
-		commit, err := commitment.SignExecutorCommitment(node.Signer, &commitBody) // nolint: vetshadow
+		commit, err := commitment.SignExecutorCommitment(node.Signer, s.rt.Runtime.ID, &commitBody) // nolint: vetshadow
 		require.NoError(err, "SignExecutorCommitment")
 
 		executorCommits = append(executorCommits, *commit)
@@ -844,7 +844,7 @@ func testSubmitEquivocationEvidence(t *testing.T, backend api.Backend, consensus
 		StorageSignatures: []signature.Signature{},
 		Header:            child.Header,
 	}
-	signedBatch1, err := commitment.SignProposedBatch(node.Signer, batch1)
+	signedBatch1, err := commitment.SignProposedBatch(node.Signer, s.rt.Runtime.ID, batch1)
 	require.NoError(err, "SignProposedBatch")
 
 	batch2 := &commitment.ProposedBatch{
@@ -852,7 +852,7 @@ func testSubmitEquivocationEvidence(t *testing.T, backend api.Backend, consensus
 		StorageSignatures: []signature.Signature{},
 		Header:            child.Header,
 	}
-	signedBatch2, err := commitment.SignProposedBatch(node.Signer, batch2)
+	signedBatch2, err := commitment.SignProposedBatch(node.Signer, s.rt.Runtime.ID, batch2)
 	require.NoError(err, "SignProposedBatch")
 
 	ch, sub, err := consensus.Staking().WatchEvents(ctx)

--- a/go/worker/common/committee/group.go
+++ b/go/worker/common/committee/group.go
@@ -208,10 +208,11 @@ func (e *EpochSnapshot) VerifyCommitteeSignatures(kind scheduler.CommitteeKind, 
 	return nil
 }
 
-// VerifyTxnSchedulerSignature verifies transaction scheduler signature.
+// VerifyTxnSchedulerSigner verifies that the given signature comes from
+// the transaction scheduler at provided round.
 //
 // Implements commitment.SignatureVerifier.
-func (e *EpochSnapshot) VerifyTxnSchedulerSignature(sig signature.Signature, round uint64) error {
+func (e *EpochSnapshot) VerifyTxnSchedulerSigner(sig signature.Signature, round uint64) error {
 	if e.executorCommittee == nil || e.executorCommittee.Committee == nil {
 		return fmt.Errorf("epoch: no active transaction scheduler")
 	}


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/3643