### PR TITLE
go/roothash/reindexBlocks: return latest known round if no new rounds are reindexed

### DIFF
--- a/.changelog/3791.bugfix.md
+++ b/.changelog/3791.bugfix.md
@@ -1,0 +1,4 @@
+go/roothash/reindexBlocks: return latest known round if no new rounds indexed
+
+This fixes a case where a storage node would not register if restarted while
+synced and there were no new runtime rounds (e.g. the runtime is suspended).

--- a/go/consensus/tendermint/roothash/roothash.go
+++ b/go/consensus/tendermint/roothash/roothash.go
@@ -474,6 +474,17 @@ func (sc *serviceClient) reindexBlocks(currentHeight int64, bh api.BlockHistory)
 		}
 	}
 
+	if lastRound == api.RoundInvalid {
+		sc.logger.Debug("no new round reindexed, return latest known round")
+		switch blk, err := bh.GetLatestBlock(sc.ctx); err {
+		case api.ErrNotFound:
+		case nil:
+			lastRound = blk.Header.Round
+		default:
+			return lastRound, fmt.Errorf("failed to get latest block: %w", err)
+		}
+	}
+
 	sc.logger.Debug("block reindex complete",
 		"last_round", lastRound,
 	)

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_dynamic.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_dynamic.go
@@ -466,6 +466,24 @@ func (sc *runtimeDynamicImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 		return err
 	}
 
+	// Restart nodes to test that the nodes will re-register although
+	// the runtime is suspended.
+	sc.Logger.Info("Restarting storage node to ensure it re-registers")
+	if err = sc.Net.StorageWorkers()[0].Stop(); err != nil {
+		return fmt.Errorf("failed to stop node: %w", err)
+	}
+	if err = sc.Net.StorageWorkers()[0].Start(); err != nil {
+		return fmt.Errorf("failed to start node: %w", err)
+	}
+
+	sc.Logger.Info("Restarting compute node to ensure it re-registers")
+	if err = sc.Net.ComputeWorkers()[0].Stop(); err != nil {
+		return fmt.Errorf("failed to stop node: %w", err)
+	}
+	if err = sc.Net.ComputeWorkers()[0].Start(); err != nil {
+		return fmt.Errorf("failed to start node: %w", err)
+	}
+
 	// Another epoch transition to make sure the runtime keeps being suspended.
 	if err = sc.epochTransition(ctx); err != nil {
 		return err


### PR DESCRIPTION
This fixes a case where a storage node would not register if restarted while synced and there were no new runtime rounds (e.g. the runtime is suspended).

Also updates the runtime-dynamic scenario to test this case.
