### PR TITLE
go/oasis-net-runner: Always honor fixture.default.setup_runtimes

### DIFF
--- a/.changelog/4009.bugfix.md
+++ b/.changelog/4009.bugfix.md
@@ -1,0 +1,1 @@
+go/oasis-net-runner: Always honor fixture.default.setup_runtimes


### PR DESCRIPTION
This fixes a behavior that was introduced in 3e6d8f911f509614361e9b4efae1e3a500b66c20 where if you set `fixture.default.setup_runtimes` to `false` it could generate an incorrect fixture when `fixture.default.runtime.binary` is set to its default value.