### PR TITLE
go/consensus/tendermint/apps/beacon: Simulate VRF gas earlier

### DIFF
--- a/.changelog/4658.bugfix.md
+++ b/.changelog/4658.bugfix.md
@@ -1,0 +1,1 @@
+go/consensus/tendermint/apps/beacon: Simulate VRF gas earlier


### PR DESCRIPTION
We shouldn't need this, but just in case.