### PR TITLE
go/runtime/registry: Refresh key manager policy on runtime changes

### DIFF
--- a/.changelog/4729.bugfix.md
+++ b/.changelog/4729.bugfix.md
@@ -1,0 +1,4 @@
+go/runtime/registry: Refresh key manager policy on runtime changes
+
+Since the runtime can change dynamically (due to version upgrades), we
+need to make sure that we notify the new runtime as well.

--- a/tests/runtimes/simple-keymanager/src/api.rs
+++ b/tests/runtimes/simple-keymanager/src/api.rs
@@ -1,7 +1,11 @@
-use oasis_core_keymanager_api_common::*;
-use oasis_core_runtime::common::crypto::signature::PrivateKey as OasisPrivateKey;
+#[cfg(target_env = "sgx")]
 use std::collections::HashSet;
 
+use oasis_core_keymanager_api_common::*;
+#[cfg(target_env = "sgx")]
+use oasis_core_runtime::common::crypto::signature::PrivateKey as OasisPrivateKey;
+
+#[cfg(target_env = "sgx")]
 pub fn trusted_policy_signers() -> TrustedPolicySigners {
     TrustedPolicySigners {
         signers: {
@@ -20,4 +24,9 @@ pub fn trusted_policy_signers() -> TrustedPolicySigners {
         },
         threshold: 2,
     }
+}
+
+#[cfg(not(target_env = "sgx"))]
+pub fn trusted_policy_signers() -> TrustedPolicySigners {
+    TrustedPolicySigners::default()
 }


### PR DESCRIPTION
Since the runtime can change dynamically (due to version upgrades), we
need to make sure that we notify the new runtime as well.