### PR TITLE
go/runtime/registry: allow client nodes to run sgx runtimes

### DIFF
--- a/.changelog/4832.feature.md
+++ b/.changelog/4832.feature.md
@@ -1,0 +1,4 @@
+go/runtime/registry: allow client nodes to run sgx runtimes
+
+Client nodes can now run runtimes in SGX, which enables them to execute
+signed queries if peered with a keymanager.

--- a/go/.golangci.yml
+++ b/go/.golangci.yml
@@ -12,15 +12,6 @@ linters-settings:
     # Enable once suggested fixes are shown: https://github.com/golangci/golangci-lint/issues/2134
     #enable:
     #  - fieldalignment
-  stylecheck:
-    go: "1.16"
-    # https://staticcheck.io/docs/options#checks
-    checks:
-      - all
-      # https://staticcheck.io/docs/checks#ST1003
-      - -ST1003
-      # https://staticcheck.io/docs/checks#ST1023
-      - -ST1023
 
 linters:
   disable-all: true
@@ -42,10 +33,10 @@ linters:
     - ineffassign
     - megacheck
     - misspell
+    - revive
     - rowserrcheck
     - staticcheck
     - structcheck
-    - stylecheck
     - typecheck
     - unconvert
     - unused
@@ -57,3 +48,11 @@ run:
     # to run, and Go plugins do not compile unless `-buildmode=plugin`
     # is set, which linters do not do.
     - oasis-test-runner/scenario/pluginsigner/example_signer_plugin
+
+exclude-use-default: false
+
+issues:
+  include:
+    - EXC0014 # un-exclude revive `exported` which warns about incorrect comments on exported items.
+  exclude:
+    - context-as-argument # revive

--- a/go/beacon/api/grpc.go
+++ b/go/beacon/api/grpc.go
@@ -82,9 +82,9 @@ var (
 	}
 )
 
-func handlerGetBaseEpoch( //nolint:golint
+func handlerGetBaseEpoch(
 	srv interface{},
-	ctx context.Context,
+	ctx context.Context, //nolint: revive
 	dec func(interface{}) error,
 	interceptor grpc.UnaryServerInterceptor,
 ) (interface{}, error) {
@@ -101,7 +101,7 @@ func handlerGetBaseEpoch( //nolint:golint
 	return interceptor(ctx, nil, info, handler)
 }
 
-func handlerGetEpoch( //nolint:golint
+func handlerGetEpoch(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -124,9 +124,9 @@ func handlerGetEpoch( //nolint:golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerGetFutureEpoch( //nolint:golint
+func handlerGetFutureEpoch(
 	srv interface{},
-	ctx context.Context,
+	ctx context.Context, //nolint: revive
 	dec func(interface{}) error,
 	interceptor grpc.UnaryServerInterceptor,
 ) (interface{}, error) {
@@ -147,7 +147,7 @@ func handlerGetFutureEpoch( //nolint:golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerWaitEpoch( // nolint: golint
+func handlerWaitEpoch(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -170,7 +170,7 @@ func handlerWaitEpoch( // nolint: golint
 	return interceptor(ctx, epoch, info, handler)
 }
 
-func handlerGetEpochBlock( //nolint:golint
+func handlerGetEpochBlock(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -193,7 +193,7 @@ func handlerGetEpochBlock( //nolint:golint
 	return interceptor(ctx, epoch, info, handler)
 }
 
-func handlerGetBeacon( //nolint:golint
+func handlerGetBeacon(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -216,7 +216,7 @@ func handlerGetBeacon( //nolint:golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerStateToGenesis( // nolint: golint
+func handlerStateToGenesis(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/common/cache/lru/lru.go
+++ b/go/common/cache/lru/lru.go
@@ -1,4 +1,4 @@
-// Package LRU implements an in-memory Least-Recently-Used cache.
+// Package lru implements an in-memory Least-Recently-Used cache.
 package lru
 
 import (
@@ -10,7 +10,7 @@ import (
 // ErrTooLarge is the error returned when a value is too large for the cache.
 var ErrTooLarge = errors.New("lru: value size exceeds maximum capacity")
 
-// Sizable is the interface implemented by types that support returning their
+// Sizeable is the interface implemented by types that support returning their
 // own memory size in bytes.
 type Sizeable interface {
 	// Size returns the size of the instance in bytes.

--- a/go/common/crypto/address/context.go
+++ b/go/common/crypto/address/context.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 )
 
-// ContextMaxSize is the maximum size of a context's identifier string.
+// ContextIdentifierMaxSize is the maximum size of a context's identifier string.
 const ContextIdentifierMaxSize = 64
 
 var (

--- a/go/common/crypto/sakg/bip32.go
+++ b/go/common/crypto/sakg/bip32.go
@@ -42,7 +42,7 @@ func (path BIP32Path) String() string {
 	return strings.Join(compStrs, "/")
 }
 
-// MarshallText encodes a BIP-0032 path into text form.
+// MarshalText encodes a BIP-0032 path into text form.
 func (path BIP32Path) MarshalText() ([]byte, error) {
 	return []byte(path.String()), nil
 }

--- a/go/common/crypto/sakg/sakg.go
+++ b/go/common/crypto/sakg/sakg.go
@@ -17,8 +17,8 @@ const MaxAccountKeyNumber = uint32(0x7fffffff)
 // ADR 0008.
 const BIP32PathPrefix = "m/44'/474'"
 
-// Generate signer for the given mnemonic, passphrase and account according to
-// ADR 0008.
+// GetAccountSigner generates a signer for the given mnemonic, passphrase and
+// account according to ADR 0008.
 func GetAccountSigner(
 	mnemonic string,
 	passphrase string,

--- a/go/common/crypto/signature/batch_verification.go
+++ b/go/common/crypto/signature/batch_verification.go
@@ -130,7 +130,7 @@ func (v *BatchVerifier) Verify() (bool, []error) {
 	return allOk && !v.hasError, ret
 }
 
-// NewBatchVerfier creates an empty BatchVerifier.
+// NewBatchVerifier creates an empty BatchVerifier.
 func NewBatchVerifier() *BatchVerifier {
 	return &BatchVerifier{
 		verifier:   ed25519.NewBatchVerifier(),

--- a/go/common/crypto/signature/signature.go
+++ b/go/common/crypto/signature/signature.go
@@ -381,7 +381,7 @@ func (s Signature) MarshalPEM() (data []byte, err error) {
 	return bytes.Join([][]byte{pk, sig}, []byte{}), nil
 }
 
-// UnmarshalPem decodes a PEM marshaled signature.
+// UnmarshalPEM decodes a PEM marshaled signature.
 func (s *Signature) UnmarshalPEM(data []byte) error {
 	// Marshalled PEM file contains public key block first...
 	blk, rest := encPem.Decode(data)

--- a/go/common/crypto/signature/signers/remote/grpc.go
+++ b/go/common/crypto/signature/signers/remote/grpc.go
@@ -112,7 +112,7 @@ func (w *wrapper) Prove(ctx context.Context, req *ProveRequest) ([]byte, error) 
 	return vrfSigner.Prove(req.Alpha)
 }
 
-func handlerPublicKeys( // nolint: golint
+func handlerPublicKeys(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -131,7 +131,7 @@ func handlerPublicKeys( // nolint: golint
 	return interceptor(ctx, nil, info, handler)
 }
 
-func handlerSign( // nolint: golint
+func handlerSign(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -154,7 +154,7 @@ func handlerSign( // nolint: golint
 	return interceptor(ctx, &req, info, handler)
 }
 
-func handlerProve( // nolint: golint
+func handlerProve(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/common/crypto/slip10/slip10.go
+++ b/go/common/crypto/slip10/slip10.go
@@ -53,7 +53,7 @@ func NewChildKey(parentSigner signature.Signer, cPar ChainCode, index uint32) (s
 		return nil, ChainCode{}, fmt.Errorf("slip10: failed to get parent public key")
 	}
 
-	kPar := unsafeSigner.UnsafeBytes()
+	kPar := unsafeSigner.UnsafeBytes() // nolint: revive
 	if len(kPar) < memory.SeedSize {
 		return nil, ChainCode{}, fmt.Errorf("slip10: invalid parent key")
 	}

--- a/go/common/dynlib/cache.go
+++ b/go/common/dynlib/cache.go
@@ -405,7 +405,7 @@ func loadCacheGlibc() (*Cache, error) {
 
 		e := new(cacheEntry)
 		e.flags = binary.LittleEndian.Uint32(rawE[0:])
-		kIdx := int(binary.LittleEndian.Uint32(rawE[4:]))
+		kIdx := int(binary.LittleEndian.Uint32(rawE[4:])) // nolint: revive
 		vIdx := int(binary.LittleEndian.Uint32(rawE[8:]))
 		e.osVersion = binary.LittleEndian.Uint32(rawE[12:])
 		e.hwcap = binary.LittleEndian.Uint64(rawE[16:])

--- a/go/common/grpc/errors_test.go
+++ b/go/common/grpc/errors_test.go
@@ -93,7 +93,7 @@ var errorTestServiceDesc = grpc.ServiceDesc{
 	Streams: []grpc.StreamDesc{},
 }
 
-func handlerErrorTest( // nolint: golint
+func handlerErrorTest(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -116,7 +116,7 @@ func handlerErrorTest( // nolint: golint
 	return interceptor(ctx, req, info, handler)
 }
 
-func handlerErrorTestWithContext( // nolint: golint
+func handlerErrorTestWithContext(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -139,7 +139,7 @@ func handlerErrorTestWithContext( // nolint: golint
 	return interceptor(ctx, req, info, handler)
 }
 
-func handlerErrorStatusTest( // nolint: golint
+func handlerErrorStatusTest(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/common/grpc/testing/ping.go
+++ b/go/common/grpc/testing/ping.go
@@ -218,7 +218,7 @@ var ServiceDesc = grpc.ServiceDesc{
 	},
 }
 
-func pingHandler( // nolint: golint
+func pingHandler(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/common/grpc/wrapper_test.go
+++ b/go/common/grpc/wrapper_test.go
@@ -148,7 +148,7 @@ var multiServiceDesc = grpc.ServiceDesc{
 	},
 }
 
-func multiPingUnaryHandler( // nolint: golint
+func multiPingUnaryHandler(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -171,7 +171,7 @@ func multiPingUnaryHandler( // nolint: golint
 	return interceptor(ctx, pq, info, handler)
 }
 
-func multiPingStreamHandler( // nolint: golint
+func multiPingStreamHandler(
 	srv interface{},
 	stream grpc.ServerStream,
 ) error {

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -122,7 +122,8 @@ const (
 	// that are reserved and must not be used.
 	RoleReserved RolesMask = ((1<<32)-1) & ^((RoleStorageRPC<<1)-1) | roleReserved2
 
-	// Human friendly role names.
+	// Human friendly role names:
+
 	RoleComputeWorkerName = "compute"
 	RoleKeyManagerName    = "key-manager"
 	RoleValidatorName     = "validator"

--- a/go/common/prettyprint/quantity.go
+++ b/go/common/prettyprint/quantity.go
@@ -78,14 +78,14 @@ func (q Quantity) String() string {
 	return q.quan.String()
 }
 
-// New creates a new Quantity, initialized to zero.
+// NewQuantity creates a new Quantity, initialized to zero.
 func NewQuantity() (q Quantity) {
 	return Quantity{
 		quan: quantity.NewQuantity(),
 	}
 }
 
-// New creates a new Quantity from a given quantity.Quantity object.
+// NewFromQuanQuantity creates a new Quantity from a given quantity.Quantity object.
 func NewFromQuanQuantity(q *quantity.Quantity) Quantity {
 	return Quantity{
 		quan:    q.Clone(),

--- a/go/common/quantity/quantity.go
+++ b/go/common/quantity/quantity.go
@@ -192,7 +192,7 @@ func (q *Quantity) IsValid() bool {
 	return isValid(&q.inner)
 }
 
-// New creates a new Quantity, initialized to zero.
+// NewQuantity creates a new Quantity, initialized to zero.
 func NewQuantity() (q *Quantity) {
 	return &Quantity{}
 }

--- a/go/common/random/random.go
+++ b/go/common/random/random.go
@@ -53,7 +53,7 @@ func (c *concurrenySafeSource) Seed(seed int64) {
 
 // Borrowed from https://github.com/cenkalti/backoff.
 
-// Returns a random value from the following interval:
+// GetRandomValueFromInterval returns a random value from the following interval:
 // 	[currentInterval - randomizationFactor * currentInterval, currentInterval + randomizationFactor * currentInterval].
 func GetRandomValueFromInterval(randomizationFactor, random float64, currentInterval time.Duration) time.Duration {
 	delta := randomizationFactor * float64(currentInterval)

--- a/go/common/sgx/aesm/types.go
+++ b/go/common/sgx/aesm/types.go
@@ -16,7 +16,7 @@ const (
 	// AttestationKeyEPIDLinkable is the unlinkable EPID attestation key type.
 	AttestationKeyEPIDLinkable AttestationKeyType = 1
 	// AttestationKeyECDSA_P256 is the ECDSA-P256 attestation key type.
-	AttestationKeyECDSA_P256 AttestationKeyType = 2
+	AttestationKeyECDSA_P256 AttestationKeyType = 2 // nolint: revive
 )
 
 // String returns a string representation of the attestation key type.

--- a/go/common/sgx/common.go
+++ b/go/common/sgx/common.go
@@ -1,4 +1,4 @@
-// Package SGX provides common Intel SGX datatypes and utilities.
+// Package sgx provides common Intel SGX datatypes and utilities.
 package sgx
 
 import (
@@ -45,12 +45,12 @@ type Attributes struct {
 	Xfrm  uint64
 }
 
-// GetFlagInit returns value of given flag attribute of the Report.
+// Contains returns value of given flag attribute of the Report.
 func (a AttributesFlags) Contains(flag AttributesFlags) bool {
 	return (uint64(a) & uint64(flag)) != 0
 }
 
-// Mrenclave is a SGX enclave identity register value (MRENCLAVE).
+// MrEnclave is a SGX enclave identity register value (MRENCLAVE).
 type MrEnclave [MrEnclaveSize]byte
 
 // MarshalBinary encodes a Mrenclave into binary form.

--- a/go/common/sgx/ias/avr.go
+++ b/go/common/sgx/ias/avr.go
@@ -408,13 +408,13 @@ func SetSkipVerify() {
 	unsafeSkipVerify = true
 }
 
-// SetAllowDebugEnclave will enable running and communicating with enclaves
+// SetAllowDebugEnclaves will enable running and communicating with enclaves
 // with debug flag enabled in AVR for the remainder of the process' lifetime.
 func SetAllowDebugEnclaves() {
 	unsafeAllowDebugEnclaves = true
 }
 
-// UnsetAllowDebugEnclave will disable running and communicating with enclaves
+// UnsetAllowDebugEnclaves will disable running and communicating with enclaves
 // with debug flag enabled in AVR for the remainder of the process' lifetime.
 func UnsetAllowDebugEnclaves() {
 	unsafeAllowDebugEnclaves = false

--- a/go/common/sgx/pcs/http.go
+++ b/go/common/sgx/pcs/http.go
@@ -79,7 +79,7 @@ func (hc *httpClient) doPCSRequest(ctx context.Context, u *url.URL, method, body
 	return resp, nil
 }
 
-func (hc *httpClient) getUrl(p string) *url.URL {
+func (hc *httpClient) getUrl(p string) *url.URL { // nolint: revive
 	u := *hc.baseURL
 	u.Path = path.Join(u.Path, p)
 	return &u

--- a/go/common/sgx/pcs/pcs.go
+++ b/go/common/sgx/pcs/pcs.go
@@ -39,13 +39,13 @@ func (bnd *QuoteBundle) Verify(ts time.Time) (*TCBLevel, error) {
 	return quote.Verify(ts, &bnd.TCB)
 }
 
-// SetAllowDebugEnclave will enable running and communicating with enclaves with debug flag enabled
+// SetAllowDebugEnclaves will enable running and communicating with enclaves with debug flag enabled
 // in report body for the remainder of the process' lifetime.
 func SetAllowDebugEnclaves() {
 	unsafeAllowDebugEnclaves = true
 }
 
-// UnsetAllowDebugEnclave will disable running and communicating with enclaves with debug flag
+// UnsetAllowDebugEnclaves will disable running and communicating with enclaves with debug flag
 // enabled in report body for the remainder of the process' lifetime.
 func UnsetAllowDebugEnclaves() {
 	unsafeAllowDebugEnclaves = false

--- a/go/common/sgx/pcs/quote.go
+++ b/go/common/sgx/pcs/quote.go
@@ -138,23 +138,23 @@ func (qh *QuoteHeader) UnmarshalBinary(data []byte) error {
 }
 
 // QEVendorID_Intel is the Quoting Enclave vendor ID for Intel (939A7233F79C4CA9940A0DB3957F0607).
-var QEVendorID_Intel = []byte{0x93, 0x9a, 0x72, 0x33, 0xf7, 0x9c, 0x4c, 0xa9, 0x94, 0x0a, 0x0d, 0xb3, 0x95, 0x7f, 0x06, 0x07}
+var QEVendorID_Intel = []byte{0x93, 0x9a, 0x72, 0x33, 0xf7, 0x9c, 0x4c, 0xa9, 0x94, 0x0a, 0x0d, 0xb3, 0x95, 0x7f, 0x06, 0x07} // nolint: revive
 
 // SGXExtension is an ASN1 SGX extension.
 type SGXExtension struct {
-	Id    asn1.ObjectIdentifier
+	Id    asn1.ObjectIdentifier // nolint: revive
 	Value asn1.RawValue
 }
 
 var (
 	// PCK_SGX_Extensions is the ASN1 Object Identifier for the SGX Extensions X509 extension.
-	PCK_SGX_Extensions = asn1.ObjectIdentifier{1, 2, 840, 113741, 1, 13, 1}
+	PCK_SGX_Extensions = asn1.ObjectIdentifier{1, 2, 840, 113741, 1, 13, 1} // nolint: revive
 
 	// PCK_SGX_Extensions_FMSPC is the ASN1 Object Identifier for the FMSPC SGX Extension.
-	PCK_SGX_Extensions_FMSPC = asn1.ObjectIdentifier{1, 2, 840, 113741, 1, 13, 1, 4}
+	PCK_SGX_Extensions_FMSPC = asn1.ObjectIdentifier{1, 2, 840, 113741, 1, 13, 1, 4} // nolint: revive
 
 	// PCK_SGX_Extensions_TCB is the ASN1 Object Identifier for the TCB SGX Extension.
-	PCK_SGX_Extensions_TCB = asn1.ObjectIdentifier{1, 2, 840, 113741, 1, 13, 1, 2}
+	PCK_SGX_Extensions_TCB = asn1.ObjectIdentifier{1, 2, 840, 113741, 1, 13, 1, 2} // nolint: revive
 )
 
 // AttestationKeyType is the attestation key type.
@@ -162,7 +162,7 @@ type AttestationKeyType uint16
 
 const (
 	// AttestationKeyECDSA_P256 is the ECDSA-P256 attestation key type.
-	AttestationKeyECDSA_P256 AttestationKeyType = 2
+	AttestationKeyECDSA_P256 AttestationKeyType = 2 // nolint: revive
 )
 
 // String returns a string representation of the attestation key type.
@@ -187,7 +187,7 @@ type QuoteSignature interface {
 }
 
 // QuoteSignatureECDSA_P256 is an ECDSA-P256 quote signature.
-type QuoteSignatureECDSA_P256 struct {
+type QuoteSignatureECDSA_P256 struct { // nolint: revive
 	Signature            SignatureECDSA_P256
 	AttestationPublicKey [64]byte
 	QEReport             ReportBody
@@ -346,7 +346,7 @@ func (qs *QuoteSignatureECDSA_P256) VerifyPCK(ts time.Time) (*PCKInfo, error) {
 				}
 
 				for _, tcbExt := range tcbExts {
-					switch compId := tcbExt.Id[len(tcbExt.Id)-1]; {
+					switch compId := tcbExt.Id[len(tcbExt.Id)-1]; { // nolint: revive
 					case compId >= 1 && compId <= 16:
 						// TCB Component SVNs
 						if _, err = asn1.Unmarshal(tcbExt.Value.FullBytes, &pckInfo.TCBCompSVN[compId-1]); err != nil {
@@ -436,7 +436,7 @@ func (qs *QuoteSignatureECDSA_P256) Verify(header *QuoteHeader, isvReport *Repor
 }
 
 // SignatureECDSA_P256 is an ECDSA-P256 signature in the form r || s.
-type SignatureECDSA_P256 [64]byte
+type SignatureECDSA_P256 [64]byte // nolint: revive
 
 // UnmarshalHex decodes the signature from a hex-encoded string.
 func (ec *SignatureECDSA_P256) UnmarshalHex(data string) error {
@@ -501,7 +501,7 @@ type CertificationData interface {
 }
 
 // CertificationData_PPID is the PPID certification data.
-type CertificationData_PPID struct {
+type CertificationData_PPID struct { // nolint: revive
 	PPID   [384]byte
 	CPUSVN [16]byte
 	PCESVN uint16
@@ -530,7 +530,7 @@ func (cd *CertificationData_PPID) UnmarshalBinary(data []byte) error {
 }
 
 // CertificationData_PCKCertificateChain is the PCK certificate chain certification data.
-type CertificationData_PCKCertificateChain struct {
+type CertificationData_PCKCertificateChain struct { // nolint: revive
 	CertificateChain []*x509.Certificate
 }
 

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -216,7 +216,7 @@ var Versions = ProtocolVersions{
 
 var goModulesVersionRegex = regexp.MustCompile(`v0.(?P<year>[0-9]{2})(?P<minor>[0-9]{2}).(?P<micro>[0-9]+)`)
 
-// Convert Go Modules compatible version to Oasis Core's canonical version.
+// ConvertGoModulesVersion converts a Go modules compatible version to Oasis Core's canonical version.
 func ConvertGoModulesVersion(goModVersion string) string {
 	match := goModulesVersionRegex.FindStringSubmatch(goModVersion)
 	// NOTE: match[0] contains the whole matched string.

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -1,5 +1,4 @@
-// Package consensus provides the implementation agnostic consensus
-// backend.
+// Package api provides the implementation agnostic consensus API.
 package api
 
 import (
@@ -263,7 +262,7 @@ type StatusState uint8
 
 var (
 	// StatusStateReady is the ready status state.
-	StatusStateReady StatusState = 0
+	StatusStateReady StatusState
 	// StatusStateSyncing is the syncing status state.
 	StatusStateSyncing StatusState = 1
 )

--- a/go/consensus/api/grpc.go
+++ b/go/consensus/api/grpc.go
@@ -167,7 +167,7 @@ var (
 	}
 )
 
-func handlerSubmitTx( // nolint: golint
+func handlerSubmitTx(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -190,7 +190,7 @@ func handlerSubmitTx( // nolint: golint
 	return interceptor(ctx, rq, info, handler)
 }
 
-func handlerStateToGenesis( // nolint: golint
+func handlerStateToGenesis(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -213,7 +213,7 @@ func handlerStateToGenesis( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerEstimateGas( // nolint: golint
+func handlerEstimateGas(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -236,7 +236,7 @@ func handlerEstimateGas( // nolint: golint
 	return interceptor(ctx, rq, info, handler)
 }
 
-func handlerGetSignerNonce( // nolint: golint
+func handlerGetSignerNonce(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -259,7 +259,7 @@ func handlerGetSignerNonce( // nolint: golint
 	return interceptor(ctx, rq, info, handler)
 }
 
-func handlerGetBlock( // nolint: golint
+func handlerGetBlock(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -282,7 +282,7 @@ func handlerGetBlock( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerGetTransactions( // nolint: golint
+func handlerGetTransactions(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -305,7 +305,7 @@ func handlerGetTransactions( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerGetTransactionsWithResults( // nolint: golint
+func handlerGetTransactionsWithResults(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -328,7 +328,7 @@ func handlerGetTransactionsWithResults( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerGetUnconfirmedTransactions( // nolint: golint
+func handlerGetUnconfirmedTransactions(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -347,7 +347,7 @@ func handlerGetUnconfirmedTransactions( // nolint: golint
 	return interceptor(ctx, nil, info, handler)
 }
 
-func handlerGetGenesisDocument( // nolint: golint
+func handlerGetGenesisDocument(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -366,7 +366,7 @@ func handlerGetGenesisDocument( // nolint: golint
 	return interceptor(ctx, nil, info, handler)
 }
 
-func handlerGetChainContext( // nolint: golint
+func handlerGetChainContext(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -385,7 +385,7 @@ func handlerGetChainContext( // nolint: golint
 	return interceptor(ctx, nil, info, handler)
 }
 
-func handlerGetStatus( // nolint: golint
+func handlerGetStatus(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -404,7 +404,7 @@ func handlerGetStatus( // nolint: golint
 	return interceptor(ctx, nil, info, handler)
 }
 
-func handlerGetNextBlockState( // nolint: golint
+func handlerGetNextBlockState(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -451,7 +451,7 @@ func handlerWatchBlocks(srv interface{}, stream grpc.ServerStream) error {
 	}
 }
 
-func handlerGetLightBlock( // nolint: golint
+func handlerGetLightBlock(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -474,7 +474,7 @@ func handlerGetLightBlock( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerGetParameters( // nolint: golint
+func handlerGetParameters(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -497,7 +497,7 @@ func handlerGetParameters( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerStateSyncGet( // nolint: golint
+func handlerStateSyncGet(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -520,7 +520,7 @@ func handlerStateSyncGet( // nolint: golint
 	return interceptor(ctx, rq, info, handler)
 }
 
-func handlerStateSyncGetPrefixes( // nolint: golint
+func handlerStateSyncGetPrefixes(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -543,7 +543,7 @@ func handlerStateSyncGetPrefixes( // nolint: golint
 	return interceptor(ctx, rq, info, handler)
 }
 
-func handlerStateSyncIterate( // nolint: golint
+func handlerStateSyncIterate(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -566,7 +566,7 @@ func handlerStateSyncIterate( // nolint: golint
 	return interceptor(ctx, rq, info, handler)
 }
 
-func handlerSubmitTxNoWait( // nolint: golint
+func handlerSubmitTxNoWait(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -589,7 +589,7 @@ func handlerSubmitTxNoWait( // nolint: golint
 	return interceptor(ctx, rq, info, handler)
 }
 
-func handlerSubmitEvidence( // nolint: golint
+func handlerSubmitEvidence(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/consensus/api/submission.go
+++ b/go/consensus/api/submission.go
@@ -212,17 +212,17 @@ func SignAndSubmitTx(ctx context.Context, backend Backend, signer signature.Sign
 // NoOpSubmissionManager implements a submission manager that doesn't support submitting transactions.
 type NoOpSubmissionManager struct{}
 
-// Implements SubmissionManager.
+// PriceDiscovery implements SubmissionManager.
 func (m *NoOpSubmissionManager) PriceDiscovery() PriceDiscovery {
 	return &noOpPriceDiscovery{}
 }
 
-// Implements SubmissionManager.
+// EstimateGasAndSetFee implements SubmissionManager.
 func (m *NoOpSubmissionManager) EstimateGasAndSetFee(ctx context.Context, signer signature.Signer, tx *transaction.Transaction) error {
 	return transaction.ErrMethodNotSupported
 }
 
-// Implements SubmissionManager.
+// SignAndSubmitTx implements SubmissionManager.
 func (m *NoOpSubmissionManager) SignAndSubmitTx(ctx context.Context, signer signature.Signer, tx *transaction.Transaction) error {
 	return transaction.ErrMethodNotSupported
 }

--- a/go/consensus/tendermint/api/api.go
+++ b/go/consensus/tendermint/api/api.go
@@ -30,7 +30,7 @@ import (
 const BackendName = "tendermint"
 
 const (
-	// LogEventPeerExchangeDisable is a log event that indicates that
+	// LogEventPeerExchangeDisabled is a log event that indicates that
 	// Tendermint's peer exchange has been disabled.
 	LogEventPeerExchangeDisabled = "tendermint/peer_exchange_disabled"
 )
@@ -344,17 +344,17 @@ type ServiceClient interface {
 // all the delivery methods. Implementations should override them as needed.
 type BaseServiceClient struct{}
 
-// Implements ServiceClient.
+// DeliverBlock implements ServiceClient.
 func (bsc *BaseServiceClient) DeliverBlock(ctx context.Context, height int64) error {
 	return nil
 }
 
-// Implements ServiceClient.
+// DeliverEvent implements ServiceClient.
 func (bsc *BaseServiceClient) DeliverEvent(ctx context.Context, height int64, tx tmtypes.Tx, ev *types.Event) error {
 	return nil
 }
 
-// Implements ServiceClient.
+// DeliverCommand implements ServiceClient.
 func (bsc *BaseServiceClient) DeliverCommand(ctx context.Context, height int64, cmd interface{}) error {
 	return nil
 }

--- a/go/consensus/tendermint/api/app.go
+++ b/go/consensus/tendermint/api/app.go
@@ -35,11 +35,11 @@ type MessageDispatcher interface {
 // NoopMessageDispatcher is a no-op message dispatcher that performs no dispatch.
 type NoopMessageDispatcher struct{}
 
-// Implements MessageDispatcher.
+// Subscribe implements MessageDispatcher.
 func (nd *NoopMessageDispatcher) Subscribe(interface{}, MessageSubscriber) {
 }
 
-// Implements MessageDispatcher.
+// Publish implements MessageDispatcher.
 func (nd *NoopMessageDispatcher) Publish(*Context, interface{}, interface{}) (interface{}, error) {
 	return nil, nil
 }

--- a/go/consensus/tendermint/apps/beacon/state/interop/interop.go
+++ b/go/consensus/tendermint/apps/beacon/state/interop/interop.go
@@ -7,7 +7,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs"
 )
 
-// Keep this in sync with tests in runtimes/consensus/state/beacon.rs.
+// InitializeTestBeaconState must be keet in sync with tests in runtimes/consensus/state/beacon.rs.
 func InitializeTestBeaconState(ctx context.Context, mkvs mkvs.Tree) error {
 	state := beaconState.NewMutableState(mkvs)
 

--- a/go/consensus/tendermint/apps/beacon/state/state_deprecated.go
+++ b/go/consensus/tendermint/apps/beacon/state/state_deprecated.go
@@ -1,3 +1,4 @@
+// Package state is deprecated.
 package state
 
 import "github.com/oasisprotocol/oasis-core/go/common/keyformat"

--- a/go/consensus/tendermint/apps/registry/state/interop/interop.go
+++ b/go/consensus/tendermint/apps/registry/state/interop/interop.go
@@ -22,7 +22,7 @@ var (
 	nodeSigner2  = memorySigner.NewTestSigner("consensus/tendermint/apps/registry/state/interop: node signer 2")
 )
 
-// Keep this in sync with tests in runtimes/consensus/state/registry.rs.
+// InitializeTestRegistryState must be kept in sync with tests in runtimes/consensus/state/registry.rs.
 func InitializeTestRegistryState(ctx context.Context, mkvs mkvs.Tree) error {
 	state := registryState.NewMutableState(mkvs)
 

--- a/go/consensus/tendermint/apps/roothash/state/state.go
+++ b/go/consensus/tendermint/apps/roothash/state/state.go
@@ -376,7 +376,7 @@ func (s *MutableState) SetIncomingMessageQueueMeta(ctx context.Context, runtimeI
 	return api.UnavailableStateError(err)
 }
 
-// SetIncomingMessageQueue sets an entry in the incoming message queue.
+// SetIncomingMessageInQueue sets an entry in the incoming message queue.
 func (s *MutableState) SetIncomingMessageInQueue(ctx context.Context, runtimeID common.Namespace, msg *message.IncomingMessage) error {
 	err := s.ms.Insert(ctx, inMsgQueueKeyFmt.Encode(&runtimeID, msg.ID), cbor.Marshal(msg))
 	return api.UnavailableStateError(err)

--- a/go/consensus/tendermint/apps/staking/state/interop/interop.go
+++ b/go/consensus/tendermint/apps/staking/state/interop/interop.go
@@ -13,7 +13,7 @@ import (
 
 var addresses []staking.Address
 
-// Keep this in sync with tests in runtimes/consensus/state/staking.rs.
+// InitializeTestStakingState must be kept in sync with tests in runtimes/consensus/state/staking.rs.
 func InitializeTestStakingState(ctx context.Context, mkvs mkvs.Tree) error {
 	state := stakingState.NewMutableState(mkvs)
 

--- a/go/consensus/tendermint/full/archive.go
+++ b/go/consensus/tendermint/full/archive.go
@@ -139,7 +139,7 @@ func (srv *archiveService) WatchBlocks(ctx context.Context) (<-chan *consensusAP
 	return ch, sub, nil
 }
 
-// New creates a new archive-only consensus service.
+// NewArchive creates a new archive-only consensus service.
 func NewArchive(
 	ctx context.Context,
 	dataDir string,

--- a/go/control/api/grpc.go
+++ b/go/control/api/grpc.go
@@ -72,7 +72,7 @@ var (
 	}
 )
 
-func handlerRequestShutdown( // nolint: golint
+func handlerRequestShutdown(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -95,7 +95,7 @@ func handlerRequestShutdown( // nolint: golint
 	return interceptor(ctx, wait, info, handler)
 }
 
-func handlerWaitSync( // nolint: golint
+func handlerWaitSync(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -114,7 +114,7 @@ func handlerWaitSync( // nolint: golint
 	return interceptor(ctx, nil, info, handler)
 }
 
-func handlerIsSynced( // nolint: golint
+func handlerIsSynced(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -133,7 +133,7 @@ func handlerIsSynced( // nolint: golint
 	return interceptor(ctx, nil, info, handler)
 }
 
-func handlerWaitReady( // nolint: golint
+func handlerWaitReady(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -152,7 +152,7 @@ func handlerWaitReady( // nolint: golint
 	return interceptor(ctx, nil, info, handler)
 }
 
-func handlerIsReady( // nolint: golint
+func handlerIsReady(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -171,7 +171,7 @@ func handlerIsReady( // nolint: golint
 	return interceptor(ctx, nil, info, handler)
 }
 
-func handlerUpgradeBinary( // nolint: golint
+func handlerUpgradeBinary(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -194,7 +194,7 @@ func handlerUpgradeBinary( // nolint: golint
 	return interceptor(ctx, &descriptor, info, handler)
 }
 
-func handlerCancelUpgrade( // nolint: golint
+func handlerCancelUpgrade(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -217,7 +217,7 @@ func handlerCancelUpgrade( // nolint: golint
 	return interceptor(ctx, &descriptor, info, handler)
 }
 
-func handlerGetStatus( // nolint: golint
+func handlerGetStatus(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/control/api/grpc_debug.go
+++ b/go/control/api/grpc_debug.go
@@ -36,7 +36,7 @@ var (
 	}
 )
 
-func handlerSetEpoch( // nolint: golint
+func handlerSetEpoch(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -59,7 +59,7 @@ func handlerSetEpoch( // nolint: golint
 	return interceptor(ctx, epoch, info, handler)
 }
 
-func handlerWaitNodesRegistered( // nolint: golint
+func handlerWaitNodesRegistered(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/control/debug.go
+++ b/go/control/debug.go
@@ -62,7 +62,7 @@ Loop:
 	return nil
 }
 
-// New creates a new oasis-node debug controller.
+// NewDebug creates a new oasis-node debug controller.
 func NewDebug(consensus consensus.Backend) api.DebugController {
 	return &debugController{
 		timeSource: consensus.Beacon(),

--- a/go/governance/api/grpc.go
+++ b/go/governance/api/grpc.go
@@ -82,7 +82,7 @@ var (
 	}
 )
 
-func handlerActiveProposals( // nolint: golint
+func handlerActiveProposals(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -105,7 +105,7 @@ func handlerActiveProposals( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerProposals( // nolint: golint
+func handlerProposals(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -128,7 +128,7 @@ func handlerProposals( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerVotes( // nolint: golint
+func handlerVotes(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -151,7 +151,7 @@ func handlerVotes( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerProposal( // nolint: golint
+func handlerProposal(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -174,7 +174,7 @@ func handlerProposal( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerPendingUpgrades( // nolint: golint
+func handlerPendingUpgrades(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -197,7 +197,7 @@ func handlerPendingUpgrades( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerStateToGenesis( // nolint: golint
+func handlerStateToGenesis(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -220,7 +220,7 @@ func handlerStateToGenesis( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerConsensusParameters( // nolint: golint
+func handlerConsensusParameters(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -243,7 +243,7 @@ func handlerConsensusParameters( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerGetEvents( // nolint: golint
+func handlerGetEvents(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/ias/api/grpc.go
+++ b/go/ias/api/grpc.go
@@ -42,7 +42,7 @@ var (
 	}
 )
 
-func handlerVerifyEvidence( // nolint: golint
+func handlerVerifyEvidence(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -65,7 +65,7 @@ func handlerVerifyEvidence( // nolint: golint
 	return interceptor(ctx, &req, info, handler)
 }
 
-func handlerGetSPIDInfo( // nolint: golint
+func handlerGetSPIDInfo(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -84,7 +84,7 @@ func handlerGetSPIDInfo( // nolint: golint
 	return interceptor(ctx, nil, info, handler)
 }
 
-func handlerGetSigRL( // nolint: golint
+func handlerGetSigRL(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/keymanager/api/grpc.go
+++ b/go/keymanager/api/grpc.go
@@ -35,7 +35,7 @@ var (
 	}
 )
 
-func handlerGetStatus( //nolint: golint
+func handlerGetStatus(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -58,7 +58,7 @@ func handlerGetStatus( //nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerGetStatuses( //nolint: golint
+func handlerGetStatuses(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/oasis-node/cmd/common/common.go
+++ b/go/oasis-node/cmd/common/common.go
@@ -35,7 +35,7 @@ const (
 	CfgConfigFile = "config"
 	CfgDataDir    = "datadir"
 
-	// RequiredRLimit is the minimum required RLIMIT_NOFILE as too low of a
+	// RequiredRlimit is the minimum required RLIMIT_NOFILE as too low of a
 	// limit can cause problems with BadgerDB.
 	RequiredRlimit = 50_000
 )

--- a/go/oasis-node/cmd/common/grpc/grpc.go
+++ b/go/oasis-node/cmd/common/grpc/grpc.go
@@ -26,7 +26,7 @@ import (
 const (
 	// CfgServerPort configures the server port.
 	CfgServerPort = "grpc.port"
-	// CfgDebugPort configures the remote address.
+	// CfgAddress configures the remote address.
 	CfgAddress = "address"
 	// CfgWait waits for the remote address to become available.
 	CfgWait = "wait"

--- a/go/oasis-node/cmd/common/metrics/cpu.go
+++ b/go/oasis-node/cmd/common/metrics/cpu.go
@@ -13,7 +13,7 @@ const (
 	MetricCPUUTimeSeconds = "oasis_node_cpu_utime_seconds"
 	MetricCPUSTimeSeconds = "oasis_node_cpu_stime_seconds"
 
-	// getconf CLK_TCK
+	// ClockTicks is getconf CLK_TCK
 	ClockTicks = 100
 )
 

--- a/go/oasis-node/cmd/common/metrics/mem.go
+++ b/go/oasis-node/cmd/common/metrics/mem.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	MetricMemVmSizeBytes   = "oasis_node_mem_vm_size_bytes" // nolint: golint
+	MetricMemVmSizeBytes   = "oasis_node_mem_vm_size_bytes" // nolint: revive
 	MetricMemRssAnonBytes  = "oasis_node_mem_rss_anon_bytes"
 	MetricMemRssFileBytes  = "oasis_node_mem_rss_file_bytes"
 	MetricMemRssShmemBytes = "oasis_node_mem_rss_shmem_bytes"

--- a/go/oasis-node/cmd/consensus/consensus.go
+++ b/go/oasis-node/cmd/consensus/consensus.go
@@ -1,4 +1,4 @@
-// Package genesis implements the consensus sub-commands.
+// Package consensus implements the consensus sub-commands.
 package consensus
 
 import (

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -44,6 +44,7 @@ import (
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 )
 
+// nolint: revive
 const (
 	cfgEntity        = "entity"
 	cfgRuntime       = "runtime"

--- a/go/oasis-node/cmd/node/control.go
+++ b/go/oasis-node/cmd/node/control.go
@@ -19,12 +19,12 @@ var (
 	_ registration.Delegate  = (*Node)(nil)
 )
 
-// Implements registration.Delegate.
+// RegistrationStopped implements registration.Delegate.
 func (n *Node) RegistrationStopped() {
 	n.Stop()
 }
 
-// Implements control.ControlledNode.
+// RequestShutdown implements control.ControlledNode.
 func (n *Node) RequestShutdown() (<-chan struct{}, error) {
 	if n.RegistrationWorker == nil {
 		// In case there is no registration worker, we can just trigger an immediate shutdown.
@@ -46,17 +46,17 @@ func (n *Node) RequestShutdown() (<-chan struct{}, error) {
 	return n.RegistrationWorker.Quit(), nil
 }
 
-// Implements control.ControlledNode.
+// Ready implements control.ControlledNode.
 func (n *Node) Ready() <-chan struct{} {
 	return n.readyCh
 }
 
-// Implements control.ControlledNode.
+// GetIdentity implements control.ControlledNode.
 func (n *Node) GetIdentity() *identity.Identity {
 	return n.Identity
 }
 
-// Implements control.ControlledNode.
+// GetRegistrationStatus implements control.ControlledNode.
 func (n *Node) GetRegistrationStatus(ctx context.Context) (*control.RegistrationStatus, error) {
 	if n.RegistrationWorker == nil {
 		return &control.RegistrationStatus{}, nil
@@ -64,7 +64,7 @@ func (n *Node) GetRegistrationStatus(ctx context.Context) (*control.Registration
 	return n.RegistrationWorker.GetRegistrationStatus(ctx)
 }
 
-// Implements control.ControlledNode.
+// GetRuntimeStatus implements control.ControlledNode.
 func (n *Node) GetRuntimeStatus(ctx context.Context) (map[common.Namespace]control.RuntimeStatus, error) {
 	runtimes := make(map[common.Namespace]control.RuntimeStatus)
 
@@ -183,7 +183,7 @@ func (n *Node) GetRuntimeStatus(ctx context.Context) (map[common.Namespace]contr
 	return runtimes, nil
 }
 
-// Implements control.ControlledNode.
+// GetPendingUpgrades implements control.ControlledNode.
 func (n *Node) GetPendingUpgrades(ctx context.Context) ([]*upgrade.PendingUpgrade, error) {
 	return n.Upgrader.PendingUpgrades(ctx)
 }

--- a/go/oasis-node/cmd/registry/runtime/runtime.go
+++ b/go/oasis-node/cmd/registry/runtime/runtime.go
@@ -28,7 +28,7 @@ const (
 	// CfgRuntimeDescriptor is the flag to specify the path to runtime descriptor.
 	CfgRuntimeDescriptor = "runtime.descriptor"
 
-	// List runtimes flags.
+	// CfgIncludeSuspended is the flag to include suspended runtimes.
 	CfgIncludeSuspended = "include_suspended"
 )
 

--- a/go/oasis-test-runner/oasis/compute.go
+++ b/go/oasis-test-runner/oasis/compute.go
@@ -116,7 +116,7 @@ func (worker *Compute) GetClientAddress() string {
 	return fmt.Sprintf("127.0.0.1:%d", worker.clientPort)
 }
 
-// WaitForRoot waits until the node syncs up to the given root.
+// WaitForRound waits until the node syncs up to the given root.
 func (worker *Compute) WaitForRound(ctx context.Context, runtimeID common.Namespace, round uint64) (uint64, error) {
 	ctrl, err := NewController(worker.SocketPath())
 	if err != nil {

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -279,7 +279,7 @@ func (f *RuntimeFixture) Create(netFixture *NetworkFixture, net *Network) (*Runt
 	})
 }
 
-// KeymangerPolicyFixgure is a key manager policy fixture.
+// KeymanagerPolicyFixture is a key manager policy fixture.
 type KeymanagerPolicyFixture struct {
 	Runtime int `json:"runtime"`
 	Serial  int `json:"serial"`

--- a/go/oasis-test-runner/oasis/network.go
+++ b/go/oasis-test-runner/oasis/network.go
@@ -856,7 +856,7 @@ func (net *Network) BasePath() string {
 	return net.baseDir.String()
 }
 
-// Implements cli.Factory.
+// GetCLIConfig implements cli.Factory.
 func (net *Network) GetCLIConfig() cli.Config {
 	cfg := cli.Config{
 		NodeBinary:  net.cfg.NodeBinary,

--- a/go/oasis-test-runner/oasis/runtime.go
+++ b/go/oasis-test-runner/oasis/runtime.go
@@ -166,7 +166,7 @@ func (rt *Runtime) RefreshRuntimeBundles() error {
 	return err
 }
 
-// ToRuntimeBundle serializes the runtime to disk and returns the bundle.
+// ToRuntimeBundles serializes the runtime to disk and returns the bundle.
 func (rt *Runtime) ToRuntimeBundles() ([]*bundle.Bundle, error) {
 	var bundles []*bundle.Bundle
 	for i := range rt.cfgSave.deployments {

--- a/go/oasis-test-runner/oasis/validator.go
+++ b/go/oasis-test-runner/oasis/validator.go
@@ -63,7 +63,7 @@ func (val *Validator) ConsensusKeyPath() string {
 	return nodeConsensusKeyPath(val.dir)
 }
 
-// Exports path returns the path to the node's exports data dir.
+// ExportsPath returns the path to the node's exports data dir.
 func (val *Validator) ExportsPath() string {
 	return nodeExportsPath(val.dir)
 }

--- a/go/oasis-test-runner/scenario/e2e/e2e.go
+++ b/go/oasis-test-runner/scenario/e2e/e2e.go
@@ -32,7 +32,7 @@ const (
 )
 
 // E2eParamsDummy is a dummy instance of E2E used to register global e2e flags.
-var E2eParamsDummy *E2E = NewE2E("")
+var E2eParamsDummy = NewE2E("")
 
 // E2E is a base scenario for oasis-node end-to-end tests.
 type E2E struct {
@@ -61,7 +61,7 @@ func NewE2E(name string) *E2E {
 	return sc
 }
 
-// Implements scenario.Scenario.
+// Clone implements scenario.Scenario.
 func (sc *E2E) Clone() E2E {
 	return E2E{
 		Net:    sc.Net,
@@ -71,22 +71,22 @@ func (sc *E2E) Clone() E2E {
 	}
 }
 
-// Implements scenario.Scenario.
+// Name implements scenario.Scenario.
 func (sc *E2E) Name() string {
 	return sc.name
 }
 
-// Implements scenario.Scenario.
+// Parameters implements scenario.Scenario.
 func (sc *E2E) Parameters() *env.ParameterFlagSet {
 	return sc.Flags
 }
 
-// Implements scenario.Scenario.
+// PreInit implements scenario.Scenario.
 func (sc *E2E) PreInit(childEnv *env.Env) error {
 	return nil
 }
 
-// Implements scenario.Scenario.
+// Fixture implements scenario.Scenario.
 func (sc *E2E) Fixture() (*oasis.NetworkFixture, error) {
 	nodeBinary, _ := sc.Flags.GetString(cfgNodeBinary)
 
@@ -114,7 +114,7 @@ func (sc *E2E) Fixture() (*oasis.NetworkFixture, error) {
 	}, nil
 }
 
-// Implements scenario.Scenario.
+// Init implements scenario.Scenario.
 func (sc *E2E) Init(childEnv *env.Env, net *oasis.Network) error {
 	sc.Net = net
 	return nil

--- a/go/oasis-test-runner/scenario/e2e/runtime/archive_api.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/archive_api.go
@@ -38,7 +38,7 @@ func (sc *archiveAPI) Fixture() (*oasis.NetworkFixture, error) {
 
 	// Add a compute node that will be turned into an archive node.
 	f.ComputeWorkers = append(f.ComputeWorkers, oasis.ComputeWorkerFixture{Entity: 1, Runtimes: []int{1}, AllowEarlyTermination: true})
-	f.Runtimes[1].Executor.GroupSize += 1
+	f.Runtimes[1].Executor.GroupSize++
 
 	f.Network.SetMockEpoch()
 	f.Network.HaltEpoch = uint64(haltEpoch)
@@ -203,7 +203,7 @@ func (sc *archiveAPI) testArchiveAPI(ctx context.Context, archiveCtrl *oasis.Con
 			}
 			select {
 			case <-blockCh:
-				wait += 1
+				wait++
 			case <-time.After(30 * time.Second):
 				return fmt.Errorf("timed out waiting for blocks")
 			}

--- a/go/oasis-test-runner/scenario/e2e/runtime/node_shutdown.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/node_shutdown.go
@@ -194,7 +194,7 @@ func (sc *nodeShutdownImpl) Run(childEnv *env.Env) error { //nolint: gocyclo
 		}
 		select {
 		case <-blockCh:
-			wait += 1
+			wait++
 		case <-time.After(30 * time.Second):
 			return fmt.Errorf("timed out waiting for blocks")
 		}

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -38,7 +38,7 @@ const (
 
 var (
 	// RuntimeParamsDummy is a dummy instance of runtimeImpl used to register global e2e/runtime flags.
-	RuntimeParamsDummy *runtimeImpl = newRuntimeImpl("", nil)
+	RuntimeParamsDummy = newRuntimeImpl("", nil)
 
 	// Runtime is the basic network + client test case with runtime support.
 	Runtime scenario.Scenario = newRuntimeImpl("runtime", BasicKVTestClient)

--- a/go/oasis-test-runner/scenario/pluginsigner/pluginsigner.go
+++ b/go/oasis-test-runner/scenario/pluginsigner/pluginsigner.go
@@ -17,7 +17,7 @@ const (
 	cfgPluginConfig = "config"
 )
 
-var pluginSignerParamsDummy *pluginSignerImpl = newPluginSignerImpl("")
+var pluginSignerParamsDummy = newPluginSignerImpl("")
 
 type pluginSignerImpl struct {
 	name   string

--- a/go/oasis-test-runner/scenario/remotesigner/remotesigner.go
+++ b/go/oasis-test-runner/scenario/remotesigner/remotesigner.go
@@ -18,7 +18,7 @@ const (
 
 // RemoteSignerParamsDummy is a dummy instance of remoteSignerImpl used to register global
 // remote-signer flags.
-var RemoteSignerParamsDummy *remoteSignerImpl = newRemoteSignerImpl("")
+var RemoteSignerParamsDummy = newRemoteSignerImpl("")
 
 type remoteSignerImpl struct {
 	name   string

--- a/go/registry/api/grpc.go
+++ b/go/registry/api/grpc.go
@@ -116,7 +116,7 @@ var (
 	}
 )
 
-func handlerGetEntity( // nolint: golint
+func handlerGetEntity(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -139,7 +139,7 @@ func handlerGetEntity( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerGetEntities( // nolint: golint
+func handlerGetEntities(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -162,7 +162,7 @@ func handlerGetEntities( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerGetNode( // nolint: golint
+func handlerGetNode(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -185,7 +185,7 @@ func handlerGetNode( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerGetNodeByConsensusAddress( // nolint: golint
+func handlerGetNodeByConsensusAddress(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -208,7 +208,7 @@ func handlerGetNodeByConsensusAddress( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerGetNodeStatus( // nolint: golint
+func handlerGetNodeStatus(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -231,7 +231,7 @@ func handlerGetNodeStatus( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerGetNodes( // nolint: golint
+func handlerGetNodes(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -254,7 +254,7 @@ func handlerGetNodes( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerGetRuntime( // nolint: golint
+func handlerGetRuntime(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -277,7 +277,7 @@ func handlerGetRuntime( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerGetRuntimes( // nolint: golint
+func handlerGetRuntimes(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -300,7 +300,7 @@ func handlerGetRuntimes( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerStateToGenesis( // nolint: golint
+func handlerStateToGenesis(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -323,7 +323,7 @@ func handlerStateToGenesis( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerGetEvents( // nolint: golint
+func handlerGetEvents(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -1571,7 +1571,7 @@ func (rt *TestRuntime) Populate(t *testing.T, backend api.Backend, consensus con
 	return BulkPopulate(t, backend, consensus, []*TestRuntime{rt}, seed)
 }
 
-// PopulateBulk bulk populates the registry for the given TestRuntimes.
+// BulkPopulate bulk populates the registry for the given TestRuntimes.
 func BulkPopulate(t *testing.T, backend api.Backend, consensus consensusAPI.Backend, runtimes []*TestRuntime, seed []byte) []*node.Node {
 	require := require.New(t)
 

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -452,7 +452,7 @@ func (e *RuntimeIDAttribute) EventValue() string {
 
 // DecodeValue decodes the attribute event value.
 func (e *RuntimeIDAttribute) DecodeValue(value string) error {
-	rtId := common.Namespace{}
+	rtId := common.Namespace{} // nolint: revive
 	if err := rtId.UnmarshalBase64([]byte(value)); err != nil {
 		return err
 	}

--- a/go/roothash/api/commitment/pool.go
+++ b/go/roothash/api/commitment/pool.go
@@ -18,6 +18,7 @@ import (
 // moduleName is the module name used for namespacing errors.
 const moduleName = "roothash/commitment"
 
+// nolint: revive
 var (
 	ErrNoRuntime              = errors.New(moduleName, 1, "roothash/commitment: no runtime configured")
 	ErrNoCommittee            = errors.New(moduleName, 2, "roothash/commitment: no committee configured")

--- a/go/roothash/api/grpc.go
+++ b/go/roothash/api/grpc.go
@@ -97,7 +97,7 @@ var (
 	}
 )
 
-func handlerGetGenesisBlock( // nolint: golint
+func handlerGetGenesisBlock(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -120,7 +120,7 @@ func handlerGetGenesisBlock( // nolint: golint
 	return interceptor(ctx, &rq, info, handler)
 }
 
-func handlerGetLatestBlock( // nolint: golint
+func handlerGetLatestBlock(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -143,7 +143,7 @@ func handlerGetLatestBlock( // nolint: golint
 	return interceptor(ctx, &rq, info, handler)
 }
 
-func handlerGetRuntimeState( // nolint: golint
+func handlerGetRuntimeState(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -166,7 +166,7 @@ func handlerGetRuntimeState( // nolint: golint
 	return interceptor(ctx, &rq, info, handler)
 }
 
-func handlerGetLastRoundResults( // nolint: golint
+func handlerGetLastRoundResults(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -189,7 +189,7 @@ func handlerGetLastRoundResults( // nolint: golint
 	return interceptor(ctx, &rq, info, handler)
 }
 
-func handlerGetIncomingMessageQueueMeta( // nolint: golint
+func handlerGetIncomingMessageQueueMeta(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -212,7 +212,7 @@ func handlerGetIncomingMessageQueueMeta( // nolint: golint
 	return interceptor(ctx, &rq, info, handler)
 }
 
-func handlerGetIncomingMessageQueue( // nolint: golint
+func handlerGetIncomingMessageQueue(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -235,7 +235,7 @@ func handlerGetIncomingMessageQueue( // nolint: golint
 	return interceptor(ctx, &rq, info, handler)
 }
 
-func handlerStateToGenesis( // nolint: golint
+func handlerStateToGenesis(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -258,7 +258,7 @@ func handlerStateToGenesis( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerConsensusParameters( // nolint: golint
+func handlerConsensusParameters(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -281,7 +281,7 @@ func handlerConsensusParameters( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerGetEvents( // nolint: golint
+func handlerGetEvents(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/runtime/client/api/grpc.go
+++ b/go/runtime/client/api/grpc.go
@@ -105,7 +105,7 @@ var (
 	}
 )
 
-func handlerSubmitTx( // nolint: golint
+func handlerSubmitTx(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -128,7 +128,7 @@ func handlerSubmitTx( // nolint: golint
 	return interceptor(ctx, &rq, info, handler)
 }
 
-func handlerSubmitTxMeta( // nolint: golint
+func handlerSubmitTxMeta(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -151,7 +151,7 @@ func handlerSubmitTxMeta( // nolint: golint
 	return interceptor(ctx, &rq, info, handler)
 }
 
-func handlerSubmitTxNoWait( // nolint: golint
+func handlerSubmitTxNoWait(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -174,7 +174,7 @@ func handlerSubmitTxNoWait( // nolint: golint
 	return interceptor(ctx, &rq, info, handler)
 }
 
-func handlerCheckTx( // nolint: golint
+func handlerCheckTx(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -224,7 +224,7 @@ func errorWrapNotFound(err error) error {
 	return wrappedErrNotFound{err}
 }
 
-func handlerGetGenesisBlock( // nolint: golint
+func handlerGetGenesisBlock(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -249,7 +249,7 @@ func handlerGetGenesisBlock( // nolint: golint
 	return interceptor(ctx, runtimeID, info, handler)
 }
 
-func handlerGetBlock( // nolint: golint
+func handlerGetBlock(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -274,7 +274,7 @@ func handlerGetBlock( // nolint: golint
 	return interceptor(ctx, &rq, info, handler)
 }
 
-func handlerGetLastRetainedBlock( // nolint: golint
+func handlerGetLastRetainedBlock(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -299,7 +299,7 @@ func handlerGetLastRetainedBlock( // nolint: golint
 	return interceptor(ctx, runtimeID, info, handler)
 }
 
-func handlerGetTransactions( // nolint: golint
+func handlerGetTransactions(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -322,7 +322,7 @@ func handlerGetTransactions( // nolint: golint
 	return interceptor(ctx, &rq, info, handler)
 }
 
-func handlerGetTransactionsWithResults( // nolint: golint
+func handlerGetTransactionsWithResults(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -345,7 +345,7 @@ func handlerGetTransactionsWithResults( // nolint: golint
 	return interceptor(ctx, &rq, info, handler)
 }
 
-func handlerGetEvents( // nolint: golint
+func handlerGetEvents(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -368,7 +368,7 @@ func handlerGetEvents( // nolint: golint
 	return interceptor(ctx, &rq, info, handler)
 }
 
-func handlerQuery( // nolint: golint
+func handlerQuery( // nolint: revive
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/runtime/host/logger.go
+++ b/go/runtime/host/logger.go
@@ -37,7 +37,7 @@ func NewRuntimeLogWrapper(logger *logging.Logger, suffixes ...interface{}) *Runt
 	}
 }
 
-// Implements io.Writer
+// Write implements io.Writer
 func (w *RuntimeLogWrapper) Write(chunk []byte) (int, error) {
 	w.buf = append(w.buf, chunk...)
 

--- a/go/runtime/host/multi/multi.go
+++ b/go/runtime/host/multi/multi.go
@@ -72,12 +72,12 @@ type Aggregate struct {
 	notifier *pubsub.Broker
 }
 
-// Implements host.Runtime.
+// ID implements host.Runtime.
 func (agg *Aggregate) ID() common.Namespace {
 	return agg.id
 }
 
-// Implements host.Runtime.
+// GetInfo implements host.Runtime.
 func (agg *Aggregate) GetInfo(ctx context.Context) (*protocol.RuntimeInfoResponse, error) {
 	agg.l.RLock()
 	defer agg.l.RUnlock()
@@ -88,7 +88,7 @@ func (agg *Aggregate) GetInfo(ctx context.Context) (*protocol.RuntimeInfoRespons
 	return agg.active.host.GetInfo(ctx)
 }
 
-// Implements host.Runtime.
+// Call implements host.Runtime.
 func (agg *Aggregate) Call(ctx context.Context, body *protocol.Body) (rsp *protocol.Body, err error) {
 	callFn := func() error {
 		agg.l.RLock()
@@ -116,7 +116,7 @@ func (agg *Aggregate) Call(ctx context.Context, body *protocol.Body) (rsp *proto
 	return
 }
 
-// Implements host.Runtime.
+// WatchEvents implements host.Runtime.
 func (agg *Aggregate) WatchEvents(ctx context.Context) (<-chan *host.Event, pubsub.ClosableSubscription, error) {
 	typedCh := make(chan *host.Event)
 	sub := agg.notifier.Subscribe()
@@ -125,7 +125,7 @@ func (agg *Aggregate) WatchEvents(ctx context.Context) (<-chan *host.Event, pubs
 	return typedCh, sub, nil
 }
 
-// Implements host.Runtime.
+// Start implements host.Runtime.
 func (agg *Aggregate) Start() error {
 	agg.l.RLock()
 	defer agg.l.RUnlock()
@@ -138,7 +138,7 @@ func (agg *Aggregate) Start() error {
 	return agg.active.host.Start()
 }
 
-// Implements host.Runtime.
+// Abort implements host.Runtime.
 func (agg *Aggregate) Abort(ctx context.Context, force bool) error {
 	agg.l.RLock()
 	defer agg.l.RUnlock()
@@ -149,7 +149,7 @@ func (agg *Aggregate) Abort(ctx context.Context, force bool) error {
 	return agg.active.host.Abort(ctx, force)
 }
 
-// Implements host.Runtime.
+// Stop implements host.Runtime.
 func (agg *Aggregate) Stop() {
 	agg.l.Lock()
 	defer agg.l.Unlock()

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -41,13 +41,13 @@ func (m MessageType) String() string {
 }
 
 const (
-	// Invalid message (should never be seen on the wire).
+	// MessageInvalid indicates an invalid message (should never be seen on the wire).
 	MessageInvalid MessageType = 0
 
-	// Request message.
+	// MessageRequest indicates a request message.
 	MessageRequest MessageType = 1
 
-	// Response message.
+	// MessageResponse indicates a response message.
 	MessageResponse MessageType = 2
 )
 
@@ -389,7 +389,7 @@ type RuntimeQueryRequest struct {
 	Args   []byte `json:"args,omitempty"`
 }
 
-// RuntimeQueryRequest is a runtime query response message body.
+// RuntimeQueryResponse is a runtime query response message body.
 type RuntimeQueryResponse struct {
 	Data []byte `json:"data,omitempty"`
 }

--- a/go/runtime/registry/config.go
+++ b/go/runtime/registry/config.go
@@ -37,7 +37,7 @@ const (
 	CfgRuntimePaths = "runtime.paths"
 	// CfgSandboxBinary configures the runtime sandbox binary location.
 	CfgSandboxBinary = "runtime.sandbox.binary"
-	// CfgRuntimeEnv sets the runtime environment. Setting an environment that does not
+	// CfgRuntimeEnvironment sets the runtime environment. Setting an environment that does not
 	// agree with the runtime descriptor or system hardware will cause an error.
 	CfgRuntimeEnvironment = "runtime.environment"
 	// CfgRuntimeSGXLoader configures the runtime loader binary required for SGX runtimes.

--- a/go/runtime/registry/config.go
+++ b/go/runtime/registry/config.go
@@ -37,6 +37,9 @@ const (
 	CfgRuntimePaths = "runtime.paths"
 	// CfgSandboxBinary configures the runtime sandbox binary location.
 	CfgSandboxBinary = "runtime.sandbox.binary"
+	// CfgRuntimeEnv sets the runtime environment. Setting an environment that does not
+	// agree with the runtime descriptor or system hardware will cause an error.
+	CfgRuntimeEnvironment = "runtime.environment"
 	// CfgRuntimeSGXLoader configures the runtime loader binary required for SGX runtimes.
 	//
 	// The same loader is used for all runtimes.
@@ -59,9 +62,6 @@ const (
 	// CfgDebugMockIDs configures mock runtime IDs for the purpose
 	// of testing.
 	CfgDebugMockIDs = "runtime.debug.mock_ids"
-	// CfgDebugForceELF forces the selection of the ELF image in runtime
-	// bundles even if a SGX image is present.
-	CfgDebugForceELF = "runtime.debug.force_elf"
 )
 
 // Flags has the configuration flags.
@@ -80,6 +80,17 @@ const (
 	// RuntimeProvisionerSandboxed is the name of the sandboxed runtime provisioner that executes
 	// runtimes as regular processes in a Linux namespaces/cgroups/SECCOMP sandbox.
 	RuntimeProvisionerSandboxed = "sandboxed"
+)
+
+const (
+	// RuntimeEnvironmentSGX specifies to run the runtime in SGX.
+	RuntimeEnvironmentSGX = "sgx"
+	// RuntimeEnvironmentELF specifies to run the runtime in the OS address space.
+	//
+	// Use of this runtime environment is only allowed if DebugDontBlameOasis flag is set.
+	RuntimeEnvironmentELF = "elf"
+	// RuntimeEnvironmentAuto specifies to run the runtime in the most appropriate location.
+	RuntimeEnvironmentAuto = "auto"
 )
 
 // RuntimeMode defines the behavior of runtime workers on this node.
@@ -191,7 +202,9 @@ func newConfig(dataDir string, consensus consensus.Backend, ias ias.Endpoint) (*
 
 	// Check if any runtimes are configured to be hosted.
 	if viper.IsSet(CfgRuntimePaths) || (cmdFlags.DebugDontBlameOasis() && viper.IsSet(CfgDebugMockIDs)) {
-		forceNoSGX := cfg.Mode.IsClientOnly() || (cmdFlags.DebugDontBlameOasis() && viper.GetBool(CfgDebugForceELF))
+		runtimeEnv := viper.GetString(CfgRuntimeEnvironment)
+		forceNoSGX := (cfg.Mode.IsClientOnly() && runtimeEnv != RuntimeEnvironmentSGX) ||
+			(cmdFlags.DebugDontBlameOasis() && runtimeEnv == RuntimeEnvironmentELF)
 
 		var rh RuntimeHostConfig
 
@@ -253,6 +266,9 @@ func newConfig(dataDir string, consensus consensus.Backend, ias ias.Endpoint) (*
 				// If no SGX is forced, remap to non-SGX.
 				if !forceNoSGX {
 					break
+				}
+				if runtimeEnv == RuntimeEnvironmentSGX {
+					return nil, fmt.Errorf("sgx runtime env requires setting the sgx loader")
 				}
 
 				rh.Provisioners[node.TEEHardwareIntelSGX], err = hostSandbox.New(hostSandbox.Config{
@@ -404,6 +420,7 @@ func init() {
 	Flags.StringSlice(CfgRuntimePaths, nil, "Paths to runtime resources (format: <path>,<path>,...)")
 	Flags.String(CfgSandboxBinary, "/usr/bin/bwrap", "Path to the sandbox binary (bubblewrap)")
 	Flags.String(CfgRuntimeSGXLoader, "", "(for SGX runtimes) Path to SGXS runtime loader binary")
+	Flags.String(CfgRuntimeEnvironment, "auto", "The runtime environment (sgx, elf, auto)")
 
 	Flags.String(CfgHistoryPrunerStrategy, history.PrunerStrategyNone, "History pruner strategy")
 	Flags.Duration(CfgHistoryPrunerInterval, 2*time.Minute, "History pruning interval")
@@ -412,9 +429,7 @@ func init() {
 	Flags.String(CfgRuntimeMode, string(RuntimeModeNone), "Runtime mode (none, compute, keymanager, client, client-stateless)")
 
 	Flags.StringSlice(CfgDebugMockIDs, nil, "Mock runtime IDs (format: <path>,<path>,...)")
-	Flags.Bool(CfgDebugForceELF, false, "Force the use of the ELF image over any TEE images")
 	_ = Flags.MarkHidden(CfgDebugMockIDs)
-	_ = Flags.MarkHidden(CfgDebugForceELF)
 
 	_ = viper.BindPFlags(Flags)
 }

--- a/go/scheduler/api/grpc.go
+++ b/go/scheduler/api/grpc.go
@@ -57,7 +57,7 @@ var (
 	}
 )
 
-func handlerGetValidators( // nolint: golint
+func handlerGetValidators(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -80,7 +80,7 @@ func handlerGetValidators( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerGetCommittees( // nolint: golint
+func handlerGetCommittees(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -103,7 +103,7 @@ func handlerGetCommittees( // nolint: golint
 	return interceptor(ctx, &req, info, handler)
 }
 
-func handlerStateToGenesis( // nolint: golint
+func handlerStateToGenesis(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -126,7 +126,7 @@ func handlerStateToGenesis( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerConsensusParameters( // nolint: golint
+func handlerConsensusParameters(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/sentry/api/grpc.go
+++ b/go/sentry/api/grpc.go
@@ -51,7 +51,7 @@ var (
 	}
 )
 
-func handlerGetAddresses( // nolint: golint
+func handlerGetAddresses(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -70,7 +70,7 @@ func handlerGetAddresses( // nolint: golint
 	return interceptor(ctx, nil, info, handler)
 }
 
-func handlerSetUpstreamTLSPubKeys( // nolint: golint
+func handlerSetUpstreamTLSPubKeys(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -93,7 +93,7 @@ func handlerSetUpstreamTLSPubKeys( // nolint: golint
 	return interceptor(ctx, &req, info, handler)
 }
 
-func handlerGetUpstreamTLSPubKeys( // nolint: golint
+func handlerGetUpstreamTLSPubKeys(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -112,7 +112,7 @@ func handlerGetUpstreamTLSPubKeys( // nolint: golint
 	return interceptor(ctx, nil, info, handler)
 }
 
-func handlerUpdatePolicies( // nolint: golint
+func handlerUpdatePolicies(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/staking/api/address.go
+++ b/go/staking/api/address.go
@@ -36,7 +36,7 @@ func (a Address) MarshalBinary() ([]byte, error) {
 	return (address.Address)(a).MarshalBinary()
 }
 
-// UnMarshalBinary decodes a binary marshaled address.
+// UnmarshalBinary decodes a binary marshaled address.
 func (a *Address) UnmarshalBinary(data []byte) error {
 	return (*address.Address)(a).UnmarshalBinary(data)
 }

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -289,7 +289,7 @@ func (e *TakeEscrowEvent) EventKind() string {
 	return "take_escrow"
 }
 
-// DebondingStartEvent is the event emitted when the debonding process has
+// DebondingStartEscrowEvent is the event emitted when the debonding process has
 // started and the given number of active shares have been moved into the
 // debonding pool and started debonding.
 //
@@ -647,6 +647,7 @@ func (p *SharePool) Withdraw(stakeDst, shareSrc, shareAmount *quantity.Quantity)
 // ThresholdKind is the kind of staking threshold.
 type ThresholdKind int
 
+// nolint: revive
 const (
 	KindEntity        ThresholdKind = 0
 	KindNodeValidator ThresholdKind = 1

--- a/go/staking/api/grpc.go
+++ b/go/staking/api/grpc.go
@@ -148,7 +148,7 @@ var (
 	}
 )
 
-func handlerTokenSymbol( // nolint: golint
+func handlerTokenSymbol(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -167,7 +167,7 @@ func handlerTokenSymbol( // nolint: golint
 	return interceptor(ctx, nil, info, handler)
 }
 
-func handlerTokenValueExponent( // nolint: golint
+func handlerTokenValueExponent(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -186,7 +186,7 @@ func handlerTokenValueExponent( // nolint: golint
 	return interceptor(ctx, nil, info, handler)
 }
 
-func handlerTotalSupply( // nolint: golint
+func handlerTotalSupply(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -209,7 +209,7 @@ func handlerTotalSupply( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerCommonPool( // nolint: golint
+func handlerCommonPool(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -232,7 +232,7 @@ func handlerCommonPool( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerLastBlockFees( // nolint: golint
+func handlerLastBlockFees(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -255,7 +255,7 @@ func handlerLastBlockFees( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerGovernanceDeposits( // nolint: golint
+func handlerGovernanceDeposits(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -278,7 +278,7 @@ func handlerGovernanceDeposits( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerThreshold( // nolint: golint
+func handlerThreshold(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -301,7 +301,7 @@ func handlerThreshold( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerAddresses( // nolint: golint
+func handlerAddresses(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -324,7 +324,7 @@ func handlerAddresses( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerAccount( // nolint: golint
+func handlerAccount(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -347,7 +347,7 @@ func handlerAccount( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerDelegationsFor( // nolint: golint
+func handlerDelegationsFor(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -370,7 +370,7 @@ func handlerDelegationsFor( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerDelegationInfosFor( // nolint: golint
+func handlerDelegationInfosFor(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -393,7 +393,7 @@ func handlerDelegationInfosFor( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerDelegationsTo( // nolint: golint
+func handlerDelegationsTo(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -416,7 +416,7 @@ func handlerDelegationsTo( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerDebondingDelegationsFor( // nolint: golint
+func handlerDebondingDelegationsFor(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -439,7 +439,7 @@ func handlerDebondingDelegationsFor( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerDebondingDelegationInfosFor( // nolint: golint
+func handlerDebondingDelegationInfosFor(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -462,7 +462,7 @@ func handlerDebondingDelegationInfosFor( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerDebondingDelegationsTo( // nolint: golint
+func handlerDebondingDelegationsTo(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -485,7 +485,7 @@ func handlerDebondingDelegationsTo( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerAllowance( // nolint: golint
+func handlerAllowance(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -508,7 +508,7 @@ func handlerAllowance( // nolint: golint
 	return interceptor(ctx, &query, info, handler)
 }
 
-func handlerStateToGenesis( // nolint: golint
+func handlerStateToGenesis(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -531,7 +531,7 @@ func handlerStateToGenesis( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerConsensusParameters( // nolint: golint
+func handlerConsensusParameters(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -554,7 +554,7 @@ func handlerConsensusParameters( // nolint: golint
 	return interceptor(ctx, height, info, handler)
 }
 
-func handlerGetEvents( // nolint: golint
+func handlerGetEvents(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/staking/api/token/token.go
+++ b/go/staking/api/token/token.go
@@ -7,11 +7,11 @@ const (
 	// ModuleName is a unique module name for the staking/token module.
 	ModuleName = "staking/token"
 
-	// Maximum length of the token symbol.
+	// TokenSymbolMaxLength is the maximum length of the token symbol.
 	TokenSymbolMaxLength = 8
-	// Regular expression defining valid token symbol characters.
+	// TokenSymbolRegexp is the regular expression defining valid token symbol characters.
 	TokenSymbolRegexp = "^[A-Z]+$" // nolint: gosec // Not that kind of token :).
-	// Maximum value of token's value base-10 exponent.
+	// TokenValueExponentMaxValue is the maximum value of token's value base-10 exponent.
 	TokenValueExponentMaxValue = 20
 )
 

--- a/go/staking/tests/state.go
+++ b/go/staking/tests/state.go
@@ -14,7 +14,7 @@ const NumAccounts = 7
 
 // Accounts stores an AccountList with staking accounts used in the
 // staking genesis state as returned by GenesisState.
-var Accounts AccountList = newAccountList()
+var Accounts = newAccountList()
 
 // newAccountList generates a new AccountList for the required number of
 // staking accounts.

--- a/go/storage/api/grpc.go
+++ b/go/storage/api/grpc.go
@@ -97,7 +97,7 @@ var (
 	}
 )
 
-func handlerSyncGet( // nolint: golint
+func handlerSyncGet(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -120,7 +120,7 @@ func handlerSyncGet( // nolint: golint
 	return interceptor(ctx, &req, info, handler)
 }
 
-func handlerSyncGetPrefixes( // nolint: golint
+func handlerSyncGetPrefixes(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -143,7 +143,7 @@ func handlerSyncGetPrefixes( // nolint: golint
 	return interceptor(ctx, &req, info, handler)
 }
 
-func handlerSyncIterate( // nolint: golint
+func handlerSyncIterate(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -166,7 +166,7 @@ func handlerSyncIterate( // nolint: golint
 	return interceptor(ctx, &req, info, handler)
 }
 
-func handlerGetCheckpoints( // nolint: golint
+func handlerGetCheckpoints(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/storage/mkvs/interop/cmd/db_json_rpc.go
+++ b/go/storage/mkvs/interop/cmd/db_json_rpc.go
@@ -90,7 +90,7 @@ type Database struct {
 	inner storage.LocalBackend
 }
 
-// Don't ask.  I think this is stupid too, and I wrote it.
+// RPCRequest should not be asked about, as the author also thinks it is stupid.
 type RPCRequest struct {
 	Payload []byte `json:"payload"`
 }
@@ -99,8 +99,8 @@ type RPCResponse struct {
 	Payload []byte `json:"payload"`
 }
 
-// Sigh, the Rust crate insists on sending args as an array.
 type (
+	// ApplyRequest and family are arrays because that's what Rust sends.
 	ApplyRequest       []RPCRequest
 	GetRequest         []RPCRequest
 	GetPrefixesRequest []RPCRequest

--- a/go/storage/mkvs/interop/cmd/protocol_server.go
+++ b/go/storage/mkvs/interop/cmd/protocol_server.go
@@ -142,7 +142,7 @@ func doProtoServer(cmd *cobra.Command, args []string) {
 	svcMgr.Wait()
 }
 
-// Register registers the grpc-server sub-command and all of it's children.
+// RegisterProtoServer registers the grpc-server sub-command and all of it's children.
 func RegisterProtoServer(parentCmd *cobra.Command) {
 	protoServerCmd.Flags().AddFlagSet(protoServerFlags)
 

--- a/go/storage/mkvs/node/key.go
+++ b/go/storage/mkvs/node/key.go
@@ -79,12 +79,12 @@ func (k Key) BitLength() Depth {
 	return Depth(len(k[:]) * 8)
 }
 
-// GetKeyBit returns the given bit of the key.
+// GetBit returns the given bit of the key.
 func (k Key) GetBit(bit Depth) bool {
 	return k[bit/8]&(1<<(7-(bit%8))) != 0
 }
 
-// SetKeyBit sets the bit at the given position bit to value val.
+// SetBit sets the bit at the given position bit to value val.
 //
 // This function is immutable and returns a new instance of Key
 func (k Key) SetBit(bit Depth, val bool) Key {
@@ -177,7 +177,7 @@ func (k Key) AppendBit(keyLen Depth, val bool) Key {
 	return newKey
 }
 
-// CommonPrefix computes length of common prefix of k and k2.
+// CommonPrefixLen computes length of common prefix of k and k2.
 //
 // Additionally, keyBitLen and k2bitLen are key lengths in bits of k and k2
 // respectively.

--- a/go/storage/mkvs/node/node.go
+++ b/go/storage/mkvs/node/node.go
@@ -24,11 +24,11 @@ var (
 )
 
 const (
-	// Prefix used in hash computations of leaf nodes.
+	// PrefixLeafNode is the prefix used in hash computations of leaf nodes.
 	PrefixLeafNode byte = 0x00
-	// Prefix used in hash computations of internal nodes.
+	// PrefixInternalNode is the prefix used in hash computations of internal nodes.
 	PrefixInternalNode byte = 0x01
-	// Prefix used to mark a nil pointer in a subtree serialization.
+	// PrefixNilNode is the prefix used to mark a nil pointer in a subtree serialization.
 	PrefixNilNode byte = 0x02
 
 	// PointerSize is the size of a node pointer in memory.
@@ -212,7 +212,7 @@ func (p *Pointer) Extract() *Pointer {
 	return p.ExtractUnchecked()
 }
 
-// Extract makes a copy of the pointer containing only hash references
+// ExtractUnchecked makes a copy of the pointer containing only hash references
 // without checking the dirty flag.
 func (p *Pointer) ExtractUnchecked() *Pointer {
 	if p == nil {
@@ -366,7 +366,7 @@ func (n *InternalNode) Extract() Node {
 	}
 }
 
-// Extract makes a copy of the node containing only hash references without
+// ExtractUnchecked makes a copy of the node containing only hash references without
 // checking the dirty flag.
 //
 // For LeafNode, it makes a deep copy so that the parent internal node always
@@ -573,7 +573,7 @@ func (n *LeafNode) Extract() Node {
 	return n.ExtractUnchecked()
 }
 
-// Extract makes a copy of the node containing only hash references
+// ExtractUnchecked makes a copy of the node containing only hash references
 // without checking the dirty flag.
 func (n *LeafNode) ExtractUnchecked() Node {
 	return &LeafNode{

--- a/go/storage/mkvs/syncer/proof.go
+++ b/go/storage/mkvs/syncer/proof.go
@@ -96,12 +96,12 @@ func (b *ProofBuilder) Include(n node.Node) {
 	b.size += 1 + uint64(len(pn.serialized))
 }
 
-// HasSubtree returns true if the subtree root node has already been included.
+// HasSubtreeRoot returns true if the subtree root node has already been included.
 func (b *ProofBuilder) HasSubtreeRoot() bool {
 	return b.included[b.subtree] != nil
 }
 
-// GetSubtree returns the subtree root hash for this proof.
+// GetSubtreeRoot returns the subtree root hash for this proof.
 func (b *ProofBuilder) GetSubtreeRoot() hash.Hash {
 	return b.subtree
 }

--- a/go/storage/mkvs/syncer/stats.go
+++ b/go/storage/mkvs/syncer/stats.go
@@ -11,7 +11,7 @@ type StatsCollector struct {
 	rs ReadSyncer
 }
 
-// NewnopReadSyncer creates a new no-op read syncer.
+// NewStatsCollector creates a new no-op read syncer.
 func NewStatsCollector(rs ReadSyncer) *StatsCollector {
 	return &StatsCollector{
 		rs: rs,

--- a/go/worker/client/committee/node.go
+++ b/go/worker/client/committee/node.go
@@ -79,25 +79,25 @@ func (n *Node) HandlePeerTx(ctx context.Context, tx []byte) error {
 	return nil
 }
 
-// Guarded by CrossNode.
+// HandleEpochTransitionLocked is guarded by CrossNode.
 func (n *Node) HandleEpochTransitionLocked(*committee.EpochSnapshot) {
 }
 
-// Guarded by CrossNode.
+// HandleNewBlockEarlyLocked is guarded by CrossNode.
 func (n *Node) HandleNewBlockEarlyLocked(*block.Block) {
 }
 
-// Guarded by CrossNode.
+// HandleNewBlockLocked is guarded by CrossNode.
 func (n *Node) HandleNewBlockLocked(blk *block.Block) {
 	// Queue block for checks.
 	n.checkCh.In() <- blk
 }
 
-// Guarded by CrossNode.
+// HandleNewEventLocked is guarded by CrossNode.
 func (n *Node) HandleNewEventLocked(*roothash.Event) {
 }
 
-// Guarded by CrossNode.
+// HandleRuntimeHostEventLocked is guarded by CrossNode.
 func (n *Node) HandleRuntimeHostEventLocked(*host.Event) {
 }
 

--- a/go/worker/common/committee/group.go
+++ b/go/worker/common/committee/group.go
@@ -34,7 +34,7 @@ func TagForCommittee(kind scheduler.CommitteeKind) string {
 }
 
 // CommitteeInfo contains information about a committee of nodes.
-type CommitteeInfo struct { // nolint: golint
+type CommitteeInfo struct { // nolint: revive
 	Indices    []int
 	Roles      []scheduler.Role
 	Committee  *scheduler.Committee

--- a/go/worker/common/committee/keymanager.go
+++ b/go/worker/common/committee/keymanager.go
@@ -72,7 +72,7 @@ func (km *KeyManagerClientWrapper) SetKeyManagerID(id *common.Namespace) {
 	km.lastPeerFeedback = nil
 }
 
-// Implements runtimeKeymanager.Client.
+// CallEnclave implements runtimeKeymanager.Client.
 func (km *KeyManagerClientWrapper) CallEnclave(
 	ctx context.Context,
 	data []byte,

--- a/go/worker/common/committee/runtime_host.go
+++ b/go/worker/common/committee/runtime_host.go
@@ -11,12 +11,12 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/runtime/txpool"
 )
 
-// Implements RuntimeHostHandlerFactory.
+// GetRuntime implements RuntimeHostHandlerFactory.
 func (n *Node) GetRuntime() runtimeRegistry.Runtime {
 	return n.Runtime
 }
 
-// Implements RuntimeHostHandlerFactory.
+// NewRuntimeHostNotifier implements RuntimeHostHandlerFactory.
 func (n *Node) NewRuntimeHostNotifier(ctx context.Context, host host.Runtime) protocol.Notifier {
 	return runtimeRegistry.NewRuntimeHostNotifier(ctx, n.Runtime, host, n.Consensus)
 }
@@ -25,7 +25,7 @@ type nodeEnvironment struct {
 	n *Node
 }
 
-// Implements RuntimeHostHandlerEnvironment.
+// GetCurrentBlock implements RuntimeHostHandlerEnvironment.
 func (env *nodeEnvironment) GetCurrentBlock(ctx context.Context) (*block.Block, error) {
 	var blk *block.Block
 	env.n.CrossNode.Lock()
@@ -34,17 +34,17 @@ func (env *nodeEnvironment) GetCurrentBlock(ctx context.Context) (*block.Block, 
 	return blk, nil
 }
 
-// Implements RuntimeHostHandlerEnvironment.
+// GetKeyManagerClient implements RuntimeHostHandlerEnvironment.
 func (env *nodeEnvironment) GetKeyManagerClient(ctx context.Context) (runtimeKeymanager.Client, error) {
 	return env.n.KeyManagerClient, nil
 }
 
-// Implements RuntimeHostHandlerEnvironment.
+// GetTxPool implements RuntimeHostHandlerEnvironment.
 func (env *nodeEnvironment) GetTxPool(ctx context.Context) (txpool.TransactionPool, error) {
 	return env.n.TxPool, nil
 }
 
-// Implements RuntimeHostHandlerFactory.
+// NewRuntimeHostHandler implements RuntimeHostHandlerFactory.
 func (n *Node) NewRuntimeHostHandler() protocol.Handler {
 	return runtimeRegistry.NewRuntimeHostHandler(&nodeEnvironment{n}, n.Runtime, n.Consensus)
 }

--- a/go/worker/common/p2p/api/crypto.go
+++ b/go/worker/common/p2p/api/crypto.go
@@ -54,7 +54,7 @@ func (s *p2pSigner) GetPublic() libp2pCrypto.PubKey {
 	return pubKey
 }
 
-// SignerToPRivKey converts a Signer to a libp2pCrypto.PrivKey.
+// SignerToPrivKey converts a Signer to a libp2pCrypto.PrivKey.
 func SignerToPrivKey(signer signature.Signer) libp2pCrypto.PrivKey {
 	return &p2pSigner{
 		signer: signer,

--- a/go/worker/common/p2p/p2p.go
+++ b/go/worker/common/p2p/p2p.go
@@ -46,7 +46,7 @@ const (
 )
 
 // messageIdContext is the domain separation context for computing message identifier hashes.
-var messageIdContext = []byte("oasis-core/p2p: message id")
+var messageIdContext = []byte("oasis-core/p2p: message id") // nolint: revive
 
 var allowUnroutableAddresses bool
 
@@ -307,7 +307,7 @@ func (p *p2p) GetMinRepublishInterval() time.Duration {
 	return seenMessagesTTL + 5*time.Second
 }
 
-func messageIdFn(pmsg *pb.Message) string {
+func messageIdFn(pmsg *pb.Message) string { // nolint: revive
 	// id := TupleHash[messageIdContext](topic, data)
 	h := tuplehash.New256(32, messageIdContext)
 	_, _ = h.Write([]byte(pmsg.GetTopic()))

--- a/go/worker/common/p2p/rpc/peermgmt.go
+++ b/go/worker/common/p2p/rpc/peermgmt.go
@@ -71,9 +71,8 @@ func (ps *peerStats) getScore(avgRequestLatency time.Duration) float64 {
 		// We have some history for this peer.
 		failRate := float64(ps.failures) / float64(ps.failures+ps.successes)
 		return float64(ps.avgRequestLatency) + failRate*float64(avgRequestLatency)
-	} else {
-		return float64(avgRequestLatency) * newPeerScoreMultiplier
 	}
+	return float64(avgRequestLatency) * newPeerScoreMultiplier
 }
 
 func (ps *peerStats) recordLatency(latency time.Duration) {

--- a/go/worker/keymanager/init.go
+++ b/go/worker/keymanager/init.go
@@ -29,7 +29,7 @@ const (
 	CfgRuntimeID = "worker.keymanager.runtime.id"
 	// CfgMayGenerate allows the enclave to generate a master secret.
 	CfgMayGenerate = "worker.keymanager.may_generate"
-	// CfgPrivatePeerPks allows adding manual, unadvertised peers that can call protected methods.
+	// CfgPrivatePeerPubKeys allows adding manual, unadvertised peers that can call protected methods.
 	CfgPrivatePeerPubKeys = "worker.keymanager.private_peer_pub_keys"
 )
 

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -53,7 +53,7 @@ type runtimeStatus struct {
 	capabilityTEE *node.CapabilityTEE
 }
 
-// The key manager worker.
+// Worker is the key manager worker.
 //
 // It behaves differently from other workers as the key manager has its
 // own runtime. It needs to keep track of executor committees for other
@@ -140,17 +140,17 @@ func (w *Worker) Initialized() <-chan struct{} {
 	return w.initCh
 }
 
-// Implements workerCommon.RuntimeHostHandlerFactory.
+// GetRuntime implements workerCommon.RuntimeHostHandlerFactory.
 func (w *Worker) GetRuntime() runtimeRegistry.Runtime {
 	return w.runtime
 }
 
-// Implements workerCommon.RuntimeHostHandlerFactory.
+// NewRuntimeHostNotifier implements workerCommon.RuntimeHostHandlerFactory.
 func (w *Worker) NewRuntimeHostNotifier(ctx context.Context, host host.Runtime) protocol.Notifier {
 	return &protocol.NoOpNotifier{}
 }
 
-// Implements workerCommon.RuntimeHostHandlerFactory.
+// NewRuntimeHostHandler implements workerCommon.RuntimeHostHandlerFactory.
 func (w *Worker) NewRuntimeHostHandler() protocol.Handler {
 	return w.runtimeHostHandler
 }

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -225,7 +225,7 @@ type Worker struct { // nolint: maligned
 	status control.RegistrationStatus
 }
 
-// DebugForceallowUnroutableAddresses allows unroutable addresses.
+// DebugForceAllowUnroutableAddresses allows unroutable addresses.
 func DebugForceAllowUnroutableAddresses() {
 	allowUnroutableAddresses = true
 }

--- a/go/worker/storage/api/grpc.go
+++ b/go/worker/storage/api/grpc.go
@@ -41,7 +41,7 @@ var (
 	}
 )
 
-func handlerGetLastSyncedRound( // nolint: golint
+func handlerGetLastSyncedRound(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -64,7 +64,7 @@ func handlerGetLastSyncedRound( // nolint: golint
 	return interceptor(ctx, rq, info, handler)
 }
 
-func handlerWaitForRound( // nolint: golint
+func handlerWaitForRound(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -87,7 +87,7 @@ func handlerWaitForRound( // nolint: golint
 	return interceptor(ctx, rq, info, handler)
 }
 
-func handlerPauseCheckpointer( // nolint: golint
+func handlerPauseCheckpointer(
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,

--- a/go/worker/storage/committee/checkpoint_sync.go
+++ b/go/worker/storage/committee/checkpoint_sync.go
@@ -345,7 +345,7 @@ func (n *Node) syncCheckpoints(genesisRound uint64) (*blockSummary, error) {
 
 	// Try all the checkpoints now, from most recent backwards.
 	var (
-		prevVersion      uint64 = ^uint64(0)
+		prevVersion      = ^uint64(0)
 		multipartRunning bool
 		mask             outstandingMask
 	)

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -372,28 +372,28 @@ func (n *Node) HandlePeerTx(ctx context.Context, tx []byte) error {
 	return nil
 }
 
-// Guarded by CrossNode.
+// HandleEpochTransitionLocked is guarded by CrossNode.
 func (n *Node) HandleEpochTransitionLocked(snapshot *committee.EpochSnapshot) {
 	// Nothing to do here.
 }
 
-// Guarded by CrossNode.
+// HandleNewBlockEarlyLocked is guarded by CrossNode.
 func (n *Node) HandleNewBlockEarlyLocked(*block.Block) {
 	// Nothing to do here.
 }
 
-// Guarded by CrossNode.
+// HandleNewBlockLocked is guarded by CrossNode.
 func (n *Node) HandleNewBlockLocked(blk *block.Block) {
 	// Notify the state syncer that there is a new block.
 	n.blockCh.In() <- blk
 }
 
-// Guarded by CrossNode.
+// HandleNewEventLocked is guarded by CrossNode.
 func (n *Node) HandleNewEventLocked(*roothashApi.Event) {
 	// Nothing to do here.
 }
 
-// Guarded by CrossNode.
+// HandleRuntimeHostEventLocked is guarded by CrossNode.
 func (n *Node) HandleRuntimeHostEventLocked(ev *host.Event) {
 	// Nothing to do here.
 }

--- a/go/worker/storage/init.go
+++ b/go/worker/storage/init.go
@@ -30,7 +30,7 @@ const (
 	// CfgWorkerCheckpointCheckInterval configures the checkpointer check interval.
 	CfgWorkerCheckpointCheckInterval = "worker.storage.checkpointer.check_interval"
 
-	// CfgCheckpointSyncDisabled disables syncing from checkpoints on worker startup.
+	// CfgWorkerCheckpointSyncDisabled disables syncing from checkpoints on worker startup.
 	CfgWorkerCheckpointSyncDisabled = "worker.storage.checkpoint_sync.disabled"
 
 	// CfgBackend configures the storage backend flag.


### PR DESCRIPTION
This PR allows client nodes to run SGX runtimes, which enables them to request keys from a (privately) peered key manager. The `RuntimeDebugForceELF` flag was replaced with a more general one. The former one doesn't seem to be used in this repo, so it should be okay.