### PR TITLE
[BACKPORT/21.3.x] go: Make sure correct namespace/hash text serialization is used

### DIFF
--- a/.changelog/4303.bugfix.md
+++ b/.changelog/4303.bugfix.md
@@ -1,0 +1,1 @@
+go: Make sure correct namespace/hash text serialization is used

--- a/go/common/crypto/hash/hash.go
+++ b/go/common/crypto/hash/hash.go
@@ -120,7 +120,7 @@ func (h *Hash) IsEmpty() bool {
 }
 
 // Hex returns the hex-encoded representation of a hash.
-func (h *Hash) Hex() string {
+func (h Hash) Hex() string {
 	return hex.EncodeToString(h[:])
 }
 

--- a/go/common/namespace.go
+++ b/go/common/namespace.go
@@ -106,7 +106,17 @@ func (n *Namespace) Equal(cmp *Namespace) bool {
 	return bytes.Equal(n[:], cmp[:])
 }
 
-// String returns the string representation of a chain namespace identifier.
+// Base64 returns the base64 string representation of a namespace identifier.
+func (n Namespace) Base64() string {
+	return base64.StdEncoding.EncodeToString(n[:])
+}
+
+// Hex returns the hexadecimal string representation of a namespace identifier.
+func (n Namespace) Hex() string {
+	return hex.EncodeToString(n[:])
+}
+
+// String returns the string representation of a namespace identifier.
 func (n Namespace) String() string {
 	return hex.EncodeToString(n[:])
 }

--- a/go/consensus/tendermint/apps/roothash/api.go
+++ b/go/consensus/tendermint/apps/roothash/api.go
@@ -61,8 +61,7 @@ func QueryForRuntime(runtimeID common.Namespace) tmpubsub.Query {
 // ValueRuntimeID returns the value that should be stored under KeyRuntimeID.
 func ValueRuntimeID(runtimeID common.Namespace) []byte {
 	// This needs to be a text field as Tendermint does not support non-text queries.
-	tagRuntimeID, _ := runtimeID.MarshalText()
-	return tagRuntimeID
+	return []byte(runtimeID.Base64())
 }
 
 // ValueExecutorCommitted is the value component of a KeyExecutorCommitted.

--- a/go/genesis/api/api.go
+++ b/go/genesis/api/api.go
@@ -65,7 +65,7 @@ func (d *Document) Hash() hash.Hash {
 // Currently this uses the hex-encoded cryptographic hash of the encoded
 // genesis document.
 func (d *Document) ChainContext() string {
-	return d.Hash().String()
+	return d.Hash().Hex()
 }
 
 // SetChainContext configures the global chain domain separation context.

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -1267,7 +1267,7 @@ func StakeClaimForNode(id signature.PublicKey) staking.StakeClaim {
 
 // StakeClaimForRuntime generates a new stake claim for a specific runtime registration.
 func StakeClaimForRuntime(id common.Namespace) staking.StakeClaim {
-	return staking.StakeClaim(fmt.Sprintf(StakeClaimRegisterRuntime, id))
+	return staking.StakeClaim(fmt.Sprintf(StakeClaimRegisterRuntime, id.Hex()))
 }
 
 // StakeThresholdsForNode returns the staking thresholds for the given node.


### PR DESCRIPTION
Backport of #4303 