### PR TITLE
docs: Remove obsolete export OASIS_UNSAFE_KM_POLICY_KEYS=1

### DIFF
--- a/docs/development-setup/building.md
+++ b/docs/development-setup/building.md
@@ -38,7 +38,6 @@ slightly different environmental variables set:
 
 ```
 export OASIS_UNSAFE_SKIP_AVR_VERIFY="1"
-export OASIS_UNSAFE_KM_POLICY_KEYS="1"
 export OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES="1"
 make
 ```


### PR DESCRIPTION
This variable is not used anymore anywhere.