### PR TITLE
go/upgrade: ensure upgrade handler exists

### DIFF
--- a/.changelog/3768.bugfix.1.md
+++ b/.changelog/3768.bugfix.1.md
@@ -1,0 +1,1 @@
+go/upgrade: ensure upgrade handler exists

--- a/.changelog/3768.bugfix.2.md
+++ b/.changelog/3768.bugfix.2.md
@@ -1,0 +1,5 @@
+Allow switching binary while an upgrade is pending or in progress
+
+Removes `RunningVersion`/`SubmittingVersion` internal pending upgrade fields.
+Binary can now be switched mid-upgrade as long as it remains compatible with
+the in-progress upgrade.

--- a/.changelog/3768.bugfix.3.md
+++ b/.changelog/3768.bugfix.3.md
@@ -1,0 +1,5 @@
+Progress the startup upgrade stage only after a successful startup step
+
+Before, the startup state was progressed before the startup stage was run,
+therefore in case of a failed startup upgrade the stage would be skipped after
+the node restart.

--- a/go/upgrade/api/api.go
+++ b/go/upgrade/api/api.go
@@ -48,18 +48,6 @@ var (
 	// the consensus layer has reached the scheduled shutdown epoch and should be interrupted.
 	ErrStopForUpgrade = errors.New(ModuleName, 1, "upgrade: reached upgrade epoch")
 
-	// ErrUpgradePending is the error returned when there is a pending upgrade and the node detects that it is
-	// not the one performing it.
-	ErrUpgradePending = errors.New(ModuleName, 2, "upgrade: this binary is scheduled to be replaced")
-
-	// ErrNewTooSoon is the error returned when the node started isn't the pre-upgrade version and the upgrade
-	// epoch hasn't been reached yet.
-	ErrNewTooSoon = errors.New(ModuleName, 3, "upgrade: running different binary before reaching the upgrade epoch")
-
-	// ErrInvalidResumingVersion is the error returned when the running node's version is different from the one that
-	// started performing the upgrade.
-	ErrInvalidResumingVersion = errors.New(ModuleName, 4, "upgrade: node restarted mid-upgrade with different version")
-
 	// ErrAlreadyPending is the error returned from SubmitDescriptor when the specific upgrade is already pending.
 	ErrAlreadyPending = errors.New(ModuleName, 5, "upgrade: submitted upgrade is already pending, can not resubmit descriptor")
 
@@ -183,11 +171,6 @@ func (d *Descriptor) EnsureCompatible() error {
 type PendingUpgrade struct {
 	// Descriptor is the upgrade descriptor describing the upgrade.
 	Descriptor *Descriptor `json:"descriptor"`
-
-	// SubmittingVersion is the version of the node used to submit the descriptor.
-	SubmittingVersion string `json:"submitting_version"`
-	// RunningVersion is the version of the node trying to execute the descriptor.
-	RunningVersion string `json:"running_version"`
 
 	// UpgradeHeight is the height at which the upgrade epoch was reached
 	// (or InvalidUpgradeHeight if it hasn't been reached yet).

--- a/go/upgrade/migrations/dummy.go
+++ b/go/upgrade/migrations/dummy.go
@@ -77,3 +77,7 @@ func (th *dummyMigrationHandler) ConsensusUpgrade(ctx *Context, privateCtx inter
 
 	return nil
 }
+
+func init() {
+	Register(DummyUpgradeName, &dummyMigrationHandler{})
+}


### PR DESCRIPTION
Also changes:
- `PushStage(api.UpgradeStageStartup)` happens only after a successful stage completion
-  removes `RunningVersion`
   - we already ensure that we are running upgrade-compatible version
   - and i think switching the version mid-upgrade (e.g. fixing a migration bug after a failure) should be fine, as long as the version stays compatible 
- removes `SubmittingVersion`
  -  this prevents changing binary while an upgrade is pending. This should be allowed - e.g. a compatible bugfix while an upgrade is pending. 