### PR TITLE
ci: build and upload release artifacts on every master merge

### DIFF
--- a/.changelog/3875.internal.md
+++ b/.changelog/3875.internal.md
@@ -1,0 +1,1 @@
+Build and upload release artifacts on every master/stable merge

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,0 +1,62 @@
+# NOTE: This name appears in GitHub's Checks API and in workflow's status badge.
+name: release-dev
+
+# Trigger the workflow when:
+on:
+  # A push occurs to one of the matched tags.
+  push:
+    branches:
+      - master
+      - stable/*
+
+# Global environment variables.
+env:
+  GORELEASER_URL_PREFIX: https://github.com/goreleaser/goreleaser/releases/download/
+  GORELEASER_VERSION: 0.152.0
+  CURL_CMD: curl --proto =https --tlsv1.2 --location --silent --show-error --fail
+
+jobs:
+
+  prepare-dev-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          # Fetch all history as the recommended way to fetch all tags and
+          # branches of the project.
+          # This allows the release helpers in common.mk to determine the
+          # project's version from git correctly.
+          # For more info, see:
+          # https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
+          fetch-depth: 0
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2.1.3
+        with:
+          go-version: "1.15.x"
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+      - name: Install Oasis Node prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install make libseccomp-dev protobuf-compiler
+      - name: Install GoReleaser
+        run: |
+          cd $(mktemp --directory /tmp/goreleaser.XXXXX)
+          ${CURL_CMD} ${GORELEASER_URL_PREFIX}/v${GORELEASER_VERSION}/${GORELEASER_TARBALL} \
+            --output ${GORELEASER_TARBALL}
+          ${CURL_CMD} ${GORELEASER_URL_PREFIX}/v${GORELEASER_VERSION}/goreleaser_checksums.txt \
+            --output CHECKSUMS
+          sha256sum --check --ignore-missing CHECKSUMS
+          tar -xf ${GORELEASER_TARBALL}
+          sudo mv goreleaser /usr/local/bin
+        env:
+          GORELEASER_TARBALL: goreleaser_Linux_x86_64.tar.gz
+      - name: Build the snapshot release
+        run: |
+          make release-build
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v2.2.2
+        with:
+          name: oasis-core-dev-release
+          path: dist/*.tar.gz


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/3875

Builds release artifacts and upload them as github action artifacts. 