### PR TITLE
go/oasis-node/cmd: Improve transaction preview when generating txns

### DIFF
--- a/.changelog/3792.feature.1.md
+++ b/.changelog/3792.feature.1.md
@@ -1,0 +1,4 @@
+go/oasis-node/cmd: Improve transaction preview when generating transactions
+
+Display amounts in tokens and display genesis document's hash when previewing
+transactions with various `oasis-node * gen_*` CLI commands.

--- a/.changelog/3792.feature.2.md
+++ b/.changelog/3792.feature.2.md
@@ -1,0 +1,1 @@
+go/oasis-node/cmd/common/context: Add `GetCtxWithGenesisInfo()` helper

--- a/go/oasis-node/cmd/common/context/context.go
+++ b/go/oasis-node/cmd/common/context/context.go
@@ -1,0 +1,20 @@
+// Package context implements common context helpers.
+package context
+
+import (
+	"context"
+
+	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
+	genesisAPI "github.com/oasisprotocol/oasis-core/go/genesis/api"
+)
+
+// GetCtxWithGenesisInfo returns a new context with values that contain
+// additional from the given genesis file (e.g. token's symbol and token value's
+// base-10 exponent, genesis document's hash).
+func GetCtxWithGenesisInfo(genesis *genesisAPI.Document) context.Context {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenSymbol, genesis.Staking.TokenSymbol)
+	ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenValueExponent, genesis.Staking.TokenValueExponent)
+	ctx = context.WithValue(ctx, prettyprint.ContextKeyGenesisHash, genesis.Hash())
+	return ctx
+}

--- a/go/oasis-node/cmd/governance/governance.go
+++ b/go/oasis-node/cmd/governance/governance.go
@@ -19,6 +19,7 @@ import (
 	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	cmdConsensus "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/consensus"
+	cmdContext "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/context"
 	cmdFlags "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	cmdGrpc "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/grpc"
 	cmdSigner "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/signer"
@@ -100,7 +101,7 @@ func doGenSubmitProposal(cmd *cobra.Command, args []string) {
 		cmdCommon.EarlyLogAndExit(err)
 	}
 
-	cmdConsensus.InitGenesis()
+	genesis := cmdConsensus.InitGenesis()
 	cmdConsensus.AssertTxFileOK()
 
 	nonce, fee := cmdConsensus.GetTxNonceAndFee()
@@ -149,7 +150,7 @@ func doGenSubmitProposal(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	cmdConsensus.SignAndSaveTx(context.Background(), tx, nil)
+	cmdConsensus.SignAndSaveTx(cmdContext.GetCtxWithGenesisInfo(genesis), tx, nil)
 }
 
 func doGenCastVote(cmd *cobra.Command, args []string) {
@@ -157,7 +158,7 @@ func doGenCastVote(cmd *cobra.Command, args []string) {
 		cmdCommon.EarlyLogAndExit(err)
 	}
 
-	cmdConsensus.InitGenesis()
+	genesis := cmdConsensus.InitGenesis()
 	cmdConsensus.AssertTxFileOK()
 
 	id := viper.GetUint64(cfgVoteProposalID)
@@ -179,7 +180,7 @@ func doGenCastVote(cmd *cobra.Command, args []string) {
 		ID:   id,
 		Vote: vote,
 	})
-	cmdConsensus.SignAndSaveTx(context.Background(), tx, nil)
+	cmdConsensus.SignAndSaveTx(cmdContext.GetCtxWithGenesisInfo(genesis), tx, nil)
 }
 
 func doProposalInfo(cmd *cobra.Command, args []string) {

--- a/go/oasis-node/cmd/keymanager/keymanager.go
+++ b/go/oasis-node/cmd/keymanager/keymanager.go
@@ -3,7 +3,6 @@ package keymanager
 
 import (
 	"bytes"
-	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -25,6 +24,7 @@ import (
 	kmApi "github.com/oasisprotocol/oasis-core/go/keymanager/api"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	cmdConsensus "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/consensus"
+	cmdContext "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/context"
 	cmdFlags "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 )
 
@@ -391,7 +391,7 @@ func doGenUpdate(cmd *cobra.Command, args []string) {
 		cmdCommon.EarlyLogAndExit(err)
 	}
 
-	cmdConsensus.InitGenesis()
+	genesis := cmdConsensus.InitGenesis()
 	cmdConsensus.AssertTxFileOK()
 
 	// Assemble the SignedPolicySGX from the policy document and detached
@@ -444,7 +444,7 @@ func doGenUpdate(cmd *cobra.Command, args []string) {
 	// Build, sign, and write the UpdatePolicy transaction.
 	nonce, fee := cmdConsensus.GetTxNonceAndFee()
 	tx := kmApi.NewUpdatePolicyTx(nonce, fee, &signedPolicy)
-	cmdConsensus.SignAndSaveTx(context.Background(), tx, nil)
+	cmdConsensus.SignAndSaveTx(cmdContext.GetCtxWithGenesisInfo(genesis), tx, nil)
 }
 
 func statusFromFlags() (*kmApi.Status, error) {

--- a/go/oasis-node/cmd/registry/entity/entity.go
+++ b/go/oasis-node/cmd/registry/entity/entity.go
@@ -23,6 +23,7 @@ import (
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	cmdConsensus "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/consensus"
+	cmdContext "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/context"
 	cmdFlags "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	cmdGrpc "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/grpc"
 	cmdSigner "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/signer"
@@ -279,7 +280,7 @@ func doGenRegister(cmd *cobra.Command, args []string) {
 		cmdCommon.EarlyLogAndExit(err)
 	}
 
-	cmdConsensus.InitGenesis()
+	genesis := cmdConsensus.InitGenesis()
 	cmdConsensus.AssertTxFileOK()
 
 	ent, signer, err := cmdCommon.LoadEntitySigner()
@@ -302,7 +303,7 @@ func doGenRegister(cmd *cobra.Command, args []string) {
 	nonce, fee := cmdConsensus.GetTxNonceAndFee()
 	tx := registry.NewRegisterEntityTx(nonce, fee, signed)
 
-	cmdConsensus.SignAndSaveTx(context.Background(), tx, signer)
+	cmdConsensus.SignAndSaveTx(cmdContext.GetCtxWithGenesisInfo(genesis), tx, signer)
 }
 
 func doGenDeregister(cmd *cobra.Command, args []string) {
@@ -310,13 +311,13 @@ func doGenDeregister(cmd *cobra.Command, args []string) {
 		cmdCommon.EarlyLogAndExit(err)
 	}
 
-	cmdConsensus.InitGenesis()
+	genesis := cmdConsensus.InitGenesis()
 	cmdConsensus.AssertTxFileOK()
 
 	nonce, fee := cmdConsensus.GetTxNonceAndFee()
 	tx := registry.NewDeregisterEntityTx(nonce, fee)
 
-	cmdConsensus.SignAndSaveTx(context.Background(), tx, nil)
+	cmdConsensus.SignAndSaveTx(cmdContext.GetCtxWithGenesisInfo(genesis), tx, nil)
 }
 
 func doList(cmd *cobra.Command, args []string) {

--- a/go/oasis-node/cmd/registry/runtime/runtime.go
+++ b/go/oasis-node/cmd/registry/runtime/runtime.go
@@ -28,6 +28,7 @@ import (
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	cmdConsensus "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/consensus"
+	cmdContext "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/context"
 	cmdFlags "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	cmdGrpc "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/grpc"
 	cmdSigner "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/signer"
@@ -206,7 +207,7 @@ func doGenRegister(cmd *cobra.Command, args []string) {
 		cmdCommon.EarlyLogAndExit(err)
 	}
 
-	cmdConsensus.InitGenesis()
+	genesis := cmdConsensus.InitGenesis()
 	cmdConsensus.AssertTxFileOK()
 
 	rt, err := runtimeFromFlags()
@@ -220,7 +221,7 @@ func doGenRegister(cmd *cobra.Command, args []string) {
 	nonce, fee := cmdConsensus.GetTxNonceAndFee()
 	tx := registry.NewRegisterRuntimeTx(nonce, fee, rt)
 
-	cmdConsensus.SignAndSaveTx(context.Background(), tx, nil)
+	cmdConsensus.SignAndSaveTx(cmdContext.GetCtxWithGenesisInfo(genesis), tx, nil)
 }
 
 func doList(cmd *cobra.Command, args []string) {

--- a/go/oasis-node/cmd/stake/account.go
+++ b/go/oasis-node/cmd/stake/account.go
@@ -11,9 +11,9 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
-	genesisAPI "github.com/oasisprotocol/oasis-core/go/genesis/api"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	cmdConsensus "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/consensus"
+	cmdContext "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/context"
 	cmdFlags "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	cmdGrpc "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/grpc"
 	"github.com/oasisprotocol/oasis-core/go/staking/api"
@@ -127,16 +127,6 @@ var (
 		Run:   doAccountWithdraw,
 	}
 )
-
-// getCtxWithInfo returns a new context with values that contain additional
-// information (ticker symbol, value base-10 exponent, genesis document's hash).
-func getCtxWithInfo(genesis *genesisAPI.Document) context.Context {
-	ctx := context.Background()
-	ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenSymbol, genesis.Staking.TokenSymbol)
-	ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenValueExponent, genesis.Staking.TokenValueExponent)
-	ctx = context.WithValue(ctx, prettyprint.ContextKeyGenesisHash, genesis.Hash())
-	return ctx
-}
 
 func doAccountInfo(cmd *cobra.Command, args []string) {
 	if err := cmdCommon.Init(); err != nil {
@@ -273,7 +263,7 @@ func doAccountTransfer(cmd *cobra.Command, args []string) {
 	nonce, fee := cmdConsensus.GetTxNonceAndFee()
 	tx := api.NewTransferTx(nonce, fee, &xfer)
 
-	cmdConsensus.SignAndSaveTx(getCtxWithInfo(genesis), tx, nil)
+	cmdConsensus.SignAndSaveTx(cmdContext.GetCtxWithGenesisInfo(genesis), tx, nil)
 }
 
 func doAccountBurn(cmd *cobra.Command, args []string) {
@@ -295,7 +285,7 @@ func doAccountBurn(cmd *cobra.Command, args []string) {
 	nonce, fee := cmdConsensus.GetTxNonceAndFee()
 	tx := api.NewBurnTx(nonce, fee, &burn)
 
-	cmdConsensus.SignAndSaveTx(getCtxWithInfo(genesis), tx, nil)
+	cmdConsensus.SignAndSaveTx(cmdContext.GetCtxWithGenesisInfo(genesis), tx, nil)
 }
 
 func doAccountEscrow(cmd *cobra.Command, args []string) {
@@ -323,7 +313,7 @@ func doAccountEscrow(cmd *cobra.Command, args []string) {
 	nonce, fee := cmdConsensus.GetTxNonceAndFee()
 	tx := api.NewAddEscrowTx(nonce, fee, &escrow)
 
-	cmdConsensus.SignAndSaveTx(getCtxWithInfo(genesis), tx, nil)
+	cmdConsensus.SignAndSaveTx(cmdContext.GetCtxWithGenesisInfo(genesis), tx, nil)
 }
 
 func doAccountReclaimEscrow(cmd *cobra.Command, args []string) {
@@ -351,7 +341,7 @@ func doAccountReclaimEscrow(cmd *cobra.Command, args []string) {
 	nonce, fee := cmdConsensus.GetTxNonceAndFee()
 	tx := api.NewReclaimEscrowTx(nonce, fee, &reclaim)
 
-	cmdConsensus.SignAndSaveTx(getCtxWithInfo(genesis), tx, nil)
+	cmdConsensus.SignAndSaveTx(cmdContext.GetCtxWithGenesisInfo(genesis), tx, nil)
 }
 
 func scanRateStep(dst *api.CommissionRateStep, raw string) error {
@@ -429,7 +419,7 @@ func doAccountAmendCommissionSchedule(cmd *cobra.Command, args []string) {
 	nonce, fee := cmdConsensus.GetTxNonceAndFee()
 	tx := api.NewAmendCommissionScheduleTx(nonce, fee, &amendCommissionSchedule)
 
-	cmdConsensus.SignAndSaveTx(getCtxWithInfo(genesis), tx, nil)
+	cmdConsensus.SignAndSaveTx(cmdContext.GetCtxWithGenesisInfo(genesis), tx, nil)
 }
 
 func doAccountAllow(cmd *cobra.Command, args []string) {
@@ -466,7 +456,7 @@ func doAccountAllow(cmd *cobra.Command, args []string) {
 	nonce, fee := cmdConsensus.GetTxNonceAndFee()
 	tx := api.NewAllowTx(nonce, fee, &allow)
 
-	cmdConsensus.SignAndSaveTx(getCtxWithInfo(genesis), tx, nil)
+	cmdConsensus.SignAndSaveTx(cmdContext.GetCtxWithGenesisInfo(genesis), tx, nil)
 }
 
 func doAccountWithdraw(cmd *cobra.Command, args []string) {
@@ -494,7 +484,7 @@ func doAccountWithdraw(cmd *cobra.Command, args []string) {
 	nonce, fee := cmdConsensus.GetTxNonceAndFee()
 	tx := api.NewWithdrawTx(nonce, fee, &withdraw)
 
-	cmdConsensus.SignAndSaveTx(getCtxWithInfo(genesis), tx, nil)
+	cmdConsensus.SignAndSaveTx(cmdContext.GetCtxWithGenesisInfo(genesis), tx, nil)
 }
 
 func registerAccountCmd() {


### PR DESCRIPTION
Display amounts in tokens and display genesis document's hash when previewing transactions with various `oasis-node * gen_*` CLI commands.