### PR TITLE
go/registry: Remove support for DeprecatedBeacon

### DIFF
--- a/.changelog/4394.internal.md
+++ b/.changelog/4394.internal.md
@@ -1,0 +1,5 @@
+go/registry: Remove support for DeprecatedBeacon
+
+The PVSS backend is no longer present in 22.x and so the field is now
+removed, and even genesis registrations without a VRF signing key will
+be rejected.

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -87,10 +87,6 @@ type Node struct { // nolint: maligned
 	// based elections.
 	VRF *VRFInfo `json:"vrf,omitempty"`
 
-	// DeprecatedBeacon contains information for this node's
-	// participation in the old PVSS based random beacon protocol.
-	DeprecatedBeacon cbor.RawMessage `json:"beacon,omitempty"`
-
 	// Runtimes are the node's runtimes.
 	Runtimes []*Runtime `json:"runtimes"`
 

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -150,6 +150,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 	nodeConsensusSigner := memorySigner.NewTestSigner("node consensus genesis sanity checks signer")
 	nodeP2PSigner := memorySigner.NewTestSigner("node P2P genesis sanity checks signer")
 	nodeTLSSigner := memorySigner.NewTestSigner("node TLS genesis sanity checks signer")
+	nodeVRFSigner := memorySigner.NewTestSigner("node VRF genesis sanity checks signer")
 	validPK := signer.Public()
 	var validNS common.Namespace
 	_ = validNS.UnmarshalBinary(validPK[:])
@@ -258,6 +259,9 @@ func TestGenesisSanityCheck(t *testing.T) {
 			ID:        nodeP2PSigner.Public(),
 			Addresses: []node.Address{testAddress},
 		},
+		VRF: &node.VRFInfo{
+			ID: nodeVRFSigner.Public(),
+		},
 		Consensus: node.ConsensusInfo{
 			ID:        nodeConsensusSigner.Public(),
 			Addresses: []node.ConsensusAddress{testConsensusAddress},
@@ -268,6 +272,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 		nodeP2PSigner,
 		nodeTLSSigner,
 		nodeConsensusSigner,
+		nodeVRFSigner,
 	}
 	signedTestNode := signNodeOrDie(nodeSigners, testNode)
 

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -620,7 +620,7 @@ func VerifyRegisterNodeArgs( // nolint: gocyclo
 		return nil, nil, err
 	}
 
-	// Validate VRFInfo, DeprecatedBeacon.
+	// Validate VRFInfo.
 	if n.VRF != nil {
 		if !sigNode.MultiSigned.IsSignedBy(n.VRF.ID) {
 			logger.Error("RegisterNode: not signed by VRF ID",
@@ -630,21 +630,8 @@ func VerifyRegisterNodeArgs( // nolint: gocyclo
 			return nil, nil, fmt.Errorf("%w: registration not signed by VRF ID", ErrInvalidArgument)
 		}
 		expectedSigners = append(expectedSigners, n.VRF.ID)
-	}
-	switch isGenesis {
-	case true:
-		// Allow legacy entries without a VRF public key, and with the old PVSS
-		// curve point to be in the genesis document, to ease transition.
-		//
-		// All new (re)registrations will require a VRF public key, and reject
-		// descriptors with the old PVSS curve point.
-	case false:
-		if n.VRF == nil {
-			return nil, nil, fmt.Errorf("%w: registration missing VRF ID", ErrInvalidArgument)
-		}
-		if n.DeprecatedBeacon != nil {
-			return nil, nil, fmt.Errorf("%w: registration contains deprecated PVSS field", ErrInvalidArgument)
-		}
+	} else {
+		return nil, nil, fmt.Errorf("%w: registration missing VRF ID", ErrInvalidArgument)
 	}
 
 	// Validate TLSInfo.


### PR DESCRIPTION
The PVSS backend is no longer present in 22.x and so the field is now
removed, and even genesis registrations without a VRF signing key will
be rejected.

Fixes #4394
Fixes #4393