### PR TITLE
storage/checkpoint_sync: add timeout for fetching checkpoints from nodes

### DIFF
--- a/.changelog/4155.internal.md
+++ b/.changelog/4155.internal.md
@@ -1,0 +1,1 @@
+storage/checkpoint_sync: add timeout for fetching checkpoints from nodes

--- a/go/oasis-test-runner/scenario/e2e/runtime/client_expire.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/client_expire.go
@@ -71,9 +71,11 @@ func (sc *clientExpireImpl) Run(childEnv *env.Env) error {
 			Args: struct {
 				Key   string `json:"key"`
 				Value string `json:"value"`
+				Nonce uint64 `json:"nonce"`
 			}{
 				Key:   "hello",
 				Value: "test",
+				Nonce: 0,
 			},
 		}),
 	})

--- a/go/worker/storage/committee/checkpoint_sync.go
+++ b/go/worker/storage/committee/checkpoint_sync.go
@@ -22,6 +22,8 @@ import (
 const (
 	// cpListTimeout is the timeout for fetching a list of checkpoints from a node.
 	cpListTimeout = 5 * time.Second
+	// cpListsTimeout is the timeout for fetching checkpoints from all nodes.
+	cpListsTimeout = 30 * time.Second
 	// cpRestoreTimeout is the timeout for restoring a checkpoint chunk from a node.
 	cpRestoreTimeout = 60 * time.Second
 
@@ -338,6 +340,11 @@ func (n *Node) getCheckpointList(nodesClient grpc.NodesClient) ([]*checkpoint.Me
 		return nil, err
 	}
 	defer cancel()
+	// Wait at most cpListsTimeout for results.
+	go func() {
+		<-time.After(cpListsTimeout)
+		cancel()
+	}()
 
 	var list []*checkpoint.Metadata
 resultLoop:


### PR DESCRIPTION
Alternative fix to https://github.com/oasisprotocol/oasis-core/pull/4152 
Not sure which one we prefer