### PR TITLE
go/worker/registration: Add a random re-registration delay

### DIFF
--- a/.changelog/4574.feature.md
+++ b/.changelog/4574.feature.md
@@ -1,0 +1,1 @@
+go/worker/registration: Add a random re-registration delay


### PR DESCRIPTION
This is hard coded to 5%, and will not be enabled if the mock backend is
in use so that the tests hopefully do not need alterations.