### PR TITLE
go/oasis-test-runner: support setting runtime state root and state

### DIFF
--- a/.changelog/4843.feature.md
+++ b/.changelog/4843.feature.md
@@ -1,0 +1,1 @@
+oasis-net-runner: support configuring runtime state and state root

--- a/go/common/copy.go
+++ b/go/common/copy.go
@@ -1,0 +1,112 @@
+package common
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// CopyFile copies the contents of the file named src to the file named
+// by dst. The file will be created if it does not already exist. If the
+// destination file exists, all it's contents will be replaced by the contents
+// of the source file. The file mode will be copied from the source and
+// the copied data is synced/flushed to stable storage.
+// Taken from: https://github.com/hasura/graphql-engine/blob/6532a658eb3dfae9dde251c6c9377f2268ecc8a8/cli/util/copy.go#L13-L115
+func CopyFile(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return
+	}
+	defer func() {
+		if e := out.Close(); e != nil {
+			err = e
+		}
+	}()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return
+	}
+
+	err = out.Sync()
+	if err != nil {
+		return
+	}
+
+	si, err := os.Stat(src)
+	if err != nil {
+		return
+	}
+	err = os.Chmod(dst, si.Mode())
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CopyDir recursively copies a directory tree, attempting to preserve permissions.
+// Source directory must exist, destination directory must *not* exist.
+// Symlinks are ignored and skipped.
+func CopyDir(src string, dst string) (err error) {
+	src = filepath.Clean(src)
+	dst = filepath.Clean(dst)
+
+	si, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !si.IsDir() {
+		return fmt.Errorf("source is not a directory")
+	}
+
+	_, err = os.Stat(dst)
+	if err != nil && !os.IsNotExist(err) {
+		return
+	}
+	if err == nil {
+		return fmt.Errorf("destination already exists")
+	}
+
+	err = os.MkdirAll(dst, si.Mode())
+	if err != nil {
+		return
+	}
+
+	entries, err := ioutil.ReadDir(src)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			err = CopyDir(srcPath, dstPath)
+			if err != nil {
+				return
+			}
+		} else {
+			// Skip symlinks.
+			if entry.Mode()&os.ModeSymlink != 0 {
+				continue
+			}
+
+			err = CopyFile(srcPath, dstPath)
+			if err != nil {
+				return
+			}
+		}
+	}
+
+	return
+}

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -6,6 +6,7 @@ import (
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
@@ -222,8 +223,9 @@ type RuntimeFixture struct { // nolint: maligned
 	Entity     int                  `json:"entity"`
 	Keymanager int                  `json:"keymanager"`
 
-	Deployments  []DeploymentCfg `json:"deployments"`
-	GenesisRound uint64          `json:"genesis_round,omitempty"`
+	Deployments      []DeploymentCfg `json:"deployments"`
+	GenesisRound     uint64          `json:"genesis_round,omitempty"`
+	GenesisStateRoot *hash.Hash      `json:"genesis_state_root,omitempty"`
 
 	Executor     registry.ExecutorParameters     `json:"executor"`
 	TxnScheduler registry.TxnSchedulerParameters `json:"txn_scheduler"`
@@ -272,6 +274,7 @@ func (f *RuntimeFixture) Create(netFixture *NetworkFixture, net *Network) (*Runt
 		AdmissionPolicy:    f.AdmissionPolicy,
 		Staking:            f.Staking,
 		GenesisRound:       f.GenesisRound,
+		GenesisStateRoot:   f.GenesisStateRoot,
 		Pruner:             f.Pruner,
 		ExcludeFromGenesis: f.ExcludeFromGenesis,
 		GovernanceModel:    f.GovernanceModel,
@@ -393,6 +396,8 @@ type ComputeWorkerFixture struct {
 
 	// Runtimes contains the indexes of the runtimes to enable.
 	Runtimes []int `json:"runtimes,omitempty"`
+	// RuntimeStatePaths are the paths to runtime state that will be copied to the compute worker node.
+	RuntimeStatePaths map[int]string `json:"runtime_state_paths"`
 
 	// RuntimeConfig contains the per-runtime node-local configuration.
 	RuntimeConfig map[int]map[string]interface{} `json:"runtime_config,omitempty"`
@@ -430,6 +435,7 @@ func (f *ComputeWorkerFixture) Create(net *Network) (*Compute, error) {
 		DisablePublicRPC:       f.DisablePublicRPC,
 		Runtimes:               f.Runtimes,
 		RuntimeConfig:          f.RuntimeConfig,
+		RuntimeStatePaths:      f.RuntimeStatePaths,
 	})
 }
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -248,13 +248,15 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 		},
 		ComputeWorkers: []oasis.ComputeWorkerFixture{
 			{Entity: 1, Runtimes: []int{1}},
-			{Entity: 1, Runtimes: []int{1}, RuntimeConfig: map[int]map[string]interface{}{
-				1: {
-					"core": map[string]interface{}{
-						"min_gas_price": 1, // Just to test support for runtime configuration.
+			{
+				Entity: 1, Runtimes: []int{1}, RuntimeConfig: map[int]map[string]interface{}{
+					1: {
+						"core": map[string]interface{}{
+							"min_gas_price": 1, // Just to test support for runtime configuration.
+						},
 					},
 				},
-			}},
+			},
 			{Entity: 1, Runtimes: []int{1}},
 		},
 		Sentries: []oasis.SentryFixture{},


### PR DESCRIPTION
Adds support for setting runtime state root and initial runtime state.

Not needed by any existing tests, but useful for external tooling to initialize network with pre-existing runtime state.