### PR TITLE
consensus/sanity-checks: skip suspended runtimes when computing stake claims

### DIFF
--- a/.changelog/4556.bugfix.md
+++ b/.changelog/4556.bugfix.md
@@ -1,0 +1,1 @@
+consensus/sanity-checks: skip suspended runtimes for computing stake claims

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -384,6 +384,9 @@ type RuntimeLookup interface {
 
 	// AllRuntimes returns a list of all runtimes (including suspended ones).
 	AllRuntimes(ctx context.Context) ([]*Runtime, error)
+
+	// Runtimes returns active runtimes (not including suspended ones).
+	Runtimes(ctx context.Context) ([]*Runtime, error)
 }
 
 // VerifyRegisterEntityArgs verifies arguments for RegisterEntity.

--- a/go/registry/api/api_test.go
+++ b/go/registry/api/api_test.go
@@ -36,6 +36,10 @@ func (rl *mockRuntimeLookup) AllRuntimes(ctx context.Context) ([]*Runtime, error
 	panic("not implemented")
 }
 
+func (rl *mockRuntimeLookup) Runtimes(ctx context.Context) ([]*Runtime, error) {
+	panic("not implemented")
+}
+
 func TestVerifyNodeUpdate(t *testing.T) {
 	logger := logging.GetLogger("registry/api/tests")
 


### PR DESCRIPTION
TODO:
- [x] add a genesis sanity-check test
