### PR TITLE
docs: Replace /oasis-sdk and /general links with full github URLs

### DIFF
--- a/.changelog/4891.doc.md
+++ b/.changelog/4891.doc.md
@@ -1,0 +1,1 @@
+doc: Use github.com URL for markdown files in other git repositories

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -10,9 +10,11 @@ linked on our website](https://oasisprotocol.org/security).
 We sketch out the general classification of the kinds of errors
 below. This is not intended to be an exhaustive list.
 
+<!-- markdownlint-disable line-length -->
 [Oasis Foundation]: https://oasisprotocol.org/
 [Oasis Core]: https://github.com/oasisprotocol/oasis-core
-[Oasis Network]: /general/oasis-network/overview
+[Oasis Network]: https://github.com/oasisprotocol/docs/blob/main/docs/general/oasis-network/overview.md
+<!-- markdownlint-enable line-length -->
 
 ## Specifications
 

--- a/docs/consensus/genesis.md
+++ b/docs/consensus/genesis.md
@@ -55,8 +55,10 @@ the parameter values that are used for the Oasis Network, see:
 
 :::
 
+<!-- markdownlint-disable line-length -->
 [Genesis File Overview]:
-  /general/oasis-network/genesis-doc
+  https://github.com/oasisprotocol/docs/blob/main/docs/general/oasis-network/genesis-doc.md
+<!-- markdownlint-enable line-length -->
 
 ### Canonical Form
 

--- a/docs/consensus/services/scheduler.md
+++ b/docs/consensus/services/scheduler.md
@@ -47,5 +47,6 @@ entity's [escrow account balance].
 [registered]: registry.md#register-node
 [`RoleValidator`]: https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go/common/node?tab=doc#RoleValidator
 [escrow account balance]: staking.md#escrow
-[genesis document]: /general/oasis-network/genesis-doc#committee-scheduler
+[genesis document]:
+  https://github.com/oasisprotocol/docs/blob/main/docs/general/oasis-network/genesis-doc.md#committee-scheduler
 <!-- markdownlint-enable line-length -->

--- a/docs/development-setup/oasis-net-runner.md
+++ b/docs/development-setup/oasis-net-runner.md
@@ -55,12 +55,12 @@ different terminal:
 By default, Oasis node is configured with a 30-second epoch, so you may
 initially need to wait for the first epoch to pass before the test client will
 make any progress. For more information on writing your own client, see the
-[Oasis SDK](/oasis-sdk).
+[Oasis SDK](https://github.com/oasisprotocol/oasis-sdk).
 
 <!-- markdownlint-disable line-length -->
 [the default network fixture]: https://github.com/oasisprotocol/oasis-core/tree/master/go/oasis-net-runner/fixtures/default.go
 [simple-keyvalue example]: https://github.com/oasisprotocol/oasis-core/tree/master/tests/runtimes/simple-keyvalue
-[Building a runtime]: /oasis-sdk/runtime/getting-started
+[Building a runtime]: https://github.com/oasisprotocol/oasis-sdk/blob/main/docs/runtime/getting-started.md
 <!-- markdownlint-enable line-length -->
 
 ## SGX Environment

--- a/docs/oasis-node/rpc.md
+++ b/docs/oasis-node/rpc.md
@@ -32,8 +32,7 @@ a subset of the consensus layer via the [Rosetta API].
 Like other parts of Oasis Core, the RPC interface exposed by Oasis Node uses the
 [gRPC protocol] with the [CBOR codec (instead of Protocol Buffers)]. If your
 application is written in Go, you can use the convenience gRPC wrappers provided
-by Oasis Core to create clients. Check the [Oasis SDK](/oasis-sdk) for more
-information.
+by Oasis Core to create clients. Check the [Oasis SDK] for more information.
 
 For example to create a gRPC client connected to the Oasis Node endpoint exposed
 by your local node at `/path/to/datadir/internal.sock` you can do:
@@ -57,6 +56,7 @@ the gRPC helpers see the [API documentation].
 [gRPC protocol]: https://grpc.io
 [CBOR codec (instead of Protocol Buffers)]: ../authenticated-grpc.md#cbor-codec
 [API documentation]: https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go/common/grpc?tab=doc
+[Oasis SDK]: https://github.com/oasisprotocol/oasis-sdk
 <!-- markdownlint-enable line-length -->
 
 ## Errors


### PR DESCRIPTION
In light of the docs restructuring https://github.com/oasisprotocol/docs/pull/200 replace any `/oasis-sdk/*` or `/general/*` links with full github.com URL.

Redirection back to the documentation's URL should be done by docusaurus preprocessor.