### PR TITLE
[BACKPORT/21.2.x] go/runtime/host/sandbox: Add deadline to bwrap pipes

### DIFF
--- a/.changelog/4111.bugfix.md
+++ b/.changelog/4111.bugfix.md
@@ -1,0 +1,4 @@
+go/runtime/host/sandbox: Add deadline to bwrap pipes
+
+This prevents the constructor from blocking forever in case something is
+wrong with the sandbox setup.


### PR DESCRIPTION
This prevents the constructor from blocking forever in case something is
wrong with the sandbox setup.