### PR TITLE
go/nodes/grpc: tweak backoff timeouts

### DIFF
--- a/.changelog/3757.internal.md
+++ b/.changelog/3757.internal.md
@@ -1,0 +1,6 @@
+go/nodes/grpc: tweak backoff timeouts
+
+Before, the default storage commit timeout was less than `grpcBackoffMaxDelay`
+which made the storage commit request retries ineffective whenever the max
+delay was reached (e.g. first few requests after a storage node was
+restarted).

--- a/go/runtime/nodes/grpc/grpc.go
+++ b/go/runtime/nodes/grpc/grpc.go
@@ -29,7 +29,7 @@ const (
 	defaultCloseDelay = 5 * time.Second
 
 	// gRPC backoff max delay when establishing connections (default: 120).
-	grpcBackoffMaxDelay = 10 * time.Second
+	grpcBackoffMaxDelay = 5 * time.Second
 	// Default.
 	grpcMinConnectTimeout = 20 * time.Second
 )
@@ -346,6 +346,10 @@ func (nc *nodesClient) updateConnectionLocked(n *node.Node) error {
 			CommonName: identity.CommonName,
 			GetServerPubKeys: func() (map[signature.PublicKey]bool, error) {
 				nc.RLock()
+				nc.logger.Debug("getting server pubkeys",
+					"pubkeys", cs.tlsKeys,
+					"node", n.ID,
+				)
 				keys := cs.tlsKeys
 				nc.RUnlock()
 				return keys, nil

--- a/go/storage/client/client.go
+++ b/go/storage/client/client.go
@@ -110,6 +110,11 @@ func (b *storageClientBackend) writeWithClient(
 			op := func() error {
 				var rerr error
 				resp, rerr = fn(ctx, api.NewStorageClient(conn.ClientConn), conn.Node)
+				b.logger.Debug("storage write request error",
+					"err", rerr,
+					"node", conn.Node,
+					"status_code", status.Code(rerr),
+				)
 				switch {
 				case status.Code(rerr) == codes.Unavailable:
 					// Storage node may be temporarily unavailable.

--- a/go/worker/common/config.go
+++ b/go/worker/common/config.go
@@ -99,7 +99,7 @@ func init() {
 	Flags.StringSlice(cfgClientAddresses, []string{}, "Address/port(s) to use for client connections when registering this node (if not set, all non-loopback local interfaces will be used)")
 	Flags.StringSlice(CfgSentryAddresses, []string{}, "Address(es) of sentry node(s) to connect to of the form [PubKey@]ip:port (where PubKey@ part represents base64 encoded node TLS public key)")
 
-	Flags.Duration(cfgStorageCommitTimeout, 5*time.Second, "Storage commit timeout")
+	Flags.Duration(cfgStorageCommitTimeout, 10*time.Second, "Storage commit timeout")
 
 	_ = viper.BindPFlags(Flags)
 }


### PR DESCRIPTION
Tweak some grpc timeouts. Before, the default storage commit timeout was less than `grpcBackoffMaxDelay` which made the storage commit request retries ineffective whenever the max delay was reached (e.g. first few requests after a storage node was restarted).

Discovered in longterm tests.