### PR TITLE
[BACKPORT/21.3.x] go/storage/api: Make metrics wrapper return proper types

### DIFF
--- a/.changelog/4411.bugfix.md
+++ b/.changelog/4411.bugfix.md
@@ -1,0 +1,8 @@
+go/storage/api: Make metrics wrapper return proper types
+
+Previously the metrics wrapper tried to support all of the different backend
+interfaces, causing problems with places that perform type checks to
+determine which backend type is in use.
+
+The metrics wrapper is now changed to return a type matching the wrapped
+backend type.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,9 +1237,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.6"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea2d928b485416e8908cff2d97d621db22b27f7b3b6729e438bcf42c671ba91"
+checksum = "469898e909a1774d844793b347135a0cd344ca2f69d082013ecb8061a2229a3a"
 dependencies = [
  "hashbrown",
 ]

--- a/go/worker/storage/init.go
+++ b/go/worker/storage/init.go
@@ -98,7 +98,7 @@ func NewLocalBackend(
 		impl = newCrashingWrapper(impl)
 	}
 
-	return api.NewMetricsWrapper(impl), nil
+	return api.NewMetricsWrapper(impl).(api.LocalBackend), nil
 }
 
 func init() {

--- a/keymanager-client/Cargo.toml
+++ b/keymanager-client/Cargo.toml
@@ -13,5 +13,5 @@ cbor = { version = "0.2.1", package = "oasis-cbor" }
 # Third party.
 futures = "0.3.17"
 io-context = "0.2.0"
-lru = "0.6.6"
+lru = "0.7.1"
 thiserror = "1.0"

--- a/keymanager-lib/Cargo.toml
+++ b/keymanager-lib/Cargo.toml
@@ -13,7 +13,7 @@ cbor = { version = "0.2.1", package = "oasis-cbor" }
 # Third party.
 anyhow = "1.0"
 lazy_static = "1.3.0"
-lru = "0.6.6"
+lru = "0.7.1"
 io-context = "0.2.0"
 rand = "0.7.3"
 sgx-isa = { version = "0.3.3", features = ["sgxstd"] }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -57,7 +57,7 @@ x509-parser = "0.11.0"
 oid-registry = "0.1.5"
 rsa = "0.5.0"
 base64-serde = "0.6.1"
-lru = "0.6.6"
+lru = "0.7.1"
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies.tokio]
 version = "1"


### PR DESCRIPTION
Backport of #4411 