### PR TITLE
go/worker/storage: Fix potential memory leak through context

### DIFF
--- a/.changelog/4290.bugfix.md
+++ b/.changelog/4290.bugfix.md
@@ -1,0 +1,1 @@
+go/worker/storage: Fix potential memory leak through context

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -529,9 +529,12 @@ func (n *Node) fetchDiff(round uint64, prevRoot, thisRoot storageApi.Root) {
 				"new_root", thisRoot,
 			)
 
+			ctx, cancel := context.WithCancel(n.ctx)
+			defer cancel()
+
 			// Prioritize committee nodes.
 			var selectedNode *node.Node
-			ctx := storageApi.WithNodeSelectionCallback(n.ctx, func(n *node.Node) {
+			ctx = storageApi.WithNodeSelectionCallback(ctx, func(n *node.Node) {
 				selectedNode = n
 			})
 			if committee := n.commonNode.Group.GetEpochSnapshot().GetStorageCommittee(); committee != nil {


### PR DESCRIPTION
See #4263 