### PR TITLE
go/runtime/client: Fail SubmitTx early for unsupported runtimes

### DIFF
--- a/.changelog/4202.bugfix.md
+++ b/.changelog/4202.bugfix.md
@@ -1,0 +1,4 @@
+go/runtime/client: Fail SubmitTx early for unsupported runtimes
+
+Make sure that the runtime is actually among the supported runtimes as
+otherwise we will not be able to actually get any results back.

--- a/go/runtime/client/client.go
+++ b/go/runtime/client/client.go
@@ -85,6 +85,12 @@ func (c *runtimeClient) submitTx(ctx context.Context, request *api.SubmitTxReque
 		return nil, fmt.Errorf("client: cannot submit transaction, p2p disabled")
 	}
 
+	// Make sure that the runtime is actually among the supported runtimes for this node as
+	// otherwise we will not be able to actually get any results back.
+	if _, err := c.common.runtimeRegistry.GetRuntime(request.RuntimeID); err != nil {
+		return nil, fmt.Errorf("client: cannot resolve runtime: %w", err)
+	}
+
 	// Make sure consensus is synced.
 	select {
 	case <-c.common.consensus.Synced():

--- a/go/runtime/client/tests/tester.go
+++ b/go/runtime/client/tests/tester.go
@@ -81,6 +81,7 @@ func testFailSubmitTransaction(
 	c api.RuntimeClient,
 	input string,
 ) {
+	// Failures during CheckTx.
 	resp, err := c.SubmitTxMeta(ctx, &api.SubmitTxRequest{Data: mock.CheckTxFailInput, RuntimeID: runtimeID})
 	require.NoError(t, err, "SubmitTxMeta")
 	require.EqualValues(t, &protocol.Error{
@@ -90,6 +91,14 @@ func testFailSubmitTransaction(
 
 	_, err = c.SubmitTx(ctx, &api.SubmitTxRequest{Data: mock.CheckTxFailInput, RuntimeID: runtimeID})
 	require.Error(t, err, "SubmitTx should fail check tx")
+
+	// Failures for unsupported runtimes.
+	var unsupportedRuntimeID common.Namespace
+	err = unsupportedRuntimeID.UnmarshalHex("0000000000000000BADF00BADF00BADF00BADF00BADF00BADF00BADF00BADF00")
+	require.NoError(t, err, "UnmarshalHex")
+
+	_, err = c.SubmitTx(ctx, &api.SubmitTxRequest{Data: []byte("irrelevant"), RuntimeID: unsupportedRuntimeID})
+	require.Error(t, err, "SubmitTx should fail for unsupported runtime")
 }
 
 func testQuery(


### PR DESCRIPTION
Fixes #4202 

Make sure that the runtime is actually among the supported runtimes as
otherwise we will not be able to actually get any results back.