### PR TITLE
[BACKPORT/21.2.x] go/worker/storage: Add missing timeout for operations

### DIFF
--- a/.changelog/4072.bugfix.1.md
+++ b/.changelog/4072.bugfix.1.md
@@ -1,0 +1,1 @@
+go/worker/storage: Don't crash on early query

--- a/.changelog/4072.bugfix.2.md
+++ b/.changelog/4072.bugfix.2.md
@@ -1,0 +1,1 @@
+go/worker/storage: Add missing timeout for operations

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -409,8 +409,11 @@ func (n *Node) WaitForRound(round uint64, root *storageApi.Root) (<-chan uint64,
 		round = root.Version
 	}
 
+	consensusRound := roothashApi.RoundInvalid
 	n.commonNode.CrossNode.Lock()
-	consensusRound := n.commonNode.CurrentBlock.Header.Round
+	if blk := n.commonNode.CurrentBlock; blk != nil {
+		consensusRound = blk.Header.Round
+	}
 	n.commonNode.CrossNode.Unlock()
 	if round > consensusRound+roundWaitConsensusOffset && !commonFlags.DebugDontBlameOasis() {
 		close(retCh)


### PR DESCRIPTION
Backport of #4072.