### PR TITLE
worker/registration: fix waiting for deregister event

### DIFF
--- a/.changelog/4662.bugfix.md
+++ b/.changelog/4662.bugfix.md
@@ -1,0 +1,1 @@
+Fix waiting for deregister event on `RequestShutdown`

--- a/go/oasis-node/cmd/common/genesis/staking.go
+++ b/go/oasis-node/cmd/common/genesis/staking.go
@@ -110,6 +110,9 @@ func NewAppendableStakingState() (*AppendableStakingState, error) {
 	st := &AppendableStakingState{
 		State: staking.Genesis{
 			Ledger: make(map[staking.Address]*staking.Account),
+			Parameters: staking.ConsensusParameters{
+				DebondingInterval: 1, // Minimum valid debonding interval.
+			},
 		},
 	}
 	if err := st.setDefaultFeeSplit(); err != nil {

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -652,9 +652,6 @@ func (w *Worker) doNodeRegistration() {
 
 		case <-w.stopCh:
 			return
-
-		case <-w.stopRegCh:
-			return
 		}
 	}
 }


### PR DESCRIPTION
Added the resuming on closed `stopRegCh`  to one place too many in https://github.com/oasisprotocol/oasis-core/commit/29dbfa840231db434911f19c47a732bb12eed9bc

TODO:
- [x] update e2e tests to ensure the node is deregistered after request shutdown