### PR TITLE
consensus: Reduce log spam

### DIFF
--- a/.changelog/4759.trivial.md
+++ b/.changelog/4759.trivial.md
@@ -1,0 +1,3 @@
+go/consensus: Reduce log severity (from Error to Debug)
+for errors that stem from bad transactions and not
+node or network problems.

--- a/go/consensus/tendermint/abci/mux.go
+++ b/go/consensus/tendermint/abci/mux.go
@@ -507,7 +507,7 @@ func (mux *abciMux) decodeTx(ctx *api.Context, rawTx []byte) (*transaction.Trans
 	if params.MaxTxSize > 0 && uint64(len(rawTx)) > params.MaxTxSize {
 		// This deliberately avoids logging the rawTx since spamming the
 		// logs is also bad.
-		ctx.Logger().ErrorQ("received oversized transaction",
+		ctx.Logger().Debug("received oversized transaction",
 			"tx_size", len(rawTx),
 		)
 		return nil, nil, consensus.ErrOversizedTx
@@ -516,20 +516,20 @@ func (mux *abciMux) decodeTx(ctx *api.Context, rawTx []byte) (*transaction.Trans
 	// Unmarshal envelope and verify transaction.
 	var sigTx transaction.SignedTransaction
 	if err := cbor.Unmarshal(rawTx, &sigTx); err != nil {
-		ctx.Logger().ErrorQ("failed to unmarshal signed transaction",
+		ctx.Logger().Debug("failed to unmarshal signed transaction",
 			"tx", base64.StdEncoding.EncodeToString(rawTx),
 		)
 		return nil, nil, err
 	}
 	var tx transaction.Transaction
 	if err := sigTx.Open(&tx); err != nil {
-		ctx.Logger().ErrorQ("failed to verify transaction signature",
+		ctx.Logger().Debug("failed to verify transaction signature",
 			"tx", base64.StdEncoding.EncodeToString(rawTx),
 		)
 		return nil, nil, err
 	}
 	if err := tx.SanityCheck(); err != nil {
-		ctx.Logger().ErrorQ("bad transaction",
+		ctx.Logger().Debug("bad transaction",
 			"tx", base64.StdEncoding.EncodeToString(rawTx),
 		)
 		return nil, nil, err
@@ -542,7 +542,7 @@ func (mux *abciMux) processTx(ctx *api.Context, tx *transaction.Transaction, txS
 	// Lookup method handler.
 	app := mux.appsByMethod[tx.Method]
 	if app == nil {
-		ctx.Logger().ErrorQ("unknown method",
+		ctx.Logger().Debug("unknown method",
 			"tx", tx,
 			"method", tx.Method,
 		)

--- a/go/consensus/tendermint/abci/mux.go
+++ b/go/consensus/tendermint/abci/mux.go
@@ -507,7 +507,7 @@ func (mux *abciMux) decodeTx(ctx *api.Context, rawTx []byte) (*transaction.Trans
 	if params.MaxTxSize > 0 && uint64(len(rawTx)) > params.MaxTxSize {
 		// This deliberately avoids logging the rawTx since spamming the
 		// logs is also bad.
-		ctx.Logger().Error("received oversized transaction",
+		ctx.Logger().ErrorQ("received oversized transaction",
 			"tx_size", len(rawTx),
 		)
 		return nil, nil, consensus.ErrOversizedTx
@@ -516,20 +516,20 @@ func (mux *abciMux) decodeTx(ctx *api.Context, rawTx []byte) (*transaction.Trans
 	// Unmarshal envelope and verify transaction.
 	var sigTx transaction.SignedTransaction
 	if err := cbor.Unmarshal(rawTx, &sigTx); err != nil {
-		ctx.Logger().Error("failed to unmarshal signed transaction",
+		ctx.Logger().ErrorQ("failed to unmarshal signed transaction",
 			"tx", base64.StdEncoding.EncodeToString(rawTx),
 		)
 		return nil, nil, err
 	}
 	var tx transaction.Transaction
 	if err := sigTx.Open(&tx); err != nil {
-		ctx.Logger().Error("failed to verify transaction signature",
+		ctx.Logger().ErrorQ("failed to verify transaction signature",
 			"tx", base64.StdEncoding.EncodeToString(rawTx),
 		)
 		return nil, nil, err
 	}
 	if err := tx.SanityCheck(); err != nil {
-		ctx.Logger().Error("bad transaction",
+		ctx.Logger().ErrorQ("bad transaction",
 			"tx", base64.StdEncoding.EncodeToString(rawTx),
 		)
 		return nil, nil, err
@@ -542,7 +542,7 @@ func (mux *abciMux) processTx(ctx *api.Context, tx *transaction.Transaction, txS
 	// Lookup method handler.
 	app := mux.appsByMethod[tx.Method]
 	if app == nil {
-		ctx.Logger().Error("unknown method",
+		ctx.Logger().ErrorQ("unknown method",
 			"tx", tx,
 			"method", tx.Method,
 		)

--- a/go/consensus/tendermint/apps/governance/transactions.go
+++ b/go/consensus/tendermint/apps/governance/transactions.go
@@ -27,7 +27,7 @@ func (app *governanceApplication) submitProposal(
 
 	// Validate proposal content basics.
 	if err := proposalContent.ValidateBasic(); err != nil {
-		ctx.Logger().ErrorQ("governance: malformed proposal content",
+		ctx.Logger().Debug("governance: malformed proposal content",
 			"content", proposalContent,
 			"err", err,
 		)
@@ -61,7 +61,7 @@ func (app *governanceApplication) submitProposal(
 
 	// Check if submitter has enough balance for proposal deposit.
 	if submitter.General.Balance.Cmp(&params.MinProposalDeposit) < 0 {
-		ctx.Logger().ErrorQ("governance: not enough balance to submit proposal",
+		ctx.Logger().Debug("governance: not enough balance to submit proposal",
 			"submitter", submitterAddr,
 			"min_proposal_deposit", params.MinProposalDeposit,
 		)
@@ -81,7 +81,7 @@ func (app *governanceApplication) submitProposal(
 		upgrade := proposalContent.Upgrade
 		// Ensure upgrade descriptor epoch is far enough in future.
 		if upgrade.Descriptor.Epoch < params.UpgradeMinEpochDiff+epoch {
-			ctx.Logger().ErrorQ("governance: upgrade descriptor epoch too soon",
+			ctx.Logger().Debug("governance: upgrade descriptor epoch too soon",
 				"submitter", submitterAddr,
 				"descriptor", upgrade.Descriptor,
 				"upgrade_min_epoch_diff", params.UpgradeMinEpochDiff,
@@ -111,7 +111,7 @@ func (app *governanceApplication) submitProposal(
 		switch err {
 		case nil:
 		case governance.ErrNoSuchUpgrade:
-			ctx.Logger().ErrorQ("governance: cancel upgrade for a non existing pending upgrade",
+			ctx.Logger().Debug("governance: cancel upgrade for a non existing pending upgrade",
 				"proposal_id", cancelUpgrade.ProposalID,
 				"err", err,
 			)
@@ -242,7 +242,7 @@ func (app *governanceApplication) castVote(
 		}
 	}
 	if !eligible {
-		ctx.Logger().ErrorQ("governance: submitter not eligible to vote",
+		ctx.Logger().Debug("governance: submitter not eligible to vote",
 			"submitter", ctx.TxSigner(),
 		)
 		return governance.ErrNotEligible
@@ -253,12 +253,12 @@ func (app *governanceApplication) castVote(
 	switch err {
 	case nil:
 	case governance.ErrNoSuchProposal:
-		ctx.Logger().ErrorQ("governance: vote for a missing proposal",
+		ctx.Logger().Debug("governance: vote for a missing proposal",
 			"proposal_id", proposalVote.ID,
 		)
 		return governance.ErrNoSuchProposal
 	default:
-		ctx.Logger().ErrorQ("governance: error loading proposal",
+		ctx.Logger().Debug("governance: error loading proposal",
 			"err", err,
 			"proposal_id", proposalVote.ID,
 		)

--- a/go/consensus/tendermint/apps/governance/transactions.go
+++ b/go/consensus/tendermint/apps/governance/transactions.go
@@ -27,7 +27,7 @@ func (app *governanceApplication) submitProposal(
 
 	// Validate proposal content basics.
 	if err := proposalContent.ValidateBasic(); err != nil {
-		ctx.Logger().Error("governance: malformed proposal content",
+		ctx.Logger().ErrorQ("governance: malformed proposal content",
 			"content", proposalContent,
 			"err", err,
 		)
@@ -61,7 +61,7 @@ func (app *governanceApplication) submitProposal(
 
 	// Check if submitter has enough balance for proposal deposit.
 	if submitter.General.Balance.Cmp(&params.MinProposalDeposit) < 0 {
-		ctx.Logger().Error("governance: not enough balance to submit proposal",
+		ctx.Logger().ErrorQ("governance: not enough balance to submit proposal",
 			"submitter", submitterAddr,
 			"min_proposal_deposit", params.MinProposalDeposit,
 		)
@@ -81,7 +81,7 @@ func (app *governanceApplication) submitProposal(
 		upgrade := proposalContent.Upgrade
 		// Ensure upgrade descriptor epoch is far enough in future.
 		if upgrade.Descriptor.Epoch < params.UpgradeMinEpochDiff+epoch {
-			ctx.Logger().Error("governance: upgrade descriptor epoch too soon",
+			ctx.Logger().ErrorQ("governance: upgrade descriptor epoch too soon",
 				"submitter", submitterAddr,
 				"descriptor", upgrade.Descriptor,
 				"upgrade_min_epoch_diff", params.UpgradeMinEpochDiff,
@@ -111,7 +111,7 @@ func (app *governanceApplication) submitProposal(
 		switch err {
 		case nil:
 		case governance.ErrNoSuchUpgrade:
-			ctx.Logger().Error("governance: cancel upgrade for a non existing pending upgrade",
+			ctx.Logger().ErrorQ("governance: cancel upgrade for a non existing pending upgrade",
 				"proposal_id", cancelUpgrade.ProposalID,
 				"err", err,
 			)
@@ -242,7 +242,7 @@ func (app *governanceApplication) castVote(
 		}
 	}
 	if !eligible {
-		ctx.Logger().Error("governance: submitter not eligible to vote",
+		ctx.Logger().ErrorQ("governance: submitter not eligible to vote",
 			"submitter", ctx.TxSigner(),
 		)
 		return governance.ErrNotEligible
@@ -253,12 +253,12 @@ func (app *governanceApplication) castVote(
 	switch err {
 	case nil:
 	case governance.ErrNoSuchProposal:
-		ctx.Logger().Error("governance: vote for a missing proposal",
+		ctx.Logger().ErrorQ("governance: vote for a missing proposal",
 			"proposal_id", proposalVote.ID,
 		)
 		return governance.ErrNoSuchProposal
 	default:
-		ctx.Logger().Error("governance: error loading proposal",
+		ctx.Logger().ErrorQ("governance: error loading proposal",
 			"err", err,
 			"proposal_id", proposalVote.ID,
 		)

--- a/go/consensus/tendermint/apps/keymanager/keymanager.go
+++ b/go/consensus/tendermint/apps/keymanager/keymanager.go
@@ -128,7 +128,7 @@ func (app *keymanagerApplication) onEpochChange(ctx *tmapi.Context, epoch beacon
 			}
 
 			if err = stakeAcc.CheckStakeClaims(*acctAddr); err != nil {
-				ctx.Logger().WarnQ("insufficient stake for key manager runtime operation",
+				ctx.Logger().Debug("insufficient stake for key manager runtime operation",
 					"err", err,
 					"entity", rt.EntityID,
 					"account", *acctAddr,

--- a/go/consensus/tendermint/apps/keymanager/keymanager.go
+++ b/go/consensus/tendermint/apps/keymanager/keymanager.go
@@ -128,7 +128,7 @@ func (app *keymanagerApplication) onEpochChange(ctx *tmapi.Context, epoch beacon
 			}
 
 			if err = stakeAcc.CheckStakeClaims(*acctAddr); err != nil {
-				ctx.Logger().Warn("insufficient stake for key manager runtime operation",
+				ctx.Logger().WarnQ("insufficient stake for key manager runtime operation",
 					"err", err,
 					"entity", rt.EntityID,
 					"account", *acctAddr,

--- a/go/consensus/tendermint/apps/registry/transactions.go
+++ b/go/consensus/tendermint/apps/registry/transactions.go
@@ -60,7 +60,7 @@ func (app *registryApplication) registerEntity(
 			registry.StakeClaimRegisterEntity,
 			staking.GlobalStakeThresholds(staking.KindEntity),
 		); err != nil {
-			ctx.Logger().ErrorQ("RegisterEntity: Insufficient stake",
+			ctx.Logger().Debug("RegisterEntity: Insufficient stake",
 				"err", err,
 				"entity", ent.ID,
 				"account", acctAddr,
@@ -110,7 +110,7 @@ func (app *registryApplication) deregisterEntity(ctx *api.Context, state *regist
 		return err
 	}
 	if hasNodes {
-		ctx.Logger().ErrorQ("DeregisterEntity: entity still has nodes",
+		ctx.Logger().Debug("DeregisterEntity: entity still has nodes",
 			"entity_id", id,
 		)
 		return registry.ErrEntityHasNodes
@@ -124,7 +124,7 @@ func (app *registryApplication) deregisterEntity(ctx *api.Context, state *regist
 		return err
 	}
 	if hasRuntimes {
-		ctx.Logger().ErrorQ("DeregisterEntity: entity still has runtimes",
+		ctx.Logger().Debug("DeregisterEntity: entity still has runtimes",
 			"entity_id", id,
 		)
 		return registry.ErrEntityHasRuntimes
@@ -167,7 +167,7 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 	// Peek into the to-be-verified node to pull out the owning entity ID.
 	var untrustedNode node.Node
 	if err := cbor.Unmarshal(sigNode.Blob, &untrustedNode); err != nil {
-		ctx.Logger().ErrorQ("RegisterNode: failed to extract entity",
+		ctx.Logger().Debug("RegisterNode: failed to extract entity",
 			"err", err,
 			"signed_node", sigNode,
 		)
@@ -231,7 +231,7 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 		}
 		wcfg, entIsWhitelisted := rt.AdmissionPolicy.EntityWhitelist.Entities[newNode.EntityID]
 		if !entIsWhitelisted {
-			ctx.Logger().ErrorQ("RegisterNode: node's entity not in a runtime's whitelist",
+			ctx.Logger().Debug("RegisterNode: node's entity not in a runtime's whitelist",
 				"entity_id", newNode.EntityID,
 				"runtime_id", rt.ID,
 				"node_id", newNode.ID,
@@ -256,7 +256,7 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 			maxNodes, exists := wcfg.MaxNodes[role]
 			if !exists {
 				// No such role found in whitelist.
-				ctx.Logger().ErrorQ("RegisterNode: runtime's whitelist does not allow nodes with given role",
+				ctx.Logger().Debug("RegisterNode: runtime's whitelist does not allow nodes with given role",
 					"role", role.String(),
 					"runtime_id", rt.ID,
 					"node_id", newNode.ID,
@@ -265,7 +265,7 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 			}
 			if maxNodes == 0 {
 				// No nodes of this type are allowed.
-				ctx.Logger().ErrorQ("RegisterNode: runtime's whitelist does not allow nodes with given role",
+				ctx.Logger().Debug("RegisterNode: runtime's whitelist does not allow nodes with given role",
 					"role", role.String(),
 					"runtime_id", rt.ID,
 				)
@@ -317,7 +317,7 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 	//
 	// Yes, this is duplicated.  Blame the sanity checker.
 	if !ctx.IsInitChain() && newNode.Expiration <= uint64(epoch) {
-		ctx.Logger().ErrorQ("RegisterNode: node descriptor is expired",
+		ctx.Logger().Debug("RegisterNode: node descriptor is expired",
 			"new_node", newNode,
 			"epoch", epoch,
 		)
@@ -379,7 +379,7 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 		acctAddr := staking.NewAddress(newNode.EntityID)
 
 		if err = stakeAcc.AddStakeClaim(acctAddr, claim, thresholds); err != nil {
-			ctx.Logger().ErrorQ("RegisterNode: insufficient stake for new node",
+			ctx.Logger().Debug("RegisterNode: insufficient stake for new node",
 				"err", err,
 				"entity", newNode.EntityID,
 				"account", acctAddr,
@@ -703,21 +703,21 @@ func (app *registryApplication) registerRuntime( // nolint: gocyclo
 
 		expectedAddr := rtToCheck.StakingAddress()
 		if expectedAddr == nil {
-			ctx.Logger().ErrorQ("RegisterRuntime: runtimes with consensus-layer governance can only be registered at genesis")
+			ctx.Logger().Debug("RegisterRuntime: runtimes with consensus-layer governance can only be registered at genesis")
 			return nil, registry.ErrForbidden
 		}
 
 		if !ctx.CallerAddress().Equal(*expectedAddr) {
 			switch rtToCheck.GovernanceModel {
 			case registry.GovernanceEntity:
-				ctx.Logger().ErrorQ("RegisterRuntime: transaction must be signed by controlling entity")
+				ctx.Logger().Debug("RegisterRuntime: transaction must be signed by controlling entity")
 				return nil, registry.ErrIncorrectTxSigner
 			case registry.GovernanceRuntime:
-				ctx.Logger().ErrorQ("RegisterRuntime: caller must be the runtime itself")
+				ctx.Logger().Debug("RegisterRuntime: caller must be the runtime itself")
 				return nil, registry.ErrForbidden
 			default:
 				// Basic validation should have caught this, but just in case...
-				ctx.Logger().ErrorQ("RegisterRuntime: invalid governance model")
+				ctx.Logger().Debug("RegisterRuntime: invalid governance model")
 				return nil, registry.ErrInvalidArgument
 			}
 		}
@@ -736,12 +736,12 @@ func (app *registryApplication) registerRuntime( // nolint: gocyclo
 			acctAddr = ctx.CallerAddress()
 		default:
 			// Basic validation should have caught this, but just in case...
-			ctx.Logger().ErrorQ("RegisterRuntime: invalid governance model")
+			ctx.Logger().Debug("RegisterRuntime: invalid governance model")
 			return nil, registry.ErrInvalidArgument
 		}
 
 		if err = stakingState.AddStakeClaim(ctx, acctAddr, claim, thresholds); err != nil {
-			ctx.Logger().ErrorQ("RegisterRuntime: insufficient stake",
+			ctx.Logger().Debug("RegisterRuntime: insufficient stake",
 				"err", err,
 				"entity", rt.EntityID,
 				"runtime", rt.ID,

--- a/go/consensus/tendermint/apps/registry/transactions.go
+++ b/go/consensus/tendermint/apps/registry/transactions.go
@@ -60,7 +60,7 @@ func (app *registryApplication) registerEntity(
 			registry.StakeClaimRegisterEntity,
 			staking.GlobalStakeThresholds(staking.KindEntity),
 		); err != nil {
-			ctx.Logger().Error("RegisterEntity: Insufficient stake",
+			ctx.Logger().ErrorQ("RegisterEntity: Insufficient stake",
 				"err", err,
 				"entity", ent.ID,
 				"account", acctAddr,
@@ -110,7 +110,7 @@ func (app *registryApplication) deregisterEntity(ctx *api.Context, state *regist
 		return err
 	}
 	if hasNodes {
-		ctx.Logger().Error("DeregisterEntity: entity still has nodes",
+		ctx.Logger().ErrorQ("DeregisterEntity: entity still has nodes",
 			"entity_id", id,
 		)
 		return registry.ErrEntityHasNodes
@@ -124,7 +124,7 @@ func (app *registryApplication) deregisterEntity(ctx *api.Context, state *regist
 		return err
 	}
 	if hasRuntimes {
-		ctx.Logger().Error("DeregisterEntity: entity still has runtimes",
+		ctx.Logger().ErrorQ("DeregisterEntity: entity still has runtimes",
 			"entity_id", id,
 		)
 		return registry.ErrEntityHasRuntimes
@@ -167,7 +167,7 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 	// Peek into the to-be-verified node to pull out the owning entity ID.
 	var untrustedNode node.Node
 	if err := cbor.Unmarshal(sigNode.Blob, &untrustedNode); err != nil {
-		ctx.Logger().Error("RegisterNode: failed to extract entity",
+		ctx.Logger().ErrorQ("RegisterNode: failed to extract entity",
 			"err", err,
 			"signed_node", sigNode,
 		)
@@ -231,7 +231,7 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 		}
 		wcfg, entIsWhitelisted := rt.AdmissionPolicy.EntityWhitelist.Entities[newNode.EntityID]
 		if !entIsWhitelisted {
-			ctx.Logger().Error("RegisterNode: node's entity not in a runtime's whitelist",
+			ctx.Logger().ErrorQ("RegisterNode: node's entity not in a runtime's whitelist",
 				"entity_id", newNode.EntityID,
 				"runtime_id", rt.ID,
 				"node_id", newNode.ID,
@@ -256,7 +256,7 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 			maxNodes, exists := wcfg.MaxNodes[role]
 			if !exists {
 				// No such role found in whitelist.
-				ctx.Logger().Error("RegisterNode: runtime's whitelist does not allow nodes with given role",
+				ctx.Logger().ErrorQ("RegisterNode: runtime's whitelist does not allow nodes with given role",
 					"role", role.String(),
 					"runtime_id", rt.ID,
 					"node_id", newNode.ID,
@@ -265,7 +265,7 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 			}
 			if maxNodes == 0 {
 				// No nodes of this type are allowed.
-				ctx.Logger().Error("RegisterNode: runtime's whitelist does not allow nodes with given role",
+				ctx.Logger().ErrorQ("RegisterNode: runtime's whitelist does not allow nodes with given role",
 					"role", role.String(),
 					"runtime_id", rt.ID,
 				)
@@ -317,7 +317,7 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 	//
 	// Yes, this is duplicated.  Blame the sanity checker.
 	if !ctx.IsInitChain() && newNode.Expiration <= uint64(epoch) {
-		ctx.Logger().Error("RegisterNode: node descriptor is expired",
+		ctx.Logger().ErrorQ("RegisterNode: node descriptor is expired",
 			"new_node", newNode,
 			"epoch", epoch,
 		)
@@ -379,7 +379,7 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 		acctAddr := staking.NewAddress(newNode.EntityID)
 
 		if err = stakeAcc.AddStakeClaim(acctAddr, claim, thresholds); err != nil {
-			ctx.Logger().Error("RegisterNode: insufficient stake for new node",
+			ctx.Logger().ErrorQ("RegisterNode: insufficient stake for new node",
 				"err", err,
 				"entity", newNode.EntityID,
 				"account", acctAddr,
@@ -703,21 +703,21 @@ func (app *registryApplication) registerRuntime( // nolint: gocyclo
 
 		expectedAddr := rtToCheck.StakingAddress()
 		if expectedAddr == nil {
-			ctx.Logger().Error("RegisterRuntime: runtimes with consensus-layer governance can only be registered at genesis")
+			ctx.Logger().ErrorQ("RegisterRuntime: runtimes with consensus-layer governance can only be registered at genesis")
 			return nil, registry.ErrForbidden
 		}
 
 		if !ctx.CallerAddress().Equal(*expectedAddr) {
 			switch rtToCheck.GovernanceModel {
 			case registry.GovernanceEntity:
-				ctx.Logger().Error("RegisterRuntime: transaction must be signed by controlling entity")
+				ctx.Logger().ErrorQ("RegisterRuntime: transaction must be signed by controlling entity")
 				return nil, registry.ErrIncorrectTxSigner
 			case registry.GovernanceRuntime:
-				ctx.Logger().Error("RegisterRuntime: caller must be the runtime itself")
+				ctx.Logger().ErrorQ("RegisterRuntime: caller must be the runtime itself")
 				return nil, registry.ErrForbidden
 			default:
 				// Basic validation should have caught this, but just in case...
-				ctx.Logger().Error("RegisterRuntime: invalid governance model")
+				ctx.Logger().ErrorQ("RegisterRuntime: invalid governance model")
 				return nil, registry.ErrInvalidArgument
 			}
 		}
@@ -736,12 +736,12 @@ func (app *registryApplication) registerRuntime( // nolint: gocyclo
 			acctAddr = ctx.CallerAddress()
 		default:
 			// Basic validation should have caught this, but just in case...
-			ctx.Logger().Error("RegisterRuntime: invalid governance model")
+			ctx.Logger().ErrorQ("RegisterRuntime: invalid governance model")
 			return nil, registry.ErrInvalidArgument
 		}
 
 		if err = stakingState.AddStakeClaim(ctx, acctAddr, claim, thresholds); err != nil {
-			ctx.Logger().Error("RegisterRuntime: insufficient stake",
+			ctx.Logger().ErrorQ("RegisterRuntime: insufficient stake",
 				"err", err,
 				"entity", rt.EntityID,
 				"runtime", rt.ID,

--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -165,7 +165,7 @@ func (app *rootHashApplication) onCommitteeChanged(ctx *tmapi.Context, state *ro
 			}
 
 			if err = stakeAcc.CheckStakeClaims(*acctAddr); err != nil {
-				ctx.Logger().WarnQ("insufficient stake for runtime operation",
+				ctx.Logger().Debug("insufficient stake for runtime operation",
 					"err", err,
 					"entity", rt.EntityID,
 					"account", *acctAddr,
@@ -220,7 +220,7 @@ func (app *rootHashApplication) suspendUnpaidRuntime(
 	rtState *roothash.RuntimeState,
 	regState *registryState.MutableState,
 ) error {
-	ctx.Logger().WarnQ("maintenance fees not paid for runtime or owner debonded, suspending",
+	ctx.Logger().Debug("maintenance fees not paid for runtime or owner debonded, suspending",
 		"runtime_id", rtState.Runtime.ID,
 	)
 
@@ -412,7 +412,7 @@ func (app *rootHashApplication) ExecuteTx(ctx *tmapi.Context, tx *transaction.Tr
 
 func (app *rootHashApplication) onNewRuntime(ctx *tmapi.Context, runtime *registry.Runtime, genesis *roothash.Genesis, suspended bool) error {
 	if !runtime.IsCompute() {
-		ctx.Logger().WarnQ("onNewRuntime: ignoring non-compute runtime",
+		ctx.Logger().Debug("onNewRuntime: ignoring non-compute runtime",
 			"runtime", runtime,
 		)
 		return nil
@@ -423,7 +423,7 @@ func (app *rootHashApplication) onNewRuntime(ctx *tmapi.Context, runtime *regist
 	_, err := state.RuntimeState(ctx, runtime.ID)
 	switch err {
 	case nil:
-		ctx.Logger().WarnQ("onNewRuntime: state for runtime already exists",
+		ctx.Logger().Debug("onNewRuntime: state for runtime already exists",
 			"runtime", runtime,
 		)
 		return nil

--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -165,7 +165,7 @@ func (app *rootHashApplication) onCommitteeChanged(ctx *tmapi.Context, state *ro
 			}
 
 			if err = stakeAcc.CheckStakeClaims(*acctAddr); err != nil {
-				ctx.Logger().Warn("insufficient stake for runtime operation",
+				ctx.Logger().WarnQ("insufficient stake for runtime operation",
 					"err", err,
 					"entity", rt.EntityID,
 					"account", *acctAddr,
@@ -220,7 +220,7 @@ func (app *rootHashApplication) suspendUnpaidRuntime(
 	rtState *roothash.RuntimeState,
 	regState *registryState.MutableState,
 ) error {
-	ctx.Logger().Warn("maintenance fees not paid for runtime or owner debonded, suspending",
+	ctx.Logger().WarnQ("maintenance fees not paid for runtime or owner debonded, suspending",
 		"runtime_id", rtState.Runtime.ID,
 	)
 
@@ -412,7 +412,7 @@ func (app *rootHashApplication) ExecuteTx(ctx *tmapi.Context, tx *transaction.Tr
 
 func (app *rootHashApplication) onNewRuntime(ctx *tmapi.Context, runtime *registry.Runtime, genesis *roothash.Genesis, suspended bool) error {
 	if !runtime.IsCompute() {
-		ctx.Logger().Warn("onNewRuntime: ignoring non-compute runtime",
+		ctx.Logger().WarnQ("onNewRuntime: ignoring non-compute runtime",
 			"runtime", runtime,
 		)
 		return nil
@@ -423,7 +423,7 @@ func (app *rootHashApplication) onNewRuntime(ctx *tmapi.Context, runtime *regist
 	_, err := state.RuntimeState(ctx, runtime.ID)
 	switch err {
 	case nil:
-		ctx.Logger().Warn("onNewRuntime: state for runtime already exists",
+		ctx.Logger().WarnQ("onNewRuntime: state for runtime already exists",
 			"runtime", runtime,
 		)
 		return nil

--- a/go/consensus/tendermint/apps/roothash/slashing.go
+++ b/go/consensus/tendermint/apps/roothash/slashing.go
@@ -70,7 +70,7 @@ func onEvidenceRuntimeEquivocation(
 	}
 	// Since evidence can be submitted for past rounds, the node can be out of stake.
 	if totalSlashed.IsZero() {
-		ctx.Logger().WarnQ("nothing to slash from entity for runtime equivocation",
+		ctx.Logger().Debug("nothing to slash from entity for runtime equivocation",
 			"penalty", penaltyAmount,
 			"addr", entityAddr,
 		)

--- a/go/consensus/tendermint/apps/roothash/slashing.go
+++ b/go/consensus/tendermint/apps/roothash/slashing.go
@@ -70,7 +70,7 @@ func onEvidenceRuntimeEquivocation(
 	}
 	// Since evidence can be submitted for past rounds, the node can be out of stake.
 	if totalSlashed.IsZero() {
-		ctx.Logger().Warn("nothing to slash from entity for runtime equivocation",
+		ctx.Logger().WarnQ("nothing to slash from entity for runtime equivocation",
 			"penalty", penaltyAmount,
 			"addr", entityAddr,
 		)

--- a/go/consensus/tendermint/apps/roothash/transactions.go
+++ b/go/consensus/tendermint/apps/roothash/transactions.go
@@ -77,7 +77,7 @@ func (app *rootHashApplication) executorProposerTimeout(
 	proposerTimeout := rtState.Runtime.TxnScheduler.ProposerTimeout
 	currentBlockHeight := rtState.CurrentBlockHeight
 	if height := ctx.BlockHeight(); height < currentBlockHeight+proposerTimeout {
-		ctx.Logger().Error("failed requesting proposer round timeout, timeout not allowed yet",
+		ctx.Logger().ErrorQ("failed requesting proposer round timeout, timeout not allowed yet",
 			"height", height,
 			"current_block_height", currentBlockHeight,
 			"proposer_timeout", proposerTimeout,
@@ -197,7 +197,7 @@ func (app *rootHashApplication) submitEvidence(
 ) error {
 	// Validate proposal content basics.
 	if err := evidence.ValidateBasic(); err != nil {
-		ctx.Logger().Error("Evidence: submitted evidence not valid",
+		ctx.Logger().ErrorQ("Evidence: submitted evidence not valid",
 			"evidence", evidence,
 			"err", err,
 		)
@@ -232,7 +232,7 @@ func (app *rootHashApplication) submitEvidence(
 
 	if len(rtState.Runtime.Staking.Slashing) == 0 {
 		// No slashing instructions for runtime, no point in collecting evidence.
-		ctx.Logger().Error("Evidence: runtime has no slashing instructions",
+		ctx.Logger().ErrorQ("Evidence: runtime has no slashing instructions",
 			"err", roothash.ErrRuntimeDoesNotSlash,
 		)
 		return roothash.ErrRuntimeDoesNotSlash
@@ -240,7 +240,7 @@ func (app *rootHashApplication) submitEvidence(
 	slash := rtState.Runtime.Staking.Slashing[staking.SlashRuntimeEquivocation].Amount
 	if slash.IsZero() {
 		// Slash amount is zero for runtime, no point in collecting evidence.
-		ctx.Logger().Error("Evidence: runtime has no slashing instructions for equivocation",
+		ctx.Logger().ErrorQ("Evidence: runtime has no slashing instructions for equivocation",
 			"err", roothash.ErrRuntimeDoesNotSlash,
 		)
 		return roothash.ErrRuntimeDoesNotSlash
@@ -254,7 +254,7 @@ func (app *rootHashApplication) submitEvidence(
 		commitA := evidence.EquivocationExecutor.CommitA
 
 		if commitA.Header.Round+params.MaxEvidenceAge < rtState.CurrentBlock.Header.Round {
-			ctx.Logger().Error("Evidence: commitment equivocation evidence expired",
+			ctx.Logger().ErrorQ("Evidence: commitment equivocation evidence expired",
 				"evidence", evidence.EquivocationExecutor,
 				"current_round", rtState.CurrentBlock.Header.Round,
 				"max_evidence_age", params.MaxEvidenceAge,
@@ -267,7 +267,7 @@ func (app *rootHashApplication) submitEvidence(
 		proposalA := evidence.EquivocationProposal.ProposalA
 
 		if proposalA.Header.Round+params.MaxEvidenceAge < rtState.CurrentBlock.Header.Round {
-			ctx.Logger().Error("Evidence: proposal equivocation evidence expired",
+			ctx.Logger().ErrorQ("Evidence: proposal equivocation evidence expired",
 				"evidence", evidence.EquivocationExecutor,
 				"current_round", rtState.CurrentBlock.Header.Round,
 				"max_evidence_age", params.MaxEvidenceAge,

--- a/go/consensus/tendermint/apps/roothash/transactions.go
+++ b/go/consensus/tendermint/apps/roothash/transactions.go
@@ -77,7 +77,7 @@ func (app *rootHashApplication) executorProposerTimeout(
 	proposerTimeout := rtState.Runtime.TxnScheduler.ProposerTimeout
 	currentBlockHeight := rtState.CurrentBlockHeight
 	if height := ctx.BlockHeight(); height < currentBlockHeight+proposerTimeout {
-		ctx.Logger().ErrorQ("failed requesting proposer round timeout, timeout not allowed yet",
+		ctx.Logger().Debug("failed requesting proposer round timeout, timeout not allowed yet",
 			"height", height,
 			"current_block_height", currentBlockHeight,
 			"proposer_timeout", proposerTimeout,
@@ -197,7 +197,7 @@ func (app *rootHashApplication) submitEvidence(
 ) error {
 	// Validate proposal content basics.
 	if err := evidence.ValidateBasic(); err != nil {
-		ctx.Logger().ErrorQ("Evidence: submitted evidence not valid",
+		ctx.Logger().Debug("Evidence: submitted evidence not valid",
 			"evidence", evidence,
 			"err", err,
 		)
@@ -232,7 +232,7 @@ func (app *rootHashApplication) submitEvidence(
 
 	if len(rtState.Runtime.Staking.Slashing) == 0 {
 		// No slashing instructions for runtime, no point in collecting evidence.
-		ctx.Logger().ErrorQ("Evidence: runtime has no slashing instructions",
+		ctx.Logger().Debug("Evidence: runtime has no slashing instructions",
 			"err", roothash.ErrRuntimeDoesNotSlash,
 		)
 		return roothash.ErrRuntimeDoesNotSlash
@@ -240,7 +240,7 @@ func (app *rootHashApplication) submitEvidence(
 	slash := rtState.Runtime.Staking.Slashing[staking.SlashRuntimeEquivocation].Amount
 	if slash.IsZero() {
 		// Slash amount is zero for runtime, no point in collecting evidence.
-		ctx.Logger().ErrorQ("Evidence: runtime has no slashing instructions for equivocation",
+		ctx.Logger().Debug("Evidence: runtime has no slashing instructions for equivocation",
 			"err", roothash.ErrRuntimeDoesNotSlash,
 		)
 		return roothash.ErrRuntimeDoesNotSlash
@@ -254,7 +254,7 @@ func (app *rootHashApplication) submitEvidence(
 		commitA := evidence.EquivocationExecutor.CommitA
 
 		if commitA.Header.Round+params.MaxEvidenceAge < rtState.CurrentBlock.Header.Round {
-			ctx.Logger().ErrorQ("Evidence: commitment equivocation evidence expired",
+			ctx.Logger().Debug("Evidence: commitment equivocation evidence expired",
 				"evidence", evidence.EquivocationExecutor,
 				"current_round", rtState.CurrentBlock.Header.Round,
 				"max_evidence_age", params.MaxEvidenceAge,
@@ -267,7 +267,7 @@ func (app *rootHashApplication) submitEvidence(
 		proposalA := evidence.EquivocationProposal.ProposalA
 
 		if proposalA.Header.Round+params.MaxEvidenceAge < rtState.CurrentBlock.Header.Round {
-			ctx.Logger().ErrorQ("Evidence: proposal equivocation evidence expired",
+			ctx.Logger().Debug("Evidence: proposal equivocation evidence expired",
 				"evidence", evidence.EquivocationExecutor,
 				"current_round", rtState.CurrentBlock.Header.Round,
 				"max_evidence_age", params.MaxEvidenceAge,

--- a/go/consensus/tendermint/apps/staking/staking.go
+++ b/go/consensus/tendermint/apps/staking/staking.go
@@ -101,7 +101,7 @@ func (app *stakingApplication) BeginBlock(ctx *api.Context, request types.Reques
 		case types.EvidenceType_LIGHT_CLIENT_ATTACK:
 			reason = staking.SlashConsensusLightClientAttack
 		default:
-			ctx.Logger().Warn("ignoring unknown evidence type",
+			ctx.Logger().WarnQ("ignoring unknown evidence type",
 				"evidence_type", evidence.Type,
 			)
 			continue

--- a/go/consensus/tendermint/apps/staking/staking.go
+++ b/go/consensus/tendermint/apps/staking/staking.go
@@ -101,7 +101,7 @@ func (app *stakingApplication) BeginBlock(ctx *api.Context, request types.Reques
 		case types.EvidenceType_LIGHT_CLIENT_ATTACK:
 			reason = staking.SlashConsensusLightClientAttack
 		default:
-			ctx.Logger().WarnQ("ignoring unknown evidence type",
+			ctx.Logger().Debug("ignoring unknown evidence type",
 				"evidence_type", evidence.Type,
 			)
 			continue

--- a/go/consensus/tendermint/apps/staking/state/state.go
+++ b/go/consensus/tendermint/apps/staking/state/state.go
@@ -802,7 +802,7 @@ func (s *MutableState) Transfer(ctx *abciAPI.Context, fromAddr, toAddr staking.A
 		return fmt.Errorf("failed to fetch consensus parameters: %w", err)
 	}
 	if from.General.Balance.Cmp(&params.MinTransactBalance) < 0 {
-		ctx.Logger().Error("source account balance too low",
+		ctx.Logger().ErrorQ("source account balance too low",
 			"account_addr", fromAddr,
 			"account_balance", from.General.Balance,
 			"min_transact_balance", params.MinTransactBalance,
@@ -810,7 +810,7 @@ func (s *MutableState) Transfer(ctx *abciAPI.Context, fromAddr, toAddr staking.A
 		return errors.WithContext(staking.ErrBalanceTooLow, "source account")
 	}
 	if to.General.Balance.Cmp(&params.MinTransactBalance) < 0 {
-		ctx.Logger().Error("after transfer dest account balance too low",
+		ctx.Logger().ErrorQ("after transfer dest account balance too low",
 			"account_addr", toAddr,
 			"account_balance", to.General.Balance,
 			"min_transact_balance", params.MinTransactBalance,

--- a/go/consensus/tendermint/apps/staking/state/state.go
+++ b/go/consensus/tendermint/apps/staking/state/state.go
@@ -802,7 +802,7 @@ func (s *MutableState) Transfer(ctx *abciAPI.Context, fromAddr, toAddr staking.A
 		return fmt.Errorf("failed to fetch consensus parameters: %w", err)
 	}
 	if from.General.Balance.Cmp(&params.MinTransactBalance) < 0 {
-		ctx.Logger().ErrorQ("source account balance too low",
+		ctx.Logger().Debug("source account balance too low",
 			"account_addr", fromAddr,
 			"account_balance", from.General.Balance,
 			"min_transact_balance", params.MinTransactBalance,
@@ -810,7 +810,7 @@ func (s *MutableState) Transfer(ctx *abciAPI.Context, fromAddr, toAddr staking.A
 		return errors.WithContext(staking.ErrBalanceTooLow, "source account")
 	}
 	if to.General.Balance.Cmp(&params.MinTransactBalance) < 0 {
-		ctx.Logger().ErrorQ("after transfer dest account balance too low",
+		ctx.Logger().Debug("after transfer dest account balance too low",
 			"account_addr", toAddr,
 			"account_balance", to.General.Balance,
 			"min_transact_balance", params.MinTransactBalance,

--- a/go/consensus/tendermint/apps/staking/transactions.go
+++ b/go/consensus/tendermint/apps/staking/transactions.go
@@ -59,7 +59,7 @@ func (app *stakingApplication) transfer(ctx *api.Context, state *stakingState.Mu
 		// Handle transfer to self as just a balance check.
 		if from.General.Balance.Cmp(&xfer.Amount) < 0 {
 			err = staking.ErrInsufficientBalance
-			ctx.Logger().Error("Transfer: self-transfer greater than balance",
+			ctx.Logger().ErrorQ("Transfer: self-transfer greater than balance",
 				"err", err,
 				"from", fromAddr,
 				"to", xfer.To,
@@ -87,7 +87,7 @@ func (app *stakingApplication) transfer(ctx *api.Context, state *stakingState.Mu
 
 		// Check against minimum balance.
 		if from.General.Balance.Cmp(&params.MinTransactBalance) < 0 {
-			ctx.Logger().Error("after transfer source account balance too low",
+			ctx.Logger().ErrorQ("after transfer source account balance too low",
 				"account_addr", fromAddr,
 				"account_balance", from.General.Balance,
 				"min_transact_balance", params.MinTransactBalance,
@@ -95,7 +95,7 @@ func (app *stakingApplication) transfer(ctx *api.Context, state *stakingState.Mu
 			return nil, errors.WithContext(staking.ErrBalanceTooLow, "source account")
 		}
 		if to.General.Balance.Cmp(&params.MinTransactBalance) < 0 {
-			ctx.Logger().Error("after transfer dest account balance too low",
+			ctx.Logger().ErrorQ("after transfer dest account balance too low",
 				"account_addr", xfer.To,
 				"account_balance", to.General.Balance,
 				"min_transact_balance", params.MinTransactBalance,
@@ -176,7 +176,7 @@ func (app *stakingApplication) burn(ctx *api.Context, state *stakingState.Mutabl
 
 	// Check against minimum balance.
 	if from.General.Balance.Cmp(&params.MinTransactBalance) < 0 {
-		ctx.Logger().Error("after burn account balance too low",
+		ctx.Logger().ErrorQ("after burn account balance too low",
 			"account_addr", fromAddr,
 			"account_balance", from.General.Balance,
 			"min_transact_balance", params.MinTransactBalance,
@@ -286,7 +286,7 @@ func (app *stakingApplication) addEscrow(ctx *api.Context, state *stakingState.M
 
 	// Check against minimum balance.
 	if from.General.Balance.Cmp(&params.MinTransactBalance) < 0 {
-		ctx.Logger().Error("after add escrow account balance too low",
+		ctx.Logger().ErrorQ("after add escrow account balance too low",
 			"account_addr", fromAddr,
 			"account_balance", from.General.Balance,
 			"min_transact_balance", params.MinTransactBalance,
@@ -526,7 +526,7 @@ func (app *stakingApplication) amendCommissionSchedule(
 	}
 
 	if err = from.Escrow.CommissionSchedule.AmendAndPruneAndValidate(&amendCommissionSchedule.Amendment, &params.CommissionScheduleRules, epoch); err != nil {
-		ctx.Logger().Error("AmendCommissionSchedule: amendment not acceptable",
+		ctx.Logger().ErrorQ("AmendCommissionSchedule: amendment not acceptable",
 			"err", err,
 			"from", fromAddr,
 		)
@@ -705,7 +705,7 @@ func (app *stakingApplication) withdraw(
 
 	// Check against minimum balance.
 	if from.General.Balance.Cmp(&params.MinTransactBalance) < 0 {
-		ctx.Logger().Error("after withdraw source account balance too low",
+		ctx.Logger().ErrorQ("after withdraw source account balance too low",
 			"account_addr", withdraw.From,
 			"account_balance", from.General.Balance,
 			"min_transact_balance", params.MinTransactBalance,
@@ -713,7 +713,7 @@ func (app *stakingApplication) withdraw(
 		return nil, errors.WithContext(staking.ErrBalanceTooLow, "source account")
 	}
 	if to.General.Balance.Cmp(&params.MinTransactBalance) < 0 {
-		ctx.Logger().Error("after withdraw dest account balance too low",
+		ctx.Logger().ErrorQ("after withdraw dest account balance too low",
 			"account_addr", toAddr,
 			"account_balance", to.General.Balance,
 			"min_transact_balance", params.MinTransactBalance,

--- a/go/consensus/tendermint/apps/staking/transactions.go
+++ b/go/consensus/tendermint/apps/staking/transactions.go
@@ -59,7 +59,7 @@ func (app *stakingApplication) transfer(ctx *api.Context, state *stakingState.Mu
 		// Handle transfer to self as just a balance check.
 		if from.General.Balance.Cmp(&xfer.Amount) < 0 {
 			err = staking.ErrInsufficientBalance
-			ctx.Logger().ErrorQ("Transfer: self-transfer greater than balance",
+			ctx.Logger().Debug("Transfer: self-transfer greater than balance",
 				"err", err,
 				"from", fromAddr,
 				"to", xfer.To,
@@ -87,7 +87,7 @@ func (app *stakingApplication) transfer(ctx *api.Context, state *stakingState.Mu
 
 		// Check against minimum balance.
 		if from.General.Balance.Cmp(&params.MinTransactBalance) < 0 {
-			ctx.Logger().ErrorQ("after transfer source account balance too low",
+			ctx.Logger().Debug("after transfer source account balance too low",
 				"account_addr", fromAddr,
 				"account_balance", from.General.Balance,
 				"min_transact_balance", params.MinTransactBalance,
@@ -95,7 +95,7 @@ func (app *stakingApplication) transfer(ctx *api.Context, state *stakingState.Mu
 			return nil, errors.WithContext(staking.ErrBalanceTooLow, "source account")
 		}
 		if to.General.Balance.Cmp(&params.MinTransactBalance) < 0 {
-			ctx.Logger().ErrorQ("after transfer dest account balance too low",
+			ctx.Logger().Debug("after transfer dest account balance too low",
 				"account_addr", xfer.To,
 				"account_balance", to.General.Balance,
 				"min_transact_balance", params.MinTransactBalance,
@@ -176,7 +176,7 @@ func (app *stakingApplication) burn(ctx *api.Context, state *stakingState.Mutabl
 
 	// Check against minimum balance.
 	if from.General.Balance.Cmp(&params.MinTransactBalance) < 0 {
-		ctx.Logger().ErrorQ("after burn account balance too low",
+		ctx.Logger().Debug("after burn account balance too low",
 			"account_addr", fromAddr,
 			"account_balance", from.General.Balance,
 			"min_transact_balance", params.MinTransactBalance,
@@ -286,7 +286,7 @@ func (app *stakingApplication) addEscrow(ctx *api.Context, state *stakingState.M
 
 	// Check against minimum balance.
 	if from.General.Balance.Cmp(&params.MinTransactBalance) < 0 {
-		ctx.Logger().ErrorQ("after add escrow account balance too low",
+		ctx.Logger().Debug("after add escrow account balance too low",
 			"account_addr", fromAddr,
 			"account_balance", from.General.Balance,
 			"min_transact_balance", params.MinTransactBalance,
@@ -526,7 +526,7 @@ func (app *stakingApplication) amendCommissionSchedule(
 	}
 
 	if err = from.Escrow.CommissionSchedule.AmendAndPruneAndValidate(&amendCommissionSchedule.Amendment, &params.CommissionScheduleRules, epoch); err != nil {
-		ctx.Logger().ErrorQ("AmendCommissionSchedule: amendment not acceptable",
+		ctx.Logger().Debug("AmendCommissionSchedule: amendment not acceptable",
 			"err", err,
 			"from", fromAddr,
 		)
@@ -705,7 +705,7 @@ func (app *stakingApplication) withdraw(
 
 	// Check against minimum balance.
 	if from.General.Balance.Cmp(&params.MinTransactBalance) < 0 {
-		ctx.Logger().ErrorQ("after withdraw source account balance too low",
+		ctx.Logger().Debug("after withdraw source account balance too low",
 			"account_addr", withdraw.From,
 			"account_balance", from.General.Balance,
 			"min_transact_balance", params.MinTransactBalance,
@@ -713,7 +713,7 @@ func (app *stakingApplication) withdraw(
 		return nil, errors.WithContext(staking.ErrBalanceTooLow, "source account")
 	}
 	if to.General.Balance.Cmp(&params.MinTransactBalance) < 0 {
-		ctx.Logger().ErrorQ("after withdraw dest account balance too low",
+		ctx.Logger().Debug("after withdraw dest account balance too low",
 			"account_addr", toAddr,
 			"account_balance", to.General.Balance,
 			"min_transact_balance", params.MinTransactBalance,


### PR DESCRIPTION
Closes https://github.com/oasisprotocol/oasis-core/issues/4196

For a manually selected subset of `Logger().Warn()` and `Logger().Error()` log statements, this PR downgrades them to `Debug()`.

I aimed to downgrade all those error logs that originate in a malformed transaction/message (= external to the node and network), and leave all those error logs that signal a problem with the node or the network itself.

In functions that deal with genesis/initstate, I erred on the side of not downgrading. This stuff doesn't get called often, and when it does, the stakes are higher.