### PR TITLE
go/staking/grpc: rename misnamed GovernanceDeposits method

### DIFF
--- a/.changelog/4652.feature.md
+++ b/.changelog/4652.feature.md
@@ -1,0 +1,4 @@
+go/staking/grpc: rename misnamed GovernanceDeposits method
+
+Previous misnamed method is deprecated, but will work in the `22.1.x`
+releases.


### PR DESCRIPTION
Backwards compatible backport of: https://github.com/oasisprotocol/oasis-core/pull/4652