### PR TITLE
go/common/node: Add custom text (un)marshaler for RolesMask type

### DIFF
--- a/.changelog/4243.feature.md
+++ b/.changelog/4243.feature.md
@@ -1,0 +1,4 @@
+go/common/node: Add custom text (un)marshaler for `RolesMask` type
+
+This will result in easy to understand `"roles"` fields in various CLI
+commands that output JSON.

--- a/go/common/node/node_test.go
+++ b/go/common/node/node_test.go
@@ -9,6 +9,80 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 )
 
+func TestRolesMask(t *testing.T) {
+	require := require.New(t)
+
+	testVectors := []struct {
+		rolesMaskString            string
+		rolesMask                  RolesMask
+		rolesMaskStringUnmarshable bool
+		rolesMaskStringCanonical   bool
+		errMsg                     string
+	}{
+		// Valid single roles.
+		{"compute", 1, true, true, ""},
+		{"storage", 2, true, true, ""},
+		{"key-manager", 4, true, true, ""},
+		{"validator", 8, true, true, ""},
+		{"consensus-rpc", 16, true, true, ""},
+		{"storage-rpc", 32, true, true, ""},
+		// Valid multiple roles.
+		{"compute,storage", 3, true, true, ""},
+		{"compute,storage,validator", 11, true, true, ""},
+		{"compute,storage,validator,consensus-rpc", 27, true, true, ""},
+		{"validator,consensus-rpc", 24, true, true, ""},
+		{"storage,storage-rpc", 34, true, true, ""},
+
+		// Invalid - extra spaces.
+		{"compute ", 1, false, false, "node: invalid role: 'compute '"},
+		{"compute ,", 1, false, false, "node: invalid role: 'compute '"},
+		{" validator", 1, false, false, "node: invalid role: ' validator'"},
+		{"compute, storage", 1, false, false, "node: invalid role: ' storage'"},
+		// Invalid - unknown role.
+		{"master", 1, false, false, "node: invalid role: 'master'"},
+		// Invalid - role mask string not in canonical order.
+		{"storage-rpc,storage", 34, true, false, ""},
+		// Invalid - duplicate role in role mask string.
+		{"compute,compute", 8, false, false, "node: duplicate role: 'compute'"},
+		{"storage,storage", 8, false, false, "node: duplicate role: 'storage'"},
+		{"key-manager,key-manager", 8, false, false, "node: duplicate role: 'key-manager'"},
+		{"validator,validator", 8, false, false, "node: duplicate role: 'validator'"},
+		{"consensus-rpc,consensus-rpc", 8, false, false, "node: duplicate role: 'consensus-rpc'"},
+		{"storage-rpc,storage-rpc", 8, false, false, "node: duplicate role: 'storage-rpc'"},
+		{"compute,storage,compute", 1, false, false, "node: duplicate role: 'compute'"},
+	}
+
+	for _, v := range testVectors {
+		var unmarshaledRolesMask RolesMask
+		err := unmarshaledRolesMask.UnmarshalText([]byte(v.rolesMaskString))
+		if !v.rolesMaskStringUnmarshable {
+			require.EqualErrorf(
+				err,
+				v.errMsg,
+				"Unmarshaling invalid roles mask: '%s' should fail with expected error message",
+				v.rolesMaskString,
+			)
+		} else {
+			require.NoErrorf(err, "Failed to unmarshal a valid roles mask: '%s'", v.rolesMaskString)
+			require.Equal(
+				v.rolesMask,
+				unmarshaledRolesMask,
+				"Unmarshaled roles mask doesn't equal expected roles mask",
+			)
+		}
+
+		textRolesMask, err := v.rolesMask.MarshalText()
+		require.NoError(err, "Failed to marshal a valid roles mask: '%s'", v.rolesMask)
+		if v.rolesMaskStringCanonical {
+			require.Equal(
+				v.rolesMaskString,
+				string(textRolesMask),
+				"Marshaled roles mask doesn't equal expected text roles mask",
+			)
+		}
+	}
+}
+
 func TestNodeDescriptor(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
This will result in easy to understand `"roles"` fields in various CLI commands that output JSON.

For example,  instead of `oasis-node control status` showing:

```
{
  ... trimmed ...
 
  "registration": {
    "last_registration": "2021-09-02T13:25:53+02:00",
    "descriptor": {

      ... trimmed ...

      "roles": 24
    },

  ... trimmed ...
}
```

  it will show:
  
```
{
  ... trimmed ...
 
  "registration": {
    "last_registration": "2021-09-02T13:25:53+02:00",
    "descriptor": {

      ... trimmed ...

      "roles": "validator,consensus-rpc"
    },

  ... trimmed ...
}
```