### PR TITLE
go/runtime: Switch to a unified bundle format

### DIFF
--- a/.changelog/4469.cfg.md
+++ b/.changelog/4469.cfg.md
@@ -1,0 +1,21 @@
+Switch to unified runtime bundles
+
+Instead of distributing runtime binaries separately, and having the node
+operator configure the appropriate binary based on runtime ID, runtime
+artifacts are now distributed under a single self-describing "fat"
+bundle file.
+
+To configure runtimes the new syntax is:
+
+```
+runtime:
+  paths:
+    - examplepath/runtime.orc
+    - anotherExamplePath/anotherRuntime.orc
+```
+
+If the commandline is being used `runtime.paths` now only takes the path
+to the runtime bundle(s).
+
+This requires downloading new builds of the runtime binaries that are
+packaged in this format.

--- a/.changelog/4469.feature.md
+++ b/.changelog/4469.feature.md
@@ -1,0 +1,5 @@
+go/oasis-node: Implement unified runtime bundles
+
+This changes runtime bundles to be unified across all supported TEE types
+and self describing so that configuring runtines is only a matter of passing
+in the runtime bundle file.

--- a/go/go.mod
+++ b/go/go.mod
@@ -218,7 +218,7 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.19.1 // indirect
-	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/mod v0.5.0 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -1318,7 +1318,6 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.5.0 h1:UG21uOlmZabA4fW5i7ZX6bjw1xELEGg/ZLgZq9auk/Q=
 golang.org/x/mod v0.5.0/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -122,8 +122,8 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 				Kind:       registry.KindKeyManager,
 				Entity:     0,
 				Keymanager: -1,
-				Binaries: map[node.TEEHardware][]string{
-					tee: {viper.GetString(cfgKeymanagerBinary)},
+				Binaries: map[node.TEEHardware]string{
+					tee: viper.GetString(cfgKeymanagerBinary),
 				},
 				AdmissionPolicy: registry.RuntimeAdmissionPolicy{
 					AnyNode: &registry.AnyNodeRuntimeAdmissionPolicy{},
@@ -171,8 +171,8 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 				Kind:       registry.KindCompute,
 				Entity:     0,
 				Keymanager: keymanagerIdx,
-				Binaries: map[node.TEEHardware][]string{
-					tee: {rt},
+				Binaries: map[node.TEEHardware]string{
+					tee: rt,
 				},
 				Executor: registry.ExecutorParameters{
 					GroupSize:       2,

--- a/go/oasis-node/cmd/debug/bundle/bundle.go
+++ b/go/oasis-node/cmd/debug/bundle/bundle.go
@@ -1,0 +1,152 @@
+// Package bundle implements the bundle sub-commands.
+package bundle
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
+	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
+	"github.com/oasisprotocol/oasis-core/go/runtime/bundle"
+)
+
+const (
+	CfgRuntimeID            = "runtime.id"
+	CfgRuntimeName          = "runtime.name"
+	CfgRuntimeVersion       = "runtime.version"
+	CfgRuntimeExecutable    = "runtime.executable"
+	CfgRuntimeSGXExecutable = "runtime.sgx.executable"
+	CfgRuntimeSGXSignature  = "runtime.sgx.signature"
+
+	CfgRuntimeBundle = "runtime.bundle"
+
+	execName    = "runtime.elf"
+	sgxExecName = "runtime.sgx"
+	sgxSigName  = "runtime.sgx.sig"
+)
+
+var (
+	bundleCmd = &cobra.Command{
+		Use:   "bundle",
+		Short: "manipulate runtime bundles",
+	}
+
+	initCmd = &cobra.Command{
+		Use:   "init",
+		Short: "create a runtime bundle",
+		Run:   doInit,
+	}
+
+	logger = logging.GetLogger("cmd/debug/bundle")
+)
+
+func doInit(cmd *cobra.Command, args []string) {
+	if err := cmdCommon.Init(); err != nil {
+		cmdCommon.EarlyLogAndExit(err)
+	}
+
+	// This creates runtimes with normalized internal filenames, for the
+	// sake of consistency, though there is no reason why this needs to
+	// be the case.
+	var err error
+	manifest := &bundle.Manifest{
+		Name:       viper.GetString(CfgRuntimeName),
+		Executable: execName,
+	}
+	if err = manifest.ID.UnmarshalText([]byte(viper.GetString(CfgRuntimeID))); err != nil {
+		logger.Error("failed to parse runtime ID",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+	if manifest.Version, err = version.FromString(viper.GetString(CfgRuntimeVersion)); err != nil {
+		logger.Error("failed to parse runtime version",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+
+	type runtimeFile struct {
+		fn, descr, dst string
+	}
+	wantFiles := []runtimeFile{
+		{
+			fn:    viper.GetString(CfgRuntimeExecutable),
+			descr: "runtime ELF binary",
+			dst:   execName,
+		},
+	}
+	if sgxExec := viper.GetString(CfgRuntimeSGXExecutable); sgxExec != "" {
+		wantFiles = append(wantFiles, runtimeFile{
+			fn:    viper.GetString(CfgRuntimeSGXExecutable),
+			descr: "runtime SGX binary",
+			dst:   sgxExecName,
+		})
+		manifest.SGX = &bundle.SGXMetadata{
+			Executable: sgxExecName,
+		}
+
+		if sgxSig := viper.GetString(CfgRuntimeSGXSignature); sgxSig != "" {
+			wantFiles = append(wantFiles, runtimeFile{
+				fn:    viper.GetString(CfgRuntimeSGXExecutable),
+				descr: "runtime SGX signature",
+				dst:   sgxSigName,
+			})
+			manifest.SGX.Signature = sgxSigName
+		}
+	}
+	bnd := &bundle.Bundle{
+		Manifest: manifest,
+	}
+	for _, v := range wantFiles {
+		if v.fn == "" {
+			logger.Error("missing runtime asset",
+				"descr", v.descr,
+			)
+			os.Exit(1)
+		}
+		var b []byte
+		if b, err = os.ReadFile(v.fn); err != nil {
+			logger.Error("failed to load runtime asset",
+				"err", err,
+				"descr", v.descr,
+			)
+			os.Exit(1)
+		}
+		_ = bnd.Add(v.dst, b)
+	}
+
+	dstFn := viper.GetString(CfgRuntimeBundle)
+	if dstFn == "" {
+		logger.Error("missing runtime bundle name")
+		os.Exit(1)
+	}
+	if err = bnd.Write(dstFn); err != nil {
+		logger.Error("failed to write runtime bundle",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+}
+
+// Register registers the bundle sub-command and all of it's children.
+func Register(parentCmd *cobra.Command) {
+	initFlags := flag.NewFlagSet("", flag.ContinueOnError)
+	initFlags.String(CfgRuntimeID, "", "runtime ID (Base16-encoded)")
+	initFlags.String(CfgRuntimeName, "", "runtime name (optional)")
+	initFlags.String(CfgRuntimeVersion, "0.0.0", "runtime version")
+	initFlags.String(CfgRuntimeExecutable, "runtime.bin", "path to runtime ELF binary")
+	initFlags.String(CfgRuntimeSGXExecutable, "", "path to runtime SGX binary")
+	initFlags.String(CfgRuntimeSGXSignature, "", "path to runtime SGX signature")
+	initFlags.String(CfgRuntimeBundle, "runtime.orc", "output path to runtime bundle")
+
+	_ = viper.BindPFlags(initFlags)
+	initCmd.Flags().AddFlagSet(initFlags)
+
+	bundleCmd.AddCommand(initCmd)
+	parentCmd.AddCommand(bundleCmd)
+}

--- a/go/oasis-node/cmd/debug/debug.go
+++ b/go/oasis-node/cmd/debug/debug.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/debug/beacon"
+	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/debug/bundle"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/debug/byzantine"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/debug/control"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/debug/dumpdb"
@@ -27,6 +28,7 @@ func Register(parentCmd *cobra.Command) {
 	control.Register(debugCmd)
 	dumpdb.Register(debugCmd)
 	beacon.Register(debugCmd)
+	bundle.Register(debugCmd)
 
 	parentCmd.AddCommand(debugCmd)
 }

--- a/go/oasis-node/node_test.go
+++ b/go/oasis-node/node_test.go
@@ -162,8 +162,8 @@ func newTestNode(t *testing.T) *testNode {
 
 	viper.Set("datadir", dataDir)
 	viper.Set("log.file", filepath.Join(dataDir, "test-node.log"))
-	viper.Set(runtimeRegistry.CfgRuntimePaths, map[string]string{
-		testRuntimeID.String(): "mock-runtime",
+	viper.Set(runtimeRegistry.CfgDebugMockIDs, []string{
+		testRuntimeID.String(),
 	})
 	viper.Set("worker.registration.entity", filepath.Join(dataDir, "entity.json"))
 	for _, kv := range testNodeStaticConfig {

--- a/go/oasis-test-runner/oasis/byzantine.go
+++ b/go/oasis-test-runner/oasis/byzantine.go
@@ -54,7 +54,7 @@ func (worker *Byzantine) AddArgs(args *argBuilder) error {
 		byzantineActivationEpoch(worker.activationEpoch)
 
 	if worker.runtime > 0 {
-		args.byzantineRuntimeID(worker.net.runtimes[worker.runtime].id)
+		args.byzantineRuntimeID(worker.net.runtimes[worker.runtime].ID())
 	}
 	for _, v := range worker.net.Runtimes() {
 		if v.kind == registry.KindCompute && v.teeHardware == node.TEEHardwareIntelSGX {
@@ -117,7 +117,7 @@ func (net *Network) NewByzantine(cfg *ByzantineCfg) (*Byzantine, error) {
 	host.features = append(host.features, worker)
 
 	if cfg.Runtime >= 0 {
-		rt := net.runtimes[cfg.Runtime].id
+		rt := net.runtimes[cfg.Runtime].ID()
 		pk := host.nodeSigner
 
 		if net.cfg.SchedulerForceElect == nil {

--- a/go/oasis-test-runner/oasis/client.go
+++ b/go/oasis-test-runner/oasis/client.go
@@ -3,7 +3,6 @@ package oasis
 import (
 	"fmt"
 
-	"github.com/oasisprotocol/oasis-core/go/common/node"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 )
 
@@ -49,7 +48,7 @@ func (client *Client) AddArgs(args *argBuilder) error {
 	for _, idx := range client.runtimes {
 		v := client.net.runtimes[idx]
 		// XXX: could support configurable binary idx if ever needed.
-		client.addHostedRuntime(v, node.TEEHardwareInvalid, 0, client.runtimeConfig[idx])
+		client.addHostedRuntime(v, client.runtimeConfig[idx])
 	}
 
 	return nil

--- a/go/oasis-test-runner/oasis/compute.go
+++ b/go/oasis-test-runner/oasis/compute.go
@@ -174,7 +174,7 @@ func (worker *Compute) AddArgs(args *argBuilder) error {
 	for _, idx := range worker.runtimes {
 		v := worker.net.runtimes[idx]
 		// XXX: could support configurable binary idx if ever needed.
-		worker.addHostedRuntime(v, v.teeHardware, 0, worker.runtimeConfig[idx])
+		worker.addHostedRuntime(v, worker.runtimeConfig[idx])
 	}
 
 	// Sentry configuration.

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -221,8 +221,8 @@ type RuntimeFixture struct { // nolint: maligned
 	Keymanager int                  `json:"keymanager"`
 	Version    version.Version      `json:"version"`
 
-	Binaries     map[node.TEEHardware][]string `json:"binaries"`
-	GenesisRound uint64                        `json:"genesis_round,omitempty"`
+	Binaries     map[node.TEEHardware]string `json:"binaries"`
+	GenesisRound uint64                      `json:"genesis_round,omitempty"`
 
 	Executor     registry.ExecutorParameters     `json:"executor"`
 	TxnScheduler registry.TxnSchedulerParameters `json:"txn_scheduler"`

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_upgrade.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
-	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
 	keymanager "github.com/oasisprotocol/oasis-core/go/keymanager/api"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
@@ -43,16 +43,14 @@ func (sc *kmUpgradeImpl) Fixture() (*oasis.NetworkFixture, error) {
 	}
 
 	// Load the upgraded keymanager binary.
-	newKmBinaries := sc.resolveRuntimeBinaries([]string{"simple-keymanager-upgrade"})
+	newKmBinaries := sc.resolveRuntimeBinaries("simple-keymanager-upgrade")
 	// Setup the upgraded runtime.
 	kmRuntimeFix := f.Runtimes[0]
 	if kmRuntimeFix.Kind != registry.KindKeyManager {
 		return nil, fmt.Errorf("expected first runtime in fixture to be keymanager runtime, got: %s", kmRuntimeFix.Kind)
 	}
-	for _, tee := range []node.TEEHardware{node.TEEHardwareInvalid, node.TEEHardwareIntelSGX} {
-		newKmBinaries[tee] = append(newKmBinaries[tee], kmRuntimeFix.Binaries[tee]...)
-	}
 	kmRuntimeFix.Binaries = newKmBinaries
+	kmRuntimeFix.Version = version.Version{Major: 0, Minor: 1, Patch: 0}
 	// The upgraded runtime will be registered later.
 	kmRuntimeFix.ExcludeFromGenesis = true
 	f.Runtimes = append(f.Runtimes, kmRuntimeFix)

--- a/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
@@ -58,7 +58,7 @@ func (sc *multipleRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
 	// Remove existing compute runtimes from fixture, remember RuntimeID and
 	// binary from the first one.
 	var id common.Namespace
-	var runtimeBinaries map[node.TEEHardware][]string
+	var runtimeBinaries map[node.TEEHardware]string
 	var rts []oasis.RuntimeFixture
 	for _, rt := range f.Runtimes {
 		if rt.Kind == registry.KindCompute {

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -182,7 +182,7 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 				AdmissionPolicy: registry.RuntimeAdmissionPolicy{
 					AnyNode: &registry.AnyNodeRuntimeAdmissionPolicy{},
 				},
-				Binaries:        sc.resolveRuntimeBinaries([]string{keyManagerBinary}),
+				Binaries:        sc.resolveRuntimeBinaries(keyManagerBinary),
 				GovernanceModel: registry.GovernanceEntity,
 			},
 			// Compute runtime.
@@ -191,7 +191,7 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 				Kind:       registry.KindCompute,
 				Entity:     0,
 				Keymanager: 0,
-				Binaries:   sc.resolveRuntimeBinaries([]string{runtimeBinary}),
+				Binaries:   sc.resolveRuntimeBinaries(runtimeBinary),
 				Executor: registry.ExecutorParameters{
 					GroupSize:       2,
 					GroupBackupSize: 1,
@@ -278,15 +278,13 @@ func (sc *runtimeImpl) getTEEHardware() (node.TEEHardware, error) {
 	return tee, nil
 }
 
-func (sc *runtimeImpl) resolveRuntimeBinaries(runtimeBinaries []string) map[node.TEEHardware][]string {
-	binaries := make(map[node.TEEHardware][]string)
+func (sc *runtimeImpl) resolveRuntimeBinaries(baseRuntimeBinary string) map[node.TEEHardware]string {
+	binaries := make(map[node.TEEHardware]string)
 	for _, tee := range []node.TEEHardware{
 		node.TEEHardwareInvalid,
 		node.TEEHardwareIntelSGX,
 	} {
-		for _, binary := range runtimeBinaries {
-			binaries[tee] = append(binaries[tee], sc.resolveRuntimeBinary(binary, tee))
-		}
+		binaries[tee] = sc.resolveRuntimeBinary(baseRuntimeBinary, tee)
 	}
 	return binaries
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_governance.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_governance.go
@@ -60,7 +60,7 @@ func (sc *runtimeGovernanceImpl) Fixture() (*oasis.NetworkFixture, error) {
 	// Remove existing compute runtimes from fixture, remember RuntimeID and
 	// binary from the first one.
 	var id common.Namespace
-	var runtimeBinaries map[node.TEEHardware][]string
+	var runtimeBinaries map[node.TEEHardware]string
 	var rts []oasis.RuntimeFixture
 	for _, rt := range f.Runtimes {
 		if rt.Kind == registry.KindCompute {

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_upgrade.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
-	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
 	keymanager "github.com/oasisprotocol/oasis-core/go/keymanager/api"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
@@ -53,13 +53,11 @@ func (sc *runtimeUpgradeImpl) Fixture() (*oasis.NetworkFixture, error) {
 	}
 
 	// Load the upgraded runtime binary.
-	newRuntimeBinaries := sc.resolveRuntimeBinaries([]string{"simple-keyvalue-upgrade"})
+	newRuntimeBinaries := sc.resolveRuntimeBinaries("simple-keyvalue-upgrade")
 
 	// Setup the upgraded runtime (first is keymanager, others should be generic compute).
 	runtimeFix := f.Runtimes[computeIndex]
-	for _, tee := range []node.TEEHardware{node.TEEHardwareInvalid, node.TEEHardwareIntelSGX} {
-		newRuntimeBinaries[tee] = append(newRuntimeBinaries[tee], runtimeFix.Binaries[tee]...)
-	}
+	runtimeFix.Version = version.Version{Major: 0, Minor: 1, Patch: 0}
 	runtimeFix.Binaries = newRuntimeBinaries
 
 	// The upgraded runtime will be registered later.

--- a/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
@@ -151,8 +151,8 @@ func (sc *trustRootImpl) registerRuntime(ctx context.Context, childEnv *env.Env)
 
 	// Register a new compute runtime.
 	compRt := sc.Net.Runtimes()[1]
-	if err := compRt.RefreshEnclaveIdentity(); err != nil {
-		return fmt.Errorf("failed to refresh enclave identity: %w", err)
+	if err := compRt.RefreshRuntimeBundle(); err != nil {
+		return fmt.Errorf("failed to refresh runtime bundle: %w", err)
 	}
 	compRtDesc := compRt.ToRuntimeDescriptor()
 	txPath := filepath.Join(childEnv.Dir(), "register_compute_runtime.json")

--- a/go/runtime/bundle/bundle.go
+++ b/go/runtime/bundle/bundle.go
@@ -1,0 +1,319 @@
+// Package bundle implements support for unified runtime bundles.
+package bundle
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/common/sgx"
+)
+
+// Bundle is a runtime bundle instance.
+type Bundle struct {
+	Manifest *Manifest
+	Data     map[string][]byte
+}
+
+// Validate validates the runtime bundle for well-formedness.
+func (bnd *Bundle) Validate() error {
+	// Ensure all the files in the manifest are present.
+	type bundleFile struct {
+		descr, fn string
+	}
+	needFiles := []bundleFile{
+		{
+			descr: "ELF executable",
+			fn:    bnd.Manifest.Executable,
+		},
+	}
+	if sgx := bnd.Manifest.SGX; sgx != nil {
+		needFiles = append(needFiles,
+			[]bundleFile{
+				{
+					descr: "SGX executable",
+					fn:    sgx.Executable,
+				},
+				{
+					descr: "SGX signature",
+					fn:    sgx.Signature,
+				},
+			}...,
+		)
+	}
+	for _, v := range needFiles {
+		if v.fn == "" {
+			return fmt.Errorf("runtime/bundle: missing %s in manifest", v.descr)
+		}
+		if len(bnd.Data[v.fn]) == 0 {
+			return fmt.Errorf("runtime/bundle: missing %s in bundle", v.descr)
+		}
+	}
+
+	// Ensure all files in the bundle have a digest entry, and that the
+	// extracted file's digest matches the one in the manifest.
+	for fn, b := range bnd.Data {
+		h := hash.NewFromBytes(b)
+
+		mh, ok := bnd.Manifest.Digests[fn]
+		if !ok {
+			// Ignore the manifest not having a digest entry, though
+			// it having one and being valid (while quite a feat) is
+			// also ok.
+			if fn == manifestName {
+				continue
+			}
+			return fmt.Errorf("runtime/bundle: missing digest: '%s'", fn)
+		}
+		if !h.Equal(&mh) {
+			return fmt.Errorf("runtime/bundle: invalid digest: '%s'", fn)
+		}
+	}
+
+	return nil
+}
+
+// Add adds/overwrites a file to/in the bundle.
+func (bnd *Bundle) Add(fn string, b []byte) error {
+	if filepath.Dir(fn) != "." {
+		return fmt.Errorf("runtime/bundle: invalid filename for add: '%s'", fn)
+	}
+
+	if bnd.Manifest.Digests == nil {
+		bnd.Manifest.Digests = make(map[string]hash.Hash)
+	}
+	if bnd.Data == nil {
+		bnd.Data = make(map[string][]byte)
+	}
+
+	h := hash.NewFromBytes(b)
+	bnd.Manifest.Digests[fn] = h
+	bnd.Data[fn] = append([]byte{}, b...) // Copy
+	return nil
+}
+
+// MrEnclave returns the MRENCLAVE of the SGX excutable.
+func (bnd *Bundle) MrEnclave() (*sgx.MrEnclave, error) {
+	if bnd.Manifest.SGX == nil {
+		return nil, fmt.Errorf("runtime/bundle: no SGX metadata")
+	}
+	d := bnd.Data[bnd.Manifest.SGX.Executable]
+	if len(d) == 0 {
+		return nil, fmt.Errorf("runtime/bundle: no SGX executable")
+	}
+
+	var mrEnclave sgx.MrEnclave
+	if err := mrEnclave.FromSgxs(bytes.NewReader(d)); err != nil {
+		return nil, fmt.Errorf("runtime/bundle: failed to derive SGX MRENCLAVE: %w", err)
+	}
+
+	return &mrEnclave, nil
+}
+
+// Write serializes a runtime bundle to the on-disk representation.
+func (bnd *Bundle) Write(fn string) error {
+	// Ensure the bundle is well-formed.
+	if err := bnd.Validate(); err != nil {
+		return fmt.Errorf("runtime/bundle: refusing to write malformed bundle: %w", err)
+	}
+
+	// Serialize the manifest.
+	rawManifest, err := json.Marshal(bnd.Manifest)
+	if err != nil {
+		return fmt.Errorf("runtime/bundle: failed to serialize manifest: %w", err)
+	}
+	if bnd.Data[manifestName] != nil {
+		// While this is "ok", instead of trying to figure out if the
+		// deserialized manifest matches the serialied one, just bail.
+		return fmt.Errorf("runtime/bundle: data contains manifest entry")
+	}
+
+	// Write out the archive to a in-memory buffer, taking care to ensure
+	// that the manifest is the 0th entry.
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+	type writeFile struct {
+		fn string
+		b  []byte
+	}
+	writeFiles := []writeFile{
+		{
+			fn: manifestName,
+			b:  rawManifest,
+		},
+	}
+	for f := range bnd.Data {
+		writeFiles = append(writeFiles, writeFile{
+			fn: f,
+			b:  bnd.Data[f],
+		})
+	}
+	for _, f := range writeFiles {
+		fw, wErr := w.Create(f.fn)
+		if wErr != nil {
+			return fmt.Errorf("runtime/bundle: failed to create file '%s': %w", f.fn, wErr)
+		}
+		if _, wErr = fw.Write(f.b); err != nil {
+			return fmt.Errorf("runtime/bundle: failed to write file '%s': %w", f.fn, wErr)
+		}
+	}
+	if err = w.Close(); err != nil {
+		return fmt.Errorf("runtime/bundle: failed to finalize bundle: %w", err)
+	}
+
+	if err = os.WriteFile(fn, buf.Bytes(), 0o600); err != nil {
+		return fmt.Errorf("runtime/bundle: failed to write bundle: %w", err)
+	}
+
+	return nil
+}
+
+// ExplodedPath returns the path that the corresponding asset will be
+// written to via WriteExploded.
+func (bnd *Bundle) ExplodedPath(dataDir, fn string) string {
+	// DATADIR/runtimes/bundles/runtimeID-version
+	subDir := filepath.Join(dataDir, "runtimes", "bundles",
+		fmt.Sprintf("%s-%s", bnd.Manifest.ID, bnd.Manifest.Version),
+	)
+
+	if fn == "" {
+		return subDir
+	}
+	return filepath.Join(subDir, fn)
+}
+
+// WriteExploded writes the extracted runtime bundle to the appropriate
+// location under the specified data directory.
+func (bnd *Bundle) WriteExploded(dataDir string) error {
+	if err := bnd.Validate(); err != nil {
+		return fmt.Errorf("runtime/bundle: refusing to explode malformed bundle: %w", err)
+	}
+
+	subDir := bnd.ExplodedPath(dataDir, "")
+
+	// Check to see if we have done this before, and be nice to SSDs by
+	// just verifying extracted data for correctness.
+	switch _, err := os.Stat(subDir); err {
+	case nil:
+		// Validate that the on-disk assets match the bundle contents.
+		//
+		// Note: This ignores extra garbage that may be on disk, but
+		// people that mess with internal directories get what they
+		// deserve.
+		for fn, expected := range bnd.Data {
+			fn = bnd.ExplodedPath(dataDir, fn)
+			b, rdErr := os.ReadFile(fn)
+			if rdErr != nil {
+				return fmt.Errorf("runtime/bundle: failed to re-load asset '%s': %w", fn, rdErr)
+			}
+			if !bytes.Equal(b, expected) {
+				return fmt.Errorf("runtime/bundle: corrupt asset: '%s'", fn)
+			}
+		}
+	default:
+		// Extract the bundle to disk.
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("runtime/bundle: failed to stat asset directory '%s': %w", subDir, err)
+		}
+
+		for _, v := range []string{
+			subDir,
+			bnd.ExplodedPath(dataDir, manifestPath),
+		} {
+			if err = os.MkdirAll(v, 0o700); err != nil {
+				return fmt.Errorf("runtime/bundle: failed to create asset sub-dir '%s': %w", v, err)
+			}
+		}
+		for fn, data := range bnd.Data {
+			fn = bnd.ExplodedPath(dataDir, fn)
+			if err = os.WriteFile(fn, data, 0o600); err != nil {
+				return fmt.Errorf("runtime/bundle: failed to write asset '%s': %w", fn, err)
+			}
+		}
+
+		if bnd.Manifest.Executable != "" {
+			if err := os.Chmod(bnd.ExplodedPath(dataDir, bnd.Manifest.Executable), 0o700); err != nil {
+				return fmt.Errorf("runtime/bundle: failed to fixup executable permissions: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Close closes the bundle, releasing resources.
+func (bnd *Bundle) Close() error {
+	bnd.Manifest = nil
+	bnd.Data = nil
+	return nil
+}
+
+// Open opens and validates a runtime bundle instance.
+func Open(fn string) (*Bundle, error) {
+	r, err := zip.OpenReader(fn)
+	if err != nil {
+		return nil, fmt.Errorf("runtime/bundle: failed to open bundle: %w", err)
+	}
+	defer r.Close()
+
+	// Read the contents.
+	//
+	// Note: This extracts everything into memory, which is somewhat
+	// expensive if it turns out the contents aren't needed.
+	data := make(map[string][]byte)
+	for i, v := range r.File {
+		// Sanitize the file name by ensuring that all names are rooted
+		// at the correct location.
+		switch i {
+		case 0:
+			// Much like the JAR files, the manifest MUST come first.
+			if v.Name != manifestName {
+				return nil, fmt.Errorf("runtime/bundle: invalid manifest file name: '%s'", v.Name)
+			}
+		default:
+			if filepath.Dir(v.Name) != "." {
+				return nil, fmt.Errorf("runtime/bundle: failed to sanitize path '%s'", v.Name)
+			}
+		}
+
+		// Extract every file into memory.
+		rd, rdErr := v.Open()
+		if rdErr != nil {
+			return nil, fmt.Errorf("runtime/bundle: failed to open '%s': %w", v.Name, rdErr)
+		}
+		defer rd.Close()
+
+		b, rdErr := io.ReadAll(rd)
+		if err != nil {
+			return nil, fmt.Errorf("runtime/bundle: failed to read '%s': %w", v.Name, rdErr)
+		}
+
+		data[v.Name] = b
+	}
+
+	// Decode the manifest.
+	var manifest Manifest
+	b, ok := data[manifestName]
+	if !ok {
+		return nil, fmt.Errorf("runtime/bundle: missing manifest")
+	}
+	if err = json.Unmarshal(b, &manifest); err != nil {
+		return nil, fmt.Errorf("runtime/bundle: failed to parse manifest: %w", err)
+	}
+
+	// Ensure the bundle is well-formed.
+	bnd := &Bundle{
+		Manifest: &manifest,
+		Data:     data,
+	}
+	if err = bnd.Validate(); err != nil {
+		return nil, err
+	}
+
+	return bnd, nil
+}

--- a/go/runtime/bundle/bundle.go
+++ b/go/runtime/bundle/bundle.go
@@ -25,6 +25,7 @@ func (bnd *Bundle) Validate() error {
 	// Ensure all the files in the manifest are present.
 	type bundleFile struct {
 		descr, fn string
+		optional  bool
 	}
 	needFiles := []bundleFile{
 		{
@@ -40,14 +41,18 @@ func (bnd *Bundle) Validate() error {
 					fn:    sgx.Executable,
 				},
 				{
-					descr: "SGX signature",
-					fn:    sgx.Signature,
+					descr:    "SGX signature",
+					fn:       sgx.Signature,
+					optional: true,
 				},
 			}...,
 		)
 	}
 	for _, v := range needFiles {
 		if v.fn == "" {
+			if v.optional {
+				continue
+			}
 			return fmt.Errorf("runtime/bundle: missing %s in manifest", v.descr)
 		}
 		if len(bnd.Data[v.fn]) == 0 {

--- a/go/runtime/bundle/bundle_test.go
+++ b/go/runtime/bundle/bundle_test.go
@@ -1,0 +1,76 @@
+package bundle
+
+import (
+	"crypto/rand"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+)
+
+func TestBundle(t *testing.T) {
+	// Create a synthetic bundle.
+	//
+	// Assets will be populated during the Add/Write combined test.
+	tmpDir := t.TempDir()
+	bundleFn := filepath.Join(tmpDir, "bundle.orc")
+	manifest := &Manifest{
+		Name: "test-runtime",
+		ID: func() common.Namespace {
+			var id common.Namespace
+			if err := id.UnmarshalHex("c000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff"); err != nil {
+				panic("failed to unmarshal id")
+			}
+			return id
+		}(),
+		Executable: "runtime.bin",
+		SGX: &SGXMetadata{
+			Executable: "runtime.sgx",
+		},
+	}
+	bundle := &Bundle{
+		Manifest: manifest,
+	}
+
+	t.Run("Add_Write", func(t *testing.T) {
+		// Generate random assets.
+		randomBuffer := func() []byte {
+			b := make([]byte, 1024*256)
+			_, err := rand.Read(b)
+			require.NoError(t, err, "rand.Read")
+			return b
+		}
+
+		err := bundle.Add(manifest.Executable, randomBuffer())
+		require.NoError(t, err, "bundle.Add(elf)")
+		err = bundle.Add(manifest.SGX.Executable, randomBuffer())
+		require.NoError(t, err, "bundle.Add(sgx)")
+
+		err = bundle.Write(bundleFn)
+		require.NoError(t, err, "bundle.Write")
+	})
+
+	t.Run("Open", func(t *testing.T) {
+		bundle2, err := Open(bundleFn)
+		require.NoError(t, err, "Open")
+
+		// Ignore the manifest, the bundle we used to create the file
+		// will not have it.
+		delete(bundle2.Manifest.Digests, manifestName)
+		delete(bundle2.Data, manifestName)
+
+		require.EqualValues(t, bundle, bundle2, "opened bundle mismatch")
+	})
+
+	t.Run("Explode", func(t *testing.T) {
+		err := bundle.WriteExploded(tmpDir)
+		require.NoError(t, err, "WriteExploded")
+
+		// Abuse the fact that we do an integrity check if the bundle
+		// is already exploded.
+		err = bundle.WriteExploded(tmpDir)
+		require.NoError(t, err, "WriteExploded(again)")
+	})
+}

--- a/go/runtime/bundle/manifest.go
+++ b/go/runtime/bundle/manifest.go
@@ -1,0 +1,43 @@
+package bundle
+
+import (
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
+)
+
+const (
+	manifestPath = "META-INF"
+	manifestName = manifestPath + "/MANIFEST.MF"
+)
+
+// Manifest is a deserialized runtime bundle manifest.
+type Manifest struct {
+	// Name is the optional human readable runtime name.
+	Name string `json:"name,omitempty"`
+
+	// ID is the runtime ID.
+	ID common.Namespace `json:"id"`
+
+	// Version is the runtime version.
+	Version version.Version `json:"version,omitempty"`
+
+	// Executable is the name of the runtime ELF executable file.
+	Executable string `json:"executable"`
+
+	// SGX is the SGX specific manifest metadata if any.
+	SGX *SGXMetadata `json:"sgx,omitempty"`
+
+	// Digests is the cryptographic digests of the bundle contents,
+	// excluding the manifest.
+	Digests map[string]hash.Hash `json:"digests"`
+}
+
+// SGXMetadata is the SGX specific manifest metadata.
+type SGXMetadata struct {
+	// Executable is the name of the SGX enclave executable file.
+	Executable string `json:"executable"`
+
+	// Signature is the name of the SGX enclave signature file.
+	Signature string `json:"signature"`
+}

--- a/go/runtime/host/host.go
+++ b/go/runtime/host/host.go
@@ -8,18 +8,14 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
+	"github.com/oasisprotocol/oasis-core/go/runtime/bundle"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 )
 
 // Config contains common configuration for the provisioned runtime.
 type Config struct {
-	// RuntimeID is the unique runtime identifier.
-	RuntimeID common.Namespace
-
-	// Path is the path to the resource required for provisioning a runtime. This can be an ELF
-	// binary, an SGXS binary or even a VM image. The semantics of this field are entirely up to the
-	// used provisioner.
-	Path string
+	// Bundle is the runtime bundle.
+	Bundle *RuntimeBundle
 
 	// Extra is an optional provisioner-specific configuration.
 	Extra interface{}
@@ -29,6 +25,14 @@ type Config struct {
 
 	// LocalConfig is the node-local runtime configuration.
 	LocalConfig map[string]interface{}
+}
+
+// RuntimeBundle is a exploded runtime bundle ready for execution.
+type RuntimeBundle struct {
+	*bundle.Bundle
+
+	// Exeuctable is the path to the extracted ELF or TEE executable.
+	Path string
 }
 
 // Provisioner is the runtime provisioner interface.

--- a/go/runtime/host/mock/mock.go
+++ b/go/runtime/host/mock/mock.go
@@ -27,7 +27,7 @@ var CheckTxFailInput = []byte("checktx-mock-fail")
 // Implements host.Provisioner.
 func (p *provisioner) NewRuntime(ctx context.Context, cfg host.Config) (host.Runtime, error) {
 	r := &runtime{
-		runtimeID: cfg.RuntimeID,
+		runtimeID: cfg.Bundle.Manifest.ID,
 		notifier:  pubsub.NewBroker(false),
 	}
 	return r, nil

--- a/go/runtime/host/sandbox/sandbox_test.go
+++ b/go/runtime/host/sandbox/sandbox_test.go
@@ -4,25 +4,34 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	tendermint "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	"github.com/oasisprotocol/oasis-core/go/runtime/bundle"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/tests"
 )
 
-var envRuntimePath = os.Getenv("OASIS_TEST_RUNTIME_HOST_RUNTIME_PATH")
+var envRuntimePath = os.Getenv("OASIS_TEST_RUNTIME_HOST_BUNDLE_PATH")
 
 func TestProvisionerSandbox(t *testing.T) {
 	const bwrapPath = "/usr/bin/bwrap" // Sensible systems only.
 
 	// Skip test if there is no runtime configured.
 	if envRuntimePath == "" {
-		t.Skip("skipping as OASIS_TEST_RUNTIME_HOST_RUNTIME_PATH is not set")
+		t.Skip("skipping as OASIS_TEST_RUNTIME_HOST_BUNDLE_PATH is not set")
 	}
 
+	bnd, err := bundle.Open(envRuntimePath)
+	require.NoError(t, err, "bundle.Open")
+
 	cfg := host.Config{
-		Path: envRuntimePath,
+		Bundle: &host.RuntimeBundle{
+			Bundle: bnd,
+			Path:   envRuntimePath,
+		},
 	}
 
 	t.Run("Naked", func(t *testing.T) {

--- a/go/runtime/host/sgx/sgx.go
+++ b/go/runtime/host/sgx/sgx.go
@@ -106,7 +106,7 @@ func (s *sgxProvisioner) loadEnclaveBinaries(rtCfg host.Config) ([]byte, []byte,
 		err         error
 	)
 
-	if sgxs, err = ioutil.ReadFile(rtCfg.Path); err != nil {
+	if sgxs, err = ioutil.ReadFile(rtCfg.Bundle.Path); err != nil {
 		return nil, nil, fmt.Errorf("failed to load enclave: %w", err)
 	}
 	if err = enclaveHash.FromSgxsBytes(sgxs); err != nil {

--- a/go/runtime/host/sgx/sgx_test.go
+++ b/go/runtime/host/sgx/sgx_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	tendermint "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
 	iasHttp "github.com/oasisprotocol/oasis-core/go/ias/http"
+	"github.com/oasisprotocol/oasis-core/go/runtime/bundle"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/tests"
@@ -23,14 +24,14 @@ import (
 const recvTimeout = 120 * time.Second
 
 var (
-	envRuntimePath       = os.Getenv("OASIS_TEST_RUNTIME_HOST_SGX_RUNTIME_PATH")
+	envRuntimePath       = os.Getenv("OASIS_TEST_RUNTIME_HOST_BUNDLE_PATH")
 	envRuntimeLoaderPath = os.Getenv("OASIS_TEST_RUNTIME_HOST_SGX_LOADER_PATH")
 )
 
 func skipIfMissingDeps(t *testing.T) {
 	// Skip test if there is no runtime configured.
 	if envRuntimePath == "" {
-		t.Skip("skipping as OASIS_TEST_RUNTIME_HOST_SGX_RUNTIME_PATH is not set")
+		t.Skip("skipping as OASIS_TEST_RUNTIME_HOST_BUNDLE_PATH is not set")
 	}
 
 	// Skip test if there is no runtime loader configured.
@@ -46,8 +47,14 @@ func TestProvisionerSGX(t *testing.T) {
 
 	require := require.New(t)
 
+	bnd, err := bundle.Open(envRuntimePath)
+	require.NoError(err, "bundle.Open")
+
 	cfg := host.Config{
-		Path: envRuntimePath,
+		Bundle: &host.RuntimeBundle{
+			Bundle: bnd,
+			Path:   envRuntimePath,
+		},
 	}
 
 	ias, err := iasHttp.New(&iasHttp.Config{

--- a/go/runtime/registry/registry.go
+++ b/go/runtime/registry/registry.go
@@ -585,7 +585,7 @@ func newRuntime(
 
 // New creates a new runtime registry.
 func New(ctx context.Context, dataDir string, consensus consensus.Backend, identity *identity.Identity, ias ias.Endpoint) (Registry, error) {
-	cfg, err := newConfig(consensus, ias)
+	cfg, err := newConfig(dataDir, consensus, ias)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/src/consensus/tendermint/verifier.rs
+++ b/runtime/src/consensus/tendermint/verifier.rs
@@ -252,11 +252,7 @@ impl Verifier {
                 return Ok(state);
             }
 
-            // Header is for the same round but it doesn't match. Looks like something funny is
-            // going on -- abort.
-            return Err(Error::VerificationFailed(anyhow!(
-                "header does not match previously seen header for the same round"
-            )));
+            // Force full verification in case of cache mismatch.
         }
 
         // Verify that the state root matches.

--- a/tests/runtimes/simple-keymanager/src/main.rs
+++ b/tests/runtimes/simple-keymanager/src/main.rs
@@ -1,15 +1,24 @@
 use oasis_core_keymanager_lib::keymanager::*;
-use oasis_core_runtime::{common::version::Version, config::Config, version_from_cargo};
+use oasis_core_runtime::{common::version::Version, config::Config};
 
 mod api;
 
-pub fn main() {
+pub fn main_with_version(version: Version) {
     let init = new_keymanager(api::trusted_policy_signers());
     oasis_core_runtime::start_runtime(
         init,
         Config {
-            version: version_from_cargo!(),
+            version,
             ..Default::default()
         },
     );
+}
+
+#[allow(dead_code)]
+pub fn main() {
+    main_with_version(Version {
+        major: 0,
+        minor: 0,
+        patch: 0,
+    })
 }

--- a/tests/runtimes/simple-keymanager/src/upgraded.rs
+++ b/tests/runtimes/simple-keymanager/src/upgraded.rs
@@ -1,6 +1,12 @@
+use oasis_core_runtime::common::version::Version;
+
 #[path = "main.rs"]
 mod real_main;
 
 fn main() {
-    real_main::main()
+    real_main::main_with_version(Version {
+        major: 0,
+        minor: 1,
+        patch: 0,
+    })
 }

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -23,7 +23,7 @@ use oasis_core_runtime::{
         Context as TxnContext,
     },
     types::{CheckTxResult, Error as RuntimeError, FeatureScheduleControl, Features},
-    version_from_cargo, Protocol, RpcDemux, RpcDispatcher, TxnDispatcher,
+    Protocol, RpcDemux, RpcDispatcher, TxnDispatcher,
 };
 use simple_keymanager::trusted_policy_signers;
 
@@ -287,7 +287,7 @@ impl TxnDispatcher for Dispatcher {
     fn set_abort_batch_flag(&mut self, _abort_batch: Arc<AtomicBool>) {}
 }
 
-pub fn main() {
+pub fn main_with_version(version: Version) {
     // Initializer.
     let init = |protocol: &Arc<Protocol>,
                 rak: &Arc<RAK>,
@@ -336,7 +336,7 @@ pub fn main() {
     oasis_core_runtime::start_runtime(
         Box::new(init),
         Config {
-            version: version_from_cargo!(),
+            version,
             trust_root,
             features: Some(Features {
                 // Enable the schedule control feature.
@@ -347,4 +347,13 @@ pub fn main() {
             ..Default::default()
         },
     );
+}
+
+#[allow(dead_code)]
+pub fn main() {
+    main_with_version(Version {
+        major: 0,
+        minor: 0,
+        patch: 0,
+    })
 }

--- a/tests/runtimes/simple-keyvalue/src/upgraded.rs
+++ b/tests/runtimes/simple-keyvalue/src/upgraded.rs
@@ -1,6 +1,12 @@
+use oasis_core_runtime::common::version::Version;
+
 #[path = "main.rs"]
 mod real_main;
 
 fn main() {
-    real_main::main()
+    real_main::main_with_version(Version {
+        major: 0,
+        minor: 1,
+        patch: 0,
+    })
 }


### PR DESCRIPTION
 * [x] Define the file format
 * [x] Implement the file format
 * [x] Switch the providers to use the file format
 * [x] Write a tool to create files in the format
 * [x] Unbreak the e2e tests
    * [x] Everything that isn't the runtime trust root test
    * [x] The runtime trust root test

Test support was implemented in the worst possible way, in an attempt to minimize code changes by having the test harness dynamically generate the runtime bundles when provisioning the network.  While it is possible to make the tests actually use pre-generated bundles, there are a handful of tests that create arbitrary runtimes as part of the test process, which will complicate matters.

Implements #4469