### PR TITLE
runtime: Add support for reporting EnclaveRPC peer feedback

### DIFF
--- a/.changelog/4757.feature.md
+++ b/.changelog/4757.feature.md
@@ -1,0 +1,4 @@
+runtime: Add support for reporting EnclaveRPC peer feedback
+
+This makes EnclaveRPC more robust as the higher-level layer in the
+runtime can trigger peer replacement on high level errors.

--- a/go/runtime/enclaverpc/api/api.go
+++ b/go/runtime/enclaverpc/api/api.go
@@ -3,9 +3,32 @@ package api
 
 // Frame is an EnclaveRPC frame.
 //
-// It is the Go analog of the Rust RPC frame defined in client/src/rpc/types.rs.
+// It is the Go analog of the Rust RPC frame defined in runtime/src/enclave_rpc/types.rs.
 type Frame struct {
 	Session            []byte `json:"session,omitempty"`
 	UntrustedPlaintext string `json:"untrusted_plaintext,omitempty"`
 	Payload            []byte `json:"payload,omitempty"`
+}
+
+// PeerFeedback is the feedback on the peer that handled the last RPC call.
+type PeerFeedback uint8
+
+const (
+	PeerFeedbackSuccess PeerFeedback = 0
+	PeerFeedbackFailure PeerFeedback = 1
+	PeerFeedbackBadPeer PeerFeedback = 2
+)
+
+// String returns a string representation of peer feedback.
+func (pf PeerFeedback) String() string {
+	switch pf {
+	case PeerFeedbackSuccess:
+		return "success"
+	case PeerFeedbackFailure:
+		return "failure"
+	case PeerFeedbackBadPeer:
+		return "bad peer"
+	default:
+		return "[unknown]"
+	}
 }

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/message"
+	enclaverpc "github.com/oasisprotocol/oasis-core/go/runtime/enclaverpc/api"
 	"github.com/oasisprotocol/oasis-core/go/runtime/transaction"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
 )
@@ -402,6 +403,14 @@ type RuntimeConsensusSyncRequest struct {
 type HostRPCCallRequest struct {
 	Endpoint string `json:"endpoint"`
 	Request  []byte `json:"request"`
+
+	// PeerFeedback contains optional peer feedback for the last RPC call under the given endpoint.
+	//
+	// This enables the runtime to notify the node whether the given peer should continue to be used
+	// or not based on higher-level logic that lives in the runtime.
+	//
+	// In case no feedback is given success is assumed.
+	PeerFeedback *enclaverpc.PeerFeedback `json:"pf,omitempty"`
 }
 
 // HostRPCCallResponse is a host RPC call response message body.

--- a/go/runtime/keymanager/api/api.go
+++ b/go/runtime/keymanager/api/api.go
@@ -1,7 +1,11 @@
 // Package api defines the key manager client API.
 package api
 
-import "context"
+import (
+	"context"
+
+	enclaverpc "github.com/oasisprotocol/oasis-core/go/runtime/enclaverpc/api"
+)
 
 // EnclaveRPCEndpoint is the name of the key manager EnclaveRPC endpoint.
 const EnclaveRPCEndpoint = "key-manager"
@@ -9,5 +13,8 @@ const EnclaveRPCEndpoint = "key-manager"
 // Client is the key manager client interface.
 type Client interface {
 	// CallEnclave calls the key manager via remote EnclaveRPC.
-	CallEnclave(ctx context.Context, data []byte) ([]byte, error)
+	//
+	// The provided peer feedback is optional feedback on the peer that handled the last EnclaveRPC
+	// request (if any) which may be used to inform the routing decision.
+	CallEnclave(ctx context.Context, data []byte, pf *enclaverpc.PeerFeedback) ([]byte, error)
 }

--- a/go/runtime/registry/host.go
+++ b/go/runtime/registry/host.go
@@ -173,7 +173,7 @@ func (h *runtimeHostHandler) Handle(ctx context.Context, body *protocol.Body) (*
 			if err != nil {
 				return nil, err
 			}
-			res, err := kmCli.CallEnclave(ctx, body.HostRPCCallRequest.Request)
+			res, err := kmCli.CallEnclave(ctx, body.HostRPCCallRequest.Request, body.HostRPCCallRequest.PeerFeedback)
 			if err != nil {
 				return nil, err
 			}

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -252,7 +252,7 @@ func (n *Node) Stop() {
 	n.stopOnce.Do(func() {
 		close(n.stopCh)
 		n.TxPool.Stop()
-		n.KeyManagerClient.setKeymanagerID(nil)
+		n.KeyManagerClient.SetKeyManagerID(nil)
 	})
 }
 
@@ -490,7 +490,7 @@ func (n *Node) handleNewBlockLocked(blk *block.Block, height int64) {
 		n.updateHostedRuntimeVersionLocked()
 
 		// Make sure to update the key manager if needed.
-		n.KeyManagerClient.setKeymanagerID(n.CurrentDescriptor.KeyManager)
+		n.KeyManagerClient.SetKeyManagerID(n.CurrentDescriptor.KeyManager)
 	}
 
 	for _, hooks := range n.hooks {
@@ -614,7 +614,7 @@ func (n *Node) worker() {
 			"keymanager_runtime_id", *rt.KeyManager,
 		)
 
-		n.KeyManagerClient.setKeymanagerID(rt.KeyManager)
+		n.KeyManagerClient.SetKeyManagerID(rt.KeyManager)
 		select {
 		case <-n.ctx.Done():
 			n.logger.Error("failed to wait for key manager",
@@ -873,7 +873,7 @@ func NewNode(
 	}
 
 	// Prepare the key manager client wrapper.
-	n.KeyManagerClient = newKeyManagerClientWrapper(n)
+	n.KeyManagerClient = NewKeyManagerClientWrapper(p2pHost, consensus, n.logger)
 
 	// Prepare the runtime host node helpers.
 	rhn, err := runtimeRegistry.NewRuntimeHostNode(n)

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -750,7 +750,13 @@ func (crw *clientRuntimeWatcher) worker() {
 		select {
 		case <-crw.w.ctx.Done():
 			return
-		case <-ch:
+		case nu := <-ch:
+			if nu.Reset {
+				// Ignore reset events to avoid clearing the access list before setting a new one.
+				// This is safe because a reset event is always followed by a freeze event after the
+				// nodes have been set (even if the new set is empty).
+				continue
+			}
 			crw.w.setAccessList(crw.runtimeID, crw.nodes.GetNodes())
 		}
 	}

--- a/runtime/src/enclave_rpc/types.rs
+++ b/runtime/src/enclave_rpc/types.rs
@@ -61,3 +61,11 @@ pub enum Message {
     Response(Response),
     Close,
 }
+
+/// Feedback on the peer that handled the last EnclaveRPC call.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, cbor::Encode, cbor::Decode)]
+pub enum PeerFeedback {
+    Success = 0,
+    Failure = 1,
+    BadPeer = 2,
+}

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -18,6 +18,7 @@ use crate::{
         roothash::{self, Block, ComputeResultsHeader, Header},
         LightBlock,
     },
+    enclave_rpc,
     storage::mkvs::{sync, WriteLog},
     transaction::types::TxnBatch,
 };
@@ -199,6 +200,8 @@ pub enum Body {
     HostRPCCallRequest {
         endpoint: String,
         request: Vec<u8>,
+        #[cbor(optional, rename = "pf")]
+        peer_feedback: Option<enclave_rpc::types::PeerFeedback>,
     },
     HostRPCCallResponse {
         response: Vec<u8>,


### PR DESCRIPTION
This makes EnclaveRPC more robust as the higher-level layer in the
runtime can trigger peer replacement on high level errors.

TODO
* [x] Also use the `KeyManagerClientWrapper` in the key manager worker.