### PR TITLE
.buildkite/longtests: update buildkite agent tag

### DIFF
--- a/.buildkite/longtests.pipeline.yml
+++ b/.buildkite/longtests.pipeline.yml
@@ -99,8 +99,7 @@ steps:
       # libp2p logging.
       IPFS_LOGGING: debug
     agents:
-      queue: default-daily
-      buildkite_agent_class: stable
+      daily: true
     # NOTE: we actually don't want to retry, but this is the only way that we
     # can execute the notify step only if tests failed.
     retry:


### PR DESCRIPTION
Longtests agents are now in the default queue, so that the agents can be used for normal CI, while no daily job is being run. The "daily=true" tag was added, so that the daily tests can target these agents.

Also as a test, the daily agents are now on ephemeral spot instances.