### PR TITLE
go/worker: Make compute and client node use local storage if available

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -210,7 +210,7 @@ steps:
   ###############
   - label: E2E tests
     parallelism: 7
-    timeout_in_minutes: 30
+    timeout_in_minutes: 32
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
       - .buildkite/scripts/test_e2e.sh
@@ -232,7 +232,7 @@ steps:
   ###########################
   - label: E2E tests - intel-sgx
     parallelism: 5
-    timeout_in_minutes: 36
+    timeout_in_minutes: 40
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
       # Only run runtime scenarios as others do not use SGX.

--- a/.changelog/3251.internal.md
+++ b/.changelog/3251.internal.md
@@ -1,0 +1,1 @@
+go/worker: Make compute and client node use local storage if available

--- a/go/common/identity/identity_test.go
+++ b/go/common/identity/identity_test.go
@@ -54,8 +54,8 @@ func TestLoadOrGenerate(t *testing.T) {
 	require.EqualValues(t, identity3.ConsensusSigner, identity4.ConsensusSigner)
 	require.NotEqual(t, identity.GetTLSSigner(), identity3.GetTLSSigner())
 	require.NotEqual(t, identity2.GetTLSSigner(), identity3.GetTLSSigner())
-	require.NotEqual(t, identity3.GetTLSSigner(), identity4.GetTLSSigner())
+	require.Equal(t, identity3.GetTLSSigner(), identity4.GetTLSSigner())
 	require.NotEqual(t, identity.GetTLSCertificate(), identity3.GetTLSCertificate())
 	require.NotEqual(t, identity2.GetTLSCertificate(), identity3.GetTLSCertificate())
-	require.NotEqual(t, identity3.GetTLSCertificate(), identity4.GetTLSCertificate())
+	require.Equal(t, identity3.GetTLSCertificate(), identity4.GetTLSCertificate())
 }

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -397,6 +397,9 @@ func (n *Node) initRuntimeWorkers() error {
 	n.svcMgr.Register(n.KeymanagerWorker)
 
 	// Initialize the executor worker.
+	// Keep this step _after_ initializing the storage worker,
+	// because the executor worker will use the local storage backend
+	// if it is available.
 	n.ExecutorWorker, err = executor.New(
 		dataDir,
 		n.CommonWorker,

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -42,28 +42,46 @@ import (
 	workerStorage "github.com/oasisprotocol/oasis-core/go/worker/storage"
 )
 
+// Argument is a single argument on the commandline, including its values.
+type Argument struct {
+	// Name is the name of the argument, i.e. the leading dashed component.
+	Name string `json:"name"`
+	// Values is the array of values passed to this argument.
+	Values []string `json:"values"`
+	// MultiValued tells the system that multiple occurrences of the same argument
+	// should have their value arrays merged.
+	MultiValued bool `json:"multi_valued"`
+}
+
 type argBuilder struct {
-	vec []string
+	vec []Argument
 
 	// dontBlameOasis is true, if CfgDebugDontBlameOasis is passed.
 	dontBlameOasis bool
 }
 
 func (args *argBuilder) internalSocketAddress(path string) *argBuilder {
-	args.vec = append(args.vec, "--"+grpc.CfgAddress, "unix:"+path)
+	args.vec = append(args.vec, Argument{
+		Name:   grpc.CfgAddress,
+		Values: []string{"unix:" + path},
+	})
 	return args
 }
 
 func (args *argBuilder) debugDontBlameOasis() *argBuilder {
 	if !args.dontBlameOasis {
-		args.vec = append(args.vec, "--"+flags.CfgDebugDontBlameOasis)
+		args.vec = append(args.vec, Argument{
+			Name: flags.CfgDebugDontBlameOasis,
+		})
 		args.dontBlameOasis = true
 	}
 	return args
 }
 
 func (args *argBuilder) debugAllowTestKeys() *argBuilder {
-	args.vec = append(args.vec, "--"+cmdCommon.CfgDebugAllowTestKeys)
+	args.vec = append(args.vec, Argument{
+		Name: cmdCommon.CfgDebugAllowTestKeys,
+	})
 	return args
 }
 
@@ -71,121 +89,134 @@ func (args *argBuilder) debugEnableProfiling(port uint16) *argBuilder {
 	if port == 0 {
 		return args
 	}
-	args.vec = append(args.vec,
-		"--"+pprof.CfgPprofBind, "0.0.0.0:"+strconv.Itoa(int(port)),
-	)
+	args.vec = append(args.vec, Argument{
+		Name:   pprof.CfgPprofBind,
+		Values: []string{"0.0.0.0:" + strconv.Itoa(int(port))},
+	})
 	return args
 }
 
 func (args *argBuilder) grpcServerPort(port uint16) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + grpc.CfgServerPort, strconv.Itoa(int(port)),
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name:   grpc.CfgServerPort,
+		Values: []string{strconv.Itoa(int(port))},
+	})
 	return args
 }
 
 func (args *argBuilder) grpcWait() *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + grpc.CfgWait,
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name: grpc.CfgWait,
+	})
 	return args
 }
 
 func (args *argBuilder) grpcLogDebug() *argBuilder {
-	args.vec = append(args.vec, "--"+commonGrpc.CfgLogDebug)
+	args.vec = append(args.vec, Argument{
+		Name: commonGrpc.CfgLogDebug,
+	})
 	return args
 }
 
 func (args *argBuilder) grpcDebugGrpcInternalSocketPath(path string) *argBuilder {
-	args.vec = append(args.vec, "--"+grpc.CfgDebugGrpcInternalSocketPath, path)
+	args.vec = append(args.vec, Argument{
+		Name:   grpc.CfgDebugGrpcInternalSocketPath,
+		Values: []string{path},
+	})
 	return args
 }
 
 func (args *argBuilder) consensusValidator() *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + flags.CfgConsensusValidator,
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name: flags.CfgConsensusValidator,
+	})
 	return args
 }
 
 func (args *argBuilder) tendermintMinGasPrice(price uint64) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + tendermintFull.CfgMinGasPrice, strconv.Itoa(int(price)),
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name:   tendermintFull.CfgMinGasPrice,
+		Values: []string{strconv.Itoa(int(price))},
+	})
 	return args
 }
 
 func (args *argBuilder) tendermintSubmissionGasPrice(price uint64) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + tendermintCommon.CfgSubmissionGasPrice, strconv.Itoa(int(price)),
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name:   tendermintCommon.CfgSubmissionGasPrice,
+		Values: []string{strconv.Itoa(int(price))},
+	})
 	return args
 }
 
 func (args *argBuilder) tendermintPrune(numKept uint64) *argBuilder {
 	if numKept > 0 {
-		args.vec = append(args.vec,
-			"--"+tendermintFull.CfgABCIPruneStrategy, abci.PruneKeepN.String(),
-			"--"+tendermintFull.CfgABCIPruneNumKept, strconv.FormatUint(numKept, 10),
-		)
+		args.vec = append(args.vec, []Argument{
+			{tendermintFull.CfgABCIPruneStrategy, []string{abci.PruneKeepN.String()}, false},
+			{tendermintFull.CfgABCIPruneNumKept, []string{strconv.FormatUint(numKept, 10)}, false},
+		}...)
 	} else {
-		args.vec = append(args.vec,
-			"--"+tendermintFull.CfgABCIPruneStrategy, abci.PruneNone.String(),
-		)
+		args.vec = append(args.vec, Argument{
+			Name:   tendermintFull.CfgABCIPruneStrategy,
+			Values: []string{abci.PruneNone.String()},
+		})
 	}
 	return args
 }
 
 func (args *argBuilder) tendermintRecoverCorruptedWAL(enable bool) *argBuilder {
 	if enable {
-		args.vec = append(args.vec, "--"+tendermintFull.CfgDebugUnsafeReplayRecoverCorruptedWAL)
+		args.vec = append(args.vec, Argument{Name: tendermintFull.CfgDebugUnsafeReplayRecoverCorruptedWAL})
 	}
 	return args
 }
 
 func (args *argBuilder) tendermintCoreAddress(port uint16) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + tendermintCommon.CfgCoreListenAddress, "tcp://0.0.0.0:" + strconv.Itoa(int(port)),
-		"--" + tendermintCommon.CfgCoreExternalAddress, "tcp://127.0.0.1:" + strconv.Itoa(int(port)),
+	args.vec = append(args.vec, []Argument{
+		{tendermintCommon.CfgCoreListenAddress, []string{"tcp://0.0.0.0:" + strconv.Itoa(int(port))}, false},
+		{tendermintCommon.CfgCoreExternalAddress, []string{"tcp://127.0.0.1:" + strconv.Itoa(int(port))}, false},
 	}...)
 	return args
 }
 
 func (args *argBuilder) tendermintSentryUpstreamAddress(addrs []string) *argBuilder {
 	for _, addr := range addrs {
-		args.vec = append(args.vec, []string{
-			"--" + tendermintFull.CfgSentryUpstreamAddress, addr,
-		}...)
+		args.vec = append(args.vec, Argument{
+			Name:        tendermintFull.CfgSentryUpstreamAddress,
+			Values:      []string{addr},
+			MultiValued: true,
+		})
 	}
 	return args
 }
 
 func (args *argBuilder) tendermintDisablePeerExchange() *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + tendermintFull.CfgP2PDisablePeerExchange,
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name: tendermintFull.CfgP2PDisablePeerExchange,
+	})
 	return args
 }
 
 func (args *argBuilder) tendermintSeedMode() *argBuilder {
-	args.vec = append(args.vec, "--"+tendermint.CfgMode, tendermint.ModeSeed)
+	args.vec = append(args.vec, Argument{
+		Name:   tendermint.CfgMode,
+		Values: []string{tendermint.ModeSeed},
+	})
 	return args
 }
 
 func (args *argBuilder) tendermintSeedDisableAddrBookFromGenesis() *argBuilder {
-	args.vec = append(args.vec, "--"+tendermintSeed.CfgDebugDisableAddrBookFromGenesis)
+	args.vec = append(args.vec, Argument{Name: tendermintSeed.CfgDebugDisableAddrBookFromGenesis})
 	return args
 }
 
 func (args *argBuilder) tendermintDebugAddrBookLenient() *argBuilder {
-	args.vec = append(args.vec, "--"+tendermintCommon.CfgDebugP2PAddrBookLenient)
+	args.vec = append(args.vec, Argument{Name: tendermintCommon.CfgDebugP2PAddrBookLenient})
 	return args
 }
 
 func (args *argBuilder) tendermintDebugAllowDuplicateIP() *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + tendermintCommon.CfgDebugP2PAllowDuplicateIP,
-	}...)
+	args.vec = append(args.vec, Argument{Name: tendermintCommon.CfgDebugP2PAllowDuplicateIP})
 	return args
 }
 
@@ -194,268 +225,292 @@ func (args *argBuilder) tendermintStateSync(
 	trustHeight uint64,
 	trustHash string,
 ) *argBuilder {
-	args.vec = append(args.vec,
-		"--"+tendermintFull.CfgConsensusStateSyncEnabled,
-		"--"+tendermintFull.CfgConsensusStateSyncTrustHeight, strconv.FormatUint(trustHeight, 10),
-		"--"+tendermintFull.CfgConsensusStateSyncTrustHash, trustHash,
-	)
+	args.vec = append(args.vec, []Argument{
+		{tendermintFull.CfgConsensusStateSyncEnabled, nil, false},
+		{tendermintFull.CfgConsensusStateSyncTrustHeight, []string{strconv.FormatUint(trustHeight, 10)}, false},
+		{tendermintFull.CfgConsensusStateSyncTrustHash, []string{trustHash}, false},
+	}...)
 	for _, address := range consensusNodes {
-		args.vec = append(args.vec, "--"+tendermintFull.CfgConsensusStateSyncConsensusNode, address)
+		args.vec = append(args.vec, Argument{tendermintFull.CfgConsensusStateSyncConsensusNode, []string{address}, true})
 	}
 	return args
 }
 
 func (args *argBuilder) tendermintUpgradeStopDelay(delay time.Duration) *argBuilder {
-	args.vec = append(args.vec,
-		"--"+tendermintFull.CfgUpgradeStopDelay, delay.String(),
-	)
+	args.vec = append(args.vec, Argument{
+		Name:   tendermintFull.CfgUpgradeStopDelay,
+		Values: []string{delay.String()},
+	})
 	return args
 }
 
 func (args *argBuilder) storageBackend(backend string) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + workerStorage.CfgBackend, backend,
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name:   workerStorage.CfgBackend,
+		Values: []string{backend},
+	})
 	return args
 }
 
 func (args *argBuilder) runtimeSupported(id common.Namespace) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + runtimeRegistry.CfgSupported, id.String(),
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name:        runtimeRegistry.CfgSupported,
+		Values:      []string{id.String()},
+		MultiValued: true,
+	})
 	return args
 }
 
 func (args *argBuilder) tendermintSupplementarySanity(interval uint64) *argBuilder {
 	if interval > 0 {
-		args.vec = append(args.vec, "--"+tendermintFull.CfgSupplementarySanityEnabled)
-		args.vec = append(args.vec, []string{
-			"--" + tendermintFull.CfgSupplementarySanityInterval, strconv.Itoa(int(interval)),
-		}...)
+		args.vec = append(args.vec, Argument{Name: tendermintFull.CfgSupplementarySanityEnabled})
+		args.vec = append(args.vec, Argument{
+			Name:   tendermintFull.CfgSupplementarySanityInterval,
+			Values: []string{strconv.Itoa(int(interval))},
+		})
 	}
 	return args
 }
 
 func (args *argBuilder) runtimeTagIndexerBackend(backend string) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + runtimeRegistry.CfgTagIndexerBackend, backend,
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name:   runtimeRegistry.CfgTagIndexerBackend,
+		Values: []string{backend},
+	})
 	return args
 }
 
 func (args *argBuilder) runtimeClientMaxTransactionAge(maxTxAge int64) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + runtimeClient.CfgMaxTransactionAge, strconv.Itoa(int(maxTxAge)),
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name:   runtimeClient.CfgMaxTransactionAge,
+		Values: []string{strconv.Itoa(int(maxTxAge))},
+	})
 	return args
 }
 
 func (args *argBuilder) workerClientPort(port uint16) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + workerCommon.CfgClientPort, strconv.Itoa(int(port)),
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name:   workerCommon.CfgClientPort,
+		Values: []string{strconv.Itoa(int(port))},
+	})
 	return args
 }
 
 func (args *argBuilder) workerCommonSentryAddresses(addrs []string) *argBuilder {
 	for _, addr := range addrs {
-		args.vec = append(args.vec, []string{
-			"--" + workerCommon.CfgSentryAddresses, addr,
-		}...)
+		args.vec = append(args.vec, Argument{
+			Name:        workerCommon.CfgSentryAddresses,
+			Values:      []string{addr},
+			MultiValued: true,
+		})
 	}
 	return args
 }
 
 func (args *argBuilder) workerSentryGrpcClientAddress(addrs []string) *argBuilder {
 	for _, addr := range addrs {
-		args.vec = append(args.vec, []string{
-			"--" + workerGrpcSentry.CfgClientAddresses, addr,
-		}...)
+		args.vec = append(args.vec, Argument{
+			Name:        workerGrpcSentry.CfgClientAddresses,
+			Values:      []string{addr},
+			MultiValued: true,
+		})
 	}
 	return args
 }
 
 func (args *argBuilder) workerSentryGrpcClientPort(port uint16) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + workerGrpcSentry.CfgClientPort, strconv.Itoa(int(port)),
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name:   workerGrpcSentry.CfgClientPort,
+		Values: []string{strconv.Itoa(int(port))},
+	})
 	return args
 }
 
 func (args *argBuilder) workerP2pPort(port uint16) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + p2p.CfgP2pPort, strconv.Itoa(int(port)),
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name:   p2p.CfgP2pPort,
+		Values: []string{strconv.Itoa(int(port))},
+	})
 	return args
 }
 
 func (args *argBuilder) workerP2pEnabled() *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + p2p.CfgP2PEnabled,
-	}...)
+	args.vec = append(args.vec, Argument{Name: p2p.CfgP2PEnabled})
 	return args
 }
 
 func (args *argBuilder) runtimeProvisioner(provisioner string) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + runtimeRegistry.CfgRuntimeProvisioner, provisioner,
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name:   runtimeRegistry.CfgRuntimeProvisioner,
+		Values: []string{provisioner},
+	})
 	return args
 }
 
 func (args *argBuilder) runtimeSGXLoader(fn string) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + runtimeRegistry.CfgRuntimeSGXLoader, fn,
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name:   runtimeRegistry.CfgRuntimeSGXLoader,
+		Values: []string{fn},
+	})
 	return args
 }
 
 func (args *argBuilder) runtimePath(id common.Namespace, fn string) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + runtimeRegistry.CfgRuntimePaths, id.String() + "=" + fn,
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name:        runtimeRegistry.CfgRuntimePaths,
+		Values:      []string{id.String() + "=" + fn},
+		MultiValued: true,
+	})
 	return args
 }
 
 func (args *argBuilder) workerComputeEnabled() *argBuilder {
-	args.vec = append(args.vec, "--"+compute.CfgWorkerEnabled)
+	args.vec = append(args.vec, Argument{Name: compute.CfgWorkerEnabled})
 	return args
 }
 
 func (args *argBuilder) workerKeymanagerEnabled() *argBuilder {
-	args.vec = append(args.vec, "--"+keymanager.CfgEnabled)
+	args.vec = append(args.vec, Argument{Name: keymanager.CfgEnabled})
 	return args
 }
 
 func (args *argBuilder) workerKeymanagerRuntimeID(id common.Namespace) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + keymanager.CfgRuntimeID, id.String(),
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name:   keymanager.CfgRuntimeID,
+		Values: []string{id.String()},
+	})
 	return args
 }
 
 func (args *argBuilder) workerKeymanagerMayGenerate() *argBuilder {
-	args.vec = append(args.vec, "--"+keymanager.CfgMayGenerate)
+	args.vec = append(args.vec, Argument{Name: keymanager.CfgMayGenerate})
 	return args
 }
 
 func (args *argBuilder) workerSentryEnabled() *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + workerSentry.CfgEnabled,
-	}...)
+	args.vec = append(args.vec, Argument{Name: workerSentry.CfgEnabled})
 	return args
 }
 
 func (args *argBuilder) workerGrpcSentryEnabled() *argBuilder {
-	args.vec = append(args.vec, "--"+workerGrpcSentry.CfgEnabled)
+	args.vec = append(args.vec, Argument{Name: workerGrpcSentry.CfgEnabled})
 	return args
 }
 
 func (args *argBuilder) grpcSentryUpstreamAddresses(addrs []string) *argBuilder {
 	for _, addr := range addrs {
-		args.vec = append(args.vec, []string{
-			"--" + workerGrpcSentry.CfgUpstreamAddress, addr,
-		}...)
+		args.vec = append(args.vec, Argument{
+			Name:        workerGrpcSentry.CfgUpstreamAddress,
+			Values:      []string{addr},
+			MultiValued: true,
+		})
 	}
 	return args
 }
 
 func (args *argBuilder) grpcSentryUpstreamIDs(ids []string) *argBuilder {
 	for _, id := range ids {
-		args.vec = append(args.vec, []string{
-			"--" + workerGrpcSentry.CfgUpstreamID, id,
-		}...)
+		args.vec = append(args.vec, Argument{
+			Name:        workerGrpcSentry.CfgUpstreamID,
+			Values:      []string{id},
+			MultiValued: true,
+		})
 	}
 	return args
 }
 
 func (args *argBuilder) workerSentryControlPort(port uint16) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + workerSentry.CfgControlPort, strconv.Itoa(int(port)),
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name:   workerSentry.CfgControlPort,
+		Values: []string{strconv.Itoa(int(port))},
+	})
 	return args
 }
 
 func (args *argBuilder) workerSentryUpstreamTLSKeys(keys []string) *argBuilder {
 	for _, key := range keys {
-		args.vec = append(args.vec, []string{
-			"--" + workerSentry.CfgAuthorizedControlPubkeys, key,
-		}...)
+		args.vec = append(args.vec, Argument{
+			Name:        workerSentry.CfgAuthorizedControlPubkeys,
+			Values:      []string{key},
+			MultiValued: true,
+		})
 	}
 	return args
 }
 
 func (args *argBuilder) workerStorageEnabled() *argBuilder {
-	args.vec = append(args.vec, "--"+workerStorage.CfgWorkerEnabled)
+	args.vec = append(args.vec, Argument{Name: workerStorage.CfgWorkerEnabled})
 	return args
 }
 
 func (args *argBuilder) workerStoragePublicRPCEnabled(enabled bool) *argBuilder {
 	if enabled {
-		args.vec = append(args.vec, "--"+workerStorage.CfgWorkerPublicRPCEnabled)
+		args.vec = append(args.vec, Argument{Name: workerStorage.CfgWorkerPublicRPCEnabled})
 	}
 	return args
 }
 
 func (args *argBuilder) workerStorageDebugIgnoreApplies(ignore bool) *argBuilder {
 	if ignore {
-		args.vec = append(args.vec, "--"+workerStorage.CfgWorkerDebugIgnoreApply)
+		args.vec = append(args.vec, Argument{Name: workerStorage.CfgWorkerDebugIgnoreApply})
 	}
 	return args
 }
 
 func (args *argBuilder) workerStorageDebugDisableCheckpointSync(disable bool) *argBuilder {
 	if disable {
-		args.vec = append(args.vec, "--"+workerStorage.CfgWorkerCheckpointSyncDisabled)
+		args.vec = append(args.vec, Argument{Name: workerStorage.CfgWorkerCheckpointSyncDisabled})
 	}
 	return args
 }
 
 func (args *argBuilder) workerStorageCheckpointCheckInterval(interval time.Duration) *argBuilder {
 	if interval > 0 {
-		args.vec = append(args.vec, "--"+workerStorage.CfgWorkerCheckpointCheckInterval, interval.String())
+		args.vec = append(args.vec, Argument{
+			Name:   workerStorage.CfgWorkerCheckpointCheckInterval,
+			Values: []string{interval.String()},
+		})
 	}
 	return args
 }
 
 func (args *argBuilder) workerCertificateRotation(enabled bool) *argBuilder {
+	arg := Argument{Name: registration.CfgRegistrationRotateCerts}
 	switch enabled {
 	case false:
-		args.vec = append(args.vec, []string{
-			"--" + registration.CfgRegistrationRotateCerts, "0",
-		}...)
+		arg.Values = []string{"0"}
 	case true:
-		args.vec = append(args.vec, []string{
-			"--" + registration.CfgRegistrationRotateCerts, "1",
-		}...)
+		arg.Values = []string{"1"}
 	}
+	args.vec = append(args.vec, arg)
 	return args
 }
 
 func (args *argBuilder) workerExecutorScheduleCheckTxEnabled() *argBuilder {
-	args.vec = append(args.vec, "--"+executor.CfgScheduleCheckTxEnabled)
+	args.vec = append(args.vec, Argument{Name: executor.CfgScheduleCheckTxEnabled})
 	return args
 }
 
 func (args *argBuilder) workerConsensusRPCEnabled() *argBuilder {
-	args.vec = append(args.vec, "--"+workerConsensusRPC.CfgWorkerEnabled)
+	args.vec = append(args.vec, Argument{Name: workerConsensusRPC.CfgWorkerEnabled})
 	return args
 }
 
 func (args *argBuilder) iasUseGenesis() *argBuilder {
-	args.vec = append(args.vec, "--ias.use_genesis")
+	args.vec = append(args.vec, Argument{Name: "ias.use_genesis"})
 	return args
 }
 
 func (args *argBuilder) iasDebugMock() *argBuilder {
-	args.vec = append(args.vec, "--ias.debug.mock")
+	args.vec = append(args.vec, Argument{Name: "ias.debug.mock"})
 	return args
 }
 
 func (args *argBuilder) iasSPID(spid []byte) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--ias.spid", hex.EncodeToString(spid),
-	}...)
+	args.vec = append(args.vec, Argument{
+		Name:   "ias.spid",
+		Values: []string{hex.EncodeToString(spid)},
+	})
 	return args
 }
 
@@ -509,37 +564,42 @@ func (args *argBuilder) addSentryKeymanagerWorkers(keymanagerWorkers []*Keymanag
 
 func (args *argBuilder) appendSeedNodes(seeds []*Seed) *argBuilder {
 	for _, seed := range seeds {
-		args.vec = append(args.vec, []string{
-			"--" + tendermintCommon.CfgP2PSeed, fmt.Sprintf("%s@127.0.0.1:%d", seed.tmAddress, seed.consensusPort),
-		}...)
+		args.vec = append(args.vec, Argument{
+			Name:        tendermintCommon.CfgP2PSeed,
+			Values:      []string{fmt.Sprintf("%s@127.0.0.1:%d", seed.tmAddress, seed.consensusPort)},
+			MultiValued: true,
+		})
 	}
 	return args
 }
 
 func (args *argBuilder) configureDebugCrashPoints(prob float64) *argBuilder {
-	args.vec = append(args.vec,
-		"--"+crash.CfgDefaultCrashPointProbability, fmt.Sprintf("%f", prob),
-	)
+	args.vec = append(args.vec, Argument{
+		Name:   crash.CfgDefaultCrashPointProbability,
+		Values: []string{fmt.Sprintf("%f", prob)},
+	})
 	return args
 }
 
 func (args *argBuilder) appendNodeMetrics(node *Node) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + metrics.CfgMetricsMode, metrics.MetricsModePush,
-		"--" + metrics.CfgMetricsAddr, viper.GetString(metrics.CfgMetricsAddr),
-		"--" + metrics.CfgMetricsInterval, viper.GetString(metrics.CfgMetricsInterval),
-		"--" + metrics.CfgMetricsJobName, node.Name,
+	args.vec = append(args.vec, []Argument{
+		{metrics.CfgMetricsMode, []string{metrics.MetricsModePush}, false},
+		{metrics.CfgMetricsAddr, []string{viper.GetString(metrics.CfgMetricsAddr)}, false},
+		{metrics.CfgMetricsInterval, []string{viper.GetString(metrics.CfgMetricsInterval)}, false},
+		{metrics.CfgMetricsJobName, []string{node.Name}, false},
 	}...)
 
 	// Append labels.
-	args.vec = append(args.vec, "--"+metrics.CfgMetricsLabels)
 	ti := node.net.env.ScenarioInfo()
 	labels := metrics.GetDefaultPushLabels(ti)
 	var l []string
 	for k, v := range labels {
 		l = append(l, k+"="+v)
 	}
-	args.vec = append(args.vec, strings.Join(l, ","))
+	args.vec = append(args.vec, Argument{
+		Name:   metrics.CfgMetricsLabels,
+		Values: []string{strings.Join(l, ",")},
+	})
 
 	return args
 }
@@ -554,10 +614,10 @@ func (args *argBuilder) appendRuntimePruner(p *RuntimePrunerCfg) *argBuilder {
 		return args
 	}
 
-	args.vec = append(args.vec, []string{
-		"--" + runtimeRegistry.CfgHistoryPrunerStrategy, p.Strategy,
-		"--" + runtimeRegistry.CfgHistoryPrunerInterval, p.Interval.String(),
-		"--" + runtimeRegistry.CfgHistoryPrunerKeepLastNum, strconv.Itoa(int(p.NumKept)),
+	args.vec = append(args.vec, []Argument{
+		{runtimeRegistry.CfgHistoryPrunerStrategy, []string{p.Strategy}, false},
+		{runtimeRegistry.CfgHistoryPrunerInterval, []string{p.Interval.String()}, false},
+		{runtimeRegistry.CfgHistoryPrunerKeepLastNum, []string{strconv.Itoa(int(p.NumKept))}, false},
 	}...)
 	return args
 }
@@ -572,31 +632,32 @@ func (args *argBuilder) appendHostedRuntime(rt *Runtime, tee node.TEEHardware, b
 func (args *argBuilder) appendEntity(ent *Entity) *argBuilder {
 	if ent.dir != nil {
 		dir := ent.dir.String()
-		args.vec = append(args.vec, []string{
-			"--" + registration.CfgRegistrationEntity, filepath.Join(dir, "entity.json"),
-		}...)
+		args.vec = append(args.vec, Argument{
+			Name:   registration.CfgRegistrationEntity,
+			Values: []string{filepath.Join(dir, "entity.json")},
+		})
 	} else if ent.isDebugTestEntity {
-		args.vec = append(args.vec, "--"+flags.CfgDebugTestEntity)
+		args.vec = append(args.vec, Argument{Name: flags.CfgDebugTestEntity})
 	}
 	return args
 }
 
 func (args *argBuilder) appendIASProxy(iasProxy *iasProxy) *argBuilder {
 	if iasProxy != nil {
-		args.vec = append(args.vec, []string{
-			"--" + ias.CfgProxyAddress, "127.0.0.1:" + strconv.Itoa(int(iasProxy.grpcPort)),
-			"--" + ias.CfgTLSCertFile, iasProxy.tlsCertPath(),
-			"--" + ias.CfgAllowDebugEnclaves,
+		args.vec = append(args.vec, []Argument{
+			{ias.CfgProxyAddress, []string{"127.0.0.1:" + strconv.Itoa(int(iasProxy.grpcPort))}, false},
+			{ias.CfgTLSCertFile, []string{iasProxy.tlsCertPath()}, false},
+			{Name: ias.CfgAllowDebugEnclaves},
 		}...)
 		if iasProxy.mock {
-			args.vec = append(args.vec, "--"+ias.CfgDebugSkipVerify)
+			args.vec = append(args.vec, Argument{Name: ias.CfgDebugSkipVerify})
 		}
 	}
 	return args
 }
 
 func (args *argBuilder) byzantineFakeSGX() *argBuilder {
-	args.vec = append(args.vec, "--"+byzantine.CfgFakeSGX)
+	args.vec = append(args.vec, Argument{Name: byzantine.CfgFakeSGX})
 	return args
 }
 
@@ -605,18 +666,74 @@ func (args *argBuilder) byzantineVersionFakeEnclaveID(rt *Runtime) *argBuilder {
 		MrEnclave: *rt.mrEnclaves[0],
 		MrSigner:  *rt.mrSigner,
 	}
-	args.vec = append(args.vec, "--"+byzantine.CfgVersionFakeEnclaveID, eid.String())
+	args.vec = append(args.vec, Argument{
+		Name:   byzantine.CfgVersionFakeEnclaveID,
+		Values: []string{eid.String()},
+	})
 	return args
 }
 
 func (args *argBuilder) byzantineActivationEpoch(epoch beacon.EpochTime) *argBuilder {
-	args.vec = append(args.vec, "--"+byzantine.CfgActivationEpoch, strconv.FormatUint(uint64(epoch), 10))
+	args.vec = append(args.vec, Argument{
+		Name:   byzantine.CfgActivationEpoch,
+		Values: []string{strconv.FormatUint(uint64(epoch), 10)},
+	})
 	return args
 }
 
 func (args *argBuilder) byzantineRuntimeID(runtimeID common.Namespace) *argBuilder {
-	args.vec = append(args.vec, "--"+byzantine.CfgRuntimeID, runtimeID.String())
+	args.vec = append(args.vec, Argument{
+		Name:   byzantine.CfgRuntimeID,
+		Values: []string{runtimeID.String()},
+	})
 	return args
+}
+
+func (args *argBuilder) merge() []string {
+	output := []string{}
+	shipped := map[string][]string{}
+	multiValued := map[string][][]string{}
+
+	slicesEqual := func(s1, s2 []string) bool {
+		if len(s1) != len(s2) {
+			return false
+		}
+		for i := range s1 {
+			if s1[i] != s2[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	for _, arg := range args.vec {
+		if arg.MultiValued {
+			ok := true
+			for _, el := range multiValued[arg.Name] {
+				if slicesEqual(el, arg.Values) {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				output = append(output, "--"+arg.Name)
+				output = append(output, arg.Values...)
+				multiValued[arg.Name] = append(multiValued[arg.Name], arg.Values)
+			}
+		} else {
+			vals, ok := shipped[arg.Name]
+			if !ok {
+				output = append(output, "--"+arg.Name)
+				output = append(output, arg.Values...)
+				shipped[arg.Name] = arg.Values
+			} else {
+				if !slicesEqual(vals, arg.Values) {
+					panic(fmt.Sprintf("args: single-valued argument given multiple times with different values (%s)", arg.Name))
+				}
+			}
+		}
+	}
+	return output
 }
 
 func newArgBuilder() *argBuilder {

--- a/go/oasis-test-runner/oasis/network.go
+++ b/go/oasis-test-runner/oasis/network.go
@@ -1,0 +1,953 @@
+package oasis
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/viper"
+
+	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/crash"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/drbg"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	fileSigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/file"
+	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
+	"github.com/oasisprotocol/oasis-core/go/common/identity"
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
+	consensusGenesis "github.com/oasisprotocol/oasis-core/go/consensus/genesis"
+	genesisFile "github.com/oasisprotocol/oasis-core/go/genesis/file"
+	genesisTestHelpers "github.com/oasisprotocol/oasis-core/go/genesis/tests"
+	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
+	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
+	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/metrics"
+	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/genesis"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/log"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis/cli"
+	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
+)
+
+// Network is a test Oasis network.
+type Network struct { // nolint: maligned
+	logger *logging.Logger
+
+	env     *env.Env
+	baseDir *env.Dir
+	running bool
+
+	nodes          []*Node
+	entities       []*Entity
+	validators     []*Validator
+	runtimes       []*Runtime
+	keymanagers    []*Keymanager
+	storageWorkers []*Storage
+	computeWorkers []*Compute
+	sentries       []*Sentry
+	clients        []*Client
+	byzantine      []*Byzantine
+	seeds          []*Seed
+
+	keymanagerPolicies []*KeymanagerPolicy
+
+	iasProxy *iasProxy
+
+	cfg          *NetworkCfg
+	nextNodePort uint16
+
+	logWatchers []*log.Watcher
+
+	controller       *Controller
+	clientController *Controller
+
+	errCh chan error
+}
+
+// IASCfg is the Oasis test network IAS configuration.
+type IASCfg struct {
+	// UseRegistry specifies whether the IAS proxy should use the registry
+	// instead of the genesis document for authenticating runtime IDs.
+	UseRegistry bool `json:"use_registry,omitempty"`
+
+	// Mock specifies if Mock IAS Proxy should be used.
+	Mock bool `json:"mock,omitempty"`
+}
+
+// NetworkCfg is the Oasis test network configuration.
+type NetworkCfg struct { // nolint: maligned
+	// GenesisFile is an optional genesis file to use.
+	GenesisFile string `json:"genesis_file,omitempty"`
+
+	// NodeBinary is the path to the Oasis node binary.
+	NodeBinary string `json:"node_binary"`
+
+	// RuntimeSGXLoaderBinary is the path to the Oasis SGX runtime loader.
+	RuntimeSGXLoaderBinary string `json:"runtime_loader_binary"`
+
+	// Consensus are the network-wide consensus parameters.
+	Consensus consensusGenesis.Genesis `json:"consensus"`
+
+	// InitialHeight is the initial block height.
+	InitialHeight int64 `json:"initial_height,omitempty"`
+
+	// HaltEpoch is the halt epoch height flag.
+	HaltEpoch uint64 `json:"halt_epoch"`
+
+	// Beacon is the network-wide beacon parameters.
+	Beacon beacon.ConsensusParameters `json:"beacon"`
+
+	// DeterministicIdentities is the deterministic identities flag.
+	DeterministicIdentities bool `json:"deterministic_identities"`
+
+	// RestoreIdentities is the restore identities flag.
+	RestoreIdentities bool `json:"restore_identities"`
+
+	// FundEntities is the fund entities flag.
+	FundEntities bool `json:"fund_entities"`
+
+	// IAS is the Network IAS configuration.
+	IAS IASCfg `json:"ias"`
+
+	// StakingGenesis is the staking genesis data to be included if
+	// GenesisFile is not set.
+	StakingGenesis *staking.Genesis `json:"staking_genesis,omitempty"`
+
+	// GovernanceParameters are the governance consensus parameters.
+	GovernanceParameters *governance.ConsensusParameters `json:"governance_parameters,omitempty"`
+
+	// A set of log watcher handler factories used by default on all nodes
+	// created in this test network.
+	DefaultLogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
+
+	// UseShortGrpcSocketPaths specifies whether nodes should use internal.sock in datadir or
+	// externally-provided.
+	UseShortGrpcSocketPaths bool `json:"-"`
+
+	// Nodes lists the names of nodes to be created, enabling an N:M mapping between physical node
+	// processes and the features they host. If a feature is specified as attached to a node that
+	// isn't listed here, a new node will be created automatically, so this list can normally be
+	// left empty. Nodes are started in the order in which they appear here (automatically created
+	// nodes are appended).
+	Nodes []string
+}
+
+// SetMockEpoch force-enables the mock epoch time keeping.
+func (cfg *NetworkCfg) SetMockEpoch() {
+	cfg.Beacon.DebugMockBackend = true
+	if cfg.Beacon.InsecureParameters != nil {
+		cfg.Beacon.InsecureParameters.Interval = defaultEpochtimeTendermintInterval
+	}
+}
+
+// Config returns the network configuration.
+func (net *Network) Config() *NetworkCfg {
+	return net.cfg
+}
+
+// Entities returns the entities associated with the network.
+func (net *Network) Entities() []*Entity {
+	return net.entities
+}
+
+// Validators returns the validators associated with the network.
+func (net *Network) Validators() []*Validator {
+	return net.validators
+}
+
+// Runtimes returns the runtimes associated with the network.
+func (net *Network) Runtimes() []*Runtime {
+	return net.runtimes
+}
+
+// Seeds returns the seed node associated with the network.
+func (net *Network) Seeds() []*Seed {
+	return net.seeds
+}
+
+// Keymanagers returns the keymanagers associated with the network.
+func (net *Network) Keymanagers() []*Keymanager {
+	return net.keymanagers
+}
+
+// StorageWorkers returns the storage worker nodes associated with the network.
+func (net *Network) StorageWorkers() []*Storage {
+	return net.storageWorkers
+}
+
+// ComputeWorkers returns the compute worker nodes associated with the network.
+func (net *Network) ComputeWorkers() []*Compute {
+	return net.computeWorkers
+}
+
+// Sentries returns the sentry nodes associated with the network.
+func (net *Network) Sentries() []*Sentry {
+	return net.sentries
+}
+
+// Clients returns the client nodes associated with the network.
+func (net *Network) Clients() []*Client {
+	return net.clients
+}
+
+// Byzantine returns the byzantine nodes associated with the network.
+func (net *Network) Byzantine() []*Byzantine {
+	return net.byzantine
+}
+
+// Nodes returns all the validator, compute, storage, keymanager and client nodes associated with
+// the network.
+//
+// Seed, sentry, byzantine and IAS proxy nodes are omitted if they're only hosting these single features.
+func (net *Network) Nodes() []*Node {
+	// Ignore net.nodes, since it contains too much.
+	var nodes []*Node
+	for _, v := range net.Validators() {
+		nodes = append(nodes, v.Node)
+	}
+	for _, s := range net.StorageWorkers() {
+		nodes = append(nodes, s.Node)
+	}
+	for _, c := range net.ComputeWorkers() {
+		nodes = append(nodes, c.Node)
+	}
+	for _, k := range net.Keymanagers() {
+		nodes = append(nodes, k.Node)
+	}
+	for _, v := range net.Clients() {
+		nodes = append(nodes, v.Node)
+	}
+	return nodes
+}
+
+// GetNamedNode retrieves the node object for the node with the given name and loads
+// the given node config into it. If no node with the given name exists, a new
+// one is created.
+func (net *Network) GetNamedNode(defaultName string, cfg *NodeCfg) (*Node, error) {
+	name := defaultName
+	if cfg != nil && cfg.Name != "" {
+		name = cfg.Name
+	}
+
+	var node *Node
+	for _, n := range net.nodes {
+		if n.Name == name {
+			node = n
+			break
+		}
+	}
+	newNode := node == nil
+	if node == nil {
+		nodeDir, err := net.baseDir.NewSubDir(name)
+		if err != nil {
+			net.logger.Error("failed to create node subdir",
+				"err", err,
+				"node_name", name,
+			)
+			return nil, fmt.Errorf("oasis/network: failed to create node subdir: %w", err)
+		}
+
+		node = &Node{
+			Name:           name,
+			net:            net,
+			dir:            nodeDir,
+			assignedPorts:  map[string]uint16{},
+			hostedRuntimes: map[common.Namespace]*hostedRuntime{},
+		}
+
+		net.nodes = append(net.nodes, node)
+	}
+
+	if cfg != nil {
+		cfg.Into(node)
+		if newNode {
+			if err := net.AddLogWatcher(node); err != nil {
+				net.logger.Error("failed to add log watcher",
+					"err", err,
+					"node_name", name,
+				)
+				return nil, fmt.Errorf("oasis/network: failed to add log watcher for %s: %w", name, err)
+			}
+		}
+	}
+	return node, nil
+}
+
+// Errors returns the channel by which node failures will be conveyed.
+func (net *Network) Errors() <-chan error {
+	return net.errCh
+}
+
+// Controller returns the network controller.
+func (net *Network) Controller() *Controller {
+	return net.controller
+}
+
+// ClientController returns the client controller connected to the first client node.
+func (net *Network) ClientController() *Controller {
+	return net.clientController
+}
+
+// NumRegisterNodes returns the number of all nodes that need to register.
+func (net *Network) NumRegisterNodes() int {
+	return len(net.validators) +
+		len(net.keymanagers) +
+		len(net.storageWorkers) +
+		len(net.computeWorkers) +
+		len(net.byzantine)
+}
+
+// AddLogWatcher adds a log watcher for the given node and creates log watcher
+// handlers from the networks's default and node's specific log watcher handler
+// factories.
+func (net *Network) AddLogWatcher(node *Node) error {
+	var logWatcherHandlers []log.WatcherHandler
+	// Add network's default log watcher handlers.
+	if !node.disableDefaultLogWatcherHandlerFactories {
+		for _, logWatcherHandlerFactory := range net.cfg.DefaultLogWatcherHandlerFactories {
+			logWatcherHandler, err := logWatcherHandlerFactory.New()
+			if err != nil {
+				return err
+			}
+			logWatcherHandlers = append(logWatcherHandlers, logWatcherHandler)
+		}
+	}
+	// Add node's specific log watcher handlers.
+	for _, logWatcherHandlerFactory := range node.logWatcherHandlerFactories {
+		logWatcherHandler, err := logWatcherHandlerFactory.New()
+		if err != nil {
+			return err
+		}
+		logWatcherHandlers = append(logWatcherHandlers, logWatcherHandler)
+	}
+	logFileWatcher, err := log.NewWatcher(&log.WatcherConfig{
+		Name:     fmt.Sprintf("%s/log", node.Name),
+		File:     nodeLogPath(node.dir),
+		Handlers: logWatcherHandlers,
+	})
+	if err != nil {
+		return err
+	}
+	net.env.AddOnCleanup(logFileWatcher.Cleanup)
+	net.logWatchers = append(net.logWatchers, logFileWatcher)
+	return nil
+}
+
+// CheckLogWatchers closes all log watchers and checks if any errors were reported
+// while the log watchers were running.
+func (net *Network) CheckLogWatchers() (err error) {
+	for _, w := range net.logWatchers {
+		w.Cleanup()
+		if logErr := <-w.Errors(); logErr != nil {
+			net.logger.Error("log watcher reported error",
+				"name", w.Name(),
+				"err", logErr,
+			)
+			err = fmt.Errorf("log watcher %s: %w", w.Name(), logErr)
+		}
+	}
+	return
+}
+
+// Start starts the network.
+func (net *Network) Start() error { // nolint: gocyclo
+	if net.running {
+		return nil
+	}
+
+	net.logger.Info("starting network")
+
+	// Figure out if the IAS proxy is needed by peeking at all the
+	// runtimes.
+	for _, v := range net.Runtimes() {
+		needIASProxy := v.teeHardware == node.TEEHardwareIntelSGX
+		if needIASProxy {
+			if _, err := net.newIASProxy(); err != nil {
+				net.logger.Error("failed to provision IAS proxy",
+					"err", err,
+				)
+				return err
+			}
+			break
+		}
+	}
+
+	if net.cfg.GenesisFile == "" {
+		net.logger.Debug("provisioning genesis doc")
+		if err := net.MakeGenesis(); err != nil {
+			net.logger.Error("failed to create genesis document",
+				"err", err,
+			)
+			return err
+		}
+	} else {
+		net.logger.Debug("using existing genesis doc",
+			"path", net.cfg.GenesisFile,
+		)
+	}
+
+	// Retrieve the genesis document and use it to configure the context for
+	// signature domain separation.
+	genesisProvider, err := genesisFile.NewFileProvider(net.GenesisPath())
+	if err != nil {
+		net.logger.Error("failed to load genesis file",
+			"err", err,
+		)
+		return err
+	}
+	genesisDoc, err := genesisProvider.GetGenesisDocument()
+	if err != nil {
+		net.logger.Error("failed to retrieve genesis document",
+			"err", err,
+		)
+		return err
+	}
+	// NOTE: We need to reset the chain context here as E2E tests can run
+	//       with different genesis documents which would change the context.
+	signature.UnsafeResetChainContext()
+	genesisDoc.SetChainContext()
+
+	var iasNodeName string
+
+	net.logger.Debug("starting IAS proxy node")
+	if net.iasProxy != nil {
+		if err = net.iasProxy.Start(); err != nil {
+			net.logger.Error("failed to start IAS proxy node",
+				"err", err,
+			)
+			return err
+		}
+		iasNodeName = net.iasProxy.Name
+	}
+
+	net.logger.Debug("starting network nodes")
+	for _, n := range net.nodes {
+		if n.Name == iasNodeName {
+			continue
+		}
+		if n.noAutoStart {
+			net.logger.Debug("skipping non-autostartable node", "name", n.Name)
+			continue
+		}
+		net.logger.Debug("starting node", "name", n.Name)
+		if err = n.Start(); err != nil {
+			net.logger.Error("failed to start node",
+				"name", n.Name,
+				"err", err,
+			)
+			return err
+		}
+
+		// HACK HACK HACK HACK HACK
+		//
+		// If you don't attempt to start the Tendermint Prometheus HTTP server
+		// (even if it is doomed to fail due to node already listening on the
+		// port), and you launch all the validators near simultaneously, there
+		// is a high chance that at least one of the validators will get upset
+		// and start refusing connections.
+		if n.hasValidators {
+			time.Sleep(validatorStartDelay)
+		}
+	}
+
+	// Use the first started validator as a controller.
+	for _, v := range net.validators {
+		if v.noAutoStart {
+			continue
+		}
+
+		if net.controller, err = NewController(net.validators[0].SocketPath()); err != nil {
+			net.logger.Error("failed to create controller",
+				"err", err,
+			)
+			return fmt.Errorf("oasis: failed to create controller: %w", err)
+		}
+		break
+	}
+
+	// Create a client controller for the first started client node.
+	for _, v := range net.clients {
+		if v.noAutoStart {
+			continue
+		}
+
+		if net.clientController, err = NewController(net.clients[0].SocketPath()); err != nil {
+			net.logger.Error("failed to create client controller",
+				"err", err,
+			)
+			return fmt.Errorf("oasis: failed to create client controller: %w", err)
+		}
+		break
+	}
+
+	net.logger.Info("network started")
+	net.running = true
+
+	return nil
+}
+
+// Stop stops the network.
+func (net *Network) Stop() {
+	net.env.Cleanup()
+	net.running = false
+}
+
+func (net *Network) runNodeBinary(consoleWriter io.Writer, args ...string) error {
+	nodeBinary := net.cfg.NodeBinary
+	cmd := exec.Command(nodeBinary, args...)
+	cmd.SysProcAttr = env.CmdAttrs
+	if consoleWriter != nil {
+		cmd.Stdout = consoleWriter
+		cmd.Stderr = consoleWriter
+	}
+
+	net.logger.Info("launching node",
+		"args", strings.Join(args, " "),
+	)
+
+	return cmd.Run()
+}
+
+func (net *Network) generateDeterministicIdentity(dir *env.Dir, rawSeed string, roles []signature.SignerRole) error {
+	_, err := GenerateDeterministicNodeKeys(dir, rawSeed, roles)
+	return err
+}
+
+func (net *Network) generateDeterministicNodeIdentity(dir *env.Dir, rawSeed string) error {
+	return net.generateDeterministicIdentity(dir, rawSeed, []signature.SignerRole{
+		signature.SignerNode,
+		signature.SignerP2P,
+		signature.SignerConsensus,
+	})
+}
+
+// GenerateDeterministicNodeKeys generates and returns deterministic node keys.
+func GenerateDeterministicNodeKeys(dir *env.Dir, rawSeed string, roles []signature.SignerRole) ([]signature.PublicKey, error) {
+	h := crypto.SHA512.New()
+	_, _ = h.Write([]byte(rawSeed))
+	seed := h.Sum(nil)
+
+	rng, err := drbg.New(crypto.SHA512, seed, nil, []byte("deterministic node identities test"))
+	if err != nil {
+		return nil, err
+	}
+
+	var dirStr string
+	factoryCtor := func(args interface{}, roles ...signature.SignerRole) (signature.SignerFactory, error) {
+		return memorySigner.NewFactory(), nil
+	}
+	if dir != nil {
+		factoryCtor = fileSigner.NewFactory
+		dirStr = dir.String()
+	}
+
+	var pks []signature.PublicKey
+	for _, role := range roles {
+		factory, err := factoryCtor(dirStr, role)
+		if err != nil {
+			return nil, err
+		}
+		signer, err := factory.Generate(role, rng)
+		if err != nil {
+			return nil, err
+		}
+		pks = append(pks, signer.Public())
+	}
+
+	return pks, nil
+}
+
+// generateTempSocketPath returns a unique filename for a node's internal socket in the test base dir
+//
+// This function is used to obtain shorter socket path than the one in datadir since that one might
+// be too long for unix socket path.
+func (net *Network) generateTempSocketPath() string {
+	f, err := ioutil.TempFile(env.GetRootDir().String(), "internal-*.sock")
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	return f.Name()
+}
+
+func (net *Network) startOasisNode(
+	node *Node,
+	subCmd []string,
+	extraArgs *argBuilder,
+) error {
+	node.Lock()
+	defer node.Unlock()
+
+	baseArgs := []string{
+		"--" + cmdCommon.CfgDataDir, node.dir.String(),
+		"--log.level", "debug",
+		"--log.format", "json",
+		"--log.file", nodeLogPath(node.dir),
+		"--genesis.file", net.GenesisPath(),
+	}
+	if len(subCmd) == 0 {
+		extraArgs = extraArgs.
+			appendIASProxy(net.iasProxy).
+			tendermintDebugAddrBookLenient().
+			tendermintDebugAllowDuplicateIP().
+			tendermintUpgradeStopDelay(10 * time.Second)
+	}
+	if net.cfg.UseShortGrpcSocketPaths {
+		// Keep the socket, if it was already generated!
+		if node.customGrpcSocketPath == "" {
+			node.customGrpcSocketPath = net.generateTempSocketPath()
+		}
+		extraArgs = extraArgs.debugDontBlameOasis()
+		extraArgs = extraArgs.grpcDebugGrpcInternalSocketPath(node.customGrpcSocketPath)
+	}
+	if node.consensusStateSync != nil {
+		extraArgs = extraArgs.tendermintStateSync(
+			node.consensusStateSync.ConsensusNodes,
+			node.consensusStateSync.TrustHeight,
+			node.consensusStateSync.TrustHash,
+		)
+	}
+	if viper.IsSet(metrics.CfgMetricsAddr) {
+		extraArgs = extraArgs.appendNodeMetrics(node)
+	}
+	args := append([]string{}, subCmd...)
+	args = append(args, baseArgs...)
+	args = append(args, extraArgs.merge()...)
+
+	w, err := node.dir.NewLogWriter(logConsoleFile)
+	if err != nil {
+		return err
+	}
+	net.env.AddOnCleanup(func() {
+		_ = w.Close()
+	})
+
+	oasisBinary := net.cfg.NodeBinary
+	cmd := exec.Command(oasisBinary, args...)
+	cmd.SysProcAttr = env.CmdAttrs
+	cmd.Stdout = w
+	cmd.Stderr = w
+
+	net.logger.Info("launching Oasis node",
+		"args", strings.Join(args, " "),
+	)
+
+	if err = cmd.Start(); err != nil {
+		return fmt.Errorf("oasis: failed to start node: %w", err)
+	}
+
+	doneCh := net.env.AddTermOnCleanup(cmd)
+	exitCh := make(chan error, 1)
+	go func() {
+		defer close(exitCh)
+
+		cmdErr := <-doneCh
+		net.logger.Debug("node terminated",
+			"err", cmdErr,
+		)
+
+		if cmdErr != nil {
+			exitCh <- cmdErr
+		}
+
+		if err := node.handleExit(cmdErr); err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) && exitErr.ExitCode() == crash.CrashDefaultExitCode {
+				// Termination due to crasher. Restart node.
+				net.logger.Info("Node debug crash point triggered. Restarting...", "node", node.Name)
+				if err = net.startOasisNode(node, subCmd, extraArgs); err != nil {
+					net.errCh <- fmt.Errorf("oasis: %s failed restarting node after crash point: %w", node.Name, err)
+				}
+				return
+			}
+
+			net.errCh <- fmt.Errorf("oasis: %s node terminated: %w", node.Name, err)
+		}
+	}()
+
+	node.cmd = cmd
+	node.exitCh = exitCh
+
+	return nil
+}
+
+// MakeGenesis generates a new Genesis file.
+func (net *Network) MakeGenesis() error {
+	args := []string{
+		"genesis", "init",
+		"--genesis.file", net.GenesisPath(),
+		"--chain.id", genesisTestHelpers.TestChainID,
+		"--initial_height", strconv.FormatInt(net.cfg.InitialHeight, 10),
+		"--halt.epoch", strconv.FormatUint(net.cfg.HaltEpoch, 10),
+		"--consensus.backend", net.cfg.Consensus.Backend,
+		"--consensus.tendermint.timeout_commit", net.cfg.Consensus.Parameters.TimeoutCommit.String(),
+		"--registry.enable_runtime_governance_models", "entity,runtime",
+		"--registry.debug.allow_unroutable_addresses", "true",
+		"--" + genesis.CfgRegistryDebugAllowTestRuntimes, "true",
+		"--scheduler.max_validators_per_entity", strconv.Itoa(len(net.Validators())),
+		"--" + genesis.CfgConsensusGasCostsTxByte, strconv.FormatUint(uint64(net.cfg.Consensus.Parameters.GasCosts[consensusGenesis.GasOpTxByte]), 10),
+		"--" + genesis.CfgConsensusStateCheckpointInterval, strconv.FormatUint(net.cfg.Consensus.Parameters.StateCheckpointInterval, 10),
+		"--" + genesis.CfgConsensusStateCheckpointNumKept, strconv.FormatUint(net.cfg.Consensus.Parameters.StateCheckpointNumKept, 10),
+		"--" + genesis.CfgStakingTokenSymbol, genesisTestHelpers.TestStakingTokenSymbol,
+		"--" + genesis.CfgStakingTokenValueExponent, strconv.FormatUint(
+			uint64(genesisTestHelpers.TestStakingTokenValueExponent), 10),
+		"--" + genesis.CfgBeaconBackend, net.cfg.Beacon.Backend,
+	}
+	switch net.cfg.Beacon.Backend {
+	case beacon.BackendInsecure:
+		args = append(args, []string{
+			"--" + genesis.CfgBeaconInsecureTendermintInterval, strconv.FormatInt(net.cfg.Beacon.InsecureParameters.Interval, 10),
+		}...)
+	case beacon.BackendPVSS:
+		args = append(args, []string{
+			"--" + genesis.CfgBeaconPVSSParticipants, strconv.FormatUint(uint64(net.cfg.Beacon.PVSSParameters.Participants), 10),
+			"--" + genesis.CfgBeaconPVSSThreshold, strconv.FormatUint(uint64(net.cfg.Beacon.PVSSParameters.Threshold), 10),
+			"--" + genesis.CfgBeaconPVSSCommitInterval, strconv.FormatInt(net.cfg.Beacon.PVSSParameters.CommitInterval, 10),
+			"--" + genesis.CfgBeaconPVSSRevealInterval, strconv.FormatInt(net.cfg.Beacon.PVSSParameters.RevealInterval, 10),
+			"--" + genesis.CfgBeaconPVSSTransitionDelay, strconv.FormatInt(net.cfg.Beacon.PVSSParameters.TransitionDelay, 10),
+		}...)
+		if pks := net.cfg.Beacon.PVSSParameters.DebugForcedParticipants; len(pks) > 0 {
+			for _, pk := range pks {
+				args = append(args, []string{
+					"--" + genesis.CfgBeaconPVSSDebugForcedParticipant, pk.String(),
+				}...)
+			}
+		}
+	default:
+		return fmt.Errorf("oasis: unsupported beacon backend: %s", net.cfg.Beacon.Backend)
+	}
+	if net.cfg.Beacon.DebugMockBackend {
+		args = append(args, "--"+genesis.CfgBeaconDebugMockBackend)
+	}
+	if net.cfg.Beacon.DebugDeterministic || net.cfg.DeterministicIdentities {
+		args = append(args, "--"+genesis.CfgBeaconDebugDeterministic)
+	}
+	if cfg := net.cfg.GovernanceParameters; cfg != nil {
+		args = append(args, []string{
+			"--" + genesis.CfgGovernanceMinProposalDeposit, strconv.FormatUint(cfg.MinProposalDeposit.ToBigInt().Uint64(), 10),
+			"--" + genesis.CfgGovernanceQuorum, strconv.FormatUint(uint64(cfg.Quorum), 10),
+			"--" + genesis.CfgGovernanceThreshold, strconv.FormatUint(uint64(cfg.Threshold), 10),
+			"--" + genesis.CfgGovernanceUpgradeCancelMinEpochDiff, strconv.FormatUint(uint64(cfg.UpgradeCancelMinEpochDiff), 10),
+			"--" + genesis.CfgGovernanceUpgradeMinEpochDiff, strconv.FormatUint(uint64(cfg.UpgradeMinEpochDiff), 10),
+			"--" + genesis.CfgGovernanceVotingPeriod, strconv.FormatUint(uint64(cfg.VotingPeriod), 10),
+		}...)
+	}
+	for _, v := range net.entities {
+		args = append(args, v.toGenesisDescriptorArgs()...)
+	}
+	for _, v := range net.validators {
+		args = append(args, v.toGenesisArgs()...)
+	}
+	for _, v := range net.runtimes {
+		args = append(args, v.toGenesisArgs()...)
+	}
+	for _, v := range net.keymanagerPolicies {
+		if err := v.provision(); err != nil {
+			return err
+		}
+	}
+	for _, v := range net.keymanagers {
+		if err := v.provisionGenesis(); err != nil {
+			return err
+		}
+		args = append(args, v.toGenesisArgs()...)
+	}
+
+	if net.cfg.StakingGenesis != nil {
+		if net.cfg.FundEntities {
+			toFund := quantity.NewFromUint64(1000000000000)
+			if net.cfg.StakingGenesis.Ledger == nil {
+				net.cfg.StakingGenesis.Ledger = make(map[staking.Address]*staking.Account)
+			}
+			for _, ent := range net.Entities() {
+				if ent.isDebugTestEntity {
+					// Debug test entities already get funded.
+					continue
+				}
+				net.cfg.StakingGenesis.Ledger[staking.NewAddress(ent.Signer().Public())] = &staking.Account{
+					General: staking.GeneralAccount{
+						Balance: *toFund,
+					},
+				}
+				_ = net.cfg.StakingGenesis.TotalSupply.Add(toFund)
+			}
+		}
+
+		path := filepath.Join(net.baseDir.String(), stakingGenesisFile)
+		b, err := json.Marshal(net.cfg.StakingGenesis)
+		if err != nil {
+			net.logger.Error("failed to serialize staking genesis file",
+				"err", err,
+			)
+			return fmt.Errorf("oasis: failed to serialize staking genesis file: %w", err)
+		}
+		if err = ioutil.WriteFile(path, b, 0o600); err != nil {
+			net.logger.Error("failed to write staking genesis file",
+				"err", err,
+			)
+			return fmt.Errorf("oasis: failed to write staking genesis file: %w", err)
+		}
+		args = append(args, "--staking", path)
+	}
+	if len(net.byzantine) > 0 {
+		// If the byzantine node is in use, disable max node expiration
+		// enforcement, because it wants to register for 1000 epochs.
+		args = append(args, []string{
+			"--" + genesis.CfgRegistryMaxNodeExpiration, "0",
+		}...)
+	}
+
+	w, err := net.baseDir.NewLogWriter("genesis_provision.log")
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	if err := net.runNodeBinary(w, args...); err != nil {
+		net.logger.Error("failed to create genesis file",
+			"err", err,
+		)
+		return fmt.Errorf("oasis: failed to create genesis file: %w", err)
+	}
+
+	return nil
+}
+
+// GenesisPath returns the path to the genesis file for the network.
+func (net *Network) GenesisPath() string {
+	if net.cfg.GenesisFile != "" {
+		return net.cfg.GenesisFile
+	}
+	return filepath.Join(net.baseDir.String(), "genesis.json")
+}
+
+// BasePath returns the path to the network base directory.
+func (net *Network) BasePath() string {
+	return net.baseDir.String()
+}
+
+// Implements cli.Factory.
+func (net *Network) GetCLIConfig() cli.Config {
+	cfg := cli.Config{
+		NodeBinary:  net.cfg.NodeBinary,
+		GenesisFile: net.GenesisPath(),
+	}
+	if len(net.Validators()) > 0 {
+		val := net.Validators()[0]
+		if net.cfg.UseShortGrpcSocketPaths && val.customGrpcSocketPath == "" {
+			val.customGrpcSocketPath = net.generateTempSocketPath()
+		}
+		cfg.NodeSocketPath = val.SocketPath()
+	}
+	return cfg
+}
+
+func (net *Network) provisionNodeIdentity(dataDir *env.Dir, seed string, persistTLS bool) (signature.PublicKey, signature.PublicKey, *x509.Certificate, error) {
+	if net.cfg.DeterministicIdentities && !net.cfg.RestoreIdentities {
+		if err := net.generateDeterministicNodeIdentity(dataDir, seed); err != nil {
+			return signature.PublicKey{}, signature.PublicKey{}, nil, fmt.Errorf("oasis: failed to generate deterministic identity: %w", err)
+		}
+	}
+
+	signerFactory, err := fileSigner.NewFactory(dataDir.String(), signature.SignerNode, signature.SignerP2P, signature.SignerConsensus)
+	if err != nil {
+		return signature.PublicKey{}, signature.PublicKey{}, nil, fmt.Errorf("oasis: failed to create node file signer factory: %w", err)
+	}
+	nodeIdentity, err := identity.LoadOrGenerate(dataDir.String(), signerFactory, persistTLS)
+	if err != nil {
+		return signature.PublicKey{}, signature.PublicKey{}, nil, fmt.Errorf("oasis: failed to provision node identity: %w", err)
+	}
+	sentryCert, err := x509.ParseCertificate(nodeIdentity.TLSSentryClientCertificate.Certificate[0])
+	if err != nil {
+		return signature.PublicKey{}, signature.PublicKey{}, nil, fmt.Errorf("oasis: failed to parse sentry client certificate: %w", err)
+	}
+	return nodeIdentity.NodeSigner.Public(), nodeIdentity.P2PSigner.Public(), sentryCert, nil
+}
+
+// New creates a new test Oasis network.
+func New(env *env.Env, cfg *NetworkCfg) (*Network, error) {
+	baseDir, err := env.NewSubDir("network")
+	if err != nil {
+		return nil, fmt.Errorf("oasis: failed to create network sub-directory: %w", err)
+	}
+
+	// Copy the config and apply some sane defaults.
+	cfgCopy := *cfg
+	if cfgCopy.Consensus.Backend == "" {
+		cfgCopy.Consensus.Backend = defaultConsensusBackend
+	}
+	if cfgCopy.Consensus.Parameters.TimeoutCommit == 0 {
+		cfgCopy.Consensus.Parameters.TimeoutCommit = defaultConsensusTimeoutCommit
+	}
+	if cfgCopy.Consensus.Parameters.GasCosts == nil {
+		cfgCopy.Consensus.Parameters.GasCosts = make(transaction.Costs)
+	}
+	if cfgCopy.Beacon.Backend == "" {
+		cfgCopy.Beacon.Backend = beacon.BackendPVSS
+	}
+	switch cfgCopy.Beacon.Backend {
+	case beacon.BackendInsecure:
+		if cfgCopy.Beacon.InsecureParameters == nil {
+			cfgCopy.Beacon.InsecureParameters = new(beacon.InsecureParameters)
+		}
+		if cfgCopy.Beacon.InsecureParameters.Interval == 0 {
+			cfgCopy.Beacon.InsecureParameters.Interval = defaultEpochtimeTendermintInterval
+		}
+	case beacon.BackendPVSS:
+		if cfgCopy.Beacon.PVSSParameters == nil {
+			cfgCopy.Beacon.PVSSParameters = new(beacon.PVSSParameters)
+		}
+		if cfgCopy.Beacon.PVSSParameters.Participants == 0 {
+			cfgCopy.Beacon.PVSSParameters.Participants = defaultPVSSParticipants
+		}
+		if cfgCopy.Beacon.PVSSParameters.Threshold == 0 {
+			cfgCopy.Beacon.PVSSParameters.Threshold = defaultPVSSThreshold
+		}
+		if cfgCopy.Beacon.PVSSParameters.CommitInterval == 0 {
+			cfgCopy.Beacon.PVSSParameters.CommitInterval = defaultPVSSCommitInterval
+		}
+		if cfgCopy.Beacon.PVSSParameters.RevealInterval == 0 {
+			cfgCopy.Beacon.PVSSParameters.RevealInterval = defaultPVSSRevealInterval
+		}
+		if cfgCopy.Beacon.PVSSParameters.TransitionDelay == 0 {
+			cfgCopy.Beacon.PVSSParameters.TransitionDelay = defaultPVSSTransitionDelay
+		}
+	}
+	if cfgCopy.InitialHeight == 0 {
+		cfgCopy.InitialHeight = defaultInitialHeight
+	}
+	if cfgCopy.HaltEpoch == 0 {
+		cfgCopy.HaltEpoch = defaultHaltEpoch
+	}
+
+	net := &Network{
+		logger:       logging.GetLogger("oasis/" + env.Name()),
+		env:          env,
+		baseDir:      baseDir,
+		cfg:          &cfgCopy,
+		nextNodePort: baseNodePort,
+		errCh:        make(chan error, maxNodes),
+	}
+
+	// Pre-provision node objects if they were listed in the top-level network fixture.
+	for _, nodeName := range cfg.Nodes {
+		_, err = net.GetNamedNode(nodeName, nil)
+		if err != nil {
+			return nil, fmt.Errorf("oasis: failed to create node %s: %w", nodeName, err)
+		}
+	}
+
+	return net, nil
+}

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -3,46 +3,22 @@ package oasis
 
 import (
 	"context"
-	"crypto"
 	"crypto/x509"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"math"
 	"os/exec"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 
-	"github.com/spf13/viper"
-
-	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
-	"github.com/oasisprotocol/oasis-core/go/common/crash"
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/drbg"
+	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	fileSigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/file"
-	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
-	"github.com/oasisprotocol/oasis-core/go/common/logging"
-	"github.com/oasisprotocol/oasis-core/go/common/node"
-	"github.com/oasisprotocol/oasis-core/go/common/quantity"
-	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
-	consensusGenesis "github.com/oasisprotocol/oasis-core/go/consensus/genesis"
-	genesisFile "github.com/oasisprotocol/oasis-core/go/genesis/file"
-	genesisTestHelpers "github.com/oasisprotocol/oasis-core/go/genesis/tests"
-	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
-	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
+	commonNode "github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/grpc"
-	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/metrics"
-	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/genesis"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/log"
-	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis/cli"
-	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
 const (
@@ -68,6 +44,11 @@ const (
 	stakingGenesisFile = "staking_genesis.json"
 
 	maxNodes = 32 // Arbitrary
+
+	nodePortConsensus = "consensus"
+	nodePortClient    = "client"
+	nodePortP2P       = "p2p"
+	nodePortPprof     = "pprof"
 )
 
 // ConsensusStateSyncCfg is a node's consensus state sync configuration.
@@ -77,22 +58,43 @@ type ConsensusStateSyncCfg struct {
 	TrustHash      string
 }
 
+// Feature is a feature or worker hosted by a concrete oasis-node process.
+type Feature interface {
+	AddArgs(args *argBuilder) error
+}
+
+// CustomStartFeature is a feature with a customized start method.
+type CustomStartFeature interface {
+	CustomStart(args *argBuilder) error
+}
+
+type hostedRuntime struct {
+	runtime   *Runtime
+	tee       commonNode.TEEHardware
+	binaryIdx int
+}
+
 // Node defines the common fields for all node types.
 type Node struct { // nolint: maligned
 	sync.Mutex
 
 	Name   string
 	NodeID signature.PublicKey
+	Args   *argBuilder
 
 	net *Network
 	dir *env.Dir
 	cmd *exec.Cmd
 
+	features       []Feature
+	hasValidators  bool
+	assignedPorts  map[string]uint16
+	hostedRuntimes map[common.Namespace]*hostedRuntime
+
 	exitCh chan error
 
 	termEarlyOk bool
 	termErrorOk bool
-	doStartNode func() error
 	isStopping  bool
 	noAutoStart bool
 
@@ -107,6 +109,41 @@ type Node struct { // nolint: maligned
 	customGrpcSocketPath string
 
 	pprofPort uint16
+
+	nodeSigner signature.PublicKey
+	p2pSigner  signature.PublicKey
+	sentryCert *x509.Certificate
+
+	entity *Entity
+}
+
+func (n *Node) getProvisionedPort(portName string) uint16 {
+	port, ok := n.assignedPorts[portName]
+	if !ok {
+		port = n.net.nextNodePort
+		n.net.nextNodePort++
+		n.assignedPorts[portName] = port
+	}
+	return port
+}
+
+func (n *Node) addHostedRuntime(rt *Runtime, tee commonNode.TEEHardware, binaryIdx int) {
+	hosted, ok := n.hostedRuntimes[rt.id]
+	if !ok {
+		n.hostedRuntimes[rt.id] = &hostedRuntime{
+			runtime:   rt,
+			tee:       tee,
+			binaryIdx: binaryIdx,
+		}
+		return
+	}
+
+	if tee > hosted.tee {
+		hosted.tee = tee
+	}
+	if binaryIdx != hosted.binaryIdx {
+		panic(fmt.Sprintf("oasis/node: conflicting runtime binary index (%d vs. %d)", binaryIdx, hosted.binaryIdx))
+	}
 }
 
 // Exit returns a channel that will close once the node shuts down.
@@ -142,6 +179,36 @@ func (n *Node) LoadIdentity() (*identity.Identity, error) {
 		return nil, err
 	}
 	return identity.Load(n.dir.String(), factory)
+}
+
+// Start starts the node.
+func (n *Node) Start() error {
+	args := newArgBuilder()
+	var customStart CustomStartFeature
+	for _, f := range n.features {
+		if err := f.AddArgs(args); err != nil {
+			return fmt.Errorf("oasis/node: failed to add arguments for feature on node %s: %w", n.Name, err)
+		}
+		if cf, ok := f.(CustomStartFeature); ok {
+			if customStart != nil {
+				return fmt.Errorf("oasis/node: multiple features with customized startup on node %s", n.Name)
+			}
+			customStart = cf
+		}
+	}
+	for _, hosted := range n.hostedRuntimes {
+		args.appendHostedRuntime(hosted.runtime, hosted.tee, hosted.binaryIdx)
+	}
+
+	if customStart != nil {
+		return customStart.CustomStart(args)
+	}
+
+	if err := n.net.startOasisNode(n, nil, args); err != nil {
+		return fmt.Errorf("oasis/node: failed to launch node %s: %w", n.Name, err)
+	}
+
+	return nil
 }
 
 func (n *Node) stopNode() error {
@@ -183,7 +250,7 @@ func (n *Node) RestartAfter(ctx context.Context, startDelay time.Duration) error
 	case <-ctx.Done():
 		return ctx.Err()
 	}
-	return n.doStartNode()
+	return n.Start()
 }
 
 // BinaryPath returns the path to the running node's process' image, or an empty string
@@ -246,8 +313,35 @@ func (n *Node) SetConsensusStateSync(cfg *ConsensusStateSyncCfg) {
 	n.consensusStateSync = cfg
 }
 
+func (n *Node) setProvisionedIdentity(persistTLS bool, seed string) error {
+	if len(seed) < 1 {
+		seed = n.Name
+	}
+	if n.sentryCert != nil {
+		return nil
+	}
+
+	nodeSigner, p2pSigner, sentryCert, err := n.net.provisionNodeIdentity(n.dir, seed, persistTLS)
+	if err != nil {
+		return err
+	}
+
+	if err := n.entity.addNode(nodeSigner); err != nil {
+		return err
+	}
+
+	n.nodeSigner = nodeSigner
+	n.p2pSigner = p2pSigner
+	n.sentryCert = sentryCert
+	copy(n.NodeID[:], nodeSigner[:])
+
+	return nil
+}
+
 // NodeCfg defines the common node configuration options.
 type NodeCfg struct { // nolint: maligned
+	Name string
+
 	AllowEarlyTermination       bool
 	AllowErrorTermination       bool
 	CrashPointsProbability      float64
@@ -261,934 +355,30 @@ type NodeCfg struct { // nolint: maligned
 
 	// Consensus contains configuration for the consensus backend.
 	Consensus ConsensusFixture
+
+	Entity *Entity
 }
 
-// Network is a test Oasis network.
-type Network struct { // nolint: maligned
-	logger *logging.Logger
-
-	env     *env.Env
-	baseDir *env.Dir
-	running bool
-
-	entities       []*Entity
-	validators     []*Validator
-	runtimes       []*Runtime
-	keymanagers    []*Keymanager
-	storageWorkers []*Storage
-	computeWorkers []*Compute
-	sentries       []*Sentry
-	clients        []*Client
-	byzantine      []*Byzantine
-	seeds          []*Seed
-
-	keymanagerPolicies []*KeymanagerPolicy
-
-	iasProxy *iasProxy
-
-	cfg          *NetworkCfg
-	nextNodePort uint16
-
-	logWatchers []*log.Watcher
-
-	controller       *Controller
-	clientController *Controller
-
-	errCh chan error
-}
-
-// IASCfg is the Oasis test network IAS configuration.
-type IASCfg struct {
-	// UseRegistry specifies whether the IAS proxy should use the registry
-	// instead of the genesis document for authenticating runtime IDs.
-	UseRegistry bool `json:"use_registry,omitempty"`
-
-	// Mock specifies if Mock IAS Proxy should be used.
-	Mock bool `json:"mock,omitempty"`
-}
-
-// NetworkCfg is the Oasis test network configuration.
-type NetworkCfg struct { // nolint: maligned
-	// GenesisFile is an optional genesis file to use.
-	GenesisFile string `json:"genesis_file,omitempty"`
-
-	// NodeBinary is the path to the Oasis node binary.
-	NodeBinary string `json:"node_binary"`
-
-	// RuntimeSGXLoaderBinary is the path to the Oasis SGX runtime loader.
-	RuntimeSGXLoaderBinary string `json:"runtime_loader_binary"`
-
-	// Consensus are the network-wide consensus parameters.
-	Consensus consensusGenesis.Genesis `json:"consensus"`
-
-	// InitialHeight is the initial block height.
-	InitialHeight int64 `json:"initial_height,omitempty"`
-
-	// HaltEpoch is the halt epoch height flag.
-	HaltEpoch uint64 `json:"halt_epoch"`
-
-	// Beacon is the network-wide beacon parameters.
-	Beacon beacon.ConsensusParameters `json:"beacon"`
-
-	// DeterministicIdentities is the deterministic identities flag.
-	DeterministicIdentities bool `json:"deterministic_identities"`
-
-	// RestoreIdentities is the restore identities flag.
-	RestoreIdentities bool `json:"restore_identities"`
-
-	// FundEntities is the fund entities flag.
-	FundEntities bool `json:"fund_entities"`
-
-	// IAS is the Network IAS configuration.
-	IAS IASCfg `json:"ias"`
-
-	// StakingGenesis is the staking genesis data to be included if
-	// GenesisFile is not set.
-	StakingGenesis *staking.Genesis `json:"staking_genesis,omitempty"`
-
-	// GovernanceParameters are the governance consensus parameters.
-	GovernanceParameters *governance.ConsensusParameters `json:"governance_parameters,omitempty"`
-
-	// A set of log watcher handler factories used by default on all nodes
-	// created in this test network.
-	DefaultLogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
-
-	// UseShortGrpcSocketPaths specifies whether nodes should use internal.sock in datadir or
-	// externally-provided.
-	UseShortGrpcSocketPaths bool `json:"-"`
-}
-
-// SetMockEpoch force-enables the mock epoch time keeping.
-func (cfg *NetworkCfg) SetMockEpoch() {
-	cfg.Beacon.DebugMockBackend = true
-	if cfg.Beacon.InsecureParameters != nil {
-		cfg.Beacon.InsecureParameters.Interval = defaultEpochtimeTendermintInterval
-	}
-}
-
-// Config returns the network configuration.
-func (net *Network) Config() *NetworkCfg {
-	return net.cfg
-}
-
-// Entities returns the entities associated with the network.
-func (net *Network) Entities() []*Entity {
-	return net.entities
-}
-
-// Validators returns the validators associated with the network.
-func (net *Network) Validators() []*Validator {
-	return net.validators
-}
-
-// Runtimes returns the runtimes associated with the network.
-func (net *Network) Runtimes() []*Runtime {
-	return net.runtimes
-}
-
-// Seeds returns the seed node associated with the network.
-func (net *Network) Seeds() []*Seed {
-	return net.seeds
-}
-
-// Keymanagers returns the keymanagers associated with the network.
-func (net *Network) Keymanagers() []*Keymanager {
-	return net.keymanagers
-}
-
-// StorageWorkers returns the storage worker nodes associated with the network.
-func (net *Network) StorageWorkers() []*Storage {
-	return net.storageWorkers
-}
-
-// ComputeWorkers returns the compute worker nodes associated with the network.
-func (net *Network) ComputeWorkers() []*Compute {
-	return net.computeWorkers
-}
-
-// Sentries returns the sentry nodes associated with the network.
-func (net *Network) Sentries() []*Sentry {
-	return net.sentries
-}
-
-// Clients returns the client nodes associated with the network.
-func (net *Network) Clients() []*Client {
-	return net.clients
-}
-
-// Byzantine returns the byzantine nodes associated with the network.
-func (net *Network) Byzantine() []*Byzantine {
-	return net.byzantine
-}
-
-// Nodes returns all the validator, compute, storage, keymanager and client nodes associated with
-// the network.
-//
-// Seed, sentry, byzantine and IAS proxy nodes are omitted.
-func (net *Network) Nodes() []*Node {
-	var nodes []*Node
-	for _, v := range net.Validators() {
-		nodes = append(nodes, &v.Node)
-	}
-	for _, s := range net.StorageWorkers() {
-		nodes = append(nodes, &s.Node)
-	}
-	for _, c := range net.ComputeWorkers() {
-		nodes = append(nodes, &c.Node)
-	}
-	for _, k := range net.Keymanagers() {
-		nodes = append(nodes, &k.Node)
-	}
-	for _, v := range net.Clients() {
-		nodes = append(nodes, &v.Node)
-	}
-	return nodes
-}
-
-// Errors returns the channel by which node failures will be conveyed.
-func (net *Network) Errors() <-chan error {
-	return net.errCh
-}
-
-// Controller returns the network controller.
-func (net *Network) Controller() *Controller {
-	return net.controller
-}
-
-// ClientController returns the client controller connected to the first client node.
-func (net *Network) ClientController() *Controller {
-	return net.clientController
-}
-
-// NumRegisterNodes returns the number of all nodes that need to register.
-func (net *Network) NumRegisterNodes() int {
-	return len(net.validators) +
-		len(net.keymanagers) +
-		len(net.storageWorkers) +
-		len(net.computeWorkers) +
-		len(net.byzantine)
-}
-
-// AddLogWatcher adds a log watcher for the given node and creates log watcher
-// handlers from the networks's default and node's specific log watcher handler
-// factories.
-func (net *Network) AddLogWatcher(node *Node) error {
-	var logWatcherHandlers []log.WatcherHandler
-	// Add network's default log watcher handlers.
-	if !node.disableDefaultLogWatcherHandlerFactories {
-		for _, logWatcherHandlerFactory := range net.cfg.DefaultLogWatcherHandlerFactories {
-			logWatcherHandler, err := logWatcherHandlerFactory.New()
-			if err != nil {
-				return err
-			}
-			logWatcherHandlers = append(logWatcherHandlers, logWatcherHandler)
-		}
-	}
-	// Add node's specific log watcher handlers.
-	for _, logWatcherHandlerFactory := range node.logWatcherHandlerFactories {
-		logWatcherHandler, err := logWatcherHandlerFactory.New()
-		if err != nil {
-			return err
-		}
-		logWatcherHandlers = append(logWatcherHandlers, logWatcherHandler)
-	}
-	logFileWatcher, err := log.NewWatcher(&log.WatcherConfig{
-		Name:     fmt.Sprintf("%s/log", node.Name),
-		File:     nodeLogPath(node.dir),
-		Handlers: logWatcherHandlers,
-	})
-	if err != nil {
-		return err
-	}
-	net.env.AddOnCleanup(logFileWatcher.Cleanup)
-	net.logWatchers = append(net.logWatchers, logFileWatcher)
-	return nil
-}
-
-// CheckLogWatchers closes all log watchers and checks if any errors were reported
-// while the log watchers were running.
-func (net *Network) CheckLogWatchers() (err error) {
-	for _, w := range net.logWatchers {
-		w.Cleanup()
-		if logErr := <-w.Errors(); logErr != nil {
-			net.logger.Error("log watcher reported error",
-				"name", w.Name(),
-				"err", logErr,
-			)
-			err = fmt.Errorf("log watcher %s: %w", w.Name(), logErr)
-		}
-	}
-	return
-}
-
-// Start starts the network.
-func (net *Network) Start() error { // nolint: gocyclo
-	if net.running {
-		return nil
-	}
-
-	net.logger.Info("starting network")
-
-	// Figure out if the IAS proxy is needed by peeking at all the
-	// runtimes.
-	for _, v := range net.Runtimes() {
-		needIASProxy := v.teeHardware == node.TEEHardwareIntelSGX
-		if needIASProxy {
-			if _, err := net.newIASProxy(); err != nil {
-				net.logger.Error("failed to provision IAS proxy",
-					"err", err,
-				)
-				return err
-			}
-			break
-		}
-	}
-
-	if net.cfg.GenesisFile == "" {
-		net.logger.Debug("provisioning genesis doc")
-		if err := net.MakeGenesis(); err != nil {
-			net.logger.Error("failed to create genesis document",
-				"err", err,
-			)
-			return err
-		}
-	} else {
-		net.logger.Debug("using existing genesis doc",
-			"path", net.cfg.GenesisFile,
-		)
-	}
-
-	// Retrieve the genesis document and use it to configure the context for
-	// signature domain separation.
-	genesisProvider, err := genesisFile.NewFileProvider(net.GenesisPath())
-	if err != nil {
-		net.logger.Error("failed to load genesis file",
-			"err", err,
-		)
-		return err
-	}
-	genesisDoc, err := genesisProvider.GetGenesisDocument()
-	if err != nil {
-		net.logger.Error("failed to retrieve genesis document",
-			"err", err,
-		)
-		return err
-	}
-	// NOTE: We need to reset the chain context here as E2E tests can run
-	//       with different genesis documents which would change the context.
-	signature.UnsafeResetChainContext()
-	genesisDoc.SetChainContext()
-
-	net.logger.Debug("starting IAS proxy node")
-	if net.iasProxy != nil {
-		if err = net.iasProxy.startNode(); err != nil {
-			net.logger.Error("failed to start IAS proxy node",
-				"err", err,
-			)
-			return err
-		}
-	}
-
-	net.logger.Debug("starting seed node(s)")
-	for _, s := range net.seeds {
-		if s.noAutoStart {
-			continue
-		}
-
-		if err = s.startNode(); err != nil {
-			net.logger.Error("failed to start seed node",
-				"err", err,
-			)
-			return err
-		}
-	}
-
-	net.logger.Debug("starting validator node(s)")
-	for _, v := range net.validators {
-		if v.noAutoStart {
-			continue
-		}
-
-		if err = v.startNode(); err != nil {
-			net.logger.Error("failed to start validator",
-				"err", err,
-			)
-			return err
-		}
-
-		// HACK HACK HACK HACK HACK
-		//
-		// If you don't attempt to start the Tendermint Prometheus HTTP server
-		// (even if it is doomed to fail due to node already listening on the
-		// port), and you launch all the validators near simultaneously, there
-		// is a high chance that at least one of the validators will get upset
-		// and start refusing connections.
-		time.Sleep(validatorStartDelay)
-	}
-
-	net.logger.Debug("starting keymanager(s)")
-	for _, km := range net.keymanagers {
-		if km.noAutoStart {
-			continue
-		}
-
-		if err = km.startNode(); err != nil {
-			net.logger.Error("failed to start keymanager node",
-				"err", err,
-			)
-			return err
-		}
-	}
-
-	net.logger.Debug("starting storage node(s)")
-	for _, v := range net.storageWorkers {
-		if v.noAutoStart {
-			continue
-		}
-
-		if err = v.startNode(); err != nil {
-			net.logger.Error("failed to start storage worker",
-				"err", err,
-			)
-			return err
-		}
-	}
-
-	net.logger.Debug("starting compute node(s)")
-	for _, v := range net.computeWorkers {
-		if v.noAutoStart {
-			continue
-		}
-
-		if err = v.startNode(); err != nil {
-			net.logger.Error("failed to start compute worker",
-				"err", err,
-			)
-			return err
-		}
-	}
-
-	net.logger.Debug("starting sentry node(s)")
-	for _, v := range net.sentries {
-		if v.noAutoStart {
-			continue
-		}
-
-		if err = v.startNode(); err != nil {
-			net.logger.Error("failed to start sentry node",
-				"err", err,
-			)
-			return err
-		}
-
-	}
-
-	net.logger.Debug("starting client node(s)")
-	for _, v := range net.clients {
-		if v.noAutoStart {
-			continue
-		}
-
-		if err = v.startNode(); err != nil {
-			net.logger.Error("failed to start client node",
-				"err", err,
-			)
-			return err
-		}
-	}
-
-	net.logger.Debug("starting byzantine node(s)")
-	for _, v := range net.byzantine {
-		if v.noAutoStart {
-			continue
-		}
-
-		if err = v.startNode(); err != nil {
-			net.logger.Error("failed to start byzantine node",
-				"err", err,
-			)
-			return err
-		}
-	}
-
-	// Use the first started validator as a controller.
-	for _, v := range net.validators {
-		if v.noAutoStart {
-			continue
-		}
-
-		if net.controller, err = NewController(net.validators[0].SocketPath()); err != nil {
-			net.logger.Error("failed to create controller",
-				"err", err,
-			)
-			return fmt.Errorf("oasis: failed to create controller: %w", err)
-		}
-		break
-	}
-
-	// Create a client controller for the first started client node.
-	for _, v := range net.clients {
-		if v.noAutoStart {
-			continue
-		}
-
-		if net.clientController, err = NewController(net.clients[0].SocketPath()); err != nil {
-			net.logger.Error("failed to create client controller",
-				"err", err,
-			)
-			return fmt.Errorf("oasis: failed to create client controller: %w", err)
-		}
-		break
-	}
-
-	net.logger.Info("network started")
-	net.running = true
-
-	return nil
-}
-
-// Stop stops the network.
-func (net *Network) Stop() {
-	net.env.Cleanup()
-	net.running = false
-}
-
-func (net *Network) runNodeBinary(consoleWriter io.Writer, args ...string) error {
-	nodeBinary := net.cfg.NodeBinary
-	cmd := exec.Command(nodeBinary, args...)
-	cmd.SysProcAttr = env.CmdAttrs
-	if consoleWriter != nil {
-		cmd.Stdout = consoleWriter
-		cmd.Stderr = consoleWriter
-	}
-
-	net.logger.Info("launching node",
-		"args", strings.Join(args, " "),
-	)
-
-	return cmd.Run()
-}
-
-func (net *Network) generateDeterministicIdentity(dir *env.Dir, rawSeed string, roles []signature.SignerRole) error {
-	_, err := GenerateDeterministicNodeKeys(dir, rawSeed, roles)
-	return err
-}
-
-func (net *Network) generateDeterministicNodeIdentity(dir *env.Dir, rawSeed string) error {
-	return net.generateDeterministicIdentity(dir, rawSeed, []signature.SignerRole{
-		signature.SignerNode,
-		signature.SignerP2P,
-		signature.SignerConsensus,
-	})
-}
-
-// GenerateDeterministicNodeKeys generates and returns deterministic node keys.
-func GenerateDeterministicNodeKeys(dir *env.Dir, rawSeed string, roles []signature.SignerRole) ([]signature.PublicKey, error) {
-	h := crypto.SHA512.New()
-	_, _ = h.Write([]byte(rawSeed))
-	seed := h.Sum(nil)
-
-	rng, err := drbg.New(crypto.SHA512, seed, nil, []byte("deterministic node identities test"))
-	if err != nil {
-		return nil, err
-	}
-
-	var dirStr string
-	factoryCtor := func(args interface{}, roles ...signature.SignerRole) (signature.SignerFactory, error) {
-		return memorySigner.NewFactory(), nil
-	}
-	if dir != nil {
-		factoryCtor = fileSigner.NewFactory
-		dirStr = dir.String()
-	}
-
-	var pks []signature.PublicKey
-	for _, role := range roles {
-		factory, err := factoryCtor(dirStr, role)
-		if err != nil {
-			return nil, err
-		}
-		signer, err := factory.Generate(role, rng)
-		if err != nil {
-			return nil, err
-		}
-		pks = append(pks, signer.Public())
-	}
-
-	return pks, nil
-}
-
-// generateTempSocketPath returns a unique filename for a node's internal socket in the test base dir
-//
-// This function is used to obtain shorter socket path than the one in datadir since that one might
-// be too long for unix socket path.
-func (net *Network) generateTempSocketPath() string {
-	f, err := ioutil.TempFile(env.GetRootDir().String(), "internal-*.sock")
-	if err != nil {
-		return ""
-	}
-	defer f.Close()
-	return f.Name()
-}
-
-func (net *Network) startOasisNode(
-	node *Node,
-	subCmd []string,
-	extraArgs *argBuilder,
-) error {
-	node.Lock()
-	defer node.Unlock()
-
-	baseArgs := []string{
-		"--" + common.CfgDataDir, node.dir.String(),
-		"--log.level", "debug",
-		"--log.format", "json",
-		"--log.file", nodeLogPath(node.dir),
-		"--genesis.file", net.GenesisPath(),
-	}
-	if len(subCmd) == 0 {
-		extraArgs = extraArgs.
-			appendIASProxy(net.iasProxy).
-			tendermintDebugAddrBookLenient().
-			tendermintDebugAllowDuplicateIP().
-			tendermintUpgradeStopDelay(10 * time.Second)
-	}
-	if net.cfg.UseShortGrpcSocketPaths {
-		// Keep the socket, if it was already generated!
-		if node.customGrpcSocketPath == "" {
-			node.customGrpcSocketPath = net.generateTempSocketPath()
-		}
-		extraArgs = extraArgs.debugDontBlameOasis()
-		extraArgs = extraArgs.grpcDebugGrpcInternalSocketPath(node.customGrpcSocketPath)
-	}
-	if node.consensusStateSync != nil {
-		extraArgs = extraArgs.tendermintStateSync(
-			node.consensusStateSync.ConsensusNodes,
-			node.consensusStateSync.TrustHeight,
-			node.consensusStateSync.TrustHash,
-		)
-	}
-	if viper.IsSet(metrics.CfgMetricsAddr) {
-		extraArgs = extraArgs.appendNodeMetrics(node)
-	}
-	args := append([]string{}, subCmd...)
-	args = append(args, baseArgs...)
-	args = append(args, extraArgs.vec...)
-
-	w, err := node.dir.NewLogWriter(logConsoleFile)
-	if err != nil {
-		return err
-	}
-	net.env.AddOnCleanup(func() {
-		_ = w.Close()
-	})
-
-	oasisBinary := net.cfg.NodeBinary
-	cmd := exec.Command(oasisBinary, args...)
-	cmd.SysProcAttr = env.CmdAttrs
-	cmd.Stdout = w
-	cmd.Stderr = w
-
-	net.logger.Info("launching Oasis node",
-		"args", strings.Join(args, " "),
-	)
-
-	if err = cmd.Start(); err != nil {
-		return fmt.Errorf("oasis: failed to start node: %w", err)
-	}
-
-	doneCh := net.env.AddTermOnCleanup(cmd)
-	exitCh := make(chan error, 1)
-	go func() {
-		defer close(exitCh)
-
-		cmdErr := <-doneCh
-		net.logger.Debug("node terminated",
-			"err", cmdErr,
-		)
-
-		if cmdErr != nil {
-			exitCh <- cmdErr
-		}
-
-		if err := node.handleExit(cmdErr); err != nil {
-			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) && exitErr.ExitCode() == crash.CrashDefaultExitCode {
-				// Termination due to crasher. Restart node.
-				net.logger.Info("Node debug crash point triggered. Restarting...", "node", node.Name)
-				if err = net.startOasisNode(node, subCmd, extraArgs); err != nil {
-					net.errCh <- fmt.Errorf("oasis: %s failed restarting node after crash point: %w", node.Name, err)
-				}
-				return
-			}
-
-			net.errCh <- fmt.Errorf("oasis: %s node terminated: %w", node.Name, err)
-		}
-	}()
-
-	node.cmd = cmd
-	node.exitCh = exitCh
-
-	return nil
-}
-
-// MakeGenesis generates a new Genesis file.
-func (net *Network) MakeGenesis() error {
-	args := []string{
-		"genesis", "init",
-		"--genesis.file", net.GenesisPath(),
-		"--chain.id", genesisTestHelpers.TestChainID,
-		"--initial_height", strconv.FormatInt(net.cfg.InitialHeight, 10),
-		"--halt.epoch", strconv.FormatUint(net.cfg.HaltEpoch, 10),
-		"--consensus.backend", net.cfg.Consensus.Backend,
-		"--consensus.tendermint.timeout_commit", net.cfg.Consensus.Parameters.TimeoutCommit.String(),
-		"--registry.enable_runtime_governance_models", "entity,runtime",
-		"--registry.debug.allow_unroutable_addresses", "true",
-		"--" + genesis.CfgRegistryDebugAllowTestRuntimes, "true",
-		"--scheduler.max_validators_per_entity", strconv.Itoa(len(net.Validators())),
-		"--" + genesis.CfgConsensusGasCostsTxByte, strconv.FormatUint(uint64(net.cfg.Consensus.Parameters.GasCosts[consensusGenesis.GasOpTxByte]), 10),
-		"--" + genesis.CfgConsensusStateCheckpointInterval, strconv.FormatUint(net.cfg.Consensus.Parameters.StateCheckpointInterval, 10),
-		"--" + genesis.CfgConsensusStateCheckpointNumKept, strconv.FormatUint(net.cfg.Consensus.Parameters.StateCheckpointNumKept, 10),
-		"--" + genesis.CfgStakingTokenSymbol, genesisTestHelpers.TestStakingTokenSymbol,
-		"--" + genesis.CfgStakingTokenValueExponent, strconv.FormatUint(
-			uint64(genesisTestHelpers.TestStakingTokenValueExponent), 10),
-		"--" + genesis.CfgBeaconBackend, net.cfg.Beacon.Backend,
-	}
-	switch net.cfg.Beacon.Backend {
-	case beacon.BackendInsecure:
-		args = append(args, []string{
-			"--" + genesis.CfgBeaconInsecureTendermintInterval, strconv.FormatInt(net.cfg.Beacon.InsecureParameters.Interval, 10),
-		}...)
-	case beacon.BackendPVSS:
-		args = append(args, []string{
-			"--" + genesis.CfgBeaconPVSSParticipants, strconv.FormatUint(uint64(net.cfg.Beacon.PVSSParameters.Participants), 10),
-			"--" + genesis.CfgBeaconPVSSThreshold, strconv.FormatUint(uint64(net.cfg.Beacon.PVSSParameters.Threshold), 10),
-			"--" + genesis.CfgBeaconPVSSCommitInterval, strconv.FormatInt(net.cfg.Beacon.PVSSParameters.CommitInterval, 10),
-			"--" + genesis.CfgBeaconPVSSRevealInterval, strconv.FormatInt(net.cfg.Beacon.PVSSParameters.RevealInterval, 10),
-			"--" + genesis.CfgBeaconPVSSTransitionDelay, strconv.FormatInt(net.cfg.Beacon.PVSSParameters.TransitionDelay, 10),
-		}...)
-		if pks := net.cfg.Beacon.PVSSParameters.DebugForcedParticipants; len(pks) > 0 {
-			for _, pk := range pks {
-				args = append(args, []string{
-					"--" + genesis.CfgBeaconPVSSDebugForcedParticipant, pk.String(),
-				}...)
-			}
-		}
-	default:
-		return fmt.Errorf("oasis: unsupported beacon backend: %s", net.cfg.Beacon.Backend)
-	}
-	if net.cfg.Beacon.DebugMockBackend {
-		args = append(args, "--"+genesis.CfgBeaconDebugMockBackend)
-	}
-	if net.cfg.Beacon.DebugDeterministic || net.cfg.DeterministicIdentities {
-		args = append(args, "--"+genesis.CfgBeaconDebugDeterministic)
-	}
-	if cfg := net.cfg.GovernanceParameters; cfg != nil {
-		args = append(args, []string{
-			"--" + genesis.CfgGovernanceMinProposalDeposit, strconv.FormatUint(cfg.MinProposalDeposit.ToBigInt().Uint64(), 10),
-			"--" + genesis.CfgGovernanceQuorum, strconv.FormatUint(uint64(cfg.Quorum), 10),
-			"--" + genesis.CfgGovernanceThreshold, strconv.FormatUint(uint64(cfg.Threshold), 10),
-			"--" + genesis.CfgGovernanceUpgradeCancelMinEpochDiff, strconv.FormatUint(uint64(cfg.UpgradeCancelMinEpochDiff), 10),
-			"--" + genesis.CfgGovernanceUpgradeMinEpochDiff, strconv.FormatUint(uint64(cfg.UpgradeMinEpochDiff), 10),
-			"--" + genesis.CfgGovernanceVotingPeriod, strconv.FormatUint(uint64(cfg.VotingPeriod), 10),
-		}...)
-	}
-	for _, v := range net.entities {
-		args = append(args, v.toGenesisDescriptorArgs()...)
-	}
-	for _, v := range net.validators {
-		args = append(args, v.toGenesisArgs()...)
-	}
-	for _, v := range net.runtimes {
-		args = append(args, v.toGenesisArgs()...)
-	}
-	for _, v := range net.keymanagerPolicies {
-		if err := v.provision(); err != nil {
-			return err
-		}
-	}
-	for _, v := range net.keymanagers {
-		if err := v.provisionGenesis(); err != nil {
-			return err
-		}
-		args = append(args, v.toGenesisArgs()...)
-	}
-
-	if net.cfg.StakingGenesis != nil {
-		if net.cfg.FundEntities {
-			toFund := quantity.NewFromUint64(1000000000000)
-			if net.cfg.StakingGenesis.Ledger == nil {
-				net.cfg.StakingGenesis.Ledger = make(map[staking.Address]*staking.Account)
-			}
-			for _, ent := range net.Entities() {
-				if ent.isDebugTestEntity {
-					// Debug test entities already get funded.
-					continue
-				}
-				net.cfg.StakingGenesis.Ledger[staking.NewAddress(ent.Signer().Public())] = &staking.Account{
-					General: staking.GeneralAccount{
-						Balance: *toFund,
-					},
-				}
-				_ = net.cfg.StakingGenesis.TotalSupply.Add(toFund)
-			}
-		}
-
-		path := filepath.Join(net.baseDir.String(), stakingGenesisFile)
-		b, err := json.Marshal(net.cfg.StakingGenesis)
-		if err != nil {
-			net.logger.Error("failed to serialize staking genesis file",
-				"err", err,
-			)
-			return fmt.Errorf("oasis: failed to serialize staking genesis file: %w", err)
-		}
-		if err = ioutil.WriteFile(path, b, 0o600); err != nil {
-			net.logger.Error("failed to write staking genesis file",
-				"err", err,
-			)
-			return fmt.Errorf("oasis: failed to write staking genesis file: %w", err)
-		}
-		args = append(args, "--staking", path)
-	}
-	if len(net.byzantine) > 0 {
-		// If the byzantine node is in use, disable max node expiration
-		// enforcement, because it wants to register for 1000 epochs.
-		args = append(args, []string{
-			"--" + genesis.CfgRegistryMaxNodeExpiration, "0",
-		}...)
-	}
-
-	w, err := net.baseDir.NewLogWriter("genesis_provision.log")
-	if err != nil {
-		return err
-	}
-	defer w.Close()
-
-	if err := net.runNodeBinary(w, args...); err != nil {
-		net.logger.Error("failed to create genesis file",
-			"err", err,
-		)
-		return fmt.Errorf("oasis: failed to create genesis file: %w", err)
-	}
-
-	return nil
-}
-
-// GenesisPath returns the path to the genesis file for the network.
-func (net *Network) GenesisPath() string {
-	if net.cfg.GenesisFile != "" {
-		return net.cfg.GenesisFile
-	}
-	return filepath.Join(net.baseDir.String(), "genesis.json")
-}
-
-// BasePath returns the path to the network base directory.
-func (net *Network) BasePath() string {
-	return net.baseDir.String()
-}
-
-// Implements cli.Factory.
-func (net *Network) GetCLIConfig() cli.Config {
-	cfg := cli.Config{
-		NodeBinary:  net.cfg.NodeBinary,
-		GenesisFile: net.GenesisPath(),
-	}
-	if len(net.Validators()) > 0 {
-		val := net.Validators()[0]
-		if net.cfg.UseShortGrpcSocketPaths && val.customGrpcSocketPath == "" {
-			val.customGrpcSocketPath = net.generateTempSocketPath()
-		}
-		cfg.NodeSocketPath = val.SocketPath()
-	}
-	return cfg
-}
-
-func (net *Network) provisionNodeIdentity(dataDir *env.Dir, seed string, persistTLS bool) (signature.PublicKey, signature.PublicKey, *x509.Certificate, error) {
-	if net.cfg.DeterministicIdentities && !net.cfg.RestoreIdentities {
-		if err := net.generateDeterministicNodeIdentity(dataDir, seed); err != nil {
-			return signature.PublicKey{}, signature.PublicKey{}, nil, fmt.Errorf("oasis: failed to generate deterministic identity: %w", err)
-		}
-	}
-
-	signerFactory, err := fileSigner.NewFactory(dataDir.String(), signature.SignerNode, signature.SignerP2P, signature.SignerConsensus)
-	if err != nil {
-		return signature.PublicKey{}, signature.PublicKey{}, nil, fmt.Errorf("oasis: failed to create node file signer factory: %w", err)
-	}
-	nodeIdentity, err := identity.LoadOrGenerate(dataDir.String(), signerFactory, persistTLS)
-	if err != nil {
-		return signature.PublicKey{}, signature.PublicKey{}, nil, fmt.Errorf("oasis: failed to provision node identity: %w", err)
+// Into sets node parameters of an existing node object from the configuration.
+func (cfg *NodeCfg) Into(node *Node) {
+	node.noAutoStart = cfg.NoAutoStart
+	node.termEarlyOk = cfg.AllowEarlyTermination
+	node.termErrorOk = cfg.AllowErrorTermination
+	node.crashPointsProbability = cfg.CrashPointsProbability
+	node.supplementarySanityInterval = cfg.SupplementarySanityInterval
+	node.disableDefaultLogWatcherHandlerFactories = cfg.DisableDefaultLogWatcherHandlerFactories
+	node.logWatcherHandlerFactories = cfg.LogWatcherHandlerFactories
+	node.consensus = cfg.Consensus
+	if node.entity != nil && cfg.Entity != nil && node.entity != cfg.Entity {
+		panic(fmt.Sprintf("oasis: entity mismatch for node %s", node.Name))
+	}
+	if cfg.Entity != nil {
+		node.entity = cfg.Entity
+	}
+
+	if node.pprofPort == 0 && cfg.EnableProfiling {
+		node.pprofPort = node.getProvisionedPort(nodePortPprof)
 	}
-	sentryCert, err := x509.ParseCertificate(nodeIdentity.TLSSentryClientCertificate.Certificate[0])
-	if err != nil {
-		return signature.PublicKey{}, signature.PublicKey{}, nil, fmt.Errorf("oasis: failed to parse sentry client certificate: %w", err)
-	}
-	return nodeIdentity.NodeSigner.Public(), nodeIdentity.P2PSigner.Public(), sentryCert, nil
-}
-
-// New creates a new test Oasis network.
-func New(env *env.Env, cfg *NetworkCfg) (*Network, error) {
-	baseDir, err := env.NewSubDir("network")
-	if err != nil {
-		return nil, fmt.Errorf("oasis: failed to create network sub-directory: %w", err)
-	}
-
-	// Copy the config and apply some sane defaults.
-	cfgCopy := *cfg
-	if cfgCopy.Consensus.Backend == "" {
-		cfgCopy.Consensus.Backend = defaultConsensusBackend
-	}
-	if cfgCopy.Consensus.Parameters.TimeoutCommit == 0 {
-		cfgCopy.Consensus.Parameters.TimeoutCommit = defaultConsensusTimeoutCommit
-	}
-	if cfgCopy.Consensus.Parameters.GasCosts == nil {
-		cfgCopy.Consensus.Parameters.GasCosts = make(transaction.Costs)
-	}
-	if cfgCopy.Beacon.Backend == "" {
-		cfgCopy.Beacon.Backend = beacon.BackendPVSS
-	}
-	switch cfgCopy.Beacon.Backend {
-	case beacon.BackendInsecure:
-		if cfgCopy.Beacon.InsecureParameters == nil {
-			cfgCopy.Beacon.InsecureParameters = new(beacon.InsecureParameters)
-		}
-		if cfgCopy.Beacon.InsecureParameters.Interval == 0 {
-			cfgCopy.Beacon.InsecureParameters.Interval = defaultEpochtimeTendermintInterval
-		}
-	case beacon.BackendPVSS:
-		if cfgCopy.Beacon.PVSSParameters == nil {
-			cfgCopy.Beacon.PVSSParameters = new(beacon.PVSSParameters)
-		}
-		if cfgCopy.Beacon.PVSSParameters.Participants == 0 {
-			cfgCopy.Beacon.PVSSParameters.Participants = defaultPVSSParticipants
-		}
-		if cfgCopy.Beacon.PVSSParameters.Threshold == 0 {
-			cfgCopy.Beacon.PVSSParameters.Threshold = defaultPVSSThreshold
-		}
-		if cfgCopy.Beacon.PVSSParameters.CommitInterval == 0 {
-			cfgCopy.Beacon.PVSSParameters.CommitInterval = defaultPVSSCommitInterval
-		}
-		if cfgCopy.Beacon.PVSSParameters.RevealInterval == 0 {
-			cfgCopy.Beacon.PVSSParameters.RevealInterval = defaultPVSSRevealInterval
-		}
-		if cfgCopy.Beacon.PVSSParameters.TransitionDelay == 0 {
-			cfgCopy.Beacon.PVSSParameters.TransitionDelay = defaultPVSSTransitionDelay
-		}
-	}
-	if cfgCopy.InitialHeight == 0 {
-		cfgCopy.InitialHeight = defaultInitialHeight
-	}
-	if cfgCopy.HaltEpoch == 0 {
-		cfgCopy.HaltEpoch = defaultHaltEpoch
-	}
-
-	return &Network{
-		logger:       logging.GetLogger("oasis/" + env.Name()),
-		env:          env,
-		baseDir:      baseDir,
-		cfg:          &cfgCopy,
-		nextNodePort: baseNodePort,
-		errCh:        make(chan error, maxNodes),
-	}, nil
 }
 
 func nodeLogPath(dir *env.Dir) string {

--- a/go/oasis-test-runner/oasis/sentry.go
+++ b/go/oasis-test-runner/oasis/sentry.go
@@ -11,7 +11,7 @@ import (
 
 // Sentry is an Oasis sentry node.
 type Sentry struct {
-	Node
+	*Node
 
 	validatorIndices  []int
 	storageIndices    []int
@@ -54,7 +54,7 @@ func (sentry *Sentry) GetSentryControlAddress() string {
 	return fmt.Sprintf("127.0.0.1:%d", sentry.controlPort)
 }
 
-func (sentry *Sentry) startNode() error {
+func (sentry *Sentry) AddArgs(args *argBuilder) error {
 	validators, err := resolveValidators(sentry.net, sentry.validatorIndices)
 	if err != nil {
 		return err
@@ -70,8 +70,7 @@ func (sentry *Sentry) startNode() error {
 		return err
 	}
 
-	args := newArgBuilder().
-		debugDontBlameOasis().
+	args.debugDontBlameOasis().
 		debugAllowTestKeys().
 		debugEnableProfiling(sentry.Node.pprofPort).
 		workerCertificateRotation(false).
@@ -87,25 +86,21 @@ func (sentry *Sentry) startNode() error {
 		internalSocketAddress(sentry.net.validators[0].SocketPath())
 
 	if len(validators) > 0 {
-		args = args.addValidatorsAsSentryUpstreams(validators)
+		args.addValidatorsAsSentryUpstreams(validators)
 	}
 
 	if len(storageWorkers) > 0 || len(keymanagerWorkers) > 0 {
-		args = args.workerGrpcSentryEnabled().
+		args.workerGrpcSentryEnabled().
 			workerSentryGrpcClientAddress([]string{fmt.Sprintf("127.0.0.1:%d", sentry.sentryPort)}).
 			workerSentryGrpcClientPort(sentry.sentryPort)
 	}
 
 	if len(storageWorkers) > 0 {
-		args = args.addSentryStorageWorkers(storageWorkers)
+		args.addSentryStorageWorkers(storageWorkers)
 	}
 
 	if len(keymanagerWorkers) > 0 {
-		args = args.addSentryKeymanagerWorkers(keymanagerWorkers)
-	}
-
-	if err = sentry.net.startOasisNode(&sentry.Node, nil, args); err != nil {
-		return fmt.Errorf("oasis/sentry: failed to launch node %s: %w", sentry.Name, err)
+		args.addSentryKeymanagerWorkers(keymanagerWorkers)
 	}
 
 	return nil
@@ -114,20 +109,15 @@ func (sentry *Sentry) startNode() error {
 // NewSentry provisions a new sentry node and adds it to the network.
 func (net *Network) NewSentry(cfg *SentryCfg) (*Sentry, error) {
 	sentryName := fmt.Sprintf("sentry-%d", len(net.sentries))
-
-	sentryDir, err := net.baseDir.NewSubDir(sentryName)
+	host, err := net.GetNamedNode(sentryName, &cfg.NodeCfg)
 	if err != nil {
-		net.logger.Error("failed to create sentry subdir",
-			"err", err,
-			"sentry_name", sentryName,
-		)
-		return nil, fmt.Errorf("oasis/sentry: failed to create sentry subdir: %w", err)
+		return nil, err
 	}
 
 	// Pre-provision node's identity to pass the sentry node's consensus
 	// address to the validator so it can configure the sentry node's consensus
 	// address as its consensus address.
-	signerFactory, err := fileSigner.NewFactory(sentryDir.String(), signature.SignerNode, signature.SignerP2P, signature.SignerConsensus)
+	signerFactory, err := fileSigner.NewFactory(host.dir.String(), signature.SignerNode, signature.SignerP2P, signature.SignerConsensus)
 	if err != nil {
 		net.logger.Error("failed to create sentry signer factory",
 			"err", err,
@@ -135,7 +125,7 @@ func (net *Network) NewSentry(cfg *SentryCfg) (*Sentry, error) {
 		)
 		return nil, fmt.Errorf("oasis/sentry: failed to create sentry file signer: %w", err)
 	}
-	sentryIdentity, err := identity.LoadOrGenerate(sentryDir.String(), signerFactory, true)
+	sentryIdentity, err := identity.LoadOrGenerate(host.dir.String(), signerFactory, true)
 	if err != nil {
 		net.logger.Error("failed to provision sentry identity",
 			"err", err,
@@ -147,42 +137,20 @@ func (net *Network) NewSentry(cfg *SentryCfg) (*Sentry, error) {
 	sentryTLSPublicKey := sentryIdentity.GetTLSSigner().Public()
 
 	sentry := &Sentry{
-		Node: Node{
-			Name:                                     sentryName,
-			net:                                      net,
-			dir:                                      sentryDir,
-			crashPointsProbability:                   cfg.CrashPointsProbability,
-			supplementarySanityInterval:              cfg.SupplementarySanityInterval,
-			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
-			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
-		},
+		Node:              host,
 		validatorIndices:  cfg.ValidatorIndices,
 		storageIndices:    cfg.StorageIndices,
 		keymanagerIndices: cfg.KeymanagerIndices,
 		p2pPublicKey:      sentryP2PPublicKey,
 		tlsPublicKey:      sentryTLSPublicKey,
 		tmAddress:         crypto.PublicKeyToTendermint(&sentryP2PPublicKey).Address().String(),
-		consensusPort:     net.nextNodePort,
-		controlPort:       net.nextNodePort + 1,
-		sentryPort:        net.nextNodePort + 2,
-	}
-	net.nextNodePort += 3
-	sentry.doStartNode = sentry.startNode
-
-	if cfg.EnableProfiling {
-		sentry.Node.pprofPort = net.nextNodePort
-		net.nextNodePort++
+		consensusPort:     host.getProvisionedPort(nodePortConsensus),
+		controlPort:       host.getProvisionedPort("sentry-control"),
+		sentryPort:        host.getProvisionedPort("sentry-client"),
 	}
 
 	net.sentries = append(net.sentries, sentry)
-
-	if err := net.AddLogWatcher(&sentry.Node); err != nil {
-		net.logger.Error("failed to add log watcher",
-			"err", err,
-			"sentry_name", sentryName,
-		)
-		return nil, fmt.Errorf("oasis/sentry: failed to add log watcher for %s: %w", sentryName, err)
-	}
+	host.features = append(host.features, sentry)
 
 	return sentry, nil
 }

--- a/go/oasis-test-runner/oasis/validator.go
+++ b/go/oasis-test-runner/oasis/validator.go
@@ -17,9 +17,7 @@ const validatorIdentitySeedTemplate = "ekiden node validator %d"
 
 // Validator is an Oasis validator.
 type Validator struct {
-	Node
-
-	entity *Entity
+	*Node
 
 	sentries []*Sentry
 
@@ -32,8 +30,6 @@ type Validator struct {
 // ValidatorCfg is the Oasis validator provisioning configuration.
 type ValidatorCfg struct {
 	NodeCfg
-
-	Entity *Entity
 
 	Sentries []*Sentry
 }
@@ -73,14 +69,8 @@ func (val *Validator) ExternalGRPCAddress() string {
 	return fmt.Sprintf("127.0.0.1:%d", val.clientPort)
 }
 
-// Start starts an Oasis node.
-func (val *Validator) Start() error {
-	return val.startNode()
-}
-
-func (val *Validator) startNode() error {
-	args := newArgBuilder().
-		debugDontBlameOasis().
+func (val *Validator) AddArgs(args *argBuilder) error {
+	args.debugDontBlameOasis().
 		debugAllowTestKeys().
 		debugEnableProfiling(val.Node.pprofPort).
 		workerCertificateRotation(true).
@@ -96,18 +86,14 @@ func (val *Validator) startNode() error {
 		appendEntity(val.entity)
 
 	if len(val.sentries) > 0 {
-		args = args.addSentries(val.sentries).
+		args.addSentries(val.sentries).
 			tendermintDisablePeerExchange()
 	} else {
-		args = args.appendSeedNodes(val.net.seeds)
+		args.appendSeedNodes(val.net.seeds)
 	}
 	if val.consensus.EnableConsensusRPCWorker {
-		args = args.workerClientPort(val.clientPort).
+		args.workerClientPort(val.clientPort).
 			workerConsensusRPCEnabled()
-	}
-
-	if err := val.net.startOasisNode(&val.Node, nil, args); err != nil {
-		return fmt.Errorf("oasis/validator: failed to launch node %s: %w", val.Name, err)
 	}
 
 	return nil
@@ -116,41 +102,16 @@ func (val *Validator) startNode() error {
 // NewValidator provisions a new validator and adds it to the network.
 func (net *Network) NewValidator(cfg *ValidatorCfg) (*Validator, error) {
 	valName := fmt.Sprintf("validator-%d", len(net.validators))
-
-	valDir, err := net.baseDir.NewSubDir(valName)
+	host, err := net.GetNamedNode(valName, &cfg.NodeCfg)
 	if err != nil {
-		net.logger.Error("failed to create validator subdir",
-			"err", err,
-			"validator_name", valName,
-		)
-		return nil, fmt.Errorf("oasis/validator: failed to create validator subdir: %w", err)
+		return nil, err
 	}
 
 	val := &Validator{
-		Node: Node{
-			Name:                                     valName,
-			net:                                      net,
-			dir:                                      valDir,
-			termEarlyOk:                              cfg.AllowEarlyTermination,
-			termErrorOk:                              cfg.AllowErrorTermination,
-			crashPointsProbability:                   cfg.CrashPointsProbability,
-			supplementarySanityInterval:              cfg.SupplementarySanityInterval,
-			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
-			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
-			consensus:                                cfg.Consensus,
-			noAutoStart:                              cfg.NoAutoStart,
-		},
-		entity:        cfg.Entity,
+		Node:          host,
 		sentries:      cfg.Sentries,
-		consensusPort: net.nextNodePort,
-		clientPort:    net.nextNodePort + 1,
-	}
-	net.nextNodePort += 2
-	val.doStartNode = val.startNode
-
-	if cfg.EnableProfiling {
-		val.Node.pprofPort = net.nextNodePort
-		net.nextNodePort++
+		consensusPort: host.getProvisionedPort(nodePortConsensus),
+		clientPort:    host.getProvisionedPort(nodePortClient),
 	}
 
 	var consensusAddrs []interface{ String() string }
@@ -174,21 +135,16 @@ func (net *Network) NewValidator(cfg *ValidatorCfg) (*Validator, error) {
 
 	// Load node's identity, so that we can pass the validator's Tendermint
 	// address to sentry node(s) to configure it as a private peer.
-	seed := fmt.Sprintf(validatorIdentitySeedTemplate, len(net.validators))
-	valNodeKey, valP2PKey, sentryClientCert, err := net.provisionNodeIdentity(valDir, seed, false)
+	err = host.setProvisionedIdentity(false, fmt.Sprintf(validatorIdentitySeedTemplate, len(net.validators)))
 	if err != nil {
 		return nil, fmt.Errorf("oasis/validator: failed to provision node identity: %w", err)
 	}
-	copy(val.NodeID[:], valNodeKey[:])
-	val.tmAddress = crypto.PublicKeyToTendermint(&valP2PKey).Address().String()
-	if err = cfg.Entity.addNode(val.NodeID); err != nil {
-		return nil, err
-	}
+	val.tmAddress = crypto.PublicKeyToTendermint(&host.p2pSigner).Address().String()
 
 	// Sentry client cert.
-	pk, ok := sentryClientCert.PublicKey.(ed25519.PublicKey)
+	pk, ok := host.sentryCert.PublicKey.(ed25519.PublicKey)
 	if !ok {
-		return nil, fmt.Errorf("oasis/validator: bad sentry client public key type (expected: Ed25519 got: %T)", sentryClientCert.PublicKey)
+		return nil, fmt.Errorf("oasis/validator: bad sentry client public key type (expected: Ed25519 got: %T)", host.sentryCert.PublicKey)
 	}
 	if err = val.sentryPubKey.UnmarshalBinary(pk[:]); err != nil {
 		return nil, fmt.Errorf("oasis/validator: sentry client public key unmarshal failure: %w", err)
@@ -221,14 +177,8 @@ func (net *Network) NewValidator(cfg *ValidatorCfg) (*Validator, error) {
 	}
 
 	net.validators = append(net.validators, val)
-
-	if err := net.AddLogWatcher(&val.Node); err != nil {
-		net.logger.Error("failed to add log watcher",
-			"err", err,
-			"validator_name", valName,
-		)
-		return nil, fmt.Errorf("oasis/validator: failed to add log watcher for %s: %w", valName, err)
-	}
+	host.features = append(host.features, val)
+	host.hasValidators = true
 
 	return val, nil
 }

--- a/go/oasis-test-runner/scenario/e2e/byzantine_beacon.go
+++ b/go/oasis-test-runner/scenario/e2e/byzantine_beacon.go
@@ -19,8 +19,8 @@ var (
 	// ByzantineBeaconHonest is the honest byzantine beacon scenario.
 	ByzantineBeaconHonest scenario.Scenario = &byzantineBeaconImpl{
 		E2E: *NewE2E("byzantine/beacon-honest"),
-		extraArgs: []string{
-			"--" + byzantine.CfgBeaconMode, byzantine.ModeBeaconHonest.String(),
+		extraArgs: []oasis.Argument{
+			{Name: byzantine.CfgBeaconMode, Values: []string{byzantine.ModeBeaconHonest.String()}},
 		},
 		identitySeed: byzantineBeaconIdentitySeed,
 	}
@@ -28,8 +28,8 @@ var (
 	// ByzantineBeaconCommitStraggler is the commit straggler byzantine beacon scenario.
 	ByzantineBeaconCommitStraggler scenario.Scenario = &byzantineBeaconImpl{
 		E2E: *NewE2E("byzantine/beacon-commit-straggler"),
-		extraArgs: []string{
-			"--" + byzantine.CfgBeaconMode, byzantine.ModeBeaconCommitStraggler.String(),
+		extraArgs: []oasis.Argument{
+			{Name: byzantine.CfgBeaconMode, Values: []string{byzantine.ModeBeaconCommitStraggler.String()}},
 		},
 		identitySeed: byzantineBeaconIdentitySeed,
 	}
@@ -37,8 +37,8 @@ var (
 	// ByzantineBeaconRevealStraggler is the reveal straggler byzantine beacon scenario.
 	ByzantineBeaconRevealStraggler scenario.Scenario = &byzantineBeaconImpl{
 		E2E: *NewE2E("byzantine/beacon-reveal-straggler"),
-		extraArgs: []string{
-			"--" + byzantine.CfgBeaconMode, byzantine.ModeBeaconRevealStraggler.String(),
+		extraArgs: []oasis.Argument{
+			{Name: byzantine.CfgBeaconMode, Values: []string{byzantine.ModeBeaconRevealStraggler.String()}},
 		},
 		identitySeed: byzantineBeaconIdentitySeed,
 	}
@@ -47,7 +47,7 @@ var (
 type byzantineBeaconImpl struct {
 	E2E
 
-	extraArgs    []string
+	extraArgs    []oasis.Argument
 	identitySeed string
 }
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/byzantine.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/byzantine.go
@@ -53,8 +53,8 @@ var (
 		oasis.ByzantineSlot1IdentitySeed,
 		false,
 		nil,
-		[]string{
-			"--" + byzantine.CfgSchedulerRoleExpected,
+		[]oasis.Argument{
+			{Name: byzantine.CfgSchedulerRoleExpected},
 		},
 	)
 	// ByzantineExecutorWrong is the byzantine executor wrong scenario.
@@ -73,8 +73,8 @@ var (
 		map[staking.SlashReason]uint64{
 			staking.SlashRuntimeIncorrectResults: 1,
 		},
-		[]string{
-			"--" + byzantine.CfgExecutorMode, byzantine.ModeExecutorWrong.String(),
+		[]oasis.Argument{
+			{Name: byzantine.CfgExecutorMode, Values: []string{byzantine.ModeExecutorWrong.String()}},
 		},
 	)
 	// ByzantineExecutorSchedulerWrong is the byzantine executor wrong scheduler scenario.
@@ -91,9 +91,9 @@ var (
 		oasis.ByzantineSlot1IdentitySeed,
 		false,
 		nil,
-		[]string{
-			"--" + byzantine.CfgSchedulerRoleExpected,
-			"--" + byzantine.CfgExecutorMode, byzantine.ModeExecutorWrong.String(),
+		[]oasis.Argument{
+			{Name: byzantine.CfgSchedulerRoleExpected},
+			{Name: byzantine.CfgExecutorMode, Values: []string{byzantine.ModeExecutorWrong.String()}},
 		},
 	)
 	// ByzantineExecutorStraggler is the byzantine executor straggler scenario.
@@ -109,8 +109,8 @@ var (
 		oasis.ByzantineDefaultIdentitySeed,
 		false,
 		nil,
-		[]string{
-			"--" + byzantine.CfgExecutorMode, byzantine.ModeExecutorStraggler.String(),
+		[]oasis.Argument{
+			{Name: byzantine.CfgExecutorMode, Values: []string{byzantine.ModeExecutorStraggler.String()}},
 		},
 	)
 	// ByzantineExecutorSchedulerStraggler is the byzantine executor scheduler straggler scenario.
@@ -127,9 +127,9 @@ var (
 		oasis.ByzantineSlot1IdentitySeed,
 		false,
 		nil,
-		[]string{
-			"--" + byzantine.CfgSchedulerRoleExpected,
-			"--" + byzantine.CfgExecutorMode, byzantine.ModeExecutorStraggler.String(),
+		[]oasis.Argument{
+			{Name: byzantine.CfgSchedulerRoleExpected},
+			{Name: byzantine.CfgExecutorMode, Values: []string{byzantine.ModeExecutorStraggler.String()}},
 		},
 	)
 	// ByzantineExecutorFailureIndicating is the byzantine executor that submits fialure indicating
@@ -146,8 +146,8 @@ var (
 		oasis.ByzantineDefaultIdentitySeed,
 		false,
 		nil,
-		[]string{
-			"--" + byzantine.CfgExecutorMode, byzantine.ModeExecutorFailureIndicating.String(),
+		[]oasis.Argument{
+			{Name: byzantine.CfgExecutorMode, Values: []string{byzantine.ModeExecutorFailureIndicating.String()}},
 		},
 	)
 	// ByzantineExecutorSchedulerFailureIndicating is the byzantine executor scheduler failure indicating scenario.
@@ -164,9 +164,9 @@ var (
 		oasis.ByzantineSlot1IdentitySeed,
 		false,
 		nil,
-		[]string{
-			"--" + byzantine.CfgSchedulerRoleExpected,
-			"--" + byzantine.CfgExecutorMode, byzantine.ModeExecutorFailureIndicating.String(),
+		[]oasis.Argument{
+			{Name: byzantine.CfgSchedulerRoleExpected},
+			{Name: byzantine.CfgExecutorMode, Values: []string{byzantine.ModeExecutorFailureIndicating.String()}},
 		},
 	)
 	// ByzantineStorageHonest is the byzantine storage honest scenario.
@@ -190,9 +190,9 @@ var (
 		oasis.ByzantineDefaultIdentitySeed,
 		false,
 		nil,
-		[]string{
+		[]oasis.Argument{
 			// Fail first 5 ApplyBatch requests.
-			"--" + byzantine.CfgNumStorageFailApply, strconv.Itoa(5),
+			{Name: byzantine.CfgNumStorageFailApply, Values: []string{strconv.Itoa(5)}},
 		},
 	)
 	// ByzantineStorageFailApplyBatch is the byzantine storage scenario where storage node fails
@@ -209,9 +209,9 @@ var (
 		oasis.ByzantineDefaultIdentitySeed,
 		false,
 		nil,
-		[]string{
+		[]oasis.Argument{
 			// Fail first 3 ApplyBatch requests - from the 2 executor workers and 1 backup node.
-			"--" + byzantine.CfgNumStorageFailApplyBatch, strconv.Itoa(3),
+			{Name: byzantine.CfgNumStorageFailApplyBatch, Values: []string{strconv.Itoa(3)}},
 		},
 	)
 	// ByzantineStorageFailRead is the byzantine storage node scenario that fails all read requests.
@@ -228,9 +228,9 @@ var (
 		// current shuffling method in the storage client. See also #1815.
 		true,
 		nil,
-		[]string{
+		[]oasis.Argument{
 			// Fail all read requests.
-			"--" + byzantine.CfgFailReadRequests,
+			{Name: byzantine.CfgFailReadRequests},
 		},
 	)
 	// ByzantineStorageCorruptGetDiff is the byzantine storage node scenario that corrupts GetDiff
@@ -243,9 +243,9 @@ var (
 		oasis.ByzantineDefaultIdentitySeed,
 		false,
 		nil,
-		[]string{
+		[]oasis.Argument{
 			// Corrupt all GetDiff responses.
-			"--" + byzantine.CfgCorruptGetDiff,
+			{Name: byzantine.CfgCorruptGetDiff},
 		},
 	)
 )
@@ -254,7 +254,7 @@ type byzantineImpl struct {
 	runtimeImpl
 
 	script    string
-	extraArgs []string
+	extraArgs []oasis.Argument
 
 	skipStorageSyncWait        bool
 	identitySeed               string
@@ -273,7 +273,7 @@ func newByzantineImpl(
 	identitySeed string,
 	skipStorageWait bool,
 	expectedSlashes map[staking.SlashReason]uint64,
-	extraArgs []string,
+	extraArgs []oasis.Argument,
 ) scenario.Scenario {
 	return &byzantineImpl{
 		runtimeImpl: *newRuntimeImpl(

--- a/go/oasis-test-runner/scenario/e2e/runtime/multihost.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/multihost.go
@@ -1,0 +1,56 @@
+package runtime
+
+import (
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
+)
+
+var (
+	// MultihostDouble is the MultiHost node scenario with nodes with two workers.
+	MultihostDouble scenario.Scenario = newMultiHostImpl("multihost-double", "simple-keyvalue-client", nil, false)
+	// MultihostTriple is the MultiHost node scenario with nodes with three workers.
+	MultihostTriple scenario.Scenario = newMultiHostImpl("multihost-triple", "simple-keyvalue-client", nil, true)
+)
+
+type multiHostImpl struct {
+	runtimeImpl
+	triple bool
+}
+
+func newMultiHostImpl(name, clientBinary string, clientArgs []string, triple bool) scenario.Scenario {
+	return &multiHostImpl{
+		runtimeImpl: *newRuntimeImpl(name, clientBinary, clientArgs),
+		triple:      triple,
+	}
+}
+
+func (sc *multiHostImpl) Clone() scenario.Scenario {
+	return &multiHostImpl{
+		runtimeImpl: *sc.runtimeImpl.Clone().(*runtimeImpl),
+		triple:      sc.triple,
+	}
+}
+
+func (sc *multiHostImpl) Fixture() (*oasis.NetworkFixture, error) {
+	f, err := sc.runtimeImpl.Fixture()
+	if err != nil {
+		return nil, err
+	}
+
+	if !sc.triple {
+		// Assign some compute, client and storage workers to shared nodes.
+		f.ComputeWorkers[0].Name = "compute-storage-0"
+		f.StorageWorkers[0].Name = "compute-storage-0"
+
+		f.Clients[0].Name = "client-storage-0"
+		f.StorageWorkers[1].Name = "client-storage-0"
+	} else {
+		// Have a node with everything.
+		const nodeName = "compute-storage-client-0"
+		f.ComputeWorkers[0].Name = nodeName
+		f.StorageWorkers[0].Name = nodeName
+		f.Clients[0].Name = nodeName
+	}
+
+	return f, nil
+}

--- a/go/oasis-test-runner/scenario/e2e/runtime/offset_restart.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/offset_restart.go
@@ -1,0 +1,97 @@
+package runtime
+
+import (
+	"context"
+
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
+)
+
+// OffsetRestart is the offset restart scenario..
+var OffsetRestart scenario.Scenario = newOffsetRestartImpl()
+
+type offsetRestartImpl struct {
+	runtimeImpl
+}
+
+func newOffsetRestartImpl() scenario.Scenario {
+	sc := &offsetRestartImpl{
+		runtimeImpl: *newRuntimeImpl("offset-restart", "test-long-term-client", []string{"--mode", "part1"}),
+	}
+	return sc
+}
+
+func (sc *offsetRestartImpl) Clone() scenario.Scenario {
+	return &offsetRestartImpl{
+		runtimeImpl: *sc.runtimeImpl.Clone().(*runtimeImpl),
+	}
+}
+
+func (sc *offsetRestartImpl) Fixture() (*oasis.NetworkFixture, error) {
+	f, err := sc.runtimeImpl.Fixture()
+	if err != nil {
+		return nil, err
+	}
+
+	f.Network.SetMockEpoch()
+
+	// Make sure the compute nodes can terminate early.
+	for i := range f.ComputeWorkers {
+		f.ComputeWorkers[i].AllowEarlyTermination = true
+	}
+
+	return f, nil
+}
+
+func (sc *offsetRestartImpl) Run(childEnv *env.Env) error {
+	ctx := context.Background()
+
+	clientErrCh, cmd, err := sc.runtimeImpl.start(childEnv)
+	if err != nil {
+		return err
+	}
+
+	fixture, err := sc.Fixture()
+	if err != nil {
+		return err
+	}
+
+	if err = sc.initialEpochTransitions(fixture); err != nil {
+		return err
+	}
+
+	if err = sc.waitClient(childEnv, cmd, clientErrCh); err != nil {
+		return err
+	}
+
+	// Restart all compute workers.
+	sc.Logger.Info("client done, restarting all compute workers")
+	for _, compute := range sc.Net.ComputeWorkers() {
+		if err = compute.Stop(); err != nil {
+			return err
+		}
+	}
+	for _, compute := range sc.Net.ComputeWorkers() {
+		if err = compute.Start(); err != nil {
+			return err
+		}
+	}
+	for _, compute := range sc.Net.ComputeWorkers() {
+		if err = compute.WaitReady(ctx); err != nil {
+			return err
+		}
+	}
+
+	// Try the client again. If the client node didn't reconnect to compute
+	// nodes successfully again, the test should hang here. This specifically tests
+	// earlier issues where the client node failed to reconnect to compute nodes
+	// if these disconnected after the client node had already seen them, thereby
+	// hanging the network (no transactions could be submitted).
+	sc.Logger.Info("network back up, trying to run client again")
+	sc.runtimeImpl.clientArgs = []string{
+		"--mode", "part2",
+		"--seed", "second_seed",
+	}
+	return sc.runtimeImpl.Run(childEnv)
+}

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -446,22 +446,22 @@ func (sc *runtimeImpl) waitNodesSynced() error {
 	sc.Logger.Info("waiting for all nodes to be synced")
 
 	for _, n := range sc.Net.Validators() {
-		if err := checkSynced(&n.Node); err != nil {
+		if err := checkSynced(n.Node); err != nil {
 			return err
 		}
 	}
 	for _, n := range sc.Net.StorageWorkers() {
-		if err := checkSynced(&n.Node); err != nil {
+		if err := checkSynced(n.Node); err != nil {
 			return err
 		}
 	}
 	for _, n := range sc.Net.ComputeWorkers() {
-		if err := checkSynced(&n.Node); err != nil {
+		if err := checkSynced(n.Node); err != nil {
 			return err
 		}
 	}
 	for _, n := range sc.Net.Clients() {
-		if err := checkSynced(&n.Node); err != nil {
+		if err := checkSynced(n.Node); err != nil {
 			return err
 		}
 	}
@@ -566,6 +566,9 @@ func RegisterScenarios() error {
 		RuntimeEncryption,
 		RuntimeGovernance,
 		RuntimeMessage,
+		// Single node with multiple workers tests.
+		MultihostDouble,
+		MultihostTriple,
 		// Byzantine executor node.
 		ByzantineExecutorHonest,
 		ByzantineExecutorSchedulerHonest,

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -609,6 +609,7 @@ func RegisterScenarios() error {
 		MultipleRuntimes,
 		// Node shutdown test.
 		NodeShutdown,
+		OffsetRestart,
 		// Gas fees tests.
 		GasFeesRuntimes,
 		// Runtime prune test.

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_inconsistent.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_inconsistent.go
@@ -141,7 +141,7 @@ func (sc *storageSyncInconsistentImpl) Run(childEnv *env.Env) error {
 	if err = messyWorker.Stop(); err != nil {
 		return err
 	}
-	if err = sc.wipe(ctx, &messyWorker.Node); err != nil {
+	if err = sc.wipe(ctx, messyWorker.Node); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
@@ -593,16 +593,16 @@ func (sc *txSourceImpl) manager(env *env.Env, errCh chan error) {
 	var restartableNodes []*oasis.Node
 	// Keep one of each types of nodes always running.
 	for _, v := range sc.Net.Validators()[1:] {
-		restartableNodes = append(restartableNodes, &v.Node)
+		restartableNodes = append(restartableNodes, v.Node)
 	}
 	for _, s := range sc.Net.StorageWorkers()[1:] {
-		restartableNodes = append(restartableNodes, &s.Node)
+		restartableNodes = append(restartableNodes, s.Node)
 	}
 	for _, c := range sc.Net.ComputeWorkers()[1:] {
-		restartableNodes = append(restartableNodes, &c.Node)
+		restartableNodes = append(restartableNodes, c.Node)
 	}
 	for _, k := range sc.Net.Keymanagers()[1:] {
-		restartableNodes = append(restartableNodes, &k.Node)
+		restartableNodes = append(restartableNodes, k.Node)
 	}
 
 	restartTicker := time.NewTicker(sc.nodeRestartInterval)
@@ -851,7 +851,7 @@ func (sc *txSourceImpl) Run(childEnv *env.Env) error {
 	// Start all configured workloads.
 	errCh := make(chan error, len(sc.clientWorkloads)+len(sc.allNodeWorkloads)+2)
 	for _, name := range sc.clientWorkloads {
-		if err := sc.startWorkload(childEnv, errCh, name, &sc.Net.Clients()[0].Node); err != nil {
+		if err := sc.startWorkload(childEnv, errCh, name, sc.Net.Clients()[0].Node); err != nil {
 			return fmt.Errorf("failed to start client workload %s: %w", name, err)
 		}
 	}

--- a/go/runtime/registry/registry.go
+++ b/go/runtime/registry/registry.go
@@ -54,6 +54,10 @@ type Registry interface {
 	// registry.
 	NewUnmanagedRuntime(ctx context.Context, runtimeID common.Namespace) (Runtime, error)
 
+	// AddRoles adds available node roles to the runtime. Specify nil as the runtimeID
+	// to set the role for all runtimes.
+	AddRoles(roles node.RolesMask, runtimeID *common.Namespace) error
+
 	// StorageRouter returns a storage backend which routes requests to the
 	// correct per-runtime storage backend based on the namespace contained
 	// in the request.
@@ -89,6 +93,12 @@ type Runtime interface {
 	// RegisterStorage sets the given local storage backend for the runtime.
 	RegisterStorage(storage storageAPI.Backend)
 
+	// AddRoles adds available node roles to the runtime.
+	AddRoles(roles node.RolesMask)
+
+	// HasRoles checks if the node has all of the roles specified for this runtime.
+	HasRoles(roles node.RolesMask) bool
+
 	// History returns the history for this runtime.
 	History() history.History
 
@@ -108,13 +118,14 @@ type Runtime interface {
 	Host(ctx context.Context) (runtimeHost.Config, runtimeHost.Provisioner, error)
 }
 
-type runtime struct {
+type runtime struct { // nolint: maligned
 	sync.RWMutex
 
 	id                   common.Namespace
 	registryDescriptor   *registry.Runtime
 	activeDescriptor     *registry.Runtime
 	activeDescriptorHash hash.Hash
+	roles                node.RolesMask
 
 	consensus    consensus.Backend
 	storage      storageAPI.Backend
@@ -192,6 +203,20 @@ func (r *runtime) RegisterStorage(storage storageAPI.Backend) {
 		panic("runtime storage backend already assigned")
 	}
 	r.storage = storage
+}
+
+func (r *runtime) AddRoles(roles node.RolesMask) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.roles |= roles
+}
+
+func (r *runtime) HasRoles(roles node.RolesMask) bool {
+	r.Lock()
+	defer r.Unlock()
+
+	return r.roles&roles == roles
 }
 
 func (r *runtime) History() history.History {
@@ -408,6 +433,25 @@ func (r *runtimeRegistry) Runtimes() []Runtime {
 
 func (r *runtimeRegistry) NewUnmanagedRuntime(ctx context.Context, runtimeID common.Namespace) (Runtime, error) {
 	return newRuntime(ctx, runtimeID, r.cfg, r.consensus, r.logger)
+}
+
+func (r *runtimeRegistry) AddRoles(roles node.RolesMask, runtimeID *common.Namespace) error {
+	r.RLock()
+	defer r.RUnlock()
+
+	if runtimeID != nil {
+		rt, ok := r.runtimes[*runtimeID]
+		if !ok {
+			return fmt.Errorf("runtime/registry: runtime %s is not supported", *runtimeID)
+		}
+		rt.AddRoles(roles)
+		return nil
+	}
+
+	for _, rt := range r.runtimes {
+		rt.AddRoles(roles)
+	}
+	return nil
 }
 
 func (r *runtimeRegistry) StorageRouter() storageAPI.Backend {

--- a/go/runtime/registry/storage_router.go
+++ b/go/runtime/registry/storage_router.go
@@ -11,76 +11,77 @@ import (
 
 var _ api.Backend = (*storageRouter)(nil)
 
-type storageRouter struct {
-	registry Registry
-}
+type RouterRuntimeStorageFunc func(ns common.Namespace) (api.Backend, error)
 
-func (sr *storageRouter) getRuntime(ns common.Namespace) (Runtime, error) {
-	return sr.registry.GetRuntime(ns)
+type RouterInitWaitFunc func()
+
+type storageRouter struct {
+	getRuntime RouterRuntimeStorageFunc
+	initWaiter RouterInitWaitFunc
 }
 
 func (sr *storageRouter) SyncGet(ctx context.Context, request *api.GetRequest) (*api.ProofResponse, error) {
-	rt, err := sr.getRuntime(request.Tree.Root.Namespace)
+	storage, err := sr.getRuntime(request.Tree.Root.Namespace)
 	if err != nil {
 		return nil, err
 	}
-	return rt.Storage().SyncGet(ctx, request)
+	return storage.SyncGet(ctx, request)
 }
 
 func (sr *storageRouter) SyncGetPrefixes(ctx context.Context, request *api.GetPrefixesRequest) (*api.ProofResponse, error) {
-	rt, err := sr.getRuntime(request.Tree.Root.Namespace)
+	storage, err := sr.getRuntime(request.Tree.Root.Namespace)
 	if err != nil {
 		return nil, err
 	}
-	return rt.Storage().SyncGetPrefixes(ctx, request)
+	return storage.SyncGetPrefixes(ctx, request)
 }
 
 func (sr *storageRouter) SyncIterate(ctx context.Context, request *api.IterateRequest) (*api.ProofResponse, error) {
-	rt, err := sr.getRuntime(request.Tree.Root.Namespace)
+	storage, err := sr.getRuntime(request.Tree.Root.Namespace)
 	if err != nil {
 		return nil, err
 	}
-	return rt.Storage().SyncIterate(ctx, request)
+	return storage.SyncIterate(ctx, request)
 }
 
 func (sr *storageRouter) Apply(ctx context.Context, request *api.ApplyRequest) ([]*api.Receipt, error) {
-	rt, err := sr.getRuntime(request.Namespace)
+	storage, err := sr.getRuntime(request.Namespace)
 	if err != nil {
 		return nil, err
 	}
-	return rt.Storage().Apply(ctx, request)
+	return storage.Apply(ctx, request)
 }
 
 func (sr *storageRouter) ApplyBatch(ctx context.Context, request *api.ApplyBatchRequest) ([]*api.Receipt, error) {
-	rt, err := sr.getRuntime(request.Namespace)
+	storage, err := sr.getRuntime(request.Namespace)
 	if err != nil {
 		return nil, err
 	}
-	return rt.Storage().ApplyBatch(ctx, request)
+	return storage.ApplyBatch(ctx, request)
 }
 
 func (sr *storageRouter) GetDiff(ctx context.Context, request *api.GetDiffRequest) (api.WriteLogIterator, error) {
-	rt, err := sr.getRuntime(request.StartRoot.Namespace)
+	storage, err := sr.getRuntime(request.StartRoot.Namespace)
 	if err != nil {
 		return nil, err
 	}
-	return rt.Storage().GetDiff(ctx, request)
+	return storage.GetDiff(ctx, request)
 }
 
 func (sr *storageRouter) GetCheckpoints(ctx context.Context, request *checkpoint.GetCheckpointsRequest) ([]*checkpoint.Metadata, error) {
-	rt, err := sr.getRuntime(request.Namespace)
+	storage, err := sr.getRuntime(request.Namespace)
 	if err != nil {
 		return nil, err
 	}
-	return rt.Storage().GetCheckpoints(ctx, request)
+	return storage.GetCheckpoints(ctx, request)
 }
 
 func (sr *storageRouter) GetCheckpointChunk(ctx context.Context, chunk *checkpoint.ChunkMetadata, w io.Writer) error {
-	rt, err := sr.getRuntime(chunk.Root.Namespace)
+	storage, err := sr.getRuntime(chunk.Root.Namespace)
 	if err != nil {
 		return err
 	}
-	return rt.Storage().GetCheckpointChunk(ctx, chunk, w)
+	return storage.GetCheckpointChunk(ctx, chunk, w)
 }
 
 func (sr *storageRouter) Cleanup() {
@@ -90,9 +91,14 @@ func (sr *storageRouter) Initialized() <-chan struct{} {
 	ch := make(chan struct{})
 	go func() {
 		defer close(ch)
-		for _, rt := range sr.registry.Runtimes() {
-			<-rt.Storage().Initialized()
-		}
+		sr.initWaiter()
 	}()
 	return ch
+}
+
+func NewStorageRouter(runtimeGetter RouterRuntimeStorageFunc, waiter RouterInitWaitFunc) api.Backend {
+	return &storageRouter{
+		getRuntime: runtimeGetter,
+		initWaiter: waiter,
+	}
 }

--- a/go/storage/api/mux.go
+++ b/go/storage/api/mux.go
@@ -1,0 +1,231 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
+)
+
+// ErrMuxDontContinue is the error that should be returned by the MuxController function
+// when an operation was successful, but the muxer shouldn't continue with other backends.
+var ErrMuxDontContinue = errors.New("dontcontinue")
+
+// MuxContinueWithError is an error type that can be returned by the MuxController function
+// when an operation failed, but the muxer should continue anyway. The error returned will be
+// last one returned by any failed operation.
+//
+// NOTE: If one backend in the muxer fails and another succeeds, then using this may cause
+// the abnormal situation of the muxer returning both a response and an error for the operation.
+type MuxContinueWithError struct {
+	wrapped error
+}
+
+func (e MuxContinueWithError) Error() string {
+	return e.wrapped.Error()
+}
+
+func (e MuxContinueWithError) Unwrap() error {
+	return e.wrapped
+}
+
+// MuxController controls how a mux storage shim steps through its backend list.
+//
+// If the controller returns an error, the muxer will normally stop iterating through the backend
+// list and return the error (with special handling for errors of type MuxContinueWithError and
+// ErrMuxDontContinue).
+type MuxController func(i int, backend Backend, meth string, resp interface{}, err error) (interface{}, error)
+
+// MuxReadOpFinishEarly is a chainable controller that stops the muxer as soon as a readonly operation is
+// successful. It passes through all other operation transparently to the next controller.
+func MuxReadOpFinishEarly(next MuxController) MuxController {
+	return func(i int, backend Backend, meth string, resp interface{}, err error) (interface{}, error) {
+		switch meth {
+		case "GetDiff":
+			fallthrough
+		case "SyncGet":
+			fallthrough
+		case "SyncGetPrefixes":
+			fallthrough
+		case "SyncIterate":
+			fallthrough
+		case "GetCheckpoints":
+			fallthrough
+		case "GetCheckpointChunk":
+			if err == nil {
+				return resp, ErrMuxDontContinue
+			}
+			return nil, &MuxContinueWithError{err}
+		default:
+			return next(i, backend, meth, resp, err)
+		}
+	}
+}
+
+// MuxIterateIgnoringErrors creates a controller that tells the muxer to continue iterating through
+// its backends even if one returns an error. The errors are stored and the last one is returned
+// at the end.
+func MuxIterateIgnoringErrors() MuxController {
+	return func(i int, backend Backend, meth string, resp interface{}, err error) (interface{}, error) {
+		if err != nil {
+			return resp, &MuxContinueWithError{err}
+		}
+		return resp, nil
+	}
+}
+
+// MuxPassthrough is a mux controller that just returns the response and error it gets. Normally, this will
+// cause the muxer to stop on error and continue on a response.
+func MuxPassthrough(i int, backend Backend, meth string, resp interface{}, err error) (interface{}, error) {
+	return resp, err
+}
+
+type storageMux struct {
+	backends   []Backend
+	controller MuxController
+
+	initOnce sync.Once
+	initCh   chan struct{}
+}
+
+func (s *storageMux) doDouble(meth string, call func(Backend) (interface{}, error)) (interface{}, error) {
+	var residual, newErr error
+	var lastResp, ctrlResp interface{}
+	for i, b := range s.backends {
+		resp, err := call(b)
+		ctrlResp, newErr = s.controller(i, b, meth, resp, err)
+		if ctrlResp != nil {
+			lastResp = ctrlResp
+		}
+		if wrapped, ok := newErr.(*MuxContinueWithError); ok {
+			residual = wrapped.Unwrap()
+			newErr = nil
+		}
+		if newErr == ErrMuxDontContinue {
+			return lastResp, residual
+		}
+		if newErr != nil {
+			return lastResp, newErr
+		}
+	}
+	return lastResp, residual
+}
+
+func (s *storageMux) Apply(ctx context.Context, request *ApplyRequest) ([]*Receipt, error) {
+	resp, err := s.doDouble("Apply", func(b Backend) (interface{}, error) {
+		return b.Apply(ctx, request)
+	})
+	var cast []*Receipt
+	if resp != nil {
+		cast = resp.([]*Receipt)
+	}
+	return cast, err
+}
+
+func (s *storageMux) ApplyBatch(ctx context.Context, request *ApplyBatchRequest) ([]*Receipt, error) {
+	resp, err := s.doDouble("ApplyBatch", func(b Backend) (interface{}, error) {
+		return b.ApplyBatch(ctx, request)
+	})
+	var cast []*Receipt
+	if resp != nil {
+		cast = resp.([]*Receipt)
+	}
+	return cast, err
+}
+
+func (s *storageMux) GetDiff(ctx context.Context, request *GetDiffRequest) (WriteLogIterator, error) {
+	resp, err := s.doDouble("GetDiff", func(b Backend) (interface{}, error) {
+		return b.GetDiff(ctx, request)
+	})
+	var cast WriteLogIterator
+	if resp != nil {
+		cast = resp.(WriteLogIterator)
+	}
+	return cast, err
+}
+
+func (s *storageMux) SyncGet(ctx context.Context, request *GetRequest) (*ProofResponse, error) {
+	resp, err := s.doDouble("SyncGet", func(b Backend) (interface{}, error) {
+		return b.SyncGet(ctx, request)
+	})
+	var cast *ProofResponse
+	if resp != nil {
+		cast = resp.(*ProofResponse)
+	}
+	return cast, err
+}
+
+func (s *storageMux) SyncGetPrefixes(ctx context.Context, request *GetPrefixesRequest) (*ProofResponse, error) {
+	resp, err := s.doDouble("SyncGetPrefixes", func(b Backend) (interface{}, error) {
+		return b.SyncGetPrefixes(ctx, request)
+	})
+	var cast *ProofResponse
+	if resp != nil {
+		cast = resp.(*ProofResponse)
+	}
+	return cast, err
+}
+
+func (s *storageMux) SyncIterate(ctx context.Context, request *IterateRequest) (*ProofResponse, error) {
+	resp, err := s.doDouble("SyncIterate", func(b Backend) (interface{}, error) {
+		return b.SyncIterate(ctx, request)
+	})
+	var cast *ProofResponse
+	if resp != nil {
+		cast = resp.(*ProofResponse)
+	}
+	return cast, err
+}
+
+func (s *storageMux) GetCheckpoints(ctx context.Context, request *checkpoint.GetCheckpointsRequest) ([]*checkpoint.Metadata, error) {
+	resp, err := s.doDouble("GetCheckpoints", func(b Backend) (interface{}, error) {
+		return b.GetCheckpoints(ctx, request)
+	})
+	var cast []*checkpoint.Metadata
+	if resp != nil {
+		cast = resp.([]*checkpoint.Metadata)
+	}
+	return cast, err
+}
+
+func (s *storageMux) GetCheckpointChunk(ctx context.Context, chunk *checkpoint.ChunkMetadata, w io.Writer) error {
+	_, err := s.doDouble("GetCheckpointChunk", func(b Backend) (interface{}, error) {
+		return nil, b.GetCheckpointChunk(ctx, chunk, w)
+	})
+	return err
+}
+
+func (s *storageMux) Cleanup() {
+	for _, b := range s.backends {
+		b.Cleanup()
+	}
+}
+
+func (s *storageMux) Initialized() <-chan struct{} {
+	s.initOnce.Do(func() {
+		go func() {
+			defer close(s.initCh)
+			for _, b := range s.backends {
+				<-b.Initialized()
+			}
+		}()
+	})
+	return s.initCh
+}
+
+// NewStorageMux constructs a multiplexer for multiple storage backends. Requests are sent to
+// all of them. It is the controller's job to determine on each step if the muxer should continue
+// with further backends or not.
+//
+// Normally, the return values are the last non-nil return of any backend and the last non-nil error
+// of any backend, so client code should take care to take into account the otherwise unusual situation
+// where both the response and error are valid non-nil values.
+func NewStorageMux(controller MuxController, backends ...Backend) Backend {
+	return &storageMux{
+		backends:   backends,
+		controller: controller,
+		initCh:     make(chan struct{}),
+	}
+}

--- a/go/storage/api/mux_test.go
+++ b/go/storage/api/mux_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type faultyBackend struct {
+	Backend
+
+	calledCh chan struct{}
+	returnCh chan error
+}
+
+func (b *faultyBackend) Apply(ctx context.Context, request *ApplyRequest) ([]*Receipt, error) {
+	b.calledCh <- struct{}{}
+	if err := <-b.returnCh; err != nil {
+		return nil, err
+	}
+	return []*Receipt{nil}, nil
+}
+
+func (b *faultyBackend) SyncGet(ctx context.Context, request *GetRequest) (*ProofResponse, error) {
+	b.calledCh <- struct{}{}
+	if err := <-b.returnCh; err != nil {
+		return nil, err
+	}
+	return &ProofResponse{}, nil
+}
+
+func TestStorageMux(t *testing.T) {
+	ctx := context.Background()
+	someError := errors.New("error")
+	calledCh := make(chan struct{}, 2)
+	faulty1 := &faultyBackend{
+		calledCh: calledCh,
+		returnCh: make(chan error, 1),
+	}
+	faulty2 := &faultyBackend{
+		calledCh: calledCh,
+		returnCh: make(chan error, 1),
+	}
+
+	mux := NewStorageMux(
+		MuxReadOpFinishEarly(MuxIterateIgnoringErrors()),
+		faulty1,
+		faulty2,
+	)
+
+	var (
+		applyResp []*Receipt
+		getResp   *ProofResponse
+		err       error
+	)
+
+	// Both need to respond to a write request.
+	faulty1.returnCh <- nil
+	faulty2.returnCh <- nil
+	_, err = mux.Apply(ctx, &ApplyRequest{})
+	require.NoError(t, err)
+	<-faulty1.calledCh
+	<-faulty2.calledCh
+
+	// If the first write fails, the second one should still go through
+	// with the controllers we set up.
+	faulty1.returnCh <- someError
+	faulty2.returnCh <- nil
+	applyResp, err = mux.Apply(ctx, &ApplyRequest{})
+	require.EqualError(t, err, "error")
+	require.NotNil(t, applyResp)
+	<-faulty1.calledCh
+	<-faulty2.calledCh
+
+	// The second one shouldn't be called when the first read request succeeds.
+	faulty1.returnCh <- nil
+	_, err = mux.SyncGet(ctx, &GetRequest{})
+	require.NoError(t, err)
+	<-faulty1.calledCh
+	select {
+	case <-faulty2.calledCh:
+		require.FailNow(t, "faulty2 shouldn't be called")
+	default:
+	}
+
+	// If the first read fails, call the second one too.
+	faulty1.returnCh <- someError
+	faulty2.returnCh <- nil
+	getResp, err = mux.SyncGet(ctx, &GetRequest{})
+	require.EqualError(t, err, "error")
+	require.NotNil(t, getResp)
+	<-faulty1.calledCh
+	<-faulty2.calledCh
+
+	// Also test early termination, all backends need to succeed.
+	mux = NewStorageMux(MuxPassthrough, faulty1, faulty2)
+	faulty1.returnCh <- someError
+	_, err = mux.Apply(ctx, &ApplyRequest{})
+	require.EqualError(t, err, "error")
+	<-faulty1.calledCh
+	select {
+	case <-faulty2.calledCh:
+		require.FailNow(t, "faulty2 shouldn't be called")
+	default:
+	}
+}

--- a/go/worker/common/committee/group.go
+++ b/go/worker/common/committee/group.go
@@ -579,7 +579,6 @@ func NewGroup(
 		return nil, fmt.Errorf("group: failed to create node watcher: %w", err)
 	}
 
-	// TODO: If the current node is a storage node, always include self (oasis-core#3251).
 	sc, err := storageClient.NewForNodes(
 		ctx,
 		identity,

--- a/go/worker/common/p2p/init.go
+++ b/go/worker/common/p2p/init.go
@@ -18,6 +18,9 @@ const (
 	CfgP2PPeerOutboundQueueSize = "worker.p2p.peer_outbound_queue_size"
 	// CfgP2PValidateQueueSize sets the libp2p gossipsub buffer size of the validate queue.
 	CfgP2PValidateQueueSize = "worker.p2p.validate_queue_size"
+	// CfgP2PConnectednessLowWater sets the ratio of connected to unconnected peers at which
+	// the peer manager will try to reconnect to disconnected nodes.
+	CfgP2PConnectednessLowWater = "worker.p2p.connectedness_low_water"
 )
 
 // Enabled reads our enabled flag from viper.
@@ -34,6 +37,7 @@ func init() {
 	Flags.StringSlice(cfgP2pAddresses, []string{}, "Address/port(s) to use for P2P connections when registering this node (if not set, all non-loopback local interfaces will be used)")
 	Flags.Int64(CfgP2PPeerOutboundQueueSize, 32, "Set libp2p gossipsub buffer size for outbound messages")
 	Flags.Int64(CfgP2PValidateQueueSize, 32, "Set libp2p gossipsub buffer size of the validate queue")
+	Flags.Float64(CfgP2PConnectednessLowWater, 0.2, "Set the low water mark at which the peer manager will try to reconnect to peers")
 
 	_ = viper.BindPFlags(Flags)
 }

--- a/go/worker/common/p2p/p2p.go
+++ b/go/worker/common/p2p/p2p.go
@@ -117,7 +117,7 @@ func (p *P2P) Publish(ctx context.Context, runtimeID common.Namespace, msg *Mess
 		return
 	}
 
-	if err := h.topic.Publish(h.ctx, rawMsg); err != nil {
+	if err := h.tryPublishing(rawMsg); err != nil {
 		h.logger.Error("failed to publish message to the network",
 			"err", err,
 		)

--- a/go/worker/compute/executor/worker.go
+++ b/go/worker/compute/executor/worker.go
@@ -149,7 +149,14 @@ func (w *Worker) registerRuntime(commonNode *committeeCommon.Node) error {
 	}
 
 	// Create committee node for the given runtime.
-	node, err := committee.NewNode(commonNode, w.commonWorker.GetConfig(), rp, w.scheduleCheckTxEnabled, w.scheduleMaxTxPoolSize, w.scheduleTxCacheSize)
+	node, err := committee.NewNode(
+		commonNode,
+		w.commonWorker.GetConfig(),
+		rp,
+		w.scheduleCheckTxEnabled,
+		w.scheduleMaxTxPoolSize,
+		w.scheduleTxCacheSize,
+	)
 	if err != nil {
 		return err
 	}

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -577,6 +577,12 @@ func (w *Worker) newRoleProvider(role node.RolesMask, runtimeID *common.Namespac
 	if !role.IsSingleRole() {
 		return nil, fmt.Errorf("RegisterRole: registration role mask does not encode a single role. RoleMask: '%s'", role)
 	}
+	if err := w.runtimeRegistry.AddRoles(role, runtimeID); err != nil {
+		w.logger.Info("runtime doesn't exist, roles not registered",
+			"err", err,
+			"role", role,
+		)
+	}
 
 	rp := &roleProvider{
 		w:         w,

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -438,6 +438,11 @@ func (n *Node) PauseCheckpointer(pause bool) error {
 	return nil
 }
 
+// GetLocalStorage returns the local storage backend used by this storage node.
+func (n *Node) GetLocalStorage() storageApi.LocalBackend {
+	return n.localStorage
+}
+
 // NodeHooks implementation.
 
 func (n *Node) HandlePeerMessage(context.Context, *p2p.Message, bool) (bool, error) {

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -92,6 +92,10 @@ const (
 	// The minimum number of rounds the worker can be behind the chain before it's sensible for
 	// it to stop advertising availability.
 	minimumRoundDelayForUnavailability = uint64(15)
+
+	// The number of rounds ahead of consensus that the worker will allow round waiters to wait.
+	// Trying to wait for rounds further in the future will return an error immediately.
+	roundWaitConsensusOffset = uint64(1)
 )
 
 type roundItem interface {
@@ -400,6 +404,14 @@ func (n *Node) WaitForRound(round uint64, root *storageApi.Root) (<-chan uint64,
 
 	if root != nil {
 		round = root.Version
+	}
+
+	n.commonNode.CrossNode.Lock()
+	consensusRound := n.commonNode.CurrentBlock.Header.Round
+	n.commonNode.CrossNode.Unlock()
+	if round > consensusRound+roundWaitConsensusOffset && !commonFlags.DebugDontBlameOasis() {
+		close(retCh)
+		return nil, storageApi.ErrVersionNotFound
 	}
 
 	n.syncedLock.Lock()

--- a/go/worker/storage/synced_storage.go
+++ b/go/worker/storage/synced_storage.go
@@ -1,0 +1,99 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
+	nodedb "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
+	"github.com/oasisprotocol/oasis-core/go/worker/storage/committee"
+)
+
+type syncedStorage struct {
+	runtime *committee.Node
+	wrapped storage.LocalBackend
+}
+
+func (s *syncedStorage) wait(ctx context.Context, root storage.Root) error {
+	ch, err := s.runtime.WaitForRound(root.Version, &root)
+	if err != nil {
+		return err
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-ch:
+		return nil
+	}
+}
+
+func (s *syncedStorage) Apply(ctx context.Context, request *storage.ApplyRequest) ([]*storage.Receipt, error) {
+	// Don't wait for write operations, since they may be required before the worker is "synced".
+	return s.wrapped.Apply(ctx, request)
+}
+
+func (s *syncedStorage) ApplyBatch(ctx context.Context, request *storage.ApplyBatchRequest) ([]*storage.Receipt, error) {
+	// Don't wait for write operations, since they may be required before the worker is "synced".
+	return s.wrapped.ApplyBatch(ctx, request)
+}
+
+func (s *syncedStorage) GetDiff(ctx context.Context, request *storage.GetDiffRequest) (storage.WriteLogIterator, error) {
+	if err := s.wait(ctx, request.EndRoot); err != nil {
+		return nil, fmt.Errorf("worker/storage: GetDiff to local storage failed: %w", err)
+	}
+	return s.wrapped.GetDiff(ctx, request)
+}
+
+func (s *syncedStorage) SyncGet(ctx context.Context, request *storage.GetRequest) (*storage.ProofResponse, error) {
+	if err := s.wait(ctx, request.Tree.Root); err != nil {
+		return nil, fmt.Errorf("worker/storage: SyncGet to local storage failed: %w", err)
+	}
+	return s.wrapped.SyncGet(ctx, request)
+}
+
+func (s *syncedStorage) SyncGetPrefixes(ctx context.Context, request *storage.GetPrefixesRequest) (*storage.ProofResponse, error) {
+	if err := s.wait(ctx, request.Tree.Root); err != nil {
+		return nil, fmt.Errorf("worker/storage: SyncGetPrefixes to local storage failed: %w", err)
+	}
+	return s.wrapped.SyncGetPrefixes(ctx, request)
+}
+
+func (s *syncedStorage) SyncIterate(ctx context.Context, request *storage.IterateRequest) (*storage.ProofResponse, error) {
+	if err := s.wait(ctx, request.Tree.Root); err != nil {
+		return nil, fmt.Errorf("worker/storage: SyncIterate to local storage failed: %w", err)
+	}
+	return s.wrapped.SyncIterate(ctx, request)
+}
+
+func (s *syncedStorage) GetCheckpoints(ctx context.Context, request *checkpoint.GetCheckpointsRequest) ([]*checkpoint.Metadata, error) {
+	return s.wrapped.GetCheckpoints(ctx, request)
+}
+
+func (s *syncedStorage) GetCheckpointChunk(ctx context.Context, chunk *checkpoint.ChunkMetadata, w io.Writer) error {
+	return s.wrapped.GetCheckpointChunk(ctx, chunk, w)
+}
+
+func (s *syncedStorage) Checkpointer() checkpoint.CreateRestorer {
+	return s.wrapped.Checkpointer()
+}
+
+func (s *syncedStorage) Cleanup() {
+	s.wrapped.Cleanup()
+}
+
+func (s *syncedStorage) Initialized() <-chan struct{} {
+	return s.wrapped.Initialized()
+}
+
+func (s *syncedStorage) NodeDB() nodedb.NodeDB {
+	return s.wrapped.NodeDB()
+}
+
+func newSyncedLocalStorage(runtime *committee.Node, backend storage.LocalBackend) storage.LocalBackend {
+	return &syncedStorage{
+		runtime: runtime,
+		wrapped: backend,
+	}
+}

--- a/go/worker/storage/worker.go
+++ b/go/worker/storage/worker.go
@@ -134,7 +134,6 @@ func (s *Worker) registerRuntime(dataDir string, commonNode *committeeCommon.Nod
 	if err != nil {
 		return fmt.Errorf("can't create local storage backend: %w", err)
 	}
-	commonNode.Runtime.RegisterStorage(localStorage)
 
 	node, err := committee.NewNode(
 		commonNode,
@@ -151,6 +150,7 @@ func (s *Worker) registerRuntime(dataDir string, commonNode *committeeCommon.Nod
 	if err != nil {
 		return err
 	}
+	commonNode.Runtime.RegisterStorage(newSyncedLocalStorage(node, localStorage))
 	commonNode.AddHooks(node)
 	s.runtimes[id] = node
 

--- a/go/worker/storage/worker.go
+++ b/go/worker/storage/worker.go
@@ -79,10 +79,24 @@ func New(
 		}
 
 		// Attach storage interface to gRPC server.
+		localRouter := registry.NewStorageRouter(
+			func(ns common.Namespace) (api.Backend, error) {
+				node := s.GetRuntime(ns)
+				if node == nil {
+					return nil, fmt.Errorf("worker/storage: runtime %s is not supported", ns)
+				}
+				return node.GetLocalStorage(), nil
+			},
+			func() {
+				for _, node := range s.runtimes {
+					<-node.Initialized()
+				}
+			},
+		)
 		s.grpcPolicy = policy.NewDynamicRuntimePolicyChecker(api.ServiceName, s.commonWorker.GrpcPolicyWatcher)
 		api.RegisterService(s.commonWorker.Grpc.Server(), &storageService{
 			w:                  s,
-			storage:            s.commonWorker.RuntimeRegistry.StorageRouter(),
+			storage:            localRouter,
 			debugRejectUpdates: viper.GetBool(CfgWorkerDebugIgnoreApply) && flags.DebugDontBlameOasis(),
 		})
 


### PR DESCRIPTION
Closes #3251 

Also fixes #3909 by making the peer manager check for disconnected peers, and closes #3900.