### PR TITLE
badger/migration: keep only last version when migrating non-managed DB

### DIFF
--- a/.changelog/4037.bugfix.md
+++ b/.changelog/4037.bugfix.md
@@ -1,0 +1,8 @@
+badger/migration: keep only last version when migrating non-managed DB
+
+Even though oasis-core always configures non-managed badger databases to keep
+a single version of keys, some databases in the wild contain multiple versions
+of the same key.
+
+Skip migrating more than the latest version when migrating non-managed
+badger databases.

--- a/go/common/badger/helpers.go
+++ b/go/common/badger/helpers.go
@@ -5,7 +5,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"strings"
 	"sync"
@@ -187,9 +186,15 @@ func migrateDatabase(opts badger.Options, managed bool) error {
 		openFnV3 = badger.OpenManaged
 	}
 
+	// All non-managed databases used by oasis-core are configured to keep only one version.
+	// Part of the migrator assumes this, therefore fail in case this is not the case.
+	if !managed && opts.NumVersionsToKeep != 1 {
+		return fmt.Errorf("migration assumes 1 version to keep for non-managed databases")
+	}
+
 	// Open the database as Badger v2.
 	optsV2 := badgerV2.DefaultOptions(opts.Dir)
-	optsV2 = optsV2.WithNumVersionsToKeep(math.MaxInt32)
+	optsV2 = optsV2.WithNumVersionsToKeep(opts.NumVersionsToKeep)
 	optsV2 = optsV2.WithLogger(nil)
 
 	dbV2, err := openFnV2(optsV2)
@@ -199,9 +204,9 @@ func migrateDatabase(opts badger.Options, managed bool) error {
 	defer dbV2.Close()
 
 	// Open the destination database as Badger v3.
-	optsV3 := badger.DefaultOptions(temporaryDbName)
-	optsV3 = optsV3.WithNumVersionsToKeep(math.MaxInt32)
-	optsV3 = optsV3.WithLogger(NewLogAdapter(logger))
+	optsV3 := opts
+	optsV3 = optsV3.WithDir(temporaryDbName)
+	optsV3 = optsV3.WithValueDir(temporaryDbName)
 
 	dbV3, err := openFnV3(optsV3)
 	if err != nil {

--- a/go/common/badger/helpers.go
+++ b/go/common/badger/helpers.go
@@ -12,6 +12,7 @@ import (
 
 	badgerV2 "github.com/dgraph-io/badger/v2"
 	"github.com/dgraph-io/badger/v3"
+	"github.com/spf13/viper"
 
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 )
@@ -207,6 +208,7 @@ func migrateDatabase(opts badger.Options, managed bool) error {
 	optsV3 := opts
 	optsV3 = optsV3.WithDir(temporaryDbName)
 	optsV3 = optsV3.WithValueDir(temporaryDbName)
+	optsV3 = optsV3.WithNumGoroutines(viper.GetInt(cfgMigrateNumGoRoutines))
 
 	dbV3, err := openFnV3(optsV3)
 	if err != nil {

--- a/go/common/badger/migrate.go
+++ b/go/common/badger/migrate.go
@@ -57,6 +57,14 @@ func backup(db *badgerV2.DB, w io.Writer, managed bool) (uint64, error) {
 				Meta:      []byte{meta},
 			}
 			list.Kv = append(list.Kv, kv)
+
+			if !managed {
+				// Migrate only last version of the key in case this is a non-managed database.
+				// All non-managed oasis-core databases are configured to only keep one version,
+				// but due to what looks like a badger bug, it can happen that a key can have
+				// multiple historical versions in the database.
+				return list, nil
+			}
 		}
 		return list, nil
 	}

--- a/go/common/badger/migrate.go
+++ b/go/common/badger/migrate.go
@@ -10,7 +10,16 @@ import (
 	badgerV2 "github.com/dgraph-io/badger/v2"
 	"github.com/dgraph-io/badger/v2/pb"
 	"github.com/golang/protobuf/proto" //nolint: staticcheck
+	flag "github.com/spf13/pflag"
+	"github.com/spf13/viper"
 )
+
+const (
+	cfgMigrateNumGoRoutines = "badger.migrate.num_go_routines"
+)
+
+// MigrationFlags has the migration flags.
+var MigrationFlags = flag.NewFlagSet("", flag.ContinueOnError)
 
 // Adapted from Badger v2 which is Copyright 2017 Dgraph Labs, Inc. and Contributors, released
 // under the Apache-2 license.
@@ -23,6 +32,7 @@ func backup(db *badgerV2.DB, w io.Writer, managed bool) (uint64, error) {
 	case false:
 		stream = db.NewStream()
 	}
+	stream.NumGo = viper.GetInt(cfgMigrateNumGoRoutines)
 
 	stream.LogPrefix = "migration"
 	stream.KeyToList = func(key []byte, itr *badgerV2.Iterator) (*pb.KVList, error) {
@@ -91,4 +101,9 @@ func backup(db *badgerV2.DB, w io.Writer, managed bool) (uint64, error) {
 		return 0, err
 	}
 	return maxVersion, nil
+}
+
+func init() {
+	MigrationFlags.Int(cfgMigrateNumGoRoutines, 8, "number of go routines to use when migrating (useful to lower memory pressure during migration)")
+	_ = viper.BindPFlags(MigrationFlags)
 }

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -14,6 +14,7 @@ import (
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/badger"
 	"github.com/oasisprotocol/oasis-core/go/common/crash"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/grpc"
@@ -797,6 +798,7 @@ func init() {
 		workerSentry.Flags,
 		workerConsensusRPC.Flags,
 		crash.InitFlags(),
+		badger.MigrationFlags,
 	} {
 		Flags.AddFlagSet(v)
 	}


### PR DESCRIPTION
Even though oasis-core always configures non-managed badger databases to keep
a single version of keys, some databases in the wild contain multiple versions
of the same key.

Skip migrating more than the latest version when migrating non-managed
badger databases.