### PR TITLE
go/staking: Remove backwards compat in UnmarshalText

### DIFF
--- a/go/staking/api/slashing.go
+++ b/go/staking/api/slashing.go
@@ -85,10 +85,6 @@ func (s SlashReason) MarshalText() ([]byte, error) {
 // UnmarshalText decodes a text slice into a SlashReason.
 func (s *SlashReason) UnmarshalText(text []byte) error {
 	switch string(text) {
-	// XXX: The "0" case is only for backward compatibility, so that the old
-	// genesis file loads -- remove this once mainnet is upgraded!
-	case "0":
-		fallthrough
 	case SlashConsensusEquivocationName:
 		*s = SlashConsensusEquivocation
 	case SlashBeaconInvalidCommitName:


### PR DESCRIPTION
Closes #3627 