### PR TITLE
governance: Allow unregistered nodes in votes

### DIFF
--- a/.changelog/4607.breaking.md
+++ b/.changelog/4607.breaking.md
@@ -1,0 +1,5 @@
+governance: Allow unregistered nodes in votes
+
+The intent from the comments is to allow votes to be cast as long as the
+entity has at least 1 validator in the active set.  This fixes entities
+with nodes that are not currently registered having their votes rejected.

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -125,7 +125,7 @@ var (
 	// checked in Oasis Core.
 	// It is converted to TendermintAppVersion whose compatibility is checked
 	// via Tendermint's version checks.
-	ConsensusProtocol = Version{Major: 5, Minor: 0, Patch: 0}
+	ConsensusProtocol = Version{Major: 6, Minor: 0, Patch: 0}
 
 	// RuntimeHostProtocol versions the protocol between the Oasis node(s) and
 	// the runtime.

--- a/go/consensus/tendermint/apps/governance/transactions.go
+++ b/go/consensus/tendermint/apps/governance/transactions.go
@@ -1,6 +1,7 @@
 package governance
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/oasisprotocol/oasis-core/go/common/node"
@@ -229,6 +230,10 @@ func (app *governanceApplication) castVote(
 		var node *node.Node
 		node, err = registryState.Node(ctx, nID)
 		if err != nil {
+			// Node not being registered is non-fatal.
+			if errors.Is(err, registryAPI.ErrNoSuchNode) {
+				continue
+			}
 			return fmt.Errorf("governance: failed to query entity node: %w", err)
 		}
 		if _, ok := currentValidators[node.Consensus.ID]; ok {

--- a/runtime/src/common/version.rs
+++ b/runtime/src/common/version.rs
@@ -77,7 +77,7 @@ pub const PROTOCOL_VERSION: Version = Version {
 // Version of the consensus protocol runtime code works with. This version MUST
 // be compatible with the one supported by the worker host.
 pub const CONSENSUS_VERSION: Version = Version {
-    major: 5,
+    major: 6,
     minor: 0,
     patch: 0,
 };


### PR DESCRIPTION
The intent from the comments is to allow votes to be cast as long as the
entity has at least 1 validator in the active set.  This fixes entities
with nodes that are not currently registered having their votes rejected.

Fixes #4607