### PR TITLE
go/upgrade migration updates

### DIFF
--- a/.changelog/4064.feature.md
+++ b/.changelog/4064.feature.md
@@ -1,0 +1,4 @@
+upgrade/migrations: add max allowances upgrade handler
+
+Adds `"consensus-staking-max-allowances-16"` upgrade handler which updates
+the consensus staking parameter `MaxAllowances` to `16`.

--- a/.changelog/4180.feature.md
+++ b/.changelog/4180.feature.md
@@ -1,0 +1,1 @@
+upgrade/migrations: add `consensus-params-update-2021-08` upgrade handler

--- a/.changelog/4267.bugfix.md
+++ b/.changelog/4267.bugfix.md
@@ -1,0 +1,1 @@
+go/upgrade: EnsureCompatible should only check consensus

--- a/go/oasis-test-runner/scenario/e2e/e2e.go
+++ b/go/oasis-test-runner/scenario/e2e/e2e.go
@@ -418,6 +418,8 @@ func RegisterScenarios() error {
 		GenesisFile,
 		// Node upgrade tests.
 		NodeUpgradeDummy,
+		NodeUpgradeMaxAllowances,
+		NodeUpgradeConsensus202108,
 		NodeUpgradeCancel,
 		// Debonding entries from genesis test.
 		Debond,

--- a/go/upgrade/api/api.go
+++ b/go/upgrade/api/api.go
@@ -161,10 +161,10 @@ func (d Descriptor) ValidateBasic() error {
 // EnsureCompatible checks if currently running binary is compatible with
 // the upgrade descriptor.
 func (d *Descriptor) EnsureCompatible() error {
-	ownVersion := version.Versions
-
-	if !ownVersion.Compatible(d.Target) {
-		return fmt.Errorf("binary version not compatible: own: %s, required: %s", ownVersion, d.Target)
+	ownConsensus := version.Versions.ConsensusProtocol
+	targetConsensus := d.Target.ConsensusProtocol
+	if ownConsensus.MaskNonMajor() != targetConsensus.MaskNonMajor() {
+		return fmt.Errorf("binary consensus version not compatible: own: %s, required: %s", ownConsensus, targetConsensus)
 	}
 	return nil
 }

--- a/go/upgrade/api/api_test.go
+++ b/go/upgrade/api/api_test.go
@@ -230,10 +230,19 @@ func TestEnsureCompatible(t *testing.T) {
 			msg: "different target should fail",
 			d: &Descriptor{
 				Versioned: cbor.NewVersioned(LatestDescriptorVersion),
-				Target:    version.ProtocolVersions{RuntimeHostProtocol: version.FromU64(42)},
+				Target:    version.ProtocolVersions{ConsensusProtocol: version.FromU64(42)},
 				Epoch:     100,
 			},
 			shouldErr: true,
+		},
+		{
+			msg: "different runtime target should not fail",
+			d: &Descriptor{
+				Versioned: cbor.NewVersioned(LatestDescriptorVersion),
+				Target:    version.ProtocolVersions{ConsensusProtocol: version.ConsensusProtocol, RuntimeHostProtocol: version.FromU64(42)},
+				Epoch:     100,
+			},
+			shouldErr: false,
 		},
 		{
 			msg: "matching identifier should not fail",

--- a/go/upgrade/migrations/consensus_max_allowances.go
+++ b/go/upgrade/migrations/consensus_max_allowances.go
@@ -1,0 +1,51 @@
+package migrations
+
+import (
+	"fmt"
+
+	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	stakingState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/staking/state"
+)
+
+const (
+	// ConsensusMaxAllowances16Handler is the name of the upgrade that sets the
+	// staking max allowances consensus parameter to 16.
+	ConsensusMaxAllowances16Handler = "consensus-max-allowances-16"
+)
+
+var _ Handler = (*maxAllowances16Handler)(nil)
+
+type maxAllowances16Handler struct{}
+
+func (th *maxAllowances16Handler) StartupUpgrade(ctx *Context) error {
+	return nil
+}
+
+func (th *maxAllowances16Handler) ConsensusUpgrade(ctx *Context, privateCtx interface{}) error {
+	abciCtx := privateCtx.(*abciAPI.Context)
+	switch abciCtx.Mode() {
+	case abciAPI.ContextBeginBlock:
+		// Nothing to do during begin block.
+	case abciAPI.ContextEndBlock:
+		// Update a consensus parameter during EndBlock.
+		state := stakingState.NewMutableState(abciCtx.State())
+
+		params, err := state.ConsensusParameters(abciCtx)
+		if err != nil {
+			return fmt.Errorf("unable to load staking consensus parameters: %w", err)
+		}
+
+		params.MaxAllowances = 16
+
+		if err = state.SetConsensusParameters(abciCtx, params); err != nil {
+			return fmt.Errorf("failed to update staking consensus parameters: %w", err)
+		}
+	default:
+		return fmt.Errorf("upgrade handler called in unexpected context: %s", abciCtx.Mode())
+	}
+	return nil
+}
+
+func init() {
+	Register(ConsensusMaxAllowances16Handler, &maxAllowances16Handler{})
+}

--- a/go/upgrade/migrations/consensus_parameters.go
+++ b/go/upgrade/migrations/consensus_parameters.go
@@ -1,0 +1,114 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
+	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	governanceState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/governance/state"
+	roothashState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/roothash/state"
+	schedulerState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/scheduler/state"
+	stakingState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/staking/state"
+	governanceAPI "github.com/oasisprotocol/oasis-core/go/governance/api"
+	roothashAPI "github.com/oasisprotocol/oasis-core/go/roothash/api"
+	stakingAPI "github.com/oasisprotocol/oasis-core/go/staking/api"
+)
+
+const (
+	// ConsensusParamsUpdate202108 is the name of the "consensus-params-update-2021-08"
+	// upgrade handler.
+	ConsensusParamsUpdate202108 = "consensus-params-update-2021-08"
+)
+
+var _ Handler = (*consensusParameters202108Handler)(nil)
+
+type consensusParameters202108Handler struct{}
+
+func (th *consensusParameters202108Handler) StartupUpgrade(ctx *Context) error {
+	return nil
+}
+
+func (th *consensusParameters202108Handler) ConsensusUpgrade(ctx *Context, privateCtx interface{}) error {
+	abciCtx := privateCtx.(*abciAPI.Context)
+	switch abciCtx.Mode() {
+	case abciAPI.ContextBeginBlock:
+		// Nothing to do during begin block.
+	case abciAPI.ContextEndBlock:
+		// Update consensus parameters during EndBlock.
+
+		stakingState := stakingState.NewMutableState(abciCtx.State())
+		stakingParams, err := stakingState.ConsensusParameters(abciCtx)
+		if err != nil {
+			return fmt.Errorf("unable to load staking consensus parameters: %w", err)
+		}
+
+		governanceState := governanceState.NewMutableState(abciCtx.State())
+		governanceParams, err := governanceState.ConsensusParameters(abciCtx)
+		if err != nil {
+			return fmt.Errorf("unable to load governance consensus parameters: %w", err)
+		}
+
+		roothashState := roothashState.NewMutableState(abciCtx.State())
+		roothashParams, err := roothashState.ConsensusParameters(abciCtx)
+		if err != nil {
+			return fmt.Errorf("unable to load roothash consensus parameters: %w", err)
+		}
+
+		schedulerState := schedulerState.NewMutableState(abciCtx.State())
+		schedulerParams, err := schedulerState.ConsensusParameters(abciCtx)
+		if err != nil {
+			return fmt.Errorf("unable to load scheduler consensus parameters: %w", err)
+		}
+
+		// Staking consensus parameters.
+		// Set MaxAllowances to 16.
+		stakingParams.MaxAllowances = 16
+		// Gas costs.
+		if stakingParams.GasCosts == nil {
+			stakingParams.GasCosts = make(transaction.Costs)
+		}
+		stakingParams.GasCosts[stakingAPI.GasOpAmendCommissionSchedule] = 1000
+		stakingParams.GasCosts[stakingAPI.GasOpAllow] = 1000
+		stakingParams.GasCosts[stakingAPI.GasOpWithdraw] = 1000
+
+		// Governance consensus parameters.
+		// Gas costs.
+		if governanceParams.GasCosts == nil {
+			governanceParams.GasCosts = make(transaction.Costs)
+		}
+		governanceParams.GasCosts[governanceAPI.GasOpCastVote] = 1000
+		governanceParams.GasCosts[governanceAPI.GasOpSubmitProposal] = 1000
+
+		// Roothash consensus parameters.
+		// Gas costs.
+		if roothashParams.GasCosts == nil {
+			roothashParams.GasCosts = make(transaction.Costs)
+		}
+		roothashParams.GasCosts[roothashAPI.GasOpEvidence] = 5000
+		roothashParams.GasCosts[roothashAPI.GasOpProposerTimeout] = 5000
+
+		// Scheduler consensus parameters.
+		// Max validators.
+		schedulerParams.MaxValidators = 110
+
+		if err = stakingState.SetConsensusParameters(abciCtx, stakingParams); err != nil {
+			return fmt.Errorf("failed to update staking consensus parameters: %w", err)
+		}
+		if err = governanceState.SetConsensusParameters(abciCtx, governanceParams); err != nil {
+			return fmt.Errorf("failed to update governance consensus parameters: %w", err)
+		}
+		if err = roothashState.SetConsensusParameters(abciCtx, roothashParams); err != nil {
+			return fmt.Errorf("failed to update roothash consensus parameters: %w", err)
+		}
+		if err = schedulerState.SetConsensusParameters(abciCtx, schedulerParams); err != nil {
+			return fmt.Errorf("failed to update scheduler consensus parameters: %w", err)
+		}
+	default:
+		return fmt.Errorf("upgrade handler called in unexpected context: %s", abciCtx.Mode())
+	}
+	return nil
+}
+
+func init() {
+	Register(ConsensusParamsUpdate202108, &consensusParameters202108Handler{})
+}


### PR DESCRIPTION
- ports missing upgrade handlers from `21.2.x` to `master`
- fixes `upgrade.EnsureCompatible` to only compare consensus versions