### PR TITLE
go/worker/storage: Add validation for IO roots in Apply operations

### DIFF
--- a/.changelog/3440.feature.md
+++ b/.changelog/3440.feature.md
@@ -1,0 +1,1 @@
+go/worker/storage: Add validation for IO roots in Apply operations

--- a/go/common/keyformat/hashed_test.go
+++ b/go/common/keyformat/hashed_test.go
@@ -36,8 +36,8 @@ func TestHashed(t *testing.T) {
 	require.True(ok, "Decode")
 	require.EqualValues(42, decInt, "decoded uint64 value must be correct")
 
-	require.Panics(func() { _ = fmt1.Decode(enc, &decInt, &decNs) })
-	require.Panics(func() { _ = fmt1.Decode(enc, &decInt, &decPh1, &decPk) })
+	require.False(fmt1.Decode(enc, &decInt, &decNs))
+	require.False(fmt1.Decode(enc, &decInt, &decPh1, &decPk))
 
 	ok = fmt1.Decode(enc, &decInt, &decPh1, &decPh2)
 	require.True(ok, "Decode")
@@ -61,5 +61,5 @@ func TestHashed(t *testing.T) {
 	require.Equal("0ac561fac838104e3f2e4ad107b4bee3e938bf15f2b15f009ccccd61a913f017", hex.EncodeToString(decPh1[:]))
 
 	var decBytes []byte
-	require.Panics(func() { _ = fmt2.Decode(enc, &decInt, &decBytes) })
+	require.False(fmt2.Decode(enc, &decInt, &decBytes))
 }

--- a/go/common/keyformat/key_format.go
+++ b/go/common/keyformat/key_format.go
@@ -182,6 +182,9 @@ func (k *KeyFormat) Encode(values ...interface{}) []byte {
 //
 // Returns false and doesn't modify the passed values if the key prefix
 // doesn't match.
+//
+// *NOTE:* If decoding fails for one of the values, previous values
+// will be modified.
 func (k *KeyFormat) Decode(data []byte, values ...interface{}) bool {
 	if data[0] != k.prefix {
 		return false
@@ -228,12 +231,12 @@ func (k *KeyFormat) Decode(data []byte, values ...interface{}) bool {
 				err = t.UnmarshalBinary(buf)
 			}
 			if err != nil {
-				panic(fmt.Sprintf("key format: failed to unmarshal: %s", err))
+				return false
 			}
 		case *[]byte:
 			if meta.custom != nil {
 				if err := meta.custom.UnmarshalBinary(t, buf); err != nil {
-					panic(fmt.Sprintf("key format: failed to unmarshal: %s", err))
+					return false
 				}
 			} else {
 				meta.checkSize(i, -1)


### PR DESCRIPTION
Closes #3440 