### PR TITLE
Fix storage worker

### DIFF
--- a/.changelog/3820.bugfix.md
+++ b/.changelog/3820.bugfix.md
@@ -1,0 +1,1 @@
+go/worker/storage: Fix Finalize and Apply failure handling

--- a/.changelog/3820.internal.1.md
+++ b/.changelog/3820.internal.1.md
@@ -1,0 +1,1 @@
+go/worker/storage: Add independent heartbeat for syncing retries

--- a/.changelog/3820.internal.2.md
+++ b/.changelog/3820.internal.2.md
@@ -1,0 +1,1 @@
+go/storage/client: Implement node blacklisting

--- a/go/oasis-node/cmd/debug/byzantine/byzantine.go
+++ b/go/oasis-node/cmd/debug/byzantine/byzantine.go
@@ -279,7 +279,8 @@ func init() {
 
 	storageFlags.Uint64(CfgNumStorageFailApplyBatch, 0, "Number of ApplyBatch requests to fail")
 	storageFlags.Uint64(CfgNumStorageFailApply, 0, "Number of Apply requests to fail")
-	storageFlags.Bool(CfgFailReadRequests, false, "If storage worker should fail read requests")
+	storageFlags.Bool(CfgFailReadRequests, false, "Whether the storage node should fail read requests")
+	storageFlags.Bool(CfgCorruptGetDiff, false, "Whether the storage node should corrupt GetDiff responses")
 	_ = viper.BindPFlags(storageFlags)
 	byzantineCmd.PersistentFlags().AddFlagSet(storageFlags)
 

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -309,6 +309,7 @@ func (n *Node) initRuntimeWorkers() error {
 
 	// Initialize the common worker.
 	n.CommonWorker, err = workerCommon.New(
+		n,
 		dataDir,
 		compute.Enabled() || workerStorage.Enabled() || workerKeymanager.Enabled(),
 		n.Identity,

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -580,6 +580,7 @@ func RegisterScenarios() error {
 		ByzantineStorageFailApply,
 		ByzantineStorageFailApplyBatch,
 		ByzantineStorageFailRead,
+		ByzantineStorageCorruptGetDiff,
 		// Storage sync test.
 		StorageSync,
 		StorageSyncFromRegistered,

--- a/go/storage/api/context.go
+++ b/go/storage/api/context.go
@@ -4,11 +4,18 @@ import (
 	"context"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
 )
 
 type contextKey string
 
-const contextKeyNodePriorityHint = contextKey("storage/node-priority-key")
+const (
+	contextKeyNodePriorityHint = contextKey("storage/node-priority-key")
+
+	contextKeyNodeBlacklist = contextKey("storage/node-blacklist")
+
+	contextKeyNodeSelectionCallback = contextKey("storage/node-selection-callback")
+)
 
 // WithNodePriorityHint sets a storage node priority hint for any storage read requests using this
 // context. Only storage nodes that overlap with the configured committee will be used.
@@ -44,4 +51,48 @@ func WithNodePriorityHintFromSignatures(ctx context.Context, sigs []signature.Si
 func NodePriorityHintFromContext(ctx context.Context) []signature.PublicKey {
 	nodes, _ := ctx.Value(contextKeyNodePriorityHint).([]signature.PublicKey)
 	return nodes
+}
+
+// WithNodeBlacklist sets a storage blacklist key for any storage requests using this context.
+// The blacklist is initially empty (i.e. all nodes are acceptable).
+func WithNodeBlacklist(ctx context.Context) context.Context {
+	return context.WithValue(ctx, contextKeyNodeBlacklist, map[signature.PublicKey]struct{}{})
+}
+
+// BlacklistAddNode adds a node to the blacklist associated with the context. If there's no
+// associated blacklist, the function does nothing.
+func BlacklistAddNode(ctx context.Context, node *node.Node) {
+	list, _ := ctx.Value(contextKeyNodeBlacklist).(map[signature.PublicKey]struct{})
+	if list != nil {
+		list[node.ID] = struct{}{}
+	}
+}
+
+// IsNodeBlacklistedInContext checks to see if the node is blacklisted in this context.
+// If the context doesn't have an associated blacklist, then no node is considered blacklisted.
+func IsNodeBlacklistedInContext(ctx context.Context, node *node.Node) bool {
+	val, ok := ctx.Value(contextKeyNodeBlacklist).(map[signature.PublicKey]struct{})
+	if !ok {
+		return false
+	}
+	_, ok = val[node.ID]
+	return ok
+}
+
+// NodeSelectionCallback is a callback used by the storage client to report connections used
+// for read requests.
+type NodeSelectionCallback = func(*node.Node)
+
+// WithNodeSelectionCallback sets a callback that will be called by the storage client on every read
+// request with the node that was eventually used to perform a successful request. If there was no
+// success, the callback isn't called.
+func WithNodeSelectionCallback(ctx context.Context, cb NodeSelectionCallback) context.Context {
+	return context.WithValue(ctx, contextKeyNodeSelectionCallback, cb)
+}
+
+// NodeSelectionCallbackFromContext returns the node selection callback associated with this context
+// or nil if none is set.
+func NodeSelectionCallbackFromContext(ctx context.Context) NodeSelectionCallback {
+	val, _ := ctx.Value(contextKeyNodeSelectionCallback).(NodeSelectionCallback)
+	return val
 }

--- a/go/storage/mkvs/db/badger/badger.go
+++ b/go/storage/mkvs/db/badger/badger.go
@@ -561,8 +561,8 @@ func (d *badgerNodeDB) Finalize(ctx context.Context, roots []node.Root) error { 
 		return api.ErrAlreadyFinalized
 	}
 
-	// Determine a set of finalized roots. Finalization is transitive, so if
-	// a parent root is finalized the child should be consider finalized too.
+	// Determine the set of finalized roots. Finalization is transitive, so if
+	// a parent root is finalized the child should be considered finalized too.
 	finalizedRoots := make(map[typedHash]bool)
 	for _, root := range roots {
 		if root.Version != version {
@@ -591,6 +591,14 @@ func (d *badgerNodeDB) Finalize(ctx context.Context, roots []node.Root) error { 
 					updated = true
 				}
 			}
+		}
+	}
+
+	// Sanity check the input roots list.
+	for iroot := range finalizedRoots {
+		h := iroot.Hash()
+		if _, ok := rootsMeta.Roots[iroot]; !ok && !h.IsEmpty() {
+			return api.ErrRootNotFound
 		}
 	}
 

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -10,6 +10,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	control "github.com/oasisprotocol/oasis-core/go/control/api"
 	keymanagerApi "github.com/oasisprotocol/oasis-core/go/keymanager/api"
 	keymanagerClient "github.com/oasisprotocol/oasis-core/go/keymanager/client"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
@@ -88,6 +89,8 @@ type NodeHooks interface {
 // Node is a committee node.
 type Node struct {
 	Runtime runtimeRegistry.Runtime
+
+	HostNode control.ControlledNode
 
 	Identity         *identity.Identity
 	KeyManager       keymanagerApi.Backend
@@ -455,6 +458,7 @@ func (n *Node) worker() {
 }
 
 func NewNode(
+	hostNode control.ControlledNode,
 	runtime runtimeRegistry.Runtime,
 	identity *identity.Identity,
 	keymanager keymanagerApi.Backend,
@@ -468,6 +472,7 @@ func NewNode(
 	ctx, cancel := context.WithCancel(context.Background())
 
 	n := &Node{
+		HostNode:   hostNode,
 		Runtime:    runtime,
 		Identity:   identity,
 		KeyManager: keymanager,

--- a/go/worker/common/worker.go
+++ b/go/worker/common/worker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	control "github.com/oasisprotocol/oasis-core/go/control/api"
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
 	ias "github.com/oasisprotocol/oasis-core/go/ias/api"
 	keymanagerApi "github.com/oasisprotocol/oasis-core/go/keymanager/api"
@@ -24,6 +25,7 @@ type Worker struct {
 	enabled bool
 	cfg     Config
 
+	HostNode          control.ControlledNode
 	DataDir           string
 	Identity          *identity.Identity
 	Consensus         consensus.Backend
@@ -181,6 +183,7 @@ func (w *Worker) NewUnmanagedCommitteeNode(runtime runtimeRegistry.Runtime, enab
 	}
 
 	return committee.NewNode(
+		w.HostNode,
 		runtime,
 		w.Identity,
 		w.KeyManager,
@@ -211,6 +214,7 @@ func (w *Worker) registerRuntime(runtime runtimeRegistry.Runtime) error {
 func newWorker(
 	ctx context.Context,
 	cancelCtx context.CancelFunc,
+	hostNode control.ControlledNode,
 	dataDir string,
 	enabled bool,
 	identity *identity.Identity,
@@ -227,6 +231,7 @@ func newWorker(
 	w := &Worker{
 		enabled:           enabled,
 		cfg:               cfg,
+		HostNode:          hostNode,
 		DataDir:           dataDir,
 		Identity:          identity,
 		Consensus:         consensus,
@@ -259,6 +264,7 @@ func newWorker(
 
 // New creates a new worker.
 func New(
+	hostNode control.ControlledNode,
 	dataDir string,
 	enabled bool,
 	identity *identity.Identity,
@@ -291,6 +297,7 @@ func New(
 	return newWorker(
 		ctx,
 		cancelCtx,
+		hostNode,
 		dataDir,
 		enabled,
 		identity,

--- a/go/worker/storage/committee/utils.go
+++ b/go/worker/storage/committee/utils.go
@@ -49,6 +49,21 @@ func (o outstandingMask) hasAll() bool {
 	return o == outstandingMaskFull
 }
 
+type inFlight struct {
+	outstanding   outstandingMask
+	awaitingRetry outstandingMask
+}
+
+func (i *inFlight) scheduleDiff(rootType storageApi.RootType) {
+	i.outstanding.add(rootType)
+	i.awaitingRetry.remove(rootType)
+}
+
+func (i *inFlight) retry(rootType storageApi.RootType) {
+	i.outstanding.remove(rootType)
+	i.awaitingRetry.add(rootType)
+}
+
 // blockSummary is a short summary of a single block.Block.
 type blockSummary struct {
 	Namespace common.Namespace  `json:"namespace"`

--- a/go/worker/storage/committee/utils.go
+++ b/go/worker/storage/committee/utils.go
@@ -3,6 +3,9 @@ package committee
 import (
 	"fmt"
 	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
@@ -81,4 +84,18 @@ func summaryFromBlock(blk *block.Block) *blockSummary {
 		Round:     blk.Header.Round,
 		Roots:     blk.Header.StorageRoots(),
 	}
+}
+
+type heartbeat struct {
+	*backoff.Ticker
+}
+
+func (h *heartbeat) reset() {
+	if h.Ticker != nil {
+		h.Stop()
+	}
+
+	boff := backoff.NewExponentialBackOff()
+	boff.InitialInterval = 5 * time.Second
+	h.Ticker = backoff.NewTicker(boff)
 }


### PR DESCRIPTION
Avoid database corruption in certain cases.

- [X] Root existence checking in Finalize
- [X] Detect Finalize failures in the worker and don't update syncing metadata
- [x] Handle Apply failures during sync (+byzantine test for it)
- [x] Sync heartbeat independent of incoming blocks