### PR TITLE
runtime/core/common/cbor: expose Error type

### DIFF
--- a/.changelog/3948.trivial.md
+++ b/.changelog/3948.trivial.md
@@ -1,0 +1,1 @@
+runtime/core/common/cbor: re-export `serde_cbor::error::Error`

--- a/runtime/src/common/cbor.rs
+++ b/runtime/src/common/cbor.rs
@@ -2,8 +2,11 @@
 use std::io::Write;
 
 use serde::{Deserialize, Serialize};
-pub use serde_cbor::value::{from_value, Value};
 use serde_cbor::{self, Result};
+pub use serde_cbor::{
+    error::Error,
+    value::{from_value, Value},
+};
 
 /// Convert a value to a `Value`.
 pub fn to_value<T>(value: T) -> Value


### PR DESCRIPTION
This PR exposes the `Error` type for easier conversion of an invalid argument found by the SDK.