### PR TITLE
[BACKPORT/21.3.x] go/storage/client: Catch GetDiff errors early

### DIFF
--- a/.changelog/4397.bugfix.md
+++ b/.changelog/4397.bugfix.md
@@ -1,0 +1,1 @@
+go/storage/client: Catch GetDiff errors early


### PR DESCRIPTION
Backport of #4397.