### PR TITLE
[BACKPORT/22.1.x] go/worker/compute: Always include resolved transactions

### DIFF
--- a/.changelog/4633.bugfix.md
+++ b/.changelog/4633.bugfix.md
@@ -1,0 +1,1 @@
+go/worker/compute: Always include resolved transactions

--- a/go/worker/compute/executor/committee/batch.go
+++ b/go/worker/compute/executor/committee/batch.go
@@ -13,8 +13,9 @@ import (
 type unresolvedBatch struct {
 	proposal *commitment.Proposal
 
-	batch      transaction.RawBatch
-	missingTxs map[hash.Hash]int
+	batch       transaction.RawBatch
+	missingTxs  map[hash.Hash]int
+	resolvedTxs map[hash.Hash][]byte
 
 	maxBatchSizeBytes uint64
 }
@@ -35,6 +36,23 @@ func (ub *unresolvedBatch) hash() hash.Hash {
 	return ub.proposal.Header.BatchHash
 }
 
+func (ub *unresolvedBatch) addResolvedTx(tx []byte) {
+	if ub.missingTxs == nil {
+		return
+	}
+
+	txHash := hash.NewFromBytes(tx)
+	if _, exists := ub.missingTxs[txHash]; !exists {
+		return
+	}
+
+	if ub.resolvedTxs == nil {
+		ub.resolvedTxs = make(map[hash.Hash][]byte)
+	}
+	ub.resolvedTxs[txHash] = tx
+	delete(ub.missingTxs, txHash)
+}
+
 func (ub *unresolvedBatch) resolve(txPool txpool.TransactionPool) (transaction.RawBatch, error) {
 	if ub.batch != nil {
 		return ub.batch, nil
@@ -47,6 +65,17 @@ func (ub *unresolvedBatch) resolve(txPool txpool.TransactionPool) (transaction.R
 	}
 
 	resolvedBatch, missingTxs := txPool.GetKnownBatch(ub.proposal.Batch)
+	if ub.resolvedTxs != nil {
+		for txHash, txIdx := range missingTxs {
+			rawTx, exists := ub.resolvedTxs[txHash]
+			if !exists {
+				continue
+			}
+
+			delete(missingTxs, txHash)
+			resolvedBatch[txIdx] = transaction.RawCheckedTransaction(rawTx)
+		}
+	}
 	if len(missingTxs) > 0 {
 		ub.missingTxs = missingTxs
 		return nil, nil


### PR DESCRIPTION
Backport of #4633.