### PR TITLE
[BACKPORT/22.1.x] go/runtime/host: Always emit StoppedEvent on stop

### DIFF
--- a/.changelog/4647.bugfix.md
+++ b/.changelog/4647.bugfix.md
@@ -1,0 +1,5 @@
+go/runtime/host: Always emit StoppedEvent on stop
+
+Previously the StoppedEvent was only emitted in case the runtime was
+previously running. In case multihost was performing a version switch when a
+runtime was not yet started, this resulted in a deadlock.

--- a/go/runtime/host/sandbox/sandbox.go
+++ b/go/runtime/host/sandbox/sandbox.go
@@ -437,10 +437,10 @@ func (r *sandboxedRuntime) manager() {
 			r.Lock()
 			r.conn = nil
 			r.Unlock()
-
-			// Notify subscribers that the runtime has stopped.
-			r.notifier.Broadcast(&host.Event{Stopped: &host.StoppedEvent{}})
 		}
+
+		// Notify subscribers that the runtime has stopped.
+		r.notifier.Broadcast(&host.Event{Stopped: &host.StoppedEvent{}})
 
 		close(r.quitCh)
 	}()


### PR DESCRIPTION
Backport of #4647.