### PR TITLE
go/oasis-net-runner: support multiple runtimes in default fixture

### DIFF
--- a/.changelog/3914.feature.1.md
+++ b/.changelog/3914.feature.1.md
@@ -1,0 +1,1 @@
+go/oasis-net-runner: support multiple runtimes in default fixture

--- a/.changelog/3914.feature.2.md
+++ b/.changelog/3914.feature.2.md
@@ -1,0 +1,1 @@
+go/oasis-net-runner: default fixture support staking genesis


### PR DESCRIPTION
Supports configuring multiple runtime in the default fixture