### PR TITLE
ci: E2E SGX tests fixes

### DIFF
--- a/.changelog/4673.internal.md
+++ b/.changelog/4673.internal.md
@@ -1,0 +1,1 @@
+ci: fix SGX E2E tests

--- a/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	timeLimitShort    = 6 * time.Minute
-	timeLimitShortSGX = 3 * time.Minute
+	timeLimitShortSGX = 6 * time.Minute
 	timeLimitLong     = 12 * time.Hour
 
 	nodeRestartIntervalLong = 2 * time.Minute
@@ -100,9 +100,9 @@ var TxSourceMultiShortSGX scenario.Scenario = &txSourceImpl{
 	consensusPruneMaxKept:             200,
 	// XXX: don't use more nodes as SGX E2E test instances cannot handle many
 	// more nodes that are currently configured.
-	numValidatorNodes:  3,
+	numValidatorNodes:  2,
 	numKeyManagerNodes: 1,
-	numComputeNodes:    4,
+	numComputeNodes:    2,
 	numClientNodes:     1,
 }
 


### PR DESCRIPTION
- fixes the runtime-upgrade sgx test
- reduces the number of nodes in the txsoruce-sgx to (hopefully) reduce the flakiness, since it appears the test was failing due to transactions timing out at times

There still might be some flakiness, but there should be no sgx test constantly failing now, as seen here: https://buildkite.com/oasisprotocol/oasis-core-ci/builds/8217