### PR TITLE
{Add,Reclaim}EscrowEvent: include share amounts

### DIFF
--- a/.changelog/3939.breaking.md
+++ b/.changelog/3939.breaking.md
@@ -1,0 +1,1 @@
+staking: Include share amounts in `AddEscrow` and `ReclaimEscrow` events

--- a/.changelog/3944.breaking.md
+++ b/.changelog/3944.breaking.md
@@ -1,0 +1,13 @@
+Update emitted events when disbursing rewards
+
+Before, a single `AddEscrow` event was emitted which did not correctly
+represent the actual state changes when rewards were disbursed.
+
+Now the following events are emitted:
+
+- `Transfer(CommonPool -> Recipient, commissionAmount)` event for the
+  commissioned part of the reward
+- `AddEscrow(Recipient -> Recipient, commissionAmount)` event for the
+  automatically escrowed commission reward
+- `AddEscrow(CommonPool -> Recipient, restAmount)` for the non-commissioned
+  part of the reward (which only increases existing shares prices)

--- a/docs/consensus/staking.md
+++ b/docs/consensus/staking.md
@@ -614,9 +614,10 @@ The add escrow event is emitted when funds are escrowed.
 
 ```golang
 type AddEscrowEvent struct {
-  Owner  Address           `json:"owner"`
-  Escrow Address           `json:"escrow"`
-  Amount quantity.Quantity `json:"amount"`
+  Owner     Address           `json:"owner"`
+  Escrow    Address           `json:"escrow"`
+  Amount    quantity.Quantity `json:"amount"`
+  NewShares quantity.Quantity `json:"new_shares"`
 }
 ```
 
@@ -626,6 +627,9 @@ type AddEscrowEvent struct {
 * `escrow` contains the address of the destination account the tokens are being
   escrowed to.
 * `amount` contains the amount (in base units) escrowed.
+* `new_shares` contains the amount of shares created as a result of the added
+  escrow event. Can be zero in case of (non-commissioned) rewards, where stake
+  is added without new shares to increase share price.
 
 #### Take Escrow Event
 
@@ -658,6 +662,7 @@ type ReclaimEscrowEvent struct {
   Owner  Address           `json:"owner"`
   Escrow Address           `json:"escrow"`
   Amount quantity.Quantity `json:"amount"`
+  Shares quantity.Quantity `json:"shares"`
 }
 ```
 
@@ -666,6 +671,7 @@ type ReclaimEscrowEvent struct {
 * `owner` contains the address of the account that reclaimed tokens from escrow.
 * `escrow` contains the address of the account escrow has been reclaimed from.
 * `amount` contains the amount (in base units) reclaimed.
+* `shares` contains the amount of shares reclaimed.
 
 ### Allowance Change Event
 

--- a/go/consensus/tendermint/apps/staking/staking.go
+++ b/go/consensus/tendermint/apps/staking/staking.go
@@ -272,12 +272,14 @@ func (app *stakingApplication) onEpochChange(ctx *api.Context, epoch beacon.Epoc
 			"escrow_addr", e.EscrowAddr,
 			"delegator_addr", e.DelegatorAddr,
 			"base_units", stakeAmount,
+			"num_shares", shareAmount,
 		)
 
 		evt := staking.ReclaimEscrowEvent{
 			Owner:  e.DelegatorAddr,
 			Escrow: e.EscrowAddr,
 			Amount: *stakeAmount,
+			Shares: *shareAmount,
 		}
 		ctx.EmitEvent(api.NewEventBuilder(app.Name()).Attribute(KeyReclaimEscrow, cbor.Marshal(evt)))
 	}

--- a/go/staking/tests/tester.go
+++ b/go/staking/tests/tester.go
@@ -714,7 +714,9 @@ func testEscrowHelper( // nolint: gocyclo
 	}
 
 	currentTotalShares := dstAcc.Escrow.Active.TotalShares.Clone()
-	_ = dstAcc.Escrow.Active.Deposit(currentTotalShares, &srcAcc.General.Balance, &escrow.Amount)
+	sharesBefore := dstAcc.Escrow.Active.TotalShares.Clone()
+	newShares, err := dstAcc.Escrow.Active.Deposit(currentTotalShares, &srcAcc.General.Balance, &escrow.Amount)
+	require.NoError(err, "src: deposit")
 
 	newSrcAcc, err := backend.Account(context.Background(), &api.OwnerQuery{Owner: srcAccData.Address, Height: consensusAPI.HeightLatest})
 	require.NoError(err, "src: Account - after")
@@ -733,6 +735,12 @@ func testEscrowHelper( // nolint: gocyclo
 	}
 	require.Equal(dstAcc.Escrow.Active.Balance, newDstAcc.Escrow.Active.Balance, "dst: active escrow balance - after")
 	require.Equal(dstAcc.Escrow.Active.TotalShares, newDstAcc.Escrow.Active.TotalShares, "dst: active escrow total shares - after")
+
+	// Compute actually added shares.
+	addedShares := dstAcc.Escrow.Active.TotalShares.Clone()
+	require.NoError(addedShares.Sub(sharesBefore), "dst: totalShares.Sub(sharesBefore)")
+	require.Equal(addedShares, newShares, "dst: expected amount of added shares")
+
 	require.True(newDstAcc.Escrow.Debonding.Balance.IsZero(), "dst: debonding escrow balance == 0 - after")
 	require.True(newDstAcc.Escrow.Debonding.TotalShares.IsZero(), "dst: debonding escrow total shares == 0 - after")
 
@@ -783,7 +791,9 @@ func testEscrowHelper( // nolint: gocyclo
 	}
 
 	currentTotalShares = dstAcc.Escrow.Active.TotalShares.Clone()
-	_ = dstAcc.Escrow.Active.Deposit(currentTotalShares, &srcAcc.General.Balance, &escrow.Amount)
+	sharesBefore = dstAcc.Escrow.Active.TotalShares.Clone()
+	newShares, err = dstAcc.Escrow.Active.Deposit(currentTotalShares, &srcAcc.General.Balance, &escrow.Amount)
+	require.NoError(err, "src: deposit - after 2nd")
 
 	newSrcAcc, err = backend.Account(context.Background(), &api.OwnerQuery{Owner: srcAccData.Address, Height: consensusAPI.HeightLatest})
 	require.NoError(err, "src: Account - after 2nd")
@@ -802,6 +812,12 @@ func testEscrowHelper( // nolint: gocyclo
 	}
 	require.Equal(dstAcc.Escrow.Active.Balance, newDstAcc.Escrow.Active.Balance, "dst: active escrow balance - after 2nd")
 	require.Equal(dstAcc.Escrow.Active.TotalShares, newDstAcc.Escrow.Active.TotalShares, "dst: active escrow total shares - after 2nd")
+
+	// Compute actually added shares.
+	addedShares = dstAcc.Escrow.Active.TotalShares.Clone()
+	require.NoError(addedShares.Sub(sharesBefore), "dst: totalShares.Sub(sharesBefore) - after 2nd")
+	require.Equal(addedShares, newShares, "dst: expected amount of added shares - after 2nd")
+
 	require.True(newDstAcc.Escrow.Debonding.Balance.IsZero(), "dst: debonding escrow balance == 0 - after 2nd")
 	require.True(newDstAcc.Escrow.Debonding.TotalShares.IsZero(), "dst: debonding escrow total shares == 0 - after 2nd")
 


### PR DESCRIPTION
Fixes: #3939

Also fixed `Escrow` events emitted when disbursing rewards. I think explicitly emitting (transfer and self-escrow) events makes more sense?