### PR TITLE
runtime: Add MaxMessages to CheckTxBatch and Query

### DIFF
--- a/.changelog/4231.breaking.md
+++ b/.changelog/4231.breaking.md
@@ -1,0 +1,5 @@
+runtime: Add `MaxMessages` to `CheckTxBatch` and `Query`
+
+This allows transaction checks and queries to access the maximum number of
+runtime messages that can be emitted per round. Previously this information
+was only available in `ExecuteTxBatch`.

--- a/go/runtime/host/helpers.go
+++ b/go/runtime/host/helpers.go
@@ -32,6 +32,7 @@ type RichRuntime interface {
 		rb *block.Block,
 		lb *consensus.LightBlock,
 		epoch beacon.EpochTime,
+		maxMessages uint32,
 		batch transaction.RawBatch,
 	) ([]protocol.CheckTxResult, error)
 
@@ -41,6 +42,7 @@ type RichRuntime interface {
 		rb *block.Block,
 		lb *consensus.LightBlock,
 		epoch beacon.EpochTime,
+		maxMessages uint32,
 		method string,
 		args cbor.RawMessage,
 	) (cbor.RawMessage, error)
@@ -64,6 +66,7 @@ func (r *richRuntime) CheckTx(
 	rb *block.Block,
 	lb *consensus.LightBlock,
 	epoch beacon.EpochTime,
+	maxMessages uint32,
 	batch transaction.RawBatch,
 ) ([]protocol.CheckTxResult, error) {
 	if rb == nil || lb == nil {
@@ -76,6 +79,7 @@ func (r *richRuntime) CheckTx(
 			Inputs:         batch,
 			Block:          *rb,
 			Epoch:          epoch,
+			MaxMessages:    maxMessages,
 		},
 	})
 	switch {
@@ -95,6 +99,7 @@ func (r *richRuntime) Query(
 	rb *block.Block,
 	lb *consensus.LightBlock,
 	epoch beacon.EpochTime,
+	maxMessages uint32,
 	method string,
 	args cbor.RawMessage,
 ) (cbor.RawMessage, error) {
@@ -107,6 +112,7 @@ func (r *richRuntime) Query(
 			ConsensusBlock: *lb,
 			Header:         rb.Header,
 			Epoch:          epoch,
+			MaxMessages:    maxMessages,
 			Method:         method,
 			Args:           args,
 		},
@@ -127,7 +133,7 @@ func (r *richRuntime) QueryBatchLimits(
 	lb *consensus.LightBlock,
 	epoch beacon.EpochTime,
 ) (map[transaction.Weight]uint64, error) {
-	resp, err := r.Query(ctx, rb, lb, epoch, protocol.MethodQueryBatchWeightLimits, nil)
+	resp, err := r.Query(ctx, rb, lb, epoch, 0, protocol.MethodQueryBatchWeightLimits, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -211,6 +211,10 @@ type RuntimeCheckTxBatchRequest struct {
 	Block block.Block `json:"block"`
 	// Epoch is the current epoch number.
 	Epoch beacon.EpochTime `json:"epoch"`
+
+	// MaxMessages is the maximum number of messages that can be emitted in this
+	// round. Any more messages will be rejected by the consensus layer.
+	MaxMessages uint32 `json:"max_messages"`
 }
 
 // CheckTxResult contains the result of a CheckTx operation.
@@ -320,6 +324,10 @@ type RuntimeQueryRequest struct {
 	Header block.Header `json:"header"`
 	// Epoch is the current epoch number.
 	Epoch beacon.EpochTime `json:"epoch"`
+
+	// MaxMessages is the maximum number of messages that can be emitted in this
+	// round. Any more messages will be rejected by the consensus layer.
+	MaxMessages uint32 `json:"max_messages"`
 
 	Method string          `json:"method"`
 	Args   cbor.RawMessage `json:"args,omitempty"`

--- a/go/worker/compute/executor/committee/node.go
+++ b/go/worker/compute/executor/committee/node.go
@@ -607,8 +607,18 @@ func (n *Node) checkTxBatch() {
 	currentEpoch := n.commonNode.Group.GetEpochSnapshot().GetEpochNumber()
 	n.commonNode.CrossNode.Unlock()
 
+	// Fetch the active descriptor so we can get the current message limits.
+	rtDsc, err := n.commonNode.Runtime.ActiveDescriptor(n.ctx)
+	if err != nil {
+		n.logger.Error("failed to get active runtime descriptor",
+			"err", err,
+		)
+		return
+	}
+	currentMaxMessages := rtDsc.Executor.MaxMessages
+
 	// Check transaction batch.
-	results, err := rt.CheckTx(n.ctx, currentBlock, currentConsensusBlock, currentEpoch, batch)
+	results, err := rt.CheckTx(n.ctx, currentBlock, currentConsensusBlock, currentEpoch, currentMaxMessages, batch)
 	if err != nil {
 		n.logger.Error("transaction batch check tx error", "err", err)
 		return

--- a/runtime/src/dispatcher.rs
+++ b/runtime/src/dispatcher.rs
@@ -276,6 +276,7 @@ impl Dispatcher {
                     inputs,
                     block,
                     epoch,
+                    max_messages,
                 } => {
                     let light_block = consensus_block.decode_meta()?;
                     let consensus_state = ConsensusState::from_protocol(
@@ -296,7 +297,7 @@ impl Dispatcher {
                         block,
                         epoch,
                         Default::default(),
-                        0,
+                        max_messages,
                         true,
                     )
                 }
@@ -308,6 +309,7 @@ impl Dispatcher {
                     consensus_block,
                     header,
                     epoch,
+                    max_messages,
                     method,
                     args,
                 } => {
@@ -327,6 +329,7 @@ impl Dispatcher {
                         ctx,
                         header,
                         epoch,
+                        max_messages,
                         method,
                         args,
                     )
@@ -365,6 +368,7 @@ impl Dispatcher {
         ctx: Context,
         header: Header,
         epoch: EpochTime,
+        max_messages: u32,
         method: String,
         args: cbor::Value,
     ) -> Result<Body, Error> {
@@ -405,7 +409,7 @@ impl Dispatcher {
             &header,
             epoch,
             &results,
-            0,
+            max_messages,
             true,
         );
         let mut overlay = OverlayTree::new(&mut cache.mkvs);

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -162,6 +162,7 @@ pub enum Body {
         inputs: TxnBatch,
         block: Block,
         epoch: EpochTime,
+        max_messages: u32,
     },
     RuntimeCheckTxBatchResponse {
         results: Vec<CheckTxResult>,
@@ -189,6 +190,7 @@ pub enum Body {
         consensus_block: LightBlock,
         header: Header,
         epoch: EpochTime,
+        max_messages: u32,
         method: String,
         #[cbor(optional)]
         args: cbor::Value,

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -550,6 +550,13 @@ fn check_nonce(nonce: u64, ctx: &mut TxnContext) -> Result<()> {
     })
 }
 
+fn check_max_messages(ctx: &mut TxnContext) -> Result<()> {
+    if ctx.max_messages < 1 {
+        return Err(anyhow!("message limit too low"));
+    }
+    Ok(())
+}
+
 /// Queries all consensus accounts.
 /// Note: this is a transaction but could be a query in a non-test runtime.
 fn consensus_accounts(
@@ -581,6 +588,7 @@ fn consensus_accounts(
 /// Withdraw from the consensus layer into the runtime account.
 fn consensus_withdraw(args: &Withdraw, ctx: &mut TxnContext) -> Result<()> {
     check_nonce(args.nonce, ctx)?;
+    check_max_messages(ctx)?;
 
     if ctx.check_only {
         return Err(CheckOnlySuccess::default().into());
@@ -605,6 +613,7 @@ fn consensus_withdraw(args: &Withdraw, ctx: &mut TxnContext) -> Result<()> {
 /// Transfer from the runtime account to another account in the consensus layer.
 fn consensus_transfer(args: &Transfer, ctx: &mut TxnContext) -> Result<()> {
     check_nonce(args.nonce, ctx)?;
+    check_max_messages(ctx)?;
 
     if ctx.check_only {
         return Err(CheckOnlySuccess::default().into());
@@ -629,6 +638,7 @@ fn consensus_transfer(args: &Transfer, ctx: &mut TxnContext) -> Result<()> {
 /// Add escrow from the runtime account to an account in the consensus layer.
 fn consensus_add_escrow(args: &AddEscrow, ctx: &mut TxnContext) -> Result<()> {
     check_nonce(args.nonce, ctx)?;
+    check_max_messages(ctx)?;
 
     if ctx.check_only {
         return Err(CheckOnlySuccess::default().into());
@@ -653,6 +663,7 @@ fn consensus_add_escrow(args: &AddEscrow, ctx: &mut TxnContext) -> Result<()> {
 /// Reclaim escrow to the runtime account.
 fn consensus_reclaim_escrow(args: &ReclaimEscrow, ctx: &mut TxnContext) -> Result<()> {
     check_nonce(args.nonce, ctx)?;
+    check_max_messages(ctx)?;
 
     if ctx.check_only {
         return Err(CheckOnlySuccess::default().into());
@@ -677,6 +688,7 @@ fn consensus_reclaim_escrow(args: &ReclaimEscrow, ctx: &mut TxnContext) -> Resul
 /// Update existing runtime with given descriptor.
 fn update_runtime(args: &UpdateRuntime, ctx: &mut TxnContext) -> Result<()> {
     check_nonce(args.nonce, ctx)?;
+    check_max_messages(ctx)?;
 
     if ctx.check_only {
         return Err(CheckOnlySuccess::default().into());


### PR DESCRIPTION
Fixes #4231 

This allows transaction checks and queries to access the maximum number of
runtime messages that can be emitted per round. Previously this information
was only available in ExecuteTxBatch.