### PR TITLE
runtime: Propagate panics during transaction/local RPC/policy dispatch

### DIFF
--- a/.changelog/4386.bugfix.md
+++ b/.changelog/4386.bugfix.md
@@ -1,0 +1,5 @@
+runtime: Propagate panics during transaction/local RPC/policy dispatch
+
+A panic during transaction/local RPC/policy dispatch signals a serious
+problem so it should be propagated and the runtime should crash to force
+state reset.


### PR DESCRIPTION
A panic during transaction/local RPC/policy dispatch signals a serious problem
so it should be propagated and the runtime should crash to force state reset.