### PR TITLE
test-runner: Read runtime version from fixture

### DIFF
--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -8,6 +8,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/log"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
@@ -225,6 +226,7 @@ type RuntimeFixture struct { // nolint: maligned
 	Kind       registry.RuntimeKind `json:"kind"`
 	Entity     int                  `json:"entity"`
 	Keymanager int                  `json:"keymanager"`
+	Version    version.Version      `json:"version"`
 
 	Binaries         map[node.TEEHardware][]string `json:"binaries"`
 	GenesisState     storage.WriteLog              `json:"genesis_state,omitempty"`
@@ -272,6 +274,7 @@ func (f *RuntimeFixture) Create(netFixture *NetworkFixture, net *Network) (*Runt
 		Keymanager:         km,
 		TEEHardware:        netFixture.TEE.Hardware,
 		MrSigner:           netFixture.TEE.MrSigner,
+		Version:            f.Version,
 		Executor:           f.Executor,
 		TxnScheduler:       f.TxnScheduler,
 		Storage:            f.Storage,

--- a/go/oasis-test-runner/oasis/runtime.go
+++ b/go/oasis-test-runner/oasis/runtime.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
@@ -52,6 +53,7 @@ type RuntimeCfg struct { // nolint: maligned
 	Keymanager  *Runtime
 	TEEHardware node.TEEHardware
 	MrSigner    *sgx.MrSigner
+	Version     version.Version
 
 	Binaries         map[node.TEEHardware][]string
 	GenesisState     storage.WriteLog
@@ -152,6 +154,7 @@ func (net *Network) NewRuntime(cfg *RuntimeCfg) (*Runtime, error) {
 		EntityID:        cfg.Entity.entity.ID,
 		Kind:            cfg.Kind,
 		TEEHardware:     cfg.TEEHardware,
+		Version:         registry.VersionInfo{Version: cfg.Version},
 		Executor:        cfg.Executor,
 		TxnScheduler:    cfg.TxnScheduler,
 		Storage:         cfg.Storage,


### PR DESCRIPTION
Fixes #4343:
- adds `version` field of type `version.Version` to runtime fixture and config structs
- fixes converting versions from `uint64`, if component values are greater than 255