### PR TITLE
[BACKPORT/21.3.x] go/runtime/client: SubmitTxNoWait propagate CheckTx err

### DIFF
--- a/.changelog/4328.bugfix.md
+++ b/.changelog/4328.bugfix.md
@@ -1,0 +1,1 @@
+go/runtime/client: `SubmitTxNoWait` should propagate CheckTx error

--- a/go/runtime/client/tests/tester.go
+++ b/go/runtime/client/tests/tester.go
@@ -89,6 +89,9 @@ func testFailSubmitTransaction(
 	_, err = c.SubmitTx(ctx, &api.SubmitTxRequest{Data: mock.CheckTxFailInput, RuntimeID: runtimeID})
 	require.Error(t, err, "SubmitTx should fail check tx")
 
+	err = c.SubmitTxNoWait(ctx, &api.SubmitTxRequest{Data: mock.CheckTxFailInput, RuntimeID: runtimeID})
+	require.Error(t, err, "SubmitTxNoWait should fail check tx")
+
 	// Failures for unsupported runtimes.
 	var unsupportedRuntimeID common.Namespace
 	err = unsupportedRuntimeID.UnmarshalHex("0000000000000000BADF00BADF00BADF00BADF00BADF00BADF00BADF00BADF00")


### PR DESCRIPTION
Backports https://github.com/oasisprotocol/oasis-core/issues/4328