### PR TITLE
go/control/status: Add fields for quick overview of node status

### DIFF
--- a/.changelog/4669.feature.md
+++ b/.changelog/4669.feature.md
@@ -1,0 +1,1 @@
+go/control/status: Add fields for quick overview of node status

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -202,8 +203,58 @@ type Vote struct {
 	VotingPower   uint64              `json:"voting_power"`
 }
 
+// StatusState is the concise status state of the consensus backend.
+type StatusState uint8
+
+var (
+	// StatusStateReady is the ready status state.
+	StatusStateReady StatusState = 0
+	// StatusStateSyncing is the syncing status state.
+	StatusStateSyncing StatusState = 1
+)
+
+// String returns a string representation of a status state.
+func (s StatusState) String() string {
+	switch s {
+	case StatusStateReady:
+		return "ready"
+	case StatusStateSyncing:
+		return "syncing"
+	default:
+		return "[invalid status state]"
+	}
+}
+
+// MarshalText encodes a StatusState into text form.
+func (s StatusState) MarshalText() ([]byte, error) {
+	switch s {
+	case StatusStateReady:
+		return []byte(StatusStateReady.String()), nil
+	case StatusStateSyncing:
+		return []byte(StatusStateSyncing.String()), nil
+	default:
+		return nil, fmt.Errorf("invalid StatusState: %d", s)
+	}
+}
+
+// UnmarshalText decodes a text slice into a StatusState.
+func (s *StatusState) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case StatusStateReady.String():
+		*s = StatusStateReady
+	case StatusStateSyncing.String():
+		*s = StatusStateSyncing
+	default:
+		return fmt.Errorf("invalid StatusState: %s", string(text))
+	}
+	return nil
+}
+
 // Status is the current status overview.
 type Status struct { // nolint: maligned
+	// Status is an concise status of the consensus backend.
+	Status StatusState `json:"status"`
+
 	// Version is the version of the consensus protocol that the node is using.
 	Version version.Version `json:"version"`
 	// Backend is the consensus backend identifier.

--- a/go/consensus/tendermint/seed/seed.go
+++ b/go/consensus/tendermint/seed/seed.go
@@ -131,6 +131,7 @@ func (srv *seedService) SupportedFeatures() consensus.FeatureMask {
 // Implements Backend.
 func (srv *seedService) GetStatus(ctx context.Context) (*consensus.Status, error) {
 	status := &consensus.Status{
+		Status:   consensus.StatusStateReady,
 		Version:  version.ConsensusProtocol,
 		Backend:  api.BackendName,
 		Features: srv.SupportedFeatures(),

--- a/go/oasis-test-runner/scenario/e2e/consensus_state_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/consensus_state_sync.go
@@ -112,6 +112,9 @@ func (sc *consensusStateSyncImpl) Run(childEnv *env.Env) error {
 		if err != nil {
 			return fmt.Errorf("failed to get status for validator %s: %w", v.Name, err)
 		}
+		if status.Consensus.Status != consensus.StatusStateReady {
+			return fmt.Errorf("validator %s not ready", v.Name)
+		}
 
 		if status.Registration.Descriptor == nil {
 			return fmt.Errorf("validator %s has not registered", v.Name)
@@ -159,6 +162,9 @@ func (sc *consensusStateSyncImpl) Run(childEnv *env.Env) error {
 	status, err := ctrl.GetStatus(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to fetch validator status: %w", err)
+	}
+	if status.Consensus.Status != consensus.StatusStateReady {
+		return fmt.Errorf("synced validator not ready")
 	}
 
 	// Make sure that the last retained height has been set correctly.

--- a/go/oasis-test-runner/scenario/e2e/early_query.go
+++ b/go/oasis-test-runner/scenario/e2e/early_query.go
@@ -95,6 +95,9 @@ func (sc *earlyQueryImpl) Run(childEnv *env.Env) error {
 	if err != nil {
 		return fmt.Errorf("failed to get status for node: %w", err)
 	}
+	if status.Consensus.Status != consensus.StatusStateSyncing {
+		return fmt.Errorf("node reports as ready before chain is initialized")
+	}
 	if status.Consensus.LatestHeight != 0 {
 		return fmt.Errorf("node reports non-zero latest height before chain is initialized")
 	}

--- a/go/oasis-test-runner/scenario/e2e/seed_api.go
+++ b/go/oasis-test-runner/scenario/e2e/seed_api.go
@@ -82,6 +82,9 @@ func (sc *seedAPI) Run(childEnv *env.Env) error { // nolint: gocyclo
 	if err != nil {
 		return fmt.Errorf("failed to get status for node: %w", err)
 	}
+	if status.Consensus.Status != consensusAPI.StatusStateReady {
+		return fmt.Errorf("seed node consensus status should be '%s', got: '%s'", consensusAPI.StatusStateReady, status.Consensus.Status)
+	}
 	if status.Consensus.LatestHeight != int64(0) {
 		return fmt.Errorf("seed node latest height should be 0, got: %d", status.Consensus.LatestHeight)
 	}

--- a/go/worker/common/api/api.go
+++ b/go/worker/common/api/api.go
@@ -1,12 +1,112 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 )
 
+// StatusState is the concise status state of the common runtime worker.
+type StatusState uint8
+
+const (
+	// StatusStateReady is the ready status state.
+	StatusStateReady StatusState = 0
+	// StatusStateWaitingConsensusSync is the waiting for consensus sync status state.
+	StatusStateWaitingConsensusSync StatusState = 1
+	// StatusStateWaitingRuntimeRegistry is the waiting for runtime registry descriptor status state.
+	StatusStateWaitingRuntimeRegistry StatusState = 2
+	// StatusStateWaitingKeymanager is the waiting for keymanager status state.
+	StatusStateWaitingKeymanager StatusState = 3
+	// StatusStateWaitingHostedRuntime is the waiting for the hosted runtime status state.
+	StatusStateWaitingHostedRuntime StatusState = 4
+	// StatusStateWaitingHistoryReindex is the waiting for runtime history reindex status state.
+	StatusStateWaitingHistoryReindex StatusState = 5
+	// StatusStateWaitingWorkersInit is the waiting for workers to initialize status state.
+	StatusStateWaitingWorkersInit StatusState = 6
+	// StatusStateRuntimeSuspended is the runtime suspended status state.
+	StatusStateRuntimeSuspended StatusState = 7
+)
+
+// String returns a string representation of a status state.
+func (s StatusState) String() string {
+	switch s {
+	case StatusStateReady:
+		return "ready"
+	case StatusStateWaitingConsensusSync:
+		return "waiting for consensus sync"
+	case StatusStateWaitingRuntimeRegistry:
+		return "waiting for runtime registry descriptor"
+	case StatusStateWaitingKeymanager:
+		return "waiting for available keymanager"
+	case StatusStateWaitingHostedRuntime:
+		return "waiting for hosted runtime provision"
+	case StatusStateWaitingHistoryReindex:
+		return "waiting for history reindex"
+	case StatusStateWaitingWorkersInit:
+		return "waiting for workers to initialize"
+	case StatusStateRuntimeSuspended:
+		return "runtime suspended"
+	default:
+		return "[invalid status state]"
+	}
+}
+
+// MarshalText encodes a StatusState into text form.
+func (s StatusState) MarshalText() ([]byte, error) {
+	switch s {
+	case StatusStateReady:
+		return []byte(StatusStateReady.String()), nil
+	case StatusStateWaitingConsensusSync:
+		return []byte(StatusStateWaitingConsensusSync.String()), nil
+	case StatusStateWaitingRuntimeRegistry:
+		return []byte(StatusStateWaitingRuntimeRegistry.String()), nil
+	case StatusStateWaitingKeymanager:
+		return []byte(StatusStateWaitingKeymanager.String()), nil
+	case StatusStateWaitingHostedRuntime:
+		return []byte(StatusStateWaitingHostedRuntime.String()), nil
+	case StatusStateWaitingHistoryReindex:
+		return []byte(StatusStateWaitingHistoryReindex.String()), nil
+	case StatusStateWaitingWorkersInit:
+		return []byte(StatusStateWaitingWorkersInit.String()), nil
+	case StatusStateRuntimeSuspended:
+		return []byte(StatusStateRuntimeSuspended.String()), nil
+	default:
+		return nil, fmt.Errorf("invalid StatusState: %d", s)
+	}
+}
+
+// UnmarshalText decodes a text slice into a StatusState.
+func (s *StatusState) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case StatusStateReady.String():
+		*s = StatusStateReady
+	case StatusStateWaitingConsensusSync.String():
+		*s = StatusStateWaitingConsensusSync
+	case StatusStateWaitingRuntimeRegistry.String():
+		*s = StatusStateWaitingRuntimeRegistry
+	case StatusStateWaitingKeymanager.String():
+		*s = StatusStateWaitingKeymanager
+	case StatusStateWaitingHostedRuntime.String():
+		*s = StatusStateWaitingHostedRuntime
+	case StatusStateWaitingHistoryReindex.String():
+		*s = StatusStateWaitingHistoryReindex
+	case StatusStateWaitingWorkersInit.String():
+		*s = StatusStateWaitingWorkersInit
+	case StatusStateRuntimeSuspended.String():
+		*s = StatusStateRuntimeSuspended
+	default:
+		return fmt.Errorf("invalid StatusState: %s", string(text))
+	}
+	return nil
+}
+
 // Status is the common runtime worker status.
 type Status struct {
+	// Status is an concise status of the committee node.
+	Status StatusState `json:"status"`
+
 	// ActiveVersion is the currently active version.
 	ActiveVersion *version.Version `json:"active_version"`
 


### PR DESCRIPTION
TODO:
- [x] not sure if current runtime worker statuses make sense, maybe some should be added as well (e.g. runtime suspended)