### PR TITLE
go/storage/mkvs: Don't fail sanity check for equal roots

### DIFF
--- a/.changelog/4381.bugfix.md
+++ b/.changelog/4381.bugfix.md
@@ -1,0 +1,4 @@
+go/storage/mkvs: Don't fail sanity check for equal roots
+
+In case the state root did not change, a write log is empty and so the sanity
+check should not require that it exists.

--- a/go/storage/mkvs/db/badger/check.go
+++ b/go/storage/mkvs/db/badger/check.go
@@ -162,9 +162,11 @@ func checkSanityInternal(ctx context.Context, db *badgerNodeDB, display DisplayH
 				if !ok {
 					return fmt.Errorf("mkvs/badger/check: missing target root (%s -> %s)", rootHash, dstRoot)
 				}
-				_, err = txn.Get(writeLogKeyFmt.Encode(dstVersion, &dstRoot, &rootHash)) //nolint: gosec
-				if err != nil {
-					return fmt.Errorf("mkvs/badger/check: missing write log (%d, %s, %s)", dstVersion, dstRoot, rootHash)
+				if !dstRoot.Equal(&rootHash) {
+					_, err = txn.Get(writeLogKeyFmt.Encode(dstVersion, &dstRoot, &rootHash)) //nolint: gosec
+					if err != nil {
+						return fmt.Errorf("mkvs/badger/check: missing write log (%d, %s, %s)", dstVersion, dstRoot, rootHash)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
In case the state root did not change, a write log is empty and so the
sanity check should not require that it exists.