### PR TITLE
go/roothash: Persist last round results in consensus state

### DIFF
--- a/.changelog/4316.breaking.md
+++ b/.changelog/4316.breaking.md
@@ -1,0 +1,6 @@
+go/roothash: Persist last round results in consensus state
+
+Previously last normal round results were only available as events at the
+height where the runtime block was emitted. This caused problems when
+consensus state sync was used as that block may not be available. Last rounds
+results are now persisted in consensus state so they remain always available.

--- a/go/consensus/tendermint/apps/roothash/api.go
+++ b/go/consensus/tendermint/apps/roothash/api.go
@@ -47,9 +47,6 @@ var (
 	// KeyFinalized is an ABCI event attribute key for finalized blocks
 	// (value is a CBOR serialized ValueFinalized).
 	KeyFinalized = []byte("finalized")
-	// KeyMessage is an ABCI event attribute key for message result events
-	// (value is a CBOR serialized ValueMessage).
-	KeyMessage = []byte("message")
 )
 
 // QueryForRuntime returns a query for filtering transactions processed by the roothash application
@@ -80,10 +77,4 @@ type ValueFinalized struct {
 type ValueExecutionDiscrepancyDetected struct {
 	ID    common.Namespace                           `json:"id"`
 	Event roothash.ExecutionDiscrepancyDetectedEvent `json:"event"`
-}
-
-// ValueMessage is the value component of a KeyMessage.
-type ValueMessage struct {
-	ID    common.Namespace      `json:"id"`
-	Event roothash.MessageEvent `json:"event"`
 }

--- a/go/consensus/tendermint/apps/roothash/genesis.go
+++ b/go/consensus/tendermint/apps/roothash/genesis.go
@@ -62,11 +62,18 @@ func (rq *rootHashQuerier) Genesis(ctx context.Context) (*roothashAPI.Genesis, e
 	// Get per-runtime states.
 	rtStates := make(map[common.Namespace]*roothashAPI.GenesisRuntimeState)
 	for _, rt := range runtimes {
+		var lastRoundResults *roothashAPI.RoundResults
+		lastRoundResults, err = rq.LastRoundResults(ctx, rt.Runtime.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch last round results for runtime '%s': %w", rt.Runtime.ID, err)
+		}
+
 		rtState := roothashAPI.GenesisRuntimeState{
 			RuntimeGenesis: registryAPI.RuntimeGenesis{
 				StateRoot: rt.CurrentBlock.Header.StateRoot,
 				Round:     rt.CurrentBlock.Header.Round,
 			},
+			MessageResults: lastRoundResults.Messages,
 		}
 
 		rtStates[rt.Runtime.ID] = &rtState

--- a/go/consensus/tendermint/apps/roothash/query.go
+++ b/go/consensus/tendermint/apps/roothash/query.go
@@ -15,6 +15,7 @@ type Query interface {
 	LatestBlock(context.Context, common.Namespace) (*block.Block, error)
 	GenesisBlock(context.Context, common.Namespace) (*block.Block, error)
 	RuntimeState(context.Context, common.Namespace) (*roothash.RuntimeState, error)
+	LastRoundResults(context.Context, common.Namespace) (*roothash.RoundResults, error)
 	Genesis(context.Context) (*roothash.Genesis, error)
 	ConsensusParameters(context.Context) (*roothash.ConsensusParameters, error)
 }
@@ -55,6 +56,10 @@ func (rq *rootHashQuerier) GenesisBlock(ctx context.Context, id common.Namespace
 
 func (rq *rootHashQuerier) RuntimeState(ctx context.Context, id common.Namespace) (*roothash.RuntimeState, error) {
 	return rq.state.RuntimeState(ctx, id)
+}
+
+func (rq *rootHashQuerier) LastRoundResults(ctx context.Context, id common.Namespace) (*roothash.RoundResults, error) {
+	return rq.state.LastRoundResults(ctx, id)
 }
 
 func (rq *rootHashQuerier) ConsensusParameters(ctx context.Context) (*roothash.ConsensusParameters, error) {

--- a/go/consensus/tendermint/apps/roothash/slashing_test.go
+++ b/go/consensus/tendermint/apps/roothash/slashing_test.go
@@ -260,13 +260,13 @@ func TestOnRuntimeIncorrectResults(t *testing.T) {
 
 	// TODO: No reward nodes.
 
-	// Multiple slash and reward nodes.
+	// Multiple slash and reward entities.
 	var toSlash, toReward []signature.PublicKey
 	for i, nod := range testNodes {
 		if i < numSlashed {
-			toSlash = append(toSlash, nod.ID)
+			toSlash = append(toSlash, nod.EntityID)
 		} else {
-			toReward = append(toReward, nod.ID)
+			toReward = append(toReward, nod.EntityID)
 		}
 	}
 	err = onRuntimeIncorrectResults(
@@ -278,7 +278,7 @@ func TestOnRuntimeIncorrectResults(t *testing.T) {
 	)
 	require.NoError(err, "should not fail")
 	runtimePercentage := quantity.NewFromUint64(uint64(runtime.Staking.RewardSlashBadResultsRuntimePercent))
-	// Ensure nodes were slash, and rewards were distributed.
+	// Ensure entities were slash, and rewards were distributed.
 	for i, nod := range testNodes {
 		acc, err := stakeState.Account(ctx, staking.NewAddress(nod.EntityID))
 		require.NoError(err, "stakeState.Account")

--- a/go/consensus/tendermint/apps/roothash/transactions.go
+++ b/go/consensus/tendermint/apps/roothash/transactions.go
@@ -145,7 +145,8 @@ func (app *rootHashApplication) executorCommit(
 		msgCtx := ctx.WithSimulation()
 		defer msgCtx.Close()
 
-		return app.processRuntimeMessages(msgCtx, rtState, msgs)
+		_, msgErr := app.processRuntimeMessages(msgCtx, rtState, msgs)
+		return msgErr
 	}
 
 	for _, commit := range cc.Commits {

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
@@ -104,6 +103,9 @@ type Backend interface {
 
 	// GetRuntimeState returns the given runtime's state.
 	GetRuntimeState(ctx context.Context, request *RuntimeRequest) (*RuntimeState, error)
+
+	// GetLastRoundResults returns the given runtime's last normal round results.
+	GetLastRoundResults(ctx context.Context, request *RuntimeRequest) (*RoundResults, error)
 
 	// WatchBlocks returns a channel that produces a stream of
 	// annotated blocks.
@@ -362,14 +364,6 @@ type ExecutionDiscrepancyDetectedEvent struct {
 type FinalizedEvent struct {
 	// Round is the round that was finalized.
 	Round uint64 `json:"round"`
-
-	// GoodComputeNodes are the public keys of compute nodes that positively contributed to the
-	// round by replicating the computation correctly.
-	GoodComputeNodes []signature.PublicKey `json:"good_compute_nodes,omitempty"`
-
-	// BadComputeNodes are the public keys of compute nodes that negatively contributed to the round
-	// by causing discrepancies.
-	BadComputeNodes []signature.PublicKey `json:"bad_compute_nodes,omitempty"`
 }
 
 // MessageEvent is a runtime message processed event.

--- a/go/roothash/api/grpc.go
+++ b/go/roothash/api/grpc.go
@@ -21,6 +21,8 @@ var (
 	methodGetLatestBlock = serviceName.NewMethod("GetLatestBlock", RuntimeRequest{})
 	// methodGetRuntimeState is the GetRuntimeState method.
 	methodGetRuntimeState = serviceName.NewMethod("GetRuntimeState", RuntimeRequest{})
+	// methodGetLastRoundResults is the GetLastRoundResults method.
+	methodGetLastRoundResults = serviceName.NewMethod("GetLastRoundResults", RuntimeRequest{})
 	// methodStateToGenesis is the StateToGenesis method.
 	methodStateToGenesis = serviceName.NewMethod("StateToGenesis", int64(0))
 	// methodConsensusParameters is the ConsensusParameters method.
@@ -49,6 +51,10 @@ var (
 			{
 				MethodName: methodGetRuntimeState.ShortName(),
 				Handler:    handlerGetRuntimeState,
+			},
+			{
+				MethodName: methodGetLastRoundResults.ShortName(),
+				Handler:    handlerGetLastRoundResults,
 			},
 			{
 				MethodName: methodStateToGenesis.ShortName(),
@@ -143,6 +149,29 @@ func handlerGetRuntimeState( // nolint: golint
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(Backend).GetRuntimeState(ctx, req.(*RuntimeRequest))
+	}
+	return interceptor(ctx, &rq, info, handler)
+}
+
+func handlerGetLastRoundResults( // nolint: golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var rq RuntimeRequest
+	if err := dec(&rq); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(Backend).GetLastRoundResults(ctx, &rq)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodGetLastRoundResults.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).GetLastRoundResults(ctx, req.(*RuntimeRequest))
 	}
 	return interceptor(ctx, &rq, info, handler)
 }
@@ -302,6 +331,14 @@ func (c *roothashClient) GetLatestBlock(ctx context.Context, request *RuntimeReq
 func (c *roothashClient) GetRuntimeState(ctx context.Context, request *RuntimeRequest) (*RuntimeState, error) {
 	var rsp RuntimeState
 	if err := c.conn.Invoke(ctx, methodGetRuntimeState.FullName(), request, &rsp); err != nil {
+		return nil, err
+	}
+	return &rsp, nil
+}
+
+func (c *roothashClient) GetLastRoundResults(ctx context.Context, request *RuntimeRequest) (*RoundResults, error) {
+	var rsp RoundResults
+	if err := c.conn.Invoke(ctx, methodGetLastRoundResults.FullName(), request, &rsp); err != nil {
 		return nil, err
 	}
 	return &rsp, nil

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -401,8 +401,6 @@ func (s *runtimeState) testSuccessfulRound(t *testing.T, backend api.Backend, co
 			// First event is Finalized.
 			fev := evts[0].Finalized
 			require.EqualValues(header.Round, fev.Round, "finalized event should have the right round")
-			require.Empty(fev.BadComputeNodes, "there should be no bad compute nodes")
-			require.Len(fev.GoodComputeNodes, len(executorNodes), "all nodes should be good (round %d)", fev.Round)
 			for i, ev := range evts[1:] {
 				switch {
 				case ev.ExecutorCommitted != nil:


### PR DESCRIPTION
Fixes #4316 
Based on #4308 

Previously last normal round results were only available as events at the height
where the runtime block was emitted. This caused problems when consensus state
sync was used as that block may not be available. Last rounds results are now
persisted in consensus state so they remain always available.