### PR TITLE
go/oasis-test-runner: support for testing update handlers

### DIFF
--- a/.changelog/4179.internal.md
+++ b/.changelog/4179.internal.md
@@ -1,0 +1,1 @@
+go/oasis-test-runner: support for testing upgrade handlers

--- a/go/oasis-test-runner/scenario/e2e/e2e.go
+++ b/go/oasis-test-runner/scenario/e2e/e2e.go
@@ -417,7 +417,7 @@ func RegisterScenarios() error {
 		// Genesis file test.
 		GenesisFile,
 		// Node upgrade tests.
-		NodeUpgrade,
+		NodeUpgradeDummy,
 		NodeUpgradeCancel,
 		// Debonding entries from genesis test.
 		Debond,


### PR DESCRIPTION
This makes it easier to e2e-test upgrade handlers. (note in `master` there's currently only the dummy handler, so this doesn't add any tests here)

TODO: 
- [x] add support for checking upgrade