### PR TITLE
go/control/api: Add node status to registration status response

### DIFF
--- a/.changelog/3783.feature.md
+++ b/.changelog/3783.feature.md
@@ -1,0 +1,1 @@
+go/control/api: Add node status to registration status response

--- a/go/control/api/api.go
+++ b/go/control/api/api.go
@@ -98,6 +98,9 @@ type RegistrationStatus struct {
 	// Descriptor is the node descriptor that the node successfully registered with. In case the
 	// node did not successfully register yet, it will be nil.
 	Descriptor *node.Node `json:"descriptor,omitempty"`
+
+	// NodeStatus is the registry live status of the node.
+	NodeStatus *registry.NodeStatus `json:"node_status,omitempty"`
 }
 
 // RuntimeStatus is the per-runtime status overview.

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -527,10 +527,20 @@ func (w *Worker) registrationStopped() {
 // GetRegistrationStatus returns the node's current registration status.
 func (w *Worker) GetRegistrationStatus(ctx context.Context) (*control.RegistrationStatus, error) {
 	w.RLock()
-	defer w.RUnlock()
-
 	status := new(control.RegistrationStatus)
 	*status = w.status
+	w.RUnlock()
+
+	if status == nil || status.Descriptor == nil {
+		return status, nil
+	}
+
+	ns, err := w.registry.GetNodeStatus(ctx, &registry.IDQuery{ID: status.Descriptor.ID, Height: consensus.HeightLatest})
+	if err != nil {
+		return nil, err
+	}
+	status.NodeStatus = ns
+
 	return status, nil
 }
 


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/3783
