### PR TITLE
go/oasis-node: allow km to have private peers

### DIFF
--- a/.changelog/4821.feature.md
+++ b/.changelog/4821.feature.md
@@ -1,0 +1,1 @@
+go/oasis-node: allow km to have private peers

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -409,6 +409,17 @@ func (args *argBuilder) workerKeymanagerMayGenerate() *argBuilder {
 	return args
 }
 
+func (args *argBuilder) workerKeymanagerPrivatePeerPubKeys(peerPKs []string) *argBuilder {
+	for _, pk := range peerPKs {
+		args.vec = append(args.vec, Argument{
+			Name:        keymanager.CfgPrivatePeerPubKeys,
+			Values:      []string{pk},
+			MultiValued: true,
+		})
+	}
+	return args
+}
+
 func (args *argBuilder) workerSentryEnabled() *argBuilder {
 	args.vec = append(args.vec, Argument{Name: workerSentry.CfgEnabled})
 	return args

--- a/go/oasis-test-runner/oasis/client.go
+++ b/go/oasis-test-runner/oasis/client.go
@@ -6,6 +6,10 @@ import (
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 )
 
+const (
+	clientIdentitySeedTemplate = "ekiden node client %d"
+)
+
 // Client is an Oasis client node.
 type Client struct {
 	*Node
@@ -68,6 +72,12 @@ func (net *Network) NewClient(cfg *ClientCfg) (*Client, error) {
 	}
 	if isNoSandbox() {
 		cfg.RuntimeProvisioner = runtimeRegistry.RuntimeProvisionerUnconfined
+	}
+
+	// Pre-provision the node identity so that we can identify the entity.
+	err = host.setProvisionedIdentity(false, fmt.Sprintf(clientIdentitySeedTemplate, len(net.clients)))
+	if err != nil {
+		return nil, fmt.Errorf("oasis/client: failed to provision node identity: %w", err)
 	}
 
 	client := &Client{

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -321,6 +321,8 @@ type KeymanagerFixture struct {
 	CrashPointsProbability float64 `json:"crash_points_probability,omitempty"`
 
 	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
+
+	PrivatePeerPubKeys []string `json:"private_peer_pub_keys,omitempty"`
 }
 
 // Create instantiates the key manager described by the fixture.
@@ -356,6 +358,7 @@ func (f *KeymanagerFixture) Create(net *Network) (*Keymanager, error) {
 		Runtime:            runtime,
 		Policy:             policy,
 		SentryIndices:      f.Sentries,
+		PrivatePeerPubKeys: f.PrivatePeerPubKeys,
 	})
 }
 

--- a/go/oasis-test-runner/oasis/ias.go
+++ b/go/oasis-test-runner/oasis/ias.go
@@ -37,7 +37,7 @@ func (ias *iasProxy) AddArgs(args *argBuilder) error {
 
 	// XXX: IAS proxy is started before the validators. Pregenerate temp validator internal socket path.
 	if ias.net.cfg.UseShortGrpcSocketPaths && ias.net.validators[0].customGrpcSocketPath == "" {
-		ias.net.validators[0].customGrpcSocketPath = ias.net.generateTempSocketPath()
+		ias.net.validators[0].customGrpcSocketPath = ias.net.generateTempSocketPath("ias")
 	}
 	args.internalSocketAddress(ias.net.validators[0].SocketPath())
 

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -162,6 +162,8 @@ type Keymanager struct { // nolint: maligned
 	p2pPort          uint16
 
 	mayGenerate bool
+
+	privatePeerPubKeys []string
 }
 
 // KeymanagerCfg is the Oasis key manager provisioning configuration.
@@ -173,6 +175,9 @@ type KeymanagerCfg struct {
 	Runtime            *Runtime
 	Policy             *KeymanagerPolicy
 	RuntimeProvisioner string
+
+	// PrivatePeerPubKeys is a list of base64-encoded libp2p public keys of peers who may call non-public methods.
+	PrivatePeerPubKeys []string
 }
 
 // IdentityKeyPath returns the paths to the node's identity key.
@@ -270,6 +275,7 @@ func (km *Keymanager) AddArgs(args *argBuilder) error {
 		runtimeSGXLoader(km.net.cfg.RuntimeSGXLoaderBinary).
 		runtimePath(km.runtime).
 		workerKeymanagerRuntimeID(km.runtime.ID()).
+		workerKeymanagerPrivatePeerPubKeys(km.privatePeerPubKeys).
 		configureDebugCrashPoints(km.crashPointsProbability).
 		tendermintSupplementarySanity(km.supplementarySanityInterval).
 		appendNetwork(km.net).
@@ -336,6 +342,7 @@ func (net *Network) NewKeymanager(cfg *KeymanagerCfg) (*Keymanager, error) {
 		workerClientPort:   host.getProvisionedPort(nodePortClient),
 		p2pPort:            host.getProvisionedPort(nodePortP2P),
 		mayGenerate:        len(net.keymanagers) == 0,
+		privatePeerPubKeys: cfg.PrivatePeerPubKeys,
 	}
 
 	net.keymanagers = append(net.keymanagers, km)

--- a/go/oasis-test-runner/oasis/network.go
+++ b/go/oasis-test-runner/oasis/network.go
@@ -579,8 +579,8 @@ func GenerateDeterministicNodeKeys(dir *env.Dir, rawSeed string, roles []signatu
 //
 // This function is used to obtain shorter socket path than the one in datadir since that one might
 // be too long for unix socket path.
-func (net *Network) generateTempSocketPath() string {
-	f, err := ioutil.TempFile(env.GetRootDir().String(), "internal-*.sock")
+func (net *Network) generateTempSocketPath(prefix string) string {
+	f, err := ioutil.TempFile(env.GetRootDir().String(), fmt.Sprintf("%s-internal-*.sock", prefix))
 	if err != nil {
 		return ""
 	}
@@ -616,7 +616,7 @@ func (net *Network) startOasisNode(
 	if net.cfg.UseShortGrpcSocketPaths {
 		// Keep the socket, if it was already generated!
 		if node.customGrpcSocketPath == "" {
-			node.customGrpcSocketPath = net.generateTempSocketPath()
+			node.customGrpcSocketPath = net.generateTempSocketPath(node.Name)
 		}
 		extraArgs = extraArgs.debugDontBlameOasis()
 		extraArgs = extraArgs.grpcDebugGrpcInternalSocketPath(node.customGrpcSocketPath)
@@ -865,7 +865,7 @@ func (net *Network) GetCLIConfig() cli.Config {
 	if len(net.Validators()) > 0 {
 		val := net.Validators()[0]
 		if net.cfg.UseShortGrpcSocketPaths && val.customGrpcSocketPath == "" {
-			val.customGrpcSocketPath = net.generateTempSocketPath()
+			val.customGrpcSocketPath = net.generateTempSocketPath(val.Node.Name)
 		}
 		cfg.NodeSocketPath = val.SocketPath()
 	}

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -345,8 +345,11 @@ func (n *Node) setProvisionedIdentity(persistTLS bool, seed string) error {
 		return err
 	}
 
-	if err := n.entity.addNode(nodeSigner); err != nil {
-		return err
+	if n.entity != nil {
+		// Client nodes may need a provisioned identity. They never need an entity, however.
+		if err := n.entity.addNode(nodeSigner); err != nil {
+			return err
+		}
 	}
 
 	n.nodeSigner = nodeSigner

--- a/go/worker/keymanager/init.go
+++ b/go/worker/keymanager/init.go
@@ -3,6 +3,7 @@ package keymanager
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 
 	core "github.com/libp2p/go-libp2p-core"
@@ -10,6 +11,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	ias "github.com/oasisprotocol/oasis-core/go/ias/api"
@@ -17,6 +19,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/runtime/localstorage"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	workerCommon "github.com/oasisprotocol/oasis-core/go/worker/common"
+	p2pAPI "github.com/oasisprotocol/oasis-core/go/worker/common/p2p/api"
 	"github.com/oasisprotocol/oasis-core/go/worker/keymanager/p2p"
 	"github.com/oasisprotocol/oasis-core/go/worker/registration"
 )
@@ -26,6 +29,8 @@ const (
 	CfgRuntimeID = "worker.keymanager.runtime.id"
 	// CfgMayGenerate allows the enclave to generate a master secret.
 	CfgMayGenerate = "worker.keymanager.may_generate"
+	// CfgPrivatePeerPks allows adding manual, unadvertised peers that can call protected methods.
+	CfgPrivatePeerPubKeys = "worker.keymanager.private_peer_pub_keys"
 )
 
 // Flags has the configuration flags.
@@ -59,6 +64,7 @@ func New(
 		initCh:              make(chan struct{}),
 		initTickerCh:        nil,
 		accessList:          make(map[core.PeerID]map[common.Namespace]struct{}),
+		privatePeers:        make(map[core.PeerID]struct{}),
 		accessListByRuntime: make(map[common.Namespace][]core.PeerID),
 		commonWorker:        commonWorker,
 		backend:             backend,
@@ -68,6 +74,22 @@ func New(
 
 	if !w.enabled {
 		return w, nil
+	}
+
+	for _, b64pk := range viper.GetStringSlice(CfgPrivatePeerPubKeys) {
+		pkBytes, err := base64.StdEncoding.DecodeString(b64pk)
+		if err != nil {
+			return nil, fmt.Errorf("oasis/keymanager: `%s` is not a base64-encoded public key (%w)", b64pk, err)
+		}
+		var pk signature.PublicKey
+		if err = pk.UnmarshalBinary(pkBytes); err != nil {
+			return nil, fmt.Errorf("oasis/keymanager: `%s` is not a public key (%w)", b64pk, err)
+		}
+		peerID, err := p2pAPI.PublicKeyToPeerID(pk)
+		if err != nil {
+			return nil, fmt.Errorf("oasis/keymanager: `%s` can not be converted to a peer id (%w)", b64pk, err)
+		}
+		w.privatePeers[peerID] = struct{}{}
 	}
 
 	var runtimeID common.Namespace
@@ -115,6 +137,7 @@ func New(
 func init() {
 	Flags.String(CfgRuntimeID, "", "Key manager Runtime ID")
 	Flags.Bool(CfgMayGenerate, false, "Key manager may generate new master secret")
+	Flags.StringSlice(CfgPrivatePeerPubKeys, []string{}, "b64-encoded public keys of unadvertised peers that may call protected methods")
 
 	_ = viper.BindPFlags(Flags)
 }


### PR DESCRIPTION
Private peers are libp2p peers which are added manually and are not advertised. The goal is to allow client nodes that the key manager likes to access km methods, which is used by the confidential evm paratime's signed queries.