### PR TITLE
[BACKPORT/22.0.x] go/oasis-node/cmd/stake: Allow querying historical account info

### DIFF
--- a/.changelog/4416.feature.md
+++ b/.changelog/4416.feature.md
@@ -1,0 +1,4 @@
+go/oasis-node/cmd/stake: Allow querying historical account info
+
+The `oasis-node stake account info` CLI command now accepts `--height` flag
+which allows one to query an account's info at an arbitrary height.

--- a/go/oasis-node/cmd/stake/account.go
+++ b/go/oasis-node/cmd/stake/account.go
@@ -21,6 +21,9 @@ import (
 )
 
 const (
+	// CfgHeight configures the consensus height.
+	CfgHeight = "height"
+
 	// CfgAccountAddr configures the account address.
 	CfgAccountAddr = "stake.account.address"
 
@@ -58,6 +61,7 @@ var (
 	sharesFlags             = flag.NewFlagSet("", flag.ContinueOnError)
 	commonEscrowFlags       = flag.NewFlagSet("", flag.ContinueOnError)
 	commissionScheduleFlags = flag.NewFlagSet("", flag.ContinueOnError)
+	accountInfoFlags        = flag.NewFlagSet("", flag.ContinueOnError)
 	accountTransferFlags    = flag.NewFlagSet("", flag.ContinueOnError)
 	accountBurnFlags        = flag.NewFlagSet("", flag.ContinueOnError)
 	accountAllowFlags       = flag.NewFlagSet("", flag.ContinueOnError)
@@ -145,7 +149,7 @@ func doAccountInfo(cmd *cobra.Command, args []string) {
 	conn, client := doConnect(cmd)
 	defer conn.Close()
 
-	height := consensus.HeightLatest
+	height := viper.GetInt64(CfgHeight)
 
 	ctx := context.Background()
 	acct := getAccount(ctx, addr, height, client)
@@ -158,6 +162,7 @@ func doAccountInfo(cmd *cobra.Command, args []string) {
 	ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenSymbol, symbol)
 	ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenValueExponent, exp)
 
+	fmt.Printf("Account State for Height: %d\n", height)
 	fmt.Println("Balance:")
 	prettyPrintAccountBalanceAndDelegationsFrom(ctx, addr, acct.General, outgoingDelegationInfos, outgoingDebondingDelegationInfos, "  ", os.Stdout)
 	fmt.Println()
@@ -509,6 +514,7 @@ func registerAccountCmd() {
 	}
 
 	accountInfoCmd.Flags().AddFlagSet(commonAccountFlags)
+	accountInfoCmd.Flags().AddFlagSet(accountInfoFlags)
 	accountNonceCmd.Flags().AddFlagSet(commonAccountFlags)
 	accountValidateAddressCmd.Flags().AddFlagSet(commonAccountFlags)
 	accountValidateAddressCmd.Flags().AddFlagSet(cmdFlags.VerboseFlags)
@@ -533,6 +539,9 @@ func init() {
 
 	sharesFlags.String(CfgShares, "0", "amount of shares for the transaction")
 	_ = viper.BindPFlags(sharesFlags)
+
+	accountInfoFlags.Int64(CfgHeight, consensus.HeightLatest, "height at which to query for info (default to latest height)")
+	_ = viper.BindPFlags(accountInfoFlags)
 
 	accountTransferFlags.String(CfgTransferDestination, "", "transfer destination account address")
 	_ = viper.BindPFlags(accountTransferFlags)

--- a/go/oasis-node/cmd/stake/account.go
+++ b/go/oasis-node/cmd/stake/account.go
@@ -145,13 +145,13 @@ func doAccountInfo(cmd *cobra.Command, args []string) {
 	defer conn.Close()
 
 	ctx := context.Background()
-	acct := getAccount(ctx, cmd, addr, client)
-	outgoingDelegationInfos := getDelegationInfosFor(ctx, cmd, addr, client)
-	incomingDelegations := getDelegationsTo(ctx, cmd, addr, client)
-	outgoingDebondingDelegationInfos := getDebondingDelegationInfosFor(ctx, cmd, addr, client)
-	incomingDebondingDelegations := getDebondingDelegationsTo(ctx, cmd, addr, client)
-	symbol := getTokenSymbol(ctx, cmd, client)
-	exp := getTokenValueExponent(ctx, cmd, client)
+	acct := getAccount(ctx, addr, client)
+	outgoingDelegationInfos := getDelegationInfosFor(ctx, addr, client)
+	incomingDelegations := getDelegationsTo(ctx, addr, client)
+	outgoingDebondingDelegationInfos := getDebondingDelegationInfosFor(ctx, addr, client)
+	incomingDebondingDelegations := getDebondingDelegationsTo(ctx, addr, client)
+	symbol := getTokenSymbol(ctx, client)
+	exp := getTokenValueExponent(ctx, client)
 	ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenSymbol, symbol)
 	ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenValueExponent, exp)
 
@@ -211,7 +211,7 @@ func doAccountNonce(cmd *cobra.Command, args []string) {
 	defer conn.Close()
 
 	ctx := context.Background()
-	acct := getAccount(ctx, cmd, addr, client)
+	acct := getAccount(ctx, addr, client)
 	fmt.Println(acct.General.Nonce)
 }
 

--- a/go/oasis-node/cmd/stake/account.go
+++ b/go/oasis-node/cmd/stake/account.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	cmdConsensus "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/consensus"
 	cmdContext "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/context"
@@ -144,12 +145,14 @@ func doAccountInfo(cmd *cobra.Command, args []string) {
 	conn, client := doConnect(cmd)
 	defer conn.Close()
 
+	height := consensus.HeightLatest
+
 	ctx := context.Background()
-	acct := getAccount(ctx, addr, client)
-	outgoingDelegationInfos := getDelegationInfosFor(ctx, addr, client)
-	incomingDelegations := getDelegationsTo(ctx, addr, client)
-	outgoingDebondingDelegationInfos := getDebondingDelegationInfosFor(ctx, addr, client)
-	incomingDebondingDelegations := getDebondingDelegationsTo(ctx, addr, client)
+	acct := getAccount(ctx, addr, height, client)
+	outgoingDelegationInfos := getDelegationInfosFor(ctx, addr, height, client)
+	incomingDelegations := getDelegationsTo(ctx, addr, height, client)
+	outgoingDebondingDelegationInfos := getDebondingDelegationInfosFor(ctx, addr, height, client)
+	incomingDebondingDelegations := getDebondingDelegationsTo(ctx, addr, height, client)
 	symbol := getTokenSymbol(ctx, client)
 	exp := getTokenValueExponent(ctx, client)
 	ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenSymbol, symbol)
@@ -210,8 +213,10 @@ func doAccountNonce(cmd *cobra.Command, args []string) {
 	conn, client := doConnect(cmd)
 	defer conn.Close()
 
+	height := consensus.HeightLatest
+
 	ctx := context.Background()
-	acct := getAccount(ctx, addr, client)
+	acct := getAccount(ctx, addr, height, client)
 	fmt.Println(acct.General.Nonce)
 }
 

--- a/go/oasis-node/cmd/stake/stake.go
+++ b/go/oasis-node/cmd/stake/stake.go
@@ -70,7 +70,7 @@ func doConnect(cmd *cobra.Command) (*grpc.ClientConn, api.Backend) {
 	return conn, client
 }
 
-func getTokenSymbol(ctx context.Context, cmd *cobra.Command, client api.Backend) string {
+func getTokenSymbol(ctx context.Context, client api.Backend) string {
 	symbol, err := client.TokenSymbol(ctx)
 	if err != nil {
 		logger.Error("failed to query token's symbol",
@@ -81,7 +81,7 @@ func getTokenSymbol(ctx context.Context, cmd *cobra.Command, client api.Backend)
 	return symbol
 }
 
-func getTokenValueExponent(ctx context.Context, cmd *cobra.Command, client api.Backend) uint8 {
+func getTokenValueExponent(ctx context.Context, client api.Backend) uint8 {
 	exp, err := client.TokenValueExponent(ctx)
 	if err != nil {
 		logger.Error("failed to query token's value exponent",
@@ -92,7 +92,7 @@ func getTokenValueExponent(ctx context.Context, cmd *cobra.Command, client api.B
 	return exp
 }
 
-func getAccount(ctx context.Context, cmd *cobra.Command, addr api.Address, client api.Backend) *api.Account {
+func getAccount(ctx context.Context, addr api.Address, client api.Backend) *api.Account {
 	acct, err := client.Account(ctx, &api.OwnerQuery{Owner: addr, Height: consensus.HeightLatest})
 	if err != nil {
 		logger.Error("failed to query account",
@@ -106,7 +106,6 @@ func getAccount(ctx context.Context, cmd *cobra.Command, addr api.Address, clien
 
 func getDelegationInfosFor(
 	ctx context.Context,
-	cmd *cobra.Command,
 	addr api.Address,
 	client api.Backend,
 ) map[api.Address]*api.DelegationInfo {
@@ -123,7 +122,6 @@ func getDelegationInfosFor(
 
 func getDelegationsTo(
 	ctx context.Context,
-	cmd *cobra.Command,
 	addr api.Address,
 	client api.Backend,
 ) map[api.Address]*api.Delegation {
@@ -140,7 +138,6 @@ func getDelegationsTo(
 
 func getDebondingDelegationInfosFor(
 	ctx context.Context,
-	cmd *cobra.Command,
 	addr api.Address,
 	client api.Backend,
 ) map[api.Address][]*api.DebondingDelegationInfo {
@@ -157,7 +154,6 @@ func getDebondingDelegationInfosFor(
 
 func getDebondingDelegationsTo(
 	ctx context.Context,
-	cmd *cobra.Command,
 	addr api.Address,
 	client api.Backend,
 ) map[api.Address][]*api.DebondingDelegation {
@@ -182,10 +178,10 @@ func doInfo(cmd *cobra.Command, args []string) {
 
 	ctx := context.Background()
 
-	symbol := getTokenSymbol(ctx, cmd, client)
+	symbol := getTokenSymbol(ctx, client)
 	fmt.Printf("Token's ticker symbol: %s\n", symbol)
 
-	exp := getTokenValueExponent(ctx, cmd, client)
+	exp := getTokenValueExponent(ctx, client)
 	fmt.Printf("Token's value base-10 exponent: %d\n", exp)
 
 	ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenSymbol, symbol)
@@ -286,7 +282,7 @@ func doList(cmd *cobra.Command, args []string) {
 			// NOTE: getAccount()'s output doesn't contain an account's address,
 			// so we need to add it manually.
 			acctWithAddr := make(map[api.Address]*api.Account)
-			acctWithAddr[addr] = getAccount(ctx, cmd, addr, client)
+			acctWithAddr[addr] = getAccount(ctx, addr, client)
 			prettyAcct, err := cmdCommon.PrettyJSONMarshal(acctWithAddr)
 			if err != nil {
 				logger.Error("failed to get pretty JSON of account",

--- a/go/oasis-node/cmd/stake/stake.go
+++ b/go/oasis-node/cmd/stake/stake.go
@@ -92,8 +92,8 @@ func getTokenValueExponent(ctx context.Context, client api.Backend) uint8 {
 	return exp
 }
 
-func getAccount(ctx context.Context, addr api.Address, client api.Backend) *api.Account {
-	acct, err := client.Account(ctx, &api.OwnerQuery{Owner: addr, Height: consensus.HeightLatest})
+func getAccount(ctx context.Context, addr api.Address, height int64, client api.Backend) *api.Account {
+	acct, err := client.Account(ctx, &api.OwnerQuery{Owner: addr, Height: height})
 	if err != nil {
 		logger.Error("failed to query account",
 			"address", addr,
@@ -107,9 +107,10 @@ func getAccount(ctx context.Context, addr api.Address, client api.Backend) *api.
 func getDelegationInfosFor(
 	ctx context.Context,
 	addr api.Address,
+	height int64,
 	client api.Backend,
 ) map[api.Address]*api.DelegationInfo {
-	delInfos, err := client.DelegationInfosFor(ctx, &api.OwnerQuery{Owner: addr, Height: consensus.HeightLatest})
+	delInfos, err := client.DelegationInfosFor(ctx, &api.OwnerQuery{Owner: addr, Height: height})
 	if err != nil {
 		logger.Error("failed to query (outgoing) delegation infos for account",
 			"address", addr,
@@ -123,9 +124,10 @@ func getDelegationInfosFor(
 func getDelegationsTo(
 	ctx context.Context,
 	addr api.Address,
+	height int64,
 	client api.Backend,
 ) map[api.Address]*api.Delegation {
-	delegations, err := client.DelegationsTo(ctx, &api.OwnerQuery{Owner: addr, Height: consensus.HeightLatest})
+	delegations, err := client.DelegationsTo(ctx, &api.OwnerQuery{Owner: addr, Height: height})
 	if err != nil {
 		logger.Error("failed to query (incoming) delegations to account",
 			"address", addr,
@@ -139,9 +141,10 @@ func getDelegationsTo(
 func getDebondingDelegationInfosFor(
 	ctx context.Context,
 	addr api.Address,
+	height int64,
 	client api.Backend,
 ) map[api.Address][]*api.DebondingDelegationInfo {
-	delInfoLists, err := client.DebondingDelegationInfosFor(ctx, &api.OwnerQuery{Owner: addr, Height: consensus.HeightLatest})
+	delInfoLists, err := client.DebondingDelegationInfosFor(ctx, &api.OwnerQuery{Owner: addr, Height: height})
 	if err != nil {
 		logger.Error("failed to query (outgoing) debonding delegation infos for account",
 			"address", addr,
@@ -155,9 +158,10 @@ func getDebondingDelegationInfosFor(
 func getDebondingDelegationsTo(
 	ctx context.Context,
 	addr api.Address,
+	height int64,
 	client api.Backend,
 ) map[api.Address][]*api.DebondingDelegation {
-	delegations, err := client.DebondingDelegationsTo(ctx, &api.OwnerQuery{Owner: addr, Height: consensus.HeightLatest})
+	delegations, err := client.DebondingDelegationsTo(ctx, &api.OwnerQuery{Owner: addr, Height: height})
 	if err != nil {
 		logger.Error("failed to query (incoming) debonding delegations to account",
 			"address", addr,
@@ -176,18 +180,17 @@ func doInfo(cmd *cobra.Command, args []string) {
 	conn, client := doConnect(cmd)
 	defer conn.Close()
 
-	ctx := context.Background()
+	height := consensus.HeightLatest
 
+	ctx := context.Background()
 	symbol := getTokenSymbol(ctx, client)
 	fmt.Printf("Token's ticker symbol: %s\n", symbol)
-
 	exp := getTokenValueExponent(ctx, client)
 	fmt.Printf("Token's value base-10 exponent: %d\n", exp)
-
 	ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenSymbol, symbol)
 	ctx = context.WithValue(ctx, prettyprint.ContextKeyTokenValueExponent, exp)
 
-	totalSupply, err := client.TotalSupply(ctx, consensus.HeightLatest)
+	totalSupply, err := client.TotalSupply(ctx, height)
 	if err != nil {
 		logger.Error("failed to query total supply",
 			"err", err,
@@ -198,7 +201,7 @@ func doInfo(cmd *cobra.Command, args []string) {
 	token.PrettyPrintAmount(ctx, *totalSupply, os.Stdout)
 	fmt.Println()
 
-	commonPool, err := client.CommonPool(ctx, consensus.HeightLatest)
+	commonPool, err := client.CommonPool(ctx, height)
 	if err != nil {
 		logger.Error("failed to query common pool",
 			"err", err,
@@ -209,7 +212,7 @@ func doInfo(cmd *cobra.Command, args []string) {
 	token.PrettyPrintAmount(ctx, *commonPool, os.Stdout)
 	fmt.Println()
 
-	lastBlockFees, err := client.LastBlockFees(ctx, consensus.HeightLatest)
+	lastBlockFees, err := client.LastBlockFees(ctx, height)
 	if err != nil {
 		logger.Error("failed to query last block fees",
 			"err", err,
@@ -220,7 +223,7 @@ func doInfo(cmd *cobra.Command, args []string) {
 	token.PrettyPrintAmount(ctx, *lastBlockFees, os.Stdout)
 	fmt.Println()
 
-	governanceDeposits, err := client.GovernanceDeposits(ctx, consensus.HeightLatest)
+	governanceDeposits, err := client.GovernanceDeposits(ctx, height)
 	if err != nil {
 		logger.Error("failed to query governance deposits",
 			"err", err,
@@ -240,7 +243,7 @@ func doInfo(cmd *cobra.Command, args []string) {
 		api.KindRuntimeKeyManager,
 	}
 	for _, kind := range thresholdsToQuery {
-		thres, err := client.Threshold(ctx, &api.ThresholdQuery{Kind: kind, Height: consensus.HeightLatest})
+		thres, err := client.Threshold(ctx, &api.ThresholdQuery{Kind: kind, Height: height})
 		if err != nil {
 			if errors.Is(err, api.ErrInvalidThreshold) {
 				logger.Warn(fmt.Sprintf("invalid staking threshold kind: %s", kind))
@@ -265,9 +268,11 @@ func doList(cmd *cobra.Command, args []string) {
 	conn, client := doConnect(cmd)
 	defer conn.Close()
 
+	height := consensus.HeightLatest
+
 	ctx := context.Background()
 
-	addresses, err := client.Addresses(ctx, consensus.HeightLatest)
+	addresses, err := client.Addresses(ctx, height)
 	if err != nil {
 		logger.Error("failed to query addresses",
 			"err", err,
@@ -282,7 +287,7 @@ func doList(cmd *cobra.Command, args []string) {
 			// NOTE: getAccount()'s output doesn't contain an account's address,
 			// so we need to add it manually.
 			acctWithAddr := make(map[api.Address]*api.Account)
-			acctWithAddr[addr] = getAccount(ctx, addr, client)
+			acctWithAddr[addr] = getAccount(ctx, addr, height, client)
 			prettyAcct, err := cmdCommon.PrettyJSONMarshal(acctWithAddr)
 			if err != nil {
 				logger.Error("failed to get pretty JSON of account",


### PR DESCRIPTION
Backport of #4416.