### PR TITLE
go/worker/compute: Only advertise active version for TEE runtimes

### DIFF
--- a/.changelog/4683.bugfix.md
+++ b/.changelog/4683.bugfix.md
@@ -1,0 +1,4 @@
+go/worker/compute: Only advertise active version for TEE runtimes
+
+Previously this caused additional downtime on upgrades due to capability
+updates not being allowed.

--- a/go/worker/compute/executor/committee/node.go
+++ b/go/worker/compute/executor/committee/node.go
@@ -1348,10 +1348,15 @@ func (n *Node) nudgeAvailabilityLocked(force bool) {
 
 		n.roleProvider.SetAvailable(func(nd *node.Node) error {
 			for _, version := range n.commonNode.Runtime.HostVersions() {
-				rt := nd.AddOrUpdateRuntime(n.commonNode.Runtime.ID(), version)
-				if rt.Version == n.runtimeVersion {
-					rt.Capabilities.TEE = n.runtimeCapabilityTEE
+				// For TEE-enabled runtimes we can only advertise the active version as this will
+				// otherwise cause additional downtime on upgrades due to capability updates not
+				// being allowed.
+				if n.runtimeCapabilityTEE != nil && version != n.runtimeVersion {
+					continue
 				}
+
+				rt := nd.AddOrUpdateRuntime(n.commonNode.Runtime.ID(), version)
+				rt.Capabilities.TEE = n.runtimeCapabilityTEE
 			}
 			return nil
 		})

--- a/go/worker/compute/executor/committee/node.go
+++ b/go/worker/compute/executor/committee/node.go
@@ -1355,6 +1355,11 @@ func (n *Node) nudgeAvailabilityLocked(force bool) {
 					continue
 				}
 
+				// Skip sending any old versions that will never be active again.
+				if version.ToU64() < n.runtimeVersion.ToU64() {
+					continue
+				}
+
 				rt := nd.AddOrUpdateRuntime(n.commonNode.Runtime.ID(), version)
 				rt.Capabilities.TEE = n.runtimeCapabilityTEE
 			}


### PR DESCRIPTION
Otherwise this will cause additional downtime on upgrades due to
capability updates not being allowed.