### PR TITLE
go/runtime/client: Add GetTransactions method, deprecate GetTxs

### DIFF
--- a/.changelog/3812.feature.md
+++ b/.changelog/3812.feature.md
@@ -1,0 +1,9 @@
+go/runtime/client: Add `GetTransactions` method, deprecate `GetTxs`
+
+A new method called `GetTransactions` has been added to replace the (now
+deprecated) `GetTxs`. The new method does not require the caller to pass
+the IO root as that is an internal detail. This makes it consistent with
+the existing `GetEvents` API.
+
+Users of `GetTxs` should migrate to `GetTransactions` as the former may be
+removed in a future release.

--- a/go/runtime/client/api/api.go
+++ b/go/runtime/client/api/api.go
@@ -71,7 +71,13 @@ type RuntimeClient interface {
 	GetTxByBlockHash(ctx context.Context, request *GetTxByBlockHashRequest) (*TxResult, error)
 
 	// GetTxs fetches all runtime transactions in a given block.
+	//
+	// DEPRECATED: This method is deprecated and may be removed in a future release, use
+	//             `GetTransactions` instead.
 	GetTxs(ctx context.Context, request *GetTxsRequest) ([][]byte, error)
+
+	// GetTransactions fetches all runtime transactions in a given block.
+	GetTransactions(ctx context.Context, request *GetTransactionsRequest) ([][]byte, error)
 
 	// GetEvents returns all events emitted in a given block.
 	GetEvents(ctx context.Context, request *GetEventsRequest) ([]*Event, error)
@@ -149,6 +155,12 @@ type GetTxsRequest struct {
 	RuntimeID common.Namespace `json:"runtime_id"`
 	Round     uint64           `json:"round"`
 	IORoot    hash.Hash        `json:"io_root"`
+}
+
+// GetTransactionsRequest is a GetTransactions request.
+type GetTransactionsRequest struct {
+	RuntimeID common.Namespace `json:"runtime_id"`
+	Round     uint64           `json:"round"`
 }
 
 // GetEventsRequest is a GetEvents request.

--- a/go/runtime/client/api/grpc.go
+++ b/go/runtime/client/api/grpc.go
@@ -38,6 +38,8 @@ var (
 	methodGetTxByBlockHash = serviceName.NewMethod("GetTxByBlockHash", GetTxByBlockHashRequest{})
 	// methodGetTxs is the GetTxs method.
 	methodGetTxs = serviceName.NewMethod("GetTxs", GetTxsRequest{})
+	// methodGetTransactions is the GetTransactions method.
+	methodGetTransactions = serviceName.NewMethod("GetTransactions", GetTransactionsRequest{})
 	// methodGetEvents is the GetEvents method.
 	methodGetEvents = serviceName.NewMethod("GetEvents", GetEventsRequest{})
 	// methodQuery is the Query method.
@@ -92,6 +94,10 @@ var (
 			{
 				MethodName: methodGetTxs.ShortName(),
 				Handler:    handlerGetTxs,
+			},
+			{
+				MethodName: methodGetTransactions.ShortName(),
+				Handler:    handlerGetTransactions,
 			},
 			{
 				MethodName: methodGetEvents.ShortName(),
@@ -368,6 +374,29 @@ func handlerGetTxs( // nolint: golint
 	return interceptor(ctx, &rq, info, handler)
 }
 
+func handlerGetTransactions( // nolint: golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var rq GetTransactionsRequest
+	if err := dec(&rq); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RuntimeClient).GetTransactions(ctx, &rq)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodGetTransactions.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RuntimeClient).GetTransactions(ctx, req.(*GetTransactionsRequest))
+	}
+	return interceptor(ctx, &rq, info, handler)
+}
+
 func handlerGetEvents( // nolint: golint
 	srv interface{},
 	ctx context.Context,
@@ -586,6 +615,14 @@ func (c *runtimeClient) GetTxByBlockHash(ctx context.Context, request *GetTxByBl
 func (c *runtimeClient) GetTxs(ctx context.Context, request *GetTxsRequest) ([][]byte, error) {
 	var rsp [][]byte
 	if err := c.conn.Invoke(ctx, methodGetTxs.FullName(), request, &rsp); err != nil {
+		return nil, err
+	}
+	return rsp, nil
+}
+
+func (c *runtimeClient) GetTransactions(ctx context.Context, request *GetTransactionsRequest) ([][]byte, error) {
+	var rsp [][]byte
+	if err := c.conn.Invoke(ctx, methodGetTransactions.FullName(), request, &rsp); err != nil {
 		return nil, err
 	}
 	return rsp, nil

--- a/go/runtime/client/client.go
+++ b/go/runtime/client/client.go
@@ -339,6 +339,29 @@ func (c *runtimeClient) GetTxs(ctx context.Context, request *api.GetTxsRequest) 
 }
 
 // Implements api.RuntimeClient.
+func (c *runtimeClient) GetTransactions(ctx context.Context, request *api.GetTransactionsRequest) ([][]byte, error) {
+	blk, err := c.GetBlock(ctx, &api.GetBlockRequest{RuntimeID: request.RuntimeID, Round: request.Round})
+	if err != nil {
+		return nil, err
+	}
+
+	tree := c.getTxnTree(blk)
+	defer tree.Close()
+
+	txs, err := tree.GetTransactions(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	inputs := [][]byte{}
+	for _, tx := range txs {
+		inputs = append(inputs, tx.Input)
+	}
+
+	return inputs, nil
+}
+
+// Implements api.RuntimeClient.
 func (c *runtimeClient) GetEvents(ctx context.Context, request *api.GetEventsRequest) ([]*api.Event, error) {
 	blk, err := c.GetBlock(ctx, &api.GetBlockRequest{RuntimeID: request.RuntimeID, Round: request.Round})
 	if err != nil {

--- a/go/runtime/client/tests/tester.go
+++ b/go/runtime/client/tests/tester.go
@@ -154,6 +154,12 @@ func testQuery(
 	// Check for values from TestNode/Client/SubmitTx
 	require.EqualValues(t, testInput, txns[0])
 
+	txns, err = c.GetTransactions(ctx, &api.GetTransactionsRequest{RuntimeID: runtimeID, Round: blk.Header.Round})
+	require.NoError(t, err, "GetTransactions")
+	require.Len(t, txns, 1)
+	// Check for values from TestNode/Client/SubmitTx
+	require.EqualValues(t, testInput, txns[0])
+
 	// Check events query (see mock worker for emitted events).
 	events, err := c.GetEvents(ctx, &api.GetEventsRequest{RuntimeID: runtimeID, Round: 2})
 	require.NoError(t, err, "GetEvents")


### PR DESCRIPTION
A new method called GetTransactions has been added to replace the now deprecated
GetTxs. The new method does not require the caller to pass the IO root as that
is an internal detail. This makes it consistent with the existing GetEvents API.

Users of GetTxs should migrate to GetTransactions as the former may be removed
in a future release.