### PR TITLE
go/worker/registration: Fix RequestShutdown for nodes with no registration

### DIFF
--- a/.changelog/3524.bugfix.md
+++ b/.changelog/3524.bugfix.md
@@ -1,0 +1,6 @@
+go/worker/registration: Fix RequestShutdown for nodes with no registration
+
+In cases where the registration worker was started with a dummy
+goroutine that just waits for the service to stop, deregistration
+requests would hang, because the dummy wasn't watching the
+deregistration channel.

--- a/go/oasis-test-runner/scenario/e2e/runtime/node_shutdown.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/node_shutdown.go
@@ -101,5 +101,34 @@ func (sc *nodeShutdownImpl) Run(childEnv *env.Env) error {
 		return err
 	}
 
+	// Get the client node to shutdown as well, to make sure the code path works in corner cases too.
+	clientNode := sc.Net.Clients()[0]
+	clientCtrl, err := oasis.NewController(clientNode.SocketPath())
+	if err != nil {
+		return err
+	}
+	if err = clientCtrl.WaitReady(ctx); err != nil {
+		return err
+	}
+
+	sc.Logger.Info("requesting client node shutdown")
+	args = []string{
+		"control", "shutdown",
+		"--log.level", "debug",
+		"--address", "unix:" + clientNode.SocketPath(),
+	}
+	if err = cli.RunSubCommand(childEnv, sc.Logger, "control-shutdown", sc.Net.Config().NodeBinary, args); err != nil {
+		return fmt.Errorf("scenario/e2e/node_shutdown: send request to client node failed: %w", err)
+	}
+
+	// Wait for the node to exit.
+	err = <-clientNode.Exit()
+	if err != env.ErrEarlyTerm {
+		sc.Logger.Error("client node exited with error",
+			"err", err,
+		)
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
In cases where the registration worker was started with a dummy
goroutine that just waits for the service to stop, deregistration
requests would hang, because the dummy wasn't watching the
deregistration channel.

Closes #3524 