### PR TITLE
prevent startup when RLIMIT_NOFILE is too low

### DIFF
--- a/.changelog/4192.breaking.md
+++ b/.changelog/4192.breaking.md
@@ -1,0 +1,13 @@
+Prevent startup when file descriptor limit is too low
+
+Before, a warning was emitted if file descriptor limit was low (below 1024).
+Since low file descriptor limit can cause problems with BadgerDB, a
+high enough limit is now required on node startup (at least 50000).
+
+Follow the [File Descriptor Limit] documentation page for details on how to
+increase the limit on your system.
+
+<!-- markdownlint-disable line-length -->
+[File Descriptor Limit]:
+  https://docs.oasis.dev/general/run-a-node/prerequisites/system-configuration#file-descriptor-limit
+<!-- markdownlint-enable line-length -->

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -115,6 +115,14 @@ func (args *argBuilder) debugAllowTestKeys() *argBuilder {
 	return args
 }
 
+func (args *argBuilder) debugSetRlimit() *argBuilder {
+	args.vec = append(args.vec, Argument{
+		Name:   cmdCommon.CfgDebugRlimit,
+		Values: []string{strconv.Itoa(int(cmdCommon.RequiredRlimit))},
+	})
+	return args
+}
+
 func (args *argBuilder) debugEnableProfiling(port uint16) *argBuilder {
 	if port == 0 {
 		return args

--- a/go/oasis-test-runner/oasis/byzantine.go
+++ b/go/oasis-test-runner/oasis/byzantine.go
@@ -37,6 +37,7 @@ type ByzantineCfg struct {
 func (worker *Byzantine) AddArgs(args *argBuilder) error {
 	args.debugDontBlameOasis().
 		debugAllowTestKeys().
+		debugSetRlimit().
 		debugEnableProfiling(worker.Node.pprofPort).
 		tendermintDebugAllowDuplicateIP().
 		tendermintCoreAddress(worker.consensusPort).

--- a/go/oasis-test-runner/oasis/client.go
+++ b/go/oasis-test-runner/oasis/client.go
@@ -33,6 +33,7 @@ type ClientCfg struct {
 func (client *Client) AddArgs(args *argBuilder) error {
 	args.debugDontBlameOasis().
 		debugAllowTestKeys().
+		debugSetRlimit().
 		debugEnableProfiling(client.Node.pprofPort).
 		runtimeProvisioner(client.runtimeProvisioner).
 		tendermintPrune(client.consensus.PruneNumKept).

--- a/go/oasis-test-runner/oasis/compute.go
+++ b/go/oasis-test-runner/oasis/compute.go
@@ -83,6 +83,7 @@ func (worker *Compute) AddArgs(args *argBuilder) error {
 
 	args.debugDontBlameOasis().
 		debugAllowTestKeys().
+		debugSetRlimit().
 		debugEnableProfiling(worker.Node.pprofPort).
 		workerCertificateRotation(true).
 		tendermintCoreAddress(worker.consensusPort).

--- a/go/oasis-test-runner/oasis/ias.go
+++ b/go/oasis-test-runner/oasis/ias.go
@@ -25,6 +25,7 @@ type iasProxy struct {
 func (ias *iasProxy) AddArgs(args *argBuilder) error {
 	args.debugDontBlameOasis().
 		debugAllowTestKeys().
+		debugSetRlimit().
 		grpcServerPort(ias.grpcPort).
 		grpcWait()
 

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -263,6 +263,7 @@ func (km *Keymanager) AddArgs(args *argBuilder) error {
 
 	args.debugDontBlameOasis().
 		debugAllowTestKeys().
+		debugSetRlimit().
 		debugEnableProfiling(km.Node.pprofPort).
 		workerCertificateRotation(true).
 		tendermintCoreAddress(km.consensusPort).

--- a/go/oasis-test-runner/oasis/seed.go
+++ b/go/oasis-test-runner/oasis/seed.go
@@ -37,6 +37,7 @@ func (seed *Seed) AddArgs(args *argBuilder) error {
 
 	args.debugDontBlameOasis().
 		debugAllowTestKeys().
+		debugSetRlimit().
 		workerCertificateRotation(true).
 		tendermintCoreAddress(seed.consensusPort).
 		appendSeedNodes(otherSeeds).

--- a/go/oasis-test-runner/oasis/sentry.go
+++ b/go/oasis-test-runner/oasis/sentry.go
@@ -72,6 +72,7 @@ func (sentry *Sentry) AddArgs(args *argBuilder) error {
 
 	args.debugDontBlameOasis().
 		debugAllowTestKeys().
+		debugSetRlimit().
 		debugEnableProfiling(sentry.Node.pprofPort).
 		workerCertificateRotation(false).
 		workerSentryEnabled().

--- a/go/oasis-test-runner/oasis/storage.go
+++ b/go/oasis-test-runner/oasis/storage.go
@@ -129,6 +129,7 @@ func (worker *Storage) PauseCheckpointer(ctx context.Context, runtimeID common.N
 func (worker *Storage) AddArgs(args *argBuilder) error {
 	args.debugDontBlameOasis().
 		debugAllowTestKeys().
+		debugSetRlimit().
 		debugEnableProfiling(worker.Node.pprofPort).
 		workerCertificateRotation(!worker.disableCertRotation).
 		tendermintCoreAddress(worker.consensusPort).

--- a/go/oasis-test-runner/oasis/validator.go
+++ b/go/oasis-test-runner/oasis/validator.go
@@ -72,6 +72,7 @@ func (val *Validator) ExternalGRPCAddress() string {
 func (val *Validator) AddArgs(args *argBuilder) error {
 	args.debugDontBlameOasis().
 		debugAllowTestKeys().
+		debugSetRlimit().
 		debugEnableProfiling(val.Node.pprofPort).
 		workerCertificateRotation(true).
 		consensusValidator().


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/4192