### PR TITLE
Add support for ephemeral keys in key manager

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -263,7 +263,7 @@ steps:
       - export CFLAGS_x86_64_fortanix_unknown_sgx="-isystem/usr/include/x86_64-linux-gnu -mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening"
       - export CC_x86_64_fortanix_unknown_sgx=clang-11
       # Only run runtime scenarios as others do not use SGX.
-      - .buildkite/scripts/test_e2e.sh --scenario e2e/runtime/runtime-encryption --scenario e2e/runtime/trust-root
+      - .buildkite/scripts/test_e2e.sh --scenario e2e/runtime/runtime-encryption --scenario e2e/runtime/trust-root --scenario e2e/runtime/keymanager-key-generation
     artifact_paths:
       - coverage-merged-e2e-*.txt
       - /tmp/e2e/**/*.log

--- a/.changelog/4888.feature.md
+++ b/.changelog/4888.feature.md
@@ -1,0 +1,1 @@
+keymanager: Add support for ephemeral keys

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1922,6 +1922,7 @@ dependencies = [
  "oasis-core-keymanager-client",
  "oasis-core-runtime",
  "rand 0.7.3",
+ "rustc-hex",
  "sgx-isa 0.3.3",
  "sp800-185",
  "tiny-keccak 2.0.2",
@@ -2758,6 +2759,7 @@ dependencies = [
  "simple-keymanager",
  "thiserror",
  "tokio 1.19.2",
+ "x25519-dalek",
 ]
 
 [[package]]

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_key_generation.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_key_generation.go
@@ -1,0 +1,240 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
+)
+
+// KeymanagerKeyGeneration is the keymanager key generation scenario.
+//
+// It uses encryption and decryption transactions provided by the
+// simple key/value runtime to test whether the key manager client
+// can retrieve private and public ephemeral keys from the key manager
+// and if the latter generates those according to the specifications.
+var KeymanagerKeyGeneration scenario.Scenario = newKmKeyGenerationImpl()
+
+type kmKeyGenerationImpl struct {
+	runtimeImpl
+}
+
+func newKmKeyGenerationImpl() scenario.Scenario {
+	return &kmKeyGenerationImpl{
+		runtimeImpl: *newRuntimeImpl("keymanager-key-generation", BasicKVEncTestClient),
+	}
+}
+
+func (sc *kmKeyGenerationImpl) Fixture() (*oasis.NetworkFixture, error) {
+	return sc.runtimeImpl.Fixture()
+}
+
+func (sc *kmKeyGenerationImpl) Clone() scenario.Scenario {
+	return &kmKeyGenerationImpl{
+		runtimeImpl: *sc.runtimeImpl.Clone().(*runtimeImpl),
+	}
+}
+
+func (sc *kmKeyGenerationImpl) Run(childEnv *env.Env) error {
+	// Start the network, but no need to start the client. Just ensure it
+	// is synced.
+	ctx := context.Background()
+	if err := sc.runtimeImpl.startNetworkAndWaitForClientSync(ctx); err != nil {
+		return err
+	}
+
+	// Initialize the nonce DRBG.
+	rng, err := drbgFromSeed(
+		[]byte("oasis-core/oasis-test-runner/e2e/runtime/keymanager-key-generation"),
+		[]byte("keymanager-key-generation"),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Data needed for encryption and decryption.
+	keyPairID := "key pair id"
+	plaintext := []byte("The quick brown fox jumps over the lazy dog")
+
+	epoch, err := sc.Net.Controller().Beacon.GetEpoch(ctx, consensus.HeightLatest)
+	if err != nil {
+		return fmt.Errorf("failed to get epoch at the latest height: %w", err)
+	}
+
+	// Encrypt plaintext using ephemeral public key for the current epoch.
+	// Successful encryption indicates that the key manager generated
+	// an ephemeral public key.
+	sc.Logger.Info("encrypting plaintext")
+	ciphertext, err := sc.submitKeyValueRuntimeEncryptTx(
+		ctx,
+		runtimeID,
+		rng.Uint64(),
+		epoch,
+		keyPairID,
+		plaintext,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt plaintext: %w", err)
+	}
+
+	// Decrypt ciphertext using ephemeral private key for the current epoch.
+	// Successful decryption indicates that the key manager generates
+	// matching public and private ephemeral keys.
+	sc.Logger.Info("decrypting ciphertext")
+	decrypted, err := sc.submitKeyValueRuntimeDecryptTx(
+		ctx,
+		runtimeID,
+		rng.Uint64(),
+		epoch,
+		keyPairID,
+		ciphertext,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt ciphertext: %w", err)
+	}
+	if !reflect.DeepEqual(decrypted, plaintext) {
+		return fmt.Errorf("decrypted ciphertext does match the plaintext (got: '%s', expected: '%s')", decrypted, plaintext)
+	}
+
+	// Decrypt ciphertext using ephemeral private key for the previous epoch.
+	// As ephemeral keys are derived from the epoch, the decryption should
+	// fail.
+	sc.Logger.Info("decrypting ciphertext with wrong epoch")
+	decrypted, err = sc.submitKeyValueRuntimeDecryptTx(
+		ctx,
+		runtimeID,
+		rng.Uint64(),
+		epoch-1,
+		keyPairID,
+		ciphertext,
+	)
+	if err == nil && reflect.DeepEqual(decrypted, plaintext) {
+		return fmt.Errorf("decryption with wrong epoch should fail or produce garbage")
+	}
+
+	// Decrypt ciphertext using ephemeral private key derived from wrong
+	// key pair id. As ephemeral keys are derived from the id, the decryption
+	// should fail.
+	sc.Logger.Info("decrypting ciphertext with wrong key pair id")
+	decrypted, err = sc.submitKeyValueRuntimeDecryptTx(
+		ctx,
+		runtimeID,
+		rng.Uint64(),
+		epoch,
+		"wrong key pair id",
+		ciphertext,
+	)
+	if err == nil && reflect.DeepEqual(decrypted, plaintext) {
+		return fmt.Errorf("decryption with wrong key pair id should fail or produce garbage")
+	}
+
+	// Change epoch and test what happens if epoch is invalid,
+	// i.e. too old or somewhere in the future.
+	epoch = epoch + 10
+
+	// Encrypt plaintext using epoch that is in the future.
+	// As public ephemeral keys are not allowed to be derived
+	// for future epoch neither for epoch that are too far
+	// in the past, the encryption should fail.
+	sc.Logger.Info("encrypting plaintext with invalid epoch")
+	_, err = sc.submitKeyValueRuntimeEncryptTx(
+		ctx,
+		runtimeID,
+		rng.Uint64(),
+		epoch,
+		keyPairID,
+		plaintext,
+	)
+	if err == nil {
+		return fmt.Errorf("encryption with invalid epoch should fail")
+	}
+
+	// Decrypt ciphertext using epoch that is in the future.
+	// The same rule holds for private ephemeral keys,
+	// so the encryption should fail.
+	sc.Logger.Info("decrypting ciphertext with invalid epoch")
+	_, err = sc.submitKeyValueRuntimeDecryptTx(
+		ctx,
+		runtimeID,
+		rng.Uint64(),
+		epoch,
+		keyPairID,
+		ciphertext,
+	)
+	if err == nil {
+		return fmt.Errorf("decryption with invalid epoch should fail")
+	}
+
+	// Check the logs whether any issues were detected.
+	err = sc.Net.CheckLogWatchers()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (sc *kmKeyGenerationImpl) submitKeyValueRuntimeEncryptTx(
+	ctx context.Context,
+	id common.Namespace,
+	nonce uint64,
+	epoch beacon.EpochTime,
+	keyPairID string,
+	plaintext []byte,
+) ([]byte, error) {
+	rawRsp, err := sc.submitRuntimeTx(ctx, runtimeID, nonce, "encrypt", struct {
+		Epoch     uint64 `json:"epoch"`
+		KeyPairID string `json:"key_pair_id"`
+		Plaintext []byte `json:"plaintext"`
+	}{
+		Epoch:     uint64(epoch),
+		KeyPairID: keyPairID,
+		Plaintext: plaintext,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to submit encrypt tx to runtime: %w", err)
+	}
+
+	var rsp []byte
+	if err = cbor.Unmarshal(rawRsp, &rsp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response from runtime: %w", err)
+	}
+
+	return rsp, nil
+}
+
+func (sc *kmKeyGenerationImpl) submitKeyValueRuntimeDecryptTx(
+	ctx context.Context,
+	id common.Namespace,
+	nonce uint64,
+	epoch beacon.EpochTime,
+	keyPairID string,
+	ciphertext []byte,
+) ([]byte, error) {
+	rawRsp, err := sc.submitRuntimeTx(ctx, runtimeID, nonce, "decrypt", struct {
+		Epoch      uint64 `json:"epoch"`
+		KeyPairID  string `json:"key_pair_id"`
+		Ciphertext []byte `json:"ciphertext"`
+	}{
+		Epoch:      uint64(epoch),
+		KeyPairID:  keyPairID,
+		Ciphertext: ciphertext,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to submit decrypt tx to runtime: %w", err)
+	}
+
+	var rsp []byte
+	if err = cbor.Unmarshal(rawRsp, &rsp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response from runtime: %w", err)
+	}
+
+	return rsp, nil
+}

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -759,6 +759,8 @@ func RegisterScenarios() error {
 		StorageEarlyStateSync,
 		// Sentry test.
 		Sentry,
+		// Keymanager key generation test.
+		KeymanagerKeyGeneration,
 		// Keymanager restart test.
 		KeymanagerRestart,
 		// Keymanager replicate test.

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -39,7 +39,8 @@ const (
 
 	// Make sure this always matches the appropriate method in
 	// `keymanager-runtime/src/methods.rs`.
-	getPublicKeyRequestMethod = "get_public_key"
+	getPublicKeyRequestMethod          = "get_public_key"
+	getPublicEphemeralKeyRequestMethod = "get_public_ephemeral_key"
 )
 
 var (
@@ -173,7 +174,7 @@ func (w *Worker) CallEnclave(ctx context.Context, data []byte) ([]byte, error) {
 	switch frame.UntrustedPlaintext {
 	case "":
 		// Anyone can connect.
-	case getPublicKeyRequestMethod:
+	case getPublicKeyRequestMethod, getPublicEphemeralKeyRequestMethod:
 		// Anyone can get public keys.
 	default:
 		if _, privatePeered := w.privatePeers[peerID]; !privatePeered {

--- a/keymanager-client/src/mock.rs
+++ b/keymanager-client/src/mock.rs
@@ -7,14 +7,14 @@ use futures::{
 };
 use io_context::Context;
 use oasis_core_keymanager_api_common::*;
-use oasis_core_runtime::common::crypto::signature::Signature;
+use oasis_core_runtime::{common::crypto::signature::Signature, consensus::beacon::EpochTime};
 
 use super::KeyManagerClient;
 
 /// Mock key manager client which stores everything locally.
 #[derive(Default)]
 pub struct MockClient {
-    keys: Mutex<HashMap<KeyPairId, KeyPair>>,
+    keys: Mutex<HashMap<(KeyPairId, Option<EpochTime>), KeyPair>>,
 }
 
 impl MockClient {
@@ -36,7 +36,7 @@ impl KeyManagerClient for MockClient {
     ) -> BoxFuture<Result<KeyPair, KeyManagerError>> {
         let mut keys = self.keys.lock().unwrap();
         let key = keys
-            .entry(key_pair_id)
+            .entry((key_pair_id, None))
             .or_insert_with(KeyPair::generate_mock)
             .clone();
 
@@ -55,6 +55,39 @@ impl KeyManagerClient for MockClient {
                 signature: Signature::default(),
             }))
         }))
+    }
+
+    fn get_or_create_ephemeral_keys(
+        &self,
+        _ctx: Context,
+        key_pair_id: KeyPairId,
+        epoch: EpochTime,
+    ) -> BoxFuture<Result<KeyPair, KeyManagerError>> {
+        let mut keys = self.keys.lock().unwrap();
+        let key = keys
+            .entry((key_pair_id, Some(epoch)))
+            .or_insert_with(KeyPair::generate_mock)
+            .clone();
+
+        Box::pin(future::ok(key))
+    }
+
+    fn get_public_ephemeral_key(
+        &self,
+        ctx: Context,
+        key_pair_id: KeyPairId,
+        epoch: EpochTime,
+    ) -> BoxFuture<Result<Option<SignedPublicKey>, KeyManagerError>> {
+        Box::pin(
+            self.get_or_create_ephemeral_keys(ctx, key_pair_id, epoch)
+                .and_then(|ck| {
+                    future::ok(Some(SignedPublicKey {
+                        key: ck.input_keypair.pk,
+                        checksum: vec![],
+                        signature: Signature::default(),
+                    }))
+                }),
+        )
     }
 
     fn replicate_master_secret(

--- a/keymanager-lib/Cargo.toml
+++ b/keymanager-lib/Cargo.toml
@@ -22,3 +22,4 @@ tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 x25519-dalek = "1.1.0"
 tokio = { version = "1", features = ["rt"] }
 zeroize = "1.4"
+rustc-hex = "2.0.1"

--- a/keymanager-lib/src/keymanager.rs
+++ b/keymanager-lib/src/keymanager.rs
@@ -46,6 +46,24 @@ pub fn new_keymanager(signers: TrustedPolicySigners) -> Box<dyn Initializer> {
         state.rpc_dispatcher.add_method(
             RpcMethod::new(
                 RpcMethodDescriptor {
+                    name: METHOD_GET_OR_CREATE_EPHEMERAL_KEYS.to_string(),
+                },
+                methods::get_or_create_ephemeral_keys,
+            ),
+            false,
+        );
+        state.rpc_dispatcher.add_method(
+            RpcMethod::new(
+                RpcMethodDescriptor {
+                    name: METHOD_GET_PUBLIC_EPHEMERAL_KEY.to_string(),
+                },
+                methods::get_public_ephemeral_key,
+            ),
+            false,
+        );
+        state.rpc_dispatcher.add_method(
+            RpcMethod::new(
+                RpcMethodDescriptor {
                     name: METHOD_REPLICATE_MASTER_SECRET.to_string(),
                 },
                 methods::replicate_master_secret,

--- a/keymanager-lib/src/methods.rs
+++ b/keymanager-lib/src/methods.rs
@@ -1,31 +1,58 @@
 //! Methods exported to remote clients via EnclaveRPC.
-use anyhow::Result;
-use oasis_core_keymanager_api_common::*;
-use oasis_core_runtime::enclave_rpc::Context as RpcContext;
-
 use crate::{kdf::Kdf, policy::Policy};
+use anyhow::Result;
+use io_context::Context;
+use oasis_core_keymanager_api_common::*;
+use oasis_core_runtime::{
+    common::{namespace::Namespace, sgx::EnclaveIdentity},
+    consensus::{beacon::EpochTime, state::beacon::ImmutableState as BeaconState},
+    enclave_rpc::Context as RpcContext,
+};
+
+/// Maximum age of ephemeral key in the number of epochs.
+const MAX_EPHEMERAL_KEY_AGE: EpochTime = 10;
 
 /// See `Kdf::get_or_create_keys`.
-pub fn get_or_create_keys(req: &RequestIds, ctx: &mut RpcContext) -> Result<KeyPair> {
-    // Authenticate the source enclave based on the MRSIGNER/MRENCLAVE/request
-    // so that the keys are never released to an incorrect enclave.
-    if !Policy::unsafe_skip() {
-        let si = ctx.session_info.as_ref();
-        let si = si.ok_or(KeyManagerError::NotAuthenticated)?;
-        let their_id = &si.verified_quote.identity;
-
-        Policy::global().may_get_or_create_keys(their_id, req)?;
-    }
+pub fn get_or_create_keys(req: &LongTermKeyRequest, ctx: &mut RpcContext) -> Result<KeyPair> {
+    authorize_private_key_generation(&req.runtime_id, ctx)?;
 
     Kdf::global().get_or_create_keys(req)
 }
 
 /// See `Kdf::get_public_key`.
-pub fn get_public_key(req: &RequestIds, _ctx: &mut RpcContext) -> Result<Option<SignedPublicKey>> {
+pub fn get_public_key(
+    req: &LongTermKeyRequest,
+    _ctx: &mut RpcContext,
+) -> Result<Option<SignedPublicKey>> {
+    // No authentication or authorization.
+    // Absolutely anyone is allowed to query public long-term keys.
+
     let kdf = Kdf::global();
+    let pk = kdf.get_public_key(req)?;
+    pk.map_or(Ok(None), |pk| Ok(Some(kdf.sign_public_key(pk)?)))
+}
 
-    // No authentication, absolutely anyone is allowed to query public keys.
+/// See `Kdf::get_or_create_keys`.
+pub fn get_or_create_ephemeral_keys(
+    req: &EphemeralKeyRequest,
+    ctx: &mut RpcContext,
+) -> Result<KeyPair> {
+    authorize_private_key_generation(&req.runtime_id, ctx)?;
+    validate_epoch(req.epoch, ctx)?;
 
+    Kdf::global().get_or_create_keys(req)
+}
+
+/// See `Kdf::get_public_key`.
+pub fn get_public_ephemeral_key(
+    req: &EphemeralKeyRequest,
+    ctx: &mut RpcContext,
+) -> Result<Option<SignedPublicKey>> {
+    // No authentication or authorization.
+    // Absolutely anyone is allowed to query public ephemeral keys.
+    validate_epoch(req.epoch, ctx)?;
+
+    let kdf = Kdf::global();
     let pk = kdf.get_public_key(req)?;
     pk.map_or(Ok(None), |pk| Ok(Some(kdf.sign_public_key(pk)?)))
 }
@@ -35,14 +62,44 @@ pub fn replicate_master_secret(
     _req: &ReplicateRequest,
     ctx: &mut RpcContext,
 ) -> Result<ReplicateResponse> {
-    // Authenticate the source enclave based on the MRSIGNER/MRNELCAVE.
-    if !Policy::unsafe_skip() {
-        let si = ctx.session_info.as_ref();
-        let si = si.ok_or(KeyManagerError::NotAuthenticated)?;
-        let their_id = &si.verified_quote.identity;
-
-        Policy::global().may_replicate_master_secret(their_id)?;
-    }
+    authorize_master_secret_replication(ctx)?;
 
     Kdf::global().replicate_master_secret()
+}
+
+/// Authorize the remote enclave so that the private keys are never released to an incorrect enclave.
+fn authorize_private_key_generation(runtime_id: &Namespace, ctx: &RpcContext) -> Result<()> {
+    if Policy::unsafe_skip() {
+        return Ok(()); // Authorize unsafe builds always.
+    }
+    let remote_enclave = authenticate(ctx)?;
+    Policy::global().may_get_or_create_keys(remote_enclave, runtime_id)
+}
+
+/// Authorize the remote enclave so that the master secret is never replicated to an incorrect enclave.
+fn authorize_master_secret_replication(ctx: &RpcContext) -> Result<()> {
+    if Policy::unsafe_skip() {
+        return Ok(()); // Authorize unsafe builds always.
+    }
+    let remote_enclave = authenticate(ctx)?;
+    Policy::global().may_replicate_master_secret(remote_enclave)
+}
+
+/// Authenticate the remote enclave based on the MRSIGNER/MRENCLAVE/request.
+fn authenticate<'a>(ctx: &'a RpcContext) -> Result<&'a EnclaveIdentity> {
+    let si = ctx.session_info.as_ref();
+    let si = si.ok_or(KeyManagerError::NotAuthenticated)?;
+    Ok(&si.verified_quote.identity)
+}
+
+// Validate that the epoch used for derivation of ephemeral private keys is not
+// in the future or too far back in the past.
+fn validate_epoch(epoch: EpochTime, ctx: &RpcContext) -> Result<()> {
+    let consensus_state = ctx.consensus_verifier.latest_state()?;
+    let beacon_state = BeaconState::new(&consensus_state);
+    let consensus_epoch = beacon_state.epoch(Context::create_child(&ctx.io_ctx))?;
+    if consensus_epoch < epoch || consensus_epoch > epoch + MAX_EPHEMERAL_KEY_AGE {
+        return Err(KeyManagerError::InvalidEpoch.into());
+    }
+    Ok(())
 }

--- a/runtime/src/enclave_rpc/context.rs
+++ b/runtime/src/enclave_rpc/context.rs
@@ -4,7 +4,7 @@ use std::{any::Any, sync::Arc};
 use io_context::Context as IoContext;
 
 use super::session::SessionInfo;
-use crate::{rak::RAK, storage::KeyValue};
+use crate::{consensus::verifier::Verifier, rak::RAK, storage::KeyValue};
 
 struct NoRuntimeContext;
 
@@ -16,6 +16,8 @@ pub struct Context<'a> {
     pub rak: Arc<RAK>,
     /// Information about the session the RPC call was delivered over.
     pub session_info: Option<Arc<SessionInfo>>,
+    /// Consensus verifier.
+    pub consensus_verifier: Arc<dyn Verifier>,
     /// Runtime-specific context.
     pub runtime: Box<dyn Any>,
     /// Untrusted local storage.
@@ -28,12 +30,14 @@ impl<'a> Context<'a> {
         io_ctx: Arc<IoContext>,
         rak: Arc<RAK>,
         session_info: Option<Arc<SessionInfo>>,
+        consensus_verifier: Arc<dyn Verifier>,
         untrusted_local_storage: &'a dyn KeyValue,
     ) -> Self {
         Self {
             io_ctx,
             rak,
             session_info,
+            consensus_verifier,
             runtime: Box::new(NoRuntimeContext),
             untrusted_local_storage,
         }

--- a/tests/runtimes/simple-keyvalue/Cargo.toml
+++ b/tests/runtimes/simple-keyvalue/Cargo.toml
@@ -32,6 +32,7 @@ anyhow = "1.0"
 thiserror = "1.0"
 io-context = "0.2.0"
 byteorder = "1.4.3"
+x25519-dalek = "1.1.0"
 tokio = { version = "1", features = ["rt"] }
 
 [build-dependencies]

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -143,6 +143,8 @@ impl Dispatcher {
             "enc_insert" => Self::dispatch_call(ctx, tx.args, Methods::enc_insert),
             "enc_get" => Self::dispatch_call(ctx, tx.args, Methods::enc_get),
             "enc_remove" => Self::dispatch_call(ctx, tx.args, Methods::enc_remove),
+            "encrypt" => Self::dispatch_call(ctx, tx.args, Methods::encrypt),
+            "decrypt" => Self::dispatch_call(ctx, tx.args, Methods::decrypt),
             _ => Err("method not found".to_string()),
         }
     }

--- a/tests/runtimes/simple-keyvalue/src/types.rs
+++ b/tests/runtimes/simple-keyvalue/src/types.rs
@@ -41,6 +41,20 @@ pub struct KeyValue {
 }
 
 #[derive(Clone, Debug, Default, cbor::Encode, cbor::Decode)]
+pub struct Encrypt {
+    pub epoch: u64,
+    pub key_pair_id: String,
+    pub plaintext: Vec<u8>,
+}
+
+#[derive(Clone, Debug, Default, cbor::Encode, cbor::Decode)]
+pub struct Decrypt {
+    pub epoch: u64,
+    pub key_pair_id: String,
+    pub ciphertext: Vec<u8>,
+}
+
+#[derive(Clone, Debug, Default, cbor::Encode, cbor::Decode)]
 pub struct Withdraw {
     pub withdraw: staking::Withdraw,
 }


### PR DESCRIPTION
Add API methods like the following:
- `get_ephemeral_key(epoch, key_pair_id)`
- `get_public_ephemeral_key(epoch, key_pair_id)`

Those would derive special ephemeral X25519 key pairs separate from the other runtime keys and where the epoch number is used as part of the derivation, but would only derive them if the epoch was not too far back in the past based on consensus layer state as seen by the key manager. Initially the epoch check may rely on untrusted consensus state provided by the key manager host node.