### PR TITLE
go/upgrade: validate migration handler name on registration

### DIFF
--- a/.changelog/4065.bugfix.md
+++ b/.changelog/4065.bugfix.md
@@ -1,0 +1,1 @@
+Validate upgrade migration handler name on registration

--- a/go/governance/gen_vectors/main.go
+++ b/go/governance/gen_vectors/main.go
@@ -19,7 +19,7 @@ import (
 	upgrade "github.com/oasisprotocol/oasis-core/go/upgrade/api"
 )
 
-func valideSubmitProposal(v uint16, epoch uint64, handler string, target version.ProtocolVersions) bool {
+func valideSubmitProposal(v uint16, epoch uint64, handler upgrade.HandlerName, target version.ProtocolVersions) bool {
 	if v < upgrade.MinDescriptorVersion || v > upgrade.MaxDescriptorVersion ||
 		epoch < uint64(upgrade.MinUpgradeEpoch) || epoch > uint64(upgrade.MaxUpgradeEpoch) ||
 		len(handler) < upgrade.MinUpgradeHandlerLength || len(handler) > upgrade.MaxUpgradeHandlerLength {
@@ -61,7 +61,7 @@ func main() {
 			// Generate upgrade proposal transactions.
 			for _, v := range []uint16{0, upgrade.LatestDescriptorVersion} {
 				for _, epoch := range []uint64{0, 1000, 10_000_000, math.MaxUint64 - 1, math.MaxUint64} {
-					for _, handler := range []string{"", "descriptor-handler", "tooooooo-long-33-char-description"} {
+					for _, handler := range []upgrade.HandlerName{"", "descriptor-handler", "tooooooo-long-33-char-description"} {
 						for _, target := range []version.ProtocolVersions{
 							{},
 							{ConsensusProtocol: version.Version{Major: 1, Minor: 2, Patch: 3}},

--- a/go/oasis-node/cmd/debug/txsource/workload/governance.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/governance.go
@@ -157,7 +157,7 @@ func (g *governanceWorkload) doUpgradeProposal() error {
 		Upgrade: &governance.UpgradeProposal{
 			Descriptor: upgrade.Descriptor{
 				Versioned: cbor.NewVersioned(upgrade.LatestDescriptorVersion),
-				Handler:   fmt.Sprintf("test-upgrade_%s", hex.EncodeToString(nameSuffix)),
+				Handler:   upgrade.HandlerName(fmt.Sprintf("test-upgrade_%s", hex.EncodeToString(nameSuffix))),
 				Target:    version.Versions,
 				Epoch:     upgradeEpoch,
 			},

--- a/go/oasis-test-runner/scenario/e2e/upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/upgrade.go
@@ -100,7 +100,7 @@ type nodeUpgradeImpl struct {
 	ctx          context.Context
 	currentEpoch beacon.EpochTime
 
-	handlerName    string
+	handlerName    upgrade.HandlerName
 	upgradeChecker upgradeChecker
 }
 
@@ -153,9 +153,9 @@ func (sc *nodeUpgradeImpl) restart(wait bool) error {
 	}
 }
 
-func newNodeUpgradeImpl(handlerName string, upgradeChecker upgradeChecker) scenario.Scenario {
+func newNodeUpgradeImpl(handlerName upgrade.HandlerName, upgradeChecker upgradeChecker) scenario.Scenario {
 	sc := &nodeUpgradeImpl{
-		E2E:            *NewE2E("node-upgrade-" + handlerName),
+		E2E:            *NewE2E("node-upgrade-" + string(handlerName)),
 		ctx:            context.Background(),
 		handlerName:    handlerName,
 		upgradeChecker: upgradeChecker,

--- a/go/upgrade/api/api.go
+++ b/go/upgrade/api/api.go
@@ -86,12 +86,28 @@ var (
 	_ prettyprint.PrettyPrinter = (*Descriptor)(nil)
 )
 
+// HandlerName is the name of the upgrade descriptor handler.
+type HandlerName string
+
+// ValidateBasic does basic validation checks of the upgrade descriptor handler name.
+func (h HandlerName) ValidateBasic() error {
+	if len(h) < MinUpgradeHandlerLength || len(h) > MaxUpgradeHandlerLength {
+		return fmt.Errorf("invalid length: %d (min: %d max: %d)",
+			len(h),
+			MinUpgradeHandlerLength,
+			MaxUpgradeHandlerLength,
+		)
+	}
+
+	return nil
+}
+
 // Descriptor describes an upgrade.
 type Descriptor struct { // nolint: maligned
 	cbor.Versioned
 
 	// Handler is the name of the upgrade handler.
-	Handler string `json:"handler"`
+	Handler HandlerName `json:"handler"`
 	// Target is upgrade's target version.
 	Target version.ProtocolVersions `json:"target"`
 	// Epoch is the epoch at which the upgrade should happen.
@@ -124,12 +140,8 @@ func (d Descriptor) ValidateBasic() error {
 			MaxDescriptorVersion,
 		)
 	}
-	if len(d.Handler) < MinUpgradeHandlerLength || len(d.Handler) > MaxUpgradeHandlerLength {
-		return fmt.Errorf("invalid upgrade descriptor handler length: %d (min: %d max: %d)",
-			len(d.Handler),
-			MinUpgradeHandlerLength,
-			MaxUpgradeHandlerLength,
-		)
+	if err := d.Handler.ValidateBasic(); err != nil {
+		return fmt.Errorf("invalid upgrade descriptor handler: %w", err)
 	}
 	if err := d.Target.ValidateBasic(); err != nil {
 		return fmt.Errorf("invalid upgrade descriptor target version: %w", err)

--- a/go/upgrade/migrations/migrations.go
+++ b/go/upgrade/migrations/migrations.go
@@ -49,7 +49,10 @@ type Context struct {
 }
 
 // Register registers a new migration handler, by upgrade name.
-func Register(name string, handler Handler) {
+func Register(name upgradeApi.HandlerName, handler Handler) {
+	if err := name.ValidateBasic(); err != nil {
+		panic(fmt.Errorf("migration handler name error: %w", err))
+	}
 	if _, isRegistered := registeredHandlers.Load(name); isRegistered {
 		panic(fmt.Errorf("migration handler already registered: %s", name))
 	}
@@ -66,7 +69,7 @@ func NewContext(upgrade *upgradeApi.PendingUpgrade, dataDir string) *Context {
 }
 
 // GetHandler returns the handler associated with the upgrade described in the context.
-func GetHandler(name string) (Handler, error) {
+func GetHandler(name upgradeApi.HandlerName) (Handler, error) {
 	h, exists := registeredHandlers.Load(name)
 	if !exists {
 		return nil, ErrMissingMigrationHandler


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/4065