### PR TITLE
go/worker/common: Always use naked local storage

### DIFF
--- a/.changelog/4093.bugfix.2.md
+++ b/.changelog/4093.bugfix.2.md
@@ -1,0 +1,1 @@
+go/storage/api/mux: Don't return an error on a successful read

--- a/.changelog/4093.bugfix.md
+++ b/.changelog/4093.bugfix.md
@@ -1,0 +1,5 @@
+go/worker/common: Always use naked local storage
+
+Previously the committee group could incorrectly use the synced version of
+the local backend which could block operations resulting in failure to fetch
+data.

--- a/go/storage/api/api.go
+++ b/go/storage/api/api.go
@@ -337,6 +337,13 @@ type LocalBackend interface {
 	NodeDB() nodedb.NodeDB
 }
 
+// WrappedLocalBackend is an interface implemented by storage backends that wrap a local storage
+// backend in order to support unwrapping.
+type WrappedLocalBackend interface {
+	// Unwrap returns the underlying local storage backend.
+	Unwrap() LocalBackend
+}
+
 // ClientBackend is a storage client backend implementation.
 type ClientBackend interface {
 	Backend

--- a/go/storage/api/mux.go
+++ b/go/storage/api/mux.go
@@ -10,7 +10,8 @@ import (
 )
 
 // ErrMuxDontContinue is the error that should be returned by the MuxController function
-// when an operation was successful, but the muxer shouldn't continue with other backends.
+// when an operation was successful, but the muxer shouldn't continue with other backends and
+// should return an overall success.
 var ErrMuxDontContinue = errors.New("dontcontinue")
 
 // MuxContinueWithError is an error type that can be returned by the MuxController function
@@ -104,7 +105,7 @@ func (s *storageMux) doDouble(meth string, call func(Backend) (interface{}, erro
 			newErr = nil
 		}
 		if newErr == ErrMuxDontContinue {
-			return lastResp, residual
+			return lastResp, nil
 		}
 		if newErr != nil {
 			return lastResp, newErr

--- a/go/storage/api/mux_test.go
+++ b/go/storage/api/mux_test.go
@@ -89,7 +89,7 @@ func TestStorageMux(t *testing.T) {
 	faulty1.returnCh <- someError
 	faulty2.returnCh <- nil
 	getResp, err = mux.SyncGet(ctx, &GetRequest{})
-	require.EqualError(t, err, "error")
+	require.NoError(t, err, "second read succeeded, so there should be no error")
 	require.NotNil(t, getResp)
 	<-faulty1.calledCh
 	<-faulty2.calledCh

--- a/go/worker/common/committee/group.go
+++ b/go/worker/common/committee/group.go
@@ -555,6 +555,11 @@ func (g *Group) Start() error {
 	var scOpts []storageClient.Option
 	var localStorageBackend storage.LocalBackend
 	if lsb, ok := g.runtime.Storage().(storage.LocalBackend); ok && g.runtime.HasRoles(node.RoleStorageWorker) {
+		// Make sure to unwrap the local backend as we need the raw local backend here.
+		if wrapped, ok := lsb.(storage.WrappedLocalBackend); ok {
+			lsb = wrapped.Unwrap()
+		}
+
 		localStorageBackend = lsb
 		scOpts = append(scOpts, storageClient.WithBackendOverride(g.identity.NodeSigner.Public(), lsb))
 	}

--- a/go/worker/storage/synced_storage.go
+++ b/go/worker/storage/synced_storage.go
@@ -91,6 +91,11 @@ func (s *syncedStorage) NodeDB() nodedb.NodeDB {
 	return s.wrapped.NodeDB()
 }
 
+// Implements storage.WrappedLocalBackend.
+func (s *syncedStorage) Unwrap() storage.LocalBackend {
+	return s.wrapped
+}
+
 func newSyncedLocalStorage(runtime *committee.Node, backend storage.LocalBackend) storage.LocalBackend {
 	return &syncedStorage{
 		runtime: runtime,


### PR DESCRIPTION
Previously the committee group could incorrectly use the synced version of the
local backend which could block operations.