### PR TITLE
restore template in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Oasis Labs Inc.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
this came up when we were adding a license to oasis-sdk in https://github.com/oasisprotocol/oasis-sdk/pull/6

here's an example of another project that came to the same conclusion: https://github.com/kubernetes/kubernetes/pull/65