### PR TITLE
github/ci-lint: cancel concurrent in-progress workflows on same branch

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -15,6 +15,11 @@ on:
       - master
       - stable/*
 
+# Cancel in progress jobs on new pushes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     # NOTE: This name appears in GitHub's Checks API.


### PR DESCRIPTION
Default behavior is that in-progress runs are not canceled (e.g. when pushing new changes to a branch).