### PR TITLE
runtime/common/crypto/signature: Switch Ed25519 to our consensus flavor

### DIFF
--- a/.changelog/3946.internal.md
+++ b/.changelog/3946.internal.md
@@ -1,0 +1,1 @@
+runtime/common/crypto/signature: Switch Ed25519 to our consensus flavor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,6 +1385,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "crossbeam 0.8.0",
+ "curve25519-dalek",
  "deoxysii",
  "ed25519-dalek",
  "futures 0.1.29",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -37,6 +37,7 @@ tokio-executor = "0.1.6"
 tendermint = "0.19.0"
 tendermint-proto = "0.19.0"
 io-context = "0.2.0"
+curve25519-dalek = "3.0.0"
 x25519-dalek = "1.1.0"
 ed25519-dalek = "1.0.1"
 deoxysii = { git = "https://github.com/oasisprotocol/deoxysii-rust" }


### PR DESCRIPTION
We currently use semantics that are close to ed25519-dalek's strict,
but we require using the cofactored verification equation.  Implementing
verification ourselves lets us alter the behavior in the future as
we see fit, though "Just use Ristretto".

TODO:
 * [x] Add tests (blocked on #3947)
 * [x] Add one of those stupid changelog fragments.