### PR TITLE
runtime: Verify consensus layer state by using a light client

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -222,6 +222,9 @@ steps:
       - /tmp/e2e/**/*.log
     env:
       OASIS_E2E_COVERAGE: enable
+      # Since the trust-root scenario is tested in SGX mode (for which it is actually relevant) no need
+      # to also test it in non-SGX mode in CI.
+      OASIS_EXCLUDE_E2E: e2e/runtime/trust-root
       TEST_BASE_DIR: /tmp
       # libp2p logging.
       IPFS_LOGGING: debug
@@ -238,12 +241,17 @@ steps:
     timeout_in_minutes: 40
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
+      # Needed as the trust-root test rebuilds the enclave with embedded trust root data.
+      - cargo install --locked --path tools
       # Only run runtime scenarios as others do not use SGX.
-      - .buildkite/scripts/test_e2e.sh --scenario e2e/runtime/runtime
+      - .buildkite/scripts/test_e2e.sh --scenario e2e/runtime/runtime --scenario e2e/runtime/trust-root
     artifact_paths:
       - coverage-merged-e2e-*.txt
       - /tmp/e2e/**/*.log
     env:
+      # Unsafe flags needed as the trust-root test rebuilds the enclave with embedded trust root data.
+      OASIS_UNSAFE_SKIP_AVR_VERIFY: "1"
+      OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES: "1"
       OASIS_E2E_COVERAGE: enable
       TEST_BASE_DIR: /tmp
       # libp2p logging.

--- a/.buildkite/scripts/test_e2e.sh
+++ b/.buildkite/scripts/test_e2e.sh
@@ -53,6 +53,8 @@ ${test_runner_binary} \
     --e2e/runtime.runtime.loader ${WORKDIR}/target/default/debug/oasis-core-runtime-loader \
     --e2e/runtime.tee_hardware ${OASIS_TEE_HARDWARE:-""} \
     --e2e/runtime.ias.mock=${ias_mock} \
+    --e2e/runtime/trust-root.runtime.source_dir ${WORKDIR}/tests/runtimes \
+    --e2e/runtime/trust-root.runtime.target_dir ${WORKDIR}/target \
     --remote-signer.binary ${WORKDIR}/go/oasis-remote-signer/oasis-remote-signer \
     --plugin-signer.name example \
     --plugin-signer.binary ${WORKDIR}/go/oasis-test-runner/scenario/pluginsigner/example_signer_plugin/example_signer_plugin \

--- a/.changelog/3952.breaking.md
+++ b/.changelog/3952.breaking.md
@@ -1,0 +1,1 @@
+runtime: Verify consensus layer state by using a light client

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "550632e31568ae1a5f47998c3aa48563030fc49b9ec91913ca337cf64fbc5ccb"
 dependencies = [
  "backtrace",
+ "serde",
 ]
 
 [[package]]
@@ -183,6 +184,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "serde",
 ]
 
 [[package]]
@@ -383,6 +385,23 @@ name = "const-oid"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
+
+[[package]]
+name = "contracts"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9424f2ca1e42776615720e5746eed6efa19866fdbaac2923ab51c294ac4d1f2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cpufeatures"
@@ -700,6 +719,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,6 +1029,12 @@ name = "gimli"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
+
+[[package]]
+name = "half"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hashbrown"
@@ -1552,6 +1590,7 @@ dependencies = [
  "jsonrpc",
  "lazy_static",
  "log",
+ "lru",
  "num-bigint",
  "num-traits",
  "oasis-cbor",
@@ -1572,7 +1611,9 @@ dependencies = [
  "sp800-185",
  "tempfile",
  "tendermint",
+ "tendermint-light-client",
  "tendermint-proto",
+ "tendermint-rpc",
  "thiserror",
  "tiny-keccak 2.0.2",
  "tokio 1.10.1",
@@ -1682,6 +1723,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2070,6 +2131,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,6 +2178,16 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
  "serde",
 ]
 
@@ -2459,6 +2539,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendermint-light-client"
+version = "0.20.0"
+source = "git+https://github.com/informalsystems/tendermint-rs?rev=1efe42c8625045fd99072718faf96e81aeb9c6e6#1efe42c8625045fd99072718faf96e81aeb9c6e6"
+dependencies = [
+ "anomaly",
+ "contracts",
+ "crossbeam-channel 0.4.4",
+ "derive_more",
+ "futures 0.3.17",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "static_assertions",
+ "tendermint",
+ "tendermint-rpc",
+ "thiserror",
+]
+
+[[package]]
 name = "tendermint-proto"
 version = "0.20.0"
 source = "git+https://github.com/informalsystems/tendermint-rs?rev=1efe42c8625045fd99072718faf96e81aeb9c6e6#1efe42c8625045fd99072718faf96e81aeb9c6e6"
@@ -2474,6 +2573,27 @@ dependencies = [
  "serde_bytes",
  "subtle-encoding",
  "thiserror",
+]
+
+[[package]]
+name = "tendermint-rpc"
+version = "0.20.0"
+source = "git+https://github.com/informalsystems/tendermint-rs?rev=1efe42c8625045fd99072718faf96e81aeb9c6e6#1efe42c8625045fd99072718faf96e81aeb9c6e6"
+dependencies = [
+ "bytes 1.0.1",
+ "chrono",
+ "getrandom 0.1.16",
+ "pin-project",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "subtle-encoding",
+ "tendermint",
+ "tendermint-proto",
+ "thiserror",
+ "url",
+ "uuid",
+ "walkdir",
 ]
 
 [[package]]
@@ -2698,6 +2818,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,6 +2846,17 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -2770,6 +2907,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/client/src/enclave_rpc/client.rs
+++ b/client/src/enclave_rpc/client.rs
@@ -158,10 +158,11 @@ impl RpcClient {
         request: types::Request,
     ) -> Result<types::Response, RpcClientError> {
         // Spawn a new controller if we haven't spawned one yet.
-        if !self
+        if self
             .inner
             .has_controller
-            .compare_and_swap(false, true, Ordering::SeqCst)
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
         {
             let mut rx = self
                 .inner

--- a/client/src/enclave_rpc/transport.rs
+++ b/client/src/enclave_rpc/transport.rs
@@ -56,7 +56,7 @@ impl Transport for RuntimeTransport {
         );
 
         match rsp {
-            Err(err) => Box::pin(future::err(err)),
+            Err(err) => Box::pin(future::err(err.into())),
             Ok(Body::HostRPCCallResponse { response }) => Box::pin(future::ok(response)),
             Ok(_) => Box::pin(future::err(anyhow!("bad response type"))),
         }

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -155,6 +155,8 @@ type NodeFixture struct {
 	// to automatically instantiate a dedicated node with a default name.
 	Name string `json:"node_name,omitempty"`
 
+	NoAutoStart bool `json:"no_auto_start,omitempty"`
+
 	ExtraArgs []Argument `json:"extra_args,omitempty"`
 }
 
@@ -170,8 +172,6 @@ type ValidatorFixture struct { // nolint: maligned
 
 	AllowEarlyTermination bool `json:"allow_early_termination"`
 	AllowErrorTermination bool `json:"allow_error_termination"`
-
-	NoAutoStart bool `json:"no_auto_start,omitempty"`
 
 	CrashPointsProbability float64 `json:"crash_points_probability,omitempty"`
 
@@ -316,8 +316,6 @@ type KeymanagerFixture struct {
 	AllowEarlyTermination bool `json:"allow_early_termination"`
 	AllowErrorTermination bool `json:"allow_error_termination"`
 
-	NoAutoStart bool `json:"no_auto_start,omitempty"`
-
 	EnableProfiling bool `json:"enable_profiling"`
 
 	Sentries []int `json:"sentries,omitempty"`
@@ -375,8 +373,6 @@ type StorageWorkerFixture struct { // nolint: maligned
 
 	AllowEarlyTermination bool `json:"allow_early_termination"`
 	AllowErrorTermination bool `json:"allow_error_termination"`
-
-	NoAutoStart bool `json:"no_auto_start,omitempty"`
 
 	EnableProfiling bool `json:"enable_profiling"`
 
@@ -445,8 +441,6 @@ type ComputeWorkerFixture struct {
 
 	AllowEarlyTermination bool `json:"allow_early_termination"`
 	AllowErrorTermination bool `json:"allow_error_termination"`
-
-	NoAutoStart bool `json:"no_auto_start,omitempty"`
 
 	EnableProfiling bool `json:"enable_profiling"`
 
@@ -529,6 +523,7 @@ func (f *SentryFixture) Create(net *Network) (*Sentry, error) {
 	return net.NewSentry(&SentryCfg{
 		NodeCfg: NodeCfg{
 			Name:                        f.Name,
+			NoAutoStart:                 f.NoAutoStart,
 			LogWatcherHandlerFactories:  f.LogWatcherHandlerFactories,
 			CrashPointsProbability:      f.CrashPointsProbability,
 			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
@@ -573,6 +568,7 @@ func (f *ClientFixture) Create(net *Network) (*Client, error) {
 			Consensus:                   f.Consensus,
 			AllowErrorTermination:       f.AllowErrorTermination,
 			AllowEarlyTermination:       f.AllowEarlyTermination,
+			NoAutoStart:                 f.NoAutoStart,
 			SupplementarySanityInterval: f.Consensus.SupplementarySanityInterval,
 			EnableProfiling:             f.EnableProfiling,
 			ExtraArgs:                   f.ExtraArgs,

--- a/go/oasis-test-runner/rust/builder.go
+++ b/go/oasis-test-runner/rust/builder.go
@@ -1,0 +1,125 @@
+// Package rust contains a Go interface to the Rust build system.
+//
+// This is needed as certain E2E tests require things to be rebuilt during tests.
+package rust
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
+)
+
+const (
+	builderSubDir         = "cargo-builder"
+	builderLogConsoleFile = "console.log"
+)
+
+// Builder provides an interface for building Rust runtimes by invoking `cargo`.
+type Builder struct {
+	env *env.Env
+
+	teeHardware node.TEEHardware
+	pkg         string
+
+	buildDir  string
+	targetDir string
+
+	envVars map[string]string
+}
+
+// SetEnv sets a build-time environment variable.
+func (b *Builder) SetEnv(key, value string) {
+	b.envVars[key] = value
+}
+
+// ResetEnv resets the build-time environment variables.
+func (b *Builder) ResetEnv() {
+	b.envVars = make(map[string]string)
+}
+
+func (b *Builder) cargoCommand(subCommand string) (*exec.Cmd, error) {
+	dir, err := b.env.NewSubDir(builderSubDir)
+	if err != nil {
+		return nil, err
+	}
+	w, err := dir.NewLogWriter(builderLogConsoleFile)
+	if err != nil {
+		return nil, err
+	}
+	b.env.AddOnCleanup(func() {
+		_ = w.Close()
+	})
+
+	cmd := exec.Command("cargo", subCommand)
+	cmd.Dir = b.buildDir
+	cmd.SysProcAttr = env.CmdAttrs
+	cmd.Stdout = w
+	cmd.Stderr = w
+
+	targetDir := b.targetDir
+	if b.teeHardware == node.TEEHardwareIntelSGX {
+		targetDir = filepath.Join(targetDir, "sgx")
+	} else {
+		targetDir = filepath.Join(targetDir, "default")
+	}
+
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("CARGO_TARGET_DIR=%s", targetDir),
+	)
+
+	return cmd, nil
+}
+
+// Build starts the build process.
+func (b *Builder) Build() error {
+	cmd, err := b.cargoCommand("build")
+	if err != nil {
+		return err
+	}
+	cmd.Args = append(cmd.Args, "--package", b.pkg)
+
+	if b.teeHardware == node.TEEHardwareIntelSGX {
+		cmd.Args = append(cmd.Args, "--target", "x86_64-fortanix-unknown-sgx")
+	}
+
+	for k, v := range b.envVars {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	if err = cmd.Run(); err != nil {
+		return fmt.Errorf("failed to build runtime with trust root: %w", err)
+	}
+
+	// When building for SGX, also convert the ELF binary to SGXS format.
+	if b.teeHardware == node.TEEHardwareIntelSGX {
+		if cmd, err = b.cargoCommand("elf2sgxs"); err != nil {
+			return fmt.Errorf("failed to elf2sgxs runtime: %w", err)
+		}
+		if err = cmd.Run(); err != nil {
+			return fmt.Errorf("failed to elf2sgxs runtime: %w", err)
+		}
+	}
+	return nil
+}
+
+// NewBuilder creates a new builder for Rust runtimes.
+func NewBuilder(
+	env *env.Env,
+	teeHardware node.TEEHardware,
+	pkg string,
+	buildDir string,
+	targetDir string,
+) *Builder {
+	return &Builder{
+		env:         env,
+		teeHardware: teeHardware,
+		pkg:         pkg,
+		buildDir:    buildDir,
+		targetDir:   targetDir,
+		envVars:     make(map[string]string),
+	}
+}

--- a/go/oasis-test-runner/scenario/e2e/consensus_state_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/consensus_state_sync.go
@@ -44,9 +44,11 @@ func (sc *consensusStateSyncImpl) Fixture() (*oasis.NetworkFixture, error) {
 	// Add an extra validator.
 	f.Validators = append(f.Validators,
 		oasis.ValidatorFixture{
-			NoAutoStart: true,
-			Entity:      1,
-			Consensus:   oasis.ConsensusFixture{EnableConsensusRPCWorker: true},
+			NodeFixture: oasis.NodeFixture{
+				NoAutoStart: true,
+			},
+			Entity:    1,
+			Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true},
 			LogWatcherHandlerFactories: []log.WatcherHandlerFactory{
 				oasis.LogEventABCIStateSyncComplete(),
 			},

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_upgrade.go
@@ -61,7 +61,13 @@ func (sc *kmUpgradeImpl) Fixture() (*oasis.NetworkFixture, error) {
 	f.Keymanagers[0].AllowEarlyTermination = true
 
 	// Add the upgraded keymanager, will be started later.
-	f.Keymanagers = append(f.Keymanagers, oasis.KeymanagerFixture{Runtime: 2, Entity: 1, NoAutoStart: true})
+	f.Keymanagers = append(f.Keymanagers, oasis.KeymanagerFixture{
+		NodeFixture: oasis.NodeFixture{
+			NoAutoStart: true,
+		},
+		Runtime: 2,
+		Entity:  1,
+	})
 
 	return f, nil
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -353,7 +353,11 @@ func (sc *runtimeImpl) Run(childEnv *env.Env) error {
 }
 
 func (sc *runtimeImpl) submitRuntimeTx(ctx context.Context, id common.Namespace, method string, args interface{}) (cbor.RawMessage, error) {
-	c := sc.Net.ClientController().RuntimeClient
+	ctrl := sc.Net.ClientController()
+	if ctrl == nil {
+		return nil, fmt.Errorf("client controller not available")
+	}
+	c := ctrl.RuntimeClient
 
 	// Submit a transaction and check the result.
 	var rsp TxnOutput
@@ -619,6 +623,8 @@ func RegisterScenarios() error {
 		RuntimeUpgrade,
 		// HistoryReindex test.
 		HistoryReindex,
+		// TrustRoot test.
+		TrustRoot,
 	} {
 		if err := cmd.Register(s); err != nil {
 			return err

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_upgrade.go
@@ -74,7 +74,13 @@ func (sc *runtimeUpgradeImpl) Fixture() (*oasis.NetworkFixture, error) {
 		f.ComputeWorkers[i].Runtimes = []int{computeIndex}
 	}
 	for i := 0; i < sc.firstNewWorker; i++ {
-		f.ComputeWorkers = append(f.ComputeWorkers, oasis.ComputeWorkerFixture{Entity: 1, NoAutoStart: true, Runtimes: []int{newComputeIndex}})
+		f.ComputeWorkers = append(f.ComputeWorkers, oasis.ComputeWorkerFixture{
+			NodeFixture: oasis.NodeFixture{
+				NoAutoStart: true,
+			},
+			Entity:   1,
+			Runtimes: []int{newComputeIndex},
+		})
 	}
 
 	// The runtime ID stays the same, so pass only one instance to the storage workers.

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_sync.go
@@ -70,17 +70,21 @@ func (sc *storageSyncImpl) Fixture() (*oasis.NetworkFixture, error) {
 
 	// One more storage worker for later, so it can do an initial sync with the snapshots.
 	f.StorageWorkers = append(f.StorageWorkers, oasis.StorageWorkerFixture{
+		NodeFixture: oasis.NodeFixture{
+			NoAutoStart: true,
+		},
 		Backend:                    database.BackendNameBadgerDB,
 		Entity:                     1,
-		NoAutoStart:                true,
 		CheckpointSyncEnabled:      true,
 		LogWatcherHandlerFactories: []log.WatcherHandlerFactory{oasis.LogAssertCheckpointSync()},
 	})
 	// And one more storage worker that will sync the consensus layer via state sync.
 	f.StorageWorkers = append(f.StorageWorkers, oasis.StorageWorkerFixture{
+		NodeFixture: oasis.NodeFixture{
+			NoAutoStart: true,
+		},
 		Backend:               database.BackendNameBadgerDB,
 		Entity:                1,
-		NoAutoStart:           true,
 		CheckpointSyncEnabled: true,
 		LogWatcherHandlerFactories: []log.WatcherHandlerFactory{
 			oasis.LogAssertCheckpointSync(),

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_from_registered.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_from_registered.go
@@ -62,9 +62,11 @@ func (sc *storageSyncFromRegisteredImpl) Fixture() (*oasis.NetworkFixture, error
 			AllowEarlyTermination:   true,
 		},
 		{
+			NodeFixture: oasis.NodeFixture{
+				NoAutoStart: true,
+			},
 			Backend:               database.BackendNameBadgerDB,
 			Entity:                1,
-			NoAutoStart:           true,
 			CheckpointSyncEnabled: true,
 		},
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_inconsistent.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_inconsistent.go
@@ -59,9 +59,11 @@ func (sc *storageSyncInconsistentImpl) Fixture() (*oasis.NetworkFixture, error) 
 
 	// One more storage worker for later, this is the one we'll be messing with.
 	f.StorageWorkers = append(f.StorageWorkers, oasis.StorageWorkerFixture{
+		NodeFixture: oasis.NodeFixture{
+			NoAutoStart: true,
+		},
 		Backend:               database.BackendNameBadgerDB,
 		Entity:                1,
-		NoAutoStart:           false,
 		CheckpointSyncEnabled: true,
 	})
 	sc.messyStorage = len(f.StorageWorkers) - 1

--- a/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
@@ -1,0 +1,268 @@
+package runtime
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/sgx"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	keymanager "github.com/oasisprotocol/oasis-core/go/keymanager/api"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis/cli"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/rust"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+)
+
+const (
+	cfgRuntimeSourceDir = "runtime.source_dir"
+	cfgRuntimeTargetDir = "runtime.target_dir"
+
+	trustRootRuntime = "simple-keyvalue"
+)
+
+// TrustRoot is the consensus trust root verification scenario.
+var TrustRoot scenario.Scenario = newTrustRootImpl()
+
+type trustRootImpl struct {
+	runtimeImpl
+}
+
+func newTrustRootImpl() *trustRootImpl {
+	sc := &trustRootImpl{
+		runtimeImpl: *newRuntimeImpl("trust-root", BasicKVTestClient),
+	}
+
+	sc.Flags.String(cfgRuntimeSourceDir, "", "path to the runtime source base dir")
+	sc.Flags.String(cfgRuntimeTargetDir, "", "path to the Cargo target dir (should be a parent of the runtime binary dir)")
+
+	return sc
+}
+
+func (sc *trustRootImpl) Clone() scenario.Scenario {
+	return &trustRootImpl{
+		runtimeImpl: *sc.runtimeImpl.Clone().(*runtimeImpl),
+	}
+}
+
+func (sc *trustRootImpl) Fixture() (*oasis.NetworkFixture, error) {
+	f, err := sc.runtimeImpl.Fixture()
+	if err != nil {
+		return nil, err
+	}
+
+	// Exclude all runtimes from genesis as we will register those dynamically since we need to
+	// generate the correct enclave identity.
+	for i := range f.Runtimes {
+		f.Runtimes[i].ExcludeFromGenesis = true
+	}
+
+	// Make sure no nodes are started initially as we need to determine the trust root and build an
+	// appropriate runtime with the trust root embedded.
+	for i := range f.ComputeWorkers {
+		f.ComputeWorkers[i].NoAutoStart = true
+	}
+	for i := range f.Clients {
+		f.Clients[i].NoAutoStart = true
+	}
+
+	return f, nil
+}
+
+func (sc *trustRootImpl) registerRuntime(ctx context.Context, childEnv *env.Env) error {
+	// Nonce used for transactions (increase this by 1 after each transaction).
+	var nonce uint64
+	cli := cli.New(childEnv, sc.Net, sc.Logger)
+
+	// Register a new keymanager runtime.
+	kmRt := sc.Net.Runtimes()[0]
+	kmTxPath := filepath.Join(childEnv.Dir(), "register_km_runtime.json")
+	if err := cli.Registry.GenerateRegisterRuntimeTx(childEnv.Dir(), kmRt.ToRuntimeDescriptor(), nonce, kmTxPath); err != nil {
+		return fmt.Errorf("failed to generate register KM runtime tx: %w", err)
+	}
+	nonce++
+	if err := cli.Consensus.SubmitTx(kmTxPath); err != nil {
+		return fmt.Errorf("failed to register KM runtime: %w", err)
+	}
+
+	// Generate and update the new keymanager runtime's policy.
+	kmPolicyPath := filepath.Join(childEnv.Dir(), "km_policy.cbor")
+	kmPolicySig1Path := filepath.Join(childEnv.Dir(), "km_policy_sig1.pem")
+	kmPolicySig2Path := filepath.Join(childEnv.Dir(), "km_policy_sig2.pem")
+	kmPolicySig3Path := filepath.Join(childEnv.Dir(), "km_policy_sig3.pem")
+	kmUpdateTxPath := filepath.Join(childEnv.Dir(), "km_gen_update.json")
+	sc.Logger.Info("building KM SGX policy enclave policies map")
+	enclavePolicies := make(map[sgx.EnclaveIdentity]*keymanager.EnclavePolicySGX)
+	kmRtEncID := kmRt.GetEnclaveIdentity()
+	var havePolicy bool
+	if kmRtEncID != nil {
+		enclavePolicies[*kmRtEncID] = &keymanager.EnclavePolicySGX{}
+		enclavePolicies[*kmRtEncID].MayQuery = make(map[common.Namespace][]sgx.EnclaveIdentity)
+		enclavePolicies[*kmRtEncID].MayReplicate = []sgx.EnclaveIdentity{}
+		for _, rt := range sc.Net.Runtimes() {
+			if rt.Kind() != registry.KindCompute {
+				continue
+			}
+			if eid := rt.GetEnclaveIdentity(); eid != nil {
+				enclavePolicies[*kmRtEncID].MayQuery[rt.ID()] = []sgx.EnclaveIdentity{*eid}
+				// This is set only in SGX mode.
+				havePolicy = true
+			}
+		}
+	}
+	sc.Logger.Info("initing KM policy")
+	if err := cli.Keymanager.InitPolicy(kmRt.ID(), 1, enclavePolicies, kmPolicyPath); err != nil {
+		return err
+	}
+	sc.Logger.Info("signing KM policy")
+	if err := cli.Keymanager.SignPolicy("1", kmPolicyPath, kmPolicySig1Path); err != nil {
+		return err
+	}
+	if err := cli.Keymanager.SignPolicy("2", kmPolicyPath, kmPolicySig2Path); err != nil {
+		return err
+	}
+	if err := cli.Keymanager.SignPolicy("3", kmPolicyPath, kmPolicySig3Path); err != nil {
+		return err
+	}
+	if havePolicy {
+		// In SGX mode, we can update the policy as intended.
+		sc.Logger.Info("updating KM policy")
+		if err := cli.Keymanager.GenUpdate(nonce, kmPolicyPath, []string{kmPolicySig1Path, kmPolicySig2Path, kmPolicySig3Path}, kmUpdateTxPath); err != nil {
+			return err
+		}
+		nonce++
+		if err := cli.Consensus.SubmitTx(kmUpdateTxPath); err != nil {
+			return fmt.Errorf("failed to update KM policy: %w", err)
+		}
+	}
+
+	// Wait for key manager nodes to register.
+	sc.Logger.Info("waiting for key manager nodes to initialize")
+	for _, n := range sc.Net.Keymanagers() {
+		if err := n.WaitReady(ctx); err != nil {
+			return fmt.Errorf("failed to wait for a key manager node: %w", err)
+		}
+	}
+
+	// Register a new compute runtime.
+	compRt := sc.Net.Runtimes()[1]
+	if err := compRt.RefreshEnclaveIdentity(); err != nil {
+		return fmt.Errorf("failed to refresh enclave identity: %w", err)
+	}
+	compRtDesc := compRt.ToRuntimeDescriptor()
+	txPath := filepath.Join(childEnv.Dir(), "register_compute_runtime.json")
+	if err := cli.Registry.GenerateRegisterRuntimeTx(childEnv.Dir(), compRtDesc, nonce, txPath); err != nil {
+		return fmt.Errorf("failed to generate register compute runtime tx: %w", err)
+	}
+	if err := cli.Consensus.SubmitTx(txPath); err != nil {
+		return fmt.Errorf("failed to register compute runtime: %w", err)
+	}
+	return nil
+}
+
+func (sc *trustRootImpl) Run(childEnv *env.Env) (err error) {
+	// Determine the required directories for building the runtime with an embedded trust root.
+	buildDir, _ := sc.Flags.GetString(cfgRuntimeSourceDir)
+	targetDir, _ := sc.Flags.GetString(cfgRuntimeTargetDir)
+	if len(buildDir) == 0 || len(targetDir) == 0 {
+		return fmt.Errorf("runtime build dir and/or target dir not configured")
+	}
+
+	if err = sc.Net.Start(); err != nil {
+		return err
+	}
+
+	// Let the network run for 10 blocks to select a suitable trust root.
+	ctx := context.Background()
+	blockCh, blockSub, err := sc.Net.Controller().Consensus.WatchBlocks(ctx)
+	if err != nil {
+		return err
+	}
+	defer blockSub.Close()
+
+	sc.Logger.Info("waiting for some blocks")
+	var blk *consensus.Block
+	for {
+		select {
+		case blk = <-blockCh:
+			if blk.Height < 10 {
+				continue
+			}
+		case <-time.After(30 * time.Second):
+			return fmt.Errorf("timed out waiting for blocks")
+		}
+
+		break
+	}
+
+	sc.Logger.Info("got some blocks, building runtime with given trust root",
+		"trust_root_height", blk.Height,
+		"trust_root_hash", hex.EncodeToString(blk.Hash),
+		"trust_root_runtime_id", runtimeID.String(),
+	)
+
+	// Build a new runtime with the given trust root embedded.
+	sc.Logger.Info("building new runtime with embedded trust root")
+
+	teeHardware, _ := sc.getTEEHardware()
+	builder := rust.NewBuilder(childEnv, teeHardware, trustRootRuntime, filepath.Join(buildDir, trustRootRuntime), targetDir)
+	builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_HEIGHT", strconv.FormatInt(blk.Height, 10))
+	builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_HASH", hex.EncodeToString(blk.Hash))
+	builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_RUNTIME_ID", runtimeID.String())
+	if err = builder.Build(); err != nil {
+		return fmt.Errorf("failed to build runtime '%s' with trust root: %w", trustRootRuntime, err)
+	}
+	defer func() {
+		// Make sure the binary is then rebuilt without the env vars set.
+		sc.Logger.Info("rebuilding runtime without the embedded trust root")
+		builder.ResetEnv()
+		if err = builder.Build(); err != nil {
+			err = fmt.Errorf("failed to build plain runtime '%s': %w", trustRootRuntime, err)
+			return
+		}
+	}()
+
+	// Now that the runtime is built, let's register it and start all the required workers.
+	if err = sc.registerRuntime(ctx, childEnv); err != nil {
+		return err
+	}
+
+	// Start the compute workers and client.
+	sc.Logger.Info("starting clients and compute workers")
+	for _, n := range sc.Net.Clients() {
+		if err = n.Start(); err != nil {
+			return fmt.Errorf("failed to start node: %w", err)
+		}
+	}
+	for _, n := range sc.Net.ComputeWorkers() {
+		if err = n.Start(); err != nil {
+			return fmt.Errorf("failed to start node: %w", err)
+		}
+	}
+
+	sc.Logger.Info("waiting for compute workers to become ready")
+	for _, n := range sc.Net.ComputeWorkers() {
+		if err = n.WaitReady(ctx); err != nil {
+			return fmt.Errorf("failed to wait for a compute worker: %w", err)
+		}
+	}
+
+	// Setup a client controller (as there is none due to the client node not being autostarted).
+	ctrl, err := oasis.NewController(sc.Net.Clients()[0].SocketPath())
+	if err != nil {
+		return fmt.Errorf("failed to create client controller: %w", err)
+	}
+	sc.Net.SetClientController(ctrl)
+
+	// Run the test client workload to ensure that blocks get processed correctly.
+	if err = sc.startTestClientOnly(ctx, childEnv); err != nil {
+		return err
+	}
+	return sc.waitTestClient()
+}

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -90,16 +90,20 @@ type Body struct {
 	RuntimeKeyManagerPolicyUpdateResponse *Empty                                 `json:",omitempty"`
 	RuntimeQueryRequest                   *RuntimeQueryRequest                   `json:",omitempty"`
 	RuntimeQueryResponse                  *RuntimeQueryResponse                  `json:",omitempty"`
+	RuntimeConsensusSyncRequest           *RuntimeConsensusSyncRequest           `json:",omitempty"`
+	RuntimeConsensusSyncResponse          *Empty                                 `json:",omitempty"`
 
 	// Host interface.
-	HostRPCCallRequest          *HostRPCCallRequest          `json:",omitempty"`
-	HostRPCCallResponse         *HostRPCCallResponse         `json:",omitempty"`
-	HostStorageSyncRequest      *HostStorageSyncRequest      `json:",omitempty"`
-	HostStorageSyncResponse     *HostStorageSyncResponse     `json:",omitempty"`
-	HostLocalStorageGetRequest  *HostLocalStorageGetRequest  `json:",omitempty"`
-	HostLocalStorageGetResponse *HostLocalStorageGetResponse `json:",omitempty"`
-	HostLocalStorageSetRequest  *HostLocalStorageSetRequest  `json:",omitempty"`
-	HostLocalStorageSetResponse *Empty                       `json:",omitempty"`
+	HostRPCCallRequest              *HostRPCCallRequest              `json:",omitempty"`
+	HostRPCCallResponse             *HostRPCCallResponse             `json:",omitempty"`
+	HostStorageSyncRequest          *HostStorageSyncRequest          `json:",omitempty"`
+	HostStorageSyncResponse         *HostStorageSyncResponse         `json:",omitempty"`
+	HostLocalStorageGetRequest      *HostLocalStorageGetRequest      `json:",omitempty"`
+	HostLocalStorageGetResponse     *HostLocalStorageGetResponse     `json:",omitempty"`
+	HostLocalStorageSetRequest      *HostLocalStorageSetRequest      `json:",omitempty"`
+	HostLocalStorageSetResponse     *Empty                           `json:",omitempty"`
+	HostFetchConsensusBlockRequest  *HostFetchConsensusBlockRequest  `json:",omitempty"`
+	HostFetchConsensusBlockResponse *HostFetchConsensusBlockResponse `json:",omitempty"`
 }
 
 // Type returns the message type by determining the name of the first non-nil member.
@@ -338,6 +342,11 @@ type RuntimeQueryResponse struct {
 	Data cbor.RawMessage `json:"data,omitempty"`
 }
 
+// RuntimeConsensusSyncRequest is a runtime consensus block synchronization request message body.
+type RuntimeConsensusSyncRequest struct {
+	Height uint64 `json:"height"`
+}
+
 // HostRPCCallRequest is a host RPC call request message body.
 type HostRPCCallRequest struct {
 	Endpoint string `json:"endpoint"`
@@ -388,4 +397,14 @@ type HostLocalStorageGetResponse struct {
 type HostLocalStorageSetRequest struct {
 	Key   []byte `json:"key"`
 	Value []byte `json:"value"`
+}
+
+// HostFetchConsensusBlockRequest is a request to host to fetch the given consensus light block.
+type HostFetchConsensusBlockRequest struct {
+	Height uint64 `json:"height"`
+}
+
+// HostFetchConsensusBlockResponse is a response from host fetching the given consensus light block.
+type HostFetchConsensusBlockResponse struct {
+	Block consensus.LightBlock `json:"block"`
 }

--- a/go/worker/compute/executor/committee/node.go
+++ b/go/worker/compute/executor/committee/node.go
@@ -1477,8 +1477,8 @@ func (n *Node) proposeBatch(
 	}
 
 	// Submit commitment.
-	n.commonNode.Group.Lock()
-	defer n.commonNode.Group.Unlock()
+	n.commonNode.CrossNode.Lock()
+	defer n.commonNode.CrossNode.Unlock()
 
 	// Make sure we are still in the right state/round.
 	state, ok := n.state.(StateProcessingBatch)

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -34,6 +34,8 @@ tokio = { version = "1", features = ["rt"] }
 # https://github.com/informalsystems/tendermint-rs/pull/926
 tendermint = { git = "https://github.com/informalsystems/tendermint-rs", rev = "1efe42c8625045fd99072718faf96e81aeb9c6e6" }
 tendermint-proto = { git = "https://github.com/informalsystems/tendermint-rs", rev = "1efe42c8625045fd99072718faf96e81aeb9c6e6" }
+tendermint-light-client = { git = "https://github.com/informalsystems/tendermint-rs", rev = "1efe42c8625045fd99072718faf96e81aeb9c6e6", default-features = false }
+tendermint-rpc = { git = "https://github.com/informalsystems/tendermint-rs", rev = "1efe42c8625045fd99072718faf96e81aeb9c6e6", default-features = false }
 io-context = "0.2.0"
 curve25519-dalek = "3.2.0"
 x25519-dalek = "1.1.0"
@@ -55,6 +57,7 @@ x509-parser = "0.11.0"
 oid-registry = "0.1.5"
 rsa = "0.5.0"
 base64-serde = "0.6.1"
+lru = "0.6.6"
 
 [dev-dependencies]
 # For storage interoperability tests only.

--- a/runtime/src/common/crypto/hash.rs
+++ b/runtime/src/common/crypto/hash.rs
@@ -1,5 +1,9 @@
 //! Hash type.
+use std::convert::TryInto;
+
 use sha2::{Digest, Sha512Trunc256};
+
+use crate::common::key_format::KeyFormatAtom;
 
 impl_bytes!(Hash, 32, "A 32-byte SHA-512/256 hash.");
 
@@ -43,5 +47,22 @@ impl Hash {
     /// Hash truncated to the given number of bytes.
     pub fn truncated(&self, n: usize) -> &[u8] {
         &self.0[..n]
+    }
+}
+
+impl KeyFormatAtom for Hash {
+    fn size() -> usize {
+        Hash::len()
+    }
+
+    fn encode_atom(self) -> Vec<u8> {
+        self.as_ref().to_vec()
+    }
+
+    fn decode_atom(data: &[u8]) -> Self
+    where
+        Self: Sized,
+    {
+        Hash(data.try_into().expect("hash: invalid decode atom data"))
     }
 }

--- a/runtime/src/consensus/mod.rs
+++ b/runtime/src/consensus/mod.rs
@@ -8,3 +8,14 @@ pub mod scheduler;
 pub mod staking;
 pub mod state;
 pub mod tendermint;
+pub mod verifier;
+
+/// The height that represents the most recent block height.
+pub const HEIGHT_LATEST: u64 = 0;
+
+/// Light consensus block.
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
+pub struct LightBlock {
+    pub height: u64,
+    pub meta: Vec<u8>,
+}

--- a/runtime/src/consensus/roothash.rs
+++ b/runtime/src/consensus/roothash.rs
@@ -4,6 +4,8 @@
 //!
 //! This **MUST** be kept in sync with go/roothash/api.
 //!
+use thiserror::Error;
+
 use crate::{
     common::{
         crypto::{
@@ -13,8 +15,18 @@ use crate::{
         namespace::Namespace,
         versioned::Versioned,
     },
-    consensus::{registry, staking},
+    consensus::{registry, staking, state::StateError},
 };
+
+/// Errors emitted by the roothash module.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("roothash: invalid runtime {0}")]
+    InvalidRuntime(Namespace),
+
+    #[error(transparent)]
+    State(#[from] StateError),
+}
 
 /// Runtime block.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, cbor::Encode, cbor::Decode)]

--- a/runtime/src/consensus/state/mod.rs
+++ b/runtime/src/consensus/state/mod.rs
@@ -11,6 +11,7 @@ use crate::{
     types::HostStorageEndpoint,
 };
 
+pub mod roothash;
 pub mod staking;
 
 #[derive(Error, Debug)]
@@ -32,7 +33,7 @@ impl ConsensusState {
 
     /// Creates consensus state using host protocol.
     pub fn from_protocol(protocol: Arc<Protocol>, root: Root) -> Self {
-        let read_syncer = HostReadSyncer::new(protocol.clone(), HostStorageEndpoint::Consensus);
+        let read_syncer = HostReadSyncer::new(protocol, HostStorageEndpoint::Consensus);
         Self {
             mkvs: Tree::make()
                 .with_capacity(100_000, 10_000_000)

--- a/runtime/src/consensus/state/roothash.rs
+++ b/runtime/src/consensus/state/roothash.rs
@@ -1,0 +1,46 @@
+//! Roothash state in the consensus layer.
+use std::convert::TryInto;
+
+use anyhow::anyhow;
+use io_context::Context;
+
+use crate::{
+    common::{
+        crypto::hash::Hash,
+        key_format::{KeyFormat, KeyFormatAtom},
+        namespace::Namespace,
+    },
+    consensus::{roothash::Error, state::StateError},
+    key_format,
+    storage::mkvs::ImmutableMKVS,
+};
+
+/// Consensus staking state wrapper.
+pub struct ImmutableState<'a, T: ImmutableMKVS> {
+    mkvs: &'a T,
+}
+
+impl<'a, T: ImmutableMKVS> ImmutableState<'a, T> {
+    /// Constructs a new ImmutableMKVS.
+    pub fn new(mkvs: &'a T) -> ImmutableState<'a, T> {
+        ImmutableState { mkvs }
+    }
+}
+
+key_format!(StateRootKeyFmt, 0x25, Hash);
+
+impl<'a, T: ImmutableMKVS> ImmutableState<'a, T> {
+    /// Returns the state root for a specific runtime.
+    pub fn state_root(&self, ctx: Context, id: Namespace) -> Result<Hash, Error> {
+        match self.mkvs.get(
+            ctx,
+            &StateRootKeyFmt(Hash::digest_bytes(id.as_ref())).encode(),
+        ) {
+            Ok(Some(b)) => Ok(Hash(b.try_into().map_err(|_| -> Error {
+                StateError::Unavailable(anyhow!("corrupted hash value")).into()
+            })?)),
+            Ok(None) => Err(Error::InvalidRuntime(id)),
+            Err(err) => Err(StateError::Unavailable(anyhow!(err)).into()),
+        }
+    }
+}

--- a/runtime/src/consensus/state/staking.rs
+++ b/runtime/src/consensus/state/staking.rs
@@ -1,3 +1,4 @@
+//! Staking state in the consensus layer.
 use std::collections::BTreeMap;
 
 use anyhow::anyhow;

--- a/runtime/src/consensus/tendermint/store.rs
+++ b/runtime/src/consensus/tendermint/store.rs
@@ -1,0 +1,108 @@
+//! An in-memory LRU store for the light client.
+use std::sync::{Mutex, MutexGuard};
+
+use tendermint_light_client::{
+    store::LightStore,
+    types::{Height, LightBlock, Status},
+};
+
+/// In-memory LRU store.
+pub struct LruStore {
+    inner: Mutex<Inner>,
+}
+
+impl std::fmt::Debug for LruStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "LruStore")
+    }
+}
+
+struct Inner {
+    unverified: lru::LruCache<Height, LightBlock>,
+    verified: lru::LruCache<Height, LightBlock>,
+    trusted: lru::LruCache<Height, LightBlock>,
+    failed: lru::LruCache<Height, LightBlock>,
+}
+
+impl Inner {
+    fn store(&mut self, status: Status) -> &mut lru::LruCache<Height, LightBlock> {
+        match status {
+            Status::Unverified => &mut self.unverified,
+            Status::Verified => &mut self.verified,
+            Status::Trusted => &mut self.trusted,
+            Status::Failed => &mut self.failed,
+        }
+    }
+}
+
+impl LruStore {
+    /// Create a new, empty, in-memory LRU store of the given capacity.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                unverified: lru::LruCache::new(capacity),
+                verified: lru::LruCache::new(capacity),
+                trusted: lru::LruCache::new(capacity),
+                failed: lru::LruCache::new(capacity),
+            }),
+        }
+    }
+
+    fn inner(&self) -> MutexGuard<'_, Inner> {
+        self.inner.lock().unwrap()
+    }
+
+    fn inner_mut(&mut self) -> &mut Inner {
+        self.inner.get_mut().unwrap()
+    }
+}
+
+impl LightStore for LruStore {
+    fn get(&self, height: Height, status: Status) -> Option<LightBlock> {
+        self.inner().store(status).get(&height).cloned()
+    }
+
+    fn insert(&mut self, light_block: LightBlock, status: Status) {
+        self.inner_mut()
+            .store(status)
+            .put(light_block.height(), light_block);
+    }
+
+    fn remove(&mut self, height: Height, status: Status) {
+        self.inner_mut().store(status).pop(&height);
+    }
+
+    fn update(&mut self, light_block: &LightBlock, status: Status) {
+        self.inner_mut()
+            .store(status)
+            .put(light_block.height(), light_block.clone());
+    }
+
+    fn highest(&self, status: Status) -> Option<LightBlock> {
+        self.inner()
+            .store(status)
+            .iter()
+            .max_by_key(|(&height, _)| height)
+            .map(|(_, lb)| lb.clone())
+    }
+
+    fn lowest(&self, status: Status) -> Option<LightBlock> {
+        self.inner()
+            .store(status)
+            .iter()
+            .min_by_key(|(&height, _)| height)
+            .map(|(_, lb)| lb.clone())
+    }
+
+    #[allow(clippy::needless_collect)]
+    fn all(&self, status: Status) -> Box<dyn Iterator<Item = LightBlock>> {
+        let light_blocks: Vec<_> = self
+            .inner()
+            .store(status)
+            .iter()
+            .map(|(_, lb)| lb.clone())
+            .collect();
+
+        Box::new(light_blocks.into_iter())
+    }
+}

--- a/runtime/src/consensus/tendermint/verifier.rs
+++ b/runtime/src/consensus/tendermint/verifier.rs
@@ -1,0 +1,699 @@
+//! Tendermint consensus layer verification logic.
+use std::{
+    collections::HashSet,
+    convert::{TryFrom, TryInto},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
+
+use anyhow::anyhow;
+use crossbeam::channel;
+use io_context::Context;
+use sgx_isa::Keypolicy;
+use slog::{error, info};
+use tendermint::{
+    block::CommitSig,
+    vote::{SignedVote, ValidatorIndex, Vote},
+};
+use tendermint_light_client::{
+    builder::LightClientBuilder,
+    components::{self, verifier::ProdVerifier},
+    light_client,
+    operations::{ProdCommitValidator, ProdHasher, VotingPowerCalculator, VotingPowerTally},
+    predicates::{errors::VerificationError, ProdPredicates},
+    supervisor::Instance,
+    types::{
+        Commit, Hash as TMHash, LightBlock as TMLightBlock, PeerId, SignedHeader, Time,
+        TrustThreshold, ValidatorSet,
+    },
+};
+use tendermint_rpc::error::Error as RpcError;
+
+use super::store::LruStore;
+use crate::{
+    common::{crypto::hash::Hash, logger::get_logger, sgx::seal, time},
+    consensus::{
+        roothash::{ComputeResultsHeader, Header},
+        state::{roothash::ImmutableState as RoothashState, ConsensusState},
+        tendermint::{decode_light_block, LightBlockMeta, TENDERMINT_CONTEXT},
+        verifier::{self, Error, TrustRoot},
+        LightBlock, HEIGHT_LATEST,
+    },
+    protocol::{Protocol, ProtocolUntrustedLocalStorage},
+    storage::KeyValue,
+    types::Body,
+};
+
+/// Maximum number of times to retry initialization.
+const MAX_INITIALIZATION_RETRIES: usize = 3;
+/// Storage key under which the sealed trust root is stored in untrusted local storage.
+const TRUST_ROOT_STORAGE_KEY: &[u8] = b"tendermint.verifier.trust_root";
+/// Domain separation context for the trust root.
+const TRUST_ROOT_CONTEXT: &[u8] = b"oasis-core/verifier: trust root";
+/// Trust root save interval (in consensus blocks).
+const TRUST_ROOT_SAVE_INTERVAL: u64 = 128;
+
+/// A verifier which performs no verification.
+pub struct NopVerifier {
+    protocol: Arc<Protocol>,
+}
+
+impl NopVerifier {
+    /// Create a new non-verifying verifier.
+    pub fn new(protocol: Arc<Protocol>) -> Self {
+        Self { protocol }
+    }
+}
+
+impl verifier::Verifier for NopVerifier {
+    fn sync(&self, _height: u64) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn verify(
+        &self,
+        consensus_block: LightBlock,
+        _runtime_header: Header,
+    ) -> Result<ConsensusState, Error> {
+        self.unverified_state(consensus_block)
+    }
+
+    fn unverified_state(&self, consensus_block: LightBlock) -> Result<ConsensusState, Error> {
+        let untrusted_block =
+            decode_light_block(consensus_block).map_err(Error::VerificationFailed)?;
+        // NOTE: No actual verification is performed.
+        let state_root = untrusted_block.get_state_root();
+        Ok(ConsensusState::from_protocol(
+            self.protocol.clone(),
+            state_root,
+        ))
+    }
+
+    fn trust(&self, _header: &ComputeResultsHeader) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+enum Command {
+    Synchronize(u64, channel::Sender<Result<(), Error>>),
+    Verify(
+        LightBlock,
+        Header,
+        channel::Sender<Result<ConsensusState, Error>>,
+    ),
+    Trust(ComputeResultsHeader, channel::Sender<Result<(), Error>>),
+}
+
+/// Tendermint consensus layer verifier.
+pub struct Verifier {
+    protocol: Arc<Protocol>,
+    trust_root: TrustRoot,
+    command_sender: channel::Sender<Command>,
+    command_receiver: channel::Receiver<Command>,
+}
+
+struct Cache {
+    last_verified_height: u64,
+    last_verified_round: u64,
+    last_trust_root: TrustRoot,
+    verified_state_roots: lru::LruCache<u64, Hash>,
+}
+
+impl Default for Cache {
+    fn default() -> Self {
+        Self {
+            last_verified_height: 0,
+            last_verified_round: 0,
+            last_trust_root: TrustRoot::default(),
+            verified_state_roots: lru::LruCache::new(128),
+        }
+    }
+}
+
+impl Verifier {
+    /// Create a new Tendermint consensus layer verifier.
+    pub fn new(protocol: Arc<Protocol>, trust_root: TrustRoot) -> Self {
+        let (command_sender, command_receiver) = channel::unbounded();
+
+        Self {
+            protocol,
+            trust_root,
+            command_sender,
+            command_receiver,
+        }
+    }
+
+    /// Return a handle to interact with the verifier.
+    pub fn handle(&self) -> impl verifier::Verifier {
+        Handle {
+            protocol: self.protocol.clone(),
+            command_sender: self.command_sender.clone(),
+        }
+    }
+
+    fn sync(&self, cache: &mut Cache, instance: &mut Instance, height: u64) -> Result<(), Error> {
+        if height < cache.last_verified_height {
+            // Ignore requests for earlier heights.
+            return Ok(());
+        }
+
+        let verified_block = instance
+            .light_client
+            .verify_to_target(height.try_into().unwrap(), &mut instance.state)
+            .map_err(|err| Error::VerificationFailed(err.into()))?;
+
+        let header = verified_block.signed_header.header;
+        cache.last_trust_root.height = header.height.into();
+        cache.last_trust_root.hash = header.hash().to_string();
+
+        Ok(())
+    }
+
+    fn verify_consensus_only(
+        &self,
+        cache: &mut Cache,
+        instance: &mut Instance,
+        consensus_block: LightBlock,
+    ) -> Result<LightBlockMeta, Error> {
+        if consensus_block.height < cache.last_verified_height {
+            // Ignore requests for earlier heights.
+            return Err(Error::VerificationFailed(anyhow!(
+                "height seems to have moved backwards"
+            )));
+        }
+
+        // Decode passed block as a Tendermint block.
+        let untrusted_block =
+            decode_light_block(consensus_block).map_err(Error::VerificationFailed)?;
+        let untrusted_header = untrusted_block
+            .signed_header
+            .as_ref()
+            .ok_or(Error::VerificationFailed(anyhow!("missing signed header")))?;
+
+        // Verify up to the block at current height.
+        let verified_block = instance
+            .light_client
+            .verify_to_target(untrusted_header.header().height, &mut instance.state)
+            .map_err(|err| Error::VerificationFailed(err.into()))?;
+
+        // Validate passed consensus block.
+        if untrusted_header != &verified_block.signed_header {
+            return Err(Error::VerificationFailed(anyhow!("header mismatch")));
+        }
+
+        let header = verified_block.signed_header.header;
+        cache.last_verified_height = header.height.into();
+        if cache.last_verified_height > cache.last_trust_root.height {
+            cache.last_trust_root.height = header.height.into();
+            cache.last_trust_root.hash = header.hash().to_string();
+        }
+
+        Ok(untrusted_block)
+    }
+
+    fn verify(
+        &self,
+        cache: &mut Cache,
+        instance: &mut Instance,
+        consensus_block: LightBlock,
+        runtime_header: Header,
+    ) -> Result<ConsensusState, Error> {
+        // Verify runtime ID matches.
+        if runtime_header.namespace != self.trust_root.runtime_id {
+            return Err(Error::VerificationFailed(anyhow!(
+                "header namespace does not match trusted runtime id"
+            )));
+        }
+
+        if runtime_header.round < cache.last_verified_round {
+            // Ignore requests for earlier rounds.
+            return Err(Error::VerificationFailed(anyhow!(
+                "round seems to have moved backwards"
+            )));
+        }
+
+        // Verify the consensus layer block first to obtain an authoritative state root.
+        let consensus_block = self.verify_consensus_only(cache, instance, consensus_block)?;
+        let state_root = consensus_block.get_state_root();
+        let state = ConsensusState::from_protocol(self.protocol.clone(), state_root);
+
+        // Check if we have already verified this runtime header to avoid re-verification.
+        if let Some(state_root) = cache.verified_state_roots.get(&runtime_header.round) {
+            if state_root == &runtime_header.state_root {
+                // Header matches, no need to perform re-verification.
+                return Ok(state);
+            }
+
+            // Header is for the same round but it doesn't match. Looks like something funny is
+            // going on -- abort.
+            return Err(Error::VerificationFailed(anyhow!(
+                "header does not match previously seen header for the same round"
+            )));
+        }
+
+        // Verify that the state root matches.
+        let roothash_state = RoothashState::new(&state);
+        let state_root = roothash_state
+            .state_root(Context::background(), self.trust_root.runtime_id)
+            .map_err(|err| {
+                Error::VerificationFailed(anyhow!("failed to retrieve trusted state root: {}", err))
+            })?;
+        if runtime_header.state_root != state_root {
+            return Err(Error::VerificationFailed(anyhow!(
+                "state root mismatch (expected: {} got: {})",
+                state_root,
+                runtime_header.state_root
+            )));
+        }
+
+        // Cache verified runtime header.
+        cache
+            .verified_state_roots
+            .put(runtime_header.round, state_root);
+        cache.last_verified_round = runtime_header.round;
+
+        Ok(state)
+    }
+
+    fn trust(&self, cache: &mut Cache, header: ComputeResultsHeader) -> Result<(), Error> {
+        if let Some(state_root) = header.state_root {
+            cache.verified_state_roots.put(header.round, state_root);
+            cache.last_verified_round = header.round;
+        }
+
+        Ok(())
+    }
+
+    /// Start the verifier in a separate thread.
+    pub fn start(self) {
+        std::thread::spawn(move || {
+            let logger = get_logger("consensus/tendermint/verifier");
+            info!(logger, "Starting consensus verifier");
+
+            // Try to initialize a couple of times as initially it may be the case that we have
+            // started while the Runtime Host Protocol has not been fully initialized so the host
+            // is still rejecting requests. This is the case because `start()` is called as part
+            // of the RHP initialization itself (when handling a `RuntimeInfoRequest`).
+            for retry in 1..=MAX_INITIALIZATION_RETRIES {
+                match self.run() {
+                    Ok(_) => {}
+                    Err(err @ Error::Builder(_)) | Err(err @ Error::TrustRootLoadingFailed) => {
+                        error!(logger, "Consensus verifier failed to initialize, retrying";
+                            "err" => %err,
+                            "retry" => retry,
+                        );
+                    }
+                    Err(err) => {
+                        // All other errors are fatal.
+                        error!(logger, "Consensus verifier terminated";
+                            "err" => %err,
+                        );
+                        return;
+                    }
+                }
+
+                // Retry to initialize the verifier.
+                std::thread::sleep(Duration::from_secs(1));
+            }
+        });
+    }
+
+    fn load_trust_root(
+        &self,
+        untrusted_local_store: &ProtocolUntrustedLocalStorage,
+    ) -> Result<TrustRoot, Error> {
+        // Attempt to load the previously sealed trust root.
+        let untrusted_value = untrusted_local_store
+            .get(TRUST_ROOT_STORAGE_KEY.to_vec())
+            .map_err(|_| Error::TrustRootLoadingFailed)?;
+        if untrusted_value.is_empty() {
+            // No previously stored trust root is available, use the embedded root.
+            return Ok(self.trust_root.clone());
+        }
+
+        // Unseal the sealed trust root.
+        let raw = seal::unseal(Keypolicy::MRENCLAVE, TRUST_ROOT_CONTEXT, &untrusted_value).unwrap();
+        let trust_root: TrustRoot = cbor::from_slice(&raw).expect("corrupted sealed trust root");
+
+        // Make sure that the loaded trust root is not older than the embedded root.
+        if trust_root.height <= self.trust_root.height {
+            return Ok(self.trust_root.clone());
+        }
+        Ok(trust_root)
+    }
+
+    fn save_trust_root(
+        &self,
+        untrusted_local_store: &ProtocolUntrustedLocalStorage,
+        cache: &Cache,
+    ) {
+        // Serialize and seal the trust root.
+        let raw = cbor::to_vec(cache.last_trust_root.clone());
+        let sealed = seal::seal(Keypolicy::MRENCLAVE, TRUST_ROOT_CONTEXT, &raw);
+
+        // Store the trust root.
+        untrusted_local_store
+            .insert(TRUST_ROOT_STORAGE_KEY.to_vec(), sealed)
+            .unwrap();
+    }
+
+    fn run(&self) -> Result<(), Error> {
+        let logger = get_logger("consensus/tendermint/verifier");
+
+        // Create the untrusted local storage for storing the sealed latest trusted root.
+        let untrusted_local_store =
+            ProtocolUntrustedLocalStorage::new(Context::background(), self.protocol.clone());
+
+        // Create a new light client instance.
+        let options = light_client::Options {
+            trust_threshold: Default::default(),
+            // XXX: Until we have a way to retrieve trusted light client headers from other nodes
+            //      (e.g., via EnclaveRPC) there is little sense in specifying a trusting period.
+            trusting_period: Duration::from_secs(3600 * 24 * 365 * 10), // 10 years
+            clock_drift: Duration::from_secs(60),
+        };
+
+        // NOTE: Peer identifier is irrelevant as the enclave is totally eclipsed.
+        let peer_id = PeerId::new([0; 20]);
+        let builder = LightClientBuilder::custom(
+            peer_id,
+            options,
+            Box::new(LruStore::new(1024)),
+            Box::new(Io::new(&self.protocol)),
+            Box::new(ProdHasher),
+            Box::new(InsecureClock),
+            Box::new(ProdVerifier::new(
+                ProdPredicates::default(),
+                DomSepVotingPowerCalculator,
+                ProdCommitValidator::default(),
+                ProdHasher::default(),
+            )),
+            Box::new(components::scheduler::basic_bisecting_schedule),
+            Box::new(ProdPredicates),
+        );
+        let trust_root = self.load_trust_root(&untrusted_local_store)?;
+        let mut instance = builder
+            .trust_primary_at(
+                trust_root.height.try_into().unwrap(),
+                TMHash::from_str(&trust_root.hash.to_uppercase()).unwrap(),
+            )
+            .map_err(|err| Error::Builder(err.into()))?
+            .build();
+
+        info!(logger, "Consensus verifier initialized";
+            "trust_root_height" => trust_root.height,
+            "trust_root_hash" => ?trust_root.hash,
+            "trust_root_runtime_id" => ?trust_root.runtime_id,
+        );
+
+        let mut last_saved_trust_root_height = trust_root.height;
+        let mut cache = Cache::default();
+        cache.last_trust_root = trust_root;
+
+        // Start the command processing loop.
+        loop {
+            let command = self.command_receiver.recv().map_err(|_| Error::Internal)?;
+
+            match command {
+                Command::Synchronize(height, sender) => {
+                    sender
+                        .send(self.sync(&mut cache, &mut instance, height))
+                        .map_err(|_| Error::Internal)?;
+                }
+                Command::Verify(consensus_block, runtime_header, sender) => {
+                    sender
+                        .send(self.verify(
+                            &mut cache,
+                            &mut instance,
+                            consensus_block,
+                            runtime_header,
+                        ))
+                        .map_err(|_| Error::Internal)?;
+                }
+                Command::Trust(header, sender) => {
+                    sender
+                        .send(self.trust(&mut cache, header))
+                        .map_err(|_| Error::Internal)?;
+                }
+            }
+
+            // Persist trusted root every once in a while.
+            if cache.last_trust_root.height - last_saved_trust_root_height
+                > TRUST_ROOT_SAVE_INTERVAL
+            {
+                self.save_trust_root(&untrusted_local_store, &cache);
+                last_saved_trust_root_height = cache.last_trust_root.height;
+            }
+        }
+    }
+}
+
+struct Handle {
+    protocol: Arc<Protocol>,
+    command_sender: channel::Sender<Command>,
+}
+
+impl verifier::Verifier for Handle {
+    fn sync(&self, height: u64) -> Result<(), Error> {
+        let (sender, receiver) = channel::bounded(1);
+        self.command_sender
+            .send(Command::Synchronize(height, sender))
+            .map_err(|_| Error::Internal)?;
+
+        receiver.recv().map_err(|_| Error::Internal)?
+    }
+
+    fn verify(
+        &self,
+        consensus_block: LightBlock,
+        runtime_header: Header,
+    ) -> Result<ConsensusState, Error> {
+        let (sender, receiver) = channel::bounded(1);
+        self.command_sender
+            .send(Command::Verify(consensus_block, runtime_header, sender))
+            .map_err(|_| Error::Internal)?;
+
+        receiver.recv().map_err(|_| Error::Internal)?
+    }
+
+    fn unverified_state(&self, consensus_block: LightBlock) -> Result<ConsensusState, Error> {
+        let untrusted_block =
+            decode_light_block(consensus_block).map_err(Error::VerificationFailed)?;
+        // NOTE: No actual verification is performed.
+        let state_root = untrusted_block.get_state_root();
+        Ok(ConsensusState::from_protocol(
+            self.protocol.clone(),
+            state_root,
+        ))
+    }
+
+    fn trust(&self, header: &ComputeResultsHeader) -> Result<(), Error> {
+        let (sender, receiver) = channel::bounded(1);
+        self.command_sender
+            .send(Command::Trust(header.clone(), sender))
+            .map_err(|_| Error::Internal)?;
+
+        receiver.recv().map_err(|_| Error::Internal)?
+    }
+}
+
+struct Io {
+    protocol: Arc<Protocol>,
+}
+
+impl Io {
+    fn new(protocol: &Arc<Protocol>) -> Self {
+        Self {
+            protocol: protocol.clone(),
+        }
+    }
+
+    fn fetch_light_block(&self, height: u64) -> Result<LightBlockMeta, components::io::IoError> {
+        use components::io::IoError;
+
+        let result = self
+            .protocol
+            .make_request(
+                Context::background(),
+                Body::HostFetchConsensusBlockRequest { height },
+            )
+            .map_err(|err| IoError::RpcError(RpcError::server_error(err.to_string())))?;
+
+        // Extract generic light block from response.
+        let block = match result {
+            Body::HostFetchConsensusBlockResponse { block } => block,
+            _ => {
+                return Err(IoError::RpcError(RpcError::server_error(
+                    "bad response".to_string(),
+                )))
+            }
+        };
+
+        // Decode block as a Tendermint light block.
+        let block = decode_light_block(block)
+            .map_err(|err| IoError::RpcError(RpcError::server_error(err.to_string())))?;
+
+        Ok(block)
+    }
+}
+
+impl components::io::Io for Io {
+    fn fetch_light_block(
+        &self,
+        height: components::io::AtHeight,
+    ) -> Result<TMLightBlock, components::io::IoError> {
+        use components::io::IoError;
+
+        let height = match height {
+            components::io::AtHeight::At(height) => height.into(),
+            components::io::AtHeight::Highest => HEIGHT_LATEST,
+        };
+
+        // Fetch light block at height and height+1.
+        let block = Io::fetch_light_block(self, height)?;
+        // NOTE: It seems that the requirement to fetch the next validator set is redundant and it
+        //       should be handled at a higher layer of the light client.
+        let next_block = Io::fetch_light_block(self, height + 1)?;
+
+        Ok(TMLightBlock {
+            signed_header: block
+                .signed_header
+                .ok_or(IoError::RpcError(RpcError::server_error(
+                    "missing signed header".to_string(),
+                )))?,
+            validators: block.validators,
+            next_validators: next_block.validators,
+            provider: PeerId::new([0; 20]),
+        })
+    }
+}
+
+struct InsecureClock;
+
+impl components::clock::Clock for InsecureClock {
+    fn now(&self) -> Time {
+        time::insecure_posix_system_time().into()
+    }
+}
+
+// Voting power calculator which uses Oasis Core's domain separation for verifying signatures.
+struct DomSepVotingPowerCalculator;
+
+impl VotingPowerCalculator for DomSepVotingPowerCalculator {
+    fn voting_power_in(
+        &self,
+        signed_header: &SignedHeader,
+        validator_set: &ValidatorSet,
+        trust_threshold: TrustThreshold,
+    ) -> Result<VotingPowerTally, VerificationError> {
+        let signatures = &signed_header.commit.signatures;
+
+        let mut tallied_voting_power = 0_u64;
+        let mut seen_validators = HashSet::new();
+
+        // Get non-absent votes from the signatures
+        let non_absent_votes = signatures.iter().enumerate().flat_map(|(idx, signature)| {
+            non_absent_vote(
+                signature,
+                ValidatorIndex::try_from(idx).unwrap(),
+                &signed_header.commit,
+            )
+            .map(|vote| (signature, vote))
+        });
+
+        for (signature, vote) in non_absent_votes {
+            // Ensure we only count a validator's power once
+            if seen_validators.contains(&vote.validator_address) {
+                return Err(VerificationError::DuplicateValidator(
+                    vote.validator_address,
+                ));
+            } else {
+                seen_validators.insert(vote.validator_address);
+            }
+
+            let validator = match validator_set.validator(vote.validator_address) {
+                Some(validator) => validator,
+                None => continue, // Cannot find matching validator, so we skip the vote
+            };
+
+            let signed_vote = SignedVote::new(
+                vote.clone(),
+                signed_header.header.chain_id.clone(),
+                vote.validator_address,
+                vote.signature,
+            );
+
+            // Check vote is valid
+            let sign_bytes = signed_vote.sign_bytes();
+            // Use Oasis Core domain separation scheme.
+            let sign_bytes = Hash::digest_bytes_list(&[TENDERMINT_CONTEXT, &sign_bytes]);
+            if validator
+                .verify_signature(sign_bytes.as_ref(), signed_vote.signature())
+                .is_err()
+            {
+                return Err(VerificationError::InvalidSignature {
+                    signature: signed_vote.signature().as_bytes().to_vec(),
+                    validator: Box::new(validator),
+                    sign_bytes: sign_bytes.as_ref().into(),
+                });
+            }
+
+            // If the vote is neither absent nor nil, tally its power
+            if signature.is_commit() {
+                tallied_voting_power += validator.power();
+            } else {
+                // It's OK. We include stray signatures (~votes for nil)
+                // to measure validator availability.
+            }
+
+            // TODO: Break out of the loop when we have enough voting power.
+            // See https://github.com/informalsystems/tendermint-rs/issues/235
+        }
+
+        let voting_power = VotingPowerTally {
+            total: self.total_power_of(validator_set),
+            tallied: tallied_voting_power,
+            trust_threshold,
+        };
+
+        Ok(voting_power)
+    }
+}
+
+// Copied from tendermint-rs as it is not public.
+fn non_absent_vote(
+    commit_sig: &CommitSig,
+    validator_index: ValidatorIndex,
+    commit: &Commit,
+) -> Option<Vote> {
+    let (validator_address, timestamp, signature, block_id) = match commit_sig {
+        CommitSig::BlockIdFlagAbsent { .. } => return None,
+        CommitSig::BlockIdFlagCommit {
+            validator_address,
+            timestamp,
+            signature,
+        } => (
+            *validator_address,
+            *timestamp,
+            signature,
+            Some(commit.block_id),
+        ),
+        CommitSig::BlockIdFlagNil {
+            validator_address,
+            timestamp,
+            signature,
+        } => (*validator_address, *timestamp, signature, None),
+    };
+
+    Some(Vote {
+        vote_type: tendermint::vote::Type::Precommit,
+        height: commit.height,
+        round: commit.round,
+        block_id,
+        timestamp: Some(timestamp),
+        validator_address,
+        validator_index,
+        signature: signature.clone(),
+    })
+}

--- a/runtime/src/consensus/verifier.rs
+++ b/runtime/src/consensus/verifier.rs
@@ -1,0 +1,67 @@
+//! Trait for consensus layer verification.
+use thiserror::Error;
+
+use super::{
+    roothash::{ComputeResultsHeader, Header},
+    state::ConsensusState,
+    LightBlock,
+};
+use crate::{common::namespace::Namespace, types};
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("builder: {0}")]
+    Builder(#[source] anyhow::Error),
+
+    #[error("verification: {0}")]
+    VerificationFailed(#[source] anyhow::Error),
+
+    #[error("trust root loading failed")]
+    TrustRootLoadingFailed,
+
+    #[error("internal error")]
+    Internal,
+}
+
+impl From<Error> for types::Error {
+    fn from(e: Error) -> Self {
+        Self {
+            module: "verifier".to_string(),
+            code: 1,
+            message: e.to_string(),
+        }
+    }
+}
+
+/// Verifier is the consensus layer state verifier trait.
+pub trait Verifier: Send + Sync {
+    /// Synchronize the verifier state up to including the passed consensus height.
+    fn sync(&self, height: u64) -> Result<(), Error>;
+
+    /// Verify that the given runtime header is valid at the given consensus layer block and return
+    /// the consensus layer state accessor for that block.
+    fn verify(
+        &self,
+        consensus_block: LightBlock,
+        runtime_header: Header,
+    ) -> Result<ConsensusState, Error>;
+
+    /// Return the consensus layer state accessor for the given consensus layer block WITHOUT
+    /// performing any verification. This method should only be used for operations that do not
+    /// require integrity guarantees.
+    fn unverified_state(&self, consensus_block: LightBlock) -> Result<ConsensusState, Error>;
+
+    /// Record the given (locally computed and thus verified) results header as trusted.
+    fn trust(&self, header: &ComputeResultsHeader) -> Result<(), Error>;
+}
+
+/// Consensus layer trust root.
+#[derive(Debug, Clone, Default, PartialEq, Eq, cbor::Encode, cbor::Decode)]
+pub struct TrustRoot {
+    /// Known trusted height.
+    pub height: u64,
+    /// Known hex-encoded trusted consensus layer header hash.
+    pub hash: String,
+    /// Known runtime identifier.
+    pub runtime_id: Namespace,
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -5,7 +5,7 @@
 //! To create a minimal runtime that doesn't expose any APIs to the
 //! outside world, you need to call the `start_runtime` function:
 //! ```rust,ignore
-//! oasis_core_runtime::start_runtime(Some(Box::new(reg)));
+//! oasis_core_runtime::start_runtime(Some(Box::new(reg)), version, Some(trust_root));
 //! ```
 //!
 //! This will start the required services needed to communicate with

--- a/runtime/src/storage/mkvs/sync/host.rs
+++ b/runtime/src/storage/mkvs/sync/host.rs
@@ -41,7 +41,7 @@ impl HostReadSyncer {
                 Ok(response)
             }
             Ok(_) => Err(ProtocolError::InvalidResponse.into()),
-            Err(error) => Err(error),
+            Err(error) => Err(error.into()),
         }
     }
 }

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -1,7 +1,7 @@
 //! Runtime storage interfaces and implementations.
 use std::sync::Arc;
 
-use anyhow::Result;
+use crate::types::Error;
 
 pub mod mkvs;
 
@@ -11,18 +11,18 @@ pub use self::mkvs::MKVS;
 /// Trivial Key/Value storage.
 pub trait KeyValue: Send + Sync {
     /// Fetch the value for a specific key.
-    fn get(&self, key: Vec<u8>) -> Result<Vec<u8>>;
+    fn get(&self, key: Vec<u8>) -> Result<Vec<u8>, Error>;
 
     /// Store a specific key/value into storage.
-    fn insert(&self, key: Vec<u8>, value: Vec<u8>) -> Result<()>;
+    fn insert(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error>;
 }
 
 impl<T: ?Sized + KeyValue> KeyValue for Arc<T> {
-    fn get(&self, key: Vec<u8>) -> Result<Vec<u8>> {
+    fn get(&self, key: Vec<u8>) -> Result<Vec<u8>, Error> {
         KeyValue::get(&**self, key)
     }
 
-    fn insert(&self, key: Vec<u8>, value: Vec<u8>) -> Result<()> {
+    fn insert(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error> {
         KeyValue::insert(&**self, key, value)
     }
 }

--- a/tests/runtimes/simple-keymanager/src/main.rs
+++ b/tests/runtimes/simple-keymanager/src/main.rs
@@ -5,5 +5,5 @@ mod api;
 
 pub fn main() {
     let init = new_keymanager(api::trusted_policy_signers());
-    oasis_core_runtime::start_runtime(init, version_from_cargo!());
+    oasis_core_runtime::start_runtime(init, version_from_cargo!(), None);
 }

--- a/tests/runtimes/simple-keyvalue/Cargo.toml
+++ b/tests/runtimes/simple-keyvalue/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/upgraded.rs"
 [package.metadata.fortanix-sgx]
 heap-size = 134217728
 stack-size = 2097152
-threads = 2
+threads = 3
 
 [dependencies]
 cbor = { version = "0.1.0", package = "oasis-cbor" }

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -9,7 +9,7 @@ use std::sync::{atomic::AtomicBool, Arc};
 use oasis_core_keymanager_client::KeyManagerClient;
 use oasis_core_runtime::{
     common::version::Version,
-    consensus::roothash::Message,
+    consensus::{roothash::Message, verifier::TrustRoot},
     protocol::HostInfo,
     rak::RAK,
     transaction::{
@@ -262,6 +262,18 @@ pub fn main() {
         Some(Box::new(dispatcher))
     };
 
+    // Determine test trust root based on build settings.
+    let trust_root = option_env!("OASIS_TESTS_CONSENSUS_TRUST_HEIGHT").map(|height| {
+        let hash = option_env!("OASIS_TESTS_CONSENSUS_TRUST_HASH").unwrap();
+        let runtime_id = option_env!("OASIS_TESTS_CONSENSUS_TRUST_RUNTIME_ID").unwrap();
+
+        TrustRoot {
+            height: u64::from_str_radix(height, 10).unwrap(),
+            hash: hash.to_string(),
+            runtime_id: runtime_id.into(),
+        }
+    });
+
     // Start the runtime.
-    oasis_core_runtime::start_runtime(Box::new(init), version_from_cargo!());
+    oasis_core_runtime::start_runtime(Box::new(init), version_from_cargo!(), trust_root);
 }


### PR DESCRIPTION
Fixes #3952 

TODO
* [x] Clean up E2E tests.
* [x] Cache last computed state root to avoid verification when the enclave itself knows it is correct (since it computed it locally).
* [x] Periodically notify runtime of new consensus layer blocks to reduce the amount of syncing needed on ExecuteTx.
* [x] Write a LRU light block store to avoid keeping all the blocks.
* [x] Persist sealed latest trusted consensus block in untrusted local storage.