### PR TITLE
[BACPORT/21.2.x] go/roothash: adds ConsensusParameters method

### DIFF
--- a/.changelog/4187.feature.md
+++ b/.changelog/4187.feature.md
@@ -1,0 +1,1 @@
+go/roothash/api: add `ConsensusParameters` method

--- a/go/consensus/tendermint/apps/roothash/query.go
+++ b/go/consensus/tendermint/apps/roothash/query.go
@@ -16,6 +16,7 @@ type Query interface {
 	GenesisBlock(context.Context, common.Namespace) (*block.Block, error)
 	RuntimeState(context.Context, common.Namespace) (*roothash.RuntimeState, error)
 	Genesis(context.Context) (*roothash.Genesis, error)
+	ConsensusParameters(context.Context) (*roothash.ConsensusParameters, error)
 }
 
 // QueryFactory is the roothash query factory.
@@ -54,6 +55,10 @@ func (rq *rootHashQuerier) GenesisBlock(ctx context.Context, id common.Namespace
 
 func (rq *rootHashQuerier) RuntimeState(ctx context.Context, id common.Namespace) (*roothash.RuntimeState, error) {
 	return rq.state.RuntimeState(ctx, id)
+}
+
+func (rq *rootHashQuerier) ConsensusParameters(ctx context.Context) (*roothash.ConsensusParameters, error) {
+	return rq.state.ConsensusParameters(ctx)
 }
 
 func (app *rootHashApplication) QueryFactory() interface{} {

--- a/go/consensus/tendermint/roothash/roothash.go
+++ b/go/consensus/tendermint/roothash/roothash.go
@@ -259,6 +259,15 @@ func (sc *serviceClient) StateToGenesis(ctx context.Context, height int64) (*api
 	return g, nil
 }
 
+func (sc *serviceClient) ConsensusParameters(ctx context.Context, height int64) (*api.ConsensusParameters, error) {
+	q, err := sc.querier.QueryAt(ctx, height)
+	if err != nil {
+		return nil, err
+	}
+
+	return q.ConsensusParameters(ctx)
+}
+
 func (sc *serviceClient) getNodeEntities(ctx context.Context, height int64, nodes []signature.PublicKey) ([]signature.PublicKey, error) {
 	var entities []signature.PublicKey
 	seen := make(map[signature.PublicKey]bool)

--- a/go/oasis-test-runner/oasis/controller.go
+++ b/go/oasis-test-runner/oasis/controller.go
@@ -10,6 +10,7 @@ import (
 	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
 	keymanager "github.com/oasisprotocol/oasis-core/go/keymanager/api"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	runtimeClient "github.com/oasisprotocol/oasis-core/go/runtime/client/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
@@ -27,6 +28,7 @@ type Controller struct {
 	Staking       staking.Backend
 	Governance    governance.Backend
 	Registry      registry.Backend
+	Roothash      roothash.Backend
 	RuntimeClient runtimeClient.RuntimeClient
 	Storage       storage.Backend
 	Keymanager    *keymanager.KeymanagerClient
@@ -61,6 +63,7 @@ func NewController(socketPath string) (*Controller, error) {
 		Staking:         staking.NewStakingClient(conn),
 		Governance:      governance.NewGovernanceClient(conn),
 		Registry:        registry.NewRegistryClient(conn),
+		Roothash:        roothash.NewRootHashClient(conn),
 		RuntimeClient:   runtimeClient.NewRuntimeClient(conn),
 		Storage:         storage.NewStorageClient(conn),
 		Keymanager:      keymanager.NewKeymanagerClient(conn),

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -122,6 +122,9 @@ type Backend interface {
 	// StateToGenesis returns the genesis state at specified block height.
 	StateToGenesis(ctx context.Context, height int64) (*Genesis, error)
 
+	// ConsensusParameters returns the roothash consensus parameters.
+	ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error)
+
 	// GetEvents returns the events at specified block height.
 	GetEvents(ctx context.Context, height int64) ([]*Event, error)
 

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -83,6 +83,10 @@ func RootHashImplementationTests(t *testing.T, backend api.Backend, consensus co
 	}
 	registryTests.BulkPopulate(t, consensus.Registry(), consensus, runtimes, seedBase)
 
+	t.Run("ConsensusParameters", func(t *testing.T) {
+		testConsensusParameters(t, backend)
+	})
+
 	// Run the various tests. (Ordering matters)
 	for _, v := range rtStates {
 		t.Run("GenesisBlock/"+v.id, func(t *testing.T) {
@@ -118,6 +122,14 @@ func RootHashImplementationTests(t *testing.T, backend api.Backend, consensus co
 	t.Run("EquivocationEvidence", func(t *testing.T) {
 		testSubmitEquivocationEvidence(t, backend, consensus, identity, rtStates)
 	})
+}
+
+func testConsensusParameters(t *testing.T, backend api.Backend) {
+	ctx := context.Background()
+
+	params, err := backend.ConsensusParameters(ctx, consensusAPI.HeightLatest)
+	require.NoError(t, err, "ConsensusParameters")
+	require.EqualValues(t, 32, params.MaxRuntimeMessages, "expected max runtime messages value")
 }
 
 func testGenesisBlock(t *testing.T, backend api.Backend, state *runtimeState) {

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -179,7 +179,7 @@ type Backend interface {
 	// StateToGenesis returns the genesis state at specified block height.
 	StateToGenesis(ctx context.Context, height int64) (*Genesis, error)
 
-	// Paremeters returns the staking consensus parameters.
+	// ConsensusParameters returns the staking consensus parameters.
 	ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error)
 
 	// GetEvents returns the events at specified block height.


### PR DESCRIPTION
Backports https://github.com/oasisprotocol/oasis-core/pull/4187