### PR TITLE
runtime/core/common/bytes: impl Copy on bytes types

### DIFF
--- a/runtime/src/common/bytes.rs
+++ b/runtime/src/common/bytes.rs
@@ -11,7 +11,7 @@
 macro_rules! impl_bytes {
     ($name:ident, $size:expr, $doc:expr) => {
         #[doc=$doc]
-        #[derive(Clone)]
+        #[derive(Clone, Copy)]
         pub struct $name(pub [u8; $size]);
 
         impl $name {
@@ -62,8 +62,6 @@ macro_rules! impl_bytes {
                 $name([0; $size])
             }
         }
-
-        impl Copy for $name {}
 
         impl Into<[u8; $size]> for $name {
             fn into(self) -> [u8; $size] {


### PR DESCRIPTION
This PR makes bytes types `Copy`,  which is useful for [`PublicKey`](https://nhynes.github.io/oasis_runtime_sdk/crypto/signature/ed25519/struct.PublicKey.html) in [`AuthProof`](https://nhynes.github.io/oasis_runtime_sdk/types/transaction/enum.AuthProof.html). It's a little easier to return a new `AuthProof` with an updated nonce than make the thing mutable with a lock.