### PR TITLE
go: Bump fxamacker/cbor to v2.3.0

### DIFF
--- a/.changelog/3986.internal.md
+++ b/.changelog/3986.internal.md
@@ -1,0 +1,1 @@
+go: Bump fxamacker/cbor to v2.3.0

--- a/go/go.mod
+++ b/go/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/dgraph-io/badger/v2 v2.2007.2
 	github.com/dgraph-io/badger/v3 v3.2103.2
 	github.com/eapache/channels v1.1.0
-	github.com/fxamacker/cbor/v2 v2.2.1-0.20200820021930-bafca87fa6db
+	github.com/fxamacker/cbor/v2 v2.3.0
 	github.com/go-kit/log v0.2.0
 	github.com/golang/protobuf v1.5.2
 	github.com/golang/snappy v0.0.4

--- a/go/go.sum
+++ b/go/go.sum
@@ -243,8 +243,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
-github.com/fxamacker/cbor/v2 v2.2.1-0.20200820021930-bafca87fa6db h1:JCjUE9xYakEXU8BtIZ2T6z10RJBgYZCC3q9lZhAaTms=
-github.com/fxamacker/cbor/v2 v2.2.1-0.20200820021930-bafca87fa6db/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/fxamacker/cbor/v2 v2.3.0 h1:aM45YGMctNakddNNAezPxDUpv38j44Abh+hifNuqXik=
+github.com/fxamacker/cbor/v2 v2.3.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=


### PR DESCRIPTION
It was just released and it includes what we were using anyway. Just need to make sure it doesn't break anything.