### PR TITLE
go/common/node/address: use custom type instead of internal net.TCPAddr

### DIFF
--- a/.changelog/4744.internal.md
+++ b/.changelog/4744.internal.md
@@ -1,0 +1,1 @@
+go/common/node/address: use custom type instead of `net.TCPAddr`

--- a/go/common/node/node_test.go
+++ b/go/common/node/node_test.go
@@ -223,10 +223,10 @@ func TestNodeForTestSerialization(t *testing.T) {
 					Addresses: []TLSAddress{
 						{
 							PubKey: signature.NewPublicKey("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4"),
-							Address: Address{TCPAddr: net.TCPAddr{
+							Address: Address{
 								IP:   net.IPv4(127, 0, 0, 1),
 								Port: 1111,
-							}},
+							},
 						},
 					},
 				},

--- a/go/consensus/tendermint/apps/registry/state/interop/interop.go
+++ b/go/consensus/tendermint/apps/registry/state/interop/interop.go
@@ -61,10 +61,10 @@ func InitializeTestRegistryState(ctx context.Context, mkvs mkvs.Tree) error {
 					Addresses: []node.TLSAddress{
 						{
 							PubKey: signature.NewPublicKey("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff2"),
-							Address: node.Address{TCPAddr: net.TCPAddr{
+							Address: node.Address{
 								IP:   net.IPv4(127, 0, 0, 1),
 								Port: 1111,
-							}},
+							},
 						},
 					},
 				},

--- a/go/oasis-node/cmd/debug/byzantine/grpc.go
+++ b/go/oasis-node/cmd/debug/byzantine/grpc.go
@@ -12,10 +12,8 @@ import (
 func getGrpcAddress() []node.Address {
 	return []node.Address{
 		{
-			TCPAddr: net.TCPAddr{
-				IP:   net.IPv4(127, 0, 0, 1),
-				Port: viper.GetInt(cmdGrpc.CfgServerPort),
-			},
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: viper.GetInt64(cmdGrpc.CfgServerPort),
 		},
 	}
 }

--- a/go/oasis-node/cmd/debug/txsource/workload/registration.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/registration.go
@@ -89,11 +89,9 @@ func getRuntime(entityID signature.PublicKey, id common.Namespace, epoch beacon.
 
 func getNodeDesc(rng *rand.Rand, nodeIdentity *identity.Identity, entityID signature.PublicKey, runtimeID common.Namespace) *node.Node {
 	nodeAddr := node.Address{
-		TCPAddr: net.TCPAddr{
-			IP:   net.IPv4(127, 0, 0, 1),
-			Port: 12345,
-			Zone: "",
-		},
+		IP:   net.IPv4(127, 0, 0, 1),
+		Port: 12345,
+		Zone: "",
 	}
 
 	// NOTE: we shouldn't be registering validators, as that would lead to

--- a/go/oasis-test-runner/scenario/e2e/registry_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/registry_cli.go
@@ -357,16 +357,16 @@ func (sc *registryCLIImpl) isRegistered(childEnv *env.Env, nodeName, nodeDataDir
 func (sc *registryCLIImpl) newTestNode(entityID signature.PublicKey) (*node.Node, []string, []string, []string, error) {
 	// Addresses.
 	testAddresses := []node.Address{
-		{TCPAddr: net.TCPAddr{
+		{
 			IP:   net.IPv4(127, 0, 0, 1),
 			Port: 12345,
 			Zone: "",
-		}},
-		{TCPAddr: net.TCPAddr{
+		},
+		{
 			IP:   net.IPv4(127, 0, 0, 2),
 			Port: 54321,
 			Zone: "",
-		}},
+		},
 	}
 	testAddressesStr := []string{}
 	for _, a := range testAddresses {

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"net"
 	"testing"
 	"time"
 
@@ -1080,10 +1079,8 @@ func (ent *TestEntity) NewTestNodes(nCompute int, idNonce []byte, runtimes []*no
 			Roles:    role,
 		}
 		addr := node.Address{
-			TCPAddr: net.TCPAddr{
-				IP:   []byte{192, 0, 2, byte(i + 1)},
-				Port: 451,
-			},
+			IP:   []byte{192, 0, 2, byte(i + 1)},
+			Port: 451,
 		}
 		nod.Node.P2P.ID = nodeIdentity.P2PSigner.Public()
 		nod.Node.P2P.Addresses = append(nod.Node.P2P.Addresses, addr)
@@ -1368,10 +1365,8 @@ func (ent *TestEntity) NewTestNodes(nCompute int, idNonce []byte, runtimes []*no
 			VRF:        nod.Node.VRF,
 		}
 		addr = node.Address{
-			TCPAddr: net.TCPAddr{
-				IP:   []byte{192, 0, 2, byte(i + 1)},
-				Port: 452,
-			},
+			IP:   []byte{192, 0, 2, byte(i + 1)},
+			Port: 452,
 		}
 		nod.UpdatedNode.P2P.ID = nod.Node.P2P.ID
 		nod.UpdatedNode.P2P.Addresses = append(nod.UpdatedNode.P2P.Addresses, addr)

--- a/go/worker/common/p2p/p2p.go
+++ b/go/worker/common/p2p/p2p.go
@@ -124,7 +124,12 @@ func (p *P2P) Addresses() []node.Address {
 			panic(err)
 		}
 		tcpAddr := (netAddr).(*net.TCPAddr)
-		nodeAddr := node.Address{TCPAddr: *tcpAddr}
+		nodeAddr := node.Address{
+			IP:   tcpAddr.IP,
+			Port: int64(tcpAddr.Port),
+			Zone: tcpAddr.Zone,
+		}
+
 		if err := registryAPI.VerifyAddress(nodeAddr, allowUnroutable); err != nil {
 			continue
 		}
@@ -329,7 +334,7 @@ func New(identity *identity.Identity, consensus consensus.Backend) (*P2P, error)
 	var registerAddresses []multiaddr.Multiaddr
 	for _, addr := range addresses {
 		var mAddr multiaddr.Multiaddr
-		mAddr, err = manet.FromNetAddr(&addr.TCPAddr)
+		mAddr, err = manet.FromNetAddr(addr.ToTCPAddr())
 		if err != nil {
 			return nil, err
 		}

--- a/go/worker/common/p2p/peermgmt.go
+++ b/go/worker/common/p2p/peermgmt.go
@@ -458,7 +458,7 @@ func nodeToAddrInfo(node *node.Node) (*peer.AddrInfo, error) {
 		return nil, fmt.Errorf("failed to extract public key from node P2P ID: %w", err)
 	}
 	for _, nodeAddr := range node.P2P.Addresses {
-		addr, err := manet.FromNetAddr(&nodeAddr.TCPAddr)
+		addr, err := manet.FromNetAddr(nodeAddr.ToTCPAddr())
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert address to libp2p format: %w", err)
 		}


### PR DESCRIPTION
Since `Address` is used in consensus state, it makes sense using an explicitly defined struct. The struct serialization is defined in a backwards compatible way.