### PR TITLE
Enable development on macOS without docker

### DIFF
--- a/.changelog/4024.feature.2.md
+++ b/.changelog/4024.feature.2.md
@@ -1,0 +1,4 @@
+go/oasis-net-runner: allow setting runtime provisioner
+
+On systems that do not support bwrap, the runtime provisioner can be
+set to `unconfined`.

--- a/.changelog/4024.feature.3.md
+++ b/.changelog/4024.feature.3.md
@@ -1,0 +1,4 @@
+go/oasis-net-runner: allow running without a keymanager
+
+This feature makes it easier to run debug runtimes that are not (yet)
+associated with a keymanager.

--- a/.changelog/4024.feature.md
+++ b/.changelog/4024.feature.md
@@ -1,0 +1,1 @@
+runtime-loader: allow bulding for non-SGX use on platforms that aren't Linux

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -30,6 +30,7 @@ const (
 	cfgNumEntities             = "fixture.default.num_entities"
 	cfgRuntimeID               = "fixture.default.runtime.id"
 	cfgRuntimeBinary           = "fixture.default.runtime.binary"
+	cfgRuntimeProvisioner      = "fixture.default.runtime.provisioner"
 	cfgRuntimeGenesisState     = "fixture.default.runtime.genesis_state"
 	cfgRuntimeLoader           = "fixture.default.runtime.loader"
 	cfgSetupRuntimes           = "fixture.default.setup_runtimes"
@@ -105,8 +106,12 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 		fixture.Entities = append(fixture.Entities, oasis.EntityCfg{})
 	}
 
+	runtimeProvisioner := viper.GetString(cfgRuntimeProvisioner)
+
 	// Always run a client node.
-	fixture.Clients = []oasis.ClientFixture{{}}
+	fixture.Clients = []oasis.ClientFixture{{
+		RuntimeProvisioner: runtimeProvisioner,
+	}}
 
 	if viper.GetBool(cfgSetupRuntimes) {
 		fixture.Runtimes = []oasis.RuntimeFixture{
@@ -129,15 +134,15 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 			{Runtime: 0, Serial: 1},
 		}
 		fixture.Keymanagers = []oasis.KeymanagerFixture{
-			{Runtime: 0, Entity: 1},
+			{Runtime: 0, Entity: 1, RuntimeProvisioner: runtimeProvisioner},
 		}
 		fixture.StorageWorkers = []oasis.StorageWorkerFixture{
 			{Backend: "badger", Entity: 1},
 		}
 		fixture.ComputeWorkers = []oasis.ComputeWorkerFixture{
-			{Entity: 1, Runtimes: []int{}},
-			{Entity: 1, Runtimes: []int{}},
-			{Entity: 1, Runtimes: []int{}},
+			{Entity: 1, Runtimes: []int{}, RuntimeProvisioner: runtimeProvisioner},
+			{Entity: 1, Runtimes: []int{}, RuntimeProvisioner: runtimeProvisioner},
+			{Entity: 1, Runtimes: []int{}, RuntimeProvisioner: runtimeProvisioner},
 		}
 
 		var runtimeIDs []common.Namespace
@@ -215,6 +220,7 @@ func init() {
 	DefaultFixtureFlags.String(cfgNodeBinary, "oasis-node", "path to the oasis-node binary")
 	DefaultFixtureFlags.StringSlice(cfgRuntimeID, []string{"8000000000000000000000000000000000000000000000000000000000000000"}, "runtime ID")
 	DefaultFixtureFlags.StringSlice(cfgRuntimeBinary, []string{"simple-keyvalue"}, "path to the runtime binary")
+	DefaultFixtureFlags.String(cfgRuntimeProvisioner, "sandboxed", "the runtime provisioner: mock, unconfined, or sandboxed")
 	// []string{""} as default doesn't work and ends up as an empty slice.
 	DefaultFixtureFlags.StringSlice(cfgRuntimeGenesisState, []string{"", ""}, "path to the runtime genesis state")
 	DefaultFixtureFlags.String(cfgRuntimeLoader, "oasis-core-runtime-loader", "path to the runtime loader")

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -308,6 +308,8 @@ type KeymanagerFixture struct {
 	Entity  int `json:"entity"`
 	Policy  int `json:"policy"`
 
+	RuntimeProvisioner string `json:"runtime_provisioner"`
+
 	AllowEarlyTermination bool `json:"allow_early_termination"`
 	AllowErrorTermination bool `json:"allow_error_termination"`
 
@@ -353,9 +355,10 @@ func (f *KeymanagerFixture) Create(net *Network) (*Keymanager, error) {
 			NoAutoStart:                 f.NoAutoStart,
 			Entity:                      entity,
 		},
-		Runtime:       runtime,
-		Policy:        policy,
-		SentryIndices: f.Sentries,
+		RuntimeProvisioner: f.RuntimeProvisioner,
+		Runtime:            runtime,
+		Policy:             policy,
+		SentryIndices:      f.Sentries,
 	})
 }
 
@@ -546,6 +549,8 @@ type ClientFixture struct {
 	// Runtimes contains the indexes of the runtimes to enable.
 	Runtimes []int `json:"runtimes,omitempty"`
 
+	RuntimeProvisioner string `json:"runtime_provisioner"`
+
 	// RuntimeConfig contains the per-runtime node-local configuration.
 	RuntimeConfig map[int]map[string]interface{} `json:"runtime_config,omitempty"`
 
@@ -564,9 +569,10 @@ func (f *ClientFixture) Create(net *Network) (*Client, error) {
 			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
 			EnableProfiling:             f.EnableProfiling,
 		},
-		MaxTransactionAge: f.MaxTransactionAge,
-		Runtimes:          f.Runtimes,
-		RuntimeConfig:     f.RuntimeConfig,
+		MaxTransactionAge:  f.MaxTransactionAge,
+		Runtimes:           f.Runtimes,
+		RuntimeProvisioner: f.RuntimeProvisioner,
+		RuntimeConfig:      f.RuntimeConfig,
 	})
 }
 

--- a/runtime-loader/Cargo.toml
+++ b/runtime-loader/Cargo.toml
@@ -5,13 +5,15 @@ authors = ["Oasis Protocol Foundation <info@oasisprotocol.org>"]
 edition = "2018"
 
 [dependencies]
-aesm-client = { version = "0.5.3", features = ["sgxs"] }
-enclave-runner = "0.4.0"
-sgxs-loaders = "0.3.1"
 clap = "2.29.1"
 failure = "0.1.5"
 futures = { version = "0.3.7", features = ["compat", "io-compat"] }
 tokio = { version = "0.2", features = ["full"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+aesm-client = { version = "0.5.3", features = ["sgxs"] }
+enclave-runner = "0.4.0"
+sgxs-loaders = "0.3.1"
 
 [[bin]]
 name = "oasis-core-runtime-loader"

--- a/runtime-loader/bin/main.rs
+++ b/runtime-loader/bin/main.rs
@@ -5,7 +5,9 @@ use std::path::Path;
 
 use clap::{App, Arg};
 
-use oasis_core_runtime_loader::{ElfLoader, Loader, SgxsLoader};
+#[cfg(target_os = "linux")]
+use oasis_core_runtime_loader::SgxsLoader;
+use oasis_core_runtime_loader::{ElfLoader, Loader};
 
 fn main() {
     let matches = App::new("Oasis runtime loader")
@@ -52,7 +54,10 @@ fn main() {
 
     // Create appropriate loader and run the runtime.
     let loader: Box<dyn Loader> = match mode {
+        #[cfg(target_os = "linux")]
         "sgxs" => Box::new(SgxsLoader),
+        #[cfg(not(target_os = "linux"))]
+        "sgxs" => panic!("SGXS loader is only supported on Linux"),
         "elf" => Box::new(ElfLoader),
         _ => panic!("Invalid runtime type specified"),
     };

--- a/runtime-loader/src/lib.rs
+++ b/runtime-loader/src/lib.rs
@@ -1,10 +1,7 @@
 //! Oasis runtime loader.
-extern crate aesm_client;
-extern crate enclave_runner;
-extern crate failure;
-extern crate sgxs_loaders;
 
 pub mod elf;
+#[cfg(target_os = "linux")]
 pub mod sgxs;
 
 use failure::Fallible;
@@ -21,4 +18,6 @@ pub trait Loader {
 }
 
 // Re-exports.
-pub use self::{elf::ElfLoader, sgxs::SgxsLoader};
+pub use elf::ElfLoader;
+#[cfg(target_os = "linux")]
+pub use sgxs::SgxsLoader;


### PR DESCRIPTION
This PR:
* adds conditional compilation to the `oasis-core-runtime-loader`
* allows setting the provisioner through `oasis-net-runner` (to unconfined)
* allows running a net without a keymanager since `simple-keymanager` isn't fun to compile with musl