### PR TITLE
go/common/identity: Refresh sentry TLS certificates

### DIFF
--- a/.changelog/4239.bugfix.md
+++ b/.changelog/4239.bugfix.md
@@ -1,0 +1,4 @@
+go/common/identity: Refresh sentry TLS certificates
+
+Since we are using public keys for TLS authentication, we make sure that
+sentry TLS certificates are refreshed to avoid them expiring.

--- a/go/common/identity/identity.go
+++ b/go/common/identity/identity.go
@@ -322,8 +322,11 @@ func doLoadOrGenerate(dataDir string, signerFactory signature.SignerFactory, sho
 
 	// Load or generate the sentry client certificate for this node.
 	tlsSentryClientCertPath, tlsSentryClientKeyPath := TLSSentryClientCertPaths(dataDir)
-	sentryClientCert, err := tlsCert.Load(tlsSentryClientCertPath, tlsSentryClientKeyPath)
+	sentryClientCert, err := tlsCert.LoadFromKey(tlsSentryClientKeyPath, CommonName)
 	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("identity: unable to read sentry client key from file: %w", err)
+		}
 		// Load failed, generate fresh sentry client cert.
 		sentryClientCert, err = tlsCert.Generate(CommonName)
 		if err != nil {


### PR DESCRIPTION
Fixes #4239 