### PR TITLE
go/runtime/host/sgx: Autodetect SGX device name

### DIFF
--- a/.changelog/4333.feature.md
+++ b/.changelog/4333.feature.md
@@ -1,0 +1,1 @@
+go/runtime/host/sgx: Autodetect SGX device name


### PR DESCRIPTION
Closes #4333.