### PR TITLE
consensus/tendermint/db/badger: Fix WriteSync for large txns

### DIFF
--- a/.changelog/4648.bugfix.md
+++ b/.changelog/4648.bugfix.md
@@ -1,0 +1,1 @@
+consensus/tendermint/db/badger: Fix WriteSync for large txns


### PR DESCRIPTION
If a transaction is too big for Badger, the correct way to handle this (according to Badger docs) is to commit the current contents of the transaction and start a new one instead of failing the entire transaction.
This PR adds proper handling for this situation.
