### PR TITLE
go/worker/executor: avoid holding lock while applying processed batch to storage

### DIFF
--- a/.changelog/3801.bugfix.md
+++ b/.changelog/3801.bugfix.md
@@ -1,0 +1,4 @@
+go/worker/executor: avoid holding lock while applying processed batch
+
+Before, the executor worker would hold the `CrossNode` lock, while doing
+requests to storage.


### PR DESCRIPTION
Also updates to use round context where appropriate (and fixes some cases where the roundCtx was accessed without the lock being held).