### PR TITLE
go/runtime/bundle: Check the ELF image when validating

### DIFF
--- a/go/runtime/bundle/bundle.go
+++ b/go/runtime/bundle/bundle.go
@@ -4,6 +4,7 @@ package bundle
 import (
 	"archive/zip"
 	"bytes"
+	"debug/elf"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -80,6 +81,13 @@ func (bnd *Bundle) Validate() error {
 			return fmt.Errorf("runtime/bundle: invalid digest: '%s'", fn)
 		}
 	}
+
+	// Make sure the ELF executable actually is an ELF image.
+	f, err := elf.NewFile(bytes.NewReader(bnd.Data[bnd.Manifest.Executable]))
+	if err != nil {
+		return fmt.Errorf("runtime/bundle: ELF executable isnt: %w", err)
+	}
+	_ = f.Close()
 
 	// Make sure the SGX signature is valid if it exists.
 	if err := bnd.verifySgxSignature(); err != nil {

--- a/go/runtime/bundle/bundle_test.go
+++ b/go/runtime/bundle/bundle_test.go
@@ -2,6 +2,7 @@ package bundle
 
 import (
 	"crypto/rand"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -11,6 +12,12 @@ import (
 )
 
 func TestBundle(t *testing.T) {
+	execFile := os.Args[0]
+	execBuf, err := os.ReadFile(execFile)
+	if err != nil {
+		t.Fatalf("failed to read test executable %s: %v", execFile, err)
+	}
+
 	// Create a synthetic bundle.
 	//
 	// Assets will be populated during the Add/Write combined test.
@@ -43,7 +50,7 @@ func TestBundle(t *testing.T) {
 			return b
 		}
 
-		err := bundle.Add(manifest.Executable, randomBuffer())
+		err := bundle.Add(manifest.Executable, execBuf)
 		require.NoError(t, err, "bundle.Add(elf)")
 		err = bundle.Add(manifest.SGX.Executable, randomBuffer())
 		require.NoError(t, err, "bundle.Add(sgx)")


### PR DESCRIPTION
Fixes #4657