### PR TITLE
[BACKPORT/22.1.x] go/worker/common/p2p: Make sure P2P stops before service cleanup runs

### DIFF
--- a/.changelog/4650.bugfix.md
+++ b/.changelog/4650.bugfix.md
@@ -1,0 +1,4 @@
+go/worker/common/p2p: Make sure P2P stops before service cleanup runs
+
+Otherwise this may result in a crash during shutdown when P2P requests are
+processed while database is already closed.

--- a/go/oasis-node/cmd/debug/byzantine/p2p.go
+++ b/go/oasis-node/cmd/debug/byzantine/p2p.go
@@ -18,8 +18,6 @@ type p2pReqRes struct {
 }
 
 type p2pHandle struct {
-	context  context.Context
-	cancel   context.CancelFunc
 	service  *p2p.P2P
 	requests chan p2pReqRes
 }
@@ -96,9 +94,8 @@ func (ph *p2pHandle) start(ht *honestTendermint, id *identity.Identity, runtimeI
 		return fmt.Errorf("P2P service already started")
 	}
 
-	ph.context, ph.cancel = context.WithCancel(context.Background())
 	var err error
-	ph.service, err = p2p.New(ph.context, id, ht.service)
+	ph.service, err = p2p.New(id, ht.service)
 	if err != nil {
 		return fmt.Errorf("P2P service New: %w", err)
 	}
@@ -114,10 +111,8 @@ func (ph *p2pHandle) stop() error {
 		return fmt.Errorf("P2P service not started")
 	}
 
-	ph.cancel()
+	ph.service.Stop()
 	ph.service = nil
-	ph.context = nil
-	ph.cancel = nil
 
 	return nil
 }

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -19,7 +19,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/persistent"
-	"github.com/oasisprotocol/oasis-core/go/common/service"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	consensusAPI "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint"
@@ -275,15 +274,14 @@ func (n *Node) initRuntimeWorkers() error {
 	// listening immediately when created, make sure that we don't start it if
 	// it is not needed.
 	if n.RuntimeRegistry.Mode() != runtimeRegistry.RuntimeModeNone {
-		p2pCtx, p2pSvc := service.NewContextCleanup(context.Background())
 		if genesisDoc.Registry.Parameters.DebugAllowUnroutableAddresses {
 			p2p.DebugForceAllowUnroutableAddresses()
 		}
-		n.P2P, err = p2p.New(p2pCtx, n.Identity, n.Consensus)
+		n.P2P, err = p2p.New(n.Identity, n.Consensus)
 		if err != nil {
 			return err
 		}
-		n.svcMgr.RegisterCleanupOnly(p2pSvc, "worker p2p")
+		n.svcMgr.Register(n.P2P)
 	}
 
 	// Initialize the common worker.


### PR DESCRIPTION
Backport of #4650.