### PR TITLE
go/worker/compute/executor: Enable schedule_check_tx.enabled by default

### DIFF
--- a/.changelog/3851.feature.md
+++ b/.changelog/3851.feature.md
@@ -1,0 +1,1 @@
+go/worker/compute/executor: Enable scheduler transaction checks by default

--- a/go/upgrade/api/api.go
+++ b/go/upgrade/api/api.go
@@ -128,7 +128,8 @@ func (d Descriptor) ValidateBasic() error {
 	if err := d.Target.ValidateBasic(); err != nil {
 		return fmt.Errorf("invalid upgrade descriptor target version: %w", err)
 	}
-	if d.Epoch < MinUpgradeEpoch || d.Epoch > MaxUpgradeEpoch {
+	minUpgradeEpoch, maxUpgradeEpoch := MinUpgradeEpoch, MaxUpgradeEpoch // Work-around for incorrect go-fuzz instrumentation.
+	if d.Epoch < minUpgradeEpoch || d.Epoch > maxUpgradeEpoch {
 		return fmt.Errorf("invalid upgrade descriptor epoch: %d (min: %d max: %d)",
 			d.Epoch,
 			MinUpgradeEpoch,

--- a/go/worker/compute/executor/init.go
+++ b/go/worker/compute/executor/init.go
@@ -39,7 +39,7 @@ func New(
 }
 
 func init() {
-	Flags.Bool(CfgScheduleCheckTxEnabled, false, "Enable checking transactions before scheduling them")
+	Flags.Bool(CfgScheduleCheckTxEnabled, true, "Enable checking transactions before scheduling them")
 	Flags.Uint64(cfgMaxTxPoolSize, 10000, "Maximum size of the scheduling transaction pool")
 	Flags.Uint64(cfgScheduleTxCacheSize, 1000, "Cache size of recently scheduled transactions to prevent re-scheduling")
 


### PR DESCRIPTION
go/upgrade: Add work-around for incorrect go-fuzz instrumentation.