### PR TITLE
bump oasis-cbor to 0.2.0

### DIFF
--- a/.changelog/4278.internal.1.md
+++ b/.changelog/4278.internal.1.md
@@ -1,0 +1,1 @@
+rust: bump `oasis-cbor` to `0.2.0`

--- a/.changelog/4278.internal.2.md
+++ b/.changelog/4278.internal.2.md
@@ -1,0 +1,1 @@
+rust: bump `base64ct` to `1.1.0`

--- a/.changelog/4278.internal.3.md
+++ b/.changelog/4278.internal.3.md
@@ -1,0 +1,1 @@
+rust: bump `crypto-bigint` to `0.2.10`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d27fb6b6f1e43147af148af49d49329413ba781aa0d5e10979831c210173b5"
+checksum = "40a96587c05c810ddbb79e2674d519cff1379517e7b91d166dff7a7cc0e9af6e"
 
 [[package]]
 name = "bech32"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,9 +569,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.2"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32a398eb1ccfbe7e4f452bc749c44d38dd732e9a253f19da224c416f00ee7f4"
+checksum = "d12477e115c0d570c12a2dfd859f80b55b60ddb5075df210d3af06d133a69f45"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "oasis-cbor"
-version = "0.1.8"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7134e2d7da8cd90a1928a9121419ede09624d18bb0a3fcbcac7e7b6232317e3f"
+checksum = "620f90b431654029f927635656e82f18e9815812e88ce781d9c09a7a40ea0b1b"
 dependencies = [
  "impl-trait-for-tuples",
  "oasis-cbor-derive",
@@ -1530,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "oasis-cbor-derive"
-version = "0.1.8"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bbc791abda671bb0c970a8e1b9adeb24689c91a8fe99fc42876a792c99861f"
+checksum = "5c7782197fedc097f3abb1148715e3a0ac440c38bec2666893bedb114d42b1c8"
 dependencies = [
  "darling",
  "proc-macro-crate",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 oasis-core-runtime = { path = "../runtime" }
-cbor = { version = "0.1.0", package = "oasis-cbor" }
+cbor = { version = "0.2.0", package = "oasis-cbor" }
 
 # Third party.
 anyhow = "1.0"

--- a/keymanager-api-common/Cargo.toml
+++ b/keymanager-api-common/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 oasis-core-runtime = { path = "../runtime" }
-cbor = { version = "0.1.8", package = "oasis-cbor" }
+cbor = { version = "0.2.0", package = "oasis-cbor" }
 
 base64 = "0.13.0"
 rustc-hex = "2.0.1"

--- a/keymanager-client/Cargo.toml
+++ b/keymanager-client/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 oasis-core-client = { path = "../client" }
 oasis-core-runtime = { path = "../runtime" }
 oasis-core-keymanager-api-common = { path = "../keymanager-api-common" }
-cbor = { version = "0.1.0", package = "oasis-cbor" }
+cbor = { version = "0.2.0", package = "oasis-cbor" }
 
 # Third party.
 futures = "0.3.17"

--- a/keymanager-lib/Cargo.toml
+++ b/keymanager-lib/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 oasis-core-runtime = { path = "../runtime" }
 oasis-core-keymanager-api-common = { path = "../keymanager-api-common" }
 oasis-core-keymanager-client = { path = "../keymanager-client" }
-cbor = { version = "0.1.0", package = "oasis-cbor" }
+cbor = { version = "0.2.0", package = "oasis-cbor" }
 
 # Third party.
 anyhow = "1.0"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Oasis Protocol Foundation <info@oasisprotocol.org>"]
 edition = "2018"
 
 [dependencies]
-cbor = { version = "0.1.0", package = "oasis-cbor" }
+cbor = { version = "0.2.0", package = "oasis-cbor" }
 
 # Third party.
 log = "0.4"

--- a/tests/runtimes/simple-keyvalue/Cargo.toml
+++ b/tests/runtimes/simple-keyvalue/Cargo.toml
@@ -20,7 +20,7 @@ stack-size = 2097152
 threads = 6
 
 [dependencies]
-cbor = { version = "0.1.0", package = "oasis-cbor" }
+cbor = { version = "0.2.0", package = "oasis-cbor" }
 oasis-core-runtime = { path = "../../../runtime" }
 oasis-core-client = { path = "../../../client" }
 oasis-core-keymanager-client = { path = "../../../keymanager-client" }


### PR DESCRIPTION
Also bumps `base64ct` and `crypto-bigint` due to build warnings about old versions being yanked from registry.