### PR TITLE
go: Add pretty-printers for governance and upgrade types

### DIFF
--- a/.changelog/3800.feature.1.md
+++ b/.changelog/3800.feature.1.md
@@ -1,0 +1,1 @@
+go/common/version: Implement `PrettyPrint` interface for `ProtocolVersions`

--- a/.changelog/3800.feature.2.md
+++ b/.changelog/3800.feature.2.md
@@ -1,0 +1,4 @@
+go/governance: Implement `PrettyPrint` interface for various types
+
+Implement `PrettyPrinter` for `ProposalContent`, `UpgradeProposal`,
+`CancelUpgradeProposal` and `ProposalVote` types.

--- a/.changelog/3800.feature.3.md
+++ b/.changelog/3800.feature.3.md
@@ -1,0 +1,1 @@
+go/upgrade: Implement `PrettyPrint` interface for `Descriptor`

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -5,15 +5,21 @@
 package version
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
 )
 
 // VersionUndefined represents an undefined version.
 const VersionUndefined = "undefined"
+
+var _ prettyprint.PrettyPrinter = (*ProtocolVersions)(nil)
 
 // NOTE: This should be kept in sync with runtime/src/common/version.rs.
 
@@ -126,6 +132,20 @@ func (pv ProtocolVersions) String() string {
 		"Consensus protocol: %s, Runtime Host protocol: %s, Runtime Committee protocol: %s",
 		pv.ConsensusProtocol, pv.RuntimeHostProtocol, pv.RuntimeCommitteeProtocol,
 	)
+}
+
+// PrettyPrint writes a pretty-printed representation of ProtocolVersions to the
+// given writer.
+func (pv ProtocolVersions) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
+	fmt.Fprintf(w, "%sConsensus Protocol: %s\n", prefix, pv.ConsensusProtocol)
+	fmt.Fprintf(w, "%sRuntime Host Protocol: %s\n", prefix, pv.RuntimeHostProtocol)
+	fmt.Fprintf(w, "%sRuntime Committee Protocol: %s\n", prefix, pv.RuntimeCommitteeProtocol)
+}
+
+// PrettyType returns a representation of ProtocolVersions that can be used for
+// pretty printing.
+func (pv ProtocolVersions) PrettyType() (interface{}, error) {
+	return pv, nil
 }
 
 // Versions are current protocol versions.

--- a/go/upgrade/api/api.go
+++ b/go/upgrade/api/api.go
@@ -4,10 +4,12 @@ package api
 import (
 	"context"
 	"fmt"
+	"io"
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
+	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 )
 
@@ -63,6 +65,8 @@ var (
 
 	// ErrUpgradeInProgress is the error returned from CancelUpgrade when the upgrade being cancelled is already in progress.
 	ErrUpgradeInProgress = errors.New(ModuleName, 6, "upgrade: can not cancel upgrade in progress")
+
+	_ prettyprint.PrettyPrinter = (*Descriptor)(nil)
 )
 
 // Descriptor describes an upgrade.
@@ -125,6 +129,21 @@ func (d *Descriptor) EnsureCompatible() error {
 		return fmt.Errorf("binary version not compatible: own: %s, required: %s", ownVersion, d.Target)
 	}
 	return nil
+}
+
+// PrettyPrint writes a pretty-printed representation of Descriptor to the given
+// writer.
+func (d Descriptor) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
+	fmt.Fprintf(w, "%sHandler: %s\n", prefix, d.Handler)
+	fmt.Fprintf(w, "%sTarget Version:\n", prefix)
+	d.Target.PrettyPrint(ctx, prefix+"  ", w)
+	fmt.Fprintf(w, "%sEpoch: %d\n", prefix, d.Epoch)
+}
+
+// PrettyType returns a representation of Descriptor that can be used for pretty
+// printing.
+func (d Descriptor) PrettyType() (interface{}, error) {
+	return d, nil
 }
 
 // PendingUpgrade describes a currently pending upgrade and includes the


### PR DESCRIPTION
Examples of various transaction pretty-prints:

```
Method: governance.SubmitProposal
Body:
  Upgrade:
    Handler: upgrade1
    Target Version:
      Consensus Protocol: 3.0.0
      Runtime Host Protocol: 2.0.0
      Runtime Committee Protocol: 2.0.0
    Epoch: 3828
Nonce:  0
Fee:
  Amount: 0.00003 ROSE
  Gas limit: 2000
  (gas price: 0.000000015 ROSE per gas unit)
```

```
Method: governance.SubmitProposal
Body:
  Cancel Upgrade:
    Proposal ID: 15
Nonce:  0
Fee:
  Amount: 0.00003 ROSE
  Gas limit: 2000
  (gas price: 0.000000015 ROSE per gas unit)
```

```
Method: governance.CastVote
Body:
  Proposal ID: 12
  Vote:        yes
Nonce:  0
Fee:
  Amount: 0.00003 ROSE
  Gas limit: 2000
  (gas price: 0.000000015 ROSE per gas unit)
```