### PR TITLE
go/runtime/host/sandbox/process: Handle missing clone3

### DIFF
--- a/.changelog/4861.bugfix.md
+++ b/.changelog/4861.bugfix.md
@@ -1,0 +1,4 @@
+go/runtime/host/sandbox/process: Handle missing clone3
+
+This should fix seccomp filter generation failures on systems with
+ancient kernel/userland pairs (RHEL8 and variants).

--- a/go/common/dynlib/cache.go
+++ b/go/common/dynlib/cache.go
@@ -336,7 +336,7 @@ func LoadCache() (*Cache, error) {
 func loadCacheGlibc() (*Cache, error) {
 	const entrySz = 4 + 4 + 4 + 4 + 8
 
-	ourOsVersion, err := getOsVersion()
+	ourOsVersion, err := GetOsVersion()
 	if err != nil {
 		return nil, err
 	}

--- a/go/common/dynlib/cache_test.go
+++ b/go/common/dynlib/cache_test.go
@@ -40,6 +40,11 @@ func TestCache(t *testing.T) {
 
 	t.Logf("Test binary: %+v", fn)
 
+	v, err := GetOsVersion()
+	if err == nil {
+		t.Logf("OS version: %02x", v)
+	}
+
 	impls := []struct {
 		name string
 		ctor ctorFn

--- a/go/common/dynlib/hwcap_linux.go
+++ b/go/common/dynlib/hwcap_linux.go
@@ -37,7 +37,8 @@ import (
 	"syscall"
 )
 
-func getOsVersion() (uint32, error) {
+// GetOsVersion returns the operating system version (major, minor, pl).
+func GetOsVersion() (uint32, error) {
 	var buf syscall.Utsname
 	err := syscall.Uname(&buf)
 	if err != nil {

--- a/go/common/dynlib/hwcap_other.go
+++ b/go/common/dynlib/hwcap_other.go
@@ -24,6 +24,6 @@
 
 package dynlib
 
-func getOsVersion() (uint32, error) {
+func GetOsVersion() (uint32, error) {
 	return 0, errUnsupported
 }


### PR DESCRIPTION
The seccomp filter generator needs to handle clone3 being missing at
least till RHEL8 and variants are burried for good.

Fixes #4861