### PR TITLE
go/consensus/tendermint/governance: Move upgrader checks

### DIFF
--- a/go/consensus/tendermint/full/full.go
+++ b/go/consensus/tendermint/full/full.go
@@ -1367,8 +1367,6 @@ func (t *fullService) syncWorker() {
 				return
 			}
 			if !isFastSyncing {
-				t.Logger.Info("Tendermint Node finished fast-sync")
-
 				// Check latest block time.
 				tmBlock, err := t.GetTendermintBlock(t.ctx, consensusAPI.HeightLatest)
 				if err != nil {


### PR DESCRIPTION
Fixes #3764 

Upgrader checks should run on every block so that any pending upgrade
descriptors are cleared after consensus upgrade is performed.