### PR TITLE
Add AddEscrow and ReclaimEscrow runtime messages

### DIFF
--- a/.changelog/3641.breaking.md
+++ b/.changelog/3641.breaking.md
@@ -1,0 +1,4 @@
+runtimes: Support for Add/ReclaimEscrow runtime messages
+
+Escrow runtime messages need to be explicitly enabled via the
+`AllowEscrowMessages` consensus parameter.

--- a/.changelog/3717.breaking.md
+++ b/.changelog/3717.breaking.md
@@ -1,0 +1,5 @@
+go/staking/state: Remove nonce as the debonding delegations disambiguator
+
+Account nonce is removed from the debonding delegations state key. Instead
+if there are multiple debonding delegations for the same account and debond
+end epoch, those get merged into a single debonding delegation record.

--- a/go/consensus/tendermint/api/context_test.go
+++ b/go/consensus/tendermint/api/context_test.go
@@ -140,4 +140,9 @@ func TestChildContext(t *testing.T) {
 	child.EmitEvent(NewEventBuilder("test").Attribute([]byte("foo"), []byte("bar")))
 	child.Close()
 	require.Empty(ctx.GetEvents(), "events should not propagate in simulation mode")
+
+	child = ctx.WithMessageExecution()
+	require.True(child.IsMessageExecution(), "child should have message execution enabled")
+	require.False(ctx.IsMessageExecution(), "parent should not have message execution enabled")
+	child.Close()
 }

--- a/go/consensus/tendermint/apps/roothash/messages.go
+++ b/go/consensus/tendermint/apps/roothash/messages.go
@@ -15,6 +15,8 @@ func (app *rootHashApplication) processRuntimeMessages(
 	rtState *roothash.RuntimeState,
 	msgs []message.Message,
 ) error {
+	ctx = ctx.WithMessageExecution()
+	defer ctx.Close()
 	ctx = ctx.WithCallerAddress(staking.NewRuntimeAddress(rtState.Runtime.ID))
 	defer ctx.Close()
 

--- a/go/consensus/tendermint/apps/staking/genesis.go
+++ b/go/consensus/tendermint/apps/staking/genesis.go
@@ -259,7 +259,7 @@ func (app *stakingApplication) initDebondingDelegations(ctx *abciAPI.Context, st
 					)
 				}
 
-				if err := state.SetDebondingDelegation(ctx, delegatorAddr, escrowAddr, uint64(idx), delegation); err != nil {
+				if err := state.SetDebondingDelegation(ctx, delegatorAddr, escrowAddr, delegation.DebondEndTime, delegation); err != nil {
 					return fmt.Errorf("tendermint/staking: failed to set debonding delegation to %s from %s index %d: %w",
 						escrowAddr, delegatorAddr, idx, err,
 					)

--- a/go/consensus/tendermint/apps/staking/staking.go
+++ b/go/consensus/tendermint/apps/staking/staking.go
@@ -253,10 +253,10 @@ func (app *stakingApplication) onEpochChange(ctx *api.Context, epoch beacon.Epoc
 		}
 
 		// Update state.
-		if err = state.RemoveFromDebondingQueue(ctx, e.Epoch, e.DelegatorAddr, e.EscrowAddr, e.Seq); err != nil {
+		if err = state.RemoveFromDebondingQueue(ctx, e.Epoch, e.DelegatorAddr, e.EscrowAddr); err != nil {
 			return fmt.Errorf("failed to remove from debonding queue: %w", err)
 		}
-		if err = state.SetDebondingDelegation(ctx, e.DelegatorAddr, e.EscrowAddr, e.Seq, nil); err != nil {
+		if err = state.SetDebondingDelegation(ctx, e.DelegatorAddr, e.EscrowAddr, e.Delegation.DebondEndTime, nil); err != nil {
 			return fmt.Errorf("failed to set debonding delegation: %w", err)
 		}
 		if err = state.SetAccount(ctx, e.DelegatorAddr, delegator); err != nil {

--- a/go/consensus/tendermint/apps/staking/staking.go
+++ b/go/consensus/tendermint/apps/staking/staking.go
@@ -120,6 +120,10 @@ func (app *stakingApplication) ExecuteMessage(ctx *api.Context, kind, msg interf
 			return app.transfer(ctx, state, m.Transfer)
 		case m.Withdraw != nil:
 			return app.withdraw(ctx, state, m.Withdraw)
+		case m.AddEscrow != nil:
+			return app.addEscrow(ctx, state, m.AddEscrow)
+		case m.ReclaimEscrow != nil:
+			return app.reclaimEscrow(ctx, state, m.ReclaimEscrow)
 		default:
 			return staking.ErrInvalidArgument
 		}

--- a/go/consensus/tendermint/apps/staking/transactions.go
+++ b/go/consensus/tendermint/apps/staking/transactions.go
@@ -383,8 +383,9 @@ func (app *stakingApplication) reclaimEscrow(ctx *api.Context, state *stakingSta
 		return staking.ErrInvalidArgument
 	}
 
-	// Include the nonce as the final disambiguator to prevent overwriting debonding delegations.
-	if err = state.SetDebondingDelegation(ctx, toAddr, reclaim.Account, to.General.Nonce, &deb); err != nil {
+	// Include the end time epoch as the disambiguator. If a debonding delegation for the same account
+	// and end time already exists, the delegations will be merged.
+	if err = state.SetDebondingDelegation(ctx, toAddr, reclaim.Account, deb.DebondEndTime, &deb); err != nil {
 		return fmt.Errorf("failed to set debonding delegation: %w", err)
 	}
 

--- a/go/consensus/tendermint/apps/staking/transactions.go
+++ b/go/consensus/tendermint/apps/staking/transactions.go
@@ -185,6 +185,11 @@ func (app *stakingApplication) addEscrow(ctx *api.Context, state *stakingState.M
 		return err
 	}
 
+	// Check if escrow messages are allowed.
+	if ctx.IsMessageExecution() && !params.AllowEscrowMessages {
+		return staking.ErrForbidden
+	}
+
 	// Return early for simulation as we only need gas accounting.
 	if ctx.IsSimulation() {
 		return nil
@@ -285,6 +290,11 @@ func (app *stakingApplication) reclaimEscrow(ctx *api.Context, state *stakingSta
 	}
 	if err = ctx.Gas().UseGas(1, staking.GasOpReclaimEscrow, params.GasCosts); err != nil {
 		return err
+	}
+
+	// Check if escrow messages are allowed.
+	if ctx.IsMessageExecution() && !params.AllowEscrowMessages {
+		return staking.ErrForbidden
 	}
 
 	// Return early for simulation as we only need gas accounting.

--- a/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
@@ -38,8 +38,9 @@ import (
 )
 
 const (
-	timeLimitShort = 3 * time.Minute
-	timeLimitLong  = 12 * time.Hour
+	timeLimitShort    = 6 * time.Minute
+	timeLimitShortSGX = 3 * time.Minute
+	timeLimitLong     = 12 * time.Hour
 
 	nodeRestartIntervalLong = 2 * time.Minute
 	nodeLongRestartInterval = 15 * time.Minute
@@ -93,7 +94,7 @@ var TxSourceMultiShortSGX scenario.Scenario = &txSourceImpl{
 	allNodeWorkloads: []string{
 		workload.NameQueries,
 	},
-	timeLimit:                         timeLimitShort,
+	timeLimit:                         timeLimitShortSGX,
 	livenessCheckInterval:             livenessCheckInterval,
 	consensusPruneDisabledProbability: 0.1,
 	consensusPruneMinKept:             100,
@@ -264,6 +265,7 @@ func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
 			FeeSplitWeightPropose:     *quantity.NewFromUint64(2),
 			FeeSplitWeightVote:        *quantity.NewFromUint64(1),
 			FeeSplitWeightNextPropose: *quantity.NewFromUint64(1),
+			AllowEscrowMessages:       true,
 		},
 		TotalSupply: *quantity.NewFromUint64(150000000400),
 		Ledger: map[staking.Address]*staking.Account{

--- a/go/roothash/api/message/message.go
+++ b/go/roothash/api/message/message.go
@@ -42,20 +42,36 @@ func MessagesHash(msgs []Message) (h hash.Hash) {
 type StakingMessage struct {
 	cbor.Versioned
 
-	Transfer *staking.Transfer `json:"transfer,omitempty"`
-	Withdraw *staking.Withdraw `json:"withdraw,omitempty"`
+	Transfer      *staking.Transfer      `json:"transfer,omitempty"`
+	Withdraw      *staking.Withdraw      `json:"withdraw,omitempty"`
+	AddEscrow     *staking.Escrow        `json:"add_escrow,omitempty"`
+	ReclaimEscrow *staking.ReclaimEscrow `json:"reclaim_escrow,omitempty"`
 }
 
 // ValidateBasic performs basic validation of the runtime message.
 func (sm *StakingMessage) ValidateBasic() error {
-	switch {
-	case sm.Transfer != nil && sm.Withdraw != nil:
-		return fmt.Errorf("staking runtime message has multiple fields set")
-	case sm.Transfer != nil:
+	var setFields uint8
+	if sm.Transfer != nil {
 		// No validation at this time.
-		return nil
-	case sm.Withdraw != nil:
+		setFields++
+	}
+	if sm.Withdraw != nil {
 		// No validation at this time.
+		setFields++
+	}
+	if sm.AddEscrow != nil {
+		// No validation at this time.
+		setFields++
+	}
+	if sm.ReclaimEscrow != nil {
+		// No validation at this time.
+		setFields++
+	}
+	switch setFields {
+	case 0:
+		return fmt.Errorf("staking runtime message has no fields set")
+	case 1:
+		// Ok.
 		return nil
 	default:
 		return fmt.Errorf("staking runtime message has no fields set")

--- a/go/roothash/api/message/message_test.go
+++ b/go/roothash/api/message/message_test.go
@@ -32,6 +32,8 @@ func TestMessageHash(t *testing.T) {
 		{[]Message{}, "c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a"},
 		{[]Message{{Staking: &StakingMessage{Transfer: &staking.Transfer{}}}}, "a6b91f974b34a9192efd12025659a768520d2f04e1dae9839677456412cdb2be"},
 		{[]Message{{Staking: &StakingMessage{Withdraw: &staking.Withdraw{}}}}, "069b0fda76d804e3fd65d4bbd875c646f15798fb573ac613100df67f5ba4c3fd"},
+		{[]Message{{Staking: &StakingMessage{AddEscrow: &staking.Escrow{}}}}, "65049870b9dae657390e44065df0c78176816876e67b96dac7791ee6a1aa42e2"},
+		{[]Message{{Staking: &StakingMessage{ReclaimEscrow: &staking.ReclaimEscrow{}}}}, "c78547eae2f104268e49827cbe624cf2b350ee59e8d693dec0673a70a4664a2e"},
 		{[]Message{{Registry: &RegistryMessage{UpdateRuntime: &registry.Runtime{
 			AdmissionPolicy: registry.RuntimeAdmissionPolicy{
 				AnyNode: &registry.AnyNodeRuntimeAdmissionPolicy{},
@@ -58,6 +60,7 @@ func TestMessageValidateBasic(t *testing.T) {
 		{"NoFieldsSet", Message{}, false},
 		{"StakingNoFieldsSet", Message{Staking: &StakingMessage{}}, false},
 		{"StakingMultipleFieldsSet", Message{Staking: &StakingMessage{Transfer: &staking.Transfer{}, Withdraw: &staking.Withdraw{}}}, false},
+		{"StakingAllFieldsSet", Message{Staking: &StakingMessage{Transfer: &staking.Transfer{}, Withdraw: &staking.Withdraw{}, AddEscrow: &staking.Escrow{}, ReclaimEscrow: &staking.ReclaimEscrow{}}}, false},
 		{"ValidStaking", Message{Staking: &StakingMessage{Transfer: &staking.Transfer{}}}, true},
 		{"RegistryNoFieldsSet", Message{Registry: &RegistryMessage{}}, false},
 		{"RegistryInvalid", Message{Registry: &RegistryMessage{UpdateRuntime: nil}}, false},

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -991,6 +991,10 @@ type ConsensusParameters struct { // nolint: maligned
 	DisableDelegation      bool             `json:"disable_delegation,omitempty"`
 	UndisableTransfersFrom map[Address]bool `json:"undisable_transfers_from,omitempty"`
 
+	// AllowEscrowMessages can be used to allow runtimes to perform AddEscrow
+	// and ReclaimEscrow via runtime messages.
+	AllowEscrowMessages bool `json:"allow_escrow_messages,omitempty"`
+
 	// MaxAllowances is the maximum number of allowances an account can have. Zero means disabled.
 	MaxAllowances uint32 `json:"max_allowances,omitempty"`
 

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -943,6 +943,18 @@ type DebondingDelegation struct {
 	DebondEndTime beacon.EpochTime  `json:"debond_end"`
 }
 
+// Merge merges debonding delegations with same debond end time by summing
+// the shares amounts.
+func (d *DebondingDelegation) Merge(other DebondingDelegation) error {
+	if d.DebondEndTime != other.DebondEndTime {
+		return fmt.Errorf("cannot merge debonding delegations, end time doesn't match")
+	}
+	if err := d.Shares.Add(&other.Shares); err != nil {
+		return fmt.Errorf("error adding debonding delegation shares: %w", err)
+	}
+	return nil
+}
+
 // Genesis is the initial staking state for use in the genesis block.
 type Genesis struct {
 	// Parameters are the staking consensus parameters.

--- a/runtime/src/consensus/roothash.rs
+++ b/runtime/src/consensus/roothash.rs
@@ -91,6 +91,10 @@ pub enum StakingMessage {
     Transfer(staking::Transfer),
     #[serde(rename = "withdraw")]
     Withdraw(staking::Withdraw),
+    #[serde(rename = "add_escrow")]
+    AddEscrow(staking::Escrow),
+    #[serde(rename = "reclaim_escrow")]
+    ReclaimEscrow(staking::ReclaimEscrow),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -362,6 +366,20 @@ mod tests {
                     msg: StakingMessage::Withdraw(staking::Withdraw::default()),
                 }],
                 "069b0fda76d804e3fd65d4bbd875c646f15798fb573ac613100df67f5ba4c3fd",
+            ),
+            (
+                vec![Message::Staking {
+                    v: 0,
+                    msg: StakingMessage::AddEscrow(staking::Escrow::default()),
+                }],
+                "65049870b9dae657390e44065df0c78176816876e67b96dac7791ee6a1aa42e2",
+            ),
+            (
+                vec![Message::Staking {
+                    v: 0,
+                    msg: StakingMessage::ReclaimEscrow(staking::ReclaimEscrow::default()),
+                }],
+                "c78547eae2f104268e49827cbe624cf2b350ee59e8d693dec0673a70a4664a2e",
             ),
             (
                 vec![Message::Registry {

--- a/runtime/src/consensus/staking.rs
+++ b/runtime/src/consensus/staking.rs
@@ -23,6 +23,20 @@ pub struct Withdraw {
     pub amount: Quantity,
 }
 
+/// A stake escrow.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Escrow {
+    pub account: Address,
+    pub amount: Quantity,
+}
+
+/// A reclaim escrow.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ReclaimEscrow {
+    pub account: Address,
+    pub shares: Quantity,
+}
+
 /// Kind of staking threshold.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize_repr, Deserialize_repr)]
 #[repr(i32)]

--- a/tests/clients/simple-keyvalue-enc/src/main.rs
+++ b/tests/clients/simple-keyvalue-enc/src/main.rs
@@ -9,7 +9,9 @@ use tokio::runtime::Runtime;
 use oasis_core_client::{create_txn_api_client, Node, TxnClient};
 use oasis_core_keymanager_client::{self, KeyManagerClient, KeyPairId};
 use oasis_core_runtime::common::{crypto::hash::Hash, namespace::Namespace};
-use simple_keyvalue_api::{with_api, Key, KeyValue, Transfer, UpdateRuntime, Withdraw};
+use simple_keyvalue_api::{
+    with_api, AddEscrow, Key, KeyValue, ReclaimEscrow, Transfer, UpdateRuntime, Withdraw,
+};
 
 with_api! {
     create_txn_api_client!(SimpleKeyValueClient, api);

--- a/tests/clients/simple-keyvalue-ops/src/main.rs
+++ b/tests/clients/simple-keyvalue-ops/src/main.rs
@@ -7,7 +7,9 @@ use tokio::runtime::Runtime;
 
 use oasis_core_client::{create_txn_api_client, Node, TxnClient};
 use oasis_core_runtime::common::{crypto::hash::Hash, namespace::Namespace};
-use simple_keyvalue_api::{with_api, Key, KeyValue, Transfer, UpdateRuntime, Withdraw};
+use simple_keyvalue_api::{
+    with_api, AddEscrow, Key, KeyValue, ReclaimEscrow, Transfer, UpdateRuntime, Withdraw,
+};
 
 with_api! {
     create_txn_api_client!(KeyValueOpsClient, api);

--- a/tests/clients/simple-keyvalue/src/main.rs
+++ b/tests/clients/simple-keyvalue/src/main.rs
@@ -25,7 +25,9 @@ use oasis_core_runtime::{
     common::{crypto::hash::Hash, namespace::Namespace},
     storage::MKVS,
 };
-use simple_keyvalue_api::{with_api, Key, KeyValue, Transfer, UpdateRuntime, Withdraw};
+use simple_keyvalue_api::{
+    with_api, AddEscrow, Key, KeyValue, ReclaimEscrow, Transfer, UpdateRuntime, Withdraw,
+};
 
 with_api! {
     create_txn_api_client!(SimpleKeyValueClient, api);

--- a/tests/clients/test-long-term/src/main.rs
+++ b/tests/clients/test-long-term/src/main.rs
@@ -7,7 +7,9 @@ use tokio::runtime::Runtime;
 
 use oasis_core_client::{create_txn_api_client, Node, TxnClient};
 use oasis_core_runtime::common::{crypto::hash::Hash, namespace::Namespace};
-use simple_keyvalue_api::{with_api, Key, KeyValue, Transfer, UpdateRuntime, Withdraw};
+use simple_keyvalue_api::{
+    with_api, AddEscrow, Key, KeyValue, ReclaimEscrow, Transfer, UpdateRuntime, Withdraw,
+};
 
 with_api! {
     create_txn_api_client!(SimpleKeyValueClient, api);

--- a/tests/runtimes/simple-keyvalue/api/src/api.rs
+++ b/tests/runtimes/simple-keyvalue/api/src/api.rs
@@ -35,6 +35,18 @@ pub struct Transfer {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
+pub struct AddEscrow {
+    pub nonce: u64,
+    pub escrow: staking::Escrow,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ReclaimEscrow {
+    pub nonce: u64,
+    pub reclaim_escrow: staking::ReclaimEscrow,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
 pub struct UpdateRuntime {
     pub update_runtime: registry::Runtime,
     // Nonce is ignored by the runtime itself and can be used to avoid duplicate
@@ -51,6 +63,12 @@ runtime_api! {
 
     // Transfer from the runtime account to another account in the consensus layer.
     pub fn consensus_transfer(Transfer) -> ();
+
+    // Add escrow from the runtime account to an account in the consensus layer.
+    pub fn consensus_add_escrow(AddEscrow) -> ();
+
+    // Reclaim escrow to the runtime account.
+    pub fn consensus_reclaim_escrow(ReclaimEscrow) -> ();
 
     // Update existing runtime with given descriptor.
     pub fn update_runtime(UpdateRuntime) -> ();

--- a/tests/runtimes/simple-keyvalue/api/src/lib.rs
+++ b/tests/runtimes/simple-keyvalue/api/src/lib.rs
@@ -5,4 +5,4 @@ extern crate oasis_core_runtime;
 #[macro_use]
 mod api;
 
-pub use api::{Key, KeyValue, Transfer, UpdateRuntime, Withdraw};
+pub use api::{AddEscrow, Key, KeyValue, ReclaimEscrow, Transfer, UpdateRuntime, Withdraw};


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/3641

TODO:
- [x] add consensus parameter to disallow add/reclaim escrow messages
- [x] add add/reclaim escrow messages to runtime txsource workload
- [x] fix reclaim_escrow (it currently relies on account nonce updating (for debonding delegations), which doesn't happen on messages)