### PR TITLE
Add support for runtime schedule control

### DIFF
--- a/.changelog/4438.feature.md
+++ b/.changelog/4438.feature.md
@@ -1,0 +1,4 @@
+Add support for runtime schedule control
+
+This feature gives runtimes control over scheduling transactions inside a
+block, so the runtimes may implement their own more advanced policies.

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_restart.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_restart.go
@@ -24,6 +24,18 @@ func newKmRestartImpl() scenario.Scenario {
 	}
 }
 
+func (sc *kmRestartImpl) Fixture() (*oasis.NetworkFixture, error) {
+	f, err := sc.runtimeImpl.Fixture()
+	if err != nil {
+		return nil, err
+	}
+
+	// The round is allowed to fail until the keymanager becomes available after restart.
+	f.Network.DefaultLogWatcherHandlerFactories = nil
+
+	return f, nil
+}
+
 func (sc *kmRestartImpl) Clone() scenario.Scenario {
 	return &kmRestartImpl{
 		runtimeImpl: *sc.runtimeImpl.Clone().(*runtimeImpl),

--- a/go/runtime/host/host.go
+++ b/go/runtime/host/host.go
@@ -45,6 +45,9 @@ type Runtime interface {
 	// ID is the runtime identifier.
 	ID() common.Namespace
 
+	// GetInfo retrieves the runtime information.
+	GetInfo(ctx context.Context) (*protocol.RuntimeInfoResponse, error)
+
 	// Call sends a request message to the runtime over the Runtime Host Protocol and waits for the
 	// response (which may be a failure).
 	Call(ctx context.Context, body *protocol.Body) (*protocol.Body, error)

--- a/go/runtime/host/mock/mock.go
+++ b/go/runtime/host/mock/mock.go
@@ -11,6 +11,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
@@ -41,6 +42,14 @@ type runtime struct {
 // Implements host.Runtime.
 func (r *runtime) ID() common.Namespace {
 	return r.runtimeID
+}
+
+// Implements host.Runtime.
+func (r *runtime) GetInfo(ctx context.Context) (rsp *protocol.RuntimeInfoResponse, err error) {
+	return &protocol.RuntimeInfoResponse{
+		ProtocolVersion: version.RuntimeHostProtocol,
+		RuntimeVersion:  version.MustFromString("0.0.0"),
+	}, nil
 }
 
 // Implements host.Runtime.

--- a/go/runtime/host/mock/mock.go
+++ b/go/runtime/host/mock/mock.go
@@ -49,6 +49,7 @@ func (r *runtime) GetInfo(ctx context.Context) (rsp *protocol.RuntimeInfoRespons
 	return &protocol.RuntimeInfoResponse{
 		ProtocolVersion: version.RuntimeHostProtocol,
 		RuntimeVersion:  version.MustFromString("0.0.0"),
+		Features:        nil,
 	}, nil
 }
 

--- a/go/runtime/host/protocol/connection.go
+++ b/go/runtime/host/protocol/connection.go
@@ -262,13 +262,12 @@ func (c *connection) Close() {
 // Implements Connection.
 func (c *connection) GetInfo(ctx context.Context) (*RuntimeInfoResponse, error) {
 	c.Lock()
-	info := c.info
-	c.Unlock()
+	defer c.Unlock()
 
-	if info == nil {
+	if c.info == nil {
 		return nil, ErrNotReady
 	}
-	return info, nil
+	return c.info, nil
 }
 
 // Implements Connection.

--- a/go/runtime/host/protocol/connection_test.go
+++ b/go/runtime/host/protocol/connection_test.go
@@ -94,6 +94,12 @@ func TestEchoRequestResponse(t *testing.T) {
 	require.Panics(func() { _ = protoA.InitGuest(context.Background(), connA) }, "connection reinit should panic")
 	require.Panics(func() { _, _ = protoB.InitHost(context.Background(), connB, &HostInfo{}) }, "connection reinit should panic")
 	require.Panics(func() { _ = protoB.InitGuest(context.Background(), connB) }, "connection reinit should panic")
+
+	_, err = protoA.GetInfo(context.Background())
+	require.Error(err, "GetInfo should fail for guest connections")
+	info, err := protoB.GetInfo(context.Background())
+	require.NoError(err, "GetInfo should succeed for host connections")
+	require.EqualValues(version.RuntimeHostProtocol, info.ProtocolVersion)
 }
 
 func TestBigMessage(t *testing.T) {

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -103,6 +103,8 @@ type Body struct {
 	HostLocalStorageSetResponse     *Empty                           `json:",omitempty"`
 	HostFetchConsensusBlockRequest  *HostFetchConsensusBlockRequest  `json:",omitempty"`
 	HostFetchConsensusBlockResponse *HostFetchConsensusBlockResponse `json:",omitempty"`
+	HostFetchTxBatchRequest         *HostFetchTxBatchRequest         `json:",omitempty"`
+	HostFetchTxBatchResponse        *HostFetchTxBatchResponse        `json:",omitempty"`
 }
 
 // Type returns the message type by determining the name of the first non-nil member.
@@ -151,13 +153,35 @@ type RuntimeInfoRequest struct {
 	LocalConfig map[string]interface{} `json:"local_config,omitempty"`
 }
 
-// RuntimeInfoResponse is a worker info response message body.
+// Features is a set of supported runtime features.
+type Features struct {
+	// ScheduleControl is the schedule control feature.
+	ScheduleControl *FeatureScheduleControl `json:"schedule_control,omitempty"`
+}
+
+// HasScheduleControl returns true when the runtime supports the schedule control feature.
+func (f *Features) HasScheduleControl() bool {
+	return f != nil && f.ScheduleControl != nil
+}
+
+// FeatureScheduleControl is a feature specifying that the runtime supports controlling the
+// scheduling of batches. This means that the scheduler should only take priority into account and
+// ignore weights, leaving it up to the runtime to decide which transactions to include.
+type FeatureScheduleControl struct {
+	// InitialBatchSize is the size of the initial batch of transactions.
+	InitialBatchSize uint32 `json:"initial_batch_size"`
+}
+
+// RuntimeInfoResponse is a runtime info response message body.
 type RuntimeInfoResponse struct {
-	// ProtocolVersion is the runtime protocol version supported by the worker.
+	// ProtocolVersion is the runtime protocol version supported by the runtime.
 	ProtocolVersion version.Version `json:"protocol_version"`
 
 	// RuntimeVersion is the version of the runtime.
 	RuntimeVersion version.Version `json:"runtime_version"`
+
+	// Features describe the features supported by the runtime.
+	Features *Features `json:"features,omitempty"`
 }
 
 // RuntimeCapabilityTEERakInitRequest is a worker RFC 0009 CapabilityTEE
@@ -281,8 +305,27 @@ func (b *ComputedBatch) String() string {
 	return "<ComputedBatch>"
 }
 
+// ExecutionMode is the batch execution mode.
+type ExecutionMode uint8
+
+const (
+	// ExecutionModeExecute is the execution mode where the batch of transactions is executed as-is
+	// without the ability to perform any modifications to the batch.
+	ExecutionModeExecute = 0
+	// ExecutionModeSchedule is the execution mode where the runtime is in control of scheduling and
+	// may arbitrarily modify the batch during execution.
+	//
+	// This execution mode will only be used in case the runtime advertises to support the schedule
+	// control feature. In this case the call will only contain up to InitialBatchSize transactions
+	// and the runtime will need to request more if it needs more.
+	ExecutionModeSchedule = 1
+)
+
 // RuntimeExecuteTxBatchRequest is a worker execute tx batch request message body.
 type RuntimeExecuteTxBatchRequest struct {
+	// Mode is the execution mode.
+	Mode ExecutionMode `json:"mode,omitempty"`
+
 	// ConsensusBlock is the consensus light block at the last finalized round
 	// height (e.g., corresponding to .Block.Header.Round).
 	ConsensusBlock consensus.LightBlock `json:"consensus_block"`
@@ -311,6 +354,16 @@ type RuntimeExecuteTxBatchRequest struct {
 type RuntimeExecuteTxBatchResponse struct {
 	Batch             ComputedBatch                 `json:"batch"`
 	BatchWeightLimits map[transaction.Weight]uint64 `json:"batch_weight_limits"`
+
+	// TxHashes are the transaction hashes of the included batch.
+	TxHashes []hash.Hash `json:"tx_hashes,omitempty"`
+	// TxRejectHashes are the transaction hashes of transactions that should be immediately removed
+	// from the scheduling queue as they are invalid.
+	TxRejectHashes []hash.Hash `json:"tx_reject_hashes,omitempty"`
+	// TxInputRoot is the root hash of all transaction inputs.
+	TxInputRoot hash.Hash `json:"tx_input_root,omitempty"`
+	// TxInputWriteLog is the write log for generating transaction inputs.
+	TxInputWriteLog storage.WriteLog `json:"tx_input_write_log,omitempty"`
 }
 
 // RuntimeKeyManagerPolicyUpdateRequest is a runtime key manager policy request
@@ -408,4 +461,20 @@ type HostFetchConsensusBlockRequest struct {
 // HostFetchConsensusBlockResponse is a response from host fetching the given consensus light block.
 type HostFetchConsensusBlockResponse struct {
 	Block consensus.LightBlock `json:"block"`
+}
+
+// HostFetchTxBatchRequest is a request to host to fetch a further batch of transactions.
+type HostFetchTxBatchRequest struct {
+	// Offset specifies the transaction hash that should serve as an offset when returning
+	// transactions from the pool. Transactions will be skipped until the given hash is encountered
+	// and only following transactions will be returned.
+	Offset *hash.Hash `json:"offset,omitempty"`
+	// Limit specifies the maximum size of the batch to request.
+	Limit uint32 `json:"limit"`
+}
+
+// HostFetchTxBatchResponse is a response from host fetching the given transaction batch.
+type HostFetchTxBatchResponse struct {
+	// Batch is a batch of transactions.
+	Batch [][]byte `json:"batch,omitempty"`
 }

--- a/go/runtime/host/sandbox/sandbox.go
+++ b/go/runtime/host/sandbox/sandbox.go
@@ -110,10 +110,9 @@ func (r *sandboxedRuntime) ID() common.Namespace {
 func (r *sandboxedRuntime) GetInfo(ctx context.Context) (rsp *protocol.RuntimeInfoResponse, err error) {
 	callFn := func() error {
 		r.RLock()
-		conn := r.conn
-		r.RUnlock()
+		defer r.RUnlock()
 
-		if conn == nil {
+		if r.conn == nil {
 			return fmt.Errorf("runtime is not ready")
 		}
 		rsp, err = r.conn.GetInfo(ctx)
@@ -129,10 +128,9 @@ func (r *sandboxedRuntime) GetInfo(ctx context.Context) (rsp *protocol.RuntimeIn
 func (r *sandboxedRuntime) Call(ctx context.Context, body *protocol.Body) (rsp *protocol.Body, err error) {
 	callFn := func() error {
 		r.RLock()
-		conn := r.conn
-		r.RUnlock()
+		defer r.RUnlock()
 
-		if conn == nil {
+		if r.conn == nil {
 			return fmt.Errorf("runtime is not ready")
 		}
 		rsp, err = r.conn.Call(ctx, body)

--- a/go/runtime/scheduling/api/api.go
+++ b/go/runtime/scheduling/api/api.go
@@ -20,6 +20,14 @@ type Scheduler interface {
 	// GetBatch returns a batch of scheduled transactions (if any is available).
 	GetBatch(force bool) []*transaction.CheckedTransaction
 
+	// GetPrioritizedBatch returns a batch of transactions ordered by priority but without taking
+	// any weight limits into account.
+	//
+	// Offset specifies the transaction hash that should serve as an offset when returning
+	// transactions from the pool. Transactions will be skipped until the given hash is encountered
+	// and only following transactions will be returned.
+	GetPrioritizedBatch(offset *hash.Hash, limit uint32) []*transaction.CheckedTransaction
+
 	// GetKnownBatch gets a set of known transactions from the transaction pool.
 	//
 	// For any missing transactions nil will be returned in their place and the map of missing

--- a/go/runtime/scheduling/simple/simple.go
+++ b/go/runtime/scheduling/simple/simple.go
@@ -49,6 +49,10 @@ func (s *scheduler) GetBatch(force bool) []*transaction.CheckedTransaction {
 	return s.txPool.GetBatch(force)
 }
 
+func (s *scheduler) GetPrioritizedBatch(offset *hash.Hash, limit uint32) []*transaction.CheckedTransaction {
+	return s.txPool.GetPrioritizedBatch(offset, limit)
+}
+
 func (s *scheduler) GetKnownBatch(batch []hash.Hash) ([]*transaction.CheckedTransaction, map[hash.Hash]int) {
 	return s.txPool.GetKnownBatch(batch)
 }

--- a/go/runtime/scheduling/simple/txpool/api/api.go
+++ b/go/runtime/scheduling/simple/txpool/api/api.go
@@ -33,6 +33,14 @@ type TxPool interface {
 	// GetBatch gets a transaction batch from the transaction pool.
 	GetBatch(force bool) []*transaction.CheckedTransaction
 
+	// GetPrioritizedBatch returns a batch of transactions ordered by priority but without taking
+	// any weight limits into account.
+	//
+	// Offset specifies the transaction hash that should serve as an offset when returning
+	// transactions from the pool. Transactions will be skipped until the given hash is encountered
+	// and only following transactions will be returned.
+	GetPrioritizedBatch(offset *hash.Hash, limit uint32) []*transaction.CheckedTransaction
+
 	// GetKnownBatch gets a set of known transactions from the transaction pool.
 	//
 	// For any missing transactions nil will be returned in their place and the map of missing

--- a/go/runtime/scheduling/simple/txpool/priorityqueue/priority_queue.go
+++ b/go/runtime/scheduling/simple/txpool/priorityqueue/priority_queue.go
@@ -197,6 +197,57 @@ func (q *priorityQueue) removeTxsLocked(items []*item) {
 }
 
 // Implements api.TxPool.
+func (q *priorityQueue) GetPrioritizedBatch(offset *hash.Hash, limit uint32) []*transaction.CheckedTransaction {
+	q.Lock()
+	defer q.Unlock()
+
+	var (
+		batch      []*transaction.CheckedTransaction
+		toRemove   []*item
+		offsetItem btree.Item
+	)
+	if offset != nil {
+		var exists bool
+		offsetItem, exists = q.transactions[*offset]
+		if !exists {
+			// Offset does not exist so no items will be matched anyway.
+			return nil
+		}
+	}
+	q.priorityIndex.DescendLessOrEqual(offsetItem, func(i btree.Item) bool {
+		item := i.(*item)
+
+		for w, l := range q.weightLimits {
+			txW := item.tx.Weight(w)
+			// Transaction weight greater than the limit. Drop the tx from the pool.
+			if txW > l {
+				toRemove = append(toRemove, item)
+				return true
+			}
+		}
+
+		// Skip the offset item itself (if specified).
+		if txHash := item.tx.Hash(); txHash.Equal(offset) {
+			return true
+		}
+
+		// Add the tx to the batch.
+		batch = append(batch, item.tx)
+		if uint32(len(batch)) >= limit { //nolint: gosimple
+			return false
+		}
+		return true
+	})
+
+	// Remove transactions discovered to be too big to even fit the batch.
+	// This can happen if weight limits changed after the transaction was
+	// already set to be scheduled.
+	q.removeTxsLocked(toRemove)
+
+	return batch
+}
+
+// Implements api.TxPool.
 func (q *priorityQueue) GetKnownBatch(batch []hash.Hash) ([]*transaction.CheckedTransaction, map[hash.Hash]int) {
 	q.Lock()
 	defer q.Unlock()

--- a/go/runtime/scheduling/simple/txpool/priorityqueue/priority_queue.go
+++ b/go/runtime/scheduling/simple/txpool/priorityqueue/priority_queue.go
@@ -172,6 +172,11 @@ func (q *priorityQueue) GetBatch(force bool) []*transaction.CheckedTransaction {
 
 func (q *priorityQueue) removeTxsLocked(items []*item) {
 	for _, item := range items {
+		// Skip already removed items to avoid corrupting the list in case of duplicates.
+		if _, exists := q.transactions[item.tx.Hash()]; !exists {
+			continue
+		}
+
 		delete(q.transactions, item.tx.Hash())
 		q.priorityIndex.Delete(item)
 		for k, v := range item.tx.Weights() {

--- a/go/runtime/scheduling/simple/txpool/tester.go
+++ b/go/runtime/scheduling/simple/txpool/tester.go
@@ -87,9 +87,10 @@ func testBasic(t *testing.T, pool api.TxPool) {
 	require.EqualValues(t, 10, len(batch), "Batch size")
 	require.EqualValues(t, 51, pool.Size(), "Size")
 
-	hashes := make([]hash.Hash, len(batch))
-	for i, tx := range batch {
-		hashes[i] = tx.Hash()
+	hashes := make([]hash.Hash, 0, len(batch))
+	for _, tx := range batch {
+		hashes = append(hashes, tx.Hash())
+		hashes = append(hashes, tx.Hash()) // Duplicate to ensure this is handled correctly.
 	}
 	pool.RemoveBatch(hashes)
 	require.EqualValues(t, 41, pool.Size(), "Size")

--- a/go/runtime/scheduling/simple/txpool/tester.go
+++ b/go/runtime/scheduling/simple/txpool/tester.go
@@ -115,6 +115,10 @@ func testGetBatch(t *testing.T, pool api.TxPool) {
 	require.EqualValues(t, 1, len(batch), "Batch size")
 	require.EqualValues(t, 1, pool.Size(), "Size")
 
+	batch = pool.GetPrioritizedBatch(nil, 10)
+	require.EqualValues(t, 1, len(batch), "Batch size")
+	require.EqualValues(t, 1, pool.Size(), "Size")
+
 	hashes := make([]hash.Hash, len(batch))
 	for i, tx := range batch {
 		hashes[i] = tx.Hash()
@@ -343,6 +347,35 @@ func testPriority(t *testing.T, pool api.TxPool) {
 		batch,
 		"elements should be returned by priority",
 	)
+
+	batch = pool.GetPrioritizedBatch(nil, 2)
+	require.Len(t, batch, 2, "two transactions should be returned")
+	require.EqualValues(
+		t,
+		[]*transaction.CheckedTransaction{
+			txs[2], // 20
+			txs[0], // 10
+		},
+		batch,
+		"elements should be returned by priority",
+	)
+
+	offsetTx := txs[2].Hash()
+	batch = pool.GetPrioritizedBatch(&offsetTx, 2)
+	require.Len(t, batch, 2, "two transactions should be returned")
+	require.EqualValues(
+		t,
+		[]*transaction.CheckedTransaction{
+			txs[0], // 10
+			txs[1], // 5
+		},
+		batch,
+		"elements should be returned by priority",
+	)
+
+	offsetTx.Empty()
+	batch = pool.GetPrioritizedBatch(&offsetTx, 2)
+	require.Len(t, batch, 0, "no transactions should be returned on invalid hash")
 
 	// When the pool is full, a higher priority transaction should still get queued.
 	highTx := transaction.NewCheckedTransaction(

--- a/go/runtime/txpool/txpool.go
+++ b/go/runtime/txpool/txpool.go
@@ -75,6 +75,14 @@ type TransactionPool interface {
 	// GetScheduledBatch returns a batch of transactions ready for scheduling.
 	GetScheduledBatch(force bool) []*transaction.CheckedTransaction
 
+	// GetPrioritizedBatch returns a batch of transactions ordered by priority but without taking
+	// any weight limits into account.
+	//
+	// Offset specifies the transaction hash that should serve as an offset when returning
+	// transactions from the pool. Transactions will be skipped until the given hash is encountered
+	// and only following transactions will be returned.
+	GetPrioritizedBatch(offset *hash.Hash, limit uint32) []*transaction.CheckedTransaction
+
 	// GetKnownBatch gets a set of known transactions from the transaction pool.
 	//
 	// For any missing transactions nil will be returned in their place and the map of missing
@@ -272,6 +280,13 @@ func (t *txPool) GetScheduledBatch(force bool) []*transaction.CheckedTransaction
 	defer t.schedulerLock.Unlock()
 
 	return t.scheduler.GetBatch(force)
+}
+
+func (t *txPool) GetPrioritizedBatch(offset *hash.Hash, limit uint32) []*transaction.CheckedTransaction {
+	t.schedulerLock.Lock()
+	defer t.schedulerLock.Unlock()
+
+	return t.scheduler.GetPrioritizedBatch(offset, limit)
 }
 
 func (t *txPool) GetKnownBatch(batch []hash.Hash) ([]*transaction.CheckedTransaction, map[hash.Hash]int) {

--- a/go/worker/common/committee/runtime_host.go
+++ b/go/worker/common/committee/runtime_host.go
@@ -8,6 +8,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
+	"github.com/oasisprotocol/oasis-core/go/runtime/txpool"
 )
 
 // Implements RuntimeHostHandlerFactory.
@@ -36,6 +37,11 @@ func (env *nodeEnvironment) GetCurrentBlock(ctx context.Context) (*block.Block, 
 // Implements RuntimeHostHandlerEnvironment.
 func (env *nodeEnvironment) GetKeyManagerClient(ctx context.Context) (keymanagerClientApi.Client, error) {
 	return env.n.KeyManagerClient, nil
+}
+
+// Implements RuntimeHostHandlerEnvironment.
+func (env *nodeEnvironment) GetTxPool(ctx context.Context) (txpool.TransactionPool, error) {
+	return env.n.TxPool, nil
 }
 
 // Implements RuntimeHostHandlerFactory.

--- a/go/worker/compute/executor/committee/batch.go
+++ b/go/worker/compute/executor/committee/batch.go
@@ -20,16 +20,27 @@ type unresolvedBatch struct {
 }
 
 func (ub *unresolvedBatch) String() string {
-	return fmt.Sprintf("UnresolvedBatch{hash: %s}", ub.proposal.Header.BatchHash)
+	switch {
+	case ub.proposal != nil:
+		return fmt.Sprintf("UnresolvedBatch{hash: %s}", ub.proposal.Header.BatchHash)
+	default:
+		return "UnresolvedBatch{?}"
+	}
 }
 
 func (ub *unresolvedBatch) hash() hash.Hash {
+	if ub.proposal == nil {
+		return hash.Hash{}
+	}
 	return ub.proposal.Header.BatchHash
 }
 
 func (ub *unresolvedBatch) resolve(txPool txpool.TransactionPool) (transaction.RawBatch, error) {
 	if ub.batch != nil {
 		return ub.batch, nil
+	}
+	if ub.proposal == nil {
+		return nil, fmt.Errorf("resolve called on unresolvable batch")
 	}
 	if len(ub.proposal.Batch) == 0 {
 		return transaction.RawBatch{}, nil

--- a/go/worker/compute/executor/committee/state.go
+++ b/go/worker/compute/executor/committee/state.go
@@ -8,6 +8,7 @@ import (
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 	"github.com/oasisprotocol/oasis-core/go/runtime/transaction"
+	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
 )
 
 // StateName is a symbolic state without the attached values.
@@ -198,11 +199,17 @@ type StateProcessingBatch struct {
 	cancelFn context.CancelFunc
 	// Channel which will provide the result.
 	done chan *processedBatch
+	// Execution mode.
+	mode protocol.ExecutionMode
 }
 
 type processedBatch struct {
 	computed *protocol.ComputedBatch
 	raw      transaction.RawBatch
+
+	txHashes        []hash.Hash
+	txInputRoot     hash.Hash
+	txInputWriteLog storage.WriteLog
 }
 
 // Name returns the name of the state.
@@ -225,8 +232,8 @@ func (s *StateProcessingBatch) cancel() {
 // StateWaitingForFinalize is the waiting for finalize state.
 type StateWaitingForFinalize struct {
 	batchStartTime time.Time
-	raw            transaction.RawBatch
 	proposedIORoot hash.Hash
+	txHashes       []hash.Hash
 }
 
 // Name returns the name of the state.

--- a/runtime/src/config.rs
+++ b/runtime/src/config.rs
@@ -1,5 +1,5 @@
 //! Runtime configuration.
-use crate::{common::version::Version, consensus::verifier::TrustRoot};
+use crate::{common::version::Version, consensus::verifier::TrustRoot, types::Features};
 
 /// Global runtime configuration.
 #[derive(Clone, Debug, Default)]
@@ -10,6 +10,8 @@ pub struct Config {
     pub trust_root: Option<TrustRoot>,
     /// Storage configuration.
     pub storage: Storage,
+    /// Advertised runtime features.
+    pub features: Option<Features>,
 }
 
 /// Storage-related configuration.

--- a/runtime/src/protocol.rs
+++ b/runtime/src/protocol.rs
@@ -464,6 +464,7 @@ impl Protocol {
         Ok(RuntimeInfoResponse {
             protocol_version: BUILD_INFO.protocol_version,
             runtime_version: self.config.version,
+            features: self.config.features.clone(),
         })
     }
 

--- a/runtime/src/transaction/dispatcher.rs
+++ b/runtime/src/transaction/dispatcher.rs
@@ -24,6 +24,23 @@ pub trait Dispatcher: Send + Sync {
         in_msgs: &[roothash::IncomingMessage],
     ) -> Result<ExecuteBatchResult, RuntimeError>;
 
+    /// Schedule and execute transactions in the given batch.
+    ///
+    /// The passed batch is an initial batch. In case the runtime needs additional items it should
+    /// request them from the host.
+    fn schedule_and_execute_batch(
+        &self,
+        _ctx: Context,
+        _initial_batch: &mut TxnBatch,
+        _in_msgs: &[roothash::IncomingMessage],
+    ) -> Result<ExecuteBatchResult, RuntimeError> {
+        Err(RuntimeError::new(
+            "rhp/dispatcher",
+            3,
+            "scheduling not supported",
+        ))
+    }
+
     /// Check the transactions in the given batch for validity.
     fn check_batch(
         &self,
@@ -62,6 +79,15 @@ impl<T: Dispatcher + ?Sized> Dispatcher for Box<T> {
         T::execute_batch(&*self, ctx, batch, in_msgs)
     }
 
+    fn schedule_and_execute_batch(
+        &self,
+        ctx: Context,
+        initial_batch: &mut TxnBatch,
+        in_msgs: &[roothash::IncomingMessage],
+    ) -> Result<ExecuteBatchResult, RuntimeError> {
+        T::schedule_and_execute_batch(&*self, ctx, initial_batch, in_msgs)
+    }
+
     fn check_batch(
         &self,
         ctx: Context,
@@ -91,6 +117,15 @@ impl<T: Dispatcher + ?Sized> Dispatcher for Arc<T> {
         in_msgs: &[roothash::IncomingMessage],
     ) -> Result<ExecuteBatchResult, RuntimeError> {
         T::execute_batch(&*self, ctx, batch, in_msgs)
+    }
+
+    fn schedule_and_execute_batch(
+        &self,
+        ctx: Context,
+        initial_batch: &mut TxnBatch,
+        in_msgs: &[roothash::IncomingMessage],
+    ) -> Result<ExecuteBatchResult, RuntimeError> {
+        T::schedule_and_execute_batch(&*self, ctx, initial_batch, in_msgs)
     }
 
     fn check_batch(
@@ -135,6 +170,10 @@ pub struct ExecuteBatchResult {
     /// Batch weight limits valid for next round. This is used as a fast-path,
     /// to avoid having the transaction scheduler query these on every round.
     pub batch_weight_limits: Option<BTreeMap<TransactionWeight, u64>>,
+    /// Hashes of transactions to reject.
+    ///
+    /// Note that these are only taken into account in schedule execution mode.
+    pub tx_reject_hashes: Vec<Hash>,
 }
 
 /// No-op dispatcher.
@@ -162,6 +201,23 @@ impl Dispatcher for NoopDispatcher {
             block_tags: Tags::new(),
             batch_weight_limits: None,
             in_msgs_count: in_msgs.len(),
+            tx_reject_hashes: Vec::new(),
+        })
+    }
+
+    fn schedule_and_execute_batch(
+        &self,
+        _ctx: Context,
+        _initial_batch: &mut TxnBatch,
+        in_msgs: &[roothash::IncomingMessage],
+    ) -> Result<ExecuteBatchResult, RuntimeError> {
+        Ok(ExecuteBatchResult {
+            results: Vec::new(),
+            messages: Vec::new(),
+            block_tags: Tags::new(),
+            batch_weight_limits: None,
+            in_msgs_count: in_msgs.len(),
+            tx_reject_hashes: Vec::new(),
         })
     }
 


### PR DESCRIPTION
Based on #4415.
Also adds functionality needed for #4436.

TODO
* [x] Cleanup.
* [x] More testing, including long-term tests.
* [x] Support for fetching more transactions from the host (so that we don't need to always dump the full txpool into the runtime to then just schedule a few of them).
* [x] Interoperability testing with old runtimes and old nodes in the same committee.
* [x] Forward-port some fixes from #4446.