### PR TITLE
.buildkite/rust/build-runtime: use --locked flag in cargo install

### DIFF
--- a/.buildkite/rust/build_runtime.sh
+++ b/.buildkite/rust/build_runtime.sh
@@ -31,6 +31,7 @@ source .buildkite/rust/common.sh
 #####################################################################
 if [ ! -x ${CARGO_INSTALL_ROOT}/bin/cargo-elf2sgxs ]; then
     cargo install \
+        --locked \
         --force \
         --path tools \
         --debug


### PR DESCRIPTION
Fixes https://buildkite.com/oasisprotocol/oasis-core-ci/builds/5982#c112f7e2-f008-4930-aab5-c0f72a67dce8