### PR TITLE
runtime: Provide consensus layer chain domain separation context

### DIFF
--- a/.changelog/3778.feature.2.md
+++ b/.changelog/3778.feature.2.md
@@ -1,0 +1,6 @@
+go/consensus: Add GetChainContext
+
+This makes it easier for clients to fetch the chain domain separation context
+as previously they needed to fetch the genesis document and compute the chain
+context from it. It also adds ChainContext to the node's consensus status
+report.

--- a/.changelog/3778.feature.md
+++ b/.changelog/3778.feature.md
@@ -1,0 +1,5 @@
+runtime: Provide consensus layer chain domain separation context
+
+This adds a way for the runtime to be informed about the chain domain
+separation context that the consensus layer is using. It can be used by the
+runtime to perform domain separation for cryptographic signatures.

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -129,6 +129,9 @@ type ClientBackend interface {
 	// GetGenesisDocument returns the original genesis document.
 	GetGenesisDocument(ctx context.Context) (*genesis.Document, error)
 
+	// GetChainContext returns the chain domain separation context.
+	GetChainContext(ctx context.Context) (string, error)
+
 	// GetStatus returns the current status overview.
 	GetStatus(ctx context.Context) (*Status, error)
 
@@ -197,6 +200,9 @@ type Status struct { // nolint: maligned
 	LastRetainedHeight int64 `json:"last_retained_height"`
 	// LastRetainedHash is the hash of the oldest retained block.
 	LastRetainedHash []byte `json:"last_retained_hash"`
+
+	// ChainContext is the chain domain separation context.
+	ChainContext string `json:"chain_context"`
 
 	// IsValidator returns whether the current node is part of the validator set.
 	IsValidator bool `json:"is_validator"`

--- a/go/consensus/api/grpc.go
+++ b/go/consensus/api/grpc.go
@@ -41,6 +41,8 @@ var (
 	methodGetUnconfirmedTransactions = serviceName.NewMethod("GetUnconfirmedTransactions", nil)
 	// methodGetGenesisDocument is the GetGenesisDocument method.
 	methodGetGenesisDocument = serviceName.NewMethod("GetGenesisDocument", nil)
+	// methodGetChainContext is the GetChainContext method.
+	methodGetChainContext = serviceName.NewMethod("GetChainContext", nil)
 	// methodGetStatus is the GetStatus method.
 	methodGetStatus = serviceName.NewMethod("GetStatus", nil)
 
@@ -102,6 +104,10 @@ var (
 			{
 				MethodName: methodGetGenesisDocument.ShortName(),
 				Handler:    handlerGetGenesisDocument,
+			},
+			{
+				MethodName: methodGetChainContext.ShortName(),
+				Handler:    handlerGetChainContext,
 			},
 			{
 				MethodName: methodGetStatus.ShortName(),
@@ -349,6 +355,25 @@ func handlerGetGenesisDocument( // nolint: golint
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ClientBackend).GetGenesisDocument(ctx)
+	}
+	return interceptor(ctx, nil, info, handler)
+}
+
+func handlerGetChainContext( // nolint: golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	if interceptor == nil {
+		return srv.(ClientBackend).GetChainContext(ctx)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodGetChainContext.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ClientBackend).GetChainContext(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -712,6 +737,14 @@ func (c *consensusClient) GetGenesisDocument(ctx context.Context) (*genesis.Docu
 		return nil, err
 	}
 	return &rsp, nil
+}
+
+func (c *consensusClient) GetChainContext(ctx context.Context) (string, error) {
+	var rsp string
+	if err := c.conn.Invoke(ctx, methodGetChainContext.FullName(), nil, &rsp); err != nil {
+		return "", err
+	}
+	return rsp, nil
 }
 
 func (c *consensusClient) GetStatus(ctx context.Context) (*Status, error) {

--- a/go/consensus/tendermint/full/full.go
+++ b/go/consensus/tendermint/full/full.go
@@ -421,6 +421,10 @@ func (t *fullService) GetGenesisDocument(ctx context.Context) (*genesisAPI.Docum
 	return t.genesis, nil
 }
 
+func (t *fullService) GetChainContext(ctx context.Context) (string, error) {
+	return t.genesis.ChainContext(), nil
+}
+
 func (t *fullService) RegisterHaltHook(hook consensusAPI.HaltHook) {
 	if !t.initialized() {
 		return
@@ -765,6 +769,7 @@ func (t *fullService) GetStatus(ctx context.Context) (*consensusAPI.Status, erro
 		Features: t.SupportedFeatures(),
 	}
 
+	status.ChainContext = t.genesis.ChainContext()
 	status.GenesisHeight = t.genesis.Height
 	if t.started() {
 		// Only attempt to fetch blocks in case the consensus service has started as otherwise

--- a/go/consensus/tendermint/seed/seed.go
+++ b/go/consensus/tendermint/seed/seed.go
@@ -153,6 +153,11 @@ func (srv *seedService) GetGenesisDocument(ctx context.Context) (*genesis.Docume
 }
 
 // Implements Backend.
+func (srv *seedService) GetChainContext(ctx context.Context) (string, error) {
+	return srv.doc.ChainContext(), nil
+}
+
+// Implements Backend.
 func (srv *seedService) GetAddresses() ([]node.ConsensusAddress, error) {
 	u, err := tmcommon.GetExternalAddress()
 	if err != nil {

--- a/go/consensus/tests/tester.go
+++ b/go/consensus/tests/tester.go
@@ -36,6 +36,10 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.ClientBackend)
 	require.NoError(err, "GetGenesisDocument")
 	require.NotNil(genDoc, "returned genesis document should not be nil")
 
+	chainCtx, err := backend.GetChainContext(ctx)
+	require.NoError(err, "GetChainContext")
+	require.EqualValues(genDoc.ChainContext(), chainCtx, "returned chain context should be correct")
+
 	blk, err := backend.GetBlock(ctx, consensus.HeightLatest)
 	require.NoError(err, "GetBlock")
 	require.NotNil(blk, "returned block should not be nil")

--- a/go/runtime/host/protocol/connection.go
+++ b/go/runtime/host/protocol/connection.go
@@ -122,6 +122,8 @@ type HostInfo struct {
 	// ConsensusProtocolVersion is the consensus protocol version that is in use for the consensus
 	// layer.
 	ConsensusProtocolVersion uint64
+	// ConsensusChainContext is the consensus layer chain domain separation context.
+	ConsensusChainContext string
 }
 
 // state is the connection state.
@@ -529,6 +531,7 @@ func (c *connection) InitHost(ctx context.Context, conn net.Conn, hi *HostInfo) 
 		RuntimeID:                c.runtimeID,
 		ConsensusBackend:         hi.ConsensusBackend,
 		ConsensusProtocolVersion: hi.ConsensusProtocolVersion,
+		ConsensusChainContext:    hi.ConsensusChainContext,
 	}})
 	switch {
 	default:

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -135,6 +135,8 @@ type RuntimeInfoRequest struct {
 	// ConsensusProtocolVersion is the consensus protocol version that is in use for the consensus
 	// layer.
 	ConsensusProtocolVersion uint64 `json:"consensus_protocol_version"`
+	// ConsensusChainContext is the consensus layer chain domain separation context.
+	ConsensusChainContext string `json:"consensus_chain_context"`
 }
 
 // RuntimeInfoResponse is a worker info response message body.

--- a/go/runtime/registry/config.go
+++ b/go/runtime/registry/config.go
@@ -113,9 +113,14 @@ func newConfig(consensus consensus.Backend, ias ias.Endpoint) (*RuntimeConfig, e
 		if err != nil {
 			return nil, fmt.Errorf("failed to get consensus layer status: %w", err)
 		}
+		gdoc, err := consensus.GetGenesisDocument(context.Background())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get genesis document: %w", err)
+		}
 		hostInfo := &hostProtocol.HostInfo{
 			ConsensusBackend:         cs.Backend,
 			ConsensusProtocolVersion: cs.Version.ToU64(),
+			ConsensusChainContext:    gdoc.ChainContext(),
 		}
 
 		// Register provisioners based on the configured provisioner.

--- a/go/runtime/registry/config.go
+++ b/go/runtime/registry/config.go
@@ -113,14 +113,14 @@ func newConfig(consensus consensus.Backend, ias ias.Endpoint) (*RuntimeConfig, e
 		if err != nil {
 			return nil, fmt.Errorf("failed to get consensus layer status: %w", err)
 		}
-		gdoc, err := consensus.GetGenesisDocument(context.Background())
+		chainCtx, err := consensus.GetChainContext(context.Background())
 		if err != nil {
-			return nil, fmt.Errorf("failed to get genesis document: %w", err)
+			return nil, fmt.Errorf("failed to get chain context: %w", err)
 		}
 		hostInfo := &hostProtocol.HostInfo{
 			ConsensusBackend:         cs.Backend,
 			ConsensusProtocolVersion: cs.Version.ToU64(),
-			ConsensusChainContext:    gdoc.ChainContext(),
+			ConsensusChainContext:    chainCtx,
 		}
 
 		// Register provisioners based on the configured provisioner.

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -71,6 +71,7 @@ pub enum Body {
         runtime_id: Namespace,
         consensus_backend: String,
         consensus_protocol_version: u64,
+        consensus_chain_context: String,
     },
     RuntimeInfoResponse {
         protocol_version: u64,


### PR DESCRIPTION
This adds a way for the runtime to be informed about the chain domain separation
context that the consensus layer is using. It can be used by the runtime to
perform domain separation for cryptographic signatures.