### PR TITLE
go/oasis-test-runner: configurable sanitychecker

### DIFF
--- a/.changelog/3719.internal.1.md
+++ b/.changelog/3719.internal.1.md
@@ -1,0 +1,4 @@
+go/oasis-test-runner: Configurable supplementary sanity checker
+
+Before the supplementary sanity checker was always automatically started on
+the validator-0.

--- a/.changelog/3719.internal.2.md
+++ b/.changelog/3719.internal.2.md
@@ -1,0 +1,3 @@
+go/oasis-test-runner: Add support for configuring `pprof`
+
+Adds support for configuring `pprof` on the test nodes.

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -78,7 +78,7 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 			{IsDebugTestEntity: true},
 		},
 		Validators: []oasis.ValidatorFixture{
-			{Entity: 1},
+			{Entity: 1, Consensus: oasis.ConsensusFixture{SupplementarySanityInterval: 1}},
 		},
 		Seeds: []oasis.SeedFixture{{}},
 	}

--- a/go/oasis-node/cmd/common/pprof/pprof.go
+++ b/go/oasis-node/cmd/common/pprof/pprof.go
@@ -18,7 +18,8 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/service"
 )
 
-const cfgPprofBind = "pprof.bind"
+// CfgPprofBind enables profiling endpoint at the given address.
+const CfgPprofBind = "pprof.bind"
 
 // Flags has the flags used by the pprof service.
 var Flags = flag.NewFlagSet("", flag.ContinueOnError)
@@ -118,7 +119,7 @@ func (p *pprofService) Cleanup() {
 
 // New constructs a new pprof service.
 func New(ctx context.Context) (service.BackgroundService, error) {
-	address := viper.GetString(cfgPprofBind)
+	address := viper.GetString(CfgPprofBind)
 
 	return &pprofService{
 		BaseBackgroundService: *service.NewBaseBackgroundService("pprof"),
@@ -129,7 +130,7 @@ func New(ctx context.Context) (service.BackgroundService, error) {
 }
 
 func init() {
-	Flags.String(cfgPprofBind, "", "enable profiling endpoint at given address")
+	Flags.String(CfgPprofBind, "", "enable profiling endpoint at given address")
 
 	_ = viper.BindPFlags(Flags)
 }

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -26,6 +26,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/grpc"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/metrics"
+	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/pprof"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/debug/byzantine"
 	runtimeClient "github.com/oasisprotocol/oasis-core/go/runtime/client"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
@@ -63,6 +64,16 @@ func (args *argBuilder) debugDontBlameOasis() *argBuilder {
 
 func (args *argBuilder) debugAllowTestKeys() *argBuilder {
 	args.vec = append(args.vec, "--"+cmdCommon.CfgDebugAllowTestKeys)
+	return args
+}
+
+func (args *argBuilder) debugEnableProfiling(port uint16) *argBuilder {
+	if port == 0 {
+		return args
+	}
+	args.vec = append(args.vec,
+		"--"+pprof.CfgPprofBind, "0.0.0.0:"+strconv.Itoa(int(port)),
+	)
 	return args
 }
 

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -208,11 +208,13 @@ func (args *argBuilder) runtimeSupported(id common.Namespace) *argBuilder {
 	return args
 }
 
-func (args *argBuilder) tendermintSupplementarySanityEnabled() *argBuilder {
-	args.vec = append(args.vec, "--"+tendermintFull.CfgSupplementarySanityEnabled)
-	args.vec = append(args.vec, []string{
-		"--" + tendermintFull.CfgSupplementarySanityInterval, "1",
-	}...)
+func (args *argBuilder) tendermintSupplementarySanity(interval uint64) *argBuilder {
+	if interval > 0 {
+		args.vec = append(args.vec, "--"+tendermintFull.CfgSupplementarySanityEnabled)
+		args.vec = append(args.vec, []string{
+			"--" + tendermintFull.CfgSupplementarySanityInterval, strconv.Itoa(int(interval)),
+		}...)
+	}
 	return args
 }
 

--- a/go/oasis-test-runner/oasis/byzantine.go
+++ b/go/oasis-test-runner/oasis/byzantine.go
@@ -41,6 +41,7 @@ func (worker *Byzantine) startNode() error {
 	args := newArgBuilder().
 		debugDontBlameOasis().
 		debugAllowTestKeys().
+		debugEnableProfiling(worker.Node.pprofPort).
 		tendermintDebugAllowDuplicateIP().
 		tendermintCoreAddress(worker.consensusPort).
 		tendermintDebugAddrBookLenient().
@@ -118,11 +119,16 @@ func (net *Network) NewByzantine(cfg *ByzantineCfg) (*Byzantine, error) {
 		activationEpoch: cfg.ActivationEpoch,
 		runtime:         cfg.Runtime,
 	}
+	net.nextNodePort += 2
 	worker.doStartNode = worker.startNode
 	copy(worker.NodeID[:], nodeKey[:])
 
+	if cfg.EnableProfiling {
+		worker.Node.pprofPort = net.nextNodePort
+		net.nextNodePort++
+	}
+
 	net.byzantine = append(net.byzantine, worker)
-	net.nextNodePort += 2
 
 	if err := net.AddLogWatcher(&worker.Node); err != nil {
 		net.logger.Error("failed to add log watcher",

--- a/go/oasis-test-runner/oasis/client.go
+++ b/go/oasis-test-runner/oasis/client.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 
 	"github.com/oasisprotocol/oasis-core/go/common/node"
-	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 )
 
 // Client is an Oasis client node.
 type Client struct {
 	Node
 
+	runtimes          []int
 	maxTransactionAge int64
 
 	consensusPort uint16
@@ -21,6 +21,7 @@ type Client struct {
 type ClientCfg struct {
 	NodeCfg
 
+	Runtimes          []int
 	MaxTransactionAge int64
 }
 
@@ -28,6 +29,7 @@ func (client *Client) startNode() error {
 	args := newArgBuilder().
 		debugDontBlameOasis().
 		debugAllowTestKeys().
+		debugEnableProfiling(client.Node.pprofPort).
 		tendermintPrune(client.consensus.PruneNumKept).
 		tendermintRecoverCorruptedWAL(client.consensus.TendermintRecoverCorruptedWAL).
 		tendermintCoreAddress(client.consensusPort).
@@ -35,17 +37,17 @@ func (client *Client) startNode() error {
 		appendSeedNodes(client.net.seeds).
 		workerP2pPort(client.p2pPort).
 		workerP2pEnabled().
-		runtimeTagIndexerBackend("bleve").
 		tendermintSupplementarySanity(client.supplementarySanityInterval)
 
 	if client.maxTransactionAge != 0 {
 		args = args.runtimeClientMaxTransactionAge(client.maxTransactionAge)
 	}
 
-	for _, v := range client.net.runtimes {
-		if v.kind != registry.KindCompute {
-			continue
-		}
+	if len(client.runtimes) > 0 {
+		args = args.runtimeTagIndexerBackend("bleve")
+	}
+	for _, idx := range client.runtimes {
+		v := client.net.runtimes[idx]
 		// XXX: could support configurable binary idx if ever needed.
 		args = args.appendHostedRuntime(v, node.TEEHardwareInvalid, 0)
 	}
@@ -85,14 +87,21 @@ func (net *Network) NewClient(cfg *ClientCfg) (*Client, error) {
 			termErrorOk:                 cfg.AllowErrorTermination,
 			supplementarySanityInterval: cfg.SupplementarySanityInterval,
 		},
+		runtimes:          cfg.Runtimes,
 		maxTransactionAge: cfg.MaxTransactionAge,
 		consensusPort:     net.nextNodePort,
 		p2pPort:           net.nextNodePort + 1,
 	}
+	net.nextNodePort += 2
+
 	client.doStartNode = client.startNode
 
+	if cfg.EnableProfiling {
+		client.Node.pprofPort = net.nextNodePort
+		net.nextNodePort++
+	}
+
 	net.clients = append(net.clients, client)
-	net.nextNodePort += 2
 
 	return client, nil
 }

--- a/go/oasis-test-runner/oasis/client.go
+++ b/go/oasis-test-runner/oasis/client.go
@@ -35,7 +35,8 @@ func (client *Client) startNode() error {
 		appendSeedNodes(client.net.seeds).
 		workerP2pPort(client.p2pPort).
 		workerP2pEnabled().
-		runtimeTagIndexerBackend("bleve")
+		runtimeTagIndexerBackend("bleve").
+		tendermintSupplementarySanity(client.supplementarySanityInterval)
 
 	if client.maxTransactionAge != 0 {
 		args = args.runtimeClientMaxTransactionAge(client.maxTransactionAge)
@@ -76,12 +77,13 @@ func (net *Network) NewClient(cfg *ClientCfg) (*Client, error) {
 
 	client := &Client{
 		Node: Node{
-			Name:        clientName,
-			net:         net,
-			dir:         clientDir,
-			consensus:   cfg.Consensus,
-			termEarlyOk: cfg.AllowEarlyTermination,
-			termErrorOk: cfg.AllowErrorTermination,
+			Name:                        clientName,
+			net:                         net,
+			dir:                         clientDir,
+			consensus:                   cfg.Consensus,
+			termEarlyOk:                 cfg.AllowEarlyTermination,
+			termErrorOk:                 cfg.AllowErrorTermination,
+			supplementarySanityInterval: cfg.SupplementarySanityInterval,
 		},
 		maxTransactionAge: cfg.MaxTransactionAge,
 		consensusPort:     net.nextNodePort,

--- a/go/oasis-test-runner/oasis/compute.go
+++ b/go/oasis-test-runner/oasis/compute.go
@@ -103,6 +103,7 @@ func (worker *Compute) startNode() error {
 		runtimeSGXLoader(worker.net.cfg.RuntimeSGXLoaderBinary).
 		workerExecutorScheduleCheckTxEnabled().
 		configureDebugCrashPoints(worker.crashPointsProbability).
+		tendermintSupplementarySanity(worker.supplementarySanityInterval).
 		appendNetwork(worker.net).
 		appendSeedNodes(worker.net.seeds).
 		appendEntity(worker.entity)
@@ -156,6 +157,7 @@ func (net *Network) NewCompute(cfg *ComputeCfg) (*Compute, error) {
 			termErrorOk:                              cfg.AllowErrorTermination,
 			noAutoStart:                              cfg.NoAutoStart,
 			crashPointsProbability:                   cfg.CrashPointsProbability,
+			supplementarySanityInterval:              cfg.SupplementarySanityInterval,
 			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
 			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
 			consensus:                                cfg.Consensus,

--- a/go/oasis-test-runner/oasis/compute.go
+++ b/go/oasis-test-runner/oasis/compute.go
@@ -91,6 +91,7 @@ func (worker *Compute) startNode() error {
 	args := newArgBuilder().
 		debugDontBlameOasis().
 		debugAllowTestKeys().
+		debugEnableProfiling(worker.Node.pprofPort).
 		workerCertificateRotation(true).
 		tendermintCoreAddress(worker.consensusPort).
 		tendermintSubmissionGasPrice(worker.consensus.SubmissionGasPrice).
@@ -169,11 +170,16 @@ func (net *Network) NewCompute(cfg *ComputeCfg) (*Compute, error) {
 		p2pPort:            net.nextNodePort + 2,
 		runtimes:           cfg.Runtimes,
 	}
+	net.nextNodePort += 3
 	worker.doStartNode = worker.startNode
 	copy(worker.NodeID[:], nodeKey[:])
 
+	if cfg.EnableProfiling {
+		worker.Node.pprofPort = net.nextNodePort
+		net.nextNodePort++
+	}
+
 	net.computeWorkers = append(net.computeWorkers, worker)
-	net.nextNodePort += 3
 
 	if err := net.AddLogWatcher(&worker.Node); err != nil {
 		net.logger.Error("failed to add log watcher",

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -141,6 +141,9 @@ type ConsensusFixture struct { // nolint: maligned
 
 	// EnableConsensusRPCWorker enables the public consensus RPC services worker.
 	EnableConsensusRPCWorker bool `json:"enable_consensusrpc_worker,omitempty"`
+
+	// SupplementarySanityInterval configures the sanity check application.
+	SupplementarySanityInterval uint64 `json:"supplementary_sanity_interval,omitempty"`
 }
 
 // TEEFixture is a TEE configuration fixture.
@@ -181,12 +184,13 @@ func (f *ValidatorFixture) Create(net *Network) (*Validator, error) {
 
 	return net.NewValidator(&ValidatorCfg{
 		NodeCfg: NodeCfg{
-			AllowEarlyTermination:      f.AllowEarlyTermination,
-			AllowErrorTermination:      f.AllowErrorTermination,
-			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
-			Consensus:                  f.Consensus,
-			NoAutoStart:                f.NoAutoStart,
-			CrashPointsProbability:     f.CrashPointsProbability,
+			AllowEarlyTermination:       f.AllowEarlyTermination,
+			AllowErrorTermination:       f.AllowErrorTermination,
+			LogWatcherHandlerFactories:  f.LogWatcherHandlerFactories,
+			Consensus:                   f.Consensus,
+			NoAutoStart:                 f.NoAutoStart,
+			CrashPointsProbability:      f.CrashPointsProbability,
+			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
 		},
 		Entity:   entity,
 		Sentries: sentries,
@@ -318,12 +322,13 @@ func (f *KeymanagerFixture) Create(net *Network) (*Keymanager, error) {
 
 	return net.NewKeymanager(&KeymanagerCfg{
 		NodeCfg: NodeCfg{
-			AllowEarlyTermination:      f.AllowEarlyTermination,
-			AllowErrorTermination:      f.AllowErrorTermination,
-			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
-			CrashPointsProbability:     f.CrashPointsProbability,
-			Consensus:                  f.Consensus,
-			NoAutoStart:                f.NoAutoStart,
+			AllowEarlyTermination:       f.AllowEarlyTermination,
+			AllowErrorTermination:       f.AllowErrorTermination,
+			LogWatcherHandlerFactories:  f.LogWatcherHandlerFactories,
+			CrashPointsProbability:      f.CrashPointsProbability,
+			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
+			Consensus:                   f.Consensus,
+			NoAutoStart:                 f.NoAutoStart,
 		},
 		Runtime:       runtime,
 		Entity:        entity,
@@ -372,12 +377,13 @@ func (f *StorageWorkerFixture) Create(net *Network) (*Storage, error) {
 
 	return net.NewStorage(&StorageCfg{
 		NodeCfg: NodeCfg{
-			AllowEarlyTermination:      f.AllowEarlyTermination,
-			AllowErrorTermination:      f.AllowErrorTermination,
-			CrashPointsProbability:     f.CrashPointsProbability,
-			NoAutoStart:                f.NoAutoStart,
-			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
-			Consensus:                  f.Consensus,
+			AllowEarlyTermination:       f.AllowEarlyTermination,
+			AllowErrorTermination:       f.AllowErrorTermination,
+			CrashPointsProbability:      f.CrashPointsProbability,
+			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
+			NoAutoStart:                 f.NoAutoStart,
+			LogWatcherHandlerFactories:  f.LogWatcherHandlerFactories,
+			Consensus:                   f.Consensus,
 		},
 		Backend:                 f.Backend,
 		Entity:                  entity,
@@ -424,12 +430,13 @@ func (f *ComputeWorkerFixture) Create(net *Network) (*Compute, error) {
 
 	return net.NewCompute(&ComputeCfg{
 		NodeCfg: NodeCfg{
-			AllowEarlyTermination:      f.AllowEarlyTermination,
-			AllowErrorTermination:      f.AllowErrorTermination,
-			NoAutoStart:                f.NoAutoStart,
-			CrashPointsProbability:     f.CrashPointsProbability,
-			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
-			Consensus:                  f.Consensus,
+			AllowEarlyTermination:       f.AllowEarlyTermination,
+			AllowErrorTermination:       f.AllowErrorTermination,
+			NoAutoStart:                 f.NoAutoStart,
+			CrashPointsProbability:      f.CrashPointsProbability,
+			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
+			LogWatcherHandlerFactories:  f.LogWatcherHandlerFactories,
+			Consensus:                   f.Consensus,
 		},
 		Entity:             entity,
 		RuntimeProvisioner: f.RuntimeProvisioner,
@@ -455,6 +462,9 @@ type SentryFixture struct {
 
 	CrashPointsProbability float64 `json:"crash_points_probability,omitempty"`
 
+	// Consensus contains configuration for the consensus backend.
+	Consensus ConsensusFixture `json:"consensus"`
+
 	Validators        []int `json:"validators"`
 	StorageWorkers    []int `json:"storage_workers"`
 	KeymanagerWorkers []int `json:"keymanager_workers"`
@@ -464,8 +474,9 @@ type SentryFixture struct {
 func (f *SentryFixture) Create(net *Network) (*Sentry, error) {
 	return net.NewSentry(&SentryCfg{
 		NodeCfg: NodeCfg{
-			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
-			CrashPointsProbability:     f.CrashPointsProbability,
+			LogWatcherHandlerFactories:  f.LogWatcherHandlerFactories,
+			CrashPointsProbability:      f.CrashPointsProbability,
+			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
 		},
 		ValidatorIndices:  f.Validators,
 		StorageIndices:    f.StorageWorkers,
@@ -489,9 +500,10 @@ type ClientFixture struct {
 func (f *ClientFixture) Create(net *Network) (*Client, error) {
 	return net.NewClient(&ClientCfg{
 		NodeCfg: NodeCfg{
-			Consensus:             f.Consensus,
-			AllowErrorTermination: f.AllowErrorTermination,
-			AllowEarlyTermination: f.AllowEarlyTermination,
+			Consensus:                   f.Consensus,
+			AllowErrorTermination:       f.AllowErrorTermination,
+			AllowEarlyTermination:       f.AllowEarlyTermination,
+			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
 		},
 		MaxTransactionAge: f.MaxTransactionAge,
 	})

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -161,6 +161,8 @@ type ValidatorFixture struct { // nolint: maligned
 
 	CrashPointsProbability float64 `json:"crash_points_probability,omitempty"`
 
+	EnableProfiling bool `json:"enable_profiling"`
+
 	Entity int `json:"entity"`
 
 	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
@@ -191,6 +193,7 @@ func (f *ValidatorFixture) Create(net *Network) (*Validator, error) {
 			NoAutoStart:                 f.NoAutoStart,
 			CrashPointsProbability:      f.CrashPointsProbability,
 			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
+			EnableProfiling:             f.EnableProfiling,
 		},
 		Entity:   entity,
 		Sentries: sentries,
@@ -295,6 +298,8 @@ type KeymanagerFixture struct {
 
 	NoAutoStart bool `json:"no_auto_start,omitempty"`
 
+	EnableProfiling bool `json:"enable_profiling"`
+
 	Sentries []int `json:"sentries,omitempty"`
 
 	// Consensus contains configuration for the consensus backend.
@@ -327,6 +332,7 @@ func (f *KeymanagerFixture) Create(net *Network) (*Keymanager, error) {
 			LogWatcherHandlerFactories:  f.LogWatcherHandlerFactories,
 			CrashPointsProbability:      f.CrashPointsProbability,
 			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
+			EnableProfiling:             f.EnableProfiling,
 			Consensus:                   f.Consensus,
 			NoAutoStart:                 f.NoAutoStart,
 		},
@@ -346,6 +352,8 @@ type StorageWorkerFixture struct { // nolint: maligned
 	AllowErrorTermination bool `json:"allow_error_termination"`
 
 	NoAutoStart bool `json:"no_auto_start,omitempty"`
+
+	EnableProfiling bool `json:"enable_profiling"`
 
 	DisableCertRotation bool `json:"disable_cert_rotation"`
 	DisablePublicRPC    bool `json:"disable_public_rpc"`
@@ -381,6 +389,7 @@ func (f *StorageWorkerFixture) Create(net *Network) (*Storage, error) {
 			AllowErrorTermination:       f.AllowErrorTermination,
 			CrashPointsProbability:      f.CrashPointsProbability,
 			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
+			EnableProfiling:             f.EnableProfiling,
 			NoAutoStart:                 f.NoAutoStart,
 			LogWatcherHandlerFactories:  f.LogWatcherHandlerFactories,
 			Consensus:                   f.Consensus,
@@ -410,6 +419,8 @@ type ComputeWorkerFixture struct {
 
 	NoAutoStart bool `json:"no_auto_start,omitempty"`
 
+	EnableProfiling bool `json:"enable_profiling"`
+
 	// Consensus contains configuration for the consensus backend.
 	Consensus ConsensusFixture `json:"consensus"`
 
@@ -435,6 +446,7 @@ func (f *ComputeWorkerFixture) Create(net *Network) (*Compute, error) {
 			NoAutoStart:                 f.NoAutoStart,
 			CrashPointsProbability:      f.CrashPointsProbability,
 			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
+			EnableProfiling:             f.EnableProfiling,
 			LogWatcherHandlerFactories:  f.LogWatcherHandlerFactories,
 			Consensus:                   f.Consensus,
 		},
@@ -462,6 +474,8 @@ type SentryFixture struct {
 
 	CrashPointsProbability float64 `json:"crash_points_probability,omitempty"`
 
+	EnableProfiling bool `json:"enable_profiling"`
+
 	// Consensus contains configuration for the consensus backend.
 	Consensus ConsensusFixture `json:"consensus"`
 
@@ -477,6 +491,7 @@ func (f *SentryFixture) Create(net *Network) (*Sentry, error) {
 			LogWatcherHandlerFactories:  f.LogWatcherHandlerFactories,
 			CrashPointsProbability:      f.CrashPointsProbability,
 			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
+			EnableProfiling:             f.EnableProfiling,
 		},
 		ValidatorIndices:  f.Validators,
 		StorageIndices:    f.StorageWorkers,
@@ -489,8 +504,13 @@ type ClientFixture struct {
 	AllowErrorTermination bool `json:"allow_error_termination"`
 	AllowEarlyTermination bool `json:"allow_early_termination"`
 
+	EnableProfiling bool `json:"enable_profiling"`
+
 	// Consensus contains configuration for the consensus backend.
 	Consensus ConsensusFixture `json:"consensus"`
+
+	// Runtimes contains the indexes of the runtimes to enable.
+	Runtimes []int `json:"runtimes,omitempty"`
 
 	// MaxTransactionAge configures the MaxTransactionAge configuration of the client.
 	MaxTransactionAge int64 `json:"max_transaction_age"`
@@ -504,8 +524,10 @@ func (f *ClientFixture) Create(net *Network) (*Client, error) {
 			AllowErrorTermination:       f.AllowErrorTermination,
 			AllowEarlyTermination:       f.AllowEarlyTermination,
 			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
+			EnableProfiling:             f.EnableProfiling,
 		},
 		MaxTransactionAge: f.MaxTransactionAge,
+		Runtimes:          f.Runtimes,
 	})
 }
 
@@ -516,6 +538,8 @@ type ByzantineFixture struct { // nolint: maligned
 
 	IdentitySeed string `json:"identity_seed"`
 	Entity       int    `json:"entity"`
+
+	EnableProfiling bool `json:"enable_profiling"`
 
 	ActivationEpoch beacon.EpochTime `json:"activation_epoch"`
 	Runtime         int              `json:"runtime"`
@@ -539,6 +563,7 @@ func (f *ByzantineFixture) Create(net *Network) (*Byzantine, error) {
 			DisableDefaultLogWatcherHandlerFactories: !f.EnableDefaultLogWatcherHandlerFactories,
 			LogWatcherHandlerFactories:               f.LogWatcherHandlerFactories,
 			Consensus:                                f.Consensus,
+			EnableProfiling:                          f.EnableProfiling,
 		},
 		Script:          f.Script,
 		ExtraArgs:       f.ExtraArgs,

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -266,6 +266,7 @@ func (km *Keymanager) startNode() error {
 	args := newArgBuilder().
 		debugDontBlameOasis().
 		debugAllowTestKeys().
+		debugEnableProfiling(km.Node.pprofPort).
 		workerCertificateRotation(true).
 		tendermintCoreAddress(km.consensusPort).
 		tendermintSubmissionGasPrice(km.consensus.SubmissionGasPrice).
@@ -361,11 +362,16 @@ func (net *Network) NewKeymanager(cfg *KeymanagerCfg) (*Keymanager, error) {
 		workerClientPort: net.nextNodePort + 1,
 		mayGenerate:      len(net.keymanagers) == 0,
 	}
+	net.nextNodePort += 2
 	km.doStartNode = km.startNode
 	copy(km.NodeID[:], nodeKey[:])
 
+	if cfg.EnableProfiling {
+		km.Node.pprofPort = net.nextNodePort
+		net.nextNodePort++
+	}
+
 	net.keymanagers = append(net.keymanagers, km)
-	net.nextNodePort += 2
 
 	if err := net.AddLogWatcher(&km.Node); err != nil {
 		net.logger.Error("failed to add log watcher",

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -279,6 +279,7 @@ func (km *Keymanager) startNode() error {
 		workerKeymanagerEnabled().
 		workerKeymanagerRuntimeID(km.runtime.id).
 		configureDebugCrashPoints(km.crashPointsProbability).
+		tendermintSupplementarySanity(km.supplementarySanityInterval).
 		appendNetwork(km.net).
 		appendEntity(km.entity)
 
@@ -344,6 +345,7 @@ func (net *Network) NewKeymanager(cfg *KeymanagerCfg) (*Keymanager, error) {
 			termEarlyOk:                              cfg.AllowEarlyTermination,
 			termErrorOk:                              cfg.AllowErrorTermination,
 			crashPointsProbability:                   cfg.CrashPointsProbability,
+			supplementarySanityInterval:              cfg.SupplementarySanityInterval,
 			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
 			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
 			consensus:                                cfg.Consensus,

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -96,7 +96,8 @@ type Node struct { // nolint: maligned
 	isStopping  bool
 	noAutoStart bool
 
-	crashPointsProbability float64
+	crashPointsProbability      float64
+	supplementarySanityInterval uint64
 
 	disableDefaultLogWatcherHandlerFactories bool
 	logWatcherHandlerFactories               []log.WatcherHandlerFactory
@@ -245,9 +246,10 @@ func (n *Node) SetConsensusStateSync(cfg *ConsensusStateSyncCfg) {
 
 // NodeCfg defines the common node configuration options.
 type NodeCfg struct { // nolint: maligned
-	AllowEarlyTermination  bool
-	AllowErrorTermination  bool
-	CrashPointsProbability float64
+	AllowEarlyTermination       bool
+	AllowErrorTermination       bool
+	CrashPointsProbability      float64
+	SupplementarySanityInterval uint64
 
 	NoAutoStart bool
 

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -105,6 +105,8 @@ type Node struct { // nolint: maligned
 	consensus            ConsensusFixture
 	consensusStateSync   *ConsensusStateSyncCfg
 	customGrpcSocketPath string
+
+	pprofPort uint16
 }
 
 // Exit returns a channel that will close once the node shuts down.
@@ -250,6 +252,7 @@ type NodeCfg struct { // nolint: maligned
 	AllowErrorTermination       bool
 	CrashPointsProbability      float64
 	SupplementarySanityInterval uint64
+	EnableProfiling             bool
 
 	NoAutoStart bool
 

--- a/go/oasis-test-runner/oasis/sentry.go
+++ b/go/oasis-test-runner/oasis/sentry.go
@@ -73,6 +73,7 @@ func (sentry *Sentry) startNode() error {
 	args := newArgBuilder().
 		debugDontBlameOasis().
 		debugAllowTestKeys().
+		debugEnableProfiling(sentry.Node.pprofPort).
 		workerCertificateRotation(false).
 		workerSentryEnabled().
 		workerSentryControlPort(sentry.controlPort).
@@ -165,10 +166,15 @@ func (net *Network) NewSentry(cfg *SentryCfg) (*Sentry, error) {
 		controlPort:       net.nextNodePort + 1,
 		sentryPort:        net.nextNodePort + 2,
 	}
+	net.nextNodePort += 3
 	sentry.doStartNode = sentry.startNode
 
+	if cfg.EnableProfiling {
+		sentry.Node.pprofPort = net.nextNodePort
+		net.nextNodePort++
+	}
+
 	net.sentries = append(net.sentries, sentry)
-	net.nextNodePort += 3
 
 	if err := net.AddLogWatcher(&sentry.Node); err != nil {
 		net.logger.Error("failed to add log watcher",

--- a/go/oasis-test-runner/oasis/sentry.go
+++ b/go/oasis-test-runner/oasis/sentry.go
@@ -80,6 +80,7 @@ func (sentry *Sentry) startNode() error {
 		tendermintPrune(sentry.consensus.PruneNumKept).
 		tendermintRecoverCorruptedWAL(sentry.consensus.TendermintRecoverCorruptedWAL).
 		configureDebugCrashPoints(sentry.crashPointsProbability).
+		tendermintSupplementarySanity(sentry.supplementarySanityInterval).
 		appendNetwork(sentry.net).
 		appendSeedNodes(sentry.net.seeds).
 		internalSocketAddress(sentry.net.validators[0].SocketPath())
@@ -150,6 +151,7 @@ func (net *Network) NewSentry(cfg *SentryCfg) (*Sentry, error) {
 			net:                                      net,
 			dir:                                      sentryDir,
 			crashPointsProbability:                   cfg.CrashPointsProbability,
+			supplementarySanityInterval:              cfg.SupplementarySanityInterval,
 			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
 			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
 		},

--- a/go/oasis-test-runner/oasis/storage.go
+++ b/go/oasis-test-runner/oasis/storage.go
@@ -111,6 +111,7 @@ func (worker *Storage) startNode() error {
 	args := newArgBuilder().
 		debugDontBlameOasis().
 		debugAllowTestKeys().
+		debugEnableProfiling(worker.Node.pprofPort).
 		workerCertificateRotation(!worker.disableCertRotation).
 		tendermintCoreAddress(worker.consensusPort).
 		tendermintSubmissionGasPrice(worker.consensus.SubmissionGasPrice).
@@ -220,11 +221,16 @@ func (net *Network) NewStorage(cfg *StorageCfg) (*Storage, error) {
 		p2pPort:                 net.nextNodePort + 2,
 		runtimes:                cfg.Runtimes,
 	}
+	net.nextNodePort += 3
 	worker.doStartNode = worker.startNode
 	copy(worker.NodeID[:], nodeKey[:])
 
+	if cfg.EnableProfiling {
+		worker.Node.pprofPort = net.nextNodePort
+		net.nextNodePort++
+	}
+
 	net.storageWorkers = append(net.storageWorkers, worker)
-	net.nextNodePort += 3
 
 	if err := net.AddLogWatcher(&worker.Node); err != nil {
 		net.logger.Error("failed to add log watcher",

--- a/go/oasis-test-runner/oasis/storage.go
+++ b/go/oasis-test-runner/oasis/storage.go
@@ -125,6 +125,7 @@ func (worker *Storage) startNode() error {
 		workerStorageDebugDisableCheckpointSync(worker.checkpointSyncDisabled).
 		workerStorageCheckpointCheckInterval(worker.checkpointCheckInterval).
 		configureDebugCrashPoints(worker.crashPointsProbability).
+		tendermintSupplementarySanity(worker.supplementarySanityInterval).
 		appendNetwork(worker.net).
 		appendEntity(worker.entity)
 
@@ -199,6 +200,7 @@ func (net *Network) NewStorage(cfg *StorageCfg) (*Storage, error) {
 			termEarlyOk:                              cfg.AllowEarlyTermination,
 			termErrorOk:                              cfg.AllowErrorTermination,
 			crashPointsProbability:                   cfg.CrashPointsProbability,
+			supplementarySanityInterval:              cfg.SupplementarySanityInterval,
 			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
 			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
 			consensus:                                cfg.Consensus,

--- a/go/oasis-test-runner/oasis/validator.go
+++ b/go/oasis-test-runner/oasis/validator.go
@@ -90,6 +90,7 @@ func (val *Validator) startNode() error {
 		tendermintPrune(val.consensus.PruneNumKept).
 		tendermintRecoverCorruptedWAL(val.consensus.TendermintRecoverCorruptedWAL).
 		configureDebugCrashPoints(val.crashPointsProbability).
+		tendermintSupplementarySanity(val.supplementarySanityInterval).
 		appendNetwork(val.net).
 		appendEntity(val.entity)
 
@@ -102,10 +103,6 @@ func (val *Validator) startNode() error {
 	if val.consensus.EnableConsensusRPCWorker {
 		args = args.workerClientPort(val.clientPort).
 			workerConsensusRPCEnabled()
-	}
-
-	if len(val.net.validators) >= 1 && val == val.net.validators[0] {
-		args = args.tendermintSupplementarySanityEnabled()
 	}
 
 	if err := val.net.startOasisNode(&val.Node, nil, args); err != nil {
@@ -136,6 +133,7 @@ func (net *Network) NewValidator(cfg *ValidatorCfg) (*Validator, error) {
 			termEarlyOk:                              cfg.AllowEarlyTermination,
 			termErrorOk:                              cfg.AllowErrorTermination,
 			crashPointsProbability:                   cfg.CrashPointsProbability,
+			supplementarySanityInterval:              cfg.SupplementarySanityInterval,
 			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
 			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
 			consensus:                                cfg.Consensus,

--- a/go/oasis-test-runner/scenario/e2e/e2e.go
+++ b/go/oasis-test-runner/scenario/e2e/e2e.go
@@ -106,7 +106,7 @@ func (sc *E2E) Fixture() (*oasis.NetworkFixture, error) {
 			{},
 		},
 		Validators: []oasis.ValidatorFixture{
-			{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true}},
+			{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true, SupplementarySanityInterval: 1}},
 			{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true}},
 			{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true}},
 		},

--- a/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
+++ b/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
@@ -106,7 +106,7 @@ func (sc *gasFeesImpl) Fixture() (*oasis.NetworkFixture, error) {
 		Validators: []oasis.ValidatorFixture{
 			// Create three validators, each with its own entity so we can test
 			// if gas disbursement works correctly.
-			{Entity: 1, Consensus: oasis.ConsensusFixture{MinGasPrice: 1}},
+			{Entity: 1, Consensus: oasis.ConsensusFixture{MinGasPrice: 1, SupplementarySanityInterval: 1}},
 			{Entity: 2, Consensus: oasis.ConsensusFixture{MinGasPrice: 1}},
 			{Entity: 3, Consensus: oasis.ConsensusFixture{MinGasPrice: 1}},
 		},

--- a/go/oasis-test-runner/scenario/e2e/genesis_file.go
+++ b/go/oasis-test-runner/scenario/e2e/genesis_file.go
@@ -44,7 +44,7 @@ func (s *genesisFileImpl) Fixture() (*oasis.NetworkFixture, error) {
 	// be possible to run this configuration as the PVSS backend
 	// currently requires multiple validators.
 	f.Validators = []oasis.ValidatorFixture{
-		{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true}},
+		{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true, SupplementarySanityInterval: 1}},
 	}
 	f.Network.Beacon.Backend = beacon.BackendInsecure
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/governance_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/governance_upgrade.go
@@ -154,7 +154,7 @@ func (sc *governanceConsensusUpgradeImpl) Fixture() (*oasis.NetworkFixture, erro
 		{Entity: 1, Runtimes: []int{1}, AllowErrorTermination: true},
 	}
 	f.Clients = []oasis.ClientFixture{
-		{AllowErrorTermination: true},
+		{AllowErrorTermination: true, Runtimes: []int{1}},
 	}
 
 	switch {

--- a/go/oasis-test-runner/scenario/e2e/runtime/governance_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/governance_upgrade.go
@@ -137,7 +137,7 @@ func (sc *governanceConsensusUpgradeImpl) Fixture() (*oasis.NetworkFixture, erro
 	}
 
 	f.Validators = []oasis.ValidatorFixture{
-		{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true}, AllowErrorTermination: true},
+		{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true, SupplementarySanityInterval: 1}, AllowErrorTermination: true},
 		{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true}, AllowErrorTermination: true},
 		{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true}, AllowErrorTermination: true},
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/late_start.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/late_start.go
@@ -63,7 +63,9 @@ func (sc *lateStartImpl) Run(childEnv *env.Env) error {
 	time.Sleep(lateStartInitialWait)
 
 	sc.Logger.Info("Starting the client node")
-	clientFixture := &oasis.ClientFixture{}
+	clientFixture := &oasis.ClientFixture{
+		Runtimes: []int{1},
+	}
 	client, err := clientFixture.Create(sc.Net)
 	if err != nil {
 		return err

--- a/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
@@ -148,6 +148,8 @@ func (sc *multipleRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
 		)
 	}
 
+	f.Clients[0].Runtimes = computeRuntimes
+
 	return f, nil
 }
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -205,7 +205,7 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 			},
 		},
 		Validators: []oasis.ValidatorFixture{
-			{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true}},
+			{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true, SupplementarySanityInterval: 1}},
 			{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true}},
 			{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true}},
 		},

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -227,7 +227,7 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 		Sentries: []oasis.SentryFixture{},
 		Seeds:    []oasis.SeedFixture{{}},
 		Clients: []oasis.ClientFixture{
-			{},
+			{Runtimes: []int{1}},
 		},
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_governance.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_governance.go
@@ -133,6 +133,7 @@ func (sc *runtimeGovernanceImpl) Fixture() (*oasis.NetworkFixture, error) {
 			},
 		)
 	}
+	f.Clients[0].Runtimes = computeRuntimes
 
 	// Set up staking.
 	f.Network.StakingGenesis = &staking.Genesis{

--- a/go/oasis-test-runner/scenario/e2e/runtime/sentry.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/sentry.go
@@ -127,6 +127,7 @@ func (s *sentryImpl) Fixture() (*oasis.NetworkFixture, error) {
 			Entity:                     1,
 			LogWatcherHandlerFactories: validatorExtraLogWatcherHandlerFactories,
 			Sentries:                   []int{0, 1},
+			Consensus:                  oasis.ConsensusFixture{SupplementarySanityInterval: 1},
 		},
 		{
 			Entity:                     1,

--- a/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
@@ -99,7 +99,7 @@ var TxSourceMultiShortSGX scenario.Scenario = &txSourceImpl{
 	consensusPruneDisabledProbability: 0.1,
 	consensusPruneMinKept:             100,
 	consensusPruneMaxKept:             200,
-	// XXX: don't use more node as SGX E2E test instances cannot handle much
+	// XXX: don't use more nodes as SGX E2E test instances cannot handle many
 	// more nodes that are currently configured.
 	numValidatorNodes:  3,
 	numKeyManagerNodes: 1,
@@ -133,13 +133,12 @@ var TxSourceMulti scenario.Scenario = &txSourceImpl{
 	consensusPruneMaxKept:             1000,
 	enableCrashPoints:                 true,
 	// Nodes getting killed commonly result in corrupted tendermint WAL when the
-	// node is restarted. Enable automatic corrupted WAL recovery for validator
-	// nodes.
+	// node is restarted. Enable automatic corrupted WAL recovery for nodes.
 	tendermintRecoverCorruptedWAL: true,
-	// Use 4 validators so that consensus can keep making progress
-	// when a node is being killed and restarted.
+	// Use 4 validators so that consensus can keep making progress when a node
+	// is being killed and restarted.
 	numValidatorNodes: 4,
-	// Use 2 keymanager so that at least one keymanager is accessible when
+	// Use 2 keymanagers so that at least one keymanager is accessible when
 	// the other one is being killed or shut down.
 	numKeyManagerNodes: 2,
 	// Use 4 storage nodes so runtime continues to work when one of the nodes
@@ -538,6 +537,13 @@ func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
 		f.ByzantineNodes[i].Consensus.SubmissionGasPrice = txSourceGasPrice
 		sc.generateConsensusFixture(&f.ByzantineNodes[i].Consensus, false)
 	}
+
+	// Add a sanity-checker client node.
+	// NOTE: we skip the sanity checker on the validators as it blocks consensus
+	// and it can cause a node to fall behind.
+	f.Clients = append(f.Clients, oasis.ClientFixture{
+		Consensus: oasis.ConsensusFixture{SupplementarySanityInterval: 1},
+	})
 
 	return f, nil
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
@@ -244,7 +244,7 @@ func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
 	f.Network.GovernanceParameters = &governance.ConsensusParameters{
 		VotingPeriod:              10,
 		MinProposalDeposit:        *quantity.NewFromUint64(300),
-		Quorum:                    90,
+		Quorum:                    75,
 		Threshold:                 90,
 		UpgradeMinEpochDiff:       40,
 		UpgradeCancelMinEpochDiff: 20,

--- a/go/oasis-test-runner/scenario/e2e/upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/upgrade.go
@@ -136,7 +136,7 @@ func (sc *nodeUpgradeImpl) Fixture() (*oasis.NetworkFixture, error) {
 			{},
 		},
 		Validators: []oasis.ValidatorFixture{
-			{Entity: 1, AllowErrorTermination: true},
+			{Entity: 1, AllowErrorTermination: true, Consensus: oasis.ConsensusFixture{SupplementarySanityInterval: 1}},
 			{Entity: 1, AllowErrorTermination: true},
 			{Entity: 1, AllowErrorTermination: true},
 			{Entity: 1, AllowErrorTermination: true},

--- a/go/oasis-test-runner/scenario/e2e/upgrade_cancel.go
+++ b/go/oasis-test-runner/scenario/e2e/upgrade_cancel.go
@@ -64,7 +64,7 @@ func (sc *nodeUpgradeCancelImpl) Fixture() (*oasis.NetworkFixture, error) {
 			{},
 		},
 		Validators: []oasis.ValidatorFixture{
-			{Entity: 1},
+			{Entity: 1, Consensus: oasis.ConsensusFixture{SupplementarySanityInterval: 1}},
 			{Entity: 1},
 			{Entity: 1},
 			{Entity: 1},


### PR DESCRIPTION
Daily longterm tests have been failing since validator-0 was falling behind the rest of the network due to the supplementary-sanity checker. This moves the supplementary-sanity checker to a new (client-1) node, which can fall behind without affecting rest of the network.

Also increase the timeout between governance workload iterations, as currently the amount of proposals was quickly pilling up over time (and both queries-workload and sanity-checker, go through all (even expired) proposal and votes).

TODO: 
- [x] run the longterm job to ensure the CI instances can handle the test suite with the additional node: https://buildkite.com/oasisprotocol/oasis-core-long-tests/builds/543