### PR TITLE
Make: Unify with Oasis Core Ledger and Rosetta Gateway repos

### DIFF
--- a/.changelog/3722.internal.1.md
+++ b/.changelog/3722.internal.1.md
@@ -1,0 +1,1 @@
+Make: Add `lint-go-mod-tidy` target

--- a/.changelog/3722.internal.md
+++ b/.changelog/3722.internal.md
@@ -1,0 +1,1 @@
+Make: Remove `build-go` target's `go` alias

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -82,15 +82,7 @@ jobs:
         # Always run this step so that all linting errors can be seen at once.
         if: always()
       - name: Check go mod tidy
-        # NOTE: go mod tidy doesn't implement a check mode yet.
-        # For more details, see: https://github.com/golang/go/issues/27005.
         run: |
-          cd go
-          go mod tidy
-          if [[ ! -z $(git status --porcelain go.mod go.sum) ]]; then
-            echo >&2 "Error: The following changes detected after running 'go mod tidy':"
-            git diff go.mod go.sum
-            exit 1
-          fi
+          make lint-go-mod-tidy
         # Always run this step so that all linting errors can be seen at once.
         if: always()

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -16,7 +16,6 @@ on:
       - stable/*
 
 jobs:
-
   lint:
     # NOTE: This name appears in GitHub's Checks API.
     name: lint
@@ -43,16 +42,17 @@ jobs:
         uses: actions/setup-go@v2.1.3
         with:
           go-version: "1.15.x"
-      - name: Install prerequisites
+      - name: Install gitlint
         run: |
-          python -m pip install \
-            https://github.com/oasislabs/towncrier/archive/oasis-master.tar.gz \
-            gitlint
+          python -m pip install gitlint
+      - name: Install towncrier
+        run: |
+          python -m pip install https://github.com/oasisprotocol/towncrier/archive/oasis-master.tar.gz
       - name: Check for presence of a Change Log fragment (only pull requests)
+        # NOTE: The pull request' base branch needs to be fetched so towncrier
+        # is able to compare the current branch with the base branch.
+        # Source: https://github.com/actions/checkout/#fetch-all-branches.
         run: |
-          # Fetch the pull request' base branch so towncrier will be able to
-          # compare the current branch with the base branch.
-          # Source: https://github.com/actions/checkout/#fetch-all-branches.
           git fetch --no-tags origin +refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}
           towncrier check --compare-with origin/${BASE_BRANCH}
         env:
@@ -80,6 +80,11 @@ jobs:
           pushd go/extra/extract-metrics && go build && popd
           make lint-docs
         # Always run this step so that all linting errors can be seen at once.
+        if: always()
+      - name: Ensure a clean code checkout
+        uses: actions/checkout@v2
+        with:
+          clean: true
         if: always()
       - name: Check go mod tidy
         run: |

--- a/go/Makefile
+++ b/go/Makefile
@@ -60,6 +60,11 @@ lint:
 	@$(ECHO) "$(CYAN)*** Running Go linters...$(OFF)"
 	@env -u GOPATH golangci-lint run --timeout 4m
 
+lint-mod-tidy:
+	@$(ECHO) "$(CYAN)*** Checking go mod tidy...$(OFF)"
+	@$(ENSURE_GIT_CLEAN)
+	@$(CHECK_GO_MOD_TIDY)
+
 # Test.
 test-targets := test-unit test-node
 


### PR DESCRIPTION
- Remove `build-go` target's non-standard `go` alias.
- Add `lint-go-mod-tidy` target.