### PR TITLE
go/consensus/tendermint: Correctly propagate errors

### DIFF
--- a/.changelog/4110.bugfix.md
+++ b/.changelog/4110.bugfix.md
@@ -1,0 +1,5 @@
+go/consensus/tendermint: Correctly propagate errors
+
+Not propagating the state unavailable error could lead to corruption when the
+database becomes unavailable (e.g., due to running out of space or file
+descriptors).


### PR DESCRIPTION
Not propagating the state unavailable error could lead to corruption when the
database becomes unavailable (e.g., due to running out of space or file
descriptors).