### PR TITLE
[BACKPORT/22.1.x]: go/runtime/host: correct clone3 version threshold

### DIFF
--- a/.changelog/4867.bugfix.md
+++ b/.changelog/4867.bugfix.md
@@ -1,0 +1,4 @@
+go/runtime/host: correct clone3 version threshold
+
+The threshold was too low and older kernels were mistakenly asked to resolve
+'clone3.'

--- a/go/runtime/host/sandbox/process/seccomp_linux.go
+++ b/go/runtime/host/sandbox/process/seccomp_linux.go
@@ -362,7 +362,7 @@ func generateSeccompPolicy(out *os.File) error {
 	if err != nil {
 		return err
 	}
-	if osVersion >= 0o50300 { // "The clone3() system call first appeared in Linux 5.3.""
+	if osVersion >= 0x50300 { // "The clone3() system call first appeared in Linux 5.3.""
 		if err = handleClone3(filter); err != nil {
 			return err
 		}


### PR DESCRIPTION
of #4867 