### PR TITLE
[BACKPORT/21.2.x] go/worker/compute: Replicate input batch locally

### DIFF
--- a/.changelog/4107.bugfix.md
+++ b/.changelog/4107.bugfix.md
@@ -1,0 +1,4 @@
+go/worker/compute: Replicate input batch locally
+
+Previously storage commit could fail in case the node was both an executor
+and a storage node but not in the storage committee.

--- a/go/storage/api/mux_test.go
+++ b/go/storage/api/mux_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 type faultyBackend struct {
-	Backend
+	LocalBackend
 
 	calledCh chan struct{}
 	returnCh chan error
@@ -45,7 +45,7 @@ func TestStorageMux(t *testing.T) {
 	}
 
 	mux := NewStorageMux(
-		MuxReadOpFinishEarly(MuxIterateIgnoringErrors()),
+		MuxReadOpFinishEarly(MuxIterateIgnoringLocalErrors()),
 		faulty1,
 		faulty2,
 	)
@@ -69,7 +69,7 @@ func TestStorageMux(t *testing.T) {
 	faulty1.returnCh <- someError
 	faulty2.returnCh <- nil
 	applyResp, err = mux.Apply(ctx, &ApplyRequest{})
-	require.EqualError(t, err, "error")
+	require.NoError(t, err)
 	require.NotNil(t, applyResp)
 	<-faulty1.calledCh
 	<-faulty2.calledCh

--- a/go/worker/common/committee/group.go
+++ b/go/worker/common/committee/group.go
@@ -255,6 +255,7 @@ type Group struct {
 	// storage is the storage backend that tracks the current committee.
 	storage       storage.Backend
 	storageClient storage.ClientBackend
+	storageLocal  storage.LocalBackend
 
 	logger *logging.Logger
 }
@@ -569,6 +570,12 @@ func (g *Group) Storage() storage.Backend {
 	return g.storage
 }
 
+// StorageLocal returns the local storage backend if the local node is also a storage node.
+// Otherwise it returns nil.
+func (g *Group) StorageLocal() storage.LocalBackend {
+	return g.storageLocal
+}
+
 // Start starts the group services.
 func (g *Group) Start() error {
 	g.Lock()
@@ -578,14 +585,13 @@ func (g *Group) Start() error {
 	// for this runtime). In this case we override the storage client's backend so that any updates
 	// don't go via gRPC but are redirected directly to the local backend instead.
 	var scOpts []storageClient.Option
-	var localStorageBackend storage.LocalBackend
 	if lsb, ok := g.runtime.Storage().(storage.LocalBackend); ok && g.runtime.HasRoles(node.RoleStorageWorker) {
 		// Make sure to unwrap the local backend as we need the raw local backend here.
 		if wrapped, ok := lsb.(storage.WrappedLocalBackend); ok {
 			lsb = wrapped.Unwrap()
 		}
 
-		localStorageBackend = lsb
+		g.storageLocal = lsb
 		scOpts = append(scOpts, storageClient.WithBackendOverride(g.identity.NodeSigner.Public(), lsb))
 	}
 
@@ -603,10 +609,10 @@ func (g *Group) Start() error {
 	g.storageClient = sc.(storage.ClientBackend)
 
 	// Create the storage multiplexer if we have a local storage backend.
-	if localStorageBackend != nil {
+	if g.storageLocal != nil {
 		g.storage = storage.NewStorageMux(
-			storage.MuxReadOpFinishEarly(storage.MuxIterateIgnoringErrors()),
-			localStorageBackend,
+			storage.MuxReadOpFinishEarly(storage.MuxIterateIgnoringLocalErrors()),
+			g.storageLocal,
 			g.storageClient,
 		)
 	} else {


### PR DESCRIPTION
Previously storage commit could fail in case the node was both an executor and
a storage node but not in the storage committee.