### PR TITLE
go/runtime/transaction: Return transactions in batch order when queried

### DIFF
--- a/.changelog/4429.bugfix.md
+++ b/.changelog/4429.bugfix.md
@@ -1,0 +1,4 @@
+go/runtime/transaction: Return transactions in batch order when queried
+
+Previously when runtime transactions were queried via a GetTransactions call,
+they were returned ordered by transaction hash instead of in execution order.

--- a/go/runtime/transaction/transaction_test.go
+++ b/go/runtime/transaction/transaction_test.go
@@ -72,9 +72,14 @@ func TestTransaction(t *testing.T) {
 
 	var txHashes []hash.Hash
 	txnsByHash := make(map[hash.Hash]*Transaction)
-	for _, tx := range txns {
+	for i, tx := range txns {
 		txnsByHash[tx.Hash()] = tx
 		txHashes = append(txHashes, tx.Hash())
+
+		// Make sure the transactions are returned in batch order.
+		if i > 0 {
+			require.EqualValues(t, testTxns[i-1], *tx, "transactions must be returned in batch order")
+		}
 	}
 
 	for _, checkTx := range testTxns {


### PR DESCRIPTION
Previously when runtime transactions were queried via a GetTransactions call,
they were returned ordered by transaction hash instead of in execution order.