### PR TITLE
go/consensus/tendermint: Make sure DBs are only closed during cleanup

### DIFF
--- a/.changelog/4823.bugfix.md
+++ b/.changelog/4823.bugfix.md
@@ -1,0 +1,1 @@
+go/consensus/tendermint: Make sure DBs are only closed during cleanup

--- a/go/consensus/tendermint/db/closer.go
+++ b/go/consensus/tendermint/db/closer.go
@@ -1,0 +1,48 @@
+package db
+
+import (
+	"sync"
+
+	dbm "github.com/tendermint/tm-db"
+)
+
+// Closer manages closing of multiple Tendermint Core databases.
+type Closer struct {
+	l   sync.Mutex
+	dbs []dbm.DB
+}
+
+// Close closes all the managed databases.
+func (c *Closer) Close() {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	for _, db := range c.dbs {
+		_ = db.Close()
+	}
+}
+
+// NewCloser creates a new empty database closer.
+func NewCloser() *Closer {
+	return &Closer{}
+}
+
+type dbWithCloser struct {
+	dbm.DB
+}
+
+func (d *dbWithCloser) Close() error {
+	// Do nothing unless explicitly closed via the closer.
+	return nil
+}
+
+// WithCloser wraps a Tendermint Core database instance so that it can only be closed by the given
+// closer instance. Direct attempts to close the returned database instance will be ignored.
+func WithCloser(db dbm.DB, closer *Closer) dbm.DB {
+	closer.l.Lock()
+	defer closer.l.Unlock()
+
+	closer.dbs = append(closer.dbs, db)
+
+	return &dbWithCloser{db}
+}

--- a/go/consensus/tendermint/full/full.go
+++ b/go/consensus/tendermint/full/full.go
@@ -658,10 +658,11 @@ func (t *fullService) lazyInit() error {
 	// Tendermint does not expose a way to access the state database and we need it to bypass some
 	// stupid things like pagination on the in-process "client".
 	wrapDbProvider := func(dbCtx *tmnode.DBContext) (tmdb.DB, error) {
-		db, derr := dbProvider(dbCtx)
+		rawDB, derr := dbProvider(dbCtx)
 		if derr != nil {
 			return nil, derr
 		}
+		db := db.WithCloser(rawDB, t.dbCloser)
 
 		switch dbCtx.ID {
 		case "state":

--- a/go/consensus/tendermint/full/light.go
+++ b/go/consensus/tendermint/full/light.go
@@ -61,6 +61,10 @@ func (n *commonNode) GetLightBlock(ctx context.Context, height int64) (*consensu
 
 // Implements LightClientBackend.
 func (n *commonNode) GetParameters(ctx context.Context, height int64) (*consensusAPI.Parameters, error) {
+	if err := n.ensureStarted(ctx); err != nil {
+		return nil, err
+	}
+
 	tmHeight, err := n.heightToTendermintHeight(height)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Tendermint Core will close the block/state store DBs during Stop which
can make certain in-flight queries trigger a panic due to the database
being already closed.

This commit introduces a DB wrapper that enables us to defer closing
the DB until Cleanup is called (as at that point all of the services
have already been stopped).