### PR TITLE
go/common/logging: Switch to go-kit/log module

### DIFF
--- a/.changelog/4117.internal.md
+++ b/.changelog/4117.internal.md
@@ -1,0 +1,4 @@
+go/common/logging: Switch to go-kit/log module
+
+This is the only part of go-kit that we are using so it makes sense to switch
+to the smaller package.

--- a/go/common/logging/logging.go
+++ b/go/common/logging/logging.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/spf13/pflag"
 
 	goLogging "github.com/whyrusleeping/go-logging"

--- a/go/go.mod
+++ b/go/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/dgraph-io/badger/v3 v3.2103.0
 	github.com/eapache/channels v1.1.0
 	github.com/fxamacker/cbor/v2 v2.2.1-0.20200820021930-bafca87fa6db
-	github.com/go-kit/kit v0.10.0
+	github.com/go-kit/log v0.1.0
 	github.com/golang/protobuf v1.5.2
 	github.com/golang/snappy v0.0.3
 	github.com/google/btree v1.0.1

--- a/go/go.sum
+++ b/go/go.sum
@@ -274,6 +274,7 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.10.0 h1:dXFJfIHVvUcpSgDOV+Ne6t7jXri8Tfv2uOLHUZ2XNuo=
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=
+github.com/go-kit/log v0.1.0 h1:DGJh0Sm43HbOeYDNnVZFl8BvcYVvjD5bqYJvp0REbwQ=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=


### PR DESCRIPTION
This is the only part of go-kit that we are using so it makes sense to switch
to the smaller package.