### PR TITLE
[BACKPORT/21.3.x] oasis-node/cmd/stake: Print actual latest height when querying info

### DIFF
--- a/.changelog/4622.bugfix.md
+++ b/.changelog/4622.bugfix.md
@@ -1,0 +1,5 @@
+go/oasis-node/cmd/stake: Print actual latest height when querying info
+
+If the `--height` flag in `oasis-node stake account info` CLI command is set
+to 0 (i.e. latest height), determine which height it actually is and present
+it in the output.


### PR DESCRIPTION
Backport of #4620.