### PR TITLE
go/governance: Replace quorum/threshold with stakeThreshold

### DIFF
--- a/.changelog/4309.breaking.md
+++ b/.changelog/4309.breaking.md
@@ -1,0 +1,8 @@
+go/governance: Replace quorum/threshold with stakeThreshold
+
+This replaces the old quorum + threshold based governance proposal
+verification with a single unified threshold that the precentage of
+yes votes in terms of total voting power (greater than or equal to).
+
+The fixgenesis conversion logic will convert the existing parameters
+to a stake threshold of 68%.

--- a/go/consensus/tendermint/apps/governance/genesis_test.go
+++ b/go/consensus/tendermint/apps/governance/genesis_test.go
@@ -302,8 +302,7 @@ func TestGenesis(t *testing.T) {
 	consensusParams := &governance.ConsensusParameters{
 		GasCosts:                  governance.DefaultGasCosts,
 		MinProposalDeposit:        *quantity.NewFromUint64(42),
-		Quorum:                    90,
-		Threshold:                 90,
+		StakeThreshold:            90,
 		UpgradeCancelMinEpochDiff: beacon.EpochTime(100),
 		UpgradeMinEpochDiff:       beacon.EpochTime(100),
 		VotingPeriod:              beacon.EpochTime(50),

--- a/go/consensus/tendermint/apps/governance/governance.go
+++ b/go/consensus/tendermint/apps/governance/governance.go
@@ -362,10 +362,9 @@ func (app *governanceApplication) closeProposal(
 		"total_voting_state", totalVotingStake,
 		"results", proposal.Results,
 		"invalid_votes", proposal.InvalidVotes,
-		"quorum", params.Quorum,
-		"threshold", params.Threshold,
+		"stake_threshold", params.StakeThreshold,
 	)
-	if err := proposal.CloseProposal(totalVotingStake, params.Quorum, params.Threshold); err != nil {
+	if err := proposal.CloseProposal(totalVotingStake, params.StakeThreshold); err != nil {
 		return err
 	}
 

--- a/go/consensus/tendermint/apps/governance/governance_test.go
+++ b/go/consensus/tendermint/apps/governance/governance_test.go
@@ -182,8 +182,7 @@ func TestCloseProposal(t *testing.T) {
 	baseConsParams := &governance.ConsensusParameters{
 		GasCosts:                  governance.DefaultGasCosts,
 		MinProposalDeposit:        *minProposalDeposit,
-		Quorum:                    90,
-		Threshold:                 90,
+		StakeThreshold:            90,
 		UpgradeCancelMinEpochDiff: beacon.EpochTime(100),
 		UpgradeMinEpochDiff:       beacon.EpochTime(100),
 		VotingPeriod:              beacon.EpochTime(50),
@@ -350,8 +349,7 @@ func TestExecuteProposal(t *testing.T) {
 	// Consensus parameters.
 	err = state.SetConsensusParameters(ctx, &governance.ConsensusParameters{
 		MinProposalDeposit:        *quantity.NewFromUint64(100),
-		Quorum:                    90,
-		Threshold:                 90,
+		StakeThreshold:            90,
 		UpgradeMinEpochDiff:       10,
 		UpgradeCancelMinEpochDiff: 10,
 	})
@@ -703,8 +701,7 @@ func TestEndBlock(t *testing.T) {
 
 	err = state.SetConsensusParameters(ctx, &governance.ConsensusParameters{
 		MinProposalDeposit:        *quantity.NewFromUint64(100),
-		Quorum:                    90,
-		Threshold:                 90,
+		StakeThreshold:            90,
 		UpgradeMinEpochDiff:       10,
 		UpgradeCancelMinEpochDiff: 10,
 	})

--- a/go/consensus/tendermint/apps/governance/transactions_test.go
+++ b/go/consensus/tendermint/apps/governance/transactions_test.go
@@ -54,8 +54,7 @@ func TestSubmitProposal(t *testing.T) {
 	baseConsParams := &governance.ConsensusParameters{
 		GasCosts:                  governance.DefaultGasCosts,
 		MinProposalDeposit:        *minProposalDeposit,
-		Quorum:                    90,
-		Threshold:                 90,
+		StakeThreshold:            90,
 		UpgradeCancelMinEpochDiff: beacon.EpochTime(100),
 		UpgradeMinEpochDiff:       beacon.EpochTime(100),
 		VotingPeriod:              beacon.EpochTime(50),
@@ -282,8 +281,7 @@ func TestCastVote(t *testing.T) {
 	params := &governance.ConsensusParameters{
 		GasCosts:                  governance.DefaultGasCosts,
 		MinProposalDeposit:        *quantity.NewFromUint64(100),
-		Quorum:                    90,
-		Threshold:                 90,
+		StakeThreshold:            90,
 		UpgradeCancelMinEpochDiff: beacon.EpochTime(100),
 		UpgradeMinEpochDiff:       beacon.EpochTime(100),
 		VotingPeriod:              beacon.EpochTime(50),

--- a/go/consensus/tendermint/tests/genesis/genesis.go
+++ b/go/consensus/tendermint/tests/genesis/genesis.go
@@ -86,8 +86,7 @@ func NewTestNodeGenesisProvider(identity *identity.Identity, ent *entity.Entity,
 		},
 		Governance: governance.Genesis{
 			Parameters: governance.ConsensusParameters{
-				Quorum:                    90,
-				Threshold:                 90,
+				StakeThreshold:            90,
 				UpgradeCancelMinEpochDiff: 20,
 				UpgradeMinEpochDiff:       20,
 				VotingPeriod:              10,

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -66,8 +66,7 @@ func testDoc() genesis.Document {
 		},
 		Governance: governance.Genesis{
 			Parameters: governance.ConsensusParameters{
-				Quorum:                    90,
-				Threshold:                 90,
+				StakeThreshold:            90,
 				VotingPeriod:              100,
 				UpgradeCancelMinEpochDiff: 200,
 				UpgradeMinEpochDiff:       200,
@@ -138,7 +137,7 @@ func TestGenesisChainContext(t *testing.T) {
 
 	// Having to update this every single time the genesis structure
 	// changes isn't annoying at all.
-	require.Equal(t, "7b6c3cd2cfb52d3bfa7a68ca0dfeb3cf43d4c5b4b3fcc0026436c110db125eba", stableDoc.ChainContext())
+	require.Equal(t, "0847c60a14845166c38d1b46ed275708c5ef07aba45aa0ecace4715505ad146f", stableDoc.ChainContext())
 }
 
 func TestGenesisSanityCheck(t *testing.T) {
@@ -734,25 +733,12 @@ func TestGenesisSanityCheck(t *testing.T) {
 
 	// Test governance sanity checks.
 	d = testDoc()
-	d.Governance.Parameters.Quorum = 1
-	require.Error(d.SanityCheck(), "quorum to low should be rejected")
+	d.Governance.Parameters.StakeThreshold = 1
+	require.Error(d.SanityCheck(), "stake threshold too low should be rejected")
 
 	d = testDoc()
-	d.Governance.Parameters.Threshold = 1
-	require.Error(d.SanityCheck(), "threshold to low should be rejected")
-
-	d = testDoc()
-	d.Governance.Parameters.Quorum = 110
-	require.Error(d.SanityCheck(), "quorum to high should be rejected")
-
-	d = testDoc()
-	d.Governance.Parameters.Threshold = 110
-	require.Error(d.SanityCheck(), "threshold to high should be rejected")
-
-	d = testDoc()
-	d.Governance.Parameters.Quorum = 80
-	d.Governance.Parameters.Threshold = 80
-	require.Error(d.SanityCheck(), "quorum*threshold to low should be rejected")
+	d.Governance.Parameters.StakeThreshold = 110
+	require.Error(d.SanityCheck(), "threshold too high should be rejected")
 
 	d = testDoc()
 	d.Governance.Parameters.UpgradeCancelMinEpochDiff = 50

--- a/go/governance/api/api.go
+++ b/go/governance/api/api.go
@@ -243,13 +243,10 @@ type ConsensusParameters struct {
 	// is closed and the votes are tallied.
 	VotingPeriod beacon.EpochTime `json:"voting_period,omitempty"`
 
-	// Quorum is he minimum percentage of voting power that needs to be cast on
-	// a proposal for the result to be valid.
-	Quorum uint8 `json:"quorum,omitempty"`
-
-	// Threshold is the minimum percentage of VoteYes votes in order for a
-	// proposal to be accepted.
-	Threshold uint8 `json:"threshold,omitempty"`
+	// StakeThreshold is the minimum percentage of VoteYes votes in terms
+	// of total voting power when the proposal expires in order for a
+	// proposal to be accepted.  This value has a lower bound of 67.
+	StakeThreshold uint8 `json:"stake_threshold,omitempty"`
 
 	// UpgradeMinEpochDiff is the minimum number of epochs between the current
 	// epoch and the proposed upgrade epoch for the upgrade proposal to be valid.

--- a/go/governance/api/sanity_check.go
+++ b/go/governance/api/sanity_check.go
@@ -14,17 +14,13 @@ func (p *ConsensusParameters) SanityCheck() error {
 	if !p.MinProposalDeposit.IsValid() {
 		return fmt.Errorf("min_proposal_deposit has invalid value")
 	}
-	// Quorum must be less or equal to 100.
-	if int64(p.Quorum) > 100 {
-		return fmt.Errorf("quorum should be less or equal to 100")
+	// StakeThreshold must be less than or equal to 100.
+	if int64(p.StakeThreshold) > 100 {
+		return fmt.Errorf("stake threshold must be less than or equal to 100")
 	}
-	// Threshold must be less or equal to 100.
-	if int64(p.Threshold) > 100 {
-		return fmt.Errorf("threshold should be less or equal to 100")
-	}
-	// Quorum * threshold should be > 2/3
-	if (uint64(p.Quorum) * uint64(p.Threshold)) <= 6666 {
-		return fmt.Errorf("product of quorum and threshold should be at least 2/3")
+	// StakeThreshold must be greater than 66.
+	if int64(p.StakeThreshold) <= 66 {
+		return fmt.Errorf("stake threshold must be greater than 66")
 	}
 	// Voting_period must be less than upgrade_min_epoch_diff.
 	if p.VotingPeriod >= p.UpgradeMinEpochDiff {

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -74,8 +74,7 @@ const (
 
 	// Governance config flags.
 	CfgGovernanceMinProposalDeposit        = "governance.min_proposal_deposit"
-	CfgGovernanceQuorum                    = "governance.quorum"
-	CfgGovernanceThreshold                 = "governance.threshold"
+	CfgGovernanceStakeThreshold            = "governance.stake_threshold"
 	CfgGovernanceUpgradeCancelMinEpochDiff = "governance.upgrade_cancel_min_epoch_diff"
 	CfgGovernanceUpgradeMinEpochDiff       = "governance.upgrade_min_epoch_diff"
 	CfgGovernanceVotingPeriod              = "governance.voting_period"
@@ -296,8 +295,7 @@ func doInitGenesis(cmd *cobra.Command, args []string) {
 		Parameters: governance.ConsensusParameters{
 			GasCosts:                  governance.DefaultGasCosts, // TODO: configurable.
 			MinProposalDeposit:        *quantity.NewFromUint64(viper.GetUint64(CfgGovernanceMinProposalDeposit)),
-			Quorum:                    uint8(viper.GetInt(CfgGovernanceQuorum)),
-			Threshold:                 uint8(viper.GetInt(CfgGovernanceThreshold)),
+			StakeThreshold:            uint8(viper.GetInt(CfgGovernanceStakeThreshold)),
 			UpgradeCancelMinEpochDiff: beacon.EpochTime(viper.GetUint64(CfgGovernanceUpgradeCancelMinEpochDiff)),
 			UpgradeMinEpochDiff:       beacon.EpochTime(viper.GetUint64(CfgGovernanceUpgradeMinEpochDiff)),
 			VotingPeriod:              beacon.EpochTime(viper.GetUint64(CfgGovernanceVotingPeriod)),
@@ -832,8 +830,7 @@ func init() {
 
 	// Governance config flags.
 	initGenesisFlags.Uint64(CfgGovernanceMinProposalDeposit, 100, "proposal deposit for governance proposals")
-	initGenesisFlags.Uint8(CfgGovernanceQuorum, 90, "required quorum for governance proposals to be accepted")
-	initGenesisFlags.Uint8(CfgGovernanceThreshold, 90, "required threshold for governance proposals to be accepted")
+	initGenesisFlags.Uint8(CfgGovernanceStakeThreshold, 90, "required stake threshold for governance proposals to be accepted")
 	initGenesisFlags.Uint64(CfgGovernanceUpgradeCancelMinEpochDiff, 300, "minimum number of epochs in advance for canceling proposals")
 	initGenesisFlags.Uint64(CfgGovernanceUpgradeMinEpochDiff, 300, "minimum number of epochs the upgrade needs to be scheduled in advance")
 	initGenesisFlags.Uint64(CfgGovernanceVotingPeriod, 100, "voting period (in epochs)")

--- a/go/oasis-test-runner/oasis/network.go
+++ b/go/oasis-test-runner/oasis/network.go
@@ -735,8 +735,7 @@ func (net *Network) MakeGenesis() error {
 	if cfg := net.cfg.GovernanceParameters; cfg != nil {
 		args = append(args, []string{
 			"--" + genesis.CfgGovernanceMinProposalDeposit, strconv.FormatUint(cfg.MinProposalDeposit.ToBigInt().Uint64(), 10),
-			"--" + genesis.CfgGovernanceQuorum, strconv.FormatUint(uint64(cfg.Quorum), 10),
-			"--" + genesis.CfgGovernanceThreshold, strconv.FormatUint(uint64(cfg.Threshold), 10),
+			"--" + genesis.CfgGovernanceStakeThreshold, strconv.FormatUint(uint64(cfg.StakeThreshold), 10),
 			"--" + genesis.CfgGovernanceUpgradeCancelMinEpochDiff, strconv.FormatUint(uint64(cfg.UpgradeCancelMinEpochDiff), 10),
 			"--" + genesis.CfgGovernanceUpgradeMinEpochDiff, strconv.FormatUint(uint64(cfg.UpgradeMinEpochDiff), 10),
 			"--" + genesis.CfgGovernanceVotingPeriod, strconv.FormatUint(uint64(cfg.VotingPeriod), 10),

--- a/go/oasis-test-runner/scenario/e2e/runtime/dump_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/dump_restore.go
@@ -80,8 +80,7 @@ func (sc *dumpRestoreImpl) Fixture() (*oasis.NetworkFixture, error) {
 	f.Network.GovernanceParameters = &governance.ConsensusParameters{
 		MinProposalDeposit:        *quantity.NewFromUint64(100),
 		VotingPeriod:              20,
-		Quorum:                    100,
-		Threshold:                 100,
+		StakeThreshold:            100,
 		UpgradeMinEpochDiff:       50,
 		UpgradeCancelMinEpochDiff: 40,
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/governance_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/governance_upgrade.go
@@ -98,8 +98,7 @@ func (sc *governanceConsensusUpgradeImpl) Fixture() (*oasis.NetworkFixture, erro
 	f.Network.GovernanceParameters = &api.ConsensusParameters{
 		MinProposalDeposit:        *quantity.NewFromUint64(100),
 		VotingPeriod:              5,
-		Quorum:                    100,
-		Threshold:                 100,
+		StakeThreshold:            100,
 		UpgradeMinEpochDiff:       20,
 		UpgradeCancelMinEpochDiff: 8,
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
@@ -229,8 +229,7 @@ func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
 	f.Network.GovernanceParameters = &governance.ConsensusParameters{
 		VotingPeriod:              10,
 		MinProposalDeposit:        *quantity.NewFromUint64(300),
-		Quorum:                    75,
-		Threshold:                 90,
+		StakeThreshold:            68,
 		UpgradeMinEpochDiff:       40,
 		UpgradeCancelMinEpochDiff: 20,
 	}


### PR DESCRIPTION
This replaces the old quorum + threshold based governance proposal
verification with a single unified threshold that the precentage of
yes votes in terms of total voting power (greater than or equal to).

The fixgenesis conversion logic will convert the existing parameters
to a stake threshold of 68%.

Fixes #4309.