### PR TITLE
runtime/client: SubmitTx variant that returns metadata

### DIFF
--- a/.changelog/4162.feature.md
+++ b/.changelog/4162.feature.md
@@ -1,0 +1,1 @@
+runtime/client: Add `SubmitTx` variant that includes metadata

--- a/go/oasis-node/cmd/debug/txsource/workload/runtime.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/runtime.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/errors"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	runtimeClient "github.com/oasisprotocol/oasis-core/go/runtime/client/api"
@@ -193,7 +194,9 @@ func (r *runtime) submitRuntimeRquest(ctx context.Context, rtc runtimeClient.Run
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to submit runtime transaction: %w", err)
 	}
-
+	if out.CheckTxError != nil {
+		return nil, 0, fmt.Errorf("SubmitTxWithMeta check tx error: %w", errors.FromCode(out.CheckTxError.Module, out.CheckTxError.Code, out.CheckTxError.Message))
+	}
 	if err = cbor.Unmarshal(out.Output, &rsp); err != nil {
 		return nil, 0, fmt.Errorf("malformed tx output from runtime: %w", err)
 	}

--- a/go/runtime/client/api/api.go
+++ b/go/runtime/client/api/api.go
@@ -47,6 +47,13 @@ type RuntimeClient interface {
 	// for transaction execution results.
 	SubmitTx(ctx context.Context, request *SubmitTxRequest) ([]byte, error)
 
+	// SubmitTxMeta submits a transaction to the runtime transaction scheduler and waits for
+	// transaction execution results.
+	//
+	// Response includes transaction metadata - e.g. round at which the transaction was included
+	// in a block.
+	SubmitTxMeta(ctx context.Context, request *SubmitTxRequest) (*SubmitTxMetaResponse, error)
+
 	// SubmitTxNoWait submits a transaction to the runtime transaction scheduler but does
 	// not wait for transaction execution.
 	SubmitTxNoWait(ctx context.Context, request *SubmitTxRequest) error
@@ -102,6 +109,13 @@ type RuntimeClientService interface {
 type SubmitTxRequest struct {
 	RuntimeID common.Namespace `json:"runtime_id"`
 	Data      []byte           `json:"data"`
+}
+
+// SubmitTxMetaResponse is the SubmitTxMeta response.
+type SubmitTxMetaResponse struct {
+	Round      uint64 `json:"round"`
+	Output     []byte `json:"data"`
+	BatchOrder uint32 `json:"batch_order"`
 }
 
 // CheckTxRequest is a CheckTx request.

--- a/go/runtime/client/api/api.go
+++ b/go/runtime/client/api/api.go
@@ -13,6 +13,7 @@ import (
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	enclaverpc "github.com/oasisprotocol/oasis-core/go/runtime/enclaverpc/api"
+	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 )
 
 const (
@@ -113,9 +114,15 @@ type SubmitTxRequest struct {
 
 // SubmitTxMetaResponse is the SubmitTxMeta response.
 type SubmitTxMetaResponse struct {
-	Round      uint64 `json:"round"`
-	Output     []byte `json:"data"`
-	BatchOrder uint32 `json:"batch_order"`
+	// Output is the transaction output.
+	Output []byte `json:"data,omitempty"`
+	// Round is the roothash round in which the transaction was executed.
+	Round uint64 `json:"round,omitempty"`
+	// BatchOrder is the order of the transaction in the execution batch.
+	BatchOrder uint32 `json:"batch_order,omitempty"`
+
+	// CheckTxError is the CheckTx error in case transaction failed the transaction check.
+	CheckTxError *protocol.Error `json:"check_tx_error,omitempty"`
 }
 
 // CheckTxRequest is a CheckTx request.

--- a/go/runtime/client/api/grpc.go
+++ b/go/runtime/client/api/grpc.go
@@ -22,6 +22,8 @@ var (
 
 	// methodSubmitTx is the SubmitTx method.
 	methodSubmitTx = serviceName.NewMethod("SubmitTx", SubmitTxRequest{})
+	// methodSubmitTxMeta is the SubmitTxMeta method.
+	methodSubmitTxMeta = serviceName.NewMethod("SubmitTxMeta", SubmitTxRequest{})
 	// methodSubmitTxNoWait is the SubmitTxNoWait method.
 	methodSubmitTxNoWait = serviceName.NewMethod("SubmitTxNoWait", SubmitTxRequest{})
 	// methodCheckTx is the CheckTx method.
@@ -60,6 +62,10 @@ var (
 			{
 				MethodName: methodSubmitTx.ShortName(),
 				Handler:    handlerSubmitTx,
+			},
+			{
+				MethodName: methodSubmitTxMeta.ShortName(),
+				Handler:    handlerSubmitTxMeta,
 			},
 			{
 				MethodName: methodSubmitTxNoWait.ShortName(),
@@ -143,6 +149,29 @@ func handlerSubmitTx( // nolint: golint
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(RuntimeClient).SubmitTx(ctx, req.(*SubmitTxRequest))
+	}
+	return interceptor(ctx, &rq, info, handler)
+}
+
+func handlerSubmitTxMeta( // nolint: golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var rq SubmitTxRequest
+	if err := dec(&rq); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RuntimeClient).SubmitTxMeta(ctx, &rq)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodSubmitTxMeta.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RuntimeClient).SubmitTxMeta(ctx, req.(*SubmitTxRequest))
 	}
 	return interceptor(ctx, &rq, info, handler)
 }
@@ -533,6 +562,14 @@ func (c *runtimeClient) SubmitTx(ctx context.Context, request *SubmitTxRequest) 
 		return nil, err
 	}
 	return rsp, nil
+}
+
+func (c *runtimeClient) SubmitTxMeta(ctx context.Context, request *SubmitTxRequest) (*SubmitTxMetaResponse, error) {
+	var rsp SubmitTxMetaResponse
+	if err := c.conn.Invoke(ctx, methodSubmitTxMeta.FullName(), request, &rsp); err != nil {
+		return nil, err
+	}
+	return &rsp, nil
 }
 
 func (c *runtimeClient) SubmitTxNoWait(ctx context.Context, request *SubmitTxRequest) error {

--- a/go/runtime/client/client.go
+++ b/go/runtime/client/client.go
@@ -137,6 +137,15 @@ func (c *runtimeClient) submitTx(ctx context.Context, request *api.SubmitTxReque
 
 // Implements api.RuntimeClient.
 func (c *runtimeClient) SubmitTx(ctx context.Context, request *api.SubmitTxRequest) ([]byte, error) {
+	resp, err := c.SubmitTxMeta(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Output, nil
+}
+
+// Implements api.RuntimeClient.
+func (c *runtimeClient) SubmitTxMeta(ctx context.Context, request *api.SubmitTxRequest) (*api.SubmitTxMetaResponse, error) {
 	respCh, err := c.submitTx(ctx, request)
 	if err != nil {
 		return nil, err

--- a/go/runtime/client/submitter.go
+++ b/go/runtime/client/submitter.go
@@ -37,7 +37,7 @@ func (w *txRequest) result(res *txResult) {
 
 type txResult struct {
 	err    error
-	result []byte
+	result *api.SubmitTxMetaResponse
 }
 
 type txSubmitter struct {
@@ -101,7 +101,11 @@ func (w *txSubmitter) checkBlock(blk *block.Block) error {
 	for txHash, tx := range matches {
 		txReq := w.transactions[txHash]
 		txReq.result(&txResult{
-			result: tx.Output,
+			result: &api.SubmitTxMetaResponse{
+				Round:      blk.Header.Round,
+				BatchOrder: tx.BatchOrder,
+				Output:     tx.Output,
+			},
 		})
 		close(txReq.respCh)
 		delete(w.transactions, txHash)

--- a/go/runtime/client/tests/tester.go
+++ b/go/runtime/client/tests/tester.go
@@ -57,11 +57,12 @@ func testSubmitTransaction(
 ) {
 	testInput := []byte(input)
 	// Submit a test transaction.
-	testOutput, err := c.SubmitTx(ctx, &api.SubmitTxRequest{Data: testInput, RuntimeID: runtimeID})
+	resp, err := c.SubmitTxMeta(ctx, &api.SubmitTxRequest{Data: testInput, RuntimeID: runtimeID})
 
 	// Check if everything is in order.
-	require.NoError(t, err, "SubmitTx")
-	require.EqualValues(t, testInput, testOutput)
+	require.NoError(t, err, "SubmitTxWithMeta")
+	require.EqualValues(t, testInput, resp.Output)
+	require.True(t, resp.Round > 0, "SubmitTxMeta round should be non zero")
 }
 
 func testQuery(


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/4162

Not sure if there's any other potentially useful metadata that could be included