### PR TITLE
[BACKPORT/21.3.x] go/common/cbor: Bump decoding limits for RPC

### DIFF
--- a/.changelog/4478.feature.md
+++ b/.changelog/4478.feature.md
@@ -1,0 +1,1 @@
+go/common/cbor: Bump decoding limits for RPC

--- a/go/common/grpc/cbor.go
+++ b/go/common/grpc/cbor.go
@@ -17,7 +17,7 @@ func (c *CBORCodec) Marshal(v interface{}) ([]byte, error) {
 }
 
 func (c *CBORCodec) Unmarshal(data []byte, v interface{}) error {
-	return cbor.Unmarshal(data, v)
+	return cbor.UnmarshalHigherLimits(data, v)
 }
 
 func (c *CBORCodec) Name() string {


### PR DESCRIPTION
A non-breaking backport of #4478.