### PR TITLE
pvss/point: implement encoding.Text{Un}Marshaler interfaces

### DIFF
--- a/go/common/crypto/pvss/s11n.go
+++ b/go/common/crypto/pvss/s11n.go
@@ -2,6 +2,7 @@ package pvss
 
 import (
 	"crypto/elliptic"
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -70,6 +71,16 @@ func (p *Point) UnmarshalPEM(data []byte) error {
 	return p.UnmarshalBinary(b)
 }
 
+// UnmarshalText decodes a text marshaled point.
+func (p *Point) UnmarshalText(text []byte) error {
+	b, err := base64.StdEncoding.DecodeString(string(text))
+	if err != nil {
+		return fmt.Errorf("pvss/s11n: failed to deserialize base64 encoded point: %w", err)
+	}
+
+	return p.UnmarshalBinary(b)
+}
+
 // MarshalBinary implements the encoding.BinaryMarshaler interface.
 func (p Point) MarshalBinary() ([]byte, error) {
 	if err := p.isWellFormed(); err != nil {
@@ -92,6 +103,16 @@ func (p Point) MarshalPEM() ([]byte, error) {
 	}
 
 	return pem.Marshal(pointPEMType, b)
+}
+
+// MarshalText encodes a point into text form.
+func (p *Point) MarshalText() ([]byte, error) {
+	b, err := p.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(base64.StdEncoding.EncodeToString(b)), nil
 }
 
 // LoadPEM loads a point from a PEM file on disk.  Iff the point is missing

--- a/go/common/crypto/pvss/s11n_test.go
+++ b/go/common/crypto/pvss/s11n_test.go
@@ -1,0 +1,26 @@
+package pvss
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPointMarshalText(t *testing.T) {
+	require := require.New(t)
+
+	// Valid point.
+	_, p, err := NewKeyPair()
+	require.NoError(err, "NewKeyPair")
+	enc, err := p.MarshalText()
+	require.NoError(err, "MarshalText")
+	var u Point
+	err = u.UnmarshalText(enc)
+	require.NoError(err, "UnmarshalText")
+	require.Equal(p, &u, "point should round-trip")
+
+	// Invalid point.
+	p = &Point{}
+	_, err = p.MarshalText()
+	require.Error(err, "MarshalText on invalid point should error")
+}


### PR DESCRIPTION
Fixes text unmarshaling of beacon point in jsons (used in cli outputs. e.g. `registry node list` or `control status`) from:
```
"beacon": {
    "point": {}
},
```
to:
```
"beacon": {
  "point": "BOwfi4VYUP2Qh87Lwq0Np9esST7cbReL11nIuRCRvsS45hm3XFG61qkBU8C6bVXT4FpUshZRjXagK5sO4MpFcXY="
},
```