### PR TITLE
worker/executor: support custom runtime batch weight limits

### DIFF
--- a/.changelog/3760.breaking.md
+++ b/.changelog/3760.breaking.md
@@ -6,9 +6,10 @@ first). Transaction weights are used by scheduler when creating batches to
 ensure no batch passes the per round weight limit. Supported limits are:
 
 - `count` - number of transactions - per round limit is a runtime parameter in
-  registry (already existed prior to this change)
+  registry (already existed prior to this change).
 - `size_bytes` - size of transactions in bytes - per round limit is a runtime
-  parameter in registry (already existed prior to this change)
+  parameter in registry (already existed prior to this change).
 - `consensus_messages` - number of emitted consensus messages - per round
-  limit is a consensus parameter (already existed prior to this change)
-- custom, runtime specific weights
+  limit is a consensus parameter (already existed prior to this change).
+- Custom, runtime specific weights. `internal.BatchWeightLimits` method is
+  queried for custom batch weight limits on every round.

--- a/go/runtime/host/helpers.go
+++ b/go/runtime/host/helpers.go
@@ -44,6 +44,14 @@ type RichRuntime interface {
 		method string,
 		args cbor.RawMessage,
 	) (cbor.RawMessage, error)
+
+	// QueryBatchLimits requests the runtime to answer the batch limits query.
+	QueryBatchLimits(
+		ctx context.Context,
+		rb *block.Block,
+		lb *consensus.LightBlock,
+		epoch beacon.EpochTime,
+	) (map[transaction.Weight]uint64, error)
 }
 
 type richRuntime struct {
@@ -117,6 +125,25 @@ func (r *richRuntime) Query(
 		return nil, errors.WithContext(ErrInternal, "malformed runtime response")
 	}
 	return resp.RuntimeQueryResponse.Data, nil
+}
+
+// Implements RichRuntime.
+func (r *richRuntime) QueryBatchLimits(
+	ctx context.Context,
+	rb *block.Block,
+	lb *consensus.LightBlock,
+	epoch beacon.EpochTime,
+) (map[transaction.Weight]uint64, error) {
+	resp, err := r.Query(ctx, rb, lb, epoch, protocol.MethodQueryBatchWeightLimits, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var weightLimits map[transaction.Weight]uint64
+	if err = cbor.Unmarshal(resp, &weightLimits); err != nil {
+		return nil, errors.WithContext(ErrInternal, fmt.Sprintf("malformed runtime response: %v", err))
+	}
+	return weightLimits, nil
 }
 
 // NewRichRuntime creates a new higher-level wrapper for a given runtime. It provides additional

--- a/go/runtime/host/mock/mock.go
+++ b/go/runtime/host/mock/mock.go
@@ -108,9 +108,18 @@ func (r *runtime) Call(ctx context.Context, body *protocol.Body) (*protocol.Body
 		}}, nil
 	case body.RuntimeQueryRequest != nil:
 		rq := body.RuntimeQueryRequest
-		return &protocol.Body{RuntimeQueryResponse: &protocol.RuntimeQueryResponse{
-			Data: cbor.Marshal(rq.Method + " world"),
-		}}, nil
+
+		switch rq.Method {
+		// Handle Batch Weight Limits request.
+		case protocol.MethodQueryBatchWeightLimits:
+			return &protocol.Body{RuntimeQueryResponse: &protocol.RuntimeQueryResponse{
+				Data: cbor.Marshal(map[transaction.Weight]uint64{}),
+			}}, nil
+		default:
+			return &protocol.Body{RuntimeQueryResponse: &protocol.RuntimeQueryResponse{
+				Data: cbor.Marshal(rq.Method + " world"),
+			}}, nil
+		}
 	default:
 		return nil, fmt.Errorf("(mock) method not supported")
 	}

--- a/go/runtime/host/protocol/connection.go
+++ b/go/runtime/host/protocol/connection.go
@@ -27,8 +27,8 @@ const (
 	connWriteTimeout = 5 * time.Second
 )
 
-// ErrNotReady is the error reported when the Runtime Host Protocol is not initialized.
 var (
+	// ErrNotReady is the error reported when the Runtime Host Protocol is not initialized.
 	ErrNotReady = errors.New(moduleName, 1, "rhp: not ready")
 
 	rhpLatency = prometheus.NewSummaryVec(

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -302,7 +302,8 @@ type RuntimeExecuteTxBatchRequest struct {
 
 // RuntimeExecuteTxBatchResponse is a worker execute tx batch response message body.
 type RuntimeExecuteTxBatchResponse struct {
-	Batch ComputedBatch `json:"batch"`
+	Batch             ComputedBatch                 `json:"batch"`
+	BatchWeightLimits map[transaction.Weight]uint64 `json:"batch_weight_limits"`
 }
 
 // RuntimeKeyManagerPolicyUpdateRequest is a runtime key manager policy request

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -21,6 +21,9 @@ import (
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
 )
 
+// MethodQueryBatchWeightLimits is the name of the runtime batch weight limits query method.
+const MethodQueryBatchWeightLimits = "internal.BatchWeightLimits"
+
 // NOTE: Bump RuntimeProtocol version in go/common/version if you
 //       change any of the structures below.
 
@@ -227,7 +230,7 @@ type CheckTxMetadata struct {
 	Priority uint64 `json:"priority,omitempty"`
 
 	// Weight are runtime specific transaction weights.
-	Weights map[string]uint64 `json:"weights,omitempty"`
+	Weights map[transaction.Weight]uint64 `json:"weights,omitempty"`
 }
 
 // IsSuccess returns true if transaction execution was successful.

--- a/go/runtime/scheduling/api/api.go
+++ b/go/runtime/scheduling/api/api.go
@@ -27,7 +27,7 @@ type Scheduler interface {
 	IsQueued(hash.Hash) bool
 
 	// UpdateParameters updates the scheduling parameters.
-	UpdateParameters(algo string, weightLimits map[string]uint64) error
+	UpdateParameters(algo string, weightLimits map[transaction.Weight]uint64) error
 
 	// Clear clears the transaction queue.
 	Clear()

--- a/go/runtime/scheduling/init.go
+++ b/go/runtime/scheduling/init.go
@@ -6,10 +6,11 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/runtime/scheduling/api"
 	"github.com/oasisprotocol/oasis-core/go/runtime/scheduling/simple"
 	"github.com/oasisprotocol/oasis-core/go/runtime/scheduling/simple/txpool/priorityqueue"
+	"github.com/oasisprotocol/oasis-core/go/runtime/transaction"
 )
 
 // New creates a new scheduler.
-func New(maxTxPoolSize uint64, algo string, weightLimits map[string]uint64) (api.Scheduler, error) {
+func New(maxTxPoolSize uint64, algo string, weightLimits map[transaction.Weight]uint64) (api.Scheduler, error) {
 	switch algo {
 	case simple.Name:
 		return simple.New(priorityqueue.Name, maxTxPoolSize, algo, weightLimits)

--- a/go/runtime/scheduling/simple/simple.go
+++ b/go/runtime/scheduling/simple/simple.go
@@ -61,7 +61,7 @@ func (s *scheduler) Clear() {
 	s.txPool.Clear()
 }
 
-func (s *scheduler) UpdateParameters(algo string, weightLimits map[string]uint64) error {
+func (s *scheduler) UpdateParameters(algo string, weightLimits map[transaction.Weight]uint64) error {
 	if algo != Name {
 		return fmt.Errorf("unexpected transaction scheduling algorithm: %s", algo)
 	}
@@ -80,7 +80,7 @@ func (s *scheduler) Name() string {
 }
 
 // New creates a new simple scheduler.
-func New(txPoolImpl string, maxTxPoolSize uint64, algo string, weightLimits map[string]uint64) (api.Scheduler, error) {
+func New(txPoolImpl string, maxTxPoolSize uint64, algo string, weightLimits map[transaction.Weight]uint64) (api.Scheduler, error) {
 	if algo != Name {
 		return nil, fmt.Errorf("unexpected transaction scheduling algorithm: %s", algo)
 	}

--- a/go/runtime/scheduling/simple/simple_test.go
+++ b/go/runtime/scheduling/simple/simple_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSimpleSchedulerPriorityQueue(t *testing.T) {
-	weightLimits := map[string]uint64{
+	weightLimits := map[transaction.Weight]uint64{
 		transaction.WeightCount:     10,
 		transaction.WeightSizeBytes: 16 * 1024 * 1024,
 	}
@@ -22,7 +22,7 @@ func TestSimpleSchedulerPriorityQueue(t *testing.T) {
 }
 
 func BenchmarkSimpleSchedulerPriorityQueue(b *testing.B) {
-	weightLimits := map[string]uint64{
+	weightLimits := map[transaction.Weight]uint64{
 		transaction.WeightCount:     1000,
 		transaction.WeightSizeBytes: 16 * 1024 * 1024,
 	}

--- a/go/runtime/scheduling/simple/txpool/api/api.go
+++ b/go/runtime/scheduling/simple/txpool/api/api.go
@@ -19,7 +19,7 @@ var (
 type Config struct {
 	MaxPoolSize uint64
 
-	WeightLimits map[string]uint64
+	WeightLimits map[transaction.Weight]uint64
 }
 
 // TxPool is the transaction pool interface.

--- a/go/runtime/scheduling/simple/txpool/priorityqueue/priority_queue.go
+++ b/go/runtime/scheduling/simple/txpool/priorityqueue/priority_queue.go
@@ -39,8 +39,8 @@ type priorityQueue struct {
 
 	maxTxPoolSize uint64
 
-	poolWeights  map[string]uint64
-	weightLimits map[string]uint64
+	poolWeights  map[transaction.Weight]uint64
+	weightLimits map[transaction.Weight]uint64
 }
 
 // Implements api.TxPool.
@@ -97,7 +97,7 @@ func (q *priorityQueue) GetBatch(force bool) []*transaction.CheckedTransaction {
 	}
 
 	var batch []*transaction.CheckedTransaction
-	batchWeights := make(map[string]uint64)
+	batchWeights := make(map[transaction.Weight]uint64)
 	for w := range q.weightLimits {
 		batchWeights[w] = 0
 	}
@@ -209,7 +209,7 @@ func (q *priorityQueue) Clear() {
 
 	q.priorityIndex.Clear(true)
 	q.transactions = make(map[hash.Hash]*item)
-	q.poolWeights = make(map[string]uint64)
+	q.poolWeights = make(map[transaction.Weight]uint64)
 }
 
 // NOTE: Assumes lock is held.
@@ -239,7 +239,7 @@ func (q *priorityQueue) isQueuedLocked(txHash hash.Hash) bool {
 func New(cfg api.Config) api.TxPool {
 	return &priorityQueue{
 		transactions:  make(map[hash.Hash]*item),
-		poolWeights:   make(map[string]uint64),
+		poolWeights:   make(map[transaction.Weight]uint64),
 		priorityIndex: btree.New(2),
 		maxTxPoolSize: cfg.MaxPoolSize,
 		weightLimits:  cfg.WeightLimits,

--- a/go/runtime/scheduling/simple/txpool/tester.go
+++ b/go/runtime/scheduling/simple/txpool/tester.go
@@ -52,7 +52,7 @@ func testBasic(t *testing.T, pool api.TxPool) {
 
 	err := pool.UpdateConfig(api.Config{
 		MaxPoolSize: 51,
-		WeightLimits: map[string]uint64{
+		WeightLimits: map[transaction.Weight]uint64{
 			transaction.WeightCount:     10,
 			transaction.WeightSizeBytes: 100,
 		},
@@ -101,7 +101,7 @@ func testGetBatch(t *testing.T, pool api.TxPool) {
 	pool.Clear()
 	err := pool.UpdateConfig(api.Config{
 		MaxPoolSize: 51,
-		WeightLimits: map[string]uint64{
+		WeightLimits: map[transaction.Weight]uint64{
 			transaction.WeightCount:     10,
 			transaction.WeightSizeBytes: 100,
 		},
@@ -132,7 +132,7 @@ func testRemoveBatch(t *testing.T, pool api.TxPool) {
 
 	err := pool.UpdateConfig(api.Config{
 		MaxPoolSize: 51,
-		WeightLimits: map[string]uint64{
+		WeightLimits: map[transaction.Weight]uint64{
 			transaction.WeightCount:     10,
 			transaction.WeightSizeBytes: 100,
 		},
@@ -176,7 +176,7 @@ func testUpdateConfig(t *testing.T, pool api.TxPool) {
 
 	err := pool.UpdateConfig(api.Config{
 		MaxPoolSize: 50,
-		WeightLimits: map[string]uint64{
+		WeightLimits: map[transaction.Weight]uint64{
 			transaction.WeightCount:     10,
 			transaction.WeightSizeBytes: 100,
 		},
@@ -194,7 +194,7 @@ func testUpdateConfig(t *testing.T, pool api.TxPool) {
 	// Update configuration to BatchSize=1.
 	err = pool.UpdateConfig(api.Config{
 		MaxPoolSize: 50,
-		WeightLimits: map[string]uint64{
+		WeightLimits: map[transaction.Weight]uint64{
 			transaction.WeightCount:     1,
 			transaction.WeightSizeBytes: 100,
 		},
@@ -214,7 +214,7 @@ func testUpdateConfig(t *testing.T, pool api.TxPool) {
 	// Update configuration back to BatchSize=10.
 	err = pool.UpdateConfig(api.Config{
 		MaxPoolSize: 50,
-		WeightLimits: map[string]uint64{
+		WeightLimits: map[transaction.Weight]uint64{
 			transaction.WeightCount:     10,
 			transaction.WeightSizeBytes: 100,
 		},
@@ -226,7 +226,7 @@ func testUpdateConfig(t *testing.T, pool api.TxPool) {
 	// Update configuration to MaxBatchSizeBytes=1.
 	err = pool.UpdateConfig(api.Config{
 		MaxPoolSize: 50,
-		WeightLimits: map[string]uint64{
+		WeightLimits: map[transaction.Weight]uint64{
 			transaction.WeightCount:     10,
 			transaction.WeightSizeBytes: 1,
 		},
@@ -244,7 +244,7 @@ func testWeights(t *testing.T, pool api.TxPool) {
 
 	err := pool.UpdateConfig(api.Config{
 		MaxPoolSize: 50,
-		WeightLimits: map[string]uint64{
+		WeightLimits: map[transaction.Weight]uint64{
 			transaction.WeightCount:             10,
 			transaction.WeightSizeBytes:         100,
 			transaction.WeightConsensusMessages: 10,
@@ -256,7 +256,7 @@ func testWeights(t *testing.T, pool api.TxPool) {
 	err = pool.Add(transaction.NewCheckedTransaction(
 		[]byte("hello world 1"),
 		0,
-		map[string]uint64{
+		map[transaction.Weight]uint64{
 			transaction.WeightConsensusMessages: 9,
 			"custom_weight":                     1,
 		},
@@ -266,7 +266,7 @@ func testWeights(t *testing.T, pool api.TxPool) {
 	err = pool.Add(transaction.NewCheckedTransaction(
 		[]byte("hello world 2"),
 		0,
-		map[string]uint64{
+		map[transaction.Weight]uint64{
 			transaction.WeightConsensusMessages: 1,
 			"custom_weight":                     4,
 		},
@@ -276,7 +276,7 @@ func testWeights(t *testing.T, pool api.TxPool) {
 	err = pool.Add(transaction.NewCheckedTransaction(
 		[]byte("hello world 3"),
 		0,
-		map[string]uint64{
+		map[transaction.Weight]uint64{
 			transaction.WeightConsensusMessages: 1,
 			"custom_weight":                     1,
 		},
@@ -288,7 +288,7 @@ func testWeights(t *testing.T, pool api.TxPool) {
 
 	err = pool.UpdateConfig(api.Config{
 		MaxPoolSize: 50,
-		WeightLimits: map[string]uint64{
+		WeightLimits: map[transaction.Weight]uint64{
 			transaction.WeightCount:             10,
 			transaction.WeightSizeBytes:         100,
 			transaction.WeightConsensusMessages: 11,
@@ -302,7 +302,7 @@ func testWeights(t *testing.T, pool api.TxPool) {
 
 	err = pool.UpdateConfig(api.Config{
 		MaxPoolSize: 50,
-		WeightLimits: map[string]uint64{
+		WeightLimits: map[transaction.Weight]uint64{
 			transaction.WeightCount:             10,
 			transaction.WeightSizeBytes:         100,
 			transaction.WeightConsensusMessages: 5,
@@ -320,7 +320,7 @@ func testPriority(t *testing.T, pool api.TxPool) {
 
 	err := pool.UpdateConfig(api.Config{
 		MaxPoolSize: 50,
-		WeightLimits: map[string]uint64{
+		WeightLimits: map[transaction.Weight]uint64{
 			transaction.WeightCount:     10,
 			transaction.WeightSizeBytes: 100,
 		},
@@ -382,7 +382,7 @@ func benchmarkIncommingQueue(b *testing.B, pool api.TxPool) {
 		pool.Clear()
 		_ = pool.UpdateConfig(api.Config{
 			MaxPoolSize: 10000000,
-			WeightLimits: map[string]uint64{
+			WeightLimits: map[transaction.Weight]uint64{
 				transaction.WeightCount:     10000000,
 				transaction.WeightSizeBytes: 10000000,
 			},
@@ -401,7 +401,7 @@ func benchmarkIncommingQueue(b *testing.B, pool api.TxPool) {
 		pool.Clear()
 		_ = pool.UpdateConfig(api.Config{
 			MaxPoolSize: 10000000,
-			WeightLimits: map[string]uint64{
+			WeightLimits: map[transaction.Weight]uint64{
 				transaction.WeightCount:     10000000,
 				transaction.WeightSizeBytes: 10000000,
 			},
@@ -423,7 +423,7 @@ func benchmarkIncommingQueue(b *testing.B, pool api.TxPool) {
 		pool.Clear()
 		_ = pool.UpdateConfig(api.Config{
 			MaxPoolSize: 10000000,
-			WeightLimits: map[string]uint64{
+			WeightLimits: map[transaction.Weight]uint64{
 				transaction.WeightCount:     10000000,
 				transaction.WeightSizeBytes: 10000000,
 			},

--- a/go/runtime/scheduling/tests/tester.go
+++ b/go/runtime/scheduling/tests/tester.go
@@ -29,7 +29,7 @@ func SchedulerImplementationTests(t *testing.T, scheduler api.Scheduler) {
 func testScheduleTransactions(t *testing.T, scheduler api.Scheduler) {
 	err := scheduler.UpdateParameters(
 		scheduler.Name(),
-		map[string]uint64{
+		map[transaction.Weight]uint64{
 			transaction.WeightCount:     100,
 			transaction.WeightSizeBytes: 1000,
 		},
@@ -39,7 +39,7 @@ func testScheduleTransactions(t *testing.T, scheduler api.Scheduler) {
 	require.EqualValues(t, 0, scheduler.UnscheduledSize(), "no transactions should be scheduled")
 
 	// Test QueueTx.
-	testTx := transaction.NewCheckedTransaction([]byte("hello world"), 10, make(map[string]uint64))
+	testTx := transaction.NewCheckedTransaction([]byte("hello world"), 10, make(map[transaction.Weight]uint64))
 	err = scheduler.QueueTx(testTx)
 	require.NoError(t, err, "QueueTx(testTx)")
 	require.True(t, scheduler.IsQueued(testTx.Hash()), "IsQueued(tx)")
@@ -75,7 +75,7 @@ func testScheduleTransactions(t *testing.T, scheduler api.Scheduler) {
 	// Update configuration to BatchSize=1.
 	err = scheduler.UpdateParameters(
 		scheduler.Name(),
-		map[string]uint64{
+		map[transaction.Weight]uint64{
 			transaction.WeightCount:     1,
 			transaction.WeightSizeBytes: 10000,
 		},
@@ -106,7 +106,7 @@ func testScheduleTransactions(t *testing.T, scheduler api.Scheduler) {
 	// Update configuration back to BatchSize=10.
 	err = scheduler.UpdateParameters(
 		scheduler.Name(),
-		map[string]uint64{
+		map[transaction.Weight]uint64{
 			transaction.WeightCount:     10,
 			transaction.WeightSizeBytes: 10000,
 		},
@@ -120,7 +120,7 @@ func testScheduleTransactions(t *testing.T, scheduler api.Scheduler) {
 	// Update configuration to MaxBatchSizeBytes=1.
 	err = scheduler.UpdateParameters(
 		scheduler.Name(),
-		map[string]uint64{
+		map[transaction.Weight]uint64{
 			transaction.WeightCount:     10,
 			transaction.WeightSizeBytes: 1,
 		},
@@ -135,14 +135,14 @@ func testScheduleTransactions(t *testing.T, scheduler api.Scheduler) {
 	// Test invalid udpate.
 	err = scheduler.UpdateParameters(
 		"invalid",
-		map[string]uint64{},
+		map[transaction.Weight]uint64{},
 	)
 	require.Error(t, err, "UpdateParameters invalid udpate")
 
 	// Test priorities.
 	err = scheduler.UpdateParameters(
 		scheduler.Name(),
-		map[string]uint64{
+		map[transaction.Weight]uint64{
 			transaction.WeightCount:     1,
 			transaction.WeightSizeBytes: 1000,
 		},
@@ -151,7 +151,7 @@ func testScheduleTransactions(t *testing.T, scheduler api.Scheduler) {
 	txs := make([]*transaction.CheckedTransaction, 50)
 	perm := rand.Perm(50)
 	for i := 0; i < 50; i++ {
-		txs[i] = transaction.NewCheckedTransaction([]byte(fmt.Sprintf("tx-%d", i)), uint64(perm[i]), map[string]uint64{})
+		txs[i] = transaction.NewCheckedTransaction([]byte(fmt.Sprintf("tx-%d", i)), uint64(perm[i]), map[transaction.Weight]uint64{})
 		require.NoError(t, scheduler.QueueTx(txs[i]))
 	}
 	returned := make([]*transaction.CheckedTransaction, 50)

--- a/go/runtime/transaction/transaction.go
+++ b/go/runtime/transaction/transaction.go
@@ -188,7 +188,7 @@ type CheckedTransaction struct {
 
 // String returns string representation of the raw transaction data.
 func (t *CheckedTransaction) String() string {
-	return string(t.tx)
+	return fmt.Sprintf("CheckedTransaction{hash: %v, priority: %v, weights: %v}", t.hash, t.priority, t.weights)
 }
 
 // RawCheckedTransactions creates a new CheckedTransactions from the raw bytes.

--- a/go/runtime/transaction/transaction.go
+++ b/go/runtime/transaction/transaction.go
@@ -149,14 +149,27 @@ type outputArtifacts struct {
 	Output []byte
 }
 
+// Weight is the transaction weight type.
+type Weight string
+
 const (
 	// WeightConsensusMessages is the consensus messages weight key.
-	WeightConsensusMessages = "consensus_messages"
+	WeightConsensusMessages = Weight("consensus_messages")
 	// WeightSizeBytes is the transaction byte size weight key.
-	WeightSizeBytes = "size_bytes"
+	WeightSizeBytes = Weight("size_bytes")
 	// WeightCount is the transaction count weight key.
-	WeightCount = "count"
+	WeightCount = Weight("count")
 )
+
+// IsCustom returns if the weight is a custom runtime weight.
+func (w Weight) IsCustom() bool {
+	switch w {
+	case WeightConsensusMessages, WeightSizeBytes, WeightCount:
+		return false
+	default:
+		return true
+	}
+}
 
 // CheckedTransaction is a checked transaction to be scheduled.
 type CheckedTransaction struct {
@@ -168,7 +181,7 @@ type CheckedTransaction struct {
 	priority uint64
 	// weights defines the transaction's runtime specific weights as specified
 	// in the CheckTx response.
-	weights map[string]uint64
+	weights map[Weight]uint64
 
 	hash hash.Hash
 }
@@ -185,9 +198,9 @@ func RawCheckedTransaction(raw []byte) *CheckedTransaction {
 
 // NewCheckedTransaction creates a new CheckedTransactions from the provided
 // bytes, priority and weights.
-func NewCheckedTransaction(tx []byte, priority uint64, weights map[string]uint64) *CheckedTransaction {
+func NewCheckedTransaction(tx []byte, priority uint64, weights map[Weight]uint64) *CheckedTransaction {
 	if weights == nil {
-		weights = make(map[string]uint64)
+		weights = make(map[Weight]uint64)
 	}
 	checkedTx := &CheckedTransaction{
 		tx:       tx,
@@ -207,7 +220,7 @@ func (t *CheckedTransaction) Priority() uint64 {
 }
 
 // Weight returns the specific transaction weight.
-func (t *CheckedTransaction) Weight(w string) uint64 {
+func (t *CheckedTransaction) Weight(w Weight) uint64 {
 	return t.weights[w]
 }
 
@@ -215,7 +228,7 @@ func (t *CheckedTransaction) Weight(w string) uint64 {
 //
 // To avoid unnecessary allocations the internal weights map is returned.
 // The caller should not modify the map.
-func (t *CheckedTransaction) Weights() map[string]uint64 {
+func (t *CheckedTransaction) Weights() map[Weight]uint64 {
 	return t.weights
 }
 

--- a/runtime/src/dispatcher.rs
+++ b/runtime/src/dispatcher.rs
@@ -329,7 +329,7 @@ impl Dispatcher {
                         header,
                         epoch,
                         method,
-                        args,
+                        args.unwrap_or(cbor::Value::Null),
                     )
                 }
                 Body::RuntimeAbortRequest {} => {
@@ -648,7 +648,7 @@ impl Dispatcher {
             Ok(result) => result,
             Err(error) => {
                 error!(self.logger, "Error while processing frame"; "err" => %error);
-                return Err(Error::new("dispatcher", 1, &format!("{}", error)));
+                return Err(Error::new("rhp/dispatcher", 1, &format!("{}", error)));
             }
         };
 
@@ -669,7 +669,7 @@ impl Dispatcher {
                             "method" => ?req.method
                         );
                         return Err(Error::new(
-                            "dispatcher",
+                            "rhp/dispatcher",
                             1,
                             "Request's method doesn't match untrusted_plaintext copy.",
                         ));
@@ -705,7 +705,7 @@ impl Dispatcher {
                         }
                         Err(error) => {
                             error!(self.logger, "Error while writing response"; "err" => %error);
-                            Err(Error::new("dispatcher", 1, &format!("{}", error)))
+                            Err(Error::new("rhp/dispatcher", 1, &format!("{}", error)))
                         }
                     }
                 }
@@ -719,13 +719,13 @@ impl Dispatcher {
                         }
                         Err(error) => {
                             error!(self.logger, "Error while closing session"; "err" => %error);
-                            Err(Error::new("dispatcher", 1, &format!("{}", error)))
+                            Err(Error::new("rhp/dispatcher", 1, &format!("{}", error)))
                         }
                     }
                 }
                 msg => {
                     warn!(self.logger, "Ignoring invalid RPC message type"; "msg" => ?msg);
-                    Err(Error::new("dispatcher", 1, "invalid RPC message type"))
+                    Err(Error::new("rhp/dispatcher", 1, "invalid RPC message type"))
                 }
             }
         } else {
@@ -745,7 +745,7 @@ impl Dispatcher {
         debug!(self.logger, "Received local RPC call request");
 
         let req: RpcRequest = cbor::from_slice(&request)
-            .map_err(|_| Error::new("dispatcher", 1, "malformed request"))?;
+            .map_err(|_| Error::new("rhp/dispatcher", 1, "malformed request"))?;
 
         // Request, dispatch.
         let ctx = ctx.freeze();

--- a/runtime/src/dispatcher.rs
+++ b/runtime/src/dispatcher.rs
@@ -549,6 +549,7 @@ impl Dispatcher {
                 rak_sig,
                 messages: results.messages,
             },
+            batch_weight_limits: results.batch_weight_limits,
         })
     }
 

--- a/runtime/src/protocol.rs
+++ b/runtime/src/protocol.rs
@@ -243,7 +243,9 @@ impl Protocol {
                         // is no need to do anything more.
                         return Ok(());
                     }
-                    Err(error) => Body::Error(Error::new("dispatcher", 1, &format!("{}", error))),
+                    Err(error) => {
+                        Body::Error(Error::new("rhp/dispatcher", 1, &format!("{}", error)))
+                    }
                 };
 
                 // Send response back.

--- a/runtime/src/transaction/dispatcher.rs
+++ b/runtime/src/transaction/dispatcher.rs
@@ -59,7 +59,11 @@ pub trait Dispatcher {
         _args: cbor::Value,
     ) -> Result<cbor::Value, RuntimeError> {
         // Default implementation returns an error.
-        Err(RuntimeError::new("dispatcher", 1, "query not supported"))
+        Err(RuntimeError::new(
+            "rhp/dispatcher",
+            2,
+            "query not supported",
+        ))
     }
 }
 
@@ -451,7 +455,7 @@ impl Dispatcher for MethodDispatcher {
                 .map(|b| b.load(Ordering::SeqCst))
                 .unwrap_or(false)
             {
-                return Err(RuntimeError::new("dispatcher", 1, "batch aborted"));
+                return Err(RuntimeError::new("rhp/dispatcher", 1, "batch aborted"));
             }
             results.push(self.dispatch_check(call, &mut ctx));
             let _ = ctx.take_tags();
@@ -483,7 +487,7 @@ impl Dispatcher for MethodDispatcher {
                 .map(|b| b.load(Ordering::SeqCst))
                 .unwrap_or(false)
             {
-                return Err(RuntimeError::new("dispatcher", 1, "batch aborted"));
+                return Err(RuntimeError::new("rhp/dispatcher", 1, "batch aborted"));
             }
             results.push(self.dispatch_execute(call, &mut ctx));
         }

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -148,6 +148,8 @@ pub enum Body {
     },
     RuntimeExecuteTxBatchResponse {
         batch: ComputedBatch,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        batch_weight_limits: Option<BTreeMap<CheckTxWeight, u64>>,
     },
     RuntimeKeyManagerPolicyUpdateRequest {
         #[serde(with = "serde_bytes")]

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -26,6 +26,9 @@ use crate::{
     transaction::types::TxnBatch,
 };
 
+/// Name of the batch weight limit runtime query method.
+pub const BATCH_WEIGHT_LIMIT_QUERY_METHOD: &'static str = "internal.BatchWeightLimits";
+
 /// Computed batch.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ComputedBatch {
@@ -156,7 +159,8 @@ pub enum Body {
         header: Header,
         epoch: EpochTime,
         method: String,
-        args: cbor::Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        args: Option<cbor::Value>,
     },
     RuntimeQueryResponse {
         data: cbor::Value,
@@ -257,6 +261,15 @@ pub enum CheckTxWeight {
     ConsensusMessages,
     /// Runtime specific weight key.
     Custom(String),
+}
+
+impl From<&str> for CheckTxWeight {
+    fn from(s: &str) -> Self {
+        match s {
+            "consensus_messages" => Self::ConsensusMessages,
+            _ => Self::Custom(s.to_string()),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/3974

See also: https://github.com/oasisprotocol/oasis-sdk/pull/146

Executor worker now queries `"internal.BatchWeightLimits"` runtime method to receive custom batch weight limits on every round.