### PR TITLE
workload/queries: bump consensus queries timeout

### DIFF
--- a/go/oasis-node/cmd/debug/txsource/workload/queries.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/queries.go
@@ -61,7 +61,7 @@ const (
 	// queriesIterationTimeout is the combined timeout for running all the queries that are executed
 	// in a single iteration. The purpose of this timeout is to prevent the client being stuck and
 	// treating that as an error instead.
-	queriesIterationTimeout = 120 * time.Second
+	queriesIterationTimeout = 300 * time.Second
 
 	// queriesNumAllowedQueryTxsHistoricalFailures is the number of allowed failures of histortical
 	// `QueryTxs` requests. A historical `QueryTxs` request can fail in case available storage


### PR DESCRIPTION
Once the state is really big (e.g. after ~11 hours in the below test run), the consensus queries iteration can take more than currently configured timeout of 2 minutes. (as it iterates through all accounts, proposals, proposals votes, active proposals...). 

Discovered in https://buildkite.com/oasisprotocol/oasis-core-long-tests/builds/850#_