### PR TITLE
rust: bump zeroize_derive to 1.2.0

### DIFF
--- a/.changelog/4282.internal.md
+++ b/.changelog/4282.internal.md
@@ -1,0 +1,1 @@
+rust: bump `zeroize_derive` to `1.2.0`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3066,9 +3066,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
+checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
It fixes  RUSTSEC-2021-0115:
https://rustsec.org/advisories/RUSTSEC-2021-0115.