### PR TITLE
go/oasis-test-runner/fixture: support configuring runtime messages

### DIFF
--- a/.changelog/4769.internal.md
+++ b/.changelog/4769.internal.md
@@ -1,0 +1,1 @@
+go/oasis-test-runner/fixture: support configuring runtime messages

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -90,8 +90,8 @@ const (
 	// Roothash config flags.
 	cfgRoothashDebugDoNotSuspendRuntimes = "roothash.debug.do_not_suspend_runtimes"
 	cfgRoothashDebugBypassStake          = "roothash.debug.bypass_stake" // nolint: gosec
-	cfgRoothashMaxRuntimeMessages        = "roothash.max_runtime_messages"
-	cfgRoothashMaxInRuntimeMessages      = "roothash.max_in_runtime_messages"
+	CfgRoothashMaxRuntimeMessages        = "roothash.max_runtime_messages"
+	CfgRoothashMaxInRuntimeMessages      = "roothash.max_in_runtime_messages"
 
 	// Staking config flags.
 	CfgStakingTokenSymbol        = "staking.token_symbol"
@@ -540,8 +540,8 @@ func AppendRootHashState(doc *genesis.Document, exports []string, l *logging.Log
 		Parameters: roothash.ConsensusParameters{
 			DebugDoNotSuspendRuntimes: viper.GetBool(cfgRoothashDebugDoNotSuspendRuntimes),
 			DebugBypassStake:          viper.GetBool(cfgRoothashDebugBypassStake),
-			MaxRuntimeMessages:        viper.GetUint32(cfgRoothashMaxRuntimeMessages),
-			MaxInRuntimeMessages:      viper.GetUint32(cfgRoothashMaxInRuntimeMessages),
+			MaxRuntimeMessages:        viper.GetUint32(CfgRoothashMaxRuntimeMessages),
+			MaxInRuntimeMessages:      viper.GetUint32(CfgRoothashMaxInRuntimeMessages),
 			// TODO: Make these configurable.
 			GasCosts: roothash.DefaultGasCosts,
 		},
@@ -849,8 +849,8 @@ func init() {
 	// Roothash config flags.
 	initGenesisFlags.Bool(cfgRoothashDebugDoNotSuspendRuntimes, false, "do not suspend runtimes (UNSAFE)")
 	initGenesisFlags.Bool(cfgRoothashDebugBypassStake, false, "bypass all roothash stake checks and operations (UNSAFE)")
-	initGenesisFlags.Uint32(cfgRoothashMaxRuntimeMessages, 128, "maximum number of runtime messages submitted in a round")
-	initGenesisFlags.Uint32(cfgRoothashMaxInRuntimeMessages, 128, "maximum number of ququed incoming runtime messages")
+	initGenesisFlags.Uint32(CfgRoothashMaxRuntimeMessages, 128, "maximum number of runtime messages submitted in a round")
+	initGenesisFlags.Uint32(CfgRoothashMaxInRuntimeMessages, 128, "maximum number of ququed incoming runtime messages")
 	_ = initGenesisFlags.MarkHidden(cfgRoothashDebugDoNotSuspendRuntimes)
 	_ = initGenesisFlags.MarkHidden(cfgRoothashDebugBypassStake)
 

--- a/go/oasis-test-runner/oasis/network.go
+++ b/go/oasis-test-runner/oasis/network.go
@@ -38,6 +38,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/log"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis/cli"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
@@ -123,6 +124,9 @@ type NetworkCfg struct { // nolint: maligned
 
 	// GovernanceParameters are the governance consensus parameters.
 	GovernanceParameters *governance.ConsensusParameters `json:"governance_parameters,omitempty"`
+
+	// RoothashParameters are the roothash consensus parameters.
+	RoothashParameters *roothash.ConsensusParameters `json:"roothash_parameters,omitempty"`
 
 	// SchedulerWeakAlpkaOk is for disabling the VRF alpha entropy requirement.
 	SchedulerWeakAlphaOk bool `json:"scheduler_weak_alpha_ok,omitempty"`
@@ -739,6 +743,12 @@ func (net *Network) MakeGenesis() error {
 			"--" + genesis.CfgGovernanceUpgradeCancelMinEpochDiff, strconv.FormatUint(uint64(cfg.UpgradeCancelMinEpochDiff), 10),
 			"--" + genesis.CfgGovernanceUpgradeMinEpochDiff, strconv.FormatUint(uint64(cfg.UpgradeMinEpochDiff), 10),
 			"--" + genesis.CfgGovernanceVotingPeriod, strconv.FormatUint(uint64(cfg.VotingPeriod), 10),
+		}...)
+	}
+	if cfg := net.cfg.RoothashParameters; cfg != nil {
+		args = append(args, []string{
+			"--" + genesis.CfgRoothashMaxRuntimeMessages, strconv.FormatUint(uint64(cfg.MaxRuntimeMessages), 10),
+			"--" + genesis.CfgRoothashMaxInRuntimeMessages, strconv.FormatUint(uint64(cfg.MaxInRuntimeMessages), 10),
 		}...)
 	}
 	if cfg := net.cfg.SchedulerForceElect; cfg != nil {


### PR DESCRIPTION
Adds support for configuring roothash max messages in network fixtures.