### PR TITLE
go/consensus/tendermint: Only reset executor pool after emitting block

### DIFF
--- a/.changelog/4323.bugfix.md
+++ b/.changelog/4323.bugfix.md
@@ -1,0 +1,5 @@
+go/consensus/tendermint: Only reset executor pool after emitting block
+
+Make sure to only reset the executor pool after any timeouts have been
+cleared (e.g. when an empty block is emitted) as otherwise there could be a
+stale timeout.


### PR DESCRIPTION
Make sure to only reset the executor pool after any timeouts have been cleared
(e.g. when an empty block is emitted) as otherwise there could be a stale
timeout.