### PR TITLE
common/crypto/ed25519: Use curve25519-voi

### DIFF
--- a/.changelog/3829.feature.1.md
+++ b/.changelog/3829.feature.1.md
@@ -1,0 +1,4 @@
+common/crypto/signature: Use curve25519-voi
+
+This Ed25519/X25519 implementation is faster and more maintainable that
+the previous in-house implementation.

--- a/.changelog/3829.feature.2.md
+++ b/.changelog/3829.feature.2.md
@@ -1,0 +1,4 @@
+common/crypto/slip10: Add a SLIP-0010 implementation
+
+Needed for some wallet stuff, and it is the least-awful hierarchical
+derivation scheme for Ed25519.

--- a/go/common/crypto/mrae/api/api.go
+++ b/go/common/crypto/mrae/api/api.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"testing"
 
-	curve25519 "github.com/oasisprotocol/ed25519/extra/x25519"
+	curve25519 "github.com/oasisprotocol/curve25519-voi/primitives/x25519"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go/common/crypto/mrae/api/api_test.go
+++ b/go/common/crypto/mrae/api/api_test.go
@@ -4,7 +4,7 @@ import (
 	"crypto/rand"
 	"testing"
 
-	curve25519 "github.com/oasisprotocol/ed25519/extra/x25519"
+	curve25519 "github.com/oasisprotocol/curve25519-voi/primitives/x25519"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go/common/crypto/signature/signer.go
+++ b/go/common/crypto/signature/signer.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/oasisprotocol/ed25519"
+	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 )
 
 const (

--- a/go/common/crypto/signature/signers/file/file_signer.go
+++ b/go/common/crypto/signature/signers/file/file_signer.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/oasisprotocol/ed25519"
+	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/pem"

--- a/go/common/crypto/signature/signers/memory/memory_signer.go
+++ b/go/common/crypto/signature/signers/memory/memory_signer.go
@@ -4,6 +4,7 @@ package memory
 import (
 	goEd25519 "crypto/ed25519"
 	"crypto/sha512"
+	"fmt"
 	"io"
 
 	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
@@ -11,8 +12,13 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 )
 
-// SignerName is the name used to identify the memory backed signer.
-const SignerName = "memory"
+const (
+	// SignerName is the name used to identify the memory backed signer.
+	SignerName = "memory"
+
+	// SeedSize is the size of an RFC 8032 seed in bytes.
+	SeedSize = ed25519.SeedSize
+)
 
 var (
 	_ signature.SignerFactory = (*Factory)(nil)
@@ -105,6 +111,19 @@ func NewFromRuntime(rtPrivKey goEd25519.PrivateKey) signature.Signer {
 	return &Signer{
 		privateKey: ed25519.NewKeyFromSeed(rtPrivKey.Seed()),
 	}
+}
+
+// NewFromSeed creates a new signer from a RFC 8032 seed.
+func NewFromSeed(seed []byte) (signature.Signer, error) {
+	if len(seed) != ed25519.SeedSize {
+		return nil, fmt.Errorf("signature/signer/memory: bad seed length: %d", len(seed))
+	}
+
+	privateKey := ed25519.NewKeyFromSeed(seed)
+
+	return &Signer{
+		privateKey: privateKey,
+	}, nil
 }
 
 // NewTestSigner generates a new signer deterministically from

--- a/go/common/crypto/signature/signers/memory/memory_signer.go
+++ b/go/common/crypto/signature/signers/memory/memory_signer.go
@@ -6,7 +6,7 @@ import (
 	"crypto/sha512"
 	"io"
 
-	"github.com/oasisprotocol/ed25519"
+	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 )

--- a/go/common/crypto/slip10/slip10.go
+++ b/go/common/crypto/slip10/slip10.go
@@ -1,0 +1,93 @@
+// Package slip10 implements the SLIP-0010 private key derivation
+// scheme for Ed25519.
+package slip10
+
+import (
+	"crypto/hmac"
+	"crypto/sha512"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
+)
+
+const (
+	// SeedSize is the BIP-0039 seed byte sequence size in bytes.
+	SeedSize = 64
+
+	// ChainCodeSize is the size of a SLIP-0010 chain code in bytes.
+	ChainCodeSize = 32
+)
+
+var curveConstant = []byte("ed25519 seed")
+
+// ChainCode is a SLIP-0010 chain code.
+type ChainCode [ChainCodeSize]byte
+
+// NewMasterKey derives a master key and chain code from a seed byte sequence.
+func NewMasterKey(seed []byte) (signature.Signer, ChainCode, error) {
+	// 1. Generate a seed byte sequence S of 512 bits according to BIP-0039.
+	if len(seed) != SeedSize {
+		return nil, ChainCode{}, fmt.Errorf("slip10: invalid seed")
+	}
+
+	// 2. Calculate I = HMAC-SHA512(Key = Curve, Data = S)
+	mac := hmac.New(sha512.New, curveConstant)
+	_, _ = mac.Write(seed)
+	I := mac.Sum(nil)
+
+	// 3. Split I into two 32-byte sequences, IL and IR.
+	// 4. Use parse256(IL) as master secret key, and IR as master chain code.
+	return splitDigest(I)
+}
+
+// NewChildKey derives a child key and chain code from a (parent key,
+// parent chain code, index) tuple.
+func NewChildKey(parentSigner signature.Signer, cPar ChainCode, index uint32) (signature.Signer, ChainCode, error) {
+	unsafeSigner, ok := parentSigner.(signature.UnsafeSigner)
+	if !ok {
+		return nil, ChainCode{}, fmt.Errorf("slip10: failed to get parent public key")
+	}
+
+	kPar := unsafeSigner.UnsafeBytes()
+	if len(kPar) < memory.SeedSize {
+		return nil, ChainCode{}, fmt.Errorf("slip10: invalid parent key")
+	}
+
+	// 1. Check whether i >= 2^31 (whether the child is a hardened key).
+	if index < 1<<31 {
+		// If not (normal child):
+		// If curve is ed25519: return failure.
+		return nil, ChainCode{}, fmt.Errorf("slip10: non-hardened keys not supported")
+	}
+
+	// If so (hardened child):
+	// let I = HMAC-SHA512(Key = cpar, Data = 0x00 || ser256(kpar) || ser32(i)).
+	// (Note: The 0x00 pads the private key to make it 33 bytes long.)
+	var b [4]byte
+	mac := hmac.New(sha512.New, cPar[:])
+	_, _ = mac.Write(b[0:1])                 // 0x00
+	_, _ = mac.Write(kPar[:memory.SeedSize]) // ser256(kPar)
+	binary.BigEndian.PutUint32(b[:], index)  // Note: The spec neglects to define ser32.
+	_, _ = mac.Write(b[:])                   // ser32(i)
+	I := mac.Sum(nil)
+
+	// 2. Split I into two 32-byte sequences, IL and IR.
+	// 3. The returned chain code ci is IR.
+	// 4. If curve is ed25519: The returned child key ki is parse256(IL).
+	return splitDigest(I)
+}
+
+func splitDigest(digest []byte) (signature.Signer, ChainCode, error) {
+	IL, IR := digest[:32], digest[32:]
+
+	var chainCode ChainCode
+	signer, err := memory.NewFromSeed(IL)
+	if err != nil {
+		return nil, chainCode, err
+	}
+	copy(chainCode[:], IR)
+
+	return signer, chainCode, nil
+}

--- a/go/common/crypto/slip10/slip10_test.go
+++ b/go/common/crypto/slip10/slip10_test.go
@@ -1,0 +1,127 @@
+package slip10
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+)
+
+var testVectors = []testVector{
+	// "Test vector 1 for ed25519" would be here, but it specifies the seed
+	// as `000102030405060708090a0b0c0d0e0f` which is not 512-bits.
+	//
+	// I hate this blockchain crap.
+
+	// "Test vector 2 for ed25519"
+	{
+		seed: "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542",
+		master: hkdOutput{
+			chainCode:  "ef70a74db9c3a5af931b5fe73ed8e1a53464133654fd55e7a66f8570b8e33c3b",
+			privateKey: "171cb88b1b3c1db25add599712e36245d75bc65a1a5c9e18d76f9f2b1eab4012",
+			publicKey:  "008fe9693f8fa62a4305a140b9764c5ee01e455963744fe18204b4fb948249308a",
+		},
+		children: []hkdOutput{
+			{
+				index:      0,
+				chainCode:  "0b78a3226f915c082bf118f83618a618ab6dec793752624cbeb622acb562862d",
+				privateKey: "1559eb2bbec5790b0c65d8693e4d0875b1747f4970ae8b650486ed7470845635",
+				publicKey:  "0086fab68dcb57aa196c77c5f264f215a112c22a912c10d123b0d03c3c28ef1037",
+			},
+			{
+				index:      2147483647,
+				chainCode:  "138f0b2551bcafeca6ff2aa88ba8ed0ed8de070841f0c4ef0165df8181eaad7f",
+				privateKey: "ea4f5bfe8694d8bb74b7b59404632fd5968b774ed545e810de9c32a4fb4192f4",
+				publicKey:  "005ba3b9ac6e90e83effcd25ac4e58a1365a9e35a3d3ae5eb07b9e4d90bcf7506d",
+			},
+			{
+				index:      1,
+				chainCode:  "73bd9fff1cfbde33a1b846c27085f711c0fe2d66fd32e139d3ebc28e5a4a6b90",
+				privateKey: "3757c7577170179c7868353ada796c839135b3d30554bbb74a4b1e4a5a58505c",
+				publicKey:  "002e66aa57069c86cc18249aecf5cb5a9cebbfd6fadeab056254763874a9352b45",
+			},
+			{
+				index:      2147483646,
+				chainCode:  "0902fe8a29f9140480a00ef244bd183e8a13288e4412d8389d140aac1794825a",
+				privateKey: "5837736c89570de861ebc173b1086da4f505d4adb387c6a1b1342d5e4ac9ec72",
+				publicKey:  "00e33c0f7d81d843c572275f287498e8d408654fdf0d1e065b84e2e6f157aab09b",
+			},
+			{
+				index:      2,
+				chainCode:  "5d70af781f3a37b829f0d060924d5e960bdc02e85423494afc0b1a41bbe196d4",
+				privateKey: "551d333177df541ad876a60ea71f00447931c0a9da16f227c11ea080d7391b8d",
+				publicKey:  "0047150c75db263559a70d5778bf36abbab30fb061ad69f69ece61a72b0cfa4fc0",
+			},
+		},
+	},
+}
+
+func mustUnhex(t *testing.T, x string) []byte {
+	b, err := hex.DecodeString(x)
+	if err != nil {
+		t.Fatalf("failed to parse hex string: %v", err)
+	}
+
+	return b
+}
+
+type hkdOutput struct {
+	index uint32
+
+	chainCode  string
+	privateKey string
+	publicKey  string
+}
+
+func (output *hkdOutput) Check(t *testing.T, signer signature.Signer, c ChainCode) {
+	if x := hex.EncodeToString(c[:]); x != output.chainCode {
+		t.Fatalf("chain code mismatch (Got %v)", x)
+	}
+
+	unsafeSigner := signer.(signature.UnsafeSigner)
+	k := unsafeSigner.UnsafeBytes()
+	if x := hex.EncodeToString(k[:32]); x != output.privateKey {
+		t.Fatalf("private key mismatch (Got %v)", x)
+	}
+
+	// The test vectors in the spec prefix the public key with a leading
+	// 0x00 for some reason that I'm too small-brained to understand.
+	// Since ed25519 public keys by definition are 256-bits, and not
+	// 264-bits, prepend the extra mystery byte when comparing the
+	// output.
+	publicKey := signer.Public()
+	if x := hex.EncodeToString(publicKey[:]); "00"+x != output.publicKey {
+		t.Fatalf("public key mismatch (Got %v)", x)
+	}
+}
+
+type testVector struct {
+	seed   string
+	master hkdOutput
+
+	children []hkdOutput
+}
+
+func (vec *testVector) Run(t *testing.T) {
+	seed := mustUnhex(t, vec.seed)
+	k, c, err := NewMasterKey(seed)
+	if err != nil {
+		t.Fatalf("failed to derive master: %v", err)
+	}
+	vec.master.Check(t, k, c)
+
+	for _, v := range vec.children {
+		index := v.index | (1 << 31) // Oh for fuck's sake.
+		k, c, err = NewChildKey(k, c, index)
+		if err != nil {
+			t.Fatalf("failed to derive child: %v", err)
+		}
+		v.Check(t, k, c)
+	}
+}
+
+func TestVectors(t *testing.T) {
+	for _, v := range testVectors {
+		v.Run(t)
+	}
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -12,8 +12,9 @@ replace (
 	github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.2
 
 	github.com/tendermint/tendermint => github.com/oasisprotocol/tendermint v0.34.9-oasis2
-	golang.org/x/crypto/curve25519 => github.com/oasisprotocol/ed25519/extra/x25519 v0.0.0-20210127160119-f7017427c1ea
-	golang.org/x/crypto/ed25519 => github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea
+
+	golang.org/x/crypto/curve25519 => github.com/oasisprotocol/curve25519-voi/primitives/x25519 v0.0.0-20210505121811-294cf0fbfb43
+	golang.org/x/crypto/ed25519 => github.com/oasisprotocol/curve25519-voi/primitives/ed25519 v0.0.0-20210505121811-294cf0fbfb43
 )
 
 require (
@@ -36,8 +37,8 @@ require (
 	github.com/libp2p/go-libp2p-core v0.8.5
 	github.com/libp2p/go-libp2p-pubsub v0.4.1
 	github.com/multiformats/go-multiaddr v0.3.1
+	github.com/oasisprotocol/curve25519-voi v0.0.0-20210505121811-294cf0fbfb43
 	github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956
-	github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/prometheus/client_golang v1.10.0
 	github.com/prometheus/common v0.20.0
@@ -55,7 +56,7 @@ require (
 	github.com/whyrusleeping/go-logging v0.0.1
 	gitlab.com/yawning/dynlib.git v0.0.0-20200603163025-35fe007b0761
 	go.dedis.ch/kyber/v3 v3.0.13
-	golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9
+	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974
 	google.golang.org/genproto v0.0.0-20201119123407-9b1e624d6bc4
 	google.golang.org/grpc v1.37.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -762,6 +762,8 @@ github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/oasisprotocol/curve25519-voi v0.0.0-20210505121811-294cf0fbfb43 h1:qnvTxmtjcuRH5NiI0Kiku6TXi2VReR/PxHFf3ahFYrg=
+github.com/oasisprotocol/curve25519-voi v0.0.0-20210505121811-294cf0fbfb43/go.mod h1:TLJifjWF6eotcfzDjKZsDqWJ+73Uvj/N85MvVyrvynM=
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956 h1:etZXZf8f2xLJFivW4tTg87nSV3KLszQ7oYot3UNcmF0=
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea h1:r4MhxgqQ1bed0fQhRINBM50Rbwsgma6oEjG4zQ444Lw=
@@ -1040,8 +1042,9 @@ golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9 h1:phUcVbl53swtrUN8kQEXFhUxPlIlWyBfKmidCu7P95o=
 golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/go/oasis-test-runner/oasis/oasis_test.go
+++ b/go/oasis-test-runner/oasis/oasis_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/oasisprotocol/ed25519"
+	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/drbg"


### PR DESCRIPTION
 * [x] Switch the import
 * [x] Use the new batch verification API
 * [x] Use expanded form public keys, under the assumption that the set of public keys is relatively static.
 * [x] Add a SLIP-0010 implementation (moved from the voi repo) 

~~This should eventually carve out the cache into somewhere else (maybe as part of voi, it seems generally useful), so that the tendermint side can also use it.  But what is there is ok as an illustration of how this will work.~~