### PR TITLE
[BACKPORT/22.1.x] go/oasis-node: allow km private peers

### DIFF
--- a/.changelog/4821.feature.md
+++ b/.changelog/4821.feature.md
@@ -1,0 +1,1 @@
+go/oasis-node: allow km to have private peers

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -408,6 +408,17 @@ func (args *argBuilder) workerKeymanagerMayGenerate() *argBuilder {
 	return args
 }
 
+func (args *argBuilder) workerKeymanagerPrivatePeerPubKeys(peerPKs []string) *argBuilder {
+	for _, pk := range peerPKs {
+		args.vec = append(args.vec, Argument{
+			Name:        keymanager.CfgPrivatePeerPubKeys,
+			Values:      []string{pk},
+			MultiValued: true,
+		})
+	}
+	return args
+}
+
 func (args *argBuilder) workerSentryEnabled() *argBuilder {
 	args.vec = append(args.vec, Argument{Name: workerSentry.CfgEnabled})
 	return args

--- a/go/oasis-test-runner/oasis/client.go
+++ b/go/oasis-test-runner/oasis/client.go
@@ -6,6 +6,10 @@ import (
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 )
 
+const (
+	clientIdentitySeedTemplate = "ekiden node client %d"
+)
+
 // Client is an Oasis client node.
 type Client struct {
 	*Node
@@ -68,6 +72,12 @@ func (net *Network) NewClient(cfg *ClientCfg) (*Client, error) {
 	}
 	if isNoSandbox() {
 		cfg.RuntimeProvisioner = runtimeRegistry.RuntimeProvisionerUnconfined
+	}
+
+	// Pre-provision the node identity so that we can identify the entity.
+	err = host.setProvisionedIdentity(false, fmt.Sprintf(clientIdentitySeedTemplate, len(net.clients)))
+	if err != nil {
+		return nil, fmt.Errorf("oasis/client: failed to provision node identity: %w", err)
 	}
 
 	client := &Client{

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -318,6 +318,8 @@ type KeymanagerFixture struct {
 	CrashPointsProbability float64 `json:"crash_points_probability,omitempty"`
 
 	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
+
+	PrivatePeerPubKeys []string `json:"private_peer_pub_keys,omitempty"`
 }
 
 // Create instantiates the key manager described by the fixture.
@@ -353,6 +355,7 @@ func (f *KeymanagerFixture) Create(net *Network) (*Keymanager, error) {
 		Runtime:            runtime,
 		Policy:             policy,
 		SentryIndices:      f.Sentries,
+		PrivatePeerPubKeys: f.PrivatePeerPubKeys,
 	})
 }
 

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -162,6 +162,8 @@ type Keymanager struct { // nolint: maligned
 	p2pPort          uint16
 
 	mayGenerate bool
+
+	privatePeerPubKeys []string
 }
 
 // KeymanagerCfg is the Oasis key manager provisioning configuration.
@@ -173,6 +175,9 @@ type KeymanagerCfg struct {
 	Runtime            *Runtime
 	Policy             *KeymanagerPolicy
 	RuntimeProvisioner string
+
+	// PrivatePeerPubKeys is a list of base64-encoded libp2p public keys of peers who may call non-public methods.
+	PrivatePeerPubKeys []string
 }
 
 // IdentityKeyPath returns the paths to the node's identity key.
@@ -270,6 +275,7 @@ func (km *Keymanager) AddArgs(args *argBuilder) error {
 		runtimeSGXLoader(km.net.cfg.RuntimeSGXLoaderBinary).
 		runtimePath(km.runtime).
 		workerKeymanagerRuntimeID(km.runtime.ID()).
+		workerKeymanagerPrivatePeerPubKeys(km.privatePeerPubKeys).
 		configureDebugCrashPoints(km.crashPointsProbability).
 		tendermintSupplementarySanity(km.supplementarySanityInterval).
 		appendNetwork(km.net).
@@ -336,6 +342,7 @@ func (net *Network) NewKeymanager(cfg *KeymanagerCfg) (*Keymanager, error) {
 		workerClientPort:   host.getProvisionedPort(nodePortClient),
 		p2pPort:            host.getProvisionedPort(nodePortP2P),
 		mayGenerate:        len(net.keymanagers) == 0,
+		privatePeerPubKeys: cfg.PrivatePeerPubKeys,
 	}
 
 	net.keymanagers = append(net.keymanagers, km)

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -334,8 +334,11 @@ func (n *Node) setProvisionedIdentity(persistTLS bool, seed string) error {
 		return err
 	}
 
-	if err := n.entity.addNode(nodeSigner); err != nil {
-		return err
+	if n.entity != nil {
+		// Client nodes may need a provisioned identity. They never need an entity, however.
+		if err := n.entity.addNode(nodeSigner); err != nil {
+			return err
+		}
 	}
 
 	n.nodeSigner = nodeSigner

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -80,6 +80,7 @@ type Worker struct { // nolint: maligned
 
 	accessList          map[core.PeerID]map[common.Namespace]struct{}
 	accessListByRuntime map[common.Namespace][]core.PeerID
+	privatePeers        map[core.PeerID]struct{}
 
 	commonWorker  *workerCommon.Worker
 	roleProvider  registration.RoleProvider
@@ -174,12 +175,14 @@ func (w *Worker) CallEnclave(ctx context.Context, data []byte) ([]byte, error) {
 	case getPublicKeyRequestMethod:
 		// Anyone can get public keys.
 	default:
-		// Defer to access control to check the policy.
-		w.RLock()
-		_, allowed := w.accessList[peerID]
-		w.RUnlock()
-		if !allowed {
-			return nil, fmt.Errorf("not authorized")
+		if _, privatePeered := w.privatePeers[peerID]; !privatePeered {
+			// Defer to access control to check the policy.
+			w.RLock()
+			_, allowed := w.accessList[peerID]
+			w.RUnlock()
+			if !allowed {
+				return nil, fmt.Errorf("not authorized")
+			}
 		}
 	}
 


### PR DESCRIPTION
Backport of
* https://github.com/oasisprotocol/oasis-core/pull/4821