### PR TITLE
[BACKPORT/21.3.x] go/staking: Fix incorrect non-existence check

### DIFF
--- a/.changelog/4340.bugfix.md
+++ b/.changelog/4340.bugfix.md
@@ -1,0 +1,1 @@
+go/staking: Fix incorrect non-existence check

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -835,7 +835,7 @@ func (sa *StakeAccumulator) AddClaimUnchecked(claim StakeClaim, thresholds []Sta
 //
 // It is an error if the stake claim does not exist.
 func (sa *StakeAccumulator) RemoveClaim(claim StakeClaim) error {
-	if sa.Claims == nil || sa.Claims[claim] == nil {
+	if _, exists := sa.Claims[claim]; !exists {
 		return fmt.Errorf("staking: claim does not exist: %s", claim)
 	}
 

--- a/go/staking/api/api_test.go
+++ b/go/staking/api/api_test.go
@@ -206,6 +206,17 @@ func TestStakeAccumulator(t *testing.T) {
 	err = acct.CheckStakeClaims(thresholds)
 	require.NoError(err, "escrow account should check out")
 
+	// Add claim with empty threshold list.
+	err = acct.AddStakeClaim(thresholds, StakeClaim("claimEmptyList"), []StakeThreshold{})
+	require.NoError(err, "adding an empty list stake claim should work")
+	err = acct.RemoveStakeClaim(StakeClaim("claimEmptyList"))
+	require.NoError(err, "removing an empty claim should work")
+
+	err = acct.AddStakeClaim(thresholds, StakeClaim("claimNilList"), nil)
+	require.NoError(err, "adding an nil list stake claim should work")
+	err = acct.RemoveStakeClaim(StakeClaim("claimNilList"))
+	require.NoError(err, "removing an nil claim should work")
+
 	// Reduce stake.
 	acct.Active.Balance = *quantity.NewFromUint64(5_000)
 	err = acct.CheckStakeClaims(thresholds)


### PR DESCRIPTION
Backport of #4340 