### PR TITLE
[BACKPORT/21.3.x] go/runtime/client: Add last retained round query

### DIFF
--- a/.changelog/4334.feature.md
+++ b/.changelog/4334.feature.md
@@ -1,0 +1,4 @@
+go/runtime/client: Add last retained round query
+
+This allows clients to query what is the earliest runtime round that the
+give node is storing.

--- a/go/control/api/api.go
+++ b/go/control/api/api.go
@@ -123,6 +123,11 @@ type RuntimeStatus struct {
 	// GenesisHash is the hash of the genesis runtime block.
 	GenesisHash hash.Hash `json:"genesis_hash"`
 
+	// LastRetainedRound is the round of the oldest retained block.
+	LastRetainedRound uint64 `json:"last_retained_round"`
+	// LastRetainedHash is the hash of the oldest retained block.
+	LastRetainedHash hash.Hash `json:"last_retained_hash"`
+
 	// Committee contains the runtime worker status in case this node is a (candidate) member of a
 	// runtime committee (e.g., compute or storage).
 	Committee *commonWorker.Status `json:"committee"`

--- a/go/oasis-node/cmd/node/control.go
+++ b/go/oasis-node/cmd/node/control.go
@@ -132,6 +132,19 @@ func (n *Node) GetRuntimeStatus(ctx context.Context) (map[common.Namespace]contr
 			)
 		}
 
+		// Fetch the oldest retained block.
+		blk, err = rt.History().GetEarliestBlock(ctx)
+		switch err {
+		case nil:
+			status.LastRetainedRound = blk.Header.Round
+			status.LastRetainedHash = blk.Header.EncodedHash()
+		default:
+			n.logger.Error("failed to fetch last retained runtime block",
+				"err", err,
+				"runtime_id", rt.ID(),
+			)
+		}
+
 		// Fetch common committee worker status.
 		if rtNode := n.CommonWorker.GetRuntime(rt.ID()); rtNode != nil {
 			status.Committee, err = rtNode.GetStatus(ctx)

--- a/go/runtime/client/api/api.go
+++ b/go/runtime/client/api/api.go
@@ -63,6 +63,9 @@ type RuntimeClient interface {
 	// GetBlock fetches the given runtime block.
 	GetBlock(ctx context.Context, request *GetBlockRequest) (*block.Block, error)
 
+	// GetLastRetainedBlock returns the last retained block.
+	GetLastRetainedBlock(ctx context.Context, runtimeID common.Namespace) (*block.Block, error)
+
 	// GetTransactions fetches all runtime transactions in a given block.
 	GetTransactions(ctx context.Context, request *GetTransactionsRequest) ([][]byte, error)
 

--- a/go/runtime/client/client.go
+++ b/go/runtime/client/client.go
@@ -273,6 +273,15 @@ func (c *runtimeClient) GetBlock(ctx context.Context, request *api.GetBlockReque
 	return rt.History().GetBlock(ctx, request.Round)
 }
 
+// Implements api.RuntimeClient.
+func (c *runtimeClient) GetLastRetainedBlock(ctx context.Context, runtimeID common.Namespace) (*block.Block, error) {
+	rt, err := c.common.runtimeRegistry.GetRuntime(runtimeID)
+	if err != nil {
+		return nil, err
+	}
+	return rt.History().GetEarliestBlock(ctx)
+}
+
 func (c *runtimeClient) getTxnTree(blk *block.Block) *transaction.Tree {
 	ioRoot := storage.Root{
 		Namespace: blk.Header.Namespace,

--- a/go/runtime/client/tests/tester.go
+++ b/go/runtime/client/tests/tester.go
@@ -139,6 +139,11 @@ func testQuery(
 	_, err = c.GetBlock(ctx, &api.GetBlockRequest{RuntimeID: runtimeID, Round: expectedLatestRound + 1})
 	require.Error(t, err, "GetBlock")
 
+	// Last retained block.
+	blkLr, err := c.GetLastRetainedBlock(ctx, runtimeID)
+	require.NoError(t, err, "GetLastRetainedBlock")
+	require.EqualValues(t, genBlk.Header.Round, blkLr.Header.Round)
+
 	// Transactions (check the mock worker for content).
 	txns, err := c.GetTransactions(ctx, &api.GetTransactionsRequest{RuntimeID: runtimeID, Round: blk.Header.Round})
 	require.NoError(t, err, "GetTransactions")


### PR DESCRIPTION
This allows clients to query what is the earliest runtime round that the
give node is storing.