### PR TITLE
runtime: Enclave quote status related cleanups/improvements

### DIFF
--- a/.changelog/4055.cfg.1.md
+++ b/.changelog/4055.cfg.1.md
@@ -1,0 +1,8 @@
+runtime: Change OASIS_STRICT_AVR_VERIFY to OASIS_UNSAFE_LAX_AVR_VERFIY
+
+Previous builds would default to lax verification.  After this change
+the default verify behavior will be the strict (requires `OK` quote
+status), unless `OASIS_UNSAFE_LAX_AVR_VERIFY` is set.
+
+Note: As with previously, this option has no effect if AVR verification
+is disabled entirely.

--- a/.changelog/4055.internal.2.md
+++ b/.changelog/4055.internal.2.md
@@ -1,0 +1,8 @@
+common/node: Verify AVR quote status
+
+When verifying a TEECapabilities structure, additionally verify the
+quote status against the new SGXConstraints.AllowedQuoteStatuses vector
+so that nodes that have an invalid quote status can be omitted from
+scheduling entirely.
+
+Note: QuoteOK is ALWAYS allowed, as disallowing it is nonsensical.

--- a/go/common/sgx/common.go
+++ b/go/common/sgx/common.go
@@ -258,9 +258,3 @@ func (id *EnclaveIdentity) UnmarshalHex(text string) error {
 func (id EnclaveIdentity) String() string {
 	return hex.EncodeToString(id.MrEnclave[:]) + hex.EncodeToString(id.MrSigner[:])
 }
-
-// Constraints are the Intel SGX TEE constraints.
-type Constraints struct {
-	// Enclaves is the allowed MRENCLAVE/MRSIGNER pairs.
-	Enclaves []EnclaveIdentity `json:"enclaves"`
-}

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -184,7 +184,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 		Kind:        registry.KindKeyManager,
 		TEEHardware: node.TEEHardwareIntelSGX,
 		Version: registry.VersionInfo{
-			TEE: cbor.Marshal(sgx.Constraints{
+			TEE: cbor.Marshal(node.SGXConstraints{
 				Enclaves: []sgx.EnclaveIdentity{{}},
 			}),
 		},
@@ -243,7 +243,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 		},
 		TEEHardware: node.TEEHardwareIntelSGX,
 		Version: registry.VersionInfo{
-			TEE: cbor.Marshal(sgx.Constraints{
+			TEE: cbor.Marshal(node.SGXConstraints{
 				Enclaves: []sgx.EnclaveIdentity{{}},
 			}),
 		},

--- a/go/oasis-node/cmd/debug/byzantine/steps_test.go
+++ b/go/oasis-node/cmd/debug/byzantine/steps_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx/ias"
 )
@@ -15,7 +16,7 @@ func TestFakeCapabilitySGX(t *testing.T) {
 	_, fakeCapabilitiesSGX, err := initFakeCapabilitiesSGX()
 	require.NoError(t, err, "initFakeCapabilitiesSGX failed")
 
-	cs := cbor.Marshal(sgx.Constraints{
+	cs := cbor.Marshal(node.SGXConstraints{
 		Enclaves: []sgx.EnclaveIdentity{{}},
 	})
 

--- a/go/oasis-node/cmd/ias/auth.go
+++ b/go/oasis-node/cmd/ias/auth.go
@@ -55,7 +55,7 @@ func (st *enclaveStore) addRuntime(runtime *registry.Runtime) (int, error) {
 		return len(st.enclaves), nil
 	}
 
-	var cs sgx.Constraints
+	var cs node.SGXConstraints
 	if err := cbor.Unmarshal(runtime.Version.TEE, &cs); err != nil {
 		return len(st.enclaves), err
 	}

--- a/go/oasis-test-runner/oasis/runtime.go
+++ b/go/oasis-test-runner/oasis/runtime.go
@@ -121,7 +121,7 @@ func (rt *Runtime) RefreshEnclaveIdentity() error {
 			enclaveIdentities = append(enclaveIdentities, sgx.EnclaveIdentity{MrEnclave: *mrEnclave, MrSigner: *rt.mrSigner})
 			mrEnclaves = append(mrEnclaves, mrEnclave)
 		}
-		rt.descriptor.Version.TEE = cbor.Marshal(sgx.Constraints{
+		rt.descriptor.Version.TEE = cbor.Marshal(node.SGXConstraints{
 			Enclaves: enclaveIdentities,
 		})
 		rt.mrEnclaves = mrEnclaves

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -19,7 +19,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
-	"github.com/oasisprotocol/oasis-core/go/common/sgx"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
@@ -996,7 +995,7 @@ func VerifyRuntime( // nolint: gocyclo
 	if rt.TEEHardware != node.TEEHardwareInvalid {
 		switch rt.TEEHardware {
 		case node.TEEHardwareIntelSGX:
-			var cs sgx.Constraints
+			var cs node.SGXConstraints
 			if err := cbor.Unmarshal(rt.Version.TEE, &cs); err != nil {
 				logger.Error("RegisterRuntime: invalid SGX TEE constraints",
 					"err", err,

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -775,7 +775,7 @@ func testRegistryRuntime(t *testing.T, backend api.Backend, consensus consensusA
 				rt.Kind = api.KindKeyManager
 				rt.TEEHardware = node.TEEHardwareIntelSGX
 
-				cs := sgx.Constraints{
+				cs := node.SGXConstraints{
 					Enclaves: []sgx.EnclaveIdentity{{}},
 				}
 				rt.Version.TEE = cbor.Marshal(cs)
@@ -812,7 +812,7 @@ func testRegistryRuntime(t *testing.T, backend api.Backend, consensus consensusA
 				rt.KeyManager = &rtMapByName["KeyManager"].ID
 				rt.TEEHardware = node.TEEHardwareIntelSGX
 
-				cs := sgx.Constraints{
+				cs := node.SGXConstraints{
 					Enclaves: []sgx.EnclaveIdentity{{}},
 				}
 				rt.Version.TEE = cbor.Marshal(cs)

--- a/runtime/src/common/sgx/avr.rs
+++ b/runtime/src/common/sgx/avr.rs
@@ -224,7 +224,7 @@ impl ParsedAVR {
 /// Verify attestation report.
 pub fn verify(avr: &AVR) -> Result<AuthenticatedAVR> {
     let unsafe_skip_avr_verification = option_env!("OASIS_UNSAFE_SKIP_AVR_VERIFY").is_some();
-    let strict_avr_verification = option_env!("OASIS_STRICT_AVR_VERIFY").is_some();
+    let unsafe_lax_avr_verification = option_env!("OASIS_UNSAFE_LAX_AVR_VERIFY").is_some();
 
     // Get the time.
     let timestamp_now = insecure_posix_time();
@@ -257,7 +257,7 @@ pub fn verify(avr: &AVR) -> Result<AuthenticatedAVR> {
         | "CONFIGURATION_NEEDED"
         | "SW_HARDENING_NEEDED"
         | "CONFIGURATION_AND_SW_HARDENING_NEEDED" => {
-            if strict_avr_verification {
+            if !unsafe_lax_avr_verification {
                 return Err(AVRError::QuoteStatusInvalid {
                     status: quote_status.to_owned(),
                 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -65,7 +65,7 @@ lazy_static! {
             //
             // Rationale: This is how IAS signifies that the host environment
             // is insecure (eg: SMT is enabled when it should not be).
-            let maybe_secure = maybe_secure && option_env!("OASIS_STRICT_AVR_VERIFY").is_some();
+            let maybe_secure = maybe_secure && option_env!("OASIS_UNSAFE_LAX_AVR_VERIFY").is_none();
 
             // The enclave MUST NOT be a debug one.
             let maybe_secure = maybe_secure && !Report::for_self().attributes.flags.contains(AttributesFlags::DEBUG);


### PR DESCRIPTION
 *  [x] runtime: Change OASIS_STRICT_AVR_VERIFY to OASIS_UNSAFE_LAX_AVR_VERFIY
  * [x] Add acceptable enclave quote statuses to SGX constraints (#4055)

Yes I had to move the `Constraints` field definition to the node package, because it doesn't belong in our IAS support code, and there will be an import loop otherwise.