### PR TITLE
go/staking: Add DebondingStartEscrowEvent

### DIFF
--- a/.changelog/4014.feature.md
+++ b/.changelog/4014.feature.md
@@ -1,0 +1,4 @@
+go/staking: Add DebondingStartEscrowEvent
+
+This makes it easier to reason about the debonded amounts, both in shares and
+in base units.

--- a/go/consensus/tendermint/apps/staking/api.go
+++ b/go/consensus/tendermint/apps/staking/api.go
@@ -41,6 +41,9 @@ var (
 	// (value is an api.AddEscrowEvent).
 	KeyAddEscrow = stakingState.KeyAddEscrow
 
+	// KeyDebondingStart is an ABCI event attribute key for DebondingStartEscrowEvents.
+	KeyDebondingStart = []byte("debonding_start")
+
 	// KeyAllowanceChange is an ABCI event attribute key for AllowanceChangeEvents.
 	KeyAllowanceChange = []byte("allowance_change")
 )

--- a/go/consensus/tendermint/staking/staking.go
+++ b/go/consensus/tendermint/staking/staking.go
@@ -369,6 +369,16 @@ func EventsFromTendermint(
 
 				evt := &api.Event{Height: height, TxHash: txHash, Escrow: &api.EscrowEvent{Add: &e}}
 				events = append(events, evt)
+			case bytes.Equal(key, app.KeyDebondingStart):
+				// Debonding start escrow event.
+				var e api.DebondingStartEscrowEvent
+				if err := cbor.Unmarshal(val, &e); err != nil {
+					errs = multierror.Append(errs, fmt.Errorf("staking: corrupt DebondingStart escrow event: %w", err))
+					continue
+				}
+
+				evt := &api.Event{Height: height, TxHash: txHash, Escrow: &api.EscrowEvent{DebondingStart: &e}}
+				events = append(events, evt)
 			case bytes.Equal(key, app.KeyBurn):
 				// Burn event.
 				var e api.BurnEvent

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -227,9 +227,10 @@ type BurnEvent struct {
 
 // EscrowEvent is an escrow event.
 type EscrowEvent struct {
-	Add     *AddEscrowEvent     `json:"add,omitempty"`
-	Take    *TakeEscrowEvent    `json:"take,omitempty"`
-	Reclaim *ReclaimEscrowEvent `json:"reclaim,omitempty"`
+	Add            *AddEscrowEvent            `json:"add,omitempty"`
+	Take           *TakeEscrowEvent           `json:"take,omitempty"`
+	DebondingStart *DebondingStartEscrowEvent `json:"debonding_start,omitempty"`
+	Reclaim        *ReclaimEscrowEvent        `json:"reclaim,omitempty"`
 }
 
 // Event signifies a staking event, returned via GetEvents.
@@ -257,6 +258,21 @@ type AddEscrowEvent struct {
 type TakeEscrowEvent struct {
 	Owner  Address           `json:"owner"`
 	Amount quantity.Quantity `json:"amount"`
+}
+
+// DebondingStartEvent is the event emitted when the debonding process has
+// started and the given number of active shares have been moved into the
+// debonding pool and started debonding.
+//
+// Note that the given amount is valid at the time of debonding start and
+// may not correspond to the final debonded amount in case any escrowed
+// stake is subject to slashing.
+type DebondingStartEscrowEvent struct {
+	Owner           Address           `json:"owner"`
+	Escrow          Address           `json:"escrow"`
+	Amount          quantity.Quantity `json:"amount"`
+	ActiveShares    quantity.Quantity `json:"active_shares"`
+	DebondingShares quantity.Quantity `json:"debonding_shares"`
 }
 
 // ReclaimEscrowEvent is the event emitted when stake is reclaimed from an


### PR DESCRIPTION
This makes it easier to reason about the debonded amounts, both in shares and
in base units.