### PR TITLE
go/staking/api: Add new delegation querying methods

### DIFF
--- a/.changelog/3774.breaking.1.md
+++ b/.changelog/3774.breaking.1.md
@@ -1,0 +1,1 @@
+go/staking/api: Rename `Delegations()` method to `DelegationsFor()`

--- a/.changelog/3774.breaking.2.md
+++ b/.changelog/3774.breaking.2.md
@@ -1,0 +1,3 @@
+go/staking/api: Rename `DebondingDelegations()` method
+
+Rename it to `DebondingDelegationsFor()`.

--- a/.changelog/3774.feature.1.md
+++ b/.changelog/3774.feature.1.md
@@ -1,0 +1,4 @@
+go/staking/api: Add `DelegationsTo()`/`DebondingDelegationsTo()` methods
+
+They can be used to obtain all incoming (debonding) delegations to the given
+account.

--- a/.changelog/3774.feature.2.md
+++ b/.changelog/3774.feature.2.md
@@ -1,0 +1,4 @@
+go/staking/api: Add `DelegationInfo` and `DebondingDelegationInfo` types
+
+They are (debonding) delegation descriptors with additional information about
+the share pool they belong to.

--- a/.changelog/3774.feature.3.md
+++ b/.changelog/3774.feature.3.md
@@ -1,0 +1,4 @@
+go/staking/api: Add `DelegationInfosFor()`/`DebondingDelegationInfosFor()`
+
+They can be used to obtain incoming (debonding) delegations with additional
+information for the given account.

--- a/.changelog/3774.feature.md
+++ b/.changelog/3774.feature.md
@@ -1,0 +1,5 @@
+go/consensus/tendermint/apps/staking/state: Add incoming delegation methods
+
+Add new methods to `ImmutableState` type for querying incoming (debonding)
+delegations to an escrow account: `DelegationsTo()` and
+`DebondingDelegationsTo()`.

--- a/.changelog/3774.internal.2.md
+++ b/.changelog/3774.internal.2.md
@@ -1,0 +1,1 @@
+go/staking/tests: Generalize account handling and add delegations

--- a/.changelog/3774.internal.md
+++ b/.changelog/3774.internal.md
@@ -1,0 +1,1 @@
+go/staking/tests/debug: Move into go/staking/tests package

--- a/go/consensus/tendermint/apps/staking/query.go
+++ b/go/consensus/tendermint/apps/staking/query.go
@@ -21,8 +21,10 @@ type Query interface {
 	Addresses(context.Context) ([]staking.Address, error)
 	Account(context.Context, staking.Address) (*staking.Account, error)
 	DelegationsFor(context.Context, staking.Address) (map[staking.Address]*staking.Delegation, error)
+	DelegationInfosFor(context.Context, staking.Address) (map[staking.Address]*staking.DelegationInfo, error)
 	DelegationsTo(context.Context, staking.Address) (map[staking.Address]*staking.Delegation, error)
 	DebondingDelegationsFor(context.Context, staking.Address) (map[staking.Address][]*staking.DebondingDelegation, error)
+	DebondingDelegationInfosFor(context.Context, staking.Address) (map[staking.Address][]*staking.DebondingDelegationInfo, error)
 	DebondingDelegationsTo(context.Context, staking.Address) (map[staking.Address][]*staking.DebondingDelegation, error)
 	Genesis(context.Context) (*staking.Genesis, error)
 	ConsensusParameters(context.Context) (*staking.ConsensusParameters, error)
@@ -125,12 +127,54 @@ func (sq *stakingQuerier) DelegationsFor(ctx context.Context, addr staking.Addre
 	return sq.state.DelegationsFor(ctx, addr)
 }
 
+func (sq *stakingQuerier) DelegationInfosFor(ctx context.Context, addr staking.Address) (map[staking.Address]*staking.DelegationInfo, error) {
+	delegations, err := sq.state.DelegationsFor(ctx, addr)
+	if err != nil {
+		return nil, err
+	}
+	delegationInfos := make(map[staking.Address]*staking.DelegationInfo, len(delegations))
+	for delAddr, del := range delegations {
+		delAcct, err := sq.state.Account(ctx, delAddr)
+		if err != nil {
+			return nil, err
+		}
+		delegationInfos[delAddr] = &staking.DelegationInfo{
+			Delegation: *del,
+			Pool:       delAcct.Escrow.Active,
+		}
+	}
+	return delegationInfos, nil
+}
+
 func (sq *stakingQuerier) DelegationsTo(ctx context.Context, addr staking.Address) (map[staking.Address]*staking.Delegation, error) {
 	return sq.state.DelegationsTo(ctx, addr)
 }
 
 func (sq *stakingQuerier) DebondingDelegationsFor(ctx context.Context, addr staking.Address) (map[staking.Address][]*staking.DebondingDelegation, error) {
 	return sq.state.DebondingDelegationsFor(ctx, addr)
+}
+
+func (sq *stakingQuerier) DebondingDelegationInfosFor(ctx context.Context, addr staking.Address) (map[staking.Address][]*staking.DebondingDelegationInfo, error) {
+	delegations, err := sq.state.DebondingDelegationsFor(ctx, addr)
+	if err != nil {
+		return nil, err
+	}
+	delegationInfos := make(map[staking.Address][]*staking.DebondingDelegationInfo, len(delegations))
+	for delAddr, delList := range delegations {
+		delAcct, err := sq.state.Account(ctx, delAddr)
+		if err != nil {
+			return nil, err
+		}
+		delInfoList := make([]*staking.DebondingDelegationInfo, len(delList))
+		for i, del := range delList {
+			delInfoList[i] = &staking.DebondingDelegationInfo{
+				DebondingDelegation: *del,
+				Pool:                delAcct.Escrow.Debonding,
+			}
+		}
+		delegationInfos[delAddr] = delInfoList
+	}
+	return delegationInfos, nil
 }
 
 func (sq *stakingQuerier) DebondingDelegationsTo(ctx context.Context, addr staking.Address) (map[staking.Address][]*staking.DebondingDelegation, error) {

--- a/go/consensus/tendermint/apps/staking/query.go
+++ b/go/consensus/tendermint/apps/staking/query.go
@@ -21,7 +21,9 @@ type Query interface {
 	Addresses(context.Context) ([]staking.Address, error)
 	Account(context.Context, staking.Address) (*staking.Account, error)
 	Delegations(context.Context, staking.Address) (map[staking.Address]*staking.Delegation, error)
+	DelegationsTo(context.Context, staking.Address) (map[staking.Address]*staking.Delegation, error)
 	DebondingDelegations(context.Context, staking.Address) (map[staking.Address][]*staking.DebondingDelegation, error)
+	DebondingDelegationsTo(context.Context, staking.Address) (map[staking.Address][]*staking.DebondingDelegation, error)
 	Genesis(context.Context) (*staking.Genesis, error)
 	ConsensusParameters(context.Context) (*staking.ConsensusParameters, error)
 }
@@ -123,8 +125,16 @@ func (sq *stakingQuerier) Delegations(ctx context.Context, addr staking.Address)
 	return sq.state.DelegationsFor(ctx, addr)
 }
 
+func (sq *stakingQuerier) DelegationsTo(ctx context.Context, addr staking.Address) (map[staking.Address]*staking.Delegation, error) {
+	return sq.state.DelegationsTo(ctx, addr)
+}
+
 func (sq *stakingQuerier) DebondingDelegations(ctx context.Context, addr staking.Address) (map[staking.Address][]*staking.DebondingDelegation, error) {
 	return sq.state.DebondingDelegationsFor(ctx, addr)
+}
+
+func (sq *stakingQuerier) DebondingDelegationsTo(ctx context.Context, addr staking.Address) (map[staking.Address][]*staking.DebondingDelegation, error) {
+	return sq.state.DebondingDelegationsTo(ctx, addr)
 }
 
 func (sq *stakingQuerier) ConsensusParameters(ctx context.Context) (*staking.ConsensusParameters, error) {

--- a/go/consensus/tendermint/apps/staking/query.go
+++ b/go/consensus/tendermint/apps/staking/query.go
@@ -20,7 +20,7 @@ type Query interface {
 	DebondingInterval(context.Context) (beacon.EpochTime, error)
 	Addresses(context.Context) ([]staking.Address, error)
 	Account(context.Context, staking.Address) (*staking.Account, error)
-	Delegations(context.Context, staking.Address) (map[staking.Address]*staking.Delegation, error)
+	DelegationsFor(context.Context, staking.Address) (map[staking.Address]*staking.Delegation, error)
 	DelegationsTo(context.Context, staking.Address) (map[staking.Address]*staking.Delegation, error)
 	DebondingDelegations(context.Context, staking.Address) (map[staking.Address][]*staking.DebondingDelegation, error)
 	DebondingDelegationsTo(context.Context, staking.Address) (map[staking.Address][]*staking.DebondingDelegation, error)
@@ -121,7 +121,7 @@ func (sq *stakingQuerier) Account(ctx context.Context, addr staking.Address) (*s
 	}
 }
 
-func (sq *stakingQuerier) Delegations(ctx context.Context, addr staking.Address) (map[staking.Address]*staking.Delegation, error) {
+func (sq *stakingQuerier) DelegationsFor(ctx context.Context, addr staking.Address) (map[staking.Address]*staking.Delegation, error) {
 	return sq.state.DelegationsFor(ctx, addr)
 }
 

--- a/go/consensus/tendermint/apps/staking/query.go
+++ b/go/consensus/tendermint/apps/staking/query.go
@@ -22,7 +22,7 @@ type Query interface {
 	Account(context.Context, staking.Address) (*staking.Account, error)
 	DelegationsFor(context.Context, staking.Address) (map[staking.Address]*staking.Delegation, error)
 	DelegationsTo(context.Context, staking.Address) (map[staking.Address]*staking.Delegation, error)
-	DebondingDelegations(context.Context, staking.Address) (map[staking.Address][]*staking.DebondingDelegation, error)
+	DebondingDelegationsFor(context.Context, staking.Address) (map[staking.Address][]*staking.DebondingDelegation, error)
 	DebondingDelegationsTo(context.Context, staking.Address) (map[staking.Address][]*staking.DebondingDelegation, error)
 	Genesis(context.Context) (*staking.Genesis, error)
 	ConsensusParameters(context.Context) (*staking.ConsensusParameters, error)
@@ -129,7 +129,7 @@ func (sq *stakingQuerier) DelegationsTo(ctx context.Context, addr staking.Addres
 	return sq.state.DelegationsTo(ctx, addr)
 }
 
-func (sq *stakingQuerier) DebondingDelegations(ctx context.Context, addr staking.Address) (map[staking.Address][]*staking.DebondingDelegation, error) {
+func (sq *stakingQuerier) DebondingDelegationsFor(ctx context.Context, addr staking.Address) (map[staking.Address][]*staking.DebondingDelegation, error) {
 	return sq.state.DebondingDelegationsFor(ctx, addr)
 }
 

--- a/go/consensus/tendermint/apps/staking/state/state.go
+++ b/go/consensus/tendermint/apps/staking/state/state.go
@@ -352,6 +352,26 @@ func (s *ImmutableState) DebondingDelegations(
 	return delegations, nil
 }
 
+func (s *ImmutableState) DebondingDelegation(
+	ctx context.Context,
+	delegatorAddr, escrowAddr staking.Address,
+	epoch beacon.EpochTime,
+) (*staking.DebondingDelegation, error) {
+	value, err := s.is.Get(ctx, debondingDelegationKeyFmt.Encode(&delegatorAddr, &escrowAddr, uint64(epoch)))
+	if err != nil {
+		return nil, abciAPI.UnavailableStateError(err)
+	}
+	if value == nil {
+		return &staking.DebondingDelegation{}, nil
+	}
+
+	var deb staking.DebondingDelegation
+	if err = cbor.Unmarshal(value, &deb); err != nil {
+		return nil, abciAPI.UnavailableStateError(err)
+	}
+	return &deb, nil
+}
+
 func (s *ImmutableState) DebondingDelegationsFor(
 	ctx context.Context,
 	delegatorAddr staking.Address,
@@ -412,26 +432,6 @@ func (s *ImmutableState) DebondingDelegationsTo(
 		return nil, abciAPI.UnavailableStateError(it.Err())
 	}
 	return delegations, nil
-}
-
-func (s *ImmutableState) DebondingDelegation(
-	ctx context.Context,
-	delegatorAddr, escrowAddr staking.Address,
-	epoch beacon.EpochTime,
-) (*staking.DebondingDelegation, error) {
-	value, err := s.is.Get(ctx, debondingDelegationKeyFmt.Encode(&delegatorAddr, &escrowAddr, uint64(epoch)))
-	if err != nil {
-		return nil, abciAPI.UnavailableStateError(err)
-	}
-	if value == nil {
-		return &staking.DebondingDelegation{}, nil
-	}
-
-	var deb staking.DebondingDelegation
-	if err = cbor.Unmarshal(value, &deb); err != nil {
-		return nil, abciAPI.UnavailableStateError(err)
-	}
-	return &deb, nil
 }
 
 type DebondingQueueEntry struct {

--- a/go/consensus/tendermint/staking/staking.go
+++ b/go/consensus/tendermint/staking/staking.go
@@ -129,6 +129,15 @@ func (sc *serviceClient) DelegationsFor(ctx context.Context, query *api.OwnerQue
 	return q.DelegationsFor(ctx, query.Owner)
 }
 
+func (sc *serviceClient) DelegationInfosFor(ctx context.Context, query *api.OwnerQuery) (map[api.Address]*api.DelegationInfo, error) {
+	q, err := sc.querier.QueryAt(ctx, query.Height)
+	if err != nil {
+		return nil, err
+	}
+
+	return q.DelegationInfosFor(ctx, query.Owner)
+}
+
 func (sc *serviceClient) DelegationsTo(ctx context.Context, query *api.OwnerQuery) (map[api.Address]*api.Delegation, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
@@ -145,6 +154,15 @@ func (sc *serviceClient) DebondingDelegationsFor(ctx context.Context, query *api
 	}
 
 	return q.DebondingDelegationsFor(ctx, query.Owner)
+}
+
+func (sc *serviceClient) DebondingDelegationInfosFor(ctx context.Context, query *api.OwnerQuery) (map[api.Address][]*api.DebondingDelegationInfo, error) {
+	q, err := sc.querier.QueryAt(ctx, query.Height)
+	if err != nil {
+		return nil, err
+	}
+
+	return q.DebondingDelegationInfosFor(ctx, query.Owner)
 }
 
 func (sc *serviceClient) DebondingDelegationsTo(ctx context.Context, query *api.OwnerQuery) (map[api.Address][]*api.DebondingDelegation, error) {

--- a/go/consensus/tendermint/staking/staking.go
+++ b/go/consensus/tendermint/staking/staking.go
@@ -120,13 +120,13 @@ func (sc *serviceClient) Account(ctx context.Context, query *api.OwnerQuery) (*a
 	return q.Account(ctx, query.Owner)
 }
 
-func (sc *serviceClient) Delegations(ctx context.Context, query *api.OwnerQuery) (map[api.Address]*api.Delegation, error) {
+func (sc *serviceClient) DelegationsFor(ctx context.Context, query *api.OwnerQuery) (map[api.Address]*api.Delegation, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
 	}
 
-	return q.Delegations(ctx, query.Owner)
+	return q.DelegationsFor(ctx, query.Owner)
 }
 
 func (sc *serviceClient) DelegationsTo(ctx context.Context, query *api.OwnerQuery) (map[api.Address]*api.Delegation, error) {

--- a/go/consensus/tendermint/staking/staking.go
+++ b/go/consensus/tendermint/staking/staking.go
@@ -129,6 +129,15 @@ func (sc *serviceClient) Delegations(ctx context.Context, query *api.OwnerQuery)
 	return q.Delegations(ctx, query.Owner)
 }
 
+func (sc *serviceClient) DelegationsTo(ctx context.Context, query *api.OwnerQuery) (map[api.Address]*api.Delegation, error) {
+	q, err := sc.querier.QueryAt(ctx, query.Height)
+	if err != nil {
+		return nil, err
+	}
+
+	return q.DelegationsTo(ctx, query.Owner)
+}
+
 func (sc *serviceClient) DebondingDelegations(ctx context.Context, query *api.OwnerQuery) (map[api.Address][]*api.DebondingDelegation, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
@@ -136,6 +145,15 @@ func (sc *serviceClient) DebondingDelegations(ctx context.Context, query *api.Ow
 	}
 
 	return q.DebondingDelegations(ctx, query.Owner)
+}
+
+func (sc *serviceClient) DebondingDelegationsTo(ctx context.Context, query *api.OwnerQuery) (map[api.Address][]*api.DebondingDelegation, error) {
+	q, err := sc.querier.QueryAt(ctx, query.Height)
+	if err != nil {
+		return nil, err
+	}
+
+	return q.DebondingDelegationsTo(ctx, query.Owner)
 }
 
 func (sc *serviceClient) Allowance(ctx context.Context, query *api.AllowanceQuery) (*quantity.Quantity, error) {

--- a/go/consensus/tendermint/staking/staking.go
+++ b/go/consensus/tendermint/staking/staking.go
@@ -138,13 +138,13 @@ func (sc *serviceClient) DelegationsTo(ctx context.Context, query *api.OwnerQuer
 	return q.DelegationsTo(ctx, query.Owner)
 }
 
-func (sc *serviceClient) DebondingDelegations(ctx context.Context, query *api.OwnerQuery) (map[api.Address][]*api.DebondingDelegation, error) {
+func (sc *serviceClient) DebondingDelegationsFor(ctx context.Context, query *api.OwnerQuery) (map[api.Address][]*api.DebondingDelegation, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
 	}
 
-	return q.DebondingDelegations(ctx, query.Owner)
+	return q.DebondingDelegationsFor(ctx, query.Owner)
 }
 
 func (sc *serviceClient) DebondingDelegationsTo(ctx context.Context, query *api.OwnerQuery) (map[api.Address][]*api.DebondingDelegation, error) {

--- a/go/consensus/tendermint/tests/genesis/genesis.go
+++ b/go/consensus/tendermint/tests/genesis/genesis.go
@@ -21,7 +21,7 @@ import (
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
-	stakingTests "github.com/oasisprotocol/oasis-core/go/staking/tests/debug"
+	stakingTests "github.com/oasisprotocol/oasis-core/go/staking/tests"
 )
 
 var _ tendermint.GenesisProvider = (*testNodeGenesisProvider)(nil)

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -33,7 +33,7 @@ import (
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 	"github.com/oasisprotocol/oasis-core/go/staking/api/token"
-	stakingTests "github.com/oasisprotocol/oasis-core/go/staking/tests/debug"
+	stakingTests "github.com/oasisprotocol/oasis-core/go/staking/tests"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
 	upgrade "github.com/oasisprotocol/oasis-core/go/upgrade/api"
 )

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -726,6 +726,9 @@ func TestGenesisSanityCheck(t *testing.T) {
 
 	// Test staking genesis checks.
 
+	testAcc1Address := stakingTests.Accounts.GetAddress(1)
+	testAcc2Address := stakingTests.Accounts.GetAddress(2)
+
 	d = testDoc()
 	d.Staking.TokenSymbol = ""
 	require.EqualError(
@@ -773,29 +776,29 @@ func TestGenesisSanityCheck(t *testing.T) {
 	require.Error(d.SanityCheck(), "invalid last block fees should be rejected")
 
 	d = testDoc()
-	d.Staking.Ledger[stakingTests.DebugStateSrcAddress].General.Balance = *quantity.NewFromUint64(100)
+	d.Staking.Ledger[testAcc1Address].General.Balance = *quantity.NewFromUint64(100)
 	require.Error(d.SanityCheck(), "invalid general balance should be rejected")
 
 	d = testDoc()
-	d.Staking.Ledger[stakingTests.DebugStateSrcAddress].Escrow.Active.Balance = *quantity.NewFromUint64(42)
+	d.Staking.Ledger[testAcc1Address].Escrow.Active.Balance = *quantity.NewFromUint64(42)
 	require.Error(d.SanityCheck(), "invalid escrow active balance should be rejected")
 
 	d = testDoc()
-	d.Staking.Ledger[stakingTests.DebugStateSrcAddress].Escrow.Debonding.Balance = *quantity.NewFromUint64(100)
+	d.Staking.Ledger[testAcc1Address].Escrow.Debonding.Balance = *quantity.NewFromUint64(100)
 	require.Error(d.SanityCheck(), "invalid escrow debonding balance should be rejected")
 
 	d = testDoc()
-	d.Staking.Ledger[stakingTests.DebugStateSrcAddress].Escrow.Active.TotalShares = *quantity.NewFromUint64(1)
+	d.Staking.Ledger[testAcc1Address].Escrow.Active.TotalShares = *quantity.NewFromUint64(1)
 	require.Error(d.SanityCheck(), "invalid escrow active total shares should be rejected")
 
 	d = testDoc()
-	d.Staking.Ledger[stakingTests.DebugStateSrcAddress].Escrow.Debonding.TotalShares = *quantity.NewFromUint64(1)
+	d.Staking.Ledger[testAcc1Address].Escrow.Debonding.TotalShares = *quantity.NewFromUint64(1)
 	require.Error(d.SanityCheck(), "invalid escrow debonding total shares should be rejected")
 
 	d = testDoc()
 	d.Staking.Delegations = map[staking.Address]map[staking.Address]*staking.Delegation{
-		stakingTests.DebugStateSrcAddress: {
-			stakingTests.DebugStateDestAddress: {
+		testAcc1Address: {
+			testAcc2Address: {
 				Shares: *quantity.NewFromUint64(1),
 			},
 		},
@@ -804,8 +807,8 @@ func TestGenesisSanityCheck(t *testing.T) {
 
 	d = testDoc()
 	d.Staking.DebondingDelegations = map[staking.Address]map[staking.Address][]*staking.DebondingDelegation{
-		stakingTests.DebugStateSrcAddress: {
-			stakingTests.DebugStateDestAddress: {
+		testAcc1Address: {
+			testAcc2Address: {
 				{
 					Shares:        *quantity.NewFromUint64(1),
 					DebondEndTime: 10,
@@ -850,7 +853,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 			{
 				CreatedAt: 1,
 				ClosesAt:  100,
-				Submitter: stakingTests.DebugStateDestAddress,
+				Submitter: testAcc2Address,
 				Content: governance.ProposalContent{
 					Upgrade: &governance.UpgradeProposal{
 						Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Epoch: 500, Identifier: cbor.Marshal(version.Versions)},
@@ -925,7 +928,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 	d.Governance.VoteEntries = map[uint64][]*governance.VoteEntry{
 		d.Governance.Proposals[0].ID: {
 			{
-				Voter: stakingTests.DebugStateSrcAddress,
+				Voter: testAcc1Address,
 				Vote:  governance.VoteYes,
 			},
 		},
@@ -949,7 +952,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 		{
 			CreatedAt: 1,
 			ClosesAt:  2,
-			Submitter: stakingTests.DebugStateDestAddress,
+			Submitter: testAcc2Address,
 			Content: governance.ProposalContent{
 				Upgrade: &governance.UpgradeProposal{
 					Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Epoch: 400, Identifier: cbor.Marshal(version.Versions)},
@@ -964,7 +967,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 	d.Governance.Proposals = append(d.Governance.Proposals, &governance.Proposal{
 		CreatedAt: 1,
 		ClosesAt:  2,
-		Submitter: stakingTests.DebugStateDestAddress,
+		Submitter: testAcc2Address,
 		Content: governance.ProposalContent{
 			Upgrade: &governance.UpgradeProposal{
 				Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Epoch: 710, Identifier: cbor.Marshal(version.Versions)},
@@ -978,7 +981,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 	d.Governance.Proposals = append(d.Governance.Proposals, &governance.Proposal{
 		CreatedAt: 1,
 		ClosesAt:  2,
-		Submitter: stakingTests.DebugStateDestAddress,
+		Submitter: testAcc2Address,
 		Content: governance.ProposalContent{
 			Upgrade: &governance.UpgradeProposal{
 				Descriptor: upgrade.Descriptor{Method: upgrade.UpgradeMethodInternal, Epoch: 410, Identifier: cbor.Marshal(version.Versions)},

--- a/go/governance/tests/tester.go
+++ b/go/governance/tests/tester.go
@@ -26,8 +26,8 @@ import (
 const recvTimeout = 5 * time.Second
 
 var (
-	submitterSigner = stakingTests.DebugStateSrcSigner
-	submitterAddr   = stakingTests.DebugStateSrcAddress
+	submitterSigner = stakingTests.Accounts.GetSigner(1)
+	submitterAddr   = stakingTests.Accounts.GetAddress(1)
 )
 
 // governanceTestsState holds the current state of governance tests.

--- a/go/governance/tests/tester.go
+++ b/go/governance/tests/tester.go
@@ -19,15 +19,15 @@ import (
 	consensusAPI "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	"github.com/oasisprotocol/oasis-core/go/governance/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
-	"github.com/oasisprotocol/oasis-core/go/staking/tests/debug"
+	stakingTests "github.com/oasisprotocol/oasis-core/go/staking/tests"
 	upgrade "github.com/oasisprotocol/oasis-core/go/upgrade/api"
 )
 
 const recvTimeout = 5 * time.Second
 
 var (
-	submitterSigner = debug.DebugStateSrcSigner
-	submitterAddr   = debug.DebugStateSrcAddress
+	submitterSigner = stakingTests.DebugStateSrcSigner
+	submitterAddr   = stakingTests.DebugStateSrcAddress
 )
 
 // governanceTestsState holds the current state of governance tests.

--- a/go/oasis-node/cmd/debug/txsource/workload/delegation.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/delegation.go
@@ -150,7 +150,7 @@ func (d *delegation) doReclaimEscrowTx(ctx context.Context, rng *rand.Rand, stak
 
 	// Query debonding end epoch for the account.
 	var debondingDelegations map[staking.Address][]*staking.DebondingDelegation
-	debondingDelegations, err = stakingClient.DebondingDelegations(ctx, &staking.OwnerQuery{
+	debondingDelegations, err = stakingClient.DebondingDelegationsFor(ctx, &staking.OwnerQuery{
 		Height: consensus.HeightLatest,
 		Owner:  d.accounts[selectedIdx].address,
 	})

--- a/go/oasis-node/cmd/debug/txsource/workload/delegation.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/delegation.go
@@ -115,7 +115,7 @@ func (d *delegation) doReclaimEscrowTx(ctx context.Context, rng *rand.Rand, stak
 	selectedIdx := perm[fromPermIdx]
 
 	// Query amount of delegated shares for the account.
-	delegations, err := stakingClient.Delegations(ctx, &staking.OwnerQuery{
+	delegations, err := stakingClient.DelegationsFor(ctx, &staking.OwnerQuery{
 		Height: consensus.HeightLatest,
 		Owner:  d.accounts[selectedIdx].address,
 	})

--- a/go/oasis-test-runner/scenario/e2e/test_accounts.go
+++ b/go/oasis-test-runner/scenario/e2e/test_accounts.go
@@ -1,6 +1,6 @@
 package e2e
 
-import stakingTests "github.com/oasisprotocol/oasis-core/go/staking/tests/debug"
+import stakingTests "github.com/oasisprotocol/oasis-core/go/staking/tests"
 
 // Deterministic Test Accounts.
 var (

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -869,7 +869,7 @@ func testSubmitEquivocationEvidence(t *testing.T, backend api.Backend, consensus
 		Amount:  *quantity.NewFromUint64(100),
 	}
 	tx := staking.NewAddEscrowTx(0, nil, escrow)
-	err = consensusAPI.SignAndSubmitTx(ctx, consensus, stakingTests.SrcSigner, tx)
+	err = consensusAPI.SignAndSubmitTx(ctx, consensus, stakingTests.Accounts.GetSigner(1), tx)
 	require.NoError(err, "AddEscrow")
 
 	// Submit evidence of executor equivocation.

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -153,6 +153,10 @@ type Backend interface {
 	// owner (delegator).
 	DelegationsFor(ctx context.Context, query *OwnerQuery) (map[Address]*Delegation, error)
 
+	// DelegationsInfosFor returns (outgoing) delegations with additional
+	// information for the given owner (delegator).
+	DelegationInfosFor(ctx context.Context, query *OwnerQuery) (map[Address]*DelegationInfo, error)
+
 	// DelegationsTo returns the list of (incoming) delegations to the given
 	// account.
 	DelegationsTo(ctx context.Context, query *OwnerQuery) (map[Address]*Delegation, error)
@@ -160,6 +164,10 @@ type Backend interface {
 	// DebondingDelegationsFor returns the list of (outgoing) debonding
 	// delegations for the given owner (delegator).
 	DebondingDelegationsFor(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegation, error)
+
+	// DebondingDelegationsInfosFor returns (outgoing) debonding delegations
+	// with additional information for the given owner (delegator).
+	DebondingDelegationInfosFor(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegationInfo, error)
 
 	// DebondingDelegationsTo returns the list of (incoming) debonding
 	// delegations to the given account.

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -157,9 +157,9 @@ type Backend interface {
 	// account.
 	DelegationsTo(ctx context.Context, query *OwnerQuery) (map[Address]*Delegation, error)
 
-	// DebondingDelegations returns the list of debonding delegations for
-	// the given owner (delegator).
-	DebondingDelegations(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegation, error)
+	// DebondingDelegationsFor returns the list of (outgoing) debonding
+	// delegations for the given owner (delegator).
+	DebondingDelegationsFor(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegation, error)
 
 	// DebondingDelegationsTo returns the list of (incoming) debonding
 	// delegations to the given account.

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -945,6 +945,14 @@ type Delegation struct {
 	Shares quantity.Quantity `json:"shares"`
 }
 
+// DelegationInfo is a delegation descriptor with additional information.
+//
+// Additional information contains the share pool the delegation belongs to.
+type DelegationInfo struct {
+	Delegation
+	Pool SharePool `json:"pool"`
+}
+
 // DebondingDelegation is a debonding delegation descriptor.
 type DebondingDelegation struct {
 	Shares        quantity.Quantity `json:"shares"`
@@ -961,6 +969,16 @@ func (d *DebondingDelegation) Merge(other DebondingDelegation) error {
 		return fmt.Errorf("error adding debonding delegation shares: %w", err)
 	}
 	return nil
+}
+
+// DebondingDelegationInfo is a debonding delegation descriptor with additional
+// information.
+//
+// Additional information contains the share pool the debonding delegation
+// belongs to.
+type DebondingDelegationInfo struct {
+	DebondingDelegation
+	Pool SharePool `json:"pool"`
 }
 
 // Genesis is the initial staking state for use in the genesis block.

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -149,9 +149,9 @@ type Backend interface {
 	// Account returns the account descriptor for the given account.
 	Account(ctx context.Context, query *OwnerQuery) (*Account, error)
 
-	// Delegations returns the list of delegations for the given owner
-	// (delegator).
-	Delegations(ctx context.Context, query *OwnerQuery) (map[Address]*Delegation, error)
+	// DelegationsFor returns the list of (outgoing) delegations for the given
+	// owner (delegator).
+	DelegationsFor(ctx context.Context, query *OwnerQuery) (map[Address]*Delegation, error)
 
 	// DelegationsTo returns the list of (incoming) delegations to the given
 	// account.

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -153,9 +153,17 @@ type Backend interface {
 	// (delegator).
 	Delegations(ctx context.Context, query *OwnerQuery) (map[Address]*Delegation, error)
 
+	// DelegationsTo returns the list of (incoming) delegations to the given
+	// account.
+	DelegationsTo(ctx context.Context, query *OwnerQuery) (map[Address]*Delegation, error)
+
 	// DebondingDelegations returns the list of debonding delegations for
 	// the given owner (delegator).
 	DebondingDelegations(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegation, error)
+
+	// DebondingDelegationsTo returns the list of (incoming) debonding
+	// delegations to the given account.
+	DebondingDelegationsTo(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegation, error)
 
 	// Allowance looks up the allowance for the given owner/beneficiary combination.
 	Allowance(ctx context.Context, query *AllowanceQuery) (*quantity.Quantity, error)

--- a/go/staking/api/grpc.go
+++ b/go/staking/api/grpc.go
@@ -34,8 +34,12 @@ var (
 	methodAccount = serviceName.NewMethod("Account", OwnerQuery{})
 	// methodDelegations is the Delegations method.
 	methodDelegations = serviceName.NewMethod("Delegations", OwnerQuery{})
+	// methodDelegationsTo is the DelegationsTo method.
+	methodDelegationsTo = serviceName.NewMethod("DelegationsTo", OwnerQuery{})
 	// methodDebondingDelegations is the DebondingDelegations method.
 	methodDebondingDelegations = serviceName.NewMethod("DebondingDelegations", OwnerQuery{})
+	// methodDebondingDelegationsTo is the DebondingDelegationsTo method.
+	methodDebondingDelegationsTo = serviceName.NewMethod("DebondingDelegationsTo", OwnerQuery{})
 	// methodAllowance is the Allowance method.
 	methodAllowance = serviceName.NewMethod("Allowance", AllowanceQuery{})
 	// methodStateToGenesis is the StateToGenesis method.
@@ -94,8 +98,16 @@ var (
 				Handler:    handlerDelegations,
 			},
 			{
+				MethodName: methodDelegationsTo.ShortName(),
+				Handler:    handlerDelegationsTo,
+			},
+			{
 				MethodName: methodDebondingDelegations.ShortName(),
 				Handler:    handlerDebondingDelegations,
+			},
+			{
+				MethodName: methodDebondingDelegationsTo.ShortName(),
+				Handler:    handlerDebondingDelegationsTo,
 			},
 			{
 				MethodName: methodAllowance.ShortName(),
@@ -346,6 +358,29 @@ func handlerDelegations( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
+func handlerDelegationsTo( // nolint: golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var query OwnerQuery
+	if err := dec(&query); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(Backend).DelegationsTo(ctx, &query)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodDelegationsTo.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).DelegationsTo(ctx, req.(*OwnerQuery))
+	}
+	return interceptor(ctx, &query, info, handler)
+}
+
 func handlerDebondingDelegations( // nolint: golint
 	srv interface{},
 	ctx context.Context,
@@ -365,6 +400,29 @@ func handlerDebondingDelegations( // nolint: golint
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(Backend).DebondingDelegations(ctx, req.(*OwnerQuery))
+	}
+	return interceptor(ctx, &query, info, handler)
+}
+
+func handlerDebondingDelegationsTo( // nolint: golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var query OwnerQuery
+	if err := dec(&query); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(Backend).DebondingDelegationsTo(ctx, &query)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodDebondingDelegationsTo.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).DebondingDelegationsTo(ctx, req.(*OwnerQuery))
 	}
 	return interceptor(ctx, &query, info, handler)
 }
@@ -578,9 +636,25 @@ func (c *stakingClient) Delegations(ctx context.Context, query *OwnerQuery) (map
 	return rsp, nil
 }
 
+func (c *stakingClient) DelegationsTo(ctx context.Context, query *OwnerQuery) (map[Address]*Delegation, error) {
+	var rsp map[Address]*Delegation
+	if err := c.conn.Invoke(ctx, methodDelegationsTo.FullName(), query, &rsp); err != nil {
+		return nil, err
+	}
+	return rsp, nil
+}
+
 func (c *stakingClient) DebondingDelegations(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegation, error) {
 	var rsp map[Address][]*DebondingDelegation
 	if err := c.conn.Invoke(ctx, methodDebondingDelegations.FullName(), query, &rsp); err != nil {
+		return nil, err
+	}
+	return rsp, nil
+}
+
+func (c *stakingClient) DebondingDelegationsTo(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegation, error) {
+	var rsp map[Address][]*DebondingDelegation
+	if err := c.conn.Invoke(ctx, methodDebondingDelegationsTo.FullName(), query, &rsp); err != nil {
 		return nil, err
 	}
 	return rsp, nil

--- a/go/staking/api/grpc.go
+++ b/go/staking/api/grpc.go
@@ -36,8 +36,8 @@ var (
 	methodDelegationsFor = serviceName.NewMethod("DelegationsFor", OwnerQuery{})
 	// methodDelegationsTo is the DelegationsTo method.
 	methodDelegationsTo = serviceName.NewMethod("DelegationsTo", OwnerQuery{})
-	// methodDebondingDelegations is the DebondingDelegations method.
-	methodDebondingDelegations = serviceName.NewMethod("DebondingDelegations", OwnerQuery{})
+	// methodDebondingDelegationsFor is the DebondingDelegationsFor method.
+	methodDebondingDelegationsFor = serviceName.NewMethod("DebondingDelegationsFor", OwnerQuery{})
 	// methodDebondingDelegationsTo is the DebondingDelegationsTo method.
 	methodDebondingDelegationsTo = serviceName.NewMethod("DebondingDelegationsTo", OwnerQuery{})
 	// methodAllowance is the Allowance method.
@@ -102,8 +102,8 @@ var (
 				Handler:    handlerDelegationsTo,
 			},
 			{
-				MethodName: methodDebondingDelegations.ShortName(),
-				Handler:    handlerDebondingDelegations,
+				MethodName: methodDebondingDelegationsFor.ShortName(),
+				Handler:    handlerDebondingDelegationsFor,
 			},
 			{
 				MethodName: methodDebondingDelegationsTo.ShortName(),
@@ -381,7 +381,7 @@ func handlerDelegationsTo( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerDebondingDelegations( // nolint: golint
+func handlerDebondingDelegationsFor( // nolint: golint
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -392,14 +392,14 @@ func handlerDebondingDelegations( // nolint: golint
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Backend).DebondingDelegations(ctx, &query)
+		return srv.(Backend).DebondingDelegationsFor(ctx, &query)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: methodDebondingDelegations.FullName(),
+		FullMethod: methodDebondingDelegationsFor.FullName(),
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(Backend).DebondingDelegations(ctx, req.(*OwnerQuery))
+		return srv.(Backend).DebondingDelegationsFor(ctx, req.(*OwnerQuery))
 	}
 	return interceptor(ctx, &query, info, handler)
 }
@@ -644,9 +644,9 @@ func (c *stakingClient) DelegationsTo(ctx context.Context, query *OwnerQuery) (m
 	return rsp, nil
 }
 
-func (c *stakingClient) DebondingDelegations(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegation, error) {
+func (c *stakingClient) DebondingDelegationsFor(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegation, error) {
 	var rsp map[Address][]*DebondingDelegation
-	if err := c.conn.Invoke(ctx, methodDebondingDelegations.FullName(), query, &rsp); err != nil {
+	if err := c.conn.Invoke(ctx, methodDebondingDelegationsFor.FullName(), query, &rsp); err != nil {
 		return nil, err
 	}
 	return rsp, nil

--- a/go/staking/api/grpc.go
+++ b/go/staking/api/grpc.go
@@ -32,8 +32,8 @@ var (
 	methodAddresses = serviceName.NewMethod("Addresses", int64(0))
 	// methodAccount is the Account method.
 	methodAccount = serviceName.NewMethod("Account", OwnerQuery{})
-	// methodDelegations is the Delegations method.
-	methodDelegations = serviceName.NewMethod("Delegations", OwnerQuery{})
+	// methodDelegationsFor is the DelegationsFor method.
+	methodDelegationsFor = serviceName.NewMethod("DelegationsFor", OwnerQuery{})
 	// methodDelegationsTo is the DelegationsTo method.
 	methodDelegationsTo = serviceName.NewMethod("DelegationsTo", OwnerQuery{})
 	// methodDebondingDelegations is the DebondingDelegations method.
@@ -94,8 +94,8 @@ var (
 				Handler:    handlerAccount,
 			},
 			{
-				MethodName: methodDelegations.ShortName(),
-				Handler:    handlerDelegations,
+				MethodName: methodDelegationsFor.ShortName(),
+				Handler:    handlerDelegationsFor,
 			},
 			{
 				MethodName: methodDelegationsTo.ShortName(),
@@ -335,7 +335,7 @@ func handlerAccount( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerDelegations( // nolint: golint
+func handlerDelegationsFor( // nolint: golint
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -346,14 +346,14 @@ func handlerDelegations( // nolint: golint
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Backend).Delegations(ctx, &query)
+		return srv.(Backend).DelegationsFor(ctx, &query)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: methodDelegations.FullName(),
+		FullMethod: methodDelegationsFor.FullName(),
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(Backend).Delegations(ctx, req.(*OwnerQuery))
+		return srv.(Backend).DelegationsFor(ctx, req.(*OwnerQuery))
 	}
 	return interceptor(ctx, &query, info, handler)
 }
@@ -628,9 +628,9 @@ func (c *stakingClient) Account(ctx context.Context, query *OwnerQuery) (*Accoun
 	return &rsp, nil
 }
 
-func (c *stakingClient) Delegations(ctx context.Context, query *OwnerQuery) (map[Address]*Delegation, error) {
+func (c *stakingClient) DelegationsFor(ctx context.Context, query *OwnerQuery) (map[Address]*Delegation, error) {
 	var rsp map[Address]*Delegation
-	if err := c.conn.Invoke(ctx, methodDelegations.FullName(), query, &rsp); err != nil {
+	if err := c.conn.Invoke(ctx, methodDelegationsFor.FullName(), query, &rsp); err != nil {
 		return nil, err
 	}
 	return rsp, nil

--- a/go/staking/api/grpc.go
+++ b/go/staking/api/grpc.go
@@ -34,10 +34,14 @@ var (
 	methodAccount = serviceName.NewMethod("Account", OwnerQuery{})
 	// methodDelegationsFor is the DelegationsFor method.
 	methodDelegationsFor = serviceName.NewMethod("DelegationsFor", OwnerQuery{})
+	// methodDelegationInfosFor is the DelegationInfosFor method.
+	methodDelegationInfosFor = serviceName.NewMethod("DelegationInfosFor", OwnerQuery{})
 	// methodDelegationsTo is the DelegationsTo method.
 	methodDelegationsTo = serviceName.NewMethod("DelegationsTo", OwnerQuery{})
 	// methodDebondingDelegationsFor is the DebondingDelegationsFor method.
 	methodDebondingDelegationsFor = serviceName.NewMethod("DebondingDelegationsFor", OwnerQuery{})
+	// methodDebondingDelegationInfosFor is the DebondingDelegationInfosFor method.
+	methodDebondingDelegationInfosFor = serviceName.NewMethod("DebondingDelegationInfosFor", OwnerQuery{})
 	// methodDebondingDelegationsTo is the DebondingDelegationsTo method.
 	methodDebondingDelegationsTo = serviceName.NewMethod("DebondingDelegationsTo", OwnerQuery{})
 	// methodAllowance is the Allowance method.
@@ -98,12 +102,20 @@ var (
 				Handler:    handlerDelegationsFor,
 			},
 			{
+				MethodName: methodDelegationInfosFor.ShortName(),
+				Handler:    handlerDelegationInfosFor,
+			},
+			{
 				MethodName: methodDelegationsTo.ShortName(),
 				Handler:    handlerDelegationsTo,
 			},
 			{
 				MethodName: methodDebondingDelegationsFor.ShortName(),
 				Handler:    handlerDebondingDelegationsFor,
+			},
+			{
+				MethodName: methodDebondingDelegationInfosFor.ShortName(),
+				Handler:    handlerDebondingDelegationInfosFor,
 			},
 			{
 				MethodName: methodDebondingDelegationsTo.ShortName(),
@@ -358,6 +370,29 @@ func handlerDelegationsFor( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
+func handlerDelegationInfosFor( // nolint: golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var query OwnerQuery
+	if err := dec(&query); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(Backend).DelegationInfosFor(ctx, &query)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodDelegationInfosFor.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).DelegationInfosFor(ctx, req.(*OwnerQuery))
+	}
+	return interceptor(ctx, &query, info, handler)
+}
+
 func handlerDelegationsTo( // nolint: golint
 	srv interface{},
 	ctx context.Context,
@@ -400,6 +435,29 @@ func handlerDebondingDelegationsFor( // nolint: golint
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(Backend).DebondingDelegationsFor(ctx, req.(*OwnerQuery))
+	}
+	return interceptor(ctx, &query, info, handler)
+}
+
+func handlerDebondingDelegationInfosFor( // nolint: golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var query OwnerQuery
+	if err := dec(&query); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(Backend).DebondingDelegationInfosFor(ctx, &query)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodDebondingDelegationInfosFor.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).DebondingDelegationInfosFor(ctx, req.(*OwnerQuery))
 	}
 	return interceptor(ctx, &query, info, handler)
 }
@@ -636,6 +694,14 @@ func (c *stakingClient) DelegationsFor(ctx context.Context, query *OwnerQuery) (
 	return rsp, nil
 }
 
+func (c *stakingClient) DelegationInfosFor(ctx context.Context, query *OwnerQuery) (map[Address]*DelegationInfo, error) {
+	var rsp map[Address]*DelegationInfo
+	if err := c.conn.Invoke(ctx, methodDelegationInfosFor.FullName(), query, &rsp); err != nil {
+		return nil, err
+	}
+	return rsp, nil
+}
+
 func (c *stakingClient) DelegationsTo(ctx context.Context, query *OwnerQuery) (map[Address]*Delegation, error) {
 	var rsp map[Address]*Delegation
 	if err := c.conn.Invoke(ctx, methodDelegationsTo.FullName(), query, &rsp); err != nil {
@@ -647,6 +713,14 @@ func (c *stakingClient) DelegationsTo(ctx context.Context, query *OwnerQuery) (m
 func (c *stakingClient) DebondingDelegationsFor(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegation, error) {
 	var rsp map[Address][]*DebondingDelegation
 	if err := c.conn.Invoke(ctx, methodDebondingDelegationsFor.FullName(), query, &rsp); err != nil {
+		return nil, err
+	}
+	return rsp, nil
+}
+
+func (c *stakingClient) DebondingDelegationInfosFor(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegationInfo, error) {
+	var rsp map[Address][]*DebondingDelegationInfo
+	if err := c.conn.Invoke(ctx, methodDebondingDelegationInfosFor.FullName(), query, &rsp); err != nil {
 		return nil, err
 	}
 	return rsp, nil

--- a/go/staking/tests/accounts.go
+++ b/go/staking/tests/accounts.go
@@ -1,0 +1,81 @@
+package tests
+
+import (
+	"crypto/rand"
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
+	"github.com/oasisprotocol/oasis-core/go/staking/api"
+)
+
+// mustGenerateSigner returns a new memory signer or panics.
+func mustGenerateSigner() signature.Signer {
+	k, err := memorySigner.NewSigner(rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+
+	return k
+}
+
+// account holds information about a staking account.
+type account struct {
+	Signer  signature.Signer
+	Address api.Address
+}
+
+// newAccount returns a new account with a new memory signer or panics.
+func newAccount() account {
+	signer := mustGenerateSigner()
+	return account{
+		Signer:  signer,
+		Address: api.NewAddress(signer.Public()),
+	}
+}
+
+// AccountList holds information about a list of staking accounts.
+type AccountList []account
+
+// GetAddress returns the address of the i-th account in the list or panics.
+//
+// NOTE: Indexing is 1-based, NOT 0-based.
+func (a AccountList) GetAddress(index int) api.Address {
+	i := index - 1
+	if i < 0 || i >= len(a) {
+		panic(fmt.Sprintf("Account with index: %d doesn't exist", index))
+	}
+	return a[i].Address
+}
+
+// GetSigner returns the signer of the i-th account in the list or panics.
+//
+// NOTE: Indexing is 1-based, NOT 0-based.
+func (a AccountList) GetSigner(index int) signature.Signer {
+	i := index - 1
+	if i < 0 || i >= len(a) {
+		panic(fmt.Sprintf("Account with index: %d doesn't exist", index))
+	}
+	return a[i].Signer
+}
+
+// getAccount returns the i-th account in the list or panics.
+//
+// NOTE: Indexing is 1-based, NOT 0-based.
+func (a AccountList) getAccount(index int) account {
+	i := index - 1
+	if i < 0 || i >= len(a) {
+		panic(fmt.Sprintf("Account with index: %d doesn't exist", index))
+	}
+	return a[i]
+}
+
+// AddressFromString returns a staking account address from its string
+// representation or panics.
+func AddressFromString(s string) api.Address {
+	var addr api.Address
+	if err := addr.UnmarshalText([]byte(s)); err != nil {
+		panic(err)
+	}
+	return addr
+}

--- a/go/staking/tests/state.go
+++ b/go/staking/tests/state.go
@@ -1,4 +1,4 @@
-package debug
+package tests
 
 import (
 	"crypto/rand"

--- a/go/staking/tests/state.go
+++ b/go/staking/tests/state.go
@@ -1,29 +1,34 @@
 package tests
 
 import (
-	"crypto/rand"
 	"math"
 
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
-	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
+	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	"github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
-var (
-	DebugStateTotalSupply            = *quantity.NewFromUint64(math.MaxInt64)
-	DebugStateSrcGeneralBalance      = *quantity.NewFromUint64(math.MaxInt64 - 100)
-	DebugStateSrcEscrowActiveBalance = *quantity.NewFromUint64(100)
-	DebugStateSrcEscrowActiveShares  = *quantity.NewFromUint64(1000)
+// NumAccounts corresponds to the number of staking accounts used in the
+// staking genesis state as returned by GenesisState.
+const NumAccounts = 7
 
-	DebugStateSrcSigner   = mustGenerateSigner()
-	DebugStateSrcAddress  = api.NewAddress(DebugStateSrcSigner.Public())
-	DebugStateDestSigner  = mustGenerateSigner()
-	DebugStateDestAddress = api.NewAddress(DebugStateDestSigner.Public())
-)
+// Accounts stores an AccountList with staking accounts used in the
+// staking genesis state as returned by GenesisState.
+var Accounts AccountList = newAccountList()
 
+// newAccountList generates a new AccountList for the required number of
+// staking accounts.
+func newAccountList() AccountList {
+	accts := make([]account, NumAccounts)
+	for i := 0; i < NumAccounts; i++ {
+		accts[i] = newAccount()
+	}
+	return accts
+}
+
+// GenesisState returns a staking genesis state that can be used in tests.
 func GenesisState() api.Genesis {
-	return api.Genesis{
+	state := api.Genesis{
 		Parameters: api.ConsensusParameters{
 			DebondingInterval: 1,
 			Thresholds: map[api.ThresholdKind]quantity.Quantity{
@@ -48,43 +53,231 @@ func GenesisState() api.Genesis {
 			// Zero RewardFactorBlockProposed is normal.
 		},
 		TokenSymbol: "TEST",
-		TotalSupply: DebugStateTotalSupply,
+		TotalSupply: *quantity.NewFromUint64(math.MaxInt64),
 		Ledger: map[api.Address]*api.Account{
-			DebugStateSrcAddress: {
+			Accounts.GetAddress(1): {
 				General: api.GeneralAccount{
-					Balance: DebugStateSrcGeneralBalance,
+					Balance: *quantity.NewFromUint64(math.MaxInt32),
 				},
 				Escrow: api.EscrowAccount{
 					Active: api.SharePool{
-						Balance:     DebugStateSrcEscrowActiveBalance,
-						TotalShares: DebugStateSrcEscrowActiveShares,
+						Balance: *quantity.NewFromUint64(100),
+						// Amount of shares will be automatically computed.
+					},
+				},
+			},
+			Accounts.GetAddress(3): {
+				General: api.GeneralAccount{
+					Balance: *quantity.NewFromUint64(math.MaxInt32),
+				},
+				Escrow: api.EscrowAccount{
+					Active: api.SharePool{
+						Balance: *quantity.NewFromUint64(5000),
+						// Amount of shares will be automatically computed.
+					},
+					Debonding: api.SharePool{
+						Balance: *quantity.NewFromUint64(3000),
+						// Amount of shares will be automatically computed.
+					},
+				},
+			},
+			Accounts.GetAddress(4): {
+				General: api.GeneralAccount{
+					Balance: *quantity.NewFromUint64(math.MaxInt32),
+				},
+				Escrow: api.EscrowAccount{
+					Active: api.SharePool{
+						Balance: *quantity.NewFromUint64(150_000),
+						// Amount of shares will be automatically computed.
+					},
+					Debonding: api.SharePool{
+						Balance: *quantity.NewFromUint64(300_000),
+						// Amount of shares will be automatically computed.
+					},
+				},
+			},
+			Accounts.GetAddress(7): {
+				General: api.GeneralAccount{
+					Balance: *quantity.NewFromUint64(math.MaxInt16),
+				},
+				Escrow: api.EscrowAccount{
+					Active: api.SharePool{
+						Balance: *quantity.NewFromUint64(42_000),
+						// Amount of shares will be automatically computed.
+					},
+					Debonding: api.SharePool{
+						Balance: *quantity.NewFromUint64(9000),
+						// Amount of shares will be automatically computed.
 					},
 				},
 			},
 		},
 		Delegations: map[api.Address]map[api.Address]*api.Delegation{
-			DebugStateSrcAddress: {
-				DebugStateSrcAddress: {
-					Shares: DebugStateSrcEscrowActiveShares,
+			Accounts.GetAddress(1): {
+				Accounts.GetAddress(1): {
+					Shares: *quantity.NewFromUint64(1000),
+				},
+			},
+			Accounts.GetAddress(3): {
+				Accounts.GetAddress(2): {
+					Shares: *quantity.NewFromUint64(1000),
+				},
+				Accounts.GetAddress(5): {
+					Shares: *quantity.NewFromUint64(5000),
+				},
+			},
+			Accounts.GetAddress(4): {
+				Accounts.GetAddress(2): {
+					Shares: *quantity.NewFromUint64(2000),
+				},
+				Accounts.GetAddress(3): {
+					Shares: *quantity.NewFromUint64(3000),
+				},
+				Accounts.GetAddress(5): {
+					Shares: *quantity.NewFromUint64(5000),
+				},
+				Accounts.GetAddress(6): {
+					Shares: *quantity.NewFromUint64(10_000),
+				},
+			},
+			Accounts.GetAddress(7): {
+				Accounts.GetAddress(1): {
+					Shares: *quantity.NewFromUint64(4000),
+				},
+				Accounts.GetAddress(5): {
+					Shares: *quantity.NewFromUint64(20_000),
+				},
+				Accounts.GetAddress(7): {
+					Shares: *quantity.NewFromUint64(7000),
+				},
+			},
+		},
+		DebondingDelegations: map[api.Address]map[api.Address][]*api.DebondingDelegation{
+			Accounts.GetAddress(3): {
+				Accounts.GetAddress(2): {
+					{
+						Shares:        *quantity.NewFromUint64(1000),
+						DebondEndTime: beacon.EpochTime(100),
+					},
+					{
+						Shares:        *quantity.NewFromUint64(500),
+						DebondEndTime: beacon.EpochTime(150),
+					},
+				},
+				Accounts.GetAddress(5): {
+					{
+						Shares:        *quantity.NewFromUint64(3000),
+						DebondEndTime: beacon.EpochTime(100),
+					},
+				},
+			},
+			Accounts.GetAddress(4): {
+				Accounts.GetAddress(3): {
+					{
+						Shares:        *quantity.NewFromUint64(1000),
+						DebondEndTime: beacon.EpochTime(100),
+					},
+				},
+				Accounts.GetAddress(4): {
+					{
+						Shares:        *quantity.NewFromUint64(300),
+						DebondEndTime: beacon.EpochTime(100),
+					},
+					{
+						Shares:        *quantity.NewFromUint64(2000),
+						DebondEndTime: beacon.EpochTime(150),
+					},
+				},
+				Accounts.GetAddress(6): {
+					{
+						Shares:        *quantity.NewFromUint64(3000),
+						DebondEndTime: beacon.EpochTime(100),
+					},
+					{
+						Shares:        *quantity.NewFromUint64(1000),
+						DebondEndTime: beacon.EpochTime(150),
+					},
+					{
+						Shares:        *quantity.NewFromUint64(5000),
+						DebondEndTime: beacon.EpochTime(200),
+					},
+					{
+						Shares:        *quantity.NewFromUint64(4000),
+						DebondEndTime: beacon.EpochTime(250),
+					},
+				},
+				Accounts.GetAddress(7): {
+					{
+						Shares:        *quantity.NewFromUint64(2000),
+						DebondEndTime: beacon.EpochTime(175),
+					},
+					{
+						Shares:        *quantity.NewFromUint64(9000),
+						DebondEndTime: beacon.EpochTime(220),
+					},
+					{
+						Shares:        *quantity.NewFromUint64(4000),
+						DebondEndTime: beacon.EpochTime(270),
+					},
+				},
+			},
+			Accounts.GetAddress(7): {
+				Accounts.GetAddress(3): {
+					{
+						Shares:        *quantity.NewFromUint64(3000),
+						DebondEndTime: beacon.EpochTime(100),
+					},
+				},
+				Accounts.GetAddress(6): {
+					{
+						Shares:        *quantity.NewFromUint64(1000),
+						DebondEndTime: beacon.EpochTime(100),
+					},
+					{
+						Shares:        *quantity.NewFromUint64(500),
+						DebondEndTime: beacon.EpochTime(150),
+					},
 				},
 			},
 		},
 	}
-}
 
-func AddressFromString(s string) api.Address {
-	var addr api.Address
-	if err := addr.UnmarshalText([]byte(s)); err != nil {
-		panic(err)
+	// Adjust common pool for the remaining balance.
+	remainingBalance := state.TotalSupply.Clone()
+	for _, acc := range state.Ledger {
+		if err := remainingBalance.Sub(&acc.General.Balance); err != nil {
+			panic(err)
+		}
+		if err := remainingBalance.Sub(&acc.Escrow.Active.Balance); err != nil {
+			panic(err)
+		}
+		if err := remainingBalance.Sub(&acc.Escrow.Debonding.Balance); err != nil {
+			panic(err)
+		}
 	}
-	return addr
-}
+	state.CommonPool = *remainingBalance
 
-func mustGenerateSigner() signature.Signer {
-	k, err := memorySigner.NewSigner(rand.Reader)
-	if err != nil {
-		panic(err)
+	// Compute total shares for all accounts.
+	for addr, dels := range state.Delegations {
+		totalShares := quantity.NewQuantity()
+		for _, del := range dels {
+			if err := totalShares.Add(&del.Shares); err != nil {
+				panic(err)
+			}
+		}
+		state.Ledger[addr].Escrow.Active.TotalShares = *totalShares
+	}
+	for addr, debDelLists := range state.DebondingDelegations {
+		totalShares := quantity.NewQuantity()
+		for _, debDelList := range debDelLists {
+			for _, debDel := range debDelList {
+				if err := totalShares.Add(&debDel.Shares); err != nil {
+					panic(err)
+				}
+			}
+		}
+		state.Ledger[addr].Escrow.Debonding.TotalShares = *totalShares
 	}
 
-	return k
+	return state
 }

--- a/go/staking/tests/tester.go
+++ b/go/staking/tests/tester.go
@@ -335,6 +335,35 @@ func testDelegations(t *testing.T, state *stakingTestsState, backend api.Backend
 			require.Lenf(debDelegationsToAcc[accts.GetAddress(i)], num, "account %d - expected %d debonding delegation(s) from account %d", a, num, i)
 		}
 	}
+
+	// Outgoing delegations for accounts.
+	//
+	// NOTE: Governance tests add a delegation from account 1 to validator's (i.e. node's) entity
+	// so we omit account 1 from these checks.
+	expectedDelegationsFor := map[int][]int{
+		// Delegations for account 2.
+		2: {3, 4},
+		// Delegations for account 3.
+		3: {4},
+		// Delegations for account 4.
+		4: {},
+		// Delegations for account 5.
+		5: {3, 4, 7},
+		// Delegations for account 6.
+		6: {4},
+		// Delegations for account 7.
+		7: {7},
+	}
+	for a := 2; a <= 7; a++ {
+		delegationsForAcc, err := backend.DelegationsFor(
+			context.Background(), &api.OwnerQuery{Owner: accts.GetAddress(a), Height: consensusAPI.HeightLatest},
+		)
+		require.NoErrorf(err, "account %d - DelegationsFor", a)
+		require.Lenf(delegationsForAcc, len(expectedDelegationsFor[a]), "account %d  - number of outgoing delegations", a)
+		for _, i := range expectedDelegationsFor[a] {
+			require.Containsf(delegationsForAcc, accts.GetAddress(i), "account %d - expected delegation to account %d", a, i)
+		}
+	}
 }
 
 func testTransfer(t *testing.T, state *stakingTestsState, backend api.Backend, consensus consensusAPI.Backend) {

--- a/go/staking/tests/tester.go
+++ b/go/staking/tests/tester.go
@@ -21,7 +21,6 @@ import (
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	"github.com/oasisprotocol/oasis-core/go/staking/api"
-	"github.com/oasisprotocol/oasis-core/go/staking/tests/debug"
 )
 
 const recvTimeout = 5 * time.Second
@@ -69,14 +68,14 @@ func newStakingTestsState(t *testing.T, backend api.Backend, consensus consensus
 }
 
 var (
-	debugGenesisState = debug.GenesisState()
+	debugGenesisState = GenesisState()
 
 	qtyOne = *quantity.NewFromUint64(1)
 
-	SrcSigner  = debug.DebugStateSrcSigner
-	SrcAddr    = debug.DebugStateSrcAddress
-	destSigner = debug.DebugStateDestSigner
-	DestAddr   = debug.DebugStateDestAddress
+	SrcSigner  = DebugStateSrcSigner
+	SrcAddr    = DebugStateSrcAddress
+	destSigner = DebugStateDestSigner
+	DestAddr   = DebugStateDestAddress
 )
 
 // StakingImplementationTests exercises the basic functionality of a staking


### PR DESCRIPTION
Additionally, refactor `go/staking/tests`:
- Move `go/staking/tests/debug` into `go/staking/tests` package.
- Generalize account handling and add delegations.

Extracted from #3725.