### PR TITLE
go/registry/gen_vectors: Stop generating transactions for v1 entities

### DIFF
--- a/.changelog/4167.internal.md
+++ b/.changelog/4167.internal.md
@@ -1,0 +1,1 @@
+go/registry/gen_vectors: Stop generating register transactions for v1 entities

--- a/go/registry/gen_vectors/main.go
+++ b/go/registry/gen_vectors/main.go
@@ -44,7 +44,7 @@ func main() {
 		for _, nonce := range []uint64{0, 1, 10, 42, 1000, 1_000_000, 10_000_000, math.MaxUint64} {
 
 			// Generate register entity transactions.
-			for _, v := range []uint16{1, entity.LatestDescriptorVersion} {
+			for _, v := range []uint16{entity.LatestDescriptorVersion} {
 				for _, numNodes := range []int{0, 1, 2, 5} {
 					entitySigner := memorySigner.NewTestSigner("oasis-core registry test vectors: RegisterEntity signer")
 					ent := entity.Entity{


### PR DESCRIPTION
Previously, register entity transactions with v1 entities were supposedly being generated, however, it turned they were not properly generated.
Inside the `testvectors.MakeTestVectorWithSigner()` call, `cbor.Unmarshal()` was being called which automatically converted a v1 entity to a v2 entity.
Hence, test vectors for register entity transactions with v1 entities lacked integrity with one portion of the test vector having a v1 entity and the other portion having a v2 entity.