### PR TITLE
go/consensus/api: Change Block's Hash field type to common Hash type

### DIFF
--- a/.changelog/4281.breaking.md
+++ b/.changelog/4281.breaking.md
@@ -1,0 +1,10 @@
+go/consensus/api: Change `Block`'s `Hash` field type to the common `Hash` type
+
+Also change the type of `Status`' hash-related fields (`LatestHash`,
+`GenesisHash`, `LastRetainedHash`) to the [common `Hash` type] to allow nicer
+text/JSON serialization.
+
+<!-- markdownlint-disable line-length -->
+[common `Hash` type]:
+  https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go/common/crypto/hash#Hash
+<!-- markdownlint-enable line-length -->

--- a/.changelog/4281.doc.md
+++ b/.changelog/4281.doc.md
@@ -1,0 +1,1 @@
+Update example output of `oasis-node control status` CLI command

--- a/.changelog/4281.feature.2.md
+++ b/.changelog/4281.feature.2.md
@@ -1,0 +1,1 @@
+go/common/crypto/hash: Add `Hex()` method to `Hash` type

--- a/.changelog/4281.feature.md
+++ b/.changelog/4281.feature.md
@@ -1,0 +1,1 @@
+go/common/crypto/hash: Add `LoadFromHexBytes()` method to `Hash` type

--- a/docs/oasis-node/cli.md
+++ b/docs/oasis-node/cli.md
@@ -13,45 +13,54 @@ oasis-node control status
 to get information like the following (example taken from a runtime compute
 node):
 
+<!-- markdownlint-disable line-length -->
 ```json
 {
-  "software_version": "20.10",
+  "software_version": "21.3",
   "identity": {
-    "node": "kO/mEZfAnnRnGqpA5JqlZLaIf+bMTIZAriivJdWSTco=",
-    "p2p": "EwriyXpMKatrC1X2Z+KsDRkdu0NXWV4/25TRSa59z8o=",
-    "consensus": "4AaxFrlyZwQhGmk58+Up/gDg5eY1mwJpFEE9WXulg9Q=",
+    "node": "iWq6Nft6dU2GWAr9U7ICbhXWwmAINIniKzMMblSo5Xs=",
+    "p2p": "dGd+pGgIlkJb0dnkBQ7vI2EWWG81pF5M1G+jL2/6pyA=",
+    "consensus": "QaMdKVwX1da0Uf82cp0DDukQQwrSjr8BwlIxc//ANE8=",
     "tls": [
-      "1ZWRWMA/gx0nfGH6xJNKAlYUPaGkBz2LxTe552bCO68=",
-      "XGOH0m3CQVSG1J9AFxefgSWF+YP6eRnxmjM5zmj2gLs="
+      "Kj8ANHwfMzcWoA1vx0OMhn4oGv8Y0vc46xMOdQUIh5c=",
+      "1C8rWqyuARkSxNXuPbDPh9XID/SiYAU3GxGk6nMwR0Q="
     ]
   },
   "consensus": {
-    "consensus_version": "1.0.0",
+    "version": {
+      "major": 4
+    },
     "backend": "tendermint",
     "features": 3,
     "node_peers": [
-      "5c8272d22b3bc0ee282c9e21682b22ce6d68078c@127.0.0.1:20000"
+      "5ab8074ce3053ef9b72d664c73e39972241442e3@57.71.39.73:26658",
+      "abb66e8780f3815d87bad488a2892b4d4b2221e3@108.15.34.59:50716"
     ],
-    "latest_height": 185,
-    "latest_hash": "N6dmMPB2A+n4EkCv684TAtARRGrxcobouHfq1daXoBk=",
-    "latest_time": "2020-09-08T11:18:54+02:00",
+    "latest_height": 5960191,
+    "latest_hash": "091c29c3d588c52421a4f215268c6b4ab1a7762c429a98fec5de9251f8907add",
+    "latest_time": "2021-09-24T21:42:29+02:00",
+    "latest_epoch": 10489,
     "latest_state_root": {
-      "ns": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-      "version": 184,
-      "hash": "ITfGAos0wY40Y1qmf7vr7f2jvA+cMRPswql3RqhTyDc="
+      "ns": "0000000000000000000000000000000000000000000000000000000000000000",
+      "version": 5960190,
+      "root_type": 1,
+      "hash": "c34581dcec59d80656d6082260d63f3206aef0a1b950c1f2c06d1eaa36a22ec3"
     },
-    "genesis_height": 1,
-    "genesis_hash": "fYbBfC987n0RXS1TsicvCVViOWjBe/9gwyEW6kTev/c=",
-    "is_validator": false
+    "genesis_height": 5891596,
+    "genesis_hash": "e9d9fb99baefc3192a866581c35bf43d7f0499c64e1c150171e87b2d5dc35087",
+    "last_retained_height": 5891596,
+    "last_retained_hash": "e9d9fb99baefc3192a866581c35bf43d7f0499c64e1c150171e87b2d5dc35087",
+    "chain_context": "9ee492b63e99eab58fd979a23dfc9b246e5fc151bfdecd48d3ba26a9d0712c2b",
+    "is_validator": true
   },
   "runtimes": {
-    "gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=": {
+    "0000000000000000000000000000000000000000000000000000000000000001": {
       "descriptor": {
-        "v": 1,
-        "id": "gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-        "entity_id": "TqUyj5Q+9vZtqu10yw6Zw7HEX3Ywe0JQA9vHyzY47TU=",
+        "v": 2,
+        "id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "entity_id": "Ldzg8aeLiUBrMYxidd5DqEzpamyV2cprmRH0pG8d/Jg=",
         "genesis": {
-          "state_root": "xnK40e9W7Sirh8NiLFEUBpvdOte4+XN0mNDAHs7wlno=",
+          "state_root": "c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a",
           "state": null,
           "storage_receipts": null,
           "round": 0
@@ -59,101 +68,154 @@ node):
         "kind": 1,
         "tee_hardware": 0,
         "versions": {
-          "version": {}
+          "version": {
+            "minor": 2
+          }
         },
-        "key_manager": "wAAAAAAAAAD///////////////////////////////8=",
         "executor": {
-          "group_size": 2,
-          "group_backup_size": 1,
-          "allowed_stragglers": 0,
-          "round_timeout": 20
+          "group_size": 3,
+          "group_backup_size": 3,
+          "allowed_stragglers": 1,
+          "round_timeout": 5,
+          "max_messages": 256
         },
         "txn_scheduler": {
           "algorithm": "simple",
-          "batch_flush_timeout": 20000000000,
-          "max_batch_size": 1,
-          "max_batch_size_bytes": 16777216,
-          "propose_batch_timeout": 20
+          "batch_flush_timeout": 1000000000,
+          "max_batch_size": 100,
+          "max_batch_size_bytes": 1048576,
+          "propose_batch_timeout": 2
         },
         "storage": {
-          "group_size": 1,
-          "min_write_replication": 1,
-          "max_apply_write_log_entries": 100000,
+          "group_size": 3,
+          "min_write_replication": 2,
+          "max_apply_write_log_entries": 10000,
           "max_apply_ops": 2,
-          "checkpoint_interval": 0,
-          "checkpoint_num_kept": 0,
-          "checkpoint_chunk_size": 0
+          "checkpoint_interval": 100,
+          "checkpoint_num_kept": 2,
+          "checkpoint_chunk_size": 8388608
         },
         "admission_policy": {
           "any_node": {}
         },
-        "staking": {}
+        "constraints": {
+          "executor": {
+            "backup-worker": {
+              "max_nodes": {
+                "limit": 1
+              },
+              "min_pool_size": {
+                "limit": 3
+              }
+            },
+            "worker": {
+              "max_nodes": {
+                "limit": 1
+              },
+              "min_pool_size": {
+                "limit": 3
+              }
+            }
+          },
+          "storage": {
+            "worker": {
+              "max_nodes": {
+                "limit": 1
+              },
+              "min_pool_size": {
+                "limit": 3
+              }
+            }
+          }
+        },
+        "staking": {},
+        "governance_model": "entity"
       },
-      "latest_round": 5,
-      "latest_hash": "3chaVOZUeJwPBZNbFUh622STrvtrEVlIee7unu/S880=",
-      "latest_time": 1599556729,
+      "latest_round": 1355,
+      "latest_hash": "2a11820c0524a8a753f7f4a268ee2d0a4f4588a89121f92a43f4be9cc6acca7e",
+      "latest_time": "2021-09-24T21:41:29+02:00",
       "latest_state_root": {
-        "ns": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-        "version": 5,
-        "hash": "xnK40e9W7Sirh8NiLFEUBpvdOte4+XN0mNDAHs7wlno="
+        "ns": "0000000000000000000000000000000000000000000000000000000000000000",
+        "version": 1355,
+        "root_type": 1,
+        "hash": "45168e11548ac5322a9a206abff4368983b5cf676b1bcb2269f5dfbdf9df7be3"
       },
       "genesis_round": 0,
-      "genesis_hash": "T4zq6ris0pGNvkgfhGmPnnDMzbMo+8rUPhfxbyAZ2tg=",
+      "genesis_hash": "aed94c03ebd2d16dfb5f6434021abf69c8c15fc69b6b19554d23da8a5a053776",
       "committee": {
-        "latest_round": 5,
-        "latest_height": 180,
-        "last_committee_update_height": 180,
-        "executor_role": "worker",
-        "storage_role": "invalid",
-        "is_txn_scheduler": true,
+        "latest_round": 1355,
+        "latest_height": 5960180,
+        "last_committee_update_height": 5960174,
+        "executor_roles": [
+          "worker",
+          "backup-worker"
+        ],
+        "storage_roles": [
+          "worker"
+        ],
+        "is_txn_scheduler": false,
         "peers": [
-          "/ip4/172.25.0.2/tcp/20015/p2p/12D3KooWQ6gDSgYBYqUfERm8BQdFtozJ5Wg6LQeLwQz1LCPPx8B4",
-          "/ip4/127.0.0.1/tcp/20012/p2p/12D3KooWQEjvQjwweWxv8mH7YbsQxJaQB7VqYu1QopWvmoFSZ6Pi"
+          "/ip4/57.71.39.73/tcp/41002/p2p/12D3KooWJvL8mYzHbcLtj91bf5sHhtrB7C8CWND5sV6Kk24eUdpQ",
+          "/ip4/108.67.32.45/tcp/26648/p2p/12D3KooWBKgcH7TGMSLuxzLxK41nTwk6DsxHRpb7HpWQXJzLurcv"
         ]
       },
-      "storage": null
+      "storage": {
+        "last_finalized_round": 1355
+      }
     }
   },
   "registration": {
-    "last_registration": "2020-09-08T11:18:51+02:00",
+    "last_registration": "2021-09-24T21:41:08+02:00",
     "descriptor": {
       "v": 1,
-      "id": "kO/mEZfAnnRnGqpA5JqlZLaIf+bMTIZAriivJdWSTco=",
-      "entity_id": "wmYfQjpQHaOj9SSmWL/oYx1kHnatBI9so+eH33E0qig=",
-      "expiration": 8,
+      "id": "iWq6Nft6dU2GWAr9U7ICbhXWwmAINIniKzMMblSo5Xs=",
+      "entity_id": "4G4ISI8hANvMRYTbxdXU+0r9m/6ZySHERR+2RDbNOU8=",
+      "expiration": 10491,
       "tls": {
-        "pub_key": "1ZWRWMA/gx0nfGH6xJNKAlYUPaGkBz2LxTe552bCO68=",
-        "next_pub_key": "XGOH0m3CQVSG1J9AFxefgSWF+YP6eRnxmjM5zmj2gLs=",
+        "pub_key": "Kj8ANHwfMzcWoA1vx0OMhn4oGv8Y0vc46xMOdQUIh5c=",
+        "next_pub_key": "1C8rWqyuARkSxNXuPbDPh9XID/SiYAU3GxGk6nMwR0Q=",
         "addresses": [
-          "XGOH0m3CQVSG1J9AFxefgSWF+YP6eRnxmjM5zmj2gLs=@172.25.0.2:20008"
+          "Kj8ANHwfMzcWoA1vx0OMhn4oGv8Y0vc46xMOdQUIh5c=@128.89.215.24:30001",
+          "1C8rWqyuARkSxNXuPbDPh9XID/SiYAU3GxGk6nMwR0Q=@128.89.215.24:30001"
         ]
       },
       "p2p": {
-        "id": "EwriyXpMKatrC1X2Z+KsDRkdu0NXWV4/25TRSa59z8o=",
+        "id": "dGd+pGgIlkJb0dnkBQ7vI2EWWG81pF5M1G+jL2/6pyA=",
         "addresses": [
-          "172.25.0.2:20009",
-          "127.0.0.1:20009"
+          "159.89.215.24:30002"
         ]
       },
       "consensus": {
-        "id": "4AaxFrlyZwQhGmk58+Up/gDg5eY1mwJpFEE9WXulg9Q=",
-        "addresses": null
+        "id": "QaMdKVwX1da0Uf82cp0DDukQQwrSjr8BwlIxc//ANE8=",
+        "addresses": [
+          "dGd+pGgIlkJb0dnkBQ7vI2EWWG81pF5M1G+jL2/6pyA=@128.89.215.24:26656"
+        ]
+      },
+      "beacon": {
+        "point": "BHg8TOqKD4wV8UCu9nICvJt7rhXFd8CxXuYiHa6X/NnzlIndzGNEJyyTr00s5rgKwX25yPmv+r2xRFbcQK6hGLE="
       },
       "runtimes": [
         {
-          "id": "gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "id": "0000000000000000000000000000000000000000000000000000000000000001",
           "version": {
-            "minor": 3
+            "minor": 2
           },
           "capabilities": {},
           "extra_info": null
         }
       ],
-      "roles": 1
+      "roles": "compute,storage,validator"
+    },
+    "node_status": {
+      "expiration_processed": false,
+      "freeze_end_time": 0,
+      "election_eligible_after": 9810
     }
-  }
+  },
+  "pending_upgrades": []
 }
 ```
+<!-- markdownlint-enable line-length -->
 
 ## `genesis`
 

--- a/go/common/crypto/hash/hash.go
+++ b/go/common/crypto/hash/hash.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"hash"
 
+	tmbytes "github.com/tendermint/tendermint/libs/bytes"
+
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 )
 
@@ -139,6 +141,13 @@ func NewFrom(v interface{}) (h Hash) {
 // NewFromBytes creates a new hash by hashing the provided byte string(s).
 func NewFromBytes(data ...[]byte) (h Hash) {
 	h.FromBytes(data...)
+	return
+}
+
+// LoadFromHexBytes creates a new hash by loading it from the given Tendermint
+// HexBytes byte array.
+func LoadFromHexBytes(data tmbytes.HexBytes) (h Hash) {
+	_ = h.UnmarshalBinary(data[:])
 	return
 }
 

--- a/go/common/crypto/hash/hash.go
+++ b/go/common/crypto/hash/hash.go
@@ -119,9 +119,14 @@ func (h *Hash) IsEmpty() bool {
 	return subtle.ConstantTimeCompare(h[:], emptyHash[:]) == 1
 }
 
+// Hex returns the hex-encoded representation of a hash.
+func (h *Hash) Hex() string {
+	return hex.EncodeToString(h[:])
+}
+
 // String returns the string representation of a hash.
 func (h Hash) String() string {
-	return hex.EncodeToString(h[:])
+	return h.Hex()
 }
 
 // Truncate returns the first n bytes of a hash.

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -9,6 +9,7 @@ import (
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
@@ -163,7 +164,7 @@ type Block struct {
 	// Height contains the block height.
 	Height int64 `json:"height"`
 	// Hash contains the block header hash.
-	Hash []byte `json:"hash"`
+	Hash hash.Hash `json:"hash"`
 	// Time is the second-granular consensus time.
 	Time time.Time `json:"time"`
 	// StateRoot is the Merkle root of the consensus state tree.
@@ -187,7 +188,7 @@ type Status struct { // nolint: maligned
 	// LatestHeight is the height of the latest block.
 	LatestHeight int64 `json:"latest_height"`
 	// LatestHash is the hash of the latest block.
-	LatestHash []byte `json:"latest_hash"`
+	LatestHash hash.Hash `json:"latest_hash"`
 	// LatestTime is the timestamp of the latest block.
 	LatestTime time.Time `json:"latest_time"`
 	// LatestEpoch is the epoch of the latest block.
@@ -198,12 +199,12 @@ type Status struct { // nolint: maligned
 	// GenesisHeight is the height of the genesis block.
 	GenesisHeight int64 `json:"genesis_height"`
 	// GenesisHash is the hash of the genesis block.
-	GenesisHash []byte `json:"genesis_hash"`
+	GenesisHash hash.Hash `json:"genesis_hash"`
 
 	// LastRetainedHeight is the height of the oldest retained block.
 	LastRetainedHeight int64 `json:"last_retained_height"`
 	// LastRetainedHash is the hash of the oldest retained block.
-	LastRetainedHash []byte `json:"last_retained_hash"`
+	LastRetainedHash hash.Hash `json:"last_retained_hash"`
 
 	// ChainContext is the chain domain separation context.
 	ChainContext string `json:"chain_context"`

--- a/go/consensus/tendermint/api/api.go
+++ b/go/consensus/tendermint/api/api.go
@@ -188,7 +188,7 @@ func NewBlock(blk *tmtypes.Block) *consensus.Block {
 
 	return &consensus.Block{
 		Height: blk.Header.Height,
-		Hash:   blk.Header.Hash(),
+		Hash:   hash.LoadFromHexBytes(blk.Header.Hash()),
 		Time:   blk.Header.Time,
 		StateRoot: mkvsNode.Root{
 			Version: uint64(blk.Header.Height) - 1,

--- a/go/oasis-test-runner/scenario/e2e/consensus_state_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/consensus_state_sync.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -93,7 +92,7 @@ func (sc *consensusStateSyncImpl) Run(childEnv *env.Env) error {
 
 	sc.Logger.Info("got some blocks, starting the validator that needs to sync",
 		"trust_height", blk.Height,
-		"trust_hash", hex.EncodeToString(blk.Hash),
+		"trust_hash", blk.Hash.Hex(),
 	)
 
 	// The last validator configured by the fixture is the one that is stopped and will sync.
@@ -135,7 +134,7 @@ func (sc *consensusStateSyncImpl) Run(childEnv *env.Env) error {
 	val.SetConsensusStateSync(&oasis.ConsensusStateSyncCfg{
 		ConsensusNodes: consensusNodes,
 		TrustHeight:    uint64(blk.Height),
-		TrustHash:      hex.EncodeToString(blk.Hash),
+		TrustHash:      blk.Hash.Hex(),
 	})
 
 	if err = val.Start(); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_sync.go
@@ -2,7 +2,6 @@ package runtime
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -268,7 +267,7 @@ func (sc *storageSyncImpl) Run(childEnv *env.Env) error { //nolint: gocyclo
 		consensusNodes = append(consensusNodes, string(rawAddress))
 
 		trustHeight = uint64(status.Consensus.LatestHeight)
-		trustHash = hex.EncodeToString(status.Consensus.LatestHash)
+		trustHash = status.Consensus.LatestHash.Hex()
 	}
 
 	// Configure state sync for the last storage node.

--- a/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
@@ -2,7 +2,6 @@ package runtime
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -203,7 +202,7 @@ func (sc *trustRootImpl) Run(childEnv *env.Env) (err error) {
 
 	sc.Logger.Info("got some blocks, building runtime with given trust root",
 		"trust_root_height", blk.Height,
-		"trust_root_hash", hex.EncodeToString(blk.Hash),
+		"trust_root_hash", blk.Hash.Hex(),
 		"trust_root_runtime_id", runtimeID.String(),
 	)
 
@@ -213,7 +212,7 @@ func (sc *trustRootImpl) Run(childEnv *env.Env) (err error) {
 	teeHardware, _ := sc.getTEEHardware()
 	builder := rust.NewBuilder(childEnv, teeHardware, trustRootRuntime, filepath.Join(buildDir, trustRootRuntime), targetDir)
 	builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_HEIGHT", strconv.FormatInt(blk.Height, 10))
-	builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_HASH", hex.EncodeToString(blk.Hash))
+	builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_HASH", blk.Hash.Hex())
 	builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_RUNTIME_ID", runtimeID.String())
 	if err = builder.Build(); err != nil {
 		return fmt.Errorf("failed to build runtime '%s' with trust root: %w", trustRootRuntime, err)


### PR DESCRIPTION
Also change the type of `Status`' hash-related field (`LatestHash`, `GenesisHash`, `LastRetainedHash`) to the [common `Hash` type](  https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go/common/crypto/hash#Hash
).

This will make all hash-related fields in the `"consensus"` part of `oasis-node control status`'s output use hex-encoding rather than Base64-encoding.

It follows a similar change for textual representation of runtime IDs and runtime state roots which was done in #4279.

The motivation for this change is to unify:
- Consensus hash representation (which used Base64-encoding previously) with runtime state root hash representation (which uses hex-encoding since #4279).
- `oasis-node control status`'s block hash representation with OASIS SCAN's and Oasis Monitor's representations which use the hex-encoding: [[1]](https://www.oasisscan.com/blocks/5185037) [[2]](https://oasismonitor.com/block/5185037)
- [State Sync's trusted height hash parameter](https://docs.oasis.dev/general/run-a-node/advanced/sync-node-using-state-sync#obtaining-trusted-height-and-hash) (i.e. `consensus.tendermint.state_sync.trusted_hash` flag) expects the hex-encoded representation of block's hash.

Example of previous `"consensus"` part of `oasis-node control status`:
```json
"consensus": {
    "version": {
      "major": 4
    },
    "backend": "tendermint",
    "features": 3,
    "node_peers": [
      "4b09be0737402c8bc3bfce0424e0e082e4e8c207@23.88.56.166:26656",
      "aa421daf91004ee86f1d916c47119325224ce3db@5.9.154.108:26656",
      "136d2d3b17be220719ab23a0611bc68e52323e5a@95.217.204.115:26656",
      "292d3fe0766368e305f300614d6fbe2fa1e3c336@85.209.48.233:26656",
      "972123ae07511a76b2b82e3d3fa7593a288f0e95@65.21.94.221:26656",
      "9493308147b401d2cd1bed56585ce833d0e3edc4@88.198.49.73:26656",
      "756f88eba54e1f701a97f7b2d911164bb42cf104@148.251.91.50:26656",
      "5b0da1fc85768a0ed86b4f4d394919d2e25222f5@65.21.35.102:36656",
      "c19e52198e86395cf841fded35fd6de6e37cb677@80.67.47.126:26656",
      "ca0e733b946ef09491e2ad26f5425c404465b774@80.64.211.67:26656",
      "245a44145281ff32b45d2c3d56d1dfa97763969f@159.203.101.120:26656",
      "e9d0043539e5cb96ec06983858a23643b00c7cb2@35.227.53.250:26656",
      "33d7ce3a882f64cd7c8e9884c6bd1dc8cea90ff2@3.64.157.46:26656",
      "988f52160f3aa9a7a33af58b5e699d06748a0064@51.15.16.108:26656",
      "3cc19a3fde93e22ce954c223aaf54c5e2e84cd32@135.181.83.158:26656",
      "94b0dd0e5ef296c59a75a2b0aa1af609c94c0c35@95.216.171.253:26656",
      "5f40ab6f70a4ba09f4553521926948705f5f3e89@194.163.169.33:26656",
      "ed1acdfa10acd4206d5131a7286697d183c9dc25@209.126.6.224:26656",
      "132111486911a7eca4eca01052209504fb0fac34@135.181.56.199:26656"
    ],
    "latest_height": 5185037,
    "latest_hash": "Id6Z/Nogj4vKCBTiRwWGDM1dqyuIZ7ZsqA77o1U3Yrc=",
    "latest_time": "2021-09-24T21:48:23+02:00",
    "latest_epoch": 8636,
    "latest_state_root": {
      "ns": "0000000000000000000000000000000000000000000000000000000000000000",
      "version": 5185036,
      "root_type": 1,
      "hash": "69356fab71735bc0976a7af0aa85efdcc14bc4befc815e53ac8eb40a58d733d3"
    },
    "genesis_height": 3027601,
    "genesis_hash": "ZwRTUSdNw9W+NwPP1OxuG1hEHRndlvXfDOpQLE9tlfQ=",
    "last_retained_height": 3027601,
    "last_retained_hash": "ZwRTUSdNw9W+NwPP1OxuG1hEHRndlvXfDOpQLE9tlfQ=",
    "chain_context": "53852332637bacb61b91b6411ab4095168ba02a50be4c3f82448438826f23898",
    "is_validator": false
  },
```

Example of new `"consensus"` part of `oasis-node control status`:
```
  "consensus": {
    "version": {
      "major": 4
    },
    "backend": "tendermint",
    "features": 3,
    "node_peers": [
      "4b09be0737402c8bc3bfce0424e0e082e4e8c207@23.88.56.166:26656",
      "aa421daf91004ee86f1d916c47119325224ce3db@5.9.154.108:26656",
      "136d2d3b17be220719ab23a0611bc68e52323e5a@95.217.204.115:26656",
      "292d3fe0766368e305f300614d6fbe2fa1e3c336@85.209.48.233:26656",
      "972123ae07511a76b2b82e3d3fa7593a288f0e95@65.21.94.221:26656",
      "9493308147b401d2cd1bed56585ce833d0e3edc4@88.198.49.73:26656",
      "756f88eba54e1f701a97f7b2d911164bb42cf104@148.251.91.50:26656",
      "5b0da1fc85768a0ed86b4f4d394919d2e25222f5@65.21.35.102:36656",
      "c19e52198e86395cf841fded35fd6de6e37cb677@80.67.47.126:26656",
      "ca0e733b946ef09491e2ad26f5425c404465b774@80.64.211.67:26656",
      "245a44145281ff32b45d2c3d56d1dfa97763969f@159.203.101.120:26656",
      "e9d0043539e5cb96ec06983858a23643b00c7cb2@35.227.53.250:26656",
      "33d7ce3a882f64cd7c8e9884c6bd1dc8cea90ff2@3.64.157.46:26656",
      "988f52160f3aa9a7a33af58b5e699d06748a0064@51.15.16.108:26656",
      "3cc19a3fde93e22ce954c223aaf54c5e2e84cd32@135.181.83.158:26656",
      "94b0dd0e5ef296c59a75a2b0aa1af609c94c0c35@95.216.171.253:26656",
      "5f40ab6f70a4ba09f4553521926948705f5f3e89@194.163.169.33:26656",
      "ed1acdfa10acd4206d5131a7286697d183c9dc25@209.126.6.224:26656",
      "132111486911a7eca4eca01052209504fb0fac34@135.181.56.199:26656"
    ],
    "latest_height": 5185037,
    "latest_hash": "21de99fcda208f8bca0814e24705860ccd5dab2b8867b66ca80efba3553762b7",
    "latest_time": "2021-09-24T21:48:23+02:00",
    "latest_epoch": 8636,
    "latest_state_root": {
      "ns": "0000000000000000000000000000000000000000000000000000000000000000",
      "version": 5185036,
      "root_type": 1,
      "hash": "69356fab71735bc0976a7af0aa85efdcc14bc4befc815e53ac8eb40a58d733d3"
    },
    "genesis_height": 3027601,
    "genesis_hash": "67045351274dc3d5be3703cfd4ec6e1b58441d19dd96f5df0cea502c4f6d95f4",
    "last_retained_height": 3027601,
    "last_retained_hash": "67045351274dc3d5be3703cfd4ec6e1b58441d19dd96f5df0cea502c4f6d95f4",
    "chain_context": "53852332637bacb61b91b6411ab4095168ba02a50be4c3f82448438826f23898",
    "is_validator": false
  },
```