### PR TITLE
go/runtime/host/multi: Release lock before calling into runtime

### DIFF
--- a/.changelog/4538.bugfix.md
+++ b/.changelog/4538.bugfix.md
@@ -1,0 +1,1 @@
+go/runtime/host/multi: Release lock before calling into runtime


### PR DESCRIPTION
Identified on the Testnet, triggered on client nodes.