### PR TITLE
go/runtime/client: Remove deprecated GetTxs method

### DIFF
--- a/.changelog/3983.feature.md
+++ b/.changelog/3983.feature.md
@@ -1,0 +1,4 @@
+go/runtime/client: Remove deprecated GetTxs method
+
+The GetTxs method has been deprecated and removed. Users should migrate
+to use GetTransactions instead.

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_message.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_message.go
@@ -117,10 +117,9 @@ func (sc *runtimeMessageImpl) Run(childEnv *env.Env) error {
 				if ht := blk.Block.Header.HeaderType; ht != block.Normal {
 					return fmt.Errorf("expected normal round, got: %d", ht)
 				}
-				txs, err := c.GetTxs(ctx, &api.GetTxsRequest{
+				txs, err := c.GetTransactions(ctx, &api.GetTransactionsRequest{
 					RuntimeID: runtimeID,
 					Round:     round,
-					IORoot:    blk.Block.Header.IORoot,
 				})
 				if err != nil {
 					return err

--- a/go/runtime/client/api/api.go
+++ b/go/runtime/client/api/api.go
@@ -70,12 +70,6 @@ type RuntimeClient interface {
 	// block is identified by its hash instead of its round number.
 	GetTxByBlockHash(ctx context.Context, request *GetTxByBlockHashRequest) (*TxResult, error)
 
-	// GetTxs fetches all runtime transactions in a given block.
-	//
-	// DEPRECATED: This method is deprecated and may be removed in a future release, use
-	//             `GetTransactions` instead.
-	GetTxs(ctx context.Context, request *GetTxsRequest) ([][]byte, error)
-
 	// GetTransactions fetches all runtime transactions in a given block.
 	GetTransactions(ctx context.Context, request *GetTransactionsRequest) ([][]byte, error)
 
@@ -148,13 +142,6 @@ type GetTxByBlockHashRequest struct {
 	RuntimeID common.Namespace `json:"runtime_id"`
 	BlockHash hash.Hash        `json:"block_hash"`
 	Index     uint32           `json:"index"`
-}
-
-// GetTxsRequest is a GetTxs request.
-type GetTxsRequest struct {
-	RuntimeID common.Namespace `json:"runtime_id"`
-	Round     uint64           `json:"round"`
-	IORoot    hash.Hash        `json:"io_root"`
 }
 
 // GetTransactionsRequest is a GetTransactions request.

--- a/go/runtime/client/api/grpc.go
+++ b/go/runtime/client/api/grpc.go
@@ -36,8 +36,6 @@ var (
 	methodGetTx = serviceName.NewMethod("GetTx", GetTxRequest{})
 	// methodGetTxByBlockHash is the GetTxByBlockHash method.
 	methodGetTxByBlockHash = serviceName.NewMethod("GetTxByBlockHash", GetTxByBlockHashRequest{})
-	// methodGetTxs is the GetTxs method.
-	methodGetTxs = serviceName.NewMethod("GetTxs", GetTxsRequest{})
 	// methodGetTransactions is the GetTransactions method.
 	methodGetTransactions = serviceName.NewMethod("GetTransactions", GetTransactionsRequest{})
 	// methodGetEvents is the GetEvents method.
@@ -90,10 +88,6 @@ var (
 			{
 				MethodName: methodGetTxByBlockHash.ShortName(),
 				Handler:    handlerGetTxByBlockHash,
-			},
-			{
-				MethodName: methodGetTxs.ShortName(),
-				Handler:    handlerGetTxs,
 			},
 			{
 				MethodName: methodGetTransactions.ShortName(),
@@ -351,29 +345,6 @@ func handlerGetTxByBlockHash( // nolint: golint
 	return interceptor(ctx, &rq, info, handler)
 }
 
-func handlerGetTxs( // nolint: golint
-	srv interface{},
-	ctx context.Context,
-	dec func(interface{}) error,
-	interceptor grpc.UnaryServerInterceptor,
-) (interface{}, error) {
-	var rq GetTxsRequest
-	if err := dec(&rq); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(RuntimeClient).GetTxs(ctx, &rq)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: methodGetTxs.FullName(),
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(RuntimeClient).GetTxs(ctx, req.(*GetTxsRequest))
-	}
-	return interceptor(ctx, &rq, info, handler)
-}
-
 func handlerGetTransactions( // nolint: golint
 	srv interface{},
 	ctx context.Context,
@@ -610,14 +581,6 @@ func (c *runtimeClient) GetTxByBlockHash(ctx context.Context, request *GetTxByBl
 		return nil, err
 	}
 	return &rsp, nil
-}
-
-func (c *runtimeClient) GetTxs(ctx context.Context, request *GetTxsRequest) ([][]byte, error) {
-	var rsp [][]byte
-	if err := c.conn.Invoke(ctx, methodGetTxs.FullName(), request, &rsp); err != nil {
-		return nil, err
-	}
-	return rsp, nil
 }
 
 func (c *runtimeClient) GetTransactions(ctx context.Context, request *GetTransactionsRequest) ([][]byte, error) {

--- a/go/runtime/client/client.go
+++ b/go/runtime/client/client.go
@@ -315,35 +315,6 @@ func (c *runtimeClient) GetTxByBlockHash(ctx context.Context, request *api.GetTx
 }
 
 // Implements api.RuntimeClient.
-func (c *runtimeClient) GetTxs(ctx context.Context, request *api.GetTxsRequest) ([][]byte, error) {
-	if request.IORoot.IsEmpty() {
-		return [][]byte{}, nil
-	}
-
-	ioRoot := storage.Root{
-		Version: request.Round,
-		Type:    storage.RootTypeIO,
-		Hash:    request.IORoot,
-	}
-	copy(ioRoot.Namespace[:], request.RuntimeID[:])
-
-	tree := transaction.NewTree(c.common.storage, ioRoot)
-	defer tree.Close()
-
-	txs, err := tree.GetTransactions(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	inputs := [][]byte{}
-	for _, tx := range txs {
-		inputs = append(inputs, tx.Input)
-	}
-
-	return inputs, nil
-}
-
-// Implements api.RuntimeClient.
 func (c *runtimeClient) GetTransactions(ctx context.Context, request *api.GetTransactionsRequest) ([][]byte, error) {
 	blk, err := c.GetBlock(ctx, &api.GetBlockRequest{RuntimeID: request.RuntimeID, Round: request.Round})
 	if err != nil {

--- a/go/runtime/client/tests/tester.go
+++ b/go/runtime/client/tests/tester.go
@@ -148,13 +148,7 @@ func testQuery(
 	require.True(t, strings.HasPrefix(string(tx.Output), "hello world"))
 
 	// Transactions (check the mock worker for content).
-	txns, err := c.GetTxs(ctx, &api.GetTxsRequest{RuntimeID: runtimeID, Round: blk.Header.Round, IORoot: blk.Header.IORoot})
-	require.NoError(t, err, "GetTxs")
-	require.Len(t, txns, 1)
-	// Check for values from TestNode/Client/SubmitTx
-	require.EqualValues(t, testInput, txns[0])
-
-	txns, err = c.GetTransactions(ctx, &api.GetTransactionsRequest{RuntimeID: runtimeID, Round: blk.Header.Round})
+	txns, err := c.GetTransactions(ctx, &api.GetTransactionsRequest{RuntimeID: runtimeID, Round: blk.Header.Round})
 	require.NoError(t, err, "GetTransactions")
 	require.Len(t, txns, 1)
 	// Check for values from TestNode/Client/SubmitTx


### PR DESCRIPTION
The GetTxs method has been deprecated and removed. Users should migrate
to use GetTransactions instead.

Fixes #3983