### PR TITLE
go/logging: libp2p log adapter

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -227,8 +227,6 @@ steps:
       # runs only on non-SGX agents.
       OASIS_EXCLUDE_E2E: e2e/runtime/trust-root,e2e/runtime/txsource-multi-short
       TEST_BASE_DIR: /tmp
-      # libp2p logging.
-      IPFS_LOGGING: debug
     retry:
       <<: *retry_agent_failure
     plugins:
@@ -251,8 +249,6 @@ steps:
     env:
       OASIS_E2E_COVERAGE: enable
       TEST_BASE_DIR: /tmp
-      # libp2p logging.
-      IPFS_LOGGING: debug
     agents:
       buildkite_agent_class: ephemeral # XXX: Use a dedicated tag instead.
     retry:
@@ -287,8 +283,6 @@ steps:
       OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES: "1"
       OASIS_E2E_COVERAGE: enable
       TEST_BASE_DIR: /tmp
-      # libp2p logging.
-      IPFS_LOGGING: debug
     agents:
       queue: intel-sgx
     retry:
@@ -320,8 +314,6 @@ steps:
       OASIS_E2E_COVERAGE: enable
       OASIS_EXCLUDE_E2E: e2e/runtime/txsource-multi,e2e/runtime/txsource-multi-short
       TEST_BASE_DIR: /tmp
-      # libp2p logging.
-      IPFS_LOGGING: debug
     agents:
       queue: intel-sgx
     retry:
@@ -347,8 +339,6 @@ steps:
     env:
       OASIS_E2E_COVERAGE: enable
       TEST_BASE_DIR: /tmp
-      # libp2p logging.
-      IPFS_LOGGING: debug
     agents:
       queue: intel-sgx
     retry:

--- a/.buildkite/longtests.pipeline.yml
+++ b/.buildkite/longtests.pipeline.yml
@@ -88,8 +88,6 @@ steps:
       - .buildkite/scripts/daily_txsource.sh --e2e/runtime.epoch.interval=${epochtime_inverval}
     env:
       TEST_BASE_DIR: /var/tmp/longtests
-      # libp2p logging.
-      IPFS_LOGGING: debug
     agents:
       daily: true
     # NOTE: we actually don't want to retry, but this is the only way that we

--- a/.changelog/4531.internal.md
+++ b/.changelog/4531.internal.md
@@ -1,0 +1,1 @@
+go: `libp2p` logs are now emitted via oasis-node logging system

--- a/go/common/logging/zap.go
+++ b/go/common/logging/zap.go
@@ -1,0 +1,281 @@
+package logging
+
+import (
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"go.uber.org/zap/zapcore"
+)
+
+// objectEncoder is an ObjectEncoder backed by a memory array inspired by
+// https://github.com/uber-go/zap/blob/6f34060764b5ea1367eecda380ba8a9a0de3f0e6/zapcore/memory_encoder.go#L28.
+type objectEncoder struct {
+	// fields contains the entire encoded log context.
+	fields []interface{}
+
+	// Current namespace.
+	currNs string
+}
+
+// AddArray implements ObjectEncoder.
+func (m *objectEncoder) AddArray(key string, v zapcore.ArrayMarshaler) error {
+	arr := &sliceArrayEncoder{elems: make([]interface{}, 0)}
+	if err := v.MarshalLogArray(arr); err != nil {
+		return err
+	}
+	m.fields = append(m.fields, key, arr.elems)
+	return nil
+}
+
+// AddObject implements ObjectEncoder.
+func (m *objectEncoder) AddObject(k string, v zapcore.ObjectMarshaler) error {
+	newMap := &objectEncoder{}
+	if err := v.MarshalLogObject(newMap); err != nil {
+		return err
+	}
+	m.fields = append(m.fields, m.namespaced(k), newMap.fields)
+	return nil
+}
+
+// AddBinary implements ObjectEncoder.
+func (m *objectEncoder) AddBinary(k string, v []byte) {
+	m.fields = append(m.fields, m.namespaced(k), v)
+}
+
+// AddByteString implements ObjectEncoder.
+func (m *objectEncoder) AddByteString(k string, v []byte) {
+	m.fields = append(m.fields, m.namespaced(k), string(v))
+}
+
+// AddBool implements ObjectEncoder.
+func (m *objectEncoder) AddBool(k string, v bool) { m.fields = append(m.fields, m.namespaced(k), v) }
+
+// AddDuration implements ObjectEncoder.
+func (m *objectEncoder) AddDuration(k string, v time.Duration) {
+	m.fields = append(m.fields, m.namespaced(k), v)
+}
+
+// AddComplex128 implements ObjectEncoder.
+func (m *objectEncoder) AddComplex128(k string, v complex128) {
+	m.fields = append(m.fields, m.namespaced(k), v)
+}
+
+// AddComplex64 implements ObjectEncoder.
+func (m *objectEncoder) AddComplex64(k string, v complex64) {
+	m.fields = append(m.fields, m.namespaced(k), v)
+}
+
+// AddFloat64 implements ObjectEncoder.
+func (m *objectEncoder) AddFloat64(k string, v float64) {
+	m.fields = append(m.fields, m.namespaced(k), v)
+}
+
+// AddFloat32 implements ObjectEncoder.
+func (m *objectEncoder) AddFloat32(k string, v float32) {
+	m.fields = append(m.fields, m.namespaced(k), v)
+}
+
+// AddInt implements ObjectEncoder.
+func (m *objectEncoder) AddInt(k string, v int) { m.fields = append(m.fields, m.namespaced(k), v) }
+
+// AddInt64 implements ObjectEncoder.
+func (m *objectEncoder) AddInt64(k string, v int64) { m.fields = append(m.fields, m.namespaced(k), v) }
+
+// AddInt32 implements ObjectEncoder.
+func (m *objectEncoder) AddInt32(k string, v int32) { m.fields = append(m.fields, m.namespaced(k), v) }
+
+// AddInt16 implements ObjectEncoder.
+func (m *objectEncoder) AddInt16(k string, v int16) { m.fields = append(m.fields, m.namespaced(k), v) }
+
+// AddInt8 implements ObjectEncoder.
+func (m *objectEncoder) AddInt8(k string, v int8) { m.fields = append(m.fields, m.namespaced(k), v) }
+
+// AddString implements ObjectEncoder.
+func (m *objectEncoder) AddString(k string, v string) {
+	m.fields = append(m.fields, m.namespaced(k), v)
+}
+
+// AddTime implements ObjectEncoder.
+func (m *objectEncoder) AddTime(k string, v time.Time) {
+	m.fields = append(m.fields, m.namespaced(k), v)
+}
+
+// AddUint implements ObjectEncoder.
+func (m *objectEncoder) AddUint(k string, v uint) { m.fields = append(m.fields, m.namespaced(k), v) }
+
+// AddUint64 implements ObjectEncoder.
+func (m *objectEncoder) AddUint64(k string, v uint64) {
+	m.fields = append(m.fields, m.namespaced(k), v)
+}
+
+// AddUint32 implements ObjectEncoder.
+func (m *objectEncoder) AddUint32(k string, v uint32) {
+	m.fields = append(m.fields, m.namespaced(k), v)
+}
+
+// AddUint16 implements ObjectEncoder.
+func (m *objectEncoder) AddUint16(k string, v uint16) {
+	m.fields = append(m.fields, m.namespaced(k), v)
+}
+
+// AddUint8 implements ObjectEncoder.
+func (m *objectEncoder) AddUint8(k string, v uint8) { m.fields = append(m.fields, m.namespaced(k), v) }
+
+// AddUintptr implements ObjectEncoder.
+func (m *objectEncoder) AddUintptr(k string, v uintptr) {
+	m.fields = append(m.fields, m.namespaced(k), v)
+}
+
+// AddReflected implements ObjectEncoder.
+func (m *objectEncoder) AddReflected(k string, v interface{}) error {
+	m.fields = append(m.fields, m.namespaced(k), v)
+	return nil
+}
+
+// OpenNamespace implements ObjectEncoder.
+func (m *objectEncoder) OpenNamespace(k string) {
+	if m.currNs == "" {
+		m.currNs = k
+	} else {
+		m.currNs += "_" + k
+	}
+}
+
+func (m *objectEncoder) namespaced(k string) string {
+	if m.currNs == "" {
+		return k
+	}
+	return m.currNs + "_" + k
+}
+
+// sliceArrayEncoder is an ArrayEncoder backed by a simple []interface{}.
+type sliceArrayEncoder struct {
+	elems []interface{}
+}
+
+func (s *sliceArrayEncoder) AppendArray(v zapcore.ArrayMarshaler) error {
+	enc := &sliceArrayEncoder{}
+	err := v.MarshalLogArray(enc)
+	s.elems = append(s.elems, enc.elems)
+	return err
+}
+
+func (s *sliceArrayEncoder) AppendObject(v zapcore.ObjectMarshaler) error {
+	m := &objectEncoder{}
+	err := v.MarshalLogObject(m)
+	s.elems = append(s.elems, m.fields)
+	return err
+}
+
+func (s *sliceArrayEncoder) AppendReflected(v interface{}) error {
+	s.elems = append(s.elems, v)
+	return nil
+}
+
+func (s *sliceArrayEncoder) AppendBool(v bool)              { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendByteString(v []byte)      { s.elems = append(s.elems, string(v)) }
+func (s *sliceArrayEncoder) AppendComplex128(v complex128)  { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendComplex64(v complex64)    { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendDuration(v time.Duration) { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendFloat64(v float64)        { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendFloat32(v float32)        { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendInt(v int)                { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendInt64(v int64)            { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendInt32(v int32)            { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendInt16(v int16)            { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendInt8(v int8)              { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendString(v string)          { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendTime(v time.Time)         { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendUint(v uint)              { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendUint64(v uint64)          { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendUint32(v uint32)          { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendUint16(v uint16)          { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendUint8(v uint8)            { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendUintptr(v uintptr)        { s.elems = append(s.elems, v) }
+
+type zapCore struct {
+	logger *Logger
+
+	modulePrefix string
+
+	sync.Mutex
+	encoder *objectEncoder
+}
+
+func newZapCore(logger log.Logger, module string, unwind int) *zapCore {
+	log := &Logger{
+		logger: log.WithPrefix(logger, "module", module, "caller", log.Caller(unwind)),
+		module: module,
+	}
+	return &zapCore{
+		logger:       log,
+		modulePrefix: module + ":",
+		encoder:      &objectEncoder{},
+	}
+}
+
+// Implements zapcore.LevelEnabler.
+func (l *zapCore) Enabled(level zapcore.Level) bool {
+	switch level {
+	case zapcore.DebugLevel:
+		return l.logger.level <= LevelDebug
+	case zapcore.InfoLevel:
+		return l.logger.level <= LevelInfo
+	case zapcore.WarnLevel:
+		return l.logger.level <= LevelWarn
+	case zapcore.ErrorLevel:
+		return l.logger.level <= LevelError
+	default:
+		// DPanic, Panic, Fatal levels..
+		return l.logger.level <= LevelError
+	}
+}
+
+// Implements zapcore.Core.
+func (l *zapCore) With(fields []zapcore.Field) zapcore.Core {
+	l.Lock()
+	defer l.Unlock()
+
+	for _, field := range fields {
+		field.AddTo(l.encoder)
+	}
+	l.logger = l.logger.With(l.encoder.fields...)
+
+	return l
+}
+
+// Implements zapcore.Core.
+func (l *zapCore) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if !l.Enabled(e.Level) {
+		return nil
+	}
+	return ce.AddCore(e, l)
+}
+
+// Implements zapcore.Core.
+func (l *zapCore) Write(e zapcore.Entry, fields []zapcore.Field) error {
+	encoder := &objectEncoder{}
+	for _, field := range fields {
+		field.AddTo(encoder)
+	}
+
+	keyvals := append([]interface{}{"msg", e.Message, "module", l.modulePrefix + e.LoggerName}, encoder.fields...)
+	switch e.Level {
+	case zapcore.DebugLevel:
+		_ = level.Debug(l.logger.logger).Log(keyvals...)
+	case zapcore.InfoLevel:
+		_ = level.Info(l.logger.logger).Log(keyvals...)
+	case zapcore.WarnLevel:
+		_ = level.Warn(l.logger.logger).Log(keyvals...)
+	default:
+		_ = level.Error(l.logger.logger).Log(keyvals...)
+	}
+	return nil
+}
+
+// Implements zapcore.Core.
+func (l *zapCore) Sync() error {
+	return nil
+}

--- a/go/common/logging/zap_test.go
+++ b/go/common/logging/zap_test.go
@@ -1,0 +1,249 @@
+package logging
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/multierr"
+	"go.uber.org/zap/zapcore"
+)
+
+// Tests are based on: https://github.com/uber-go/zap/blob/master/zapcore/memory_encoder_test.go
+
+// maybeNamespace is an ObjectMarshaler that sometimes opens a namespace
+type maybeNamespace struct{ bool }
+
+func (m maybeNamespace) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("obj-out", "obj-outside-namespace")
+	if m.bool {
+		enc.OpenNamespace("obj-namespace")
+		enc.AddString("obj-in", "obj-inside-namespace")
+	}
+	return nil
+}
+
+// Nested Array- and ObjectMarshalers.
+type turducken struct{}
+
+func (t turducken) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	return enc.AddArray("ducks", zapcore.ArrayMarshalerFunc(func(arr zapcore.ArrayEncoder) error {
+		for i := 0; i < 2; i++ {
+			if err := arr.AppendObject(zapcore.ObjectMarshalerFunc(func(inner zapcore.ObjectEncoder) error {
+				inner.AddString("in", "chicken")
+				return nil
+			})); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+}
+
+type turduckens int
+
+func (t turduckens) MarshalLogArray(enc zapcore.ArrayEncoder) error {
+	var err error
+	tur := turducken{}
+	for i := 0; i < int(t); i++ {
+		err = multierr.Append(err, enc.AppendObject(tur))
+	}
+	return err
+}
+
+func TestObjectEncoder(t *testing.T) {
+	// Ensure our custom encoder encodes all types as expected.
+
+	expectedTur := []interface{}{
+		"ducks",
+		[]interface{}{
+			[]interface{}{"in", "chicken"},
+			[]interface{}{"in", "chicken"},
+		},
+	}
+	tests := []struct {
+		desc     string
+		f        func(zapcore.ObjectEncoder)
+		expected interface{}
+	}{
+		{
+			desc: "AddArray",
+			f: func(e zapcore.ObjectEncoder) {
+				assert.NoError(t, e.AddArray("k", zapcore.ArrayMarshalerFunc(func(arr zapcore.ArrayEncoder) error {
+					arr.AppendBool(true)
+					arr.AppendBool(false)
+					arr.AppendBool(true)
+					return nil
+				})), "Expected AddArray to succeed.")
+			},
+			expected: []interface{}{"k", []interface{}{true, false, true}},
+		},
+		{
+			desc: "AddArray (nested)",
+			f: func(e zapcore.ObjectEncoder) {
+				assert.NoError(t, e.AddArray("k", turduckens(2)), "Expected AddArray to succeed.")
+			},
+			expected: []interface{}{"k", []interface{}{expectedTur, expectedTur}},
+		},
+		{
+			desc: "AddArray (empty)",
+			f: func(e zapcore.ObjectEncoder) {
+				assert.NoError(t, e.AddArray("k", turduckens(0)), "Expected AddArray to succeed.")
+			},
+			expected: []interface{}{"k", []interface{}{}},
+		},
+		{
+			desc:     "AddBinary",
+			f:        func(e zapcore.ObjectEncoder) { e.AddBinary("k", []byte("foo")) },
+			expected: []interface{}{"k", []byte("foo")},
+		},
+		{
+			desc:     "AddByteString",
+			f:        func(e zapcore.ObjectEncoder) { e.AddByteString("k", []byte("foo")) },
+			expected: []interface{}{"k", "foo"},
+		},
+		{
+			desc:     "AddBool",
+			f:        func(e zapcore.ObjectEncoder) { e.AddBool("k", true) },
+			expected: []interface{}{"k", true},
+		},
+		{
+			desc:     "AddComplex128",
+			f:        func(e zapcore.ObjectEncoder) { e.AddComplex128("k", 1+2i) },
+			expected: []interface{}{"k", 1 + 2i},
+		},
+		{
+			desc:     "AddComplex64",
+			f:        func(e zapcore.ObjectEncoder) { e.AddComplex64("k", 1+2i) },
+			expected: []interface{}{"k", complex64(1 + 2i)},
+		},
+		{
+			desc:     "AddDuration",
+			f:        func(e zapcore.ObjectEncoder) { e.AddDuration("k", time.Millisecond) },
+			expected: []interface{}{"k", time.Millisecond},
+		},
+		{
+			desc:     "AddFloat64",
+			f:        func(e zapcore.ObjectEncoder) { e.AddFloat64("k", 3.14) },
+			expected: []interface{}{"k", 3.14},
+		},
+		{
+			desc:     "AddFloat32",
+			f:        func(e zapcore.ObjectEncoder) { e.AddFloat32("k", 3.14) },
+			expected: []interface{}{"k", float32(3.14)},
+		},
+		{
+			desc:     "AddInt",
+			f:        func(e zapcore.ObjectEncoder) { e.AddInt("k", 42) },
+			expected: []interface{}{"k", 42},
+		},
+
+		{
+			desc:     "AddInt64",
+			f:        func(e zapcore.ObjectEncoder) { e.AddInt64("k", 42) },
+			expected: []interface{}{"k", int64(42)},
+		},
+		{
+			desc:     "AddInt32",
+			f:        func(e zapcore.ObjectEncoder) { e.AddInt32("k", 42) },
+			expected: []interface{}{"k", int32(42)},
+		},
+
+		{
+			desc:     "AddInt16",
+			f:        func(e zapcore.ObjectEncoder) { e.AddInt16("k", 42) },
+			expected: []interface{}{"k", int16(42)},
+		},
+		{
+			desc:     "AddInt8",
+			f:        func(e zapcore.ObjectEncoder) { e.AddInt8("k", 42) },
+			expected: []interface{}{"k", int8(42)},
+		},
+
+		{
+			desc:     "AddString",
+			f:        func(e zapcore.ObjectEncoder) { e.AddString("k", "v") },
+			expected: []interface{}{"k", "v"},
+		},
+		{
+			desc:     "AddTime",
+			f:        func(e zapcore.ObjectEncoder) { e.AddTime("k", time.Unix(0, 100)) },
+			expected: []interface{}{"k", time.Unix(0, 100)},
+		},
+		{
+			desc:     "AddUint",
+			f:        func(e zapcore.ObjectEncoder) { e.AddUint("k", 42) },
+			expected: []interface{}{"k", uint(42)},
+		},
+		{
+			desc:     "AddUint64",
+			f:        func(e zapcore.ObjectEncoder) { e.AddUint64("k", 42) },
+			expected: []interface{}{"k", uint64(42)},
+		},
+		{
+			desc:     "AddUint32",
+			f:        func(e zapcore.ObjectEncoder) { e.AddUint32("k", 42) },
+			expected: []interface{}{"k", uint32(42)},
+		},
+		{
+			desc:     "AddUint16",
+			f:        func(e zapcore.ObjectEncoder) { e.AddUint16("k", 42) },
+			expected: []interface{}{"k", uint16(42)},
+		},
+		{
+			desc:     "AddUint8",
+			f:        func(e zapcore.ObjectEncoder) { e.AddUint8("k", 42) },
+			expected: []interface{}{"k", uint8(42)},
+		},
+		{
+			desc:     "AddUintptr",
+			f:        func(e zapcore.ObjectEncoder) { e.AddUintptr("k", 42) },
+			expected: []interface{}{"k", uintptr(42)},
+		},
+		{
+			desc: "AddReflected",
+			f: func(e zapcore.ObjectEncoder) {
+				assert.NoError(t, e.AddReflected("k", map[string]interface{}{"foo": 5}), "Expected AddReflected to succeed.")
+			},
+			expected: []interface{}{"k", map[string]interface{}{"foo": 5}},
+		},
+		{
+			desc: "OpenNamespace",
+			f: func(e zapcore.ObjectEncoder) {
+				e.OpenNamespace("k")
+				e.AddInt("foo", 1)
+				e.OpenNamespace("middle")
+				e.AddInt("foo", 2)
+				e.OpenNamespace("inner")
+				e.AddInt("foo", 3)
+			},
+			expected: []interface{}{"k_foo", 1, "k_middle_foo", 2, "k_middle_inner_foo", 3},
+		},
+		{
+			desc: "object (no nested namespace) then string",
+			f: func(e zapcore.ObjectEncoder) {
+				e.OpenNamespace("k")
+				_ = e.AddObject("obj", maybeNamespace{false})
+				e.AddString("not-obj", "should-be-outside-obj")
+			},
+			expected: []interface{}{"k_obj", []interface{}{"obj-out", "obj-outside-namespace"}, "k_not-obj", "should-be-outside-obj"},
+		},
+		{
+			desc: "object (with nested namespace) then string",
+			f: func(e zapcore.ObjectEncoder) {
+				e.OpenNamespace("k")
+				_ = e.AddObject("obj", maybeNamespace{true})
+				e.AddString("not-obj", "should-be-outside-obj")
+			},
+			expected: []interface{}{"k_obj", []interface{}{"obj-out", "obj-outside-namespace", "obj-namespace_obj-in", "obj-inside-namespace"}, "k_not-obj", "should-be-outside-obj"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			enc := &objectEncoder{}
+			tt.f(enc)
+			assert.Equal(t, tt.expected, enc.fields, "Unexpected encoder output.")
+		})
+	}
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/hpcloud/tail v1.0.0
 	github.com/ianbruene/go-difflib v1.2.0
+	github.com/ipfs/go-log/v2 v2.5.0
 	github.com/libp2p/go-libp2p v0.18.0-rc4
 	github.com/libp2p/go-libp2p-core v0.14.0
 	github.com/libp2p/go-libp2p-pubsub v0.6.1
@@ -55,7 +56,8 @@ require (
 	github.com/tendermint/tm-db v0.6.6
 	github.com/thepudds/fzgo v0.2.2
 	github.com/tyler-smith/go-bip39 v1.1.0
-	github.com/whyrusleeping/go-logging v0.0.1
+	go.uber.org/multierr v1.7.0
+	go.uber.org/zap v1.19.1
 	golang.org/x/crypto v0.0.0-20210915214749-c084706c2272
 	golang.org/x/net v0.0.0-20211005001312-d4b1ae081e3b
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa
@@ -114,7 +116,6 @@ require (
 	github.com/ipfs/go-datastore v0.5.0 // indirect
 	github.com/ipfs/go-ipfs-util v0.0.2 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
-	github.com/ipfs/go-log/v2 v2.5.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jbenet/goprocess v0.1.4 // indirect
@@ -213,8 +214,6 @@ require (
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	go.uber.org/multierr v1.7.0 // indirect
-	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/mod v0.5.0 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -1182,8 +1182,6 @@ github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMI
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc/go.mod h1:bopw91TMyo8J3tvftk8xmU2kPmlrt4nScJQZU2hE5EM=
-github.com/whyrusleeping/go-logging v0.0.1 h1:fwpzlmT0kRC/Fmd0MdmGgJG/CXIZ6gFq46FQZjprUcc=
-github.com/whyrusleeping/go-logging v0.0.1/go.mod h1:lDPYj54zutzG1XYfHAhcc7oNXEburHQBn+Iqd4yS4vE=
 github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9/go.mod h1:j4l84WPFclQPj320J9gp0XwNKBb3U0zt5CBqjPp22G4=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 h1:E9S12nwJwEOXe2d6gT6qxdvqMnNq+VnSsKPgm2ZZNds=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7/go.mod h1:X2c0RVCI1eSUFI8eLcY3c0423ykwiUdxLJtkDvruhjI=


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/4531

libp2p logs are now emitted through oasis-node logging system.

Example logs:

```
{"caller":"id.go:453","level":"debug","module":"libp2p:net/identify","msg":"/ipfs/id/1.0.0 received message from 12D3KooWCUm3BxCXj5UTfkhbRnxb7hicz3tTTZbphbKhGSz3vTdb /ip4/192.168.88.233/tcp/20020","ts":"2022-03-08T08:47:57.699910867Z"}
{"caller":"obsaddr.go:397","level":"debug","module":"libp2p:net/identify","msg":"added own observed listen addr","observed":"/ip4/192.168.88.233/tcp/20012","ts":"2022-03-08T08:47:57.700039654Z"}
{"caller":"id.go:649","level":"debug","module":"libp2p:net/identify","msg":"12D3KooWBPiJ4rzKgz4NRka2zRAMF5JDYXNf6r5xDMxuusWNZYaw received listen addrs for 12D3KooWCUm3BxCXj5UTfkhbRnxb7hicz3tTTZbphbKhGSz3vTdb: [/ip4/192.168.88.233/tcp/20020]","ts":"2022-03-08T08:47:57.700066819Z"}
{"caller":"gossipsub.go:511","level":"debug","module":"libp2p:pubsub","msg":"PEERUP: Add new peer 12D3KooWCUm3BxCXj5UTfkhbRnxb7hicz3tTTZbphbKhGSz3vTdb using /meshsub/1.1.0","ts":"2022-03-08T08:47:57.700137429Z"}
{"caller":"basic_host.go:414","level":"debug","module":"libp2p:basichost","msg":"protocol negotiation took 770.404µs","ts":"2022-03-08T08:47:57.700386848Z"}
{"caller":"gossipsub.go:807","level":"debug","module":"libp2p:pubsub","msg":"GRAFT: add mesh link from 12D3KooWCUm3BxCXj5UTfkhbRnxb7hicz3tTTZbphbKhGSz3vTdb in 1de8816252b0093d3ad4b113923e44178f7ef43e09946bd2b4a49326cecc3573/4/8000000000000000000000000000000000000000000000000000000000000000/tx","ts":"2022-03-08T08:47:58.05448337Z"}
{"caller":"basic_host.go:414","level":"debug","module":"libp2p:basichost","msg":"protocol negotiation took 56.272µs","ts":"2022-03-08T08:48:01.703049297Z"}
{"caller":"validation.go:457","level":"debug","module":"libp2p:pubsub","msg":"validation done; took 92.596µs","ts":"2022-03-08T08:48:01.705158878Z"}
{"caller":"validation.go:457","level":"debug","module":"libp2p:pubsub","msg":"validation done; took 69.458µs","ts":"2022-03-08T08:48:01.716050092Z"}
{"caller":"basic_host.go:414","level":"debug","module":"libp2p:basichost","msg":"protocol negotiation took 46.358µs","ts":"2022-03-08T08:48:05.594683073Z"}
{"caller":"basic_host.go:414","level":"debug","module":"libp2p:basichost","msg":"protocol negotiation took 48.098µs","ts":"2022-03-08T08:48:05.594955572Z"}
{"caller":"pubsub.go:626","level":"info","module":"libp2p:pubsub","msg":"pubsub processloop shutting down","ts":"2022-03-08T08:48:10.61096531Z"}
```

Wrapping zap into go-git is not as performant as using zap directly, but the consistency is worth it i think. If we're concerend with logging performance we could look into using something like `zap` or `zerolog` as the base of common/logger. 