### PR TITLE
go/roothash: Finish commitment processing early when possible

### DIFF
--- a/.changelog/3790.breaking.md
+++ b/.changelog/3790.breaking.md
@@ -1,0 +1,6 @@
+go/roothash: Finish commitment processing early when possible
+
+When the set of current commitments already determines the fate of the
+process (e.g., when there is a discrepancy or a majority of votes indicate
+success), proceed with the process instead of waiting for the remaining
+commitments.


### PR DESCRIPTION
When the set of current commitments already determines the fate of the process
(e.g., when there is a discrepancy or a majority of votes indicate success),
proceed with the process instead of waiting for the remaining commitments.