### PR TITLE
runtime: Bump honggfuzz to 0.5.54, arbitrary to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
 name = "arbitrary"
-version = "0.4.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db55d72333851e17d572bec876e390cd3b11eb1ef53ae821dd9f3b653d2b4569"
+checksum = "698b65a961a9d730fb45b6b0327e20207810c9f61ee421b082b27ba003f49e2b"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -556,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "0.4.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a012b5e473dc912f0db0546a1c9c6a194ce8494feb66fa0237160926f9e0e6"
+checksum = "df89dd0d075dea5cc5fdd6d5df6b8a61172a710b3efac1d6bdb9dd8b78f82c1a"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -895,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "honggfuzz"
-version = "0.5.52"
+version = "0.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ead88897bcad1c396806d6ccba260a0363e11da997472e9e19ab9889969083a2"
+checksum = "bea09577d948a98a5f59b7c891e274c4fb35ad52f67782b3d0cb53b9c05301f1"
 dependencies = [
  "arbitrary",
  "lazy_static",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -44,8 +44,8 @@ zeroize = "1.2"
 intrusive-collections = "0.8"
 sha2 = "0.9.3"
 hmac = "0.10.1"
-honggfuzz = "0.5.52"
-arbitrary = { version = "0.4.7", features = ["derive"] }
+honggfuzz = "0.5.54"
+arbitrary = { version = "1.0.0", features = ["derive"] }
 num-bigint = { version = "0.4", features = ["serde"] }
 num-traits = "0.2.14"
 bech32 = "0.8.0"


### PR DESCRIPTION
These two need to be bumped together.