### PR TITLE
tests/workload/runtime: Wait for 3rd epoch for compute nodes to be up

### DIFF
--- a/.changelog/4395.internal.md
+++ b/.changelog/4395.internal.md
@@ -1,0 +1,4 @@
+tests/workload/runtime: Wait for 3rd epoch for compute nodes to be up
+
+Since the VRF-based scheduler was introduced the compute nodes only become
+eligible for election in the third epoch after genesis.

--- a/go/oasis-node/cmd/debug/txsource/workload/runtime.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/runtime.go
@@ -726,10 +726,10 @@ func (r *runtime) Run(
 	// Set up the runtime client.
 	rtc := runtimeClient.NewRuntimeClient(conn)
 
-	// Wait for 2nd epoch, so that runtimes are up and running.
-	r.Logger.Info("waiting for 2nd epoch")
-	if err := beacon.WaitEpoch(ctx, 2); err != nil {
-		return fmt.Errorf("failed waiting for 2nd epoch: %w", err)
+	// Wait for 3rd epoch, so that runtimes are up and running.
+	r.Logger.Info("waiting for 3rd epoch")
+	if err := beacon.WaitEpoch(ctx, 3); err != nil {
+		return fmt.Errorf("failed waiting for 3rd epoch: %w", err)
 	}
 
 	var totalWeight int


### PR DESCRIPTION
Since the VRF-based scheduler was introduced the compute nodes only become
eligible for election in the third epoch after genesis.