### PR TITLE
go/consensus/tendermint/api: Add transaction context

### DIFF
--- a/.changelog/4426.internal.md
+++ b/.changelog/4426.internal.md
@@ -1,0 +1,4 @@
+go/consensus/tendermint/api: Add transaction context
+
+The old way of doing checkpoints is removed as the new transaction context
+supports nesting and event isolation.

--- a/go/consensus/tendermint/apps/registry/transactions.go
+++ b/go/consensus/tendermint/apps/registry/transactions.go
@@ -362,9 +362,9 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 		return err
 	}
 
-	// Create a new state checkpoint and rollback in case we fail.
-	sc := ctx.StartCheckpoint()
-	defer sc.Close()
+	// Start a new transaction and rollback in case we fail.
+	ctx = ctx.NewTransaction()
+	defer ctx.Close()
 
 	// Check that the entity has enough stake for this node registration.
 	var stakeAcc *stakingState.StakeAccumulatorCache
@@ -526,14 +526,14 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 		}
 	}
 
-	sc.Commit()
-
 	ctx.Logger().Debug("RegisterNode: registered",
 		"node", newNode,
 		"roles", newNode.Roles,
 	)
 
 	ctx.EmitEvent(api.NewEventBuilder(app.Name()).Attribute(KeyNodeRegistered, cbor.Marshal(newNode)))
+
+	ctx.Commit()
 
 	return nil
 }

--- a/go/consensus/tendermint/apps/roothash/messages.go
+++ b/go/consensus/tendermint/apps/roothash/messages.go
@@ -26,8 +26,8 @@ func (app *rootHashApplication) processRuntimeMessages(
 	case true:
 		// Gas estimation -- use parent gas accountant, discard state updates (there shouldn't be
 		// any as we are using simulation mode, but make sure).
-		cp := ctx.StartCheckpoint()
-		defer cp.Close()
+		ctx = ctx.NewTransaction()
+		defer ctx.Close()
 	}
 
 	var results []*roothash.MessageEvent

--- a/go/storage/mkvs/overlay.go
+++ b/go/storage/mkvs/overlay.go
@@ -11,7 +11,7 @@ import (
 var _ OverlayTree = (*treeOverlay)(nil)
 
 type treeOverlay struct {
-	inner   Tree
+	inner   KeyValueTree
 	overlay Tree
 
 	dirty map[string]bool
@@ -24,10 +24,10 @@ type treeOverlay struct {
 // as the inner tree has its own cache and double caching makes less sense.
 //
 // The overlay is not safe for concurrent use.
-func NewOverlay(inner Tree) OverlayTree {
+func NewOverlay(inner KeyValueTree) OverlayTree {
 	return &treeOverlay{
 		inner:   inner,
-		overlay: New(nil, nil, inner.RootType(), WithoutWriteLog()),
+		overlay: New(nil, nil, node.RootTypeState, WithoutWriteLog()),
 		dirty:   make(map[string]bool),
 	}
 }


### PR DESCRIPTION
The old way of doing checkpoints is removed as the new transaction
context supports nesting and event isolation.