### PR TITLE
go/oasis-node/cmd: Use pretty-printed variant when outputting JSON

### DIFF
--- a/.changelog/4266.feature.1.md
+++ b/.changelog/4266.feature.1.md
@@ -1,0 +1,1 @@
+go/oasis-node/cmd: Use pretty-printed variant when outputting JSON

--- a/.changelog/4266.feature.2.md
+++ b/.changelog/4266.feature.2.md
@@ -1,0 +1,1 @@
+go/common/entity: Use pretty-printed JSON when saving entity to file

--- a/.changelog/4266.internal.md
+++ b/.changelog/4266.internal.md
@@ -1,0 +1,1 @@
+go/oasis-node/cmd/common: Add `PrettyJSONMarshal()` helper

--- a/go/common/entity/entity.go
+++ b/go/common/entity/entity.go
@@ -129,7 +129,7 @@ func (e *Entity) Save(baseDir string) error {
 	entityPath := filepath.Join(baseDir, entityFilename)
 
 	// Write to disk.
-	b, err := json.Marshal(e)
+	b, err := json.MarshalIndent(e, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/go/oasis-node/cmd/common/consensus/consensus.go
+++ b/go/oasis-node/cmd/common/consensus/consensus.go
@@ -3,7 +3,6 @@ package consensus
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -142,15 +141,15 @@ func SignAndSaveTx(ctx context.Context, tx *transaction.Transaction, signer sign
 		os.Exit(1)
 	}
 
-	rawTx, err := json.Marshal(sigTx)
+	prettySigTx, err := cmdCommon.PrettyJSONMarshal(sigTx)
 	if err != nil {
-		logger.Error("failed to marshal transaction",
+		logger.Error("failed to get pretty JSON of signed transaction",
 			"err", err,
 		)
 		os.Exit(1)
 	}
-	if err = ioutil.WriteFile(viper.GetString(CfgTxFile), rawTx, 0o600); err != nil {
-		logger.Error("failed to save transaction",
+	if err = ioutil.WriteFile(viper.GetString(CfgTxFile), prettySigTx, 0o600); err != nil {
+		logger.Error("failed to save signed transaction",
 			"err", err,
 		)
 		os.Exit(1)

--- a/go/oasis-node/cmd/common/json.go
+++ b/go/oasis-node/cmd/common/json.go
@@ -1,0 +1,15 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// PrettyJSONMarshal returns pretty-printed JSON encoding of v.
+func PrettyJSONMarshal(v interface{}) ([]byte, error) {
+	formatted, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal to pretty JSON: %w", err)
+	}
+	return formatted, nil
+}

--- a/go/oasis-node/cmd/control/control.go
+++ b/go/oasis-node/cmd/control/control.go
@@ -220,14 +220,14 @@ func doStatus(cmd *cobra.Command, args []string) {
 		)
 		os.Exit(128)
 	}
-	formatted, err := json.MarshalIndent(status, "", "  ")
+	prettyStatus, err := cmdCommon.PrettyJSONMarshal(status)
 	if err != nil {
-		logger.Error("failed to format status",
+		logger.Error("failed to get pretty JSON of node status",
 			"err", err,
 		)
 		os.Exit(1)
 	}
-	fmt.Println(string(formatted))
+	fmt.Println(string(prettyStatus))
 }
 
 // Register registers the client sub-command and all of it's children.

--- a/go/oasis-node/cmd/debug/beacon/beacon.go
+++ b/go/oasis-node/cmd/debug/beacon/beacon.go
@@ -3,7 +3,6 @@ package beacon
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -84,14 +83,14 @@ func doBeaconStatus(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	formatted, err := json.MarshalIndent(prettyOut, "", "  ")
+	prettyJSON, err := cmdCommon.PrettyJSONMarshal(prettyOut)
 	if err != nil {
-		logger.Error("failed to format state",
+		logger.Error("failed to get pretty JSON of beacon state",
 			"err", err,
 		)
 		os.Exit(1)
 	}
-	fmt.Println(string(formatted))
+	fmt.Println(string(prettyJSON))
 }
 
 // Register registers the beacon sub-command and all of it's children.

--- a/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
+++ b/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
@@ -3,7 +3,6 @@ package dumpdb
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -254,14 +253,14 @@ func doDumpDB(cmd *cobra.Command, args []string) {
 	if shouldClose {
 		defer w.Close()
 	}
-	raw, err := json.Marshal(doc)
+	prettyDoc, err := cmdCommon.PrettyJSONMarshal(doc)
 	if err != nil {
 		logger.Error("failed to marshal state dump into JSON",
 			"err", err,
 		)
 		return
 	}
-	if _, err := w.Write(raw); err != nil {
+	if _, err := w.Write(prettyDoc); err != nil {
 		logger.Error("failed to write state dump file",
 			"err", err,
 		)

--- a/go/oasis-node/cmd/governance/governance.go
+++ b/go/oasis-node/cmd/governance/governance.go
@@ -198,14 +198,20 @@ func doProposalInfo(cmd *cobra.Command, args []string) {
 	defer conn.Close()
 
 	ctx := context.Background()
-	p, err := client.Proposal(ctx, &governance.ProposalQuery{Height: consensus.HeightLatest, ProposalID: id})
+	proposal, err := client.Proposal(ctx, &governance.ProposalQuery{Height: consensus.HeightLatest, ProposalID: id})
 	if err != nil {
 		logger.Error("error querying proposal", "err", err)
 		os.Exit(1)
 	}
 
-	o, _ := json.Marshal(p)
-	fmt.Println(string(o))
+	prettyProposal, err := cmdCommon.PrettyJSONMarshal(proposal)
+	if err != nil {
+		logger.Error("failed to get pretty JSON of proposal",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+	fmt.Println(string(prettyProposal))
 }
 
 func doProposalVotes(cmd *cobra.Command, args []string) {
@@ -229,8 +235,14 @@ func doProposalVotes(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	o, _ := json.Marshal(votes)
-	fmt.Println(string(o))
+	prettyVotes, err := cmdCommon.PrettyJSONMarshal(votes)
+	if err != nil {
+		logger.Error("failed to get pretty JSON of votes",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+	fmt.Println(string(prettyVotes))
 }
 
 func doListProposals(cmd *cobra.Command, args []string) {
@@ -256,8 +268,14 @@ func doListProposals(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	o, _ := json.Marshal(proposals)
-	fmt.Println(string(o))
+	prettyProposals, err := cmdCommon.PrettyJSONMarshal(proposals)
+	if err != nil {
+		logger.Error("failed to get pretty JSON of proposals",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+	fmt.Println(string(prettyProposals))
 }
 
 // Register registers the governance sub-command and all of it's children.

--- a/go/oasis-node/cmd/registry/entity/entity.go
+++ b/go/oasis-node/cmd/registry/entity/entity.go
@@ -264,8 +264,14 @@ func signAndWriteEntityGenesis(dataDir string, signer signature.Signer, ent *ent
 	}
 
 	// Write out the signed entity registration.
-	b, _ := json.Marshal(signed)
-	if err = ioutil.WriteFile(filepath.Join(dataDir, entityGenesisFilename), b, 0o600); err != nil {
+	prettySigned, err := cmdCommon.PrettyJSONMarshal(signed)
+	if err != nil {
+		logger.Error("failed to get pretty JSON of signed entity genesis registration",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+	if err = ioutil.WriteFile(filepath.Join(dataDir, entityGenesisFilename), prettySigned, 0o600); err != nil {
 		logger.Error("failed to write signed entity genesis registration",
 			"err", err,
 		)
@@ -337,16 +343,24 @@ func doList(cmd *cobra.Command, args []string) {
 	}
 
 	for _, ent := range entities {
-		var s string
+		var entString string
 		switch cmdFlags.Verbose() {
 		case true:
-			b, _ := json.Marshal(ent)
-			s = string(b)
+			prettyEnt, err := cmdCommon.PrettyJSONMarshal(ent)
+			if err != nil {
+				logger.Error("failed to get pretty JSON of entity",
+					"err", err,
+					"entity ID", ent.ID.String(),
+				)
+				entString = fmt.Sprintf("[invalid pretty JSON for entity %s]", ent.ID)
+			} else {
+				entString = string(prettyEnt)
+			}
 		default:
-			s = ent.ID.String()
+			entString = ent.ID.String()
 		}
 
-		fmt.Printf("%v\n", s)
+		fmt.Println(entString)
 	}
 }
 

--- a/go/oasis-node/cmd/registry/runtime/runtime.go
+++ b/go/oasis-node/cmd/registry/runtime/runtime.go
@@ -133,16 +133,24 @@ func doList(cmd *cobra.Command, args []string) {
 	}
 
 	for _, rt := range runtimes {
-		var s string
+		var rtString string
 		switch cmdFlags.Verbose() {
 		case true:
-			b, _ := json.Marshal(rt)
-			s = string(b)
+			prettyRt, err := cmdCommon.PrettyJSONMarshal(rt)
+			if err != nil {
+				logger.Error("failed to get pretty JSON of runtime",
+					"err", err,
+					"runtime ID", rt.ID.String(),
+				)
+				rtString = fmt.Sprintf("[invalid pretty JSON for runtime %s]", rt.ID)
+			} else {
+				rtString = string(prettyRt)
+			}
 		default:
-			s = rt.ID.String()
+			rtString = rt.ID.String()
 		}
 
-		fmt.Printf("%v\n", s)
+		fmt.Println(rtString)
 	}
 }
 

--- a/go/oasis-node/cmd/stake/stake.go
+++ b/go/oasis-node/cmd/stake/stake.go
@@ -3,7 +3,6 @@ package stake
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -282,20 +281,28 @@ func doList(cmd *cobra.Command, args []string) {
 	}
 
 	for _, addr := range addresses {
-		var s string
+		var acctString string
 		switch cmdFlags.Verbose() {
 		case true:
 			// NOTE: getAccount()'s output doesn't contain an account's address,
 			// so we need to add it manually.
-			acctMap := make(map[api.Address]*api.Account)
-			acctMap[addr] = getAccount(ctx, cmd, addr, client)
-			b, _ := json.Marshal(acctMap)
-			s = string(b)
+			acctWithAddr := make(map[api.Address]*api.Account)
+			acctWithAddr[addr] = getAccount(ctx, cmd, addr, client)
+			prettyAcct, err := cmdCommon.PrettyJSONMarshal(acctWithAddr)
+			if err != nil {
+				logger.Error("failed to get pretty JSON of account",
+					"err", err,
+					"address", addr,
+				)
+				acctString = fmt.Sprintf("[invalid pretty JSON for account %s]", addr)
+			} else {
+				acctString = string(prettyAcct)
+			}
 		default:
-			s = addr.String()
+			acctString = addr.String()
 		}
 
-		fmt.Printf("%v\n", s)
+		fmt.Println(acctString)
 	}
 }
 


### PR DESCRIPTION
Add `PrettyJSONMarshal()` helper to unify how things are outputted to JSON.