### PR TITLE
[BACKPORT/21.2.x] go/registry: Update test vectors and add its own body type to MethodDeregisterEntity

### DIFF
--- a/.changelog/4167.internal.md
+++ b/.changelog/4167.internal.md
@@ -1,0 +1,1 @@
+go/registry/gen_vectors: Stop generating register transactions for v1 entities

--- a/.changelog/4177.feature.md
+++ b/.changelog/4177.feature.md
@@ -1,0 +1,1 @@
+go/registry/api: Add its own body type to `MethodDeregisterEntity`

--- a/.changelog/4177.internal.md
+++ b/.changelog/4177.internal.md
@@ -1,0 +1,1 @@
+go/registry/gen_vectors: Add vectors for deregister entity transactions

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -124,7 +124,7 @@ var (
 	// MethodRegisterEntity is the method name for entity registrations.
 	MethodRegisterEntity = transaction.NewMethodName(ModuleName, "RegisterEntity", entity.SignedEntity{})
 	// MethodDeregisterEntity is the method name for entity deregistrations.
-	MethodDeregisterEntity = transaction.NewMethodName(ModuleName, "DeregisterEntity", nil)
+	MethodDeregisterEntity = transaction.NewMethodName(ModuleName, "DeregisterEntity", DeregisterEntity{})
 	// MethodRegisterNode is the method name for node registrations.
 	MethodRegisterNode = transaction.NewMethodName(ModuleName, "RegisterNode", node.MultiSignedNode{})
 	// MethodUnfreezeNode is the method name for unfreezing nodes.
@@ -250,6 +250,9 @@ type ConsensusAddressQuery struct {
 	Height  int64  `json:"height"`
 	Address []byte `json:"address"`
 }
+
+// DeregisterEntity is a request to deregister an entity.
+type DeregisterEntity struct{}
 
 // NewRegisterEntityTx creates a new register entity transaction.
 func NewRegisterEntityTx(nonce uint64, fee *transaction.Fee, sigEnt *entity.SignedEntity) *transaction.Transaction {

--- a/go/registry/gen_vectors/main.go
+++ b/go/registry/gen_vectors/main.go
@@ -44,7 +44,7 @@ func main() {
 		for _, nonce := range []uint64{0, 1, 10, 42, 1000, 1_000_000, 10_000_000, math.MaxUint64} {
 
 			// Generate register entity transactions.
-			for _, v := range []uint16{1, entity.LatestDescriptorVersion} {
+			for _, v := range []uint16{entity.LatestDescriptorVersion} {
 				for _, numNodes := range []int{0, 1, 2, 5} {
 					entitySigner := memorySigner.NewTestSigner("oasis-core registry test vectors: RegisterEntity signer")
 					ent := entity.Entity{

--- a/go/registry/gen_vectors/main.go
+++ b/go/registry/gen_vectors/main.go
@@ -65,9 +65,13 @@ func main() {
 				}
 			}
 
+			// Generate deregister entity transactions.
+			tx := registry.NewDeregisterEntityTx(nonce, fee)
+			vectors = append(vectors, testvectors.MakeTestVector("DeregisterEntity", tx, true))
+
 			// Generate unfreeze node transactions.
 			nodeSigner := memorySigner.NewTestSigner("oasis-core registry test vectors: UnfreezeNode signer")
-			tx := registry.NewUnfreezeNodeTx(nonce, fee, &registry.UnfreezeNode{
+			tx = registry.NewUnfreezeNodeTx(nonce, fee, &registry.UnfreezeNode{
 				NodeID: nodeSigner.Public(),
 			})
 			vectors = append(vectors, testvectors.MakeTestVector("UnfreezeNode", tx, true))


### PR DESCRIPTION
Backport of #4167 and #4177.