### PR TITLE
go/worker/executor: batch CheckTx transactions

### DIFF
--- a/.changelog/2548.feature.md
+++ b/.changelog/2548.feature.md
@@ -1,0 +1,1 @@
+go/worker/executor: batch runtime CheckTx transactions

--- a/go/runtime/client/tests/tester.go
+++ b/go/runtime/client/tests/tester.go
@@ -141,7 +141,7 @@ func testQuery(
 	// Check that indexer has indexed txn keys (check the mock worker for key/values).
 	tx, err = c.QueryTx(ctx, &api.QueryTxRequest{RuntimeID: runtimeID, Key: []byte("txn_foo"), Value: []byte("txn_bar")})
 	require.NoError(t, err, "QueryTx")
-	require.EqualValues(t, 2, tx.Block.Header.Round)
+	require.EqualValues(t, 3, tx.Block.Header.Round)
 	require.EqualValues(t, 0, tx.Index)
 	// Check for values from TestNode/ExecutorWorker/QueueTx
 	require.True(t, strings.HasPrefix(string(tx.Input), "hello world"))
@@ -161,7 +161,7 @@ func testQuery(
 	require.EqualValues(t, testInput, txns[0])
 
 	// Check events query (see mock worker for emitted events).
-	events, err := c.GetEvents(ctx, &api.GetEventsRequest{RuntimeID: runtimeID, Round: 2})
+	events, err := c.GetEvents(ctx, &api.GetEventsRequest{RuntimeID: runtimeID, Round: 3})
 	require.NoError(t, err, "GetEvents")
 	require.Len(t, events, 1)
 	require.EqualValues(t, []byte("txn_foo"), events[0].Key)
@@ -170,7 +170,7 @@ func testQuery(
 	// Test advanced transaction queries.
 	query := api.Query{
 		RoundMin: 0,
-		RoundMax: 3,
+		RoundMax: 4,
 		Conditions: []api.QueryCondition{
 			{Key: []byte("txn_foo"), Values: [][]byte{[]byte("txn_bar")}},
 		},
@@ -182,7 +182,7 @@ func testQuery(
 	sort.Slice(results, func(i, j int) bool {
 		return bytes.Compare(results[i].Input, results[j].Input) < 0
 	})
-	require.EqualValues(t, 2, results[0].Block.Header.Round)
+	require.EqualValues(t, 3, results[0].Block.Header.Round)
 	require.EqualValues(t, 0, results[0].Index)
 	// Check for values from TestNode/ExecutorWorker/QueueTx
 	require.True(t, strings.HasPrefix(string(results[0].Input), "hello world"))

--- a/go/runtime/scheduling/simple/orderedmap/ordered_map.go
+++ b/go/runtime/scheduling/simple/orderedmap/ordered_map.go
@@ -1,0 +1,195 @@
+// Package orderedmap implements a queue backed by an ordered map.
+package orderedmap
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/runtime/scheduling/simple/txpool/api"
+)
+
+type pair struct {
+	Key   hash.Hash
+	Value []byte
+
+	element *list.Element
+}
+
+// OrderedMap is a queue backed by an ordered map.
+type OrderedMap struct {
+	sync.Mutex
+
+	transactions map[hash.Hash]*pair
+	queue        *list.List
+
+	maxTxPoolSize uint64
+	maxBatchSize  uint64
+}
+
+// Add adds transaction into the queue.
+func (q *OrderedMap) Add(tx []byte) error {
+	txHash := hash.NewFromBytes(tx)
+
+	q.Lock()
+	defer q.Unlock()
+
+	// Check if there is room in the queue.
+	if uint64(q.queue.Len()) >= q.maxTxPoolSize {
+		return api.ErrFull
+	}
+
+	if err := q.checkTxLocked(tx, txHash); err != nil {
+		return err
+	}
+
+	q.addTxLocked(tx, txHash)
+
+	return nil
+}
+
+// AddBatch adds a batch of transactions into the queue.
+func (q *OrderedMap) AddBatch(batch [][]byte) error {
+	// Compute all hashes before taking the lock.
+	var txHashes []hash.Hash
+	for _, tx := range batch {
+		txHash := hash.NewFromBytes(tx)
+		txHashes = append(txHashes, txHash)
+	}
+
+	q.Lock()
+	defer q.Unlock()
+
+	var errs error
+	for i, tx := range batch {
+		if err := q.checkTxLocked(tx, txHashes[i]); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("failed inserting tx: %d, error: %w", i, err))
+			continue
+		}
+
+		// Check if there is room in the queue.
+		if uint64(q.queue.Len()) >= q.maxTxPoolSize {
+			errs = multierror.Append(errs, fmt.Errorf("failed inserting tx: %d, error: %w", i, api.ErrFull))
+			return errs
+		}
+
+		// Add the tx if checks passed.
+		q.addTxLocked(tx, txHashes[i])
+	}
+
+	if len(q.transactions) != q.queue.Len() {
+		panic(fmt.Errorf("inconsistent sizes of the underlying list (%v) and map (%v), after AddBatch", q.queue.Len(), len(q.transactions)))
+	}
+
+	return errs
+}
+
+// GetBatch gets a batch of transactions from the queue.
+func (q *OrderedMap) GetBatch() [][]byte {
+	q.Lock()
+	defer q.Unlock()
+
+	var batch [][]byte
+	current := q.queue.Back()
+	for {
+		if current == nil {
+			break
+		}
+		// Check if the batch already has enough transactions.
+		if uint64(len(batch)) >= q.maxBatchSize {
+			break
+		}
+
+		el := current.Value.(*pair)
+
+		batch = append(batch, el.Value)
+		current = current.Prev()
+	}
+
+	return batch
+}
+
+// RemoveBatch removes a batch of transactions from the queue.
+func (q *OrderedMap) RemoveBatch(batch [][]byte) {
+	q.Lock()
+	defer q.Unlock()
+
+	for _, tx := range batch {
+		txHash := hash.NewFromBytes(tx)
+		if pair, ok := q.transactions[txHash]; ok {
+			q.queue.Remove(pair.element)
+			delete(q.transactions, pair.Key)
+		}
+	}
+	if len(q.transactions) != q.queue.Len() {
+		panic(fmt.Errorf("inconsistent sizes of the underlying list (%v) and map (%v) after RemoveBatch", q.queue.Len(), len(q.transactions)))
+	}
+}
+
+// IsQueued checks if a transactions is already queued.
+func (q *OrderedMap) IsQueued(txHash hash.Hash) bool {
+	q.Lock()
+	defer q.Unlock()
+
+	return q.isQueuedLocked(txHash)
+}
+
+// Size returns size of the queue.
+func (q *OrderedMap) Size() uint64 {
+	q.Lock()
+	defer q.Unlock()
+
+	return uint64(q.queue.Len())
+}
+
+// Clear empties the queue.
+func (q *OrderedMap) Clear() {
+	q.Lock()
+	defer q.Unlock()
+
+	q.queue = list.New()
+	q.transactions = make(map[hash.Hash]*pair)
+}
+
+// NOTE: Assumes lock is held.
+func (q *OrderedMap) isQueuedLocked(txHash hash.Hash) bool {
+	_, ok := q.transactions[txHash]
+	return ok
+}
+
+// NOTE: Assumes lock is held.
+func (q *OrderedMap) checkTxLocked(tx []byte, txHash hash.Hash) error {
+	if q.isQueuedLocked(txHash) {
+		return api.ErrCallAlreadyExists
+	}
+
+	return nil
+}
+
+// NOTE: Assumes lock is held and that checkTxLocked has been called.
+func (q *OrderedMap) addTxLocked(tx []byte, txHash hash.Hash) {
+	// Assuming checkTxLocked has been called before, this can happen if
+	// duplicate transactions are in the same batch -- just ignore them.
+	if _, exists := q.transactions[txHash]; exists {
+		return
+	}
+	p := &pair{
+		Key:   txHash,
+		Value: tx,
+	}
+	p.element = q.queue.PushFront(p)
+	q.transactions[txHash] = p
+}
+
+// New returns a new incoming queue.
+func New(maxPoolSize, maxBatchSize uint64) *OrderedMap {
+	return &OrderedMap{
+		transactions:  make(map[hash.Hash]*pair),
+		queue:         list.New(),
+		maxTxPoolSize: maxPoolSize,
+		maxBatchSize:  maxBatchSize,
+	}
+}

--- a/go/runtime/scheduling/simple/orderedmap/ordered_map_test.go
+++ b/go/runtime/scheduling/simple/orderedmap/ordered_map_test.go
@@ -1,0 +1,96 @@
+package orderedmap
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrderedMapBasic(t *testing.T) {
+	queue := New(51, 10)
+
+	err := queue.Add([]byte("hello world"))
+	require.NoError(t, err, "Add")
+
+	err = queue.Add([]byte("hello world"))
+	require.Error(t, err, "Add error on duplicates")
+
+	// Add some more calls.
+	for i := 0; i < 50; i++ {
+		err = queue.Add([]byte(fmt.Sprintf("call %d", i)))
+		require.NoError(t, err, "Add")
+	}
+
+	err = queue.Add([]byte("another call"))
+	require.Error(t, err, "Add error on queue full")
+
+	require.EqualValues(t, 51, queue.Size(), "Size")
+
+	batch := queue.GetBatch()
+	require.EqualValues(t, 10, len(batch), "Batch size")
+	require.EqualValues(t, 51, queue.Size(), "Size")
+
+	queue.RemoveBatch(batch)
+	require.EqualValues(t, 41, queue.Size(), "Size")
+
+	require.EqualValues(t, batch[0], []byte("hello world"))
+	for i := 0; i < 9; i++ {
+		require.EqualValues(t, batch[i+1], []byte(fmt.Sprintf("call %d", i)))
+	}
+	// Not a duplicate anymore.
+	err = queue.Add([]byte("hello world"))
+	require.NoError(t, err, "Add")
+	require.EqualValues(t, 42, queue.Size(), "Size")
+
+	queue.Clear()
+	require.EqualValues(t, 0, queue.Size(), "Size")
+}
+
+func TestOrderedMapGetBatch(t *testing.T) {
+	queue := New(51, 10)
+
+	batch := queue.GetBatch()
+	require.EqualValues(t, 0, len(batch), "Batch size")
+	require.EqualValues(t, 0, queue.Size(), "Size")
+
+	err := queue.Add([]byte("hello world"))
+	require.NoError(t, err, "Add")
+
+	batch = queue.GetBatch()
+	require.EqualValues(t, 1, len(batch), "Batch size")
+	require.EqualValues(t, 1, queue.Size(), "Size")
+
+	queue.RemoveBatch(batch)
+	require.EqualValues(t, 0, queue.Size(), "Size")
+}
+
+func TestOrderedMapRemoveBatch(t *testing.T) {
+	queue := New(51, 10)
+
+	queue.RemoveBatch([][]byte{})
+
+	for _, tx := range [][]byte{
+		[]byte("hello world"),
+		[]byte("one"),
+		[]byte("two"),
+		[]byte("three"),
+	} {
+		require.NoError(t, queue.Add(tx), "Add")
+	}
+	require.EqualValues(t, 4, queue.Size(), "Size")
+
+	queue.RemoveBatch([][]byte{})
+	require.EqualValues(t, 4, queue.Size(), "Size")
+
+	queue.RemoveBatch([][]byte{
+		[]byte("hello world"),
+		[]byte("two"),
+	})
+	require.EqualValues(t, 2, queue.Size(), "Size")
+
+	queue.RemoveBatch([][]byte{
+		[]byte("hello world"),
+	})
+	require.EqualValues(t, 2, queue.Size(), "Size")
+}

--- a/go/worker/compute/executor/committee/batch.go
+++ b/go/worker/compute/executor/committee/batch.go
@@ -44,5 +44,6 @@ func (ub *unresolvedBatch) resolve(ctx context.Context, sb storage.Backend) (tra
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch inputs from storage: %w", err)
 	}
+	ub.batch = batch
 	return batch, nil
 }

--- a/go/worker/compute/executor/init.go
+++ b/go/worker/compute/executor/init.go
@@ -12,6 +12,7 @@ import (
 const (
 	cfgMaxTxPoolSize       = "worker.executor.schedule_max_tx_pool_size"
 	cfgScheduleTxCacheSize = "worker.executor.schedule_tx_cache_size"
+	cfgCheckTxMaxBatchSize = "worker.executor.check_tx_max_batch_size"
 )
 
 // Flags has the configuration flags.
@@ -30,12 +31,14 @@ func New(
 		registration,
 		viper.GetUint64(cfgMaxTxPoolSize),
 		viper.GetUint64(cfgScheduleTxCacheSize),
+		viper.GetUint64(cfgCheckTxMaxBatchSize),
 	)
 }
 
 func init() {
-	Flags.Uint64(cfgMaxTxPoolSize, 10000, "Maximum size of the scheduling transaction pool")
-	Flags.Uint64(cfgScheduleTxCacheSize, 1000, "Cache size of recently scheduled transactions to prevent re-scheduling")
+	Flags.Uint64(cfgMaxTxPoolSize, 10_000, "Maximum size of the scheduling transaction pool")
+	Flags.Uint64(cfgScheduleTxCacheSize, 10_000, "Cache size of recently scheduled transactions to prevent re-scheduling")
+	Flags.Uint64(cfgCheckTxMaxBatchSize, 10_000, "Maximum check tx batch size")
 
 	_ = viper.BindPFlags(Flags)
 }

--- a/go/worker/compute/executor/worker.go
+++ b/go/worker/compute/executor/worker.go
@@ -19,6 +19,7 @@ type Worker struct {
 
 	scheduleMaxTxPoolSize uint64
 	scheduleTxCacheSize   uint64
+	checkTxMaxBatchSize   uint64
 
 	commonWorker *workerCommon.Worker
 	registration *registration.Worker
@@ -154,6 +155,7 @@ func (w *Worker) registerRuntime(commonNode *committeeCommon.Node) error {
 		rp,
 		w.scheduleMaxTxPoolSize,
 		w.scheduleTxCacheSize,
+		w.checkTxMaxBatchSize,
 	)
 	if err != nil {
 		return err
@@ -176,6 +178,7 @@ func newWorker(
 	registration *registration.Worker,
 	scheduleMaxTxPoolSize uint64,
 	scheduleTxCacheSize uint64,
+	checkTxMaxBatchSize uint64,
 ) (*Worker, error) {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
@@ -184,6 +187,7 @@ func newWorker(
 		commonWorker:          commonWorker,
 		scheduleMaxTxPoolSize: scheduleMaxTxPoolSize,
 		scheduleTxCacheSize:   scheduleTxCacheSize,
+		checkTxMaxBatchSize:   checkTxMaxBatchSize,
 		registration:          registration,
 		runtimes:              make(map[common.Namespace]*committee.Node),
 		ctx:                   ctx,


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/2548

TODO: 
- [ ] make sure in oasis-sdk that batch-wide limits are not applied to check-tx batches - as for check-tx the scheduler cannot know the weights up-front. so the runtime should not enforce batch-wide limits