### PR TITLE
 go/runtime: Add key manager EnclaveRPC support to client runtime hosts

### DIFF
--- a/.changelog/4244.breaking.md
+++ b/.changelog/4244.breaking.md
@@ -1,0 +1,4 @@
+Remove EnclaveRPC client gRPC interface
+
+Since the SDK now supports using the key manager, the idea is that EnclaveRPC
+calls should be done from the runtime and exposed via queries.

--- a/.changelog/4244.bugfix.md
+++ b/.changelog/4244.bugfix.md
@@ -1,0 +1,7 @@
+go/runtime: Add key manager EnclaveRPC support to client runtime hosts
+
+Previously runtimes hosted on client nodes were not able to issue EnclaveRPC
+requests as the endpoint was not implemented in the handler. This unifies the
+handler implementations between the client and compute nodes and makes sure
+that key manager requests are possible (of course client nodes will only be
+able to request public keys).

--- a/client/src/enclave_rpc/client.rs
+++ b/client/src/enclave_rpc/client.rs
@@ -228,10 +228,8 @@ impl RpcClient {
             if session.inner.is_connected() {
                 return Ok(());
             }
-            if session.inner.is_closed() {
-                // In case the session is closed, reset it.
-                session.reset();
-            }
+            // Make sure the session is reset for a new connection.
+            session.reset();
 
             // Handshake1 -> Handshake2
             session

--- a/go/keymanager/client/api/api.go
+++ b/go/keymanager/client/api/api.go
@@ -1,0 +1,14 @@
+// Package api defines the key manager client API.
+package api
+
+import "context"
+
+// Client is the key manager client interface.
+type Client interface {
+	// CallRemote calls the key manager via remote EnclaveRPC.
+	CallRemote(ctx context.Context, data []byte) ([]byte, error)
+
+	// Initialized returns a channel which is closed when the key manager client initialization has
+	// completed and the client is ready to service requests.
+	Initialized() <-chan struct{}
+}

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -45,7 +45,6 @@ import (
 	roothashAPI "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	runtimeClient "github.com/oasisprotocol/oasis-core/go/runtime/client"
 	runtimeClientAPI "github.com/oasisprotocol/oasis-core/go/runtime/client/api"
-	enclaverpc "github.com/oasisprotocol/oasis-core/go/runtime/enclaverpc/api"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 	"github.com/oasisprotocol/oasis-core/go/sentry"
@@ -244,7 +243,6 @@ func (n *Node) startRuntimeServices() error {
 	}
 	n.svcMgr.Register(n.RuntimeClient)
 	runtimeClientAPI.RegisterService(n.grpcInternal.Server(), n.RuntimeClient)
-	enclaverpc.RegisterService(n.grpcInternal.Server(), n.RuntimeClient)
 
 	// Start workers (requires NodeController for checking, if nodes are synced).
 	if err = n.startRuntimeWorkers(); err != nil {

--- a/go/runtime/client/api/api.go
+++ b/go/runtime/client/api/api.go
@@ -11,7 +11,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/service"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
-	enclaverpc "github.com/oasisprotocol/oasis-core/go/runtime/enclaverpc/api"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 )
 
@@ -41,8 +40,6 @@ var (
 
 // RuntimeClient is the runtime client interface.
 type RuntimeClient interface {
-	enclaverpc.Transport
-
 	// SubmitTx submits a transaction to the runtime transaction scheduler and waits
 	// for transaction execution results.
 	SubmitTx(ctx context.Context, request *SubmitTxRequest) ([]byte, error)

--- a/go/runtime/client/api/grpc.go
+++ b/go/runtime/client/api/grpc.go
@@ -13,7 +13,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
-	enclaverpc "github.com/oasisprotocol/oasis-core/go/runtime/enclaverpc/api"
 )
 
 var (
@@ -369,8 +368,6 @@ func RegisterService(server *grpc.Server, service RuntimeClient) {
 }
 
 type runtimeClient struct {
-	enclaverpc.Transport
-
 	conn *grpc.ClientConn
 }
 
@@ -476,7 +473,6 @@ func (c *runtimeClient) WatchBlocks(ctx context.Context, runtimeID common.Namesp
 // NewRuntimeClient creates a new gRPC runtime client service.
 func NewRuntimeClient(c *grpc.ClientConn) RuntimeClient {
 	return &runtimeClient{
-		Transport: enclaverpc.NewTransportClient(c),
-		conn:      c,
+		conn: c,
 	}
 }

--- a/go/runtime/registry/host.go
+++ b/go/runtime/registry/host.go
@@ -2,11 +2,21 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	keymanagerApi "github.com/oasisprotocol/oasis-core/go/keymanager/api"
+	keymanagerClientApi "github.com/oasisprotocol/oasis-core/go/keymanager/client/api"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
+	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/syncer"
 )
 
 // RuntimeHostNode provides methods for nodes that need to host runtimes.
@@ -36,7 +46,7 @@ func (n *RuntimeHostNode) ProvisionHostedRuntime(ctx context.Context) (host.Rich
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to provision runtime: %w", err)
 	}
-	notifier := n.factory.NewNotifier(ctx, prt)
+	notifier := n.factory.NewRuntimeHostNotifier(ctx, prt)
 	rr := host.NewRichRuntime(prt)
 
 	n.Lock()
@@ -77,8 +87,8 @@ type RuntimeHostHandlerFactory interface {
 	// NewRuntimeHostHandler creates a new runtime host handler.
 	NewRuntimeHostHandler() protocol.Handler
 
-	// NewNotifier creates a new runtime host notifier.
-	NewNotifier(ctx context.Context, host host.Runtime) protocol.Notifier
+	// NewRuntimeHostNotifier creates a new runtime host notifier.
+	NewRuntimeHostNotifier(ctx context.Context, host host.Runtime) protocol.Notifier
 }
 
 // NewRuntimeHostNode creates a new runtime host node.
@@ -87,4 +97,249 @@ func NewRuntimeHostNode(factory RuntimeHostHandlerFactory) (*RuntimeHostNode, er
 		factory:       factory,
 		runtimeNotify: make(chan struct{}),
 	}, nil
+}
+
+var (
+	errMethodNotSupported   = errors.New("method not supported")
+	errEndpointNotSupported = errors.New("endpoint not supported")
+)
+
+// RuntimeHostHandlerEnvironment is the host environment interface.
+type RuntimeHostHandlerEnvironment interface {
+	// GetCurrentBlock returns the most recent runtime block.
+	GetCurrentBlock(ctx context.Context) (*block.Block, error)
+
+	// GetKeyManagerClient returns the key manager client for this runtime.
+	GetKeyManagerClient(ctx context.Context) (keymanagerClientApi.Client, error)
+}
+
+// RuntimeHostHandler is a runtime host handler suitable for compute runtimes. It provides the
+// required set of methods for interacting with the outside world.
+type runtimeHostHandler struct {
+	env       RuntimeHostHandlerEnvironment
+	runtime   Runtime
+	consensus consensus.Backend
+}
+
+// Implements protocol.Handler.
+func (h *runtimeHostHandler) Handle(ctx context.Context, body *protocol.Body) (*protocol.Body, error) {
+	// RPC.
+	if body.HostRPCCallRequest != nil {
+		switch body.HostRPCCallRequest.Endpoint {
+		case keymanagerApi.EnclaveRPCEndpoint:
+			// Call into the remote key manager.
+			kmCli, err := h.env.GetKeyManagerClient(ctx)
+			if err != nil {
+				return nil, err
+			}
+			res, err := kmCli.CallRemote(ctx, body.HostRPCCallRequest.Request)
+			if err != nil {
+				return nil, err
+			}
+			return &protocol.Body{HostRPCCallResponse: &protocol.HostRPCCallResponse{
+				Response: cbor.FixSliceForSerde(res),
+			}}, nil
+		default:
+			return nil, errEndpointNotSupported
+		}
+	}
+	// Storage.
+	if body.HostStorageSyncRequest != nil {
+		rq := body.HostStorageSyncRequest
+
+		var rs syncer.ReadSyncer
+		switch rq.Endpoint {
+		case protocol.HostStorageEndpointRuntime:
+			// Runtime storage.
+			rs = h.runtime.Storage()
+
+			// Prioritize nodes that signed the last storage receipts.
+			if blk, _ := h.env.GetCurrentBlock(ctx); blk != nil {
+				ctx = storage.WithNodePriorityHintFromSignatures(ctx, blk.Header.StorageSignatures)
+			}
+		case protocol.HostStorageEndpointConsensus:
+			// Consensus state storage.
+			rs = h.consensus.State()
+		default:
+			return nil, errEndpointNotSupported
+		}
+
+		var rsp *storage.ProofResponse
+		var err error
+		switch {
+		case rq.SyncGet != nil:
+			rsp, err = rs.SyncGet(ctx, rq.SyncGet)
+		case rq.SyncGetPrefixes != nil:
+			rsp, err = rs.SyncGetPrefixes(ctx, rq.SyncGetPrefixes)
+		case rq.SyncIterate != nil:
+			rsp, err = rs.SyncIterate(ctx, rq.SyncIterate)
+		default:
+			return nil, errMethodNotSupported
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		return &protocol.Body{HostStorageSyncResponse: &protocol.HostStorageSyncResponse{ProofResponse: rsp}}, nil
+	}
+	// Local storage.
+	if body.HostLocalStorageGetRequest != nil {
+		value, err := h.runtime.LocalStorage().Get(body.HostLocalStorageGetRequest.Key)
+		if err != nil {
+			return nil, err
+		}
+		return &protocol.Body{HostLocalStorageGetResponse: &protocol.HostLocalStorageGetResponse{Value: value}}, nil
+	}
+	if body.HostLocalStorageSetRequest != nil {
+		if err := h.runtime.LocalStorage().Set(body.HostLocalStorageSetRequest.Key, body.HostLocalStorageSetRequest.Value); err != nil {
+			return nil, err
+		}
+		return &protocol.Body{HostLocalStorageSetResponse: &protocol.Empty{}}, nil
+	}
+
+	return nil, errMethodNotSupported
+}
+
+// runtimeHostNotifier is a runtime host notifier suitable for compute runtimes. It handles things
+// like key manager policy updates.
+type runtimeHostNotifier struct {
+	sync.Mutex
+
+	ctx context.Context
+
+	stopCh chan struct{}
+
+	started   bool
+	runtime   Runtime
+	host      host.Runtime
+	consensus consensus.Backend
+
+	logger *logging.Logger
+}
+
+func (n *runtimeHostNotifier) watchPolicyUpdates() {
+	// Subscribe to runtime descriptor updates.
+	dscCh, dscSub, err := n.runtime.WatchRegistryDescriptor()
+	if err != nil {
+		n.logger.Error("failed to subscribe to registry descriptor updates",
+			"err", err,
+		)
+		return
+	}
+	defer dscSub.Close()
+
+	// Subscribe to key manager status updates.
+	stCh, stSub := n.consensus.KeyManager().WatchStatuses()
+	defer stSub.Close()
+	n.logger.Debug("watching policy updates")
+
+	var rtDsc *registry.Runtime
+	for {
+		var st *keymanagerApi.Status
+		select {
+		case <-n.ctx.Done():
+			n.logger.Debug("context canceled")
+			return
+		case <-n.stopCh:
+			n.logger.Debug("termination requested")
+			return
+		case rtDsc = <-dscCh:
+			n.logger.Debug("got registry descriptor update")
+
+			// Ignore updates if key manager is not needed.
+			if rtDsc.KeyManager == nil {
+				n.logger.Debug("no key manager needed for this runtime")
+				continue
+			}
+			// GetStatus(context.Context, *registry.NamespaceQuery) (*Status, error)
+
+			var err error
+			st, err = n.consensus.KeyManager().GetStatus(n.ctx, &registry.NamespaceQuery{
+				Height: consensus.HeightLatest,
+				ID:     *rtDsc.KeyManager,
+			})
+			if err != nil {
+				n.logger.Warn("failed to fetch key manager status",
+					"err", err,
+				)
+				continue
+			}
+		case st = <-stCh:
+			// Ignore status updates if key manager is not yet known (is nil)
+			// or if the status update is for a different key manager.
+			if rtDsc == nil || !st.ID.Equal(rtDsc.KeyManager) {
+				continue
+			}
+		}
+
+		// Update key manager policy.
+		n.logger.Debug("got policy update", "status", st)
+
+		raw := cbor.Marshal(st.Policy)
+		req := &protocol.Body{RuntimeKeyManagerPolicyUpdateRequest: &protocol.RuntimeKeyManagerPolicyUpdateRequest{
+			SignedPolicyRaw: raw,
+		}}
+
+		response, err := n.host.Call(n.ctx, req)
+		if err != nil {
+			n.logger.Error("failed dispatching key manager policy update to runtime",
+				"err", err,
+			)
+			continue
+		}
+		n.logger.Debug("key manager policy updated dispatched", "response", response)
+	}
+}
+
+// Implements protocol.Notifier.
+func (n *runtimeHostNotifier) Start() error {
+	n.Lock()
+	defer n.Unlock()
+
+	if n.started {
+		return nil
+	}
+	n.started = true
+
+	go n.watchPolicyUpdates()
+
+	return nil
+}
+
+// Implements protocol.Notifier.
+func (n *runtimeHostNotifier) Stop() {
+	close(n.stopCh)
+}
+
+// NewRuntimeHostNotifier returns a protocol notifier that handles key manager policy updates.
+func NewRuntimeHostNotifier(
+	ctx context.Context,
+	runtime Runtime,
+	host host.Runtime,
+	consensus consensus.Backend,
+) protocol.Notifier {
+	return &runtimeHostNotifier{
+		ctx:       ctx,
+		stopCh:    make(chan struct{}),
+		runtime:   runtime,
+		host:      host,
+		consensus: consensus,
+		logger:    logging.GetLogger("runtime/registry/host"),
+	}
+}
+
+// NewRuntimeHostHandler returns a protocol handler that provides the required host methods for the
+// runtime to interact with the outside world.
+//
+// The passed identity may be nil.
+func NewRuntimeHostHandler(
+	env RuntimeHostHandlerEnvironment,
+	runtime Runtime,
+	consensus consensus.Backend,
+) protocol.Handler {
+	return &runtimeHostHandler{
+		env:       env,
+		runtime:   runtime,
+		consensus: consensus,
+	}
 }

--- a/go/worker/common/committee/runtime_host.go
+++ b/go/worker/common/committee/runtime_host.go
@@ -2,234 +2,43 @@ package committee
 
 import (
 	"context"
-	"errors"
-	"sync"
 
-	"github.com/oasisprotocol/oasis-core/go/common/cbor"
-	"github.com/oasisprotocol/oasis-core/go/common/logging"
-	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
-	keymanagerApi "github.com/oasisprotocol/oasis-core/go/keymanager/api"
-	keymanagerClient "github.com/oasisprotocol/oasis-core/go/keymanager/client"
+	keymanagerClientApi "github.com/oasisprotocol/oasis-core/go/keymanager/client/api"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
-	"github.com/oasisprotocol/oasis-core/go/runtime/localstorage"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
-	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
-	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/syncer"
 )
-
-var (
-	errMethodNotSupported   = errors.New("method not supported")
-	errEndpointNotSupported = errors.New("endpoint not supported")
-)
-
-// computeRuntimeHostHandler is a runtime host handler suitable for compute runtimes.
-type computeRuntimeHostHandler struct {
-	node    *Node
-	runtime runtimeRegistry.Runtime
-
-	storage          storage.Backend
-	keyManager       keymanagerApi.Backend
-	keyManagerClient *keymanagerClient.Client
-	localStorage     localstorage.LocalStorage
-	consensus        consensus.Backend
-}
-
-func (h *computeRuntimeHostHandler) Handle(ctx context.Context, body *protocol.Body) (*protocol.Body, error) {
-	// RPC.
-	if body.HostRPCCallRequest != nil {
-		switch body.HostRPCCallRequest.Endpoint {
-		case keymanagerApi.EnclaveRPCEndpoint:
-			// Call into the remote key manager.
-			if h.keyManagerClient == nil {
-				return nil, errEndpointNotSupported
-			}
-			res, err := h.keyManagerClient.CallRemote(ctx, body.HostRPCCallRequest.Request)
-			if err != nil {
-				return nil, err
-			}
-			return &protocol.Body{HostRPCCallResponse: &protocol.HostRPCCallResponse{
-				Response: cbor.FixSliceForSerde(res),
-			}}, nil
-		default:
-			return nil, errEndpointNotSupported
-		}
-	}
-	// Storage.
-	if body.HostStorageSyncRequest != nil {
-		rq := body.HostStorageSyncRequest
-
-		var rs syncer.ReadSyncer
-		switch rq.Endpoint {
-		case protocol.HostStorageEndpointRuntime:
-			// Runtime storage.
-			rs = h.storage
-
-			// Prioritize nodes that signed the last storage receipts.
-			h.node.CrossNode.Lock()
-			blk := h.node.CurrentBlock
-			h.node.CrossNode.Unlock()
-			if blk != nil {
-				ctx = storage.WithNodePriorityHintFromSignatures(ctx, blk.Header.StorageSignatures)
-			}
-		case protocol.HostStorageEndpointConsensus:
-			// Consensus state storage.
-			rs = h.consensus.State()
-		default:
-			return nil, errEndpointNotSupported
-		}
-
-		var rsp *storage.ProofResponse
-		var err error
-		switch {
-		case rq.SyncGet != nil:
-			rsp, err = rs.SyncGet(ctx, rq.SyncGet)
-		case rq.SyncGetPrefixes != nil:
-			rsp, err = rs.SyncGetPrefixes(ctx, rq.SyncGetPrefixes)
-		case rq.SyncIterate != nil:
-			rsp, err = rs.SyncIterate(ctx, rq.SyncIterate)
-		default:
-			return nil, errMethodNotSupported
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		return &protocol.Body{HostStorageSyncResponse: &protocol.HostStorageSyncResponse{ProofResponse: rsp}}, nil
-	}
-	// Local storage.
-	if body.HostLocalStorageGetRequest != nil {
-		value, err := h.localStorage.Get(body.HostLocalStorageGetRequest.Key)
-		if err != nil {
-			return nil, err
-		}
-		return &protocol.Body{HostLocalStorageGetResponse: &protocol.HostLocalStorageGetResponse{Value: value}}, nil
-	}
-	if body.HostLocalStorageSetRequest != nil {
-		if err := h.localStorage.Set(body.HostLocalStorageSetRequest.Key, body.HostLocalStorageSetRequest.Value); err != nil {
-			return nil, err
-		}
-		return &protocol.Body{HostLocalStorageSetResponse: &protocol.Empty{}}, nil
-	}
-
-	return nil, errMethodNotSupported
-}
 
 // Implements RuntimeHostHandlerFactory.
 func (n *Node) GetRuntime() runtimeRegistry.Runtime {
 	return n.Runtime
 }
 
-// computeRuntimeHostNotifier is a runtime host notifier suitable for compute
-// runtimes.
-type computeRuntimeHostNotifier struct {
-	sync.Mutex
-
-	ctx context.Context
-
-	stopCh chan struct{}
-
-	started    bool
-	runtime    runtimeRegistry.Runtime
-	host       host.Runtime
-	keyManager keymanagerApi.Backend
-
-	logger *logging.Logger
-}
-
-func (n *computeRuntimeHostNotifier) watchPolicyUpdates() {
-	// Wait for the runtime.
-	rt, err := n.runtime.RegistryDescriptor(n.ctx)
-	if err != nil {
-		n.logger.Error("failed to wait for registry descriptor",
-			"err", err,
-		)
-		return
-	}
-	if rt.KeyManager == nil {
-		n.logger.Info("no keymanager needed, not watching for policy updates")
-		return
-	}
-
-	stCh, stSub := n.keyManager.WatchStatuses()
-	defer stSub.Close()
-	n.logger.Info("watching policy updates", "keymanager_runtime", rt.KeyManager)
-
-	for {
-		select {
-		case <-n.ctx.Done():
-			n.logger.Warn("contex canceled")
-			return
-		case <-n.stopCh:
-			n.logger.Warn("termination requested")
-			return
-		case st := <-stCh:
-			n.logger.Debug("got policy update", "status", st)
-
-			// Ignore status updates if key manager is not yet known (is nil)
-			// or if the status update is for a different key manager.
-			if !st.ID.Equal(rt.KeyManager) {
-				continue
-			}
-
-			raw := cbor.Marshal(st.Policy)
-			req := &protocol.Body{RuntimeKeyManagerPolicyUpdateRequest: &protocol.RuntimeKeyManagerPolicyUpdateRequest{
-				SignedPolicyRaw: raw,
-			}}
-
-			response, err := n.host.Call(n.ctx, req)
-			if err != nil {
-				n.logger.Error("failed dispatching key manager policy update to runtime",
-					"err", err,
-				)
-				continue
-			}
-			n.logger.Debug("key manager policy updated dispatched", "response", response)
-		}
-	}
-}
-
-// Implements protocol.Notifier.
-func (n *computeRuntimeHostNotifier) Start() error {
-	n.Lock()
-	defer n.Unlock()
-
-	if n.started {
-		return nil
-	}
-	n.started = true
-
-	go n.watchPolicyUpdates()
-
-	return nil
-}
-
-// Implements protocol.Notifier.
-func (n *computeRuntimeHostNotifier) Stop() {
-	close(n.stopCh)
-}
-
 // Implements RuntimeHostHandlerFactory.
-func (n *Node) NewNotifier(ctx context.Context, host host.Runtime) protocol.Notifier {
-	return &computeRuntimeHostNotifier{
-		ctx:        ctx,
-		stopCh:     make(chan struct{}),
-		runtime:    n.Runtime,
-		host:       host,
-		keyManager: n.KeyManager,
-		logger:     logging.GetLogger("committee/runtime-host"),
-	}
+func (n *Node) NewRuntimeHostNotifier(ctx context.Context, host host.Runtime) protocol.Notifier {
+	return runtimeRegistry.NewRuntimeHostNotifier(ctx, n.Runtime, host, n.Consensus)
+}
+
+type nodeEnvironment struct {
+	n *Node
+}
+
+// Implements RuntimeHostHandlerEnvironment.
+func (env *nodeEnvironment) GetCurrentBlock(ctx context.Context) (*block.Block, error) {
+	var blk *block.Block
+	env.n.CrossNode.Lock()
+	blk = env.n.CurrentBlock
+	env.n.CrossNode.Unlock()
+	return blk, nil
+}
+
+// Implements RuntimeHostHandlerEnvironment.
+func (env *nodeEnvironment) GetKeyManagerClient(ctx context.Context) (keymanagerClientApi.Client, error) {
+	return env.n.KeyManagerClient, nil
 }
 
 // Implements RuntimeHostHandlerFactory.
 func (n *Node) NewRuntimeHostHandler() protocol.Handler {
-	return &computeRuntimeHostHandler{
-		node:             n,
-		runtime:          n.Runtime,
-		storage:          n.Runtime.Storage(),
-		keyManager:       n.KeyManager,
-		keyManagerClient: n.KeyManagerClient,
-		localStorage:     n.Runtime.LocalStorage(),
-		consensus:        n.Consensus,
-	}
+	return runtimeRegistry.NewRuntimeHostHandler(&nodeEnvironment{n}, n.Runtime, n.Consensus)
 }

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -135,7 +135,7 @@ func (w *Worker) GetRuntime() runtimeRegistry.Runtime {
 }
 
 // Implements workerCommon.RuntimeHostHandlerFactory.
-func (w *Worker) NewNotifier(ctx context.Context, host host.Runtime) protocol.Notifier {
+func (w *Worker) NewRuntimeHostNotifier(ctx context.Context, host host.Runtime) protocol.Notifier {
 	return &protocol.NoOpNotifier{}
 }
 


### PR DESCRIPTION
Previously runtimes hosted on client nodes were not able to issue EnclaveRPC
requests as the endpoint was not implemented in the handler. This unifies the
handler implementations between the client and compute nodes and makes sure that
key manager requests are possible (of course client nodes will only be able to
request public keys).

Also removes the EnclaveRPC client interface as the idea is to go through runtime
queries (as the SDK now supports using the key manager). Note that the client part
of EnclaveRPC transport was already removed when doing the gRPC refactor.