### PR TITLE
go/runtime/host: correct clone3 version threshold

### DIFF
--- a/.changelog/4867.bugfix.md
+++ b/.changelog/4867.bugfix.md
@@ -1,0 +1,4 @@
+go/runtime/host: correct clone3 version threshold
+
+The threshold was too low and older kernels were mistakenly asked to resolve
+'clone3.'

--- a/go/runtime/host/sandbox/process/seccomp_linux.go
+++ b/go/runtime/host/sandbox/process/seccomp_linux.go
@@ -362,7 +362,7 @@ func generateSeccompPolicy(out *os.File) error {
 	if err != nil {
 		return err
 	}
-	if osVersion >= 0o50300 { // "The clone3() system call first appeared in Linux 5.3.""
+	if osVersion >= 0x50300 { // "The clone3() system call first appeared in Linux 5.3.""
 		if err = handleClone3(filter); err != nil {
 			return err
 		}


### PR DESCRIPTION
expressing the version octets in hexadecimal instead of octal

the effect of the bug was that the threshold was too low and older kernels were mistakenly asked to resolve 'clone3,' resulting in 

> {"caller":"sandbox.go:463","err":"failed to spawn sandbox: sandbox: error while generating seccomp policy: could not resolve name to syscall: "clone3"","level":"error","module":"runtime/host/sandbox","msg":"failed to start runtime","runtime_id":"000000000000000000000000000000000000000000000000e2eaa99fc008f87f","ts":"2022-07-27T06:22:04.5330855Z"}