### PR TITLE
go/worker/common: Move committee storage to Group

### DIFF
--- a/.changelog/4061.bugfix.md
+++ b/.changelog/4061.bugfix.md
@@ -1,0 +1,1 @@
+go/worker/executor: Do not route local storage applies via gRPC

--- a/.changelog/4061.internal.md
+++ b/.changelog/4061.internal.md
@@ -1,0 +1,1 @@
+go/worker/common: Move committee storage to Group

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -399,9 +399,6 @@ func (n *Node) initRuntimeWorkers() error {
 	n.svcMgr.Register(n.KeymanagerWorker)
 
 	// Initialize the executor worker.
-	// Keep this step _after_ initializing the storage worker,
-	// because the executor worker will use the local storage backend
-	// if it is available.
 	n.ExecutorWorker, err = executor.New(
 		dataDir,
 		n.CommonWorker,
@@ -433,6 +430,11 @@ func (n *Node) initRuntimeWorkers() error {
 }
 
 func (n *Node) startRuntimeWorkers() error {
+	// Start the common worker.
+	if err := n.CommonWorker.Start(); err != nil {
+		return err
+	}
+
 	// Start the runtime client service.
 	if err := n.RuntimeClient.Start(); err != nil {
 		return fmt.Errorf("failed to start runtime client service: %w", err)
@@ -445,11 +447,6 @@ func (n *Node) startRuntimeWorkers() error {
 
 	// Start the executor worker.
 	if err := n.ExecutorWorker.Start(); err != nil {
-		return err
-	}
-
-	// Start the common worker.
-	if err := n.CommonWorker.Start(); err != nil {
 		return err
 	}
 

--- a/go/runtime/registry/registry.go
+++ b/go/runtime/registry/registry.go
@@ -127,6 +127,7 @@ type runtime struct { // nolint: maligned
 	activeDescriptor     *registry.Runtime
 	activeDescriptorHash hash.Hash
 	roles                node.RolesMask
+	managed              bool
 
 	consensus    consensus.Backend
 	storage      storageAPI.Backend
@@ -232,7 +233,7 @@ func (r *runtime) Storage() storageAPI.Backend {
 	r.RLock()
 	defer r.RUnlock()
 
-	if r.storage == nil {
+	if r.storage == nil && r.managed {
 		panic("runtime storage accessed before initialization")
 	}
 	return r.storage
@@ -517,6 +518,7 @@ func (r *runtimeRegistry) addSupportedRuntime(ctx context.Context, id common.Nam
 	if err != nil {
 		return err
 	}
+	rt.managed = true
 
 	// Create runtime history keeper.
 	history, err := history.New(path, id, &r.cfg.History)

--- a/go/worker/common/committee/group.go
+++ b/go/worker/common/committee/group.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
-	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
@@ -235,8 +234,9 @@ func (e *EpochSnapshot) VerifyTxnSchedulerSigner(sig signature.Signature, round 
 type Group struct {
 	sync.RWMutex
 
-	identity  *identity.Identity
-	runtimeID common.Namespace
+	ctx      context.Context
+	identity *identity.Identity
+	runtime  runtimeRegistry.Runtime
 
 	consensus consensus.Backend
 
@@ -248,7 +248,8 @@ type Group struct {
 	// nodes is a node descriptor watcher for all nodes that are part of any of our committees.
 	nodes nodes.VersionedNodeDescriptorWatcher
 	// storage is the storage backend that tracks the current committee.
-	storage storage.ClientBackend
+	storage       storage.Backend
+	storageClient storage.ClientBackend
 
 	logger *logging.Logger
 }
@@ -311,7 +312,7 @@ func (g *Group) EpochTransition(ctx context.Context, height int64) error {
 
 	// Request committees from scheduler.
 	committees, err := g.consensus.Scheduler().GetCommittees(ctx, &scheduler.GetCommitteesRequest{
-		RuntimeID: g.runtimeID,
+		RuntimeID: g.runtime.ID(),
 		Height:    height,
 	})
 	if err != nil {
@@ -372,14 +373,17 @@ func (g *Group) EpochTransition(ctx context.Context, height int64) error {
 	}
 
 	// Fetch current runtime descriptor.
-	runtime, err := g.consensus.Registry().GetRuntime(ctx, &registry.NamespaceQuery{ID: g.runtimeID, Height: height})
+	runtime, err := g.consensus.Registry().GetRuntime(ctx, &registry.NamespaceQuery{ID: g.runtime.ID(), Height: height})
 	if err != nil {
 		return err
 	}
 
 	// Freeze the committee and make sure the storage client has been updated.
 	g.nodes.Freeze(height)
-	if err = g.storage.EnsureCommitteeVersion(ctx, height); err != nil {
+	if g.storageClient == nil {
+		return fmt.Errorf("group: storage not yet initialized")
+	}
+	if err = g.storageClient.EnsureCommitteeVersion(ctx, height); err != nil {
 		return fmt.Errorf("group: failed to ensure committee version: %w", err)
 	}
 
@@ -522,7 +526,7 @@ func (g *Group) Publish(msg *p2p.Message) error {
 	msg.GroupVersion = g.activeEpoch.groupVersion
 
 	// Publish message to the P2P network.
-	g.p2p.Publish(pubCtx, g.runtimeID, msg)
+	g.p2p.Publish(pubCtx, g.runtime.ID(), msg)
 
 	return nil
 }
@@ -532,12 +536,50 @@ func (g *Group) Peers() []string {
 	if g.p2p == nil {
 		return nil
 	}
-	return g.p2p.Peers(g.runtimeID)
+	return g.p2p.Peers(g.runtime.ID())
 }
 
 // Storage returns the storage client backend that talks to the runtime group.
 func (g *Group) Storage() storage.Backend {
 	return g.storage
+}
+
+// Start starts the group services.
+func (g *Group) Start() error {
+	g.Lock()
+	defer g.Unlock()
+
+	// Check if we have the local storage backend available (e.g., this node is also a storage node
+	// for this runtime). In this case we override the storage client's backend so that any updates
+	// don't go via gRPC but are redirected directly to the local backend instead.
+	var localStorageBackend storage.LocalBackend
+	if lsb, ok := g.runtime.Storage().(storage.LocalBackend); ok && g.runtime.HasRoles(node.RoleStorageWorker) {
+		localStorageBackend = lsb
+	}
+
+	// Create the storage client.
+	sc, err := storageClient.NewForNodes(
+		g.ctx,
+		g.identity,
+		nodes.NewFilteredNodeLookup(g.nodes, nodes.TagFilter(TagForCommittee(scheduler.KindStorage))),
+		g.runtime,
+	)
+	if err != nil {
+		return fmt.Errorf("group: failed to create storage client: %w", err)
+	}
+	g.storageClient = sc.(storage.ClientBackend)
+
+	// Create the storage multiplexer if we have a local storage backend.
+	if localStorageBackend != nil {
+		g.storage = storage.NewStorageMux(
+			storage.MuxReadOpFinishEarly(storage.MuxIterateIgnoringErrors()),
+			localStorageBackend,
+			g.storageClient,
+		)
+	} else {
+		g.storage = g.storageClient
+	}
+	return nil
 }
 
 // NewGroup creates a new group.
@@ -554,24 +596,14 @@ func NewGroup(
 		return nil, fmt.Errorf("group: failed to create node watcher: %w", err)
 	}
 
-	sc, err := storageClient.NewForNodes(
-		ctx,
-		identity,
-		nodes.NewFilteredNodeLookup(nw, nodes.TagFilter(TagForCommittee(scheduler.KindStorage))),
-		runtime,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("group: failed to create storage client: %w", err)
-	}
-
 	g := &Group{
+		ctx:       ctx,
 		identity:  identity,
-		runtimeID: runtime.ID(),
+		runtime:   runtime,
 		consensus: consensus,
 		handler:   handler,
 		p2p:       p2p,
 		nodes:     nw,
-		storage:   sc.(storage.ClientBackend),
 		logger:    logging.GetLogger("worker/common/committee/group").With("runtime_id", runtime.ID()),
 	}
 

--- a/go/worker/common/committee/group.go
+++ b/go/worker/common/committee/group.go
@@ -552,9 +552,11 @@ func (g *Group) Start() error {
 	// Check if we have the local storage backend available (e.g., this node is also a storage node
 	// for this runtime). In this case we override the storage client's backend so that any updates
 	// don't go via gRPC but are redirected directly to the local backend instead.
+	var scOpts []storageClient.Option
 	var localStorageBackend storage.LocalBackend
 	if lsb, ok := g.runtime.Storage().(storage.LocalBackend); ok && g.runtime.HasRoles(node.RoleStorageWorker) {
 		localStorageBackend = lsb
+		scOpts = append(scOpts, storageClient.WithBackendOverride(g.identity.NodeSigner.Public(), lsb))
 	}
 
 	// Create the storage client.
@@ -563,6 +565,7 @@ func (g *Group) Start() error {
 		g.identity,
 		nodes.NewFilteredNodeLookup(g.nodes, nodes.TagFilter(TagForCommittee(scheduler.KindStorage))),
 		g.runtime,
+		scOpts...,
 	)
 	if err != nil {
 		return fmt.Errorf("group: failed to create storage client: %w", err)

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -2,6 +2,7 @@ package committee
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -128,6 +129,10 @@ func (n *Node) Name() string {
 
 // Start starts the service.
 func (n *Node) Start() error {
+	if err := n.Group.Start(); err != nil {
+		return fmt.Errorf("failed to start group services: %w", err)
+	}
+
 	go n.worker()
 	return nil
 }

--- a/go/worker/compute/executor/committee/node.go
+++ b/go/worker/compute/executor/committee/node.go
@@ -161,8 +161,6 @@ type Node struct { // nolint: maligned
 	commonCfg    commonWorker.Config
 	roleProvider registration.RoleProvider
 
-	storage storage.Backend
-
 	ctx       context.Context
 	cancelCtx context.CancelFunc
 	stopCh    chan struct{}
@@ -959,7 +957,7 @@ func (n *Node) handleScheduleBatch(force bool) {
 
 	// Commit I/O tree to storage and obtain receipts.
 
-	ioReceipts, err := n.storage.Apply(roundCtx, &storage.ApplyRequest{
+	ioReceipts, err := n.commonNode.Group.Storage().Apply(roundCtx, &storage.ApplyRequest{
 		Namespace: blk.Header.Namespace,
 		RootType:  storage.RootTypeIO,
 		SrcRound:  blk.Header.Round + 1,
@@ -1107,7 +1105,7 @@ func (n *Node) startProcessingBatchLocked(batch *unresolvedBatch) {
 
 		// Resolve the batch and dispatch it to the runtime.
 		readStartTime := time.Now()
-		resolvedBatch, err := batch.resolve(ctx, n.storage)
+		resolvedBatch, err := batch.resolve(ctx, n.commonNode.Group.Storage())
 		if err != nil {
 			n.logger.Error("failed to resolve batch",
 				"err", err,
@@ -1262,7 +1260,7 @@ func (n *Node) proposeBatch(
 			},
 		}
 
-		receipts, err := n.storage.ApplyBatch(ctx, &storage.ApplyBatchRequest{
+		receipts, err := n.commonNode.Group.Storage().ApplyBatch(ctx, &storage.ApplyBatchRequest{
 			Namespace: lastHeader.Namespace,
 			DstRound:  lastHeader.Round + 1,
 			Ops:       applyOps,
@@ -1704,10 +1702,6 @@ func (n *Node) worker() {
 }
 
 // NewNode initializes a new executor node.
-//
-// NOTE: If the node is also a storage node, the executor node will use the
-// local storage backend in addition to the committee connections, so the storage
-// worker needs to be initialized before constructing the executor node.
 func NewNode(
 	commonNode *committee.Node,
 	commonCfg commonWorker.Config,
@@ -1735,17 +1729,6 @@ func NewNode(
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	var storageMux storage.Backend
-	if lsb, ok := commonNode.Runtime.Storage().(storage.LocalBackend); ok && commonNode.Runtime.HasRoles(node.RoleStorageWorker) {
-		storageMux = storage.NewStorageMux(
-			storage.MuxReadOpFinishEarly(storage.MuxIterateIgnoringErrors()),
-			lsb,
-			commonNode.Group.Storage(),
-		)
-	} else {
-		storageMux = commonNode.Group.Storage()
-	}
-
 	n := &Node{
 		RuntimeHostNode:       rhn,
 		commonNode:            commonNode,
@@ -1755,7 +1738,6 @@ func NewNode(
 		lastScheduledCache:    cache,
 		roundWeightLimits:     make(map[transaction.Weight]uint64),
 		scheduleCh:            channels.NewRingChannel(1),
-		storage:               storageMux,
 		ctx:                   ctx,
 		cancelCtx:             cancel,
 		stopCh:                make(chan struct{}),


### PR DESCRIPTION
Move committee storage to `Group` to make it available to all subworkers (instead of the executor worker having a specialized case) and change it so that it doesn't go through gRPC when communicating with the local node.