### PR TITLE
go/consensus/tendermint/full: Unify started indicators

### DIFF
--- a/.changelog/4809.trivial.md
+++ b/.changelog/4809.trivial.md
@@ -1,0 +1,7 @@
+go/consensus/tendermint/full: Unify started indicators
+
+Previously there were two sets of "node started" indicators, one for the
+commonNode and the other one for the fullService/archiveService. Due to
+how things were initialized this could cause the full node to report
+that it is "started" too soon which would cause some queries to trigger
+a segmentation fault instead of blocking.


### PR DESCRIPTION
Previously there were two sets of "node started" indicators (introduced in #4571), one for the commonNode and the other one for the fullService/archiveService. Due to how things were initialized this could cause the full node to report that it is "started" too soon which would cause some queries to trigger a segmentation fault instead of blocking.

(Discovered in long-term tests.)