### PR TITLE
go/common/quantity: Avoid side-effects on errors

### DIFF
--- a/.changelog/4790.bugfix.md
+++ b/.changelog/4790.bugfix.md
@@ -1,0 +1,1 @@
+go/common/quantity: Avoid side-effects on errors

--- a/go/common/quantity/quantity.go
+++ b/go/common/quantity/quantity.go
@@ -45,13 +45,8 @@ func (q *Quantity) MarshalBinary() ([]byte, error) {
 func (q *Quantity) UnmarshalBinary(data []byte) error {
 	var tmp big.Int
 	tmp.SetBytes(data)
-	q.inner.Set(&tmp)
 
-	if !q.IsValid() {
-		return ErrInvalidQuantity
-	}
-
-	return nil
+	return q.FromBigInt(&tmp)
 }
 
 // MarshalText encodes a Quantity into text form.
@@ -65,13 +60,8 @@ func (q *Quantity) UnmarshalText(text []byte) error {
 	if err := tmp.UnmarshalText(text); err != nil {
 		return err
 	}
-	q.inner.Set(&tmp)
 
-	if !q.IsValid() {
-		return ErrInvalidQuantity
-	}
-
-	return nil
+	return q.FromBigInt(&tmp)
 }
 
 // FromInt64 converts from an int64 to a Quantity.


### PR DESCRIPTION
In theory this is non-breaking because we check errors and don't use the set value.