### PR TITLE
Updates useful for oasis-sdk#96

### DIFF
--- a/.changelog/4025.cfg.md
+++ b/.changelog/4025.cfg.md
@@ -1,0 +1,6 @@
+Add flags controlling libp2p validator concurrency
+
+- `worker.p2p.validate_concurrency` - libp2p gossipsub per topic validator
+    concurrency limit
+- `worker.p2p.validate_throttle` - libp2p gossipsub validator concurrency
+    limit

--- a/.changelog/4025.feature.md
+++ b/.changelog/4025.feature.md
@@ -1,0 +1,1 @@
+oasis-net-runner: support setting custom node arguments in fixtures

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -75,6 +75,11 @@ func (args *argBuilder) clone() *argBuilder {
 	}
 }
 
+func (args *argBuilder) extraArgs(extra []Argument) *argBuilder {
+	args.vec = append(args.vec, extra...)
+	return args
+}
+
 func (args *argBuilder) mergeConfigMap(cfg map[string]interface{}) *argBuilder {
 	if args.config == nil {
 		args.config = viper.New()

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -154,6 +154,8 @@ type NodeFixture struct {
 	// Name is the name of the node that hosts the feature. Leave empty
 	// to automatically instantiate a dedicated node with a default name.
 	Name string `json:"node_name,omitempty"`
+
+	ExtraArgs []Argument `json:"extra_args,omitempty"`
 }
 
 // TEEFixture is a TEE configuration fixture.
@@ -208,6 +210,7 @@ func (f *ValidatorFixture) Create(net *Network) (*Validator, error) {
 			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
 			EnableProfiling:             f.EnableProfiling,
 			Entity:                      entity,
+			ExtraArgs:                   f.ExtraArgs,
 		},
 		Sentries: sentries,
 	})
@@ -354,6 +357,7 @@ func (f *KeymanagerFixture) Create(net *Network) (*Keymanager, error) {
 			Consensus:                   f.Consensus,
 			NoAutoStart:                 f.NoAutoStart,
 			Entity:                      entity,
+			ExtraArgs:                   f.ExtraArgs,
 		},
 		RuntimeProvisioner: f.RuntimeProvisioner,
 		Runtime:            runtime,
@@ -416,6 +420,7 @@ func (f *StorageWorkerFixture) Create(net *Network) (*Storage, error) {
 			LogWatcherHandlerFactories:  f.LogWatcherHandlerFactories,
 			Consensus:                   f.Consensus,
 			Entity:                      entity,
+			ExtraArgs:                   f.ExtraArgs,
 		},
 		Backend:                 f.Backend,
 		SentryIndices:           f.Sentries,
@@ -478,6 +483,7 @@ func (f *ComputeWorkerFixture) Create(net *Network) (*Compute, error) {
 			LogWatcherHandlerFactories:  f.LogWatcherHandlerFactories,
 			Consensus:                   f.Consensus,
 			Entity:                      entity,
+			ExtraArgs:                   f.ExtraArgs,
 		},
 		RuntimeProvisioner: f.RuntimeProvisioner,
 		Runtimes:           f.Runtimes,
@@ -527,6 +533,7 @@ func (f *SentryFixture) Create(net *Network) (*Sentry, error) {
 			CrashPointsProbability:      f.CrashPointsProbability,
 			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
 			EnableProfiling:             f.EnableProfiling,
+			ExtraArgs:                   f.ExtraArgs,
 		},
 		ValidatorIndices:  f.Validators,
 		StorageIndices:    f.StorageWorkers,
@@ -568,6 +575,7 @@ func (f *ClientFixture) Create(net *Network) (*Client, error) {
 			AllowEarlyTermination:       f.AllowEarlyTermination,
 			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
 			EnableProfiling:             f.EnableProfiling,
+			ExtraArgs:                   f.ExtraArgs,
 		},
 		MaxTransactionAge:  f.MaxTransactionAge,
 		Runtimes:           f.Runtimes,

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -81,12 +81,12 @@ type Node struct { // nolint: maligned
 
 	Name   string
 	NodeID signature.PublicKey
-	Args   *argBuilder
 
 	net *Network
 	dir *env.Dir
 	cmd *exec.Cmd
 
+	extraArgs      []Argument
 	features       []Feature
 	hasValidators  bool
 	assignedPorts  map[string]uint16
@@ -201,6 +201,8 @@ func (n *Node) Start() error {
 	for _, hosted := range n.hostedRuntimes {
 		args.appendHostedRuntime(hosted.runtime, hosted.tee, hosted.binaryIdx, hosted.localConfig)
 	}
+
+	args.extraArgs(n.extraArgs)
 
 	if customStart != nil {
 		return customStart.CustomStart(args)
@@ -359,6 +361,8 @@ type NodeCfg struct { // nolint: maligned
 	Consensus ConsensusFixture
 
 	Entity *Entity
+
+	ExtraArgs []Argument
 }
 
 // Into sets node parameters of an existing node object from the configuration.
@@ -381,6 +385,7 @@ func (cfg *NodeCfg) Into(node *Node) {
 	if node.pprofPort == 0 && cfg.EnableProfiling {
 		node.pprofPort = node.getProvisionedPort(nodePortPprof)
 	}
+	node.extraArgs = cfg.ExtraArgs
 }
 
 func nodeLogPath(dir *env.Dir) string {

--- a/go/worker/common/p2p/init.go
+++ b/go/worker/common/p2p/init.go
@@ -18,6 +18,12 @@ const (
 	CfgP2PPeerOutboundQueueSize = "worker.p2p.peer_outbound_queue_size"
 	// CfgP2PValidateQueueSize sets the libp2p gossipsub buffer size of the validate queue.
 	CfgP2PValidateQueueSize = "worker.p2p.validate_queue_size"
+	// CfgP2PValidateConcurrency sets the libp2p gossipsub per topic validator concurrency limit.
+	// Note: this is a per-topic concurrency limit. We use one topic per runtime.
+	CfgP2PValidateConcurrency = "worker.p2p.validate_concurrency"
+	// CfgP2PValidateThrottle sets the libp2p gossipsub validator concurrency limit.
+	// Note: this is a global (across all topics) validator concurrency limit.
+	CfgP2PValidateThrottle = "worker.p2p.validate_throttle"
 	// CfgP2PConnectednessLowWater sets the ratio of connected to unconnected peers at which
 	// the peer manager will try to reconnect to disconnected nodes.
 	CfgP2PConnectednessLowWater = "worker.p2p.connectedness_low_water"
@@ -37,6 +43,8 @@ func init() {
 	Flags.StringSlice(cfgP2pAddresses, []string{}, "Address/port(s) to use for P2P connections when registering this node (if not set, all non-loopback local interfaces will be used)")
 	Flags.Int64(CfgP2PPeerOutboundQueueSize, 32, "Set libp2p gossipsub buffer size for outbound messages")
 	Flags.Int64(CfgP2PValidateQueueSize, 32, "Set libp2p gossipsub buffer size of the validate queue")
+	Flags.Int64(CfgP2PValidateConcurrency, 1024, "Set libp2p gossipsub per topic validator concurrency limit")
+	Flags.Int64(CfgP2PValidateThrottle, 8192, "Set libp2p gossipsub validator concurrency limit")
 	Flags.Float64(CfgP2PConnectednessLowWater, 0.2, "Set the low water mark at which the peer manager will try to reconnect to peers")
 
 	_ = viper.BindPFlags(Flags)

--- a/go/worker/common/p2p/p2p.go
+++ b/go/worker/common/p2p/p2p.go
@@ -141,7 +141,11 @@ func (p *P2P) RegisterHandler(runtimeID common.Namespace, handler Handler) {
 			panic(fmt.Sprintf("worker/common/p2p: failed to initialize topic handler: %s", err))
 		}
 		p.topics[runtimeID] = h
-		_ = p.pubsub.RegisterTopicValidator(topicID, h.topicMessageValidator)
+		_ = p.pubsub.RegisterTopicValidator(
+			topicID,
+			h.topicMessageValidator,
+			pubsub.WithValidatorConcurrency(viper.GetInt(CfgP2PValidateConcurrency)),
+		)
 	default:
 		topic.handlersLock.Lock()
 		defer topic.handlersLock.Unlock()
@@ -213,6 +217,7 @@ func New(ctx context.Context, identity *identity.Identity, consensus consensus.B
 		pubsub.WithFloodPublish(true),
 		pubsub.WithPeerOutboundQueueSize(viper.GetInt(CfgP2PPeerOutboundQueueSize)),
 		pubsub.WithValidateQueueSize(viper.GetInt(CfgP2PValidateQueueSize)),
+		pubsub.WithValidateThrottle(viper.GetInt(CfgP2PValidateThrottle)),
 		pubsub.WithMessageIdFn(func(pmsg *pb.Message) string {
 			h := hash.NewFromBytes(pmsg.Data)
 			return string(h[:])


### PR DESCRIPTION
Some updates useful for https://github.com/oasisprotocol/oasis-sdk/issues/96

- configurable libp2p gossipsub validator concurrences
- ~increase `runtime/src/dispatcher.rs` channel backlog size~
- support setting custom node arguments in oasis-runner fixtures