### PR TITLE
Runtime workers should wait for history reindex

### DIFF
--- a/.changelog/3889.bugfix.md
+++ b/.changelog/3889.bugfix.md
@@ -1,0 +1,7 @@
+Runtime workers should wait for history reindex
+
+If a node first syncs consensus without any runtimes configured and a runtime
+is configured later, the workers should wait for historic runtime block
+reindexing to complete before continuing with initialization. Otherwise
+historic block queries may fail and prevent the worker from operating
+normally.


### PR DESCRIPTION
Fixes #3889 

If a node first syncs consensus without any runtimes configured and a runtime
is configured later, the workers should wait for historic runtime block
reindexing to complete before continuing with initialization. Otherwise
historic block queries may fail and prevent the worker from operating
normally.