### PR TITLE
[BACKPORT/21.3.x] go/runtime/host/sandbox: Properly handle clone3 in seccomp policy

### DIFF
--- a/.changelog/4687.bugfix.md
+++ b/.changelog/4687.bugfix.md
@@ -1,0 +1,13 @@
+go/runtime/host/sandbox: Properly handle clone3 in seccomp policy
+
+We need to handle the clone3 syscall in a special manner as there are
+several complications to its handling:
+
+- Newer glibc versions will try clone3 first and if they see EPERM they
+  will instantly fail making the program unable to spawn threads.
+
+- The clone3 syscall is much more complex than clone and so we can't
+  simply inspect its flags as we do for clone.
+
+Therefore we need to reject the syscall with ENOSYS, causing fallback to
+clone.


### PR DESCRIPTION
We need to handle the clone3 syscall in a special manner as there are
several complications to its handling:

- Newer glibc versions will try clone3 first and if they see EPERM they
  will instantly fail making the program unable to spawn threads.

- The clone3 syscall is much more complex than clone and so we can't
  simply inspect its flags as we do for clone.

Therefore we need to reject the syscall with ENOSYS, causing fallback to
clone.