### PR TITLE
[BACKPORT/21.3.x] go/consensus/tendermint/roothash: Only index the correct runtime

### DIFF
--- a/.changelog/4351.bugfix.md
+++ b/.changelog/4351.bugfix.md
@@ -1,0 +1,5 @@
+go/consensus/tendermint/roothash: Only index the correct runtime
+
+In case multiple runtimes were being tracked, the indexing process could
+incorrectly set the last indexed round which could make it skip to index a
+round.

--- a/go/consensus/tendermint/roothash/roothash.go
+++ b/go/consensus/tendermint/roothash/roothash.go
@@ -406,7 +406,8 @@ func (sc *serviceClient) reindexBlocks(currentHeight int64, bh api.BlockHistory)
 		return lastRound, nil
 	}
 
-	logger := sc.logger.With("runtime_id", bh.RuntimeID())
+	runtimeID := bh.RuntimeID()
+	logger := sc.logger.With("runtime_id", runtimeID)
 
 	var err error
 	var lastHeight int64
@@ -482,8 +483,8 @@ func (sc *serviceClient) reindexBlocks(currentHeight int64, bh api.BlockHistory)
 						return 0, fmt.Errorf("failed to unmarshal finalized event: %w", err)
 					}
 
-					// Only process finalized events for tracked runtimes.
-					if sc.trackedRuntime[value.ID] == nil {
+					// Only process finalized events for the given runtime.
+					if !value.ID.Equal(&runtimeID) {
 						continue
 					}
 					if err = sc.processFinalizedEvent(sc.ctx, height, value.ID, &value.Event.Round, false); err != nil {


### PR DESCRIPTION
Backport of #4351.