### PR TITLE
oasis-net-runner: Fix fixtures without a keymanager

### DIFF
--- a/.changelog/4564.bugfix.md
+++ b/.changelog/4564.bugfix.md
@@ -1,0 +1,1 @@
+oasis-net-runner: Fix fixtures without a keymanager

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -126,16 +126,16 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 					AnyNode: &registry.AnyNodeRuntimeAdmissionPolicy{},
 				},
 				GovernanceModel: registry.GovernanceEntity,
-				Deployments: []oasis.DeploymentCfg{
-					{
-						Binaries: map[node.TEEHardware]string{
-							tee: viper.GetString(cfgKeymanagerBinary),
-						},
-					},
-				},
 			},
 		}
 		if usingKeymanager {
+			fixture.Runtimes[0].Deployments = []oasis.DeploymentCfg{
+				{
+					Binaries: map[node.TEEHardware]string{
+						tee: viper.GetString(cfgKeymanagerBinary),
+					},
+				},
+			}
 			fixture.KeymanagerPolicies = []oasis.KeymanagerPolicyFixture{
 				{Runtime: 0, Serial: 1},
 			}


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-core/issues/4533