### PR TITLE
oasis-node: Make semver parsing less strict

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,4 +2,5 @@
 ignore = [
     "RUSTSEC-2020-0071", # Remove once upstream dependencies are updated.
     "RUSTSEC-2020-0159", # Remove once upstream dependencies are updated.
+    "RUSTSEC-2021-0124", # Remove once upstream dependencies are updated.
 ]

--- a/.changelog/4366.bugfix.md
+++ b/.changelog/4366.bugfix.md
@@ -1,0 +1,5 @@
+oasis-node: Make semver parsing less strict
+
+Semver parsing behavior changed in #4343 was too strict. This hotfix changes
+parsing of versions so that only major component is required whereas minor and
+patch are optional and any remaining components are ignored.

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -59,19 +59,20 @@ func (v Version) String() string {
 }
 
 // FromString parses version in semver format. e.g. "1.0.0"
+// major.minor.patch components are considered where major is mandatory.
+// Any component following patch is ignored.
 func FromString(s string) (Version, error) {
 	// Trim potential pre-release suffix.
 	s = strings.Split(s, "-")[0]
 	// Trim potential git commit.
 	s = strings.Split(s, "+")[0]
+	// Take at most four components: major.minor.patch.remainder.
 	split := strings.SplitN(s, ".", 4)
-	if len(split) != 3 {
-		return Version{}, fmt.Errorf("version: failed to parse SemVer '%s': exactly three components are required", s)
-	}
 
-	var semVers []uint16 = []uint16{0, 0, 0}
+	semVers := []uint16{0, 0, 0}
 	for i, v := range split {
 		if i >= 3 {
+			// Ignore any components following major.minor.patch.
 			break
 		}
 		ver, err := strconv.ParseUint(v, 10, 16)

--- a/go/common/version/version_test.go
+++ b/go/common/version/version_test.go
@@ -73,10 +73,15 @@ func TestFromString(t *testing.T) {
 		{"1.2.3", Version{1, 2, 3}},
 		{"1.2.3-alpha", Version{1, 2, 3}},
 		{"1.2.3-alpha+git0253df22", Version{1, 2, 3}},
+		{"1.2.3-alpha+git0253df22-devbranch", Version{1, 2, 3}},
 		{"1.2.3+git0253df22", Version{1, 2, 3}},
+		{"1.2.3+git0253df22-devbranch", Version{1, 2, 3}},
 		{"1.2.3-beta.1", Version{1, 2, 3}},
 		{"300.400.500", Version{300, 400, 500}},
 		{"30000.40000.50000", Version{30000, 40000, 50000}},
+		{"1.0", Version{1, 0, 0}},
+		{"1", Version{1, 0, 0}},
+		{"1.2.3.4", Version{1, 2, 3}},
 	} {
 		version, err := FromString(v.semver)
 		require.NoError(err)
@@ -88,7 +93,6 @@ func TestFromString(t *testing.T) {
 		"",
 		"100000.0.0", "0.100000.0", "0.0.100000",
 		"-1.0.0", "0.-1.0", "0.0.-1",
-		"1.0", "1",
 		"a.b.c",
 	} {
 		_, err := FromString(v)


### PR DESCRIPTION
Semver parsing behavior changed in https://github.com/oasisprotocol/oasis-core/issues/4343 was too strict. This hotfix changes parsing of versions so that only `major` component is required whereas `minor` and `patch` are optional and any remaining components are ignored.