### PR TITLE
go/common/errors: expose all grpc errors as coded

### DIFF
--- a/.changelog/4067.feature.md
+++ b/.changelog/4067.feature.md
@@ -1,0 +1,1 @@
+Expose runtime query error details to clients

--- a/go/common/errors/errors.go
+++ b/go/common/errors/errors.go
@@ -109,7 +109,11 @@ func New(module string, code uint32, msg string) error {
 func FromCode(module string, code uint32, context string) error {
 	err, exists := registeredErrors.Load(errorKey(module, code))
 	if !exists || err == errUnknownError {
-		return errors.New(context)
+		return WithContext(&codedError{
+			module: module,
+			code:   code,
+			msg:    context,
+		}, context)
 	}
 
 	return WithContext(err.(*codedError), context)

--- a/go/common/errors/errors_test.go
+++ b/go/common/errors/errors_test.go
@@ -1,7 +1,6 @@
 package errors
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
@@ -72,7 +71,7 @@ func TestErrors(t *testing.T) {
 
 	// Unknown module and code.
 	err = FromCode("test/does-not-exist", 5, "")
-	require.Equal(err, errors.New(""))
-	err = FromCode("test/errors", 3, "")
-	require.Equal(err, errors.New(""))
+	require.Equal(err, New("test/does-not-exist", 5, ""))
+	err = FromCode("test/errors", 3, "a test error occurred")
+	require.Equal(err, WithContext(New("test/errors", 3, "a test error occurred"), "a test error occurred"))
 }


### PR DESCRIPTION
This PR makes it possible to decode the actual error variant via `details` in the gRPC error response status.

re: https://github.com/oasisprotocol/oasis-sdk/pull/139/commits/860e4233b5b07b716177d1994f02f980fe93a0f0