### PR TITLE
go/common/identity: Save re-generated sentry client and node's persistent TLS certificate

### DIFF
--- a/.changelog/4382.bugfix.1.md
+++ b/.changelog/4382.bugfix.1.md
@@ -1,0 +1,8 @@
+go/common/identity: Save re-generated sentry client TLS certificate
+
+Sentry client TLS certificate is always re-generated from the private key when
+the Oasis Node starts.
+
+Previously, the re-generated sentry client TLS certificate was not saved to
+disk, which caused confusion since the on-disk certificate file (i.e.
+`sentry_client_tls_identity_cert.pem`) had incorrect/outdated expiry date.

--- a/.changelog/4382.bugfix.2.md
+++ b/.changelog/4382.bugfix.2.md
@@ -1,0 +1,8 @@
+go/common/identity: Save re-generated node's persistent TLS certificate
+
+If a node's TLS certificate is persistent, it is always re-generated from the
+private key when the Oasis Node starts.
+
+Previously, the re-generated node's persistent TLS certificate was not saved
+to disk, which caused confusion since the on-disk certificate file (i.e.
+`tls_identity_cert.pem`) had incorrect/outdated expiry date.

--- a/go/common/identity/identity.go
+++ b/go/common/identity/identity.go
@@ -332,23 +332,29 @@ func doLoadOrGenerate(dataDir string, signerFactory signature.SignerFactory, sho
 		}
 	}
 
-	// Load or generate the sentry client certificate for this node.
+	// Load and re-generate the sentry client TLS certificate for this node (if
+	// it exists).
+	// NOTE: This will reuse the sentry client's private key (if it exists)
+	// and re-generate the TLS certificate with a validity of 1 year.
+	// NOTE: The node needs to be restarted at least once a year so the TLS
+	// certificate doesn't expire.
 	tlsSentryClientCertPath, tlsSentryClientKeyPath := TLSSentryClientCertPaths(dataDir)
 	sentryClientCert, err := tlsCert.LoadFromKey(tlsSentryClientKeyPath, CommonName)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return nil, fmt.Errorf("identity: unable to read sentry client key from file: %w", err)
 		}
-		// Load failed, generate fresh sentry client cert.
+		// Loading sentry client's private key failed, generate a new
+		// private key and the corresponding TLS certificate.
 		sentryClientCert, err = tlsCert.Generate(CommonName)
 		if err != nil {
 			return nil, err
 		}
-		// And save it to disk.
-		err = tlsCert.Save(tlsSentryClientCertPath, tlsSentryClientKeyPath, sentryClientCert)
-		if err != nil {
-			return nil, err
-		}
+	}
+	// Save the re-generated TLS certificate (and private key) to disk.
+	err = tlsCert.Save(tlsSentryClientCertPath, tlsSentryClientKeyPath, sentryClientCert)
+	if err != nil {
+		return nil, err
 	}
 
 	return &Identity{

--- a/go/common/identity/identity_test.go
+++ b/go/common/identity/identity_test.go
@@ -20,10 +20,14 @@ func TestLoadOrGenerate(t *testing.T) {
 	factory, err := fileSigner.NewFactory(dataDir, RequiredSignerRoles...)
 	require.NoError(t, err, "NewFactory")
 
+	tlsSentryClientCertPath, _ := TLSSentryClientCertPaths(dataDir)
+
 	// Generate a new identity.
 	identity, err := LoadOrGenerate(dataDir, factory, true)
 	require.NoError(t, err, "LoadOrGenerate")
 	require.EqualValues(t, []signature.PublicKey{identity.GetTLSSigner().Public()}, identity.GetTLSPubKeys())
+	tlsSentryClientCertFile1, err := ioutil.ReadFile(tlsSentryClientCertPath)
+	require.NoError(t, err, "read sentry client TLS cert")
 
 	// Sleep to make sure that any regenerated TLS certificates will have different expiration.
 	time.Sleep(2 * time.Second)
@@ -40,6 +44,9 @@ func TestLoadOrGenerate(t *testing.T) {
 	require.EqualValues(t, identity.GetTLSPubKeys(), identity2.GetTLSPubKeys())
 	require.NotEqual(t, identity.TLSSentryClientCertificate, identity2.TLSSentryClientCertificate)
 	require.EqualValues(t, identity.TLSSentryClientCertificate.PrivateKey, identity2.TLSSentryClientCertificate.PrivateKey)
+	tlsSentryClientCertFile2, err := ioutil.ReadFile(tlsSentryClientCertPath)
+	require.NoError(t, err, "read sentry client TLS cert (2)")
+	require.NotEqualValues(t, tlsSentryClientCertFile1, tlsSentryClientCertFile2)
 
 	dataDir2, err := ioutil.TempDir("", "oasis-identity-test2_")
 	require.NoError(t, err, "create data dir (2)")

--- a/go/common/identity/identity_test.go
+++ b/go/common/identity/identity_test.go
@@ -20,12 +20,15 @@ func TestLoadOrGenerate(t *testing.T) {
 	factory, err := fileSigner.NewFactory(dataDir, RequiredSignerRoles...)
 	require.NoError(t, err, "NewFactory")
 
+	tlsCertPath, _ := TLSCertPaths(dataDir)
 	tlsSentryClientCertPath, _ := TLSSentryClientCertPaths(dataDir)
 
 	// Generate a new identity.
 	identity, err := LoadOrGenerate(dataDir, factory, true)
 	require.NoError(t, err, "LoadOrGenerate")
 	require.EqualValues(t, []signature.PublicKey{identity.GetTLSSigner().Public()}, identity.GetTLSPubKeys())
+	tlsCertFile1, err := ioutil.ReadFile(tlsCertPath)
+	require.NoError(t, err, "read TLS cert")
 	tlsSentryClientCertFile1, err := ioutil.ReadFile(tlsSentryClientCertPath)
 	require.NoError(t, err, "read sentry client TLS cert")
 
@@ -44,6 +47,9 @@ func TestLoadOrGenerate(t *testing.T) {
 	require.EqualValues(t, identity.GetTLSPubKeys(), identity2.GetTLSPubKeys())
 	require.NotEqual(t, identity.TLSSentryClientCertificate, identity2.TLSSentryClientCertificate)
 	require.EqualValues(t, identity.TLSSentryClientCertificate.PrivateKey, identity2.TLSSentryClientCertificate.PrivateKey)
+	tlsCertFile2, err := ioutil.ReadFile(tlsCertPath)
+	require.NoError(t, err, "read TLS cert (2)")
+	require.NotEqualValues(t, tlsCertFile1, tlsCertFile2)
 	tlsSentryClientCertFile2, err := ioutil.ReadFile(tlsSentryClientCertPath)
 	require.NoError(t, err, "read sentry client TLS cert (2)")
 	require.NotEqualValues(t, tlsSentryClientCertFile1, tlsSentryClientCertFile2)


### PR DESCRIPTION
Sentry client TLS certificate is always re-generated from the private key when the Oasis Node starts.

Previously, the re-generated sentry client TLS certificate was not saved to disk, which caused confusion since the on-disk certificate file (i.e. `sentry_client_tls_identity_cert.pem`) had incorrect/outdated expiry date.

Also, save re-generated node's persistent TLS certificate. If a node's TLS certificate is persistent, it is always re-generated from the private key when the Oasis Node starts.
    
Previously, the re-generated node's persistent TLS certificate was not saved to disk, which caused confusion since the on-disk certificate file (i.e. `tls_identity_cert.pem`) had incorrect/outdated expiry date.
