### PR TITLE
go/runtime: fix round in runtime query

### DIFF
--- a/.changelog/4210.bugfix.md
+++ b/.changelog/4210.bugfix.md
@@ -1,0 +1,1 @@
+go/runtime: fix ignored round in runtime Query

--- a/go/roothash/api/history.go
+++ b/go/roothash/api/history.go
@@ -33,6 +33,9 @@ type BlockHistory interface {
 	// GetBlock returns the block at a specific round.
 	GetBlock(ctx context.Context, round uint64) (*block.Block, error)
 
+	// GetAnnotatedBlock returns the annotated block at a specific round.
+	GetAnnotatedBlock(ctx context.Context, round uint64) (*AnnotatedBlock, error)
+
 	// GetLatestBlock returns the block at latest round.
 	GetLatestBlock(ctx context.Context) (*block.Block, error)
 

--- a/go/runtime/client/tests/tester.go
+++ b/go/runtime/client/tests/tester.go
@@ -233,10 +233,34 @@ func testQuery(
 		Method:    "hello",
 	})
 	require.NoError(t, err, "Query")
-	var decMethod string
-	err = cbor.Unmarshal(rsp.Data, &decMethod)
+	var decResp string
+	err = cbor.Unmarshal(rsp.Data, &decResp)
 	require.NoError(t, err, "cbor.Unmarshal(<QueryResponse.Data>)")
-	require.EqualValues(t, "hello world", decMethod, "Query response should be correct")
+	require.True(t, strings.HasPrefix(decResp, "hello world"), "Query response should be correct")
+
+	rsp, err = c.Query(ctx, &api.QueryRequest{
+		RuntimeID: runtimeID,
+		Round:     1,
+		Method:    "hello",
+	})
+	require.NoError(t, err, "Query")
+	var decResp2 string
+	err = cbor.Unmarshal(rsp.Data, &decResp2)
+	require.NoError(t, err, "cbor.Unmarshal(<QueryResponse.Data>)")
+	require.True(t, strings.HasPrefix(decResp2, "hello world"), "Query response at round 1 should be correct")
+	require.NotEqualValues(t, decResp, decResp2, "Query responses for different rounds should not be equal (round consensus height should be included in response)")
+
+	rsp, err = c.Query(ctx, &api.QueryRequest{
+		RuntimeID: runtimeID,
+		Round:     1,
+		Method:    "hello",
+	})
+	require.NoError(t, err, "Query")
+	var decResp3 string
+	err = cbor.Unmarshal(rsp.Data, &decResp3)
+	require.NoError(t, err, "cbor.Unmarshal(<QueryResponse.Data>)")
+	require.True(t, strings.HasPrefix(decResp3, "hello world"), "Query response at round 1 should be correct")
+	require.EqualValues(t, decResp2, decResp3, "Query responses for same round should be equal (round consensus height should be included in response)")
 
 	// Execute CheckTx using the mock runtime host.
 	err = c.CheckTx(ctx, &api.CheckTxRequest{

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -76,6 +76,10 @@ func (h *nopHistory) GetBlock(ctx context.Context, round uint64) (*block.Block, 
 	return nil, errNopHistory
 }
 
+func (h *nopHistory) GetAnnotatedBlock(ctx context.Context, round uint64) (*roothash.AnnotatedBlock, error) {
+	return nil, errNopHistory
+}
+
 func (h *nopHistory) GetLatestBlock(ctx context.Context) (*block.Block, error) {
 	return nil, errNopHistory
 }
@@ -153,6 +157,13 @@ func (h *runtimeHistory) GetBlock(ctx context.Context, round uint64) (*block.Blo
 	}
 
 	return annBlk.Block, nil
+}
+
+func (h *runtimeHistory) GetAnnotatedBlock(ctx context.Context, round uint64) (*roothash.AnnotatedBlock, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	return h.db.getBlock(round)
 }
 
 func (h *runtimeHistory) GetLatestBlock(ctx context.Context) (*block.Block, error) {

--- a/go/runtime/history/history_test.go
+++ b/go/runtime/history/history_test.go
@@ -41,6 +41,10 @@ func TestHistory(t *testing.T) {
 	require.Error(err, "GetBlock should fail for non-indexed block")
 	require.Equal(roothash.ErrNotFound, err)
 
+	_, err = history.GetAnnotatedBlock(context.Background(), 10)
+	require.Error(err, "GetAnnotatedBlock should fail for non-indexed block")
+	require.Equal(roothash.ErrNotFound, err)
+
 	_, err = history.GetLatestBlock(context.Background())
 	require.Error(err, "GetLatestBlock should fail for no indexed block")
 	require.Equal(roothash.ErrNotFound, err)
@@ -84,6 +88,7 @@ func TestHistory(t *testing.T) {
 	blk.Block.Header.Round = 5
 	err = history.Commit(&blk, roundResults)
 	require.Error(err, "Commit should fail for a lower round")
+	blk.Block.Header.Round = 10
 
 	lastHeight, err = history.LastConsensusHeight()
 	require.NoError(err, "LastConsensusHeight")
@@ -92,6 +97,10 @@ func TestHistory(t *testing.T) {
 	gotBlk, err := history.GetBlock(context.Background(), 10)
 	require.NoError(err, "GetBlock")
 	require.Equal(&putBlk, gotBlk, "GetBlock should return the correct block")
+
+	gotAnnBlk, err := history.GetAnnotatedBlock(context.Background(), 10)
+	require.NoError(err, "GetAnnotatedBlock")
+	require.Equal(&blk, gotAnnBlk, "GetAnnotatedBlock should return the correct block")
 
 	gotLatestBlk, err := history.GetLatestBlock(context.Background())
 	require.NoError(err, "GetLatestBlock")
@@ -121,6 +130,10 @@ func TestHistory(t *testing.T) {
 	gotBlk, err = history.GetBlock(context.Background(), 10)
 	require.NoError(err, "GetBlock")
 	require.Equal(&putBlk, gotBlk, "GetBlock should return the correct block")
+
+	gotAnnBlk, err = history.GetAnnotatedBlock(context.Background(), 10)
+	require.NoError(err, "GetAnnotatedBlock")
+	require.Equal(&blk, gotAnnBlk, "GetAnnotatedBlock should return the correct block")
 
 	gotLatestBlk, err = history.GetLatestBlock(context.Background())
 	require.NoError(err, "GetLatestBlock")

--- a/go/runtime/host/mock/mock.go
+++ b/go/runtime/host/mock/mock.go
@@ -130,7 +130,7 @@ func (r *runtime) Call(ctx context.Context, body *protocol.Body) (*protocol.Body
 			}}, nil
 		default:
 			return &protocol.Body{RuntimeQueryResponse: &protocol.RuntimeQueryResponse{
-				Data: cbor.Marshal(rq.Method + " world"),
+				Data: cbor.Marshal(rq.Method + " world at:" + fmt.Sprintf("%d", rq.ConsensusBlock.Height)),
 			}}, nil
 		}
 	default:


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/4206

TODO:
- [x] test for `GetAnnotatedBlock`
- [x] test for querying past rounds