### PR TITLE
go/tests/txsource: Bump liveness and queries timeouts

### DIFF
--- a/go/oasis-node/cmd/debug/txsource/workload/queries.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/queries.go
@@ -61,7 +61,7 @@ const (
 	// queriesIterationTimeout is the combined timeout for running all the queries that are executed
 	// in a single iteration. The purpose of this timeout is to prevent the client being stuck and
 	// treating that as an error instead.
-	queriesIterationTimeout = 60 * time.Second
+	queriesIterationTimeout = 120 * time.Second
 
 	// queriesNumAllowedQueryTxsHistoricalFailures is the number of allowed failures of histortical
 	// `QueryTxs` requests. A historical `QueryTxs` request can fail in case available storage

--- a/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
@@ -45,7 +45,7 @@ const (
 	nodeRestartIntervalLong = 2 * time.Minute
 	nodeLongRestartInterval = 15 * time.Minute
 	nodeLongRestartDuration = 10 * time.Minute
-	livenessCheckInterval   = 1 * time.Minute
+	livenessCheckInterval   = 2 * time.Minute
 	txSourceGasPrice        = 1
 
 	crashPointProbability = 0.0005


### PR DESCRIPTION
Consensus not making progress while one validator is shutdown for 10 mins and another is being restarted (leaving 2 out of 4 validators up) is a common reason for failures, specially whenever the check interval got lined up with the restart.

Also bumps the queries timeout to be more in line with other timeouts across workloads.