### PR TITLE
Add support for node suspension due to runtime liveness failures

### DIFF
--- a/.changelog/4470.breaking.md
+++ b/.changelog/4470.breaking.md
@@ -1,0 +1,1 @@
+Add support for node suspension due to runtime liveness failures

--- a/go/consensus/tendermint/apps/roothash/liveness.go
+++ b/go/consensus/tendermint/apps/roothash/liveness.go
@@ -1,0 +1,95 @@
+package roothash
+
+import (
+	"fmt"
+
+	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	registryState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry/state"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
+	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
+)
+
+// processLivenessStatistics checks the liveness statistics for the last epoch and penalizes any
+// nodes that didn't satisfy the liveness condition.
+func processLivenessStatistics(ctx *tmapi.Context, epoch beacon.EpochTime, rtState *roothash.RuntimeState) error {
+	if rtState.ExecutorPool == nil || rtState.LivenessStatistics == nil || rtState.Suspended {
+		return nil
+	}
+
+	// Skip evaluation if the number of total live rounds is below the set minimum.
+	totalRounds := rtState.LivenessStatistics.TotalRounds
+	if totalRounds == 0 || totalRounds < rtState.Runtime.Executor.MinLiveRoundsForEvaluation {
+		return nil
+	}
+
+	minLiveRoundsPercent := uint64(rtState.Runtime.Executor.MinLiveRoundsPercent)
+	minLiveRounds := (rtState.LivenessStatistics.TotalRounds * minLiveRoundsPercent) / 100
+	maxFailures := rtState.Runtime.Executor.MaxLivenessFailures
+	if maxFailures == 0 {
+		maxFailures = 255
+	}
+	slashParams := rtState.Runtime.Staking.Slashing[staking.SlashRuntimeLiveness]
+
+	ctx.Logger().Debug("evaluating node liveness",
+		"min_live_rounds", minLiveRounds,
+		"max_failures", maxFailures,
+		"freeze_duration", slashParams.FreezeInterval,
+		"slash_amount", slashParams.Amount,
+	)
+
+	// Collect per node liveness statistics as a single node can have multiple roles.
+	goodRoundsPerNode := make(map[signature.PublicKey]uint64)
+	for i, member := range rtState.ExecutorPool.Committee.Members {
+		goodRoundsPerNode[member.PublicKey] += rtState.LivenessStatistics.LiveRounds[i]
+	}
+
+	// Penalize nodes that were not live enough.
+	regState := registryState.NewMutableState(ctx.State())
+	for nodeID, liveRounds := range goodRoundsPerNode {
+		if liveRounds >= minLiveRounds {
+			continue
+		}
+
+		ctx.Logger().Debug("node deemed faulty",
+			"node_id", nodeID,
+			"live_rounds", liveRounds,
+			"min_live_rounds", minLiveRounds,
+		)
+
+		status, err := regState.NodeStatus(ctx, nodeID)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve status for node %s: %w", nodeID, err)
+		}
+		if status.IsSuspended(rtState.Runtime.ID, epoch) {
+			continue
+		}
+
+		status.RecordFailure(rtState.Runtime.ID, epoch)
+
+		// Check if the node has reached the maximum allowed number of failures.
+		fault := status.Faults[rtState.Runtime.ID]
+		if fault.Failures >= maxFailures {
+			// Make sure to freeze forever if this would otherwise overflow.
+			if epoch > registry.FreezeForever-slashParams.FreezeInterval {
+				status.FreezeEndTime = registry.FreezeForever
+			} else {
+				status.FreezeEndTime = epoch + slashParams.FreezeInterval
+			}
+
+			// Slash if configured.
+			err = onRuntimeLivenessFailure(ctx, nodeID, &slashParams.Amount)
+			if err != nil {
+				return fmt.Errorf("failed to slash node %s: %w", nodeID, err)
+			}
+		}
+
+		if err = regState.SetNodeStatus(ctx, nodeID, status); err != nil {
+			return fmt.Errorf("failed to set node status for node %s: %w", nodeID, err)
+		}
+	}
+
+	return nil
+}

--- a/go/consensus/tendermint/apps/scheduler/api/api.go
+++ b/go/consensus/tendermint/apps/scheduler/api/api.go
@@ -1,0 +1,7 @@
+// Package api defines the scheduler application API for other applications.
+package api
+
+type messageKind uint8
+
+// MessageBeforeSchedule is the message kind for before-schedule notifications.
+var MessageBeforeSchedule = messageKind(0)

--- a/go/oasis-node/cmd/debug/byzantine/byzantine.go
+++ b/go/oasis-node/cmd/debug/byzantine/byzantine.go
@@ -274,6 +274,11 @@ func doExecutorScenario(cmd *cobra.Command, args []string) { //nolint: gocyclo
 		panic(fmt.Sprintf("compute publish to chain failed: %+v", err))
 	}
 	logger.Debug("executor: commitment sent")
+
+	// If this is supposed to be a storage node, keep it running forever.
+	if viper.GetBool(CfgCorruptGetDiff) {
+		select {}
+	}
 }
 
 // Register registers the byzantine sub-command and all of its children.

--- a/go/oasis-node/cmd/debug/byzantine/grpc.go
+++ b/go/oasis-node/cmd/debug/byzantine/grpc.go
@@ -1,20 +1,13 @@
 package byzantine
 
 import (
-	"fmt"
 	"net"
 
 	"github.com/spf13/viper"
 
-	"github.com/oasisprotocol/oasis-core/go/common/grpc"
-	"github.com/oasisprotocol/oasis-core/go/common/identity"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	cmdGrpc "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/grpc"
 )
-
-type externalGrpc struct {
-	grpc *grpc.Server
-}
 
 func getGrpcAddress() []node.Address {
 	return []node.Address{
@@ -25,45 +18,4 @@ func getGrpcAddress() []node.Address {
 			},
 		},
 	}
-}
-
-func newExternalGrpc(id *identity.Identity) (*externalGrpc, error) {
-	// Create externally-accessible gRPC server.
-	serverConfig := &grpc.ServerConfig{
-		Name:     "external",
-		Port:     uint16(viper.GetInt(cmdGrpc.CfgServerPort)),
-		Identity: id,
-	}
-	grpc, err := grpc.NewServer(serverConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	g := &externalGrpc{
-		grpc,
-	}
-
-	return g, nil
-}
-
-func (g *externalGrpc) start() error {
-	if g.grpc == nil {
-		return fmt.Errorf("grpc service not initialized")
-	}
-
-	// Run the gRPC server.
-	if err := g.grpc.Start(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (g *externalGrpc) stop() {
-	if g.grpc == nil {
-		return
-	}
-
-	g.grpc.Stop()
-	g.grpc = nil
 }

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -92,6 +92,19 @@ type ExecutorParameters struct {
 	// MaxMessages is the maximum number of messages that can be emitted by the runtime in a
 	// single round.
 	MaxMessages uint32 `json:"max_messages"`
+
+	// MinLiveRoundsPercent is the minimum percentage of rounds in an epoch that a node must
+	// participate in positively in order to be considered live. Nodes not satisfying this may be
+	// penalized.
+	MinLiveRoundsPercent uint8 `json:"min_live_rounds_percent,omitempty"`
+
+	// MinLiveRoundsForEvaluation is the minimum number of live rounds in an epoch for the liveness
+	// calculations to be considered for evaluation.
+	MinLiveRoundsForEvaluation uint64 `json:"min_live_rounds_eval,omitempty"`
+
+	// MaxLivenessFailures is the maximum number of liveness failures that are tolerated before
+	// suspending and/or slashing the node. Zero means unlimited.
+	MaxLivenessFailures uint8 `json:"max_liveness_fails,omitempty"`
 }
 
 // ValidateBasic performs basic executor parameter validity checks.
@@ -105,6 +118,10 @@ func (e *ExecutorParameters) ValidateBasic() error {
 
 	if e.RoundTimeout <= 0 {
 		return fmt.Errorf("round timeout too small")
+	}
+
+	if e.MinLiveRoundsPercent > 100 {
+		return fmt.Errorf("minimum live rounds percentage cannot be greater than 100")
 	}
 
 	return nil

--- a/go/registry/api/status.go
+++ b/go/registry/api/status.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
+	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 )
 
@@ -27,6 +28,9 @@ type NodeStatus struct {
 	//
 	// Note: A value of 0 is treated unconditionally as "ineligible".
 	ElectionEligibleAfter beacon.EpochTime `json:"election_eligible_after"`
+	// Faults is a set of fault records for nodes that are experiencing
+	// liveness failures when participating in specific committees.
+	Faults map[common.Namespace]*Fault `json:"faults,omitempty"`
 }
 
 // IsFrozen returns true if the node is currently frozen (prevented
@@ -38,6 +42,96 @@ func (ns NodeStatus) IsFrozen() bool {
 // Unfreeze makes the node unfrozen.
 func (ns *NodeStatus) Unfreeze() {
 	ns.FreezeEndTime = 0
+}
+
+// RecordFailure records a liveness failure in the epoch preceding the specified epoch.
+func (ns *NodeStatus) RecordFailure(runtimeID common.Namespace, epoch beacon.EpochTime) {
+	if ns.Faults == nil {
+		ns.Faults = make(map[common.Namespace]*Fault)
+	}
+	fault, exists := ns.Faults[runtimeID]
+	if !exists {
+		fault = &Fault{}
+		ns.Faults[runtimeID] = fault
+	}
+
+	fault.RecordFailure(epoch)
+}
+
+// RecordSuccess records success in the epoch preceding the specified epoch.
+func (ns *NodeStatus) RecordSuccess(runtimeID common.Namespace, epoch beacon.EpochTime) {
+	fault, exists := ns.Faults[runtimeID]
+	if !exists {
+		return
+	}
+
+	fault.RecordSuccess(epoch)
+	if fault.Failures == 0 {
+		// Remove failure record once the counter reaches zero.
+		delete(ns.Faults, runtimeID)
+	}
+	if len(ns.Faults) == 0 {
+		ns.Faults = nil
+	}
+}
+
+// IsSuspended checks whether the node is suspended in the given epoch.
+func (ns *NodeStatus) IsSuspended(runtimeID common.Namespace, epoch beacon.EpochTime) bool {
+	// If a node is frozen it is also suspended.
+	if ns.IsFrozen() {
+		return true
+	}
+
+	fault, exists := ns.Faults[runtimeID]
+	if !exists {
+		return false
+	}
+	return fault.IsSuspended(epoch)
+}
+
+// Fault is used to track the state of nodes that are experiencing liveness failures.
+type Fault struct {
+	// Failures is the number of times a node has been declared faulty.
+	Failures uint8 `json:"failures,omitempty"`
+	// SuspendedUntil specifies the epoch number until the node is not eligible for being scheduled
+	// into the committee for which it is deemed faulty.
+	SuspendedUntil beacon.EpochTime `json:"suspended_until,omitempty"`
+}
+
+// RecordFailure records a liveness failure in the epoch preceding the specified epoch.
+func (f *Fault) RecordFailure(epoch beacon.EpochTime) {
+	f.Failures++
+	f.scheduleSuspension(epoch)
+}
+
+// RecordSuccess records success in the epoch preceding the specified epoch.
+func (f *Fault) RecordSuccess(epoch beacon.EpochTime) {
+	// We reduce the failure counter.
+	if f.Failures > 0 {
+		f.Failures--
+	}
+	f.scheduleSuspension(epoch)
+}
+
+func (f *Fault) scheduleSuspension(epoch beacon.EpochTime) {
+	// Determine how long the node should be suspended for.
+	switch {
+	case f.Failures == 0:
+		// No failures, no suspension.
+		f.SuspendedUntil = 0
+	case f.Failures > 6:
+		// Prevent suspending for too long (max 64 epochs).
+		suspensionDuration := beacon.EpochTime(1 << 6)
+		f.SuspendedUntil = epoch + suspensionDuration
+	default:
+		suspensionDuration := beacon.EpochTime(1 << f.Failures)
+		f.SuspendedUntil = epoch + suspensionDuration
+	}
+}
+
+// IsSuspended checks whether the node is suspended in the given epoch.
+func (f *Fault) IsSuspended(epoch beacon.EpochTime) bool {
+	return f.SuspendedUntil > 0 && epoch < f.SuspendedUntil
 }
 
 // UnfreezeNode is a request to unfreeze a frozen node.

--- a/go/registry/api/status_test.go
+++ b/go/registry/api/status_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+)
+
+func TestStatusFaults(t *testing.T) {
+	require := require.New(t)
+
+	var testRuntimeID common.Namespace
+
+	var ns NodeStatus
+	require.False(ns.IsFrozen(), "default node status should be non-frozen")
+	require.False(ns.IsSuspended(testRuntimeID, 1), "default node status should be non-suspended")
+
+	// Simulate liveness failure in epoch 0, recorded when transitioning to epoch 1.
+	ns.RecordFailure(testRuntimeID, 1)
+	require.Len(ns.Faults, 1, "faults set should have a fault")
+	require.False(ns.IsFrozen(), "should not be immediately frozen on failure")
+	require.True(ns.IsSuspended(testRuntimeID, 1), "should be suspended in epoch 1")
+	require.True(ns.IsSuspended(testRuntimeID, 2), "should be suspended in epoch 2")
+	require.False(ns.IsSuspended(testRuntimeID, 3), "should not be suspended in epoch 3")
+	require.False(ns.IsSuspended(testRuntimeID, 4), "should not be suspended in epoch 4")
+
+	// Simulate another liveness failure in epoch 3, recorded when transitioning to epoch 4.
+	ns.RecordFailure(testRuntimeID, 4)
+	require.True(ns.IsSuspended(testRuntimeID, 4), "should be suspended in epoch 4")
+	require.True(ns.IsSuspended(testRuntimeID, 5), "should be suspended in epoch 5")
+	require.True(ns.IsSuspended(testRuntimeID, 6), "should be suspended in epoch 6")
+	require.True(ns.IsSuspended(testRuntimeID, 7), "should be suspended in epoch 7")
+	require.False(ns.IsSuspended(testRuntimeID, 8), "should not be suspended in epoch 8")
+
+	// Simulate another liveness failure in epoch 8.
+	ns.RecordFailure(testRuntimeID, 9)
+	require.True(ns.IsSuspended(testRuntimeID, 11), "should be suspended in epoch 11")
+	require.True(ns.IsSuspended(testRuntimeID, 12), "should be suspended in epoch 12")
+	require.True(ns.IsSuspended(testRuntimeID, 13), "should be suspended in epoch 13")
+	require.True(ns.IsSuspended(testRuntimeID, 14), "should be suspended in epoch 14")
+	require.True(ns.IsSuspended(testRuntimeID, 15), "should be suspended in epoch 15")
+	require.True(ns.IsSuspended(testRuntimeID, 16), "should be suspended in epoch 16")
+	require.False(ns.IsSuspended(testRuntimeID, 17), "should not be suspended in epoch 17")
+
+	// Simulate success in epoch 17.
+	ns.RecordSuccess(testRuntimeID, 18)
+	require.False(ns.IsFrozen(), "node should no longer be frozen")
+	require.True(ns.IsSuspended(testRuntimeID, 18), "should be suspended in epoch 18")
+	require.True(ns.IsSuspended(testRuntimeID, 19), "should be suspended in epoch 19")
+	require.True(ns.IsSuspended(testRuntimeID, 20), "should be suspended in epoch 20")
+	require.True(ns.IsSuspended(testRuntimeID, 21), "should be suspended in epoch 21")
+	require.False(ns.IsSuspended(testRuntimeID, 22), "should not be suspended in epoch 22")
+
+	// Simulate success in epoch 22.
+	ns.RecordSuccess(testRuntimeID, 23)
+	require.False(ns.IsFrozen(), "node should no longer be frozen")
+	require.True(ns.IsSuspended(testRuntimeID, 23), "should be suspended in epoch 23")
+	require.True(ns.IsSuspended(testRuntimeID, 24), "should be suspended in epoch 24")
+	require.False(ns.IsSuspended(testRuntimeID, 25), "should not be suspended in epoch 25")
+
+	// Simulate success in epoch 25.
+	ns.RecordSuccess(testRuntimeID, 26)
+	require.False(ns.IsFrozen(), "node should no longer be frozen")
+	require.False(ns.IsSuspended(testRuntimeID, 26), "should not be suspended in epoch 26")
+	require.Len(ns.Faults, 0, "faults set should be cleared")
+}

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -393,7 +393,11 @@ type RuntimeState struct {
 	// LastNormalHeight is the consensus block height corresponding to LastNormalRound.
 	LastNormalHeight int64 `json:"last_normal_height"`
 
+	// ExecutorPool contains the executor commitment pool.
 	ExecutorPool *commitment.Pool `json:"executor_pool"`
+
+	// LivenessStatistics contains the liveness statistics for the current epoch.
+	LivenessStatistics *LivenessStatistics `json:"liveness_stats"`
 }
 
 // AnnotatedBlock is an annotated roothash block.

--- a/go/roothash/api/liveness.go
+++ b/go/roothash/api/liveness.go
@@ -1,0 +1,20 @@
+package api
+
+// LivenessStatistics has the per-epoch liveness statistics for nodes.
+type LivenessStatistics struct {
+	// TotalRounds is the total number of rounds in the last epoch, excluding any rounds generated
+	// by the roothash service itself.
+	TotalRounds uint64 `json:"total_rounds"`
+
+	// LiveRounds is a list of counters, specified in committee order (e.g. counter at index i has
+	// the value for node i in the committee).
+	LiveRounds []uint64 `json:"good_rounds"`
+}
+
+// NewLivenessStatistics creates a new instance of per-epoch liveness statistics.
+func NewLivenessStatistics(numNodes int) *LivenessStatistics {
+	return &LivenessStatistics{
+		TotalRounds: 0,
+		LiveRounds:  make([]uint64, numNodes),
+	}
+}

--- a/go/staking/api/slashing.go
+++ b/go/staking/api/slashing.go
@@ -28,6 +28,8 @@ const (
 	// SlashRuntimeEquivocation is slashing due to signing two different
 	// executor commits or proposed batches for the same round.
 	SlashRuntimeEquivocation SlashReason = 0x81
+	// SlashRuntimeLiveness is slashing due to not doing the required work.
+	SlashRuntimeLiveness SlashReason = 0x82
 
 	// SlashConsensusEquivocationName is the string representation of SlashConsensusEquivocation.
 	SlashConsensusEquivocationName = "consensus-equivocation"
@@ -37,6 +39,8 @@ const (
 	SlashRuntimeIncorrectResultsName = "runtime-incorrect-results"
 	// SlashRuntimeEquivocationName is the string representation of SlashRuntimeEquivocation.
 	SlashRuntimeEquivocationName = "runtime-equivocation"
+	// SlashRuntimeLivenessName is the string representation of SlashRuntimeLiveness.
+	SlashRuntimeLivenessName = "runtime-liveness"
 )
 
 // String returns a string representation of a SlashReason.
@@ -55,6 +59,8 @@ func (s SlashReason) checkedString() (string, error) {
 		return SlashRuntimeIncorrectResultsName, nil
 	case SlashRuntimeEquivocation:
 		return SlashRuntimeEquivocationName, nil
+	case SlashRuntimeLiveness:
+		return SlashRuntimeLivenessName, nil
 	default:
 		return "[unknown slash reason]", fmt.Errorf("unknown slash reason: %d", s)
 	}
@@ -81,6 +87,8 @@ func (s *SlashReason) UnmarshalText(text []byte) error {
 		*s = SlashRuntimeIncorrectResults
 	case SlashRuntimeEquivocationName:
 		*s = SlashRuntimeEquivocation
+	case SlashRuntimeLivenessName:
+		*s = SlashRuntimeLiveness
 	default:
 		return fmt.Errorf("invalid slash reason: %s", string(text))
 	}

--- a/runtime/src/consensus/registry.rs
+++ b/runtime/src/consensus/registry.rs
@@ -43,11 +43,23 @@ pub struct ExecutorParameters {
     pub group_backup_size: u16,
     /// Number of allowed stragglers.
     pub allowed_stragglers: u16,
-    /// rRound timeout in consensus blocks.
+    /// Round timeout in consensus blocks.
     pub round_timeout: i64,
     /// Maximum number of messages that can be emitted by the runtime
     /// in a single round.
     pub max_messages: u32,
+    /// Minimum percentage of rounds in an epoch that a node must participate in positively in order
+    /// to be considered live. Nodes not satisfying this may be penalized.
+    #[cbor(optional, default, skip_serializing_if = "num_traits::Zero::is_zero")]
+    pub min_live_rounds_percent: u8,
+    /// Minimum number of live rounds in an epoch for the liveness calculations to be considered for
+    /// evaluation.
+    #[cbor(optional, default, skip_serializing_if = "num_traits::Zero::is_zero")]
+    pub min_live_rounds_eval: u64,
+    /// Maximum number of liveness failures that are tolerated before suspending and/or slashing the
+    /// node. Zero means unlimited.
+    #[cbor(optional, default, skip_serializing_if = "num_traits::Zero::is_zero")]
+    pub max_liveness_fails: u8,
 }
 
 /// Parameters for the runtime transaction scheduler.

--- a/runtime/src/consensus/roothash.rs
+++ b/runtime/src/consensus/roothash.rs
@@ -356,6 +356,7 @@ mod tests {
                 allowed_stragglers: 1,
                 round_timeout: 10,
                 max_messages: 32,
+                ..Default::default()
             },
             txn_scheduler: registry::TxnSchedulerParameters {
                 batch_flush_timeout: 20000000000, // 20 seconds.

--- a/runtime/src/consensus/staking.rs
+++ b/runtime/src/consensus/staking.rs
@@ -194,6 +194,8 @@ pub enum SlashReason {
     /// Slashing due to signing two different executor commits or proposed batches for the same
     /// round.
     RuntimeEquivocation = 0x81,
+    /// Slashing due to not doing the required work.
+    RuntimeLiveness = 0x82,
 }
 
 /// Per-reason slashing configuration.


### PR DESCRIPTION
TODO
* [x] Basic structures for tracking node liveness faults.
* [x] Update the scheduler service to ignore suspended nodes when electing committees.
* [x] Update the roothash service to track node liveness failure in the previous epoch.
* [x] Support for slashing.
* [x] Tests.