### PR TITLE
keymanager-client: Skip policy when OASIS_UNSAFE_SKIP_KM_POLICY is set

### DIFF
--- a/.buildkite/rust/common.sh
+++ b/.buildkite/rust/common.sh
@@ -8,6 +8,5 @@ source .buildkite/scripts/common.sh
 # Set up environment
 ####################
 export OASIS_UNSAFE_SKIP_AVR_VERIFY="1"
-export OASIS_UNSAFE_KM_POLICY_KEYS="1"
 export OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES="1"
 export RUST_BACKTRACE="1"

--- a/.buildkite/scripts/sgx_ias_tests.sh
+++ b/.buildkite/scripts/sgx_ias_tests.sh
@@ -14,11 +14,10 @@ set -x
 export GO_BUILD_E2E_COVERAGE=1
 # Ensure AVR verify is not skipped.
 unset OASIS_UNSAFE_SKIP_AVR_VERIFY
-export OASIS_TEE_HARDWARE=intel-sgx
-# Allow use of usnafe km policy keys.
-export OASIS_UNSAFE_KM_POLICY_KEYS=1
-# Allow debug encalves (tests are running against developemnt endpoint).
+# Allow debug enclaves (tests are running against developemnt endpoint).
 export OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1
+# Use Intel SGX.
+export OASIS_TEE_HARDWARE=intel-sgx
 
 make all
 .buildkite/scripts/test_e2e.sh --scenario e2e/runtime/runtime-encryption

--- a/.changelog/4878.internal.md
+++ b/.changelog/4878.internal.md
@@ -1,0 +1,1 @@
+keymanager-client: Skip policy when OASIS_UNSAFE_SKIP_KM_POLICY is set

--- a/docs/development-setup/building.md
+++ b/docs/development-setup/building.md
@@ -39,16 +39,13 @@ slightly different environmental variables set:
 
 ```
 export OASIS_UNSAFE_SKIP_AVR_VERIFY="1"
-export OASIS_UNSAFE_KM_POLICY_KEYS="1"
 export OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES="1"
 make
 ```
 
-The AVR flag is there because we are running a node in a local development
+The AVR flag is there because we are running the node in a local development
 environment and we will not do any attestation with Intel's remote servers. The
-KM policy keys flag allows testing keys to be used while verifying the security
-policy of the node. TEE hardware flag denotes the trusted execution environment
-engine for running the Oasis node and the tests below.
+debug enclaves flag allows enclaves in debug mode to be used.
 
 To run an Oasis node under SGX make sure:
 

--- a/docs/development-setup/building.md
+++ b/docs/development-setup/building.md
@@ -14,6 +14,7 @@ the following in the top-level directory:
 ```
 export OASIS_UNSAFE_SKIP_AVR_VERIFY="1"
 export OASIS_UNSAFE_SKIP_KM_POLICY="1"
+export OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES="1"
 make
 ```
 

--- a/tests/runtimes/simple-keymanager/src/api.rs
+++ b/tests/runtimes/simple-keymanager/src/api.rs
@@ -1,11 +1,8 @@
-#[cfg(target_env = "sgx")]
 use std::collections::HashSet;
 
 use oasis_core_keymanager_api_common::*;
-#[cfg(target_env = "sgx")]
 use oasis_core_runtime::common::crypto::signature::PrivateKey as OasisPrivateKey;
 
-#[cfg(target_env = "sgx")]
 pub fn trusted_policy_signers() -> TrustedPolicySigners {
     TrustedPolicySigners {
         signers: {
@@ -24,9 +21,4 @@ pub fn trusted_policy_signers() -> TrustedPolicySigners {
         },
         threshold: 2,
     }
-}
-
-#[cfg(not(target_env = "sgx"))]
-pub fn trusted_policy_signers() -> TrustedPolicySigners {
-    TrustedPolicySigners::default()
 }


### PR DESCRIPTION
Fixes #4876 