### PR TITLE
backport 22.0.x - go/signature: apply options on registered contexts

### DIFF
--- a/.changelog/4591.feature.md
+++ b/.changelog/4591.feature.md
@@ -1,0 +1,1 @@
+go/signature: Apply options on registered contexts

--- a/go/common/crypto/signature/signer.go
+++ b/go/common/crypto/signature/signer.go
@@ -313,20 +313,20 @@ type UnsafeSigner interface {
 
 // PrepareSignerContext prepares a context for use during signing by a Signer.
 func PrepareSignerContext(context Context) ([]byte, error) {
-	// The remote signer implementation uses the raw context, and
-	// registration is dealt with client side.  Just check that the
-	// length is sensible, even though the client should be sending
-	// something sane.
-	if allowUnregisteredContexts {
-		if cLen := len(context); cLen == 0 || cLen > ed25519.ContextMaxSize {
-			return nil, errMalformedContext
-		}
-		return []byte(context), nil
-	}
-
-	// Ensure that the context is registered for use.
 	rawOpts, isRegistered := registeredContexts.Load(context)
 	if !isRegistered {
+		// The remote signer implementation uses the raw context, and
+		// registration is dealt with client side.  Just check that the
+		// length is sensible, even though the client should be sending
+		// something sane.
+		if allowUnregisteredContexts {
+			if cLen := len(context); cLen == 0 || cLen > ed25519.ContextMaxSize {
+				return nil, errMalformedContext
+			}
+			return []byte(context), nil
+		}
+
+		// Ensure that the context is registered for use.
 		return nil, errUnregisteredContext
 	}
 	opts := rawOpts.(*contextOptions)

--- a/go/common/crypto/signature/signer_test.go
+++ b/go/common/crypto/signature/signer_test.go
@@ -126,6 +126,10 @@ func TestContext(t *testing.T) {
 	require.NoError(err, "PrepareSignerMessage should work")
 	require.NotEqual(msg3, msg4, "messages for different contexts should be different")
 
+	ctx5 := NewContext("test: dummy context 5", WithChainSeparation())
+	msg5, err := PrepareSignerMessage(ctx5, []byte("message"))
+	require.NoError(err, "PrepareSignerMessage before UnsafeResetChainContext")
+
 	// The remote signer requires bypassing the context registration checks.
 	UnsafeAllowUnregisteredContexts()
 	defer func() {
@@ -135,6 +139,10 @@ func TestContext(t *testing.T) {
 
 	_, err = PrepareSignerMessage(unregCtx, []byte("message"))
 	require.NoError(err, "PrepareSignerMessage should work with unregisered context (bypassed)")
+
+	msg5UAUC, err := PrepareSignerMessage(ctx5, []byte("message"))
+	require.NoError(err, "PrepareSignerMessage after UnsafeAllowUnregisteredContexts")
+	require.Equal(msg5, msg5UAUC, "message for same chain context should be same")
 }
 
 func TestSignerRoles(t *testing.T) {

--- a/go/common/crypto/signature/signer_test.go
+++ b/go/common/crypto/signature/signer_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 	"github.com/stretchr/testify/require"
 )
 
@@ -139,6 +140,10 @@ func TestContext(t *testing.T) {
 
 	_, err = PrepareSignerMessage(unregCtx, []byte("message"))
 	require.NoError(err, "PrepareSignerMessage should work with unregisered context (bypassed)")
+
+	overlongUnregCtx := Context("test: l" + strings.Repeat("o", ed25519.ContextMaxSize) + "ng")
+	_, err = PrepareSignerMessage(overlongUnregCtx, []byte("message"))
+	require.Error(err, "PrepareSignerMessage should fail with overlong unregistered context")
 
 	msg5UAUC, err := PrepareSignerMessage(ctx5, []byte("message"))
 	require.NoError(err, "PrepareSignerMessage after UnsafeAllowUnregisteredContexts")


### PR DESCRIPTION
backport #4591