### PR TITLE
docs: Add gcc-multilib dependency to development setup

### DIFF
--- a/docs/development-setup/prerequisites.md
+++ b/docs/development-setup/prerequisites.md
@@ -31,7 +31,7 @@ Core:
 
   <!-- markdownlint-disable line-length -->
   ```
-  sudo apt install bubblewrap gcc g++ protobuf-compiler make cmake libssl-dev libseccomp-dev pkg-config
+  sudo apt install bubblewrap gcc g++ gcc-multilib protobuf-compiler make cmake libssl-dev libseccomp-dev pkg-config
   ```
   <!-- markdownlint-enable line-length -->
 


### PR DESCRIPTION
This is required to build the Cipher paratime.