### PR TITLE
runtime: allow SW_HARDENING_NEEDED IAS quote status

### DIFF
--- a/.changelog/4491.bugfix.md
+++ b/.changelog/4491.bugfix.md
@@ -1,0 +1,1 @@
+Allow launching enclaves with `SW_HARDENING_NEEDED` quote status

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -478,15 +478,15 @@ type SGXConstraints struct {
 	// AllowedQuoteStatuses are the allowed quote statuses for the node
 	// to be scheduled as a compute worker.
 	//
-	// Note: QuoteOK is ALWAYS allowed, and does not need to be specified.
+	// Note: QuoteOK and QuoteSwHardeningNeeded are ALWAYS allowed, and do not need to be specified.
 	AllowedQuoteStatuses []ias.ISVEnclaveQuoteStatus `json:"allowed_quote_statuses,omitempty"`
 }
 
 func (constraints *SGXConstraints) quoteStatusAllowed(avr *ias.AttestationVerificationReport) bool {
 	status := avr.ISVEnclaveQuoteStatus
 
-	// Always allow "OK".
-	if status == ias.QuoteOK {
+	// Always allow "OK" and "SW_HARDENING_NEEDED".
+	if status == ias.QuoteOK || status == ias.QuoteSwHardeningNeeded {
 		return true
 	}
 

--- a/runtime/src/common/sgx/avr.rs
+++ b/runtime/src/common/sgx/avr.rs
@@ -253,11 +253,8 @@ pub fn verify(avr: &AVR) -> Result<AuthenticatedAVR> {
 
     let quote_status = avr_body.isv_enclave_quote_status()?;
     match quote_status.as_str() {
-        "OK" => {}
-        "GROUP_OUT_OF_DATE"
-        | "CONFIGURATION_NEEDED"
-        | "SW_HARDENING_NEEDED"
-        | "CONFIGURATION_AND_SW_HARDENING_NEEDED" => {
+        "OK" | "SW_HARDENING_NEEDED" => {}
+        "GROUP_OUT_OF_DATE" | "CONFIGURATION_NEEDED" | "CONFIGURATION_AND_SW_HARDENING_NEEDED" => {
             if !unsafe_lax_avr_verification {
                 return Err(AVRError::QuoteStatusInvalid {
                     status: quote_status.to_owned(),


### PR DESCRIPTION
`SW_HARDENING_NEEDED` should be allowed since it only indicates that additional SW hardening might be needed for the platform.
Discovered this in the failing SGX E2E: due to INTEL-SA-00334 (which is overed by https://github.com/oasisprotocol/oasis-core/issues/2987)