### PR TITLE
runtime: Support for block tags

### DIFF
--- a/.changelog/3848.breaking.md
+++ b/.changelog/3848.breaking.md
@@ -1,0 +1,1 @@
+runtime: Add support for block tags

--- a/go/runtime/transaction/tags.go
+++ b/go/runtime/transaction/tags.go
@@ -2,6 +2,10 @@ package transaction
 
 import "github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 
+// TagBlockTxHash is the hash used for block emitted tags not tied to a specific
+// transaction.
+var TagBlockTxHash = hash.Hash([32]byte{})
+
 // Tag is a key/value pair of arbitrary byte blobs with runtime-dependent
 // semantics which can be indexed to allow easier lookup of transactions
 // on runtime clients.

--- a/runtime/src/dispatcher.rs
+++ b/runtime/src/dispatcher.rs
@@ -477,6 +477,10 @@ impl Dispatcher {
                 .expect("add transaction must succeed");
         }
 
+        txn_tree
+            .add_block_tags(Context::create_child(&ctx), results.block_tags)
+            .expect("adding block tags must succeed");
+
         let (io_write_log, io_root) = txn_tree
             .commit(Context::create_child(&ctx))
             .expect("io commit must succeed");

--- a/runtime/src/transaction/dispatcher.rs
+++ b/runtime/src/transaction/dispatcher.rs
@@ -112,6 +112,8 @@ pub struct ExecuteBatchResult {
     pub results: Vec<ExecuteTxResult>,
     /// Emitted runtime messages.
     pub messages: Vec<roothash::Message>,
+    /// Block emitted tags (not emitted by a specific transaction).
+    pub block_tags: Tags,
 }
 
 /// No-op dispatcher.
@@ -135,6 +137,7 @@ impl Dispatcher for NoopDispatcher {
         Ok(ExecuteBatchResult {
             results: Vec::new(),
             messages: Vec::new(),
+            block_tags: Tags::new(),
         })
     }
 
@@ -491,6 +494,8 @@ impl Dispatcher for MethodDispatcher {
         Ok(ExecuteBatchResult {
             results,
             messages: ctx.close(),
+            // No support for block tags in the deprecated dispatcher.
+            block_tags: Tags::new(),
         })
     }
 

--- a/runtime/src/transaction/tree.rs
+++ b/runtime/src/transaction/tree.rs
@@ -74,6 +74,9 @@ struct TagKeyFormat {
     tx_hash: Hash,
 }
 
+/// Hash used for block emitted tags not tied to a specific transaction.
+pub const TAG_BLOCK_TX_HASH: Hash = Hash([0u8; 32]);
+
 impl KeyFormat for TagKeyFormat {
     fn prefix() -> u8 {
         'E' as u8
@@ -209,6 +212,25 @@ impl Tree {
                 &TagKeyFormat {
                     key: tag.key,
                     tx_hash,
+                }
+                .encode(),
+                &tag.value,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// Add block tags.
+    pub fn add_block_tags(&mut self, ctx: Context, tags: Tags) -> Result<()> {
+        let ctx = ctx.freeze();
+
+        for tag in tags {
+            self.tree.insert(
+                Context::create_child(&ctx),
+                &TagKeyFormat {
+                    key: tag.key,
+                    tx_hash: TAG_BLOCK_TX_HASH,
                 }
                 .encode(),
                 &tag.value,


### PR DESCRIPTION
Runtime: Add support for block tags (tags not emitted by a specific transaction).

Needed for: oasis-sdk#consensus-module (https://github.com/oasisprotocol/oasis-sdk/pull/92)