### PR TITLE
workload/runtime: ensure correct round for validating events

### DIFF
--- a/.changelog/4161.internal.md
+++ b/.changelog/4161.internal.md
@@ -1,0 +1,1 @@
+workload/runtime: ensure correct round for validating events


### PR DESCRIPTION
Ensure `validateEvents` queries events for the correct round.

Reason for failure in https://buildkite.com/oasisprotocol/oasis-core-long-tests/builds/852