### PR TITLE
runtime/simple-keyvalue: check nonces

### DIFF
--- a/.changelog/4154.internal.md
+++ b/.changelog/4154.internal.md
@@ -1,0 +1,1 @@
+runtime/simple-keyvalue: check nonces

--- a/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
@@ -182,7 +182,7 @@ func (sc *multipleRuntimesImpl) Run(childEnv *env.Env) error {
 					"runtime_id", rt.ID,
 				)
 
-				if _, err := sc.submitKeyValueRuntimeInsertTx(ctx, rt.ID, "hello", fmt.Sprintf("world at iteration %d from %s", i, rt.ID), 0); err != nil {
+				if _, err := sc.submitKeyValueRuntimeInsertTx(ctx, rt.ID, "hello", fmt.Sprintf("world at iteration %d from %s", i, rt.ID), uint64(i)); err != nil {
 					return err
 				}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_dynamic.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_dynamic.go
@@ -102,6 +102,7 @@ func (sc *runtimeDynamicImpl) epochTransition(ctx context.Context) error {
 }
 
 func (sc *runtimeDynamicImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
+	var rtNonce uint64
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
@@ -267,11 +268,12 @@ func (sc *runtimeDynamicImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 				ctx,
 				runtimeID,
 				runtimeDynamicTestKey,
-				1234567890,
+				rtNonce,
 			)
 			if err != nil {
 				return err
 			}
+			rtNonce++
 			if rsp != runtimeDynamicTestValue {
 				return fmt.Errorf("incorrect value returned by runtime: %s", rsp)
 			}
@@ -281,9 +283,10 @@ func (sc *runtimeDynamicImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 		sc.Logger.Info("submitting transaction to runtime",
 			"seq", i,
 		)
-		if _, err := sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, "hello", fmt.Sprintf("world %d", i), 0); err != nil {
+		if _, err := sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, "hello", fmt.Sprintf("world %d", i), rtNonce); err != nil {
 			return err
 		}
+		rtNonce++
 	}
 
 	// Stop all runtime nodes, so they will not re-register, causing the nodes to expire.
@@ -370,9 +373,10 @@ func (sc *runtimeDynamicImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 
 	// Submit a runtime transaction to check whether the runtimes got resumed.
 	sc.Logger.Info("submitting transaction to runtime")
-	if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, "hello", "final world", 0); err != nil {
+	if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, "hello", "final world", rtNonce); err != nil {
 		return err
 	}
+	rtNonce++
 
 	// Now reclaim all stake from the debug entity which owns the runtime.
 	sc.Logger.Info("reclaiming stake from entity which owns the runtime")
@@ -528,7 +532,7 @@ func (sc *runtimeDynamicImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 
 	// Submit a runtime transaction to check whether the runtimes got resumed.
 	sc.Logger.Info("submitting transaction to runtime")
-	if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, "hello", "final world for sure", 0); err != nil {
+	if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, "hello", "final world for sure", rtNonce); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_governance.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_governance.go
@@ -247,6 +247,7 @@ func (sc *runtimeGovernanceImpl) Run(childEnv *env.Env) error {
 	}
 
 	ctx := context.Background()
+	var rtNonce uint64
 
 	// Filter compute runtimes.
 	var crt []*registry.Runtime
@@ -273,11 +274,14 @@ func (sc *runtimeGovernanceImpl) Run(childEnv *env.Env) error {
 
 	if _, err = sc.submitRuntimeTx(ctx, rt.ID, "update_runtime", struct {
 		UpdateRuntime registry.Runtime `json:"update_runtime"`
+		Nonce         uint64           `json:"nonce"`
 	}{
 		UpdateRuntime: newRT,
+		Nonce:         rtNonce,
 	}); err != nil {
 		return err
 	}
+	rtNonce++
 
 	// Epoch transition.
 	sc.Logger.Info("triggering epoch transition",
@@ -321,8 +325,10 @@ func (sc *runtimeGovernanceImpl) Run(childEnv *env.Env) error {
 	)
 	if _, err = sc.submitRuntimeTx(ctx, otherRT.ID, "update_runtime", struct {
 		UpdateRuntime registry.Runtime `json:"update_runtime"`
+		Nonce         uint64           `json:"nonce"`
 	}{
 		UpdateRuntime: newRT,
+		Nonce:         rtNonce,
 	}); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_prune.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_prune.go
@@ -82,7 +82,7 @@ func (sc *runtimePruneImpl) Run(childEnv *env.Env) error {
 			"seq", i,
 		)
 
-		if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, "hello", fmt.Sprintf("world %d", i), 0); err != nil {
+		if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, "hello", fmt.Sprintf("world %d", i), uint64(i)); err != nil {
 			return err
 		}
 	}

--- a/tests/runtimes/simple-keyvalue/api/src/api.rs
+++ b/tests/runtimes/simple-keyvalue/api/src/api.rs
@@ -6,20 +6,14 @@ use oasis_core_runtime::{
 #[derive(Clone, cbor::Encode, cbor::Decode)]
 pub struct Key {
     pub key: String,
-    // Nonce is ignored by the runtime itself and can be used to avoid duplicate
-    // runtime transactions.
-    #[cbor(optional)]
-    pub nonce: Option<u64>,
+    pub nonce: u64,
 }
 
 #[derive(Clone, cbor::Encode, cbor::Decode)]
 pub struct KeyValue {
     pub key: String,
     pub value: String,
-    // Nonce is ignored by the runtime itself and can be used to avoid duplicate
-    // runtime transactions.
-    #[cbor(optional)]
-    pub nonce: Option<u64>,
+    pub nonce: u64,
 }
 
 #[derive(Clone, cbor::Encode, cbor::Decode)]
@@ -49,10 +43,7 @@ pub struct ReclaimEscrow {
 #[derive(Clone, cbor::Encode, cbor::Decode)]
 pub struct UpdateRuntime {
     pub update_runtime: registry::Runtime,
-    // Nonce is ignored by the runtime itself and can be used to avoid duplicate
-    // runtime transactions.
-    #[cbor(optional)]
-    pub nonce: Option<u64>,
+    pub nonce: u64,
 }
 
 runtime_api! {


### PR DESCRIPTION
Most daily-longtest errors come from the re-execution of simple-keyvalue transaction which happens due to runtime not enforcing nonces and worker nodes being continuously restarted/killed.

TODO: 
- [x] probably need to update some clients/tests