### PR TITLE
runtime: Add state_at to consensus Verifier trait

### DIFF
--- a/.changelog/4893.internal.1.md
+++ b/.changelog/4893.internal.1.md
@@ -1,0 +1,4 @@
+runtime: Add state_at to consensus Verifier trait
+
+This allows fetching historic consensus layer state in addition to the
+latest state.

--- a/.changelog/4893.internal.2.md
+++ b/.changelog/4893.internal.2.md
@@ -1,0 +1,1 @@
+runtime: Refactor dispatcher initializer and expose consensus_verifier

--- a/runtime/src/consensus/verifier.rs
+++ b/runtime/src/consensus/verifier.rs
@@ -100,6 +100,9 @@ pub trait Verifier: Send + Sync {
     /// verification manually if needed.
     fn state_at(&self, height: u64) -> Result<ConsensusState, Error>;
 
+    /// Return the latest known consensus layer height.
+    fn latest_height(&self) -> Result<u64, Error>;
+
     /// Record the given (locally computed and thus verified) results header as trusted.
     fn trust(&self, header: &ComputeResultsHeader) -> Result<(), Error>;
 }

--- a/runtime/src/consensus/verifier.rs
+++ b/runtime/src/consensus/verifier.rs
@@ -92,6 +92,14 @@ pub trait Verifier: Send + Sync {
     /// verification manually if needed.
     fn latest_state(&self) -> Result<ConsensusState, Error>;
 
+    /// Return the verified consensus layer state for a given height.
+    ///
+    /// # Warning
+    ///
+    /// The state is not verified to be fresh. Use `verify_state_freshness` to perform this
+    /// verification manually if needed.
+    fn state_at(&self, height: u64) -> Result<ConsensusState, Error>;
+
     /// Record the given (locally computed and thus verified) results header as trusted.
     fn trust(&self, header: &ComputeResultsHeader) -> Result<(), Error>;
 }


### PR DESCRIPTION
* runtime: Add state_at to consensus Verifier trait
  
  This allows fetching historic consensus layer state in addition to the
  latest state.
* runtime: Refactor dispatcher initializer and expose consensus_verifier