### PR TITLE
docs: Avoid / in backport/changelog git branch names in Release Process

### DIFF
--- a/.changelog/3891.doc.md
+++ b/.changelog/3891.doc.md
@@ -1,0 +1,3 @@
+Note that `RELEASE_BRANCH` variable needs to be exported in [Release Process]
+
+[Release Process]: docs/release-process.md

--- a/.changelog/3891.docs.md
+++ b/.changelog/3891.docs.md
@@ -1,3 +1,0 @@
-Note that `RELEASE_BRANCH` variable need to be exported in [Release Process]
-
-[Release Process]: docs/release-process.md

--- a/.changelog/3993.doc.md
+++ b/.changelog/3993.doc.md
@@ -1,0 +1,3 @@
+Note that `RELEASE_BRANCH` variable needs to be exported in [Release Process]
+
+[Release Process]: docs/release-process.md

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -175,11 +175,11 @@ export RELEASE_BRANCH="stable/21.2.x"
 
 ### Back-port Changes
 
-Create a new branch, e.g. `${RELEASE_BRANCH}/backport-foo`, from the
+Create a new branch, e.g. `${RELEASE_BRANCH}-backport-foo`, from the
 `${RELEASE_BRANCH}` branch:
 
 ```bash
-git checkout -b ${RELEASE_BRANCH}/backport-foo ${RELEASE_BRANCH}
+git checkout -b ${RELEASE_BRANCH}-backport-foo ${RELEASE_BRANCH}
 ```
 
 After back-porting all the desired changes, push it to the origin and make a
@@ -191,11 +191,11 @@ As with a regular release, the back-ported changes should include the
 corresponding [Change Log Fragments] that need to be assembled into a new
 section of the [Change Log] using the `changelog` [Make] target.
 
-Create a new branch, e.g. `${RELEASE_BRANCH}/changelog`, from the
+Create a new branch, e.g. `${RELEASE_BRANCH}-changelog`, from the
 `${RELEASE_BRANCH}` branch:
 
 ```bash
-git checkout -b ${RELEASE_BRANCH}/changelog ${RELEASE_BRANCH}
+git checkout -b ${RELEASE_BRANCH}-changelog ${RELEASE_BRANCH}
 ```
 
 Then run [Make]'s `changelog` target:


### PR DESCRIPTION
Apparently, Git has a limitation where if branch named `b` exists, no branch named `b/something` can be created:
https://stackoverflow.com/a/22630664/1872673.

Hence, if branch named `stable/21.2.x` exists, one is unable to create a `stable/21.2.x/backport-foo` or `stable/21.2.x/changelog` branch.