### PR TITLE
oasis-node/cmd/genesis: Fix reading height argument

### DIFF
--- a/.changelog/4892.bugfix.md
+++ b/.changelog/4892.bugfix.md
@@ -1,0 +1,5 @@
+go/oasis-node/cmd/genesis:  Fix reading of height argument when dumping state
+
+Command line argument for block height was mistakenly read from an invalid
+source, which caused all state dumps to be made at height 0 (the most recent
+block height).

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -627,7 +627,14 @@ func doDumpGenesis(cmd *cobra.Command, args []string) {
 
 	client := consensus.NewConsensusClient(conn)
 
-	doc, err := client.StateToGenesis(ctx, viper.GetInt64(cfgBlockHeight))
+	height, err := cmd.Flags().GetInt64(cfgBlockHeight)
+	if err != nil {
+		logger.Error("failed to read block height",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+	doc, err := client.StateToGenesis(ctx, height)
 	if err != nil {
 		logger.Error("failed to generate genesis document",
 			"err", err,


### PR DESCRIPTION
When dumping genesis state the height argument is not parsed correctly.

Tested locally.

```
# Fixed version without height argument.
➜  oasis-core git:(peternose/fix/dump-genesis) ✗ oasis-node genesis dump --address unix:/.../internal.sock 
➜  oasis-core git:(peternose/fix/dump-genesis) ✗ grep height genesis.json                                                                                           
  "height": 1752,
  
# Fixed version with height argument.
➜  oasis-core git:(peternose/fix/dump-genesis) ✗ oasis-node genesis dump --height=13 --address unix:/.../internal.sock     
➜  oasis-core git:(peternose/fix/dump-genesis) ✗ grep height genesis.json 
  "height": 13,
 
# Current version with height argument.
➜  oasis-core git:(master) ✗ oasis-node genesis dump --height=13 --address unix:/.../internal.sock
➜  oasis-core git:(master) ✗ grep height genesis.json                                                                                                       
  "height": 1929, 
 ```