### PR TITLE
go/storage/api: Handle context cancellation in receiveWriteLogIterator

### DIFF
--- a/.changelog/4292.bugfix.md
+++ b/.changelog/4292.bugfix.md
@@ -1,0 +1,1 @@
+go/storage/api: Handle context cancellation in receiveWriteLogIterator


### PR DESCRIPTION
Exposed by fix for memory leak in #4290, the `receiveWriteLogIterator` did not handle context cancellation correctly and instead spinned forever.

Also see #4263.