### PR TITLE
go/consensus/tendermint: Add `consensus.tendermint.halt_height`

### DIFF
--- a/.changelog/4793.feature.md
+++ b/.changelog/4793.feature.md
@@ -1,0 +1,4 @@
+go/consensus/tendermint: Add `consensus.tendermint.halt_height`
+
+This is equivalent to the cosmos `halt-height` option, to be used to
+bring a node down gracefully at a specific height.

--- a/go/consensus/tendermint/full/full.go
+++ b/go/consensus/tendermint/full/full.go
@@ -128,6 +128,9 @@ const (
 
 	// CfgUpgradeStopDelay is the average amount of time to delay shutting down the node on upgrade.
 	CfgUpgradeStopDelay = "consensus.tendermint.upgrade.stop_delay"
+
+	// CfgHaltHeight is the block height at which the local node should be shutdown.
+	CfgHaltHeight = "consensus.tendermint.halt_height"
 )
 
 const (
@@ -1157,6 +1160,7 @@ func (t *fullService) lazyInit() error {
 		StorageBackend:            db.GetBackendName(),
 		Pruning:                   pruneCfg,
 		HaltEpochHeight:           t.genesis.HaltEpoch,
+		HaltBlockHeight:           viper.GetUint64(CfgHaltHeight),
 		MinGasPrice:               viper.GetUint64(CfgMinGasPrice),
 		OwnTxSigner:               t.identity.NodeSigner.Public(),
 		DisableCheckpointer:       viper.GetBool(CfgCheckpointerDisabled),
@@ -1594,6 +1598,8 @@ func init() {
 
 	Flags.Bool(CfgSupplementarySanityEnabled, false, "enable supplementary sanity checks (slows down consensus)")
 	Flags.Uint64(CfgSupplementarySanityInterval, 10, "supplementary sanity check interval (in blocks)")
+
+	Flags.Uint64(CfgHaltHeight, 0, "height at which to force-shutdown the node (in blocks)")
 
 	// State sync.
 	Flags.Bool(CfgConsensusStateSyncEnabled, false, "enable state sync")


### PR DESCRIPTION
This is equivalent to the cosmos `halt-height` option, to be used to
bring a node down gracefully at a specific height.  Hopefully this will
never need to be used.