### PR TITLE
[BACKPORT/21.2.x] go/consensus/tendermint: Fix last retained version query

### DIFF
--- a/.changelog/4060.bugfix.md
+++ b/.changelog/4060.bugfix.md
@@ -1,0 +1,4 @@
+go/consensus/tendermint: Fix last retained version query
+
+Previously the reported version was incorrect when the node used state sync
+and pruning was disabled.

--- a/go/consensus/tendermint/abci/prune.go
+++ b/go/consensus/tendermint/abci/prune.go
@@ -115,6 +115,9 @@ func (p *genericPruner) Initialize(latestVersion uint64) error {
 		return fmt.Errorf("failed to get earliest version: %w", err)
 	}
 
+	// Initially, the earliest version is the last retained version.
+	p.lastRetainedVersion = p.earliestVersion
+
 	return p.doPrune(context.Background(), latestVersion)
 }
 

--- a/go/consensus/tendermint/full/full.go
+++ b/go/consensus/tendermint/full/full.go
@@ -999,7 +999,10 @@ func (t *fullService) initialize() error {
 }
 
 func (t *fullService) GetLastRetainedVersion(ctx context.Context) (int64, error) {
-	return t.mux.State().LastRetainedVersion()
+	if err := t.ensureStarted(ctx); err != nil {
+		return -1, err
+	}
+	return t.node.BlockStore().Base(), nil
 }
 
 func (t *fullService) heightToTendermintHeight(height int64) (int64, error) {

--- a/go/oasis-test-runner/scenario/e2e/consensus_state_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/consensus_state_sync.go
@@ -148,5 +148,20 @@ func (sc *consensusStateSyncImpl) Run(childEnv *env.Env) error {
 		return err
 	}
 
+	// Query the validator status.
+	ctrl, err := oasis.NewController(val.SocketPath())
+	if err != nil {
+		return fmt.Errorf("failed to create controller for validator %s: %w", val.Name, err)
+	}
+	status, err := ctrl.GetStatus(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch validator status: %w", err)
+	}
+
+	// Make sure that the last retained height has been set correctly.
+	if lrh := status.Consensus.LastRetainedHeight; lrh < 20 {
+		return fmt.Errorf("unexpected last retained height from state synced node (got: %d)", lrh)
+	}
+
 	return nil
 }


### PR DESCRIPTION
Backport of #4076.