### PR TITLE
go/consensus: Store runtime state roots in a single key

### DIFF
--- a/.changelog/3782.breaking.md
+++ b/.changelog/3782.breaking.md
@@ -1,0 +1,5 @@
+go/consensus: Store runtime state roots in a single key
+
+That makes it easier to construct proofs starting at the consensus state root
+that prove what the state root of a specific runtime is. You can then chain
+these proofs to prove something about runtime state.


### PR DESCRIPTION
That makes it easier to construct proofs starting at the consensus state root
that prove what the state root of a specific runtime is. You can then chain
these proofs to prove something about runtime state.