### PR TITLE
go/consensus/tendermint: Request state refresh on consensus init

### DIFF
--- a/.changelog/4237.feature.md
+++ b/.changelog/4237.feature.md
@@ -1,0 +1,7 @@
+go/consensus/tendermint: Request state refresh on consensus init
+
+Previously pending upgrade descriptors were only refreshed during governance
+proposal execution or after finishing a state sync. This is changed so that
+the `MessageStateSyncCompleted` message is also emitted after consensus
+initialization on already synced nodes so pending upgrades get installed even
+in case state was synced manually (out of band).

--- a/go/upgrade/api/api.go
+++ b/go/upgrade/api/api.go
@@ -80,6 +80,9 @@ var (
 	// ErrUpgradeNotFound is the error returned when the upgrade in question cannot be found.
 	ErrUpgradeNotFound = errors.New(ModuleName, 7, "upgrade: not found")
 
+	// ErrBadDescriptor is the error returned when the provided descriptor is bad.
+	ErrBadDescriptor = errors.New(ModuleName, 8, "upgrade: bad descriptor")
+
 	_ prettyprint.PrettyPrinter = (*Descriptor)(nil)
 )
 

--- a/go/upgrade/upgrade.go
+++ b/go/upgrade/upgrade.go
@@ -38,11 +38,15 @@ type upgradeManager struct {
 
 // Implements api.Backend.
 func (u *upgradeManager) SubmitDescriptor(ctx context.Context, descriptor *api.Descriptor) error {
+	if descriptor == nil {
+		return api.ErrBadDescriptor
+	}
+
 	u.Lock()
 	defer u.Unlock()
 
 	for _, pu := range u.pending {
-		if pu.Descriptor == descriptor {
+		if pu.Descriptor.Equals(descriptor) {
 			return api.ErrAlreadyPending
 		}
 	}
@@ -89,6 +93,10 @@ func (u *upgradeManager) HasPendingUpgradeAt(ctx context.Context, height int64) 
 
 // Implements api.Backend.
 func (u *upgradeManager) CancelUpgrade(ctx context.Context, descriptor *api.Descriptor) error {
+	if descriptor == nil {
+		return api.ErrBadDescriptor
+	}
+
 	u.Lock()
 	defer u.Unlock()
 
@@ -118,6 +126,10 @@ func (u *upgradeManager) CancelUpgrade(ctx context.Context, descriptor *api.Desc
 
 // Implements api.Backend.
 func (u *upgradeManager) GetUpgrade(ctx context.Context, descriptor *api.Descriptor) (*api.PendingUpgrade, error) {
+	if descriptor == nil {
+		return nil, api.ErrBadDescriptor
+	}
+
 	u.Lock()
 	defer u.Unlock()
 


### PR DESCRIPTION
Fixes #4237 

Previously pending upgrade descriptors were only refreshed during governance
proposal execution or after finishing a state sync. This is changed so that the
MessageStateSyncCompleted message is also emitted after consensus initialization
on already synced nodes so pending upgrades get installed even in case state was
synced manually (out of band).