### PR TITLE
go/runtime/client: add SubmitTxNoWait method

### DIFF
--- a/.changelog/3444.feature.md
+++ b/.changelog/3444.feature.md
@@ -1,0 +1,4 @@
+go/runtime/client: add SubmitTxNoWait method
+
+SubmitTxNoWait method publishes the runtime transaction and doesn't wait for
+results.

--- a/go/oasis-test-runner/scenario/e2e/runtime/client_expire.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/client_expire.go
@@ -5,10 +5,13 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
 	"github.com/oasisprotocol/oasis-core/go/runtime/client/api"
+	runtimeClient "github.com/oasisprotocol/oasis-core/go/runtime/client/api"
+	runtimeTransaction "github.com/oasisprotocol/oasis-core/go/runtime/transaction"
 )
 
 // ClientExpire is the ClientExpire node scenario.
@@ -59,6 +62,23 @@ func (sc *clientExpireImpl) Run(childEnv *env.Env) error {
 	}
 	if err = nodeCtrl.WaitReady(ctx); err != nil {
 		return err
+	}
+
+	err = nodeCtrl.RuntimeClient.SubmitTxNoWait(ctx, &runtimeClient.SubmitTxRequest{
+		RuntimeID: runtimeID,
+		Data: cbor.Marshal(&runtimeTransaction.TxnCall{
+			Method: "insert",
+			Args: struct {
+				Key   string `json:"key"`
+				Value string `json:"value"`
+			}{
+				Key:   "hello",
+				Value: "test",
+			},
+		}),
+	})
+	if err != nil {
+		return fmt.Errorf("SubmitTxNoWait expected no error, got: %b", err)
 	}
 
 	err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, "hello", "test")

--- a/go/oasis-test-runner/scenario/e2e/runtime/late_start.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/late_start.go
@@ -78,6 +78,22 @@ func (sc *lateStartImpl) Run(childEnv *env.Env) error {
 	if err != nil {
 		return fmt.Errorf("failed to create controller for client: %w", err)
 	}
+	err = ctrl.RuntimeClient.SubmitTxNoWait(ctx, &runtimeClient.SubmitTxRequest{
+		RuntimeID: runtimeID,
+		Data: cbor.Marshal(&runtimeTransaction.TxnCall{
+			Method: "insert",
+			Args: struct {
+				Key   string `json:"key"`
+				Value string `json:"value"`
+			}{
+				Key:   "hello",
+				Value: "test",
+			},
+		}),
+	})
+	if !errors.Is(err, api.ErrNotSynced) {
+		return fmt.Errorf("expected error: %v, got: %v", api.ErrNotSynced, err)
+	}
 	_, err = ctrl.RuntimeClient.SubmitTx(ctx, &runtimeClient.SubmitTxRequest{
 		RuntimeID: runtimeID,
 		Data: cbor.Marshal(&runtimeTransaction.TxnCall{

--- a/go/runtime/client/api/api.go
+++ b/go/runtime/client/api/api.go
@@ -43,8 +43,13 @@ var (
 type RuntimeClient interface {
 	enclaverpc.Transport
 
-	// SubmitTx submits a transaction to the runtime transaction scheduler.
+	// SubmitTx submits a transaction to the runtime transaction scheduler and waits
+	// for transaction execution results.
 	SubmitTx(ctx context.Context, request *SubmitTxRequest) ([]byte, error)
+
+	// SubmitTxNoWait submits a transaction to the runtime transaction scheduler but does
+	// not wait for transaction execution.
+	SubmitTxNoWait(ctx context.Context, request *SubmitTxRequest) error
 
 	// CheckTx asks the local runtime to check the specified transaction.
 	CheckTx(ctx context.Context, request *CheckTxRequest) error

--- a/go/runtime/client/api/grpc.go
+++ b/go/runtime/client/api/grpc.go
@@ -22,6 +22,8 @@ var (
 
 	// methodSubmitTx is the SubmitTx method.
 	methodSubmitTx = serviceName.NewMethod("SubmitTx", SubmitTxRequest{})
+	// methodSubmitTxNoWait is the SubmitTxNoWait method.
+	methodSubmitTxNoWait = serviceName.NewMethod("SubmitTxNoWait", SubmitTxRequest{})
 	// methodCheckTx is the CheckTx method.
 	methodCheckTx = serviceName.NewMethod("CheckTx", CheckTxRequest{})
 	// methodGetGenesisBlock is the GetGenesisBlock method.
@@ -58,6 +60,10 @@ var (
 			{
 				MethodName: methodSubmitTx.ShortName(),
 				Handler:    handlerSubmitTx,
+			},
+			{
+				MethodName: methodSubmitTxNoWait.ShortName(),
+				Handler:    handlerSubmitTxNoWait,
 			},
 			{
 				MethodName: methodCheckTx.ShortName(),
@@ -137,6 +143,29 @@ func handlerSubmitTx( // nolint: golint
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(RuntimeClient).SubmitTx(ctx, req.(*SubmitTxRequest))
+	}
+	return interceptor(ctx, &rq, info, handler)
+}
+
+func handlerSubmitTxNoWait( // nolint: golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var rq SubmitTxRequest
+	if err := dec(&rq); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return nil, srv.(RuntimeClient).SubmitTxNoWait(ctx, &rq)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodSubmitTxNoWait.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, srv.(RuntimeClient).SubmitTxNoWait(ctx, req.(*SubmitTxRequest))
 	}
 	return interceptor(ctx, &rq, info, handler)
 }
@@ -504,6 +533,10 @@ func (c *runtimeClient) SubmitTx(ctx context.Context, request *SubmitTxRequest) 
 		return nil, err
 	}
 	return rsp, nil
+}
+
+func (c *runtimeClient) SubmitTxNoWait(ctx context.Context, request *SubmitTxRequest) error {
+	return c.conn.Invoke(ctx, methodSubmitTxNoWait.FullName(), request, nil)
 }
 
 func (c *runtimeClient) CheckTx(ctx context.Context, request *CheckTxRequest) error {


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/3444

TODO: 
- [x] do some more updates in `client/watcher.go` (now `client/submitter.go`) it is not just a watcher anymore but also submits transactions. Also removed the implementation of `BackgroundService` trait in the submitter for some minor simplifications -   since this is a `runtime/client` package private struct only used by the client (which remains a `BackgroundService`) i think that's fine.