### PR TITLE
go/worker/common: Properly handle dynamic key manager configuration

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -271,7 +271,7 @@ steps:
       # Needed as the trust-root test rebuilds the enclave with embedded trust root data.
       - cargo install --locked --path tools
       # Only run runtime scenarios as others do not use SGX.
-      - .buildkite/scripts/test_e2e.sh --scenario e2e/runtime/runtime --scenario e2e/runtime/trust-root
+      - .buildkite/scripts/test_e2e.sh --scenario e2e/runtime/runtime-encryption --scenario e2e/runtime/trust-root
     artifact_paths:
       - coverage-merged-e2e-*.txt
       - /tmp/e2e/**/*.log

--- a/.changelog/4715.feature.md
+++ b/.changelog/4715.feature.md
@@ -1,0 +1,4 @@
+go/worker/common: Properly handle dynamic key manager configuration
+
+Since the runtime can go from having no key manager configured to having one,
+the worker node should handle this correctly.

--- a/go/worker/common/committee/keymanager.go
+++ b/go/worker/common/committee/keymanager.go
@@ -1,0 +1,86 @@
+package committee
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	keymanagerP2P "github.com/oasisprotocol/oasis-core/go/worker/keymanager/p2p"
+)
+
+// KeyManagerClientWrapper is a wrapper for the key manager P2P client that handles deferred
+// initialization after the key manager runtime ID is known.
+type KeyManagerClientWrapper struct {
+	l sync.RWMutex
+
+	id  *common.Namespace
+	n   *Node
+	cli keymanagerP2P.Client
+}
+
+// Initialized returns a channel that gets closed when the client is initialized.
+func (km *KeyManagerClientWrapper) Initialized() <-chan struct{} {
+	km.l.RLock()
+	defer km.l.RUnlock()
+
+	// If no active key manager client, return a closed channel.
+	if km.cli == nil {
+		initCh := make(chan struct{})
+		close(initCh)
+		return initCh
+	}
+
+	return km.cli.Initialized()
+}
+
+func (km *KeyManagerClientWrapper) setKeymanagerID(id *common.Namespace) {
+	km.l.Lock()
+	defer km.l.Unlock()
+
+	// Only reinitialize in case the key manager ID changes.
+	if km.id == id || (km.id != nil && km.id.Equal(id)) {
+		return
+	}
+
+	km.n.logger.Debug("key manager updated",
+		"keymanager_id", id,
+	)
+	km.id = id
+
+	if km.cli != nil {
+		km.cli.Stop()
+		km.cli = nil
+	}
+
+	if id != nil {
+		km.cli = keymanagerP2P.NewClient(km.n.P2P, km.n.Consensus, *id)
+	}
+}
+
+// Implements runtimeKeymanager.Client.
+func (km *KeyManagerClientWrapper) CallEnclave(ctx context.Context, data []byte) ([]byte, error) {
+	km.l.RLock()
+	cli := km.cli
+	km.l.RUnlock()
+
+	if cli == nil {
+		return nil, fmt.Errorf("key manager not available")
+	}
+
+	rsp, pf, err := km.cli.CallEnclave(ctx, &keymanagerP2P.CallEnclaveRequest{
+		Data: data,
+	})
+	if err != nil {
+		return nil, err
+	}
+	// TODO: Support reporting peer feedback from the enclave.
+	pf.RecordSuccess()
+	return rsp.Data, nil
+}
+
+func newKeyManagerClientWrapper(n *Node) *KeyManagerClientWrapper {
+	return &KeyManagerClientWrapper{
+		n: n,
+	}
+}

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -26,7 +26,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/worker/common/api"
 	"github.com/oasisprotocol/oasis-core/go/worker/common/p2p"
 	"github.com/oasisprotocol/oasis-core/go/worker/common/p2p/txsync"
-	keymanagerP2P "github.com/oasisprotocol/oasis-core/go/worker/keymanager/p2p"
 )
 
 const periodicMetricsInterval = 60 * time.Second
@@ -159,7 +158,7 @@ type Node struct {
 
 	Identity         *identity.Identity
 	KeyManager       keymanager.Backend
-	KeyManagerClient keymanagerP2P.Client
+	KeyManagerClient *KeyManagerClientWrapper
 	Consensus        consensus.Backend
 	Group            *Group
 	P2P              *p2p.P2P
@@ -252,10 +251,7 @@ func (n *Node) Stop() {
 	n.stopOnce.Do(func() {
 		close(n.stopCh)
 		n.TxPool.Stop()
-
-		if n.KeyManagerClient != nil {
-			n.KeyManagerClient.Stop()
-		}
+		n.KeyManagerClient.setKeymanagerID(nil)
 	})
 }
 
@@ -491,6 +487,9 @@ func (n *Node) handleNewBlockLocked(blk *block.Block, height int64) {
 		}
 
 		n.updateHostedRuntimeVersionLocked()
+
+		// Make sure to update the key manager if needed.
+		n.KeyManagerClient.setKeymanagerID(n.CurrentDescriptor.KeyManager)
 	}
 
 	for _, hooks := range n.hooks {
@@ -613,7 +612,7 @@ func (n *Node) worker() {
 			"keymanager_runtime_id", *rt.KeyManager,
 		)
 
-		n.KeyManagerClient = keymanagerP2P.NewClient(n.P2P, n.Consensus, *rt.KeyManager)
+		n.KeyManagerClient.setKeymanagerID(rt.KeyManager)
 		select {
 		case <-n.ctx.Done():
 			n.logger.Error("failed to wait for key manager",
@@ -866,6 +865,9 @@ func NewNode(
 		initCh:     make(chan struct{}),
 		logger:     logging.GetLogger("worker/common/committee").With("runtime_id", runtime.ID()),
 	}
+
+	// Prepare the key manager client wrapper.
+	n.KeyManagerClient = newKeyManagerClientWrapper(n)
 
 	// Prepare the runtime host node helpers.
 	rhn, err := runtimeRegistry.NewRuntimeHostNode(n)

--- a/go/worker/common/committee/runtime_host.go
+++ b/go/worker/common/committee/runtime_host.go
@@ -9,7 +9,6 @@ import (
 	runtimeKeymanager "github.com/oasisprotocol/oasis-core/go/runtime/keymanager/api"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	"github.com/oasisprotocol/oasis-core/go/runtime/txpool"
-	keymanagerP2P "github.com/oasisprotocol/oasis-core/go/worker/keymanager/p2p"
 )
 
 // Implements RuntimeHostHandlerFactory.
@@ -35,25 +34,9 @@ func (env *nodeEnvironment) GetCurrentBlock(ctx context.Context) (*block.Block, 
 	return blk, nil
 }
 
-type keymanagerClientWrapper struct {
-	cli keymanagerP2P.Client
-}
-
-func (km *keymanagerClientWrapper) CallEnclave(ctx context.Context, data []byte) ([]byte, error) {
-	rsp, pf, err := km.cli.CallEnclave(ctx, &keymanagerP2P.CallEnclaveRequest{
-		Data: data,
-	})
-	if err != nil {
-		return nil, err
-	}
-	// TODO: Support reporting peer feedback from the enclave.
-	pf.RecordSuccess()
-	return rsp.Data, nil
-}
-
 // Implements RuntimeHostHandlerEnvironment.
 func (env *nodeEnvironment) GetKeyManagerClient(ctx context.Context) (runtimeKeymanager.Client, error) {
-	return &keymanagerClientWrapper{cli: env.n.KeyManagerClient}, nil
+	return env.n.KeyManagerClient, nil
 }
 
 // Implements RuntimeHostHandlerEnvironment.


### PR DESCRIPTION
Since the runtime can go from having no key manager configured to having
one, the worker node should handle this correctly.