### PR TITLE
go/oasis-node/cmd: unsafe-reset preserve mkvs by default

### DIFF
--- a/.changelog/4588.feature.md
+++ b/.changelog/4588.feature.md
@@ -1,0 +1,7 @@
+go/oasis-node/cmd: Preserve MKVS database by default in unsafe-reset
+
+Preserving the MKVS database is becoming the more common workflow, so we're
+making that the default for `oasis-node unsafe-reset`.
+
+Use `--preserve.mkvs_database=false` to wipe the mkvs database as the
+previous default did.

--- a/go/oasis-node/cmd/node/unsafe_reset.go
+++ b/go/oasis-node/cmd/node/unsafe_reset.go
@@ -129,6 +129,6 @@ func doUnsafeReset(cmd *cobra.Command, args []string) {
 
 func init() {
 	unsafeResetFlags.Bool(CfgPreserveLocalStorage, false, "preserve per-runtime untrusted local storage")
-	unsafeResetFlags.Bool(CfgPreserveMKVSDatabase, false, "preserve per-runtime MKVS database")
+	unsafeResetFlags.Bool(CfgPreserveMKVSDatabase, true, "preserve per-runtime MKVS database")
 	_ = viper.BindPFlags(unsafeResetFlags)
 }

--- a/go/oasis-test-runner/oasis/cli/cli.go
+++ b/go/oasis-test-runner/oasis/cli/cli.go
@@ -76,8 +76,8 @@ func New(env *env.Env, factory Factory, logger *logging.Logger) *Helpers {
 // runtime state.
 func (h *Helpers) UnsafeReset(dataDir string, preserveRuntimeStorage, preserveLocalStorage bool) error {
 	args := []string{"unsafe-reset", "--" + cmdCommon.CfgDataDir, dataDir}
-	if preserveRuntimeStorage {
-		args = append(args, "--"+cmdNode.CfgPreserveMKVSDatabase)
+	if !preserveRuntimeStorage {
+		args = append(args, "--"+cmdNode.CfgPreserveMKVSDatabase+"=false")
 	}
 	if preserveLocalStorage {
 		args = append(args, "--"+cmdNode.CfgPreserveLocalStorage)


### PR DESCRIPTION
cross reference: https://app.clickup.com/t/294pfzp

Preserving the mkvs database is becoming the more common workflow, so we're changing the default to be true.

Use `--preserve.mkvs_database=false` to wipe the mkvs database as the previous default did.