### PR TITLE
go/runtime/config: fix SGX provisioner check

### DIFF
--- a/.changelog/4734.bugfix.md
+++ b/.changelog/4734.bugfix.md
@@ -1,0 +1,4 @@
+go/runtime/config: fix SGX provisioner check for runtimes without SGX
+
+This fixes a bug in `22.1.5` where an SGX provisioner was required even for
+non-SGX runtimes.


### PR DESCRIPTION
TODO:
- [x] test

This should fix the SGX provisioner check. Currently SGX provisioner needs to be set even for non-sgx runtimes, caused by: https://github.com/oasisprotocol/oasis-core/pull/4734