### PR TITLE
consensus/tendermint: Handle validator fetching error in GetStatus()

### DIFF
--- a/.changelog/4085.bugfix.md
+++ b/.changelog/4085.bugfix.md
@@ -1,0 +1,1 @@
+go/consensus/tendermint: Handle validator fetching error in `GetStatus()`

--- a/go/consensus/tendermint/full/full.go
+++ b/go/consensus/tendermint/full/full.go
@@ -835,11 +835,13 @@ func (t *fullService) GetStatus(ctx context.Context) (*consensusAPI.Status, erro
 		}
 		vals, err := t.stateStore.LoadValidators(valSetHeight)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load validator set: %w", err)
+			// Failed to load validator set.
+			status.IsValidator = false
+		} else {
+			consensusPk := t.identity.ConsensusSigner.Public()
+			consensusAddr := []byte(crypto.PublicKeyToTendermint(&consensusPk).Address())
+			status.IsValidator = vals.HasAddress(consensusAddr)
 		}
-		consensusPk := t.identity.ConsensusSigner.Public()
-		consensusAddr := []byte(crypto.PublicKeyToTendermint(&consensusPk).Address())
-		status.IsValidator = vals.HasAddress(consensusAddr)
 	}
 
 	return status, nil


### PR DESCRIPTION
This should enable returning other useful `GetStatus()` info when failing to load the validator set for a given height.