### PR TITLE
runtime/consensus/verifier: Support trust root consensus layer upgrades

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -212,10 +212,10 @@ steps:
       - /tmp/e2e/**/runtime_genesis.json
     env:
       OASIS_E2E_COVERAGE: enable
-      # Since the trust-root scenario is tested in SGX mode (for which it is actually relevant) no need
-      # to also test it in non-SGX mode in CI. Also exclude txsource-multi-short so that we ensure it
-      # runs only on non-SGX agents.
-      OASIS_EXCLUDE_E2E: e2e/runtime/trust-root,e2e/runtime/txsource-multi-short
+      # Since the trust-root scenarios are tested in SGX mode (for which they are actually relevant)
+      # no need to also test them in non-SGX mode in CI. Also exclude txsource-multi-short so that
+      # we ensure it runs only on non-SGX agents.
+      OASIS_EXCLUDE_E2E: e2e/runtime/trust-root/simple,e2e/runtime/trust-root/change,e2e/runtime/trust-root/change-fails,e2e/runtime/txsource-multi-short
       TEST_BASE_DIR: /tmp
     retry:
       <<: *retry_agent_failure
@@ -255,6 +255,7 @@ steps:
       - "build-rust-runtime-loader"
       - "build-rust-runtimes"
     branches: "!master !stable/*"
+    parallelism: 2
     timeout_in_minutes: 20
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
@@ -263,7 +264,7 @@ steps:
       - export CFLAGS_x86_64_fortanix_unknown_sgx="-isystem/usr/include/x86_64-linux-gnu -mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening"
       - export CC_x86_64_fortanix_unknown_sgx=clang-11
       # Only run runtime scenarios as others do not use SGX.
-      - .buildkite/scripts/test_e2e.sh --scenario e2e/runtime/runtime-encryption --scenario e2e/runtime/trust-root --scenario e2e/runtime/keymanager-key-generation
+      - .buildkite/scripts/test_e2e.sh --scenario e2e/runtime/runtime-encryption --scenario e2e/runtime/trust-root/.+ --scenario e2e/runtime/keymanager-key-generation
     artifact_paths:
       - coverage-merged-e2e-*.txt
       - /tmp/e2e/**/*.log

--- a/.buildkite/scripts/test_e2e.sh
+++ b/.buildkite/scripts/test_e2e.sh
@@ -53,8 +53,8 @@ ${test_runner_binary} \
     --e2e/runtime.runtime.loader ${WORKDIR}/target/default/debug/oasis-core-runtime-loader \
     --e2e/runtime.tee_hardware ${OASIS_TEE_HARDWARE:-""} \
     --e2e/runtime.ias.mock=${ias_mock} \
-    --e2e/runtime/trust-root.runtime.source_dir ${WORKDIR}/tests/runtimes \
-    --e2e/runtime/trust-root.runtime.target_dir ${WORKDIR}/target \
+    --e2e/runtime/trust-root/{simple,change,change-fails}.runtime.source_dir=${WORKDIR}/tests/runtimes \
+    --e2e/runtime/trust-root/{simple,change,change-fails}.runtime.target_dir=${WORKDIR}/target \
     --remote-signer.binary ${WORKDIR}/go/oasis-remote-signer/oasis-remote-signer \
     --plugin-signer.name example \
     --plugin-signer.binary ${WORKDIR}/go/oasis-test-runner/scenario/pluginsigner/example_signer_plugin/example_signer_plugin \

--- a/.changelog/4903.feature.md
+++ b/.changelog/4903.feature.md
@@ -1,0 +1,1 @@
+runtime/consensus/verifier: Support trust root consensus layer upgrades

--- a/go/oasis-test-runner/oasis/network.go
+++ b/go/oasis-test-runner/oasis/network.go
@@ -478,7 +478,7 @@ func (net *Network) Start() error { // nolint: gocyclo
 			continue
 		}
 
-		if net.controller, err = NewController(net.validators[0].SocketPath()); err != nil {
+		if net.controller, err = NewController(v.SocketPath()); err != nil {
 			net.logger.Error("failed to create controller",
 				"err", err,
 			)
@@ -493,7 +493,7 @@ func (net *Network) Start() error { // nolint: gocyclo
 			continue
 		}
 
-		if net.clientController, err = NewController(net.clients[0].SocketPath()); err != nil {
+		if net.clientController, err = NewController(v.SocketPath()); err != nil {
 			net.logger.Error("failed to create client controller",
 				"err", err,
 			)

--- a/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
+++ b/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
@@ -132,7 +132,7 @@ func (sc *gasFeesImpl) Run(childEnv *env.Env) error {
 		if err != nil {
 			return err
 		}
-		if err := sc.DumpRestoreNetwork(childEnv, fixture, false, nil); err != nil {
+		if err := sc.DumpRestoreNetwork(childEnv, fixture, false, nil, nil); err != nil {
 			return err
 		}
 		if err := sc.runTests(ctx); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/runtime/dump_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/dump_restore.go
@@ -165,7 +165,7 @@ func (sc *dumpRestoreImpl) Run(childEnv *env.Env) error {
 		return err
 	}
 
-	if err = sc.DumpRestoreNetwork(childEnv, fixture, true, sc.mapGenesisDocumentFn); err != nil {
+	if err = sc.DumpRestoreNetwork(childEnv, fixture, true, sc.mapGenesisDocumentFn, nil); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/halt_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/halt_restore.go
@@ -160,7 +160,7 @@ func (sc *haltRestoreImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 	// Stop the network.
 	sc.Logger.Info("stopping the network")
 	sc.Net.Stop()
-	if err = sc.ResetConsensusState(childEnv); err != nil {
+	if err = sc.ResetConsensusState(childEnv, nil); err != nil {
 		return fmt.Errorf("failed to reset consensus state: %w", err)
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/halt_restore_nonmock.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/halt_restore_nonmock.go
@@ -89,7 +89,7 @@ func (sc *haltRestoreNonMockImpl) Run(childEnv *env.Env) error { // nolint: gocy
 	// Stop the network.
 	sc.Logger.Info("stopping the network")
 	sc.Net.Stop()
-	if err = sc.ResetConsensusState(childEnv); err != nil {
+	if err = sc.ResetConsensusState(childEnv, nil); err != nil {
 		return fmt.Errorf("failed to reset consensus state: %w", err)
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -799,6 +799,8 @@ func RegisterScenarios() error {
 		HistoryReindex,
 		// TrustRoot test.
 		TrustRoot,
+		TrustRootChangeTest,
+		TrustRootChangeFailsTest,
 		// Archive node API test.
 		ArchiveAPI,
 	} {

--- a/go/oasis-test-runner/scenario/e2e/runtime/trust_root_change.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/trust_root_change.go
@@ -1,0 +1,417 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/log"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario/e2e"
+)
+
+const (
+	// LogEventTrustRootChangeNoTrust is the event emitted when a compute
+	// worker fails to initialize the verifier as there is not enough trust
+	// in the new light block.
+	LogEventTrustRootChangeNoTrust = "consensus/tendermint/verifier/chain_context/no_trust"
+
+	// LogEventTrustRootChangeFailed is the event emitted when a compute
+	// worker fails to initialize the verifier as the new light block is
+	// invalid, e.g. has lower height than the last known trusted block.
+	LogEventTrustRootChangeFailed = "consensus/tendermint/verifier/chain_context/failed"
+)
+
+var (
+	// TrustRootChangeTest is a happy path scenario which tests if trust
+	// can be transferred to a new light block when consensus chain context
+	// changes, e.g. on dump-restore network upgrades.
+	TrustRootChangeTest scenario.Scenario = newTrustRootChangeImpl("change", NewLongTermTestClient().WithMode(ModePart1NoMsg), true)
+
+	// TrustRootChangeFailsTest is an unhappy path scenario which tests
+	// that trust is never transferred to untrusted or invalid light blocks when
+	// consensus chain context changes.
+	TrustRootChangeFailsTest scenario.Scenario = newTrustRootChangeImpl("change-fails", BasicKVTestClient, false)
+)
+
+type trustRootChangeImpl struct {
+	trustRootImpl
+
+	// Happy or unhappy scenario.
+	happy bool
+}
+
+func newTrustRootChangeImpl(name string, testClient TestClient, happy bool) *trustRootChangeImpl {
+	// We will use 3 validators inherited from trust root scenario fixture
+	// to test what happens if the new validator set doesn't have enough
+	// voting power after chain context changes. Since all validators have
+	// the same voting power we can remove one of them and the rest will have
+	// only 2/3 of the votes, just a bit too shy.
+	//
+	// For happy path we use a long-term test client as it enables us to test
+	// if the key/value store remains intact after multiple chain context
+	// changes.
+	sc := &trustRootChangeImpl{
+		trustRootImpl: *newTrustRootImpl(name, testClient),
+		happy:         happy,
+	}
+
+	return sc
+}
+
+func (sc *trustRootChangeImpl) Clone() scenario.Scenario {
+	return &trustRootChangeImpl{
+		trustRootImpl: *sc.trustRootImpl.Clone().(*trustRootImpl),
+		happy:         sc.happy,
+	}
+}
+
+func (sc *trustRootChangeImpl) Run(childEnv *env.Env) error {
+	if !sc.happy {
+		return sc.unhappyRun(childEnv)
+	}
+	return sc.happyRun(childEnv)
+}
+
+// happyRun tests that trust is transferred to a new light block when consensus
+// chain context changes if validator set has enough votes.
+//
+// It consists of 3 steps:
+//   - Build a simple key/value runtime with an embedded trust root, register
+//     it to the network together with key manager runtime and test that
+//     everything works.
+//   - Do dump/restore procedure which simulates a real network upgrade.
+//     This step will stop the network, clear everything except runtime's
+//     local storage (we need it as the verifier has last trust root
+//     stored in it) and change consensus chain context. The latter will
+//     force the verifier to check if transition to a new light block
+//     is possible.
+//   - Start the network and test if everything works.
+//   - Repeat last two points. Chain context transition can be done repeatedly,
+//     as long as new light blocks are trusted and valid.
+func (sc *trustRootChangeImpl) happyRun(childEnv *env.Env) (err error) {
+	ctx := context.Background()
+
+	// Step 1: Build a simple key/value runtime and start the network.
+	rebuild, err := sc.buildKeyValueRuntime(ctx, childEnv)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err2 := rebuild(); err2 != nil {
+			err = fmt.Errorf("%w (original error: %s)", err2, err)
+		}
+	}()
+
+	// All chain contexts should be unique.
+	chainContexts := make(map[string]struct{})
+	c, err := sc.chainContext(ctx)
+	if err != nil {
+		return err
+	}
+	chainContexts[c] = struct{}{}
+
+	for round := int64(1); round <= 2; round++ {
+		// Step 2: Dump/restore network.
+		if err = sc.dumpRestoreNetwork(childEnv, nil, nil); err != nil {
+			return err
+		}
+
+		// Step 3: Start the network and test if everything works.
+		if err = sc.Net.Start(); err != nil {
+			return err
+		}
+
+		// Assert that chain context has changed. Test is meaningless if this
+		// doesn't happen.
+		c, err = sc.chainContext(ctx)
+		if err != nil {
+			return err
+		}
+		if _, ok := chainContexts[c]; ok {
+			return fmt.Errorf("chain context hasn't changed")
+		}
+		chainContexts[c] = struct{}{}
+
+		// Test runtime to be sure that blocks get processed correctly.
+		// We do this by checking if key/value store was successfully restored.
+		if err := sc.startClientAndComputeWorkers(ctx, childEnv); err != nil {
+			return err
+		}
+		if err := sc.startRestoredStateTestClient(ctx, childEnv, round); err != nil {
+			return err
+		}
+	}
+
+	// Check logs whether any issues were detected.
+	if err := sc.Net.CheckLogWatchers(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// unhappyRun tests that trust is never transferred to untrusted or invalid
+// light blocks when consensus chain context changes.
+//
+// It consists of 5 steps:
+//   - Build a simple key/value runtime with an embedded trust root, register
+//     it to the network together with key manager runtime and test that
+//     everything works.
+//   - Stop the network, set genesis height to 1 and reset the consensus state.
+//     This will cause a chain context change when the network will be started
+//     again. When doing state wipe be careful not to delete compute workers
+//     local storages as they contain sealed trusted roots.
+//   - Start the network. If everything works as expected, compute workers
+//     should never be ready as the verifier cannot transfer trust to light
+//     blocks on a new chain.
+//   - Repeat last two points. This time set genesis height to something big
+//     and remove one validator from the set so that we can simulate what
+//     happens when the new validator set has only 2/3 of the voting power.
+func (sc *trustRootChangeImpl) unhappyRun(childEnv *env.Env) (err error) {
+	ctx := context.Background()
+
+	// Step 1: Build a simple key/value runtime and start the network.
+	rebuild, err := sc.buildKeyValueRuntime(ctx, childEnv)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err2 := rebuild(); err2 != nil {
+			err = fmt.Errorf("%w (original error: %s)", err2, err)
+		}
+	}()
+
+	chainContext, err := sc.chainContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Prepare functions for dump/restore procedures.
+	nodeID := sc.Net.Validators()[2].NodeID // Selected for removal in step 4.
+
+	f := []func(fixture *oasis.NetworkFixture){
+		// First dump with too low genesis height.
+		func(fixture *oasis.NetworkFixture) {
+			// Make sure all nodes are started initially although we only need
+			// one compute worker. We have to start them as otherwise tendermint
+			// reset will fail.
+			for i := range fixture.ComputeWorkers {
+				fixture.ComputeWorkers[i].NoAutoStart = false
+			}
+			for i := range fixture.Clients {
+				fixture.Clients[i].NoAutoStart = false
+			}
+
+			// Observe logs for invalid genesis block error messages.
+			fixture.ComputeWorkers[0].LogWatcherHandlerFactories = []log.WatcherHandlerFactory{
+				oasis.LogAssertEvent(LogEventTrustRootChangeFailed, "the verifier should emit invalid genesis block event"),
+			}
+		},
+
+		// Second dump without one validator.
+		func(fixture *oasis.NetworkFixture) {
+			// Remove one validator in the set so that trust validation will
+			// fail and observe logs for failure.
+			fixture.Validators = fixture.Validators[:2]
+			fixture.ComputeWorkers[0].NoAutoStart = false
+			fixture.ComputeWorkers[0].LogWatcherHandlerFactories = []log.WatcherHandlerFactory{
+				oasis.LogAssertEvent(LogEventTrustRootChangeNoTrust, "the verifier should emit not trusted chain event"),
+			}
+		},
+	}
+
+	g := []func(doc *genesis.Document){
+		// First dump with too low genesis height.
+		func(doc *genesis.Document) {
+			// Reset height to get an invalid genesis block error message.
+			doc.Height = 1
+		},
+
+		// Second dump without one validator.
+		func(doc *genesis.Document) {
+			// Remove one validator from the genesis. Since the order
+			// of validators in fixture and genesis may not be the same,
+			// be careful to remove the right one.
+			nodes := make([]*node.MultiSignedNode, 0, 2)
+			for _, n := range doc.Registry.Nodes {
+				if n.Signatures[0].PublicKey != nodeID {
+					nodes = append(nodes, n)
+				}
+			}
+			doc.Registry.Nodes = nodes
+
+			// Remove status also.
+			delete(doc.Registry.NodeStatuses, nodeID)
+
+			// Height should be larger than the height of the latest trust root.
+			doc.Height = 1000
+		},
+	}
+
+	for i := 0; i < 2; i++ {
+		// Step 2,4: Dump/restore network.
+		if err = sc.dumpRestoreNetwork(childEnv, f[i], g[i]); err != nil {
+			return err
+		}
+
+		// Step 3,5: Start the network and verify compute workers.
+		if err = sc.Net.Start(); err != nil {
+			return err
+		}
+		if err = sc.Net.Controller().WaitNodesRegistered(ctx, len(sc.Net.Validators())); err != nil {
+			return err
+		}
+
+		// Assert that chain context has changed. Test is meaningless if this
+		// doesn't happen.
+		newChainContext, err := sc.chainContext(ctx)
+		if err != nil {
+			return err
+		}
+		if newChainContext == chainContext {
+			return fmt.Errorf("chain context hasn't changed")
+		}
+
+		// Running network for few blocks so that compute workers have enough
+		// time to get ready.
+		_, err = sc.waitBlocks(ctx, 25)
+		if err != nil {
+			return err
+		}
+
+		// Starting the key/value runtime should now be a problem for compute
+		// workers as the verifier will never initialize.
+		if err := sc.Net.CheckLogWatchers(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (sc *trustRootChangeImpl) buildKeyValueRuntime(ctx context.Context, childEnv *env.Env) (func() error, error) {
+	// Start network with validators only, as configured in the fixture.
+	// We need those to produce blocks from which we pick one and use it
+	// as our embedded trust root.
+	if err := sc.Net.Start(); err != nil {
+		return nil, err
+	}
+	if err := sc.Net.Controller().WaitNodesRegistered(ctx, len(sc.Net.Validators())); err != nil {
+		return nil, err
+	}
+
+	// Pick one block and use it as an embedded trust root.
+	block, err := sc.waitBlocks(ctx, 3)
+	if err != nil {
+		return nil, err
+	}
+	chainContext, err := sc.chainContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	root := trustRoot{
+		height:       strconv.FormatInt(block.Height, 10),
+		hash:         block.Hash.Hex(),
+		runtimeID:    runtimeID.String(),
+		chainContext: chainContext,
+	}
+
+	// Build the runtime using given trust root. Observe that we are changing
+	// the binary here, so we need to rebuild the runtime when we are done.
+	rebuild, err := sc.buildRuntimeBinary(ctx, childEnv, root)
+	if err != nil {
+		return nil, err
+	}
+
+	// Once binary with the embedded root is built, we can register runtimes.
+	if err = sc.registerRuntimes(ctx, childEnv); err != nil {
+		return nil, err
+	}
+
+	// Test runtime to be sure that blocks get processed correctly.
+	// Remember that only validators are currently running.
+	if err = sc.startClientAndComputeWorkers(ctx, childEnv); err != nil {
+		return nil, err
+	}
+
+	// Test transactions.
+	if err := sc.startTestClientOnly(ctx, childEnv); err != nil {
+		return nil, err
+	}
+	if err := sc.waitTestClient(); err != nil {
+		return nil, err
+	}
+
+	return rebuild, nil
+}
+
+func (sc *trustRootChangeImpl) dumpRestoreNetwork(childEnv *env.Env, f func(*oasis.NetworkFixture), g func(*genesis.Document)) error {
+	fixture, err := sc.Fixture()
+	if err != nil {
+		return err
+	}
+
+	// Apply changes to the fixture.
+	if f != nil {
+		f(fixture)
+	}
+
+	// Don't delete trust root.
+	resetFlags := map[uint8]bool{
+		e2e.PreserveComputeWorkerLocalStorage:   true,
+		e2e.PreserveComputeWorkerRuntimeStorage: true, // default, needed
+		e2e.PreserveKeymanagerLocalStorage:      true, // default, needed
+	}
+	if err = sc.DumpRestoreNetwork(childEnv, fixture, false, g, resetFlags); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (sc *trustRootChangeImpl) startClientAndComputeWorkers(ctx context.Context, childEnv *env.Env) error {
+	// Start client and compute workers as they are not auto started.
+	sc.Logger.Info("starting clients and compute workers")
+	for _, n := range sc.Net.Clients() {
+		if err := n.Start(); err != nil {
+			return fmt.Errorf("failed to start node: %w", err)
+		}
+	}
+	for _, n := range sc.Net.ComputeWorkers() {
+		if err := n.Start(); err != nil {
+			return fmt.Errorf("failed to start node: %w", err)
+		}
+	}
+	sc.Logger.Info("waiting for compute workers to become ready")
+	for _, n := range sc.Net.ComputeWorkers() {
+		if err := n.WaitReady(ctx); err != nil {
+			return fmt.Errorf("failed to wait for a compute worker: %w", err)
+		}
+	}
+
+	// Setup a client controller as there is none due to the client node not
+	// being auto started.
+	ctrl, err := oasis.NewController(sc.Net.Clients()[0].SocketPath())
+	if err != nil {
+		return fmt.Errorf("failed to create client controller: %w", err)
+	}
+	sc.Net.SetClientController(ctrl)
+
+	return nil
+}
+
+func (sc *trustRootChangeImpl) startRestoredStateTestClient(ctx context.Context, childEnv *env.Env, round int64) error {
+	// Check that everything works with restored state.
+	seed := fmt.Sprintf("seed %d", round)
+	newTestClient := sc.testClient.Clone().(*LongTermTestClient)
+	sc.runtimeImpl.testClient = newTestClient.WithMode(ModePart2).WithSeed(seed)
+	if err := sc.runtimeImpl.Run(childEnv); err != nil {
+		return err
+	}
+	return nil
+}

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -107,6 +107,8 @@ type Body struct {
 	HostFetchConsensusBlockResponse *HostFetchConsensusBlockResponse `json:",omitempty"`
 	HostFetchTxBatchRequest         *HostFetchTxBatchRequest         `json:",omitempty"`
 	HostFetchTxBatchResponse        *HostFetchTxBatchResponse        `json:",omitempty"`
+	HostFetchGenesisHeightRequest   *HostFetchGenesisHeightRequest   `json:",omitempty"`
+	HostFetchGenesisHeightResponse  *HostFetchGenesisHeightResponse  `json:",omitempty"`
 }
 
 // Type returns the message type by determining the name of the first non-nil member.
@@ -476,6 +478,14 @@ type HostFetchConsensusBlockRequest struct {
 // HostFetchConsensusBlockResponse is a response from host fetching the given consensus light block.
 type HostFetchConsensusBlockResponse struct {
 	Block consensus.LightBlock `json:"block"`
+}
+
+// HostFetchGenesisHeightRequest is a request to host to fetch the consensus genesis height.
+type HostFetchGenesisHeightRequest struct{}
+
+// HostFetchGenesisHeightResponse is a response from host fetching the consensus genesis height.
+type HostFetchGenesisHeightResponse struct {
+	Height uint64 `json:"height"`
 }
 
 // HostFetchTxBatchRequest is a request to host to fetch a further batch of transactions.

--- a/go/runtime/registry/host.go
+++ b/go/runtime/registry/host.go
@@ -242,6 +242,15 @@ func (h *runtimeHostHandler) Handle(ctx context.Context, body *protocol.Body) (*
 			Block: *lb,
 		}}, nil
 	}
+	if body.HostFetchGenesisHeightRequest != nil {
+		doc, err := h.consensus.GetGenesisDocument(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return &protocol.Body{HostFetchGenesisHeightResponse: &protocol.HostFetchGenesisHeightResponse{
+			Height: uint64(doc.Height),
+		}}, nil
+	}
 	// Transaction pool.
 	if rq := body.HostFetchTxBatchRequest; rq != nil {
 		txPool, err := h.env.GetTxPool(ctx)

--- a/runtime/src/consensus/tendermint/mod.rs
+++ b/runtime/src/consensus/tendermint/mod.rs
@@ -28,6 +28,21 @@ pub fn decode_light_block(light_block: LightBlock) -> Result<LightBlockMeta> {
     LightBlockMeta::decode_vec(&light_block.meta).map_err(|e| anyhow!("{}", e))
 }
 
+/// Encode the light block metadata to a Tendermint light block.
+pub fn encode_light_block(light_block_meta: &LightBlockMeta) -> Result<LightBlock> {
+    let height = u64::from(
+        light_block_meta
+            .signed_header
+            .as_ref()
+            .ok_or_else(|| anyhow!("signed header should be present"))?
+            .header
+            .height,
+    );
+    let meta = LightBlockMeta::encode_vec(light_block_meta).map_err(|e| anyhow!("{}", e))?;
+
+    Ok(LightBlock { height, meta })
+}
+
 /// Extract state root from the given signed block header.
 ///
 /// # Panics

--- a/runtime/src/consensus/verifier.rs
+++ b/runtime/src/consensus/verifier.rs
@@ -23,8 +23,11 @@ pub enum Error {
     #[error("verification: {0}")]
     VerificationFailed(#[source] anyhow::Error),
 
-    #[error("trust root loading failed")]
-    TrustRootLoadingFailed,
+    #[error("trusted state loading failed")]
+    TrustedStateLoadingFailed,
+
+    #[error("consensus chain context transition failed: {0}")]
+    ChainContextTransitionFailed(#[source] anyhow::Error),
 
     #[error("internal consensus verifier error")]
     Internal,
@@ -35,8 +38,9 @@ impl Error {
         match self {
             Error::Builder(_) => 1,
             Error::VerificationFailed(_) => 2,
-            Error::TrustRootLoadingFailed => 3,
-            Error::Internal => 4,
+            Error::TrustedStateLoadingFailed => 3,
+            Error::ChainContextTransitionFailed(_) => 4,
+            Error::Internal => 5,
         }
     }
 }
@@ -116,6 +120,20 @@ pub struct TrustRoot {
     pub hash: String,
     /// Known runtime identifier.
     pub runtime_id: Namespace,
+    /// Known consensus chain context.
+    pub chain_context: String,
+}
+
+/// Trusted state containing trust root and trusted light block.
+#[derive(Debug, Clone, Default, cbor::Encode, cbor::Decode)]
+pub struct TrustedState {
+    /// Trust root.
+    pub trust_root: TrustRoot,
+    /// Trusted light block.
+    ///
+    /// Optional as we don't want to force trusted state for embedded trust
+    /// root to have a matching trusted light block.
+    pub trusted_block: Option<LightBlock>,
 }
 
 /// Verify consensus layer state freshness based on our internal state.

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -238,6 +238,10 @@ pub enum Body {
         #[cbor(optional)]
         batch: Option<TxnBatch>,
     },
+    HostFetchGenesisHeightRequest {},
+    HostFetchGenesisHeightResponse {
+        height: u64,
+    },
 }
 
 impl Default for Body {

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -386,11 +386,13 @@ pub fn main_with_version(version: Version) {
     let trust_root = option_env!("OASIS_TESTS_CONSENSUS_TRUST_HEIGHT").map(|height| {
         let hash = option_env!("OASIS_TESTS_CONSENSUS_TRUST_HASH").unwrap();
         let runtime_id = option_env!("OASIS_TESTS_CONSENSUS_TRUST_RUNTIME_ID").unwrap();
+        let chain_context = option_env!("OASIS_TESTS_CONSENSUS_TRUST_CHAIN_CONTEXT").unwrap();
 
         TrustRoot {
             height: height.parse::<u64>().unwrap(),
             hash: hash.to_string(),
             runtime_id: runtime_id.into(),
+            chain_context: chain_context.to_string(),
         }
     });
 


### PR DESCRIPTION
Tested locally. Without changes compute workers are stuck with error messages `Consensus verifier failed to initialize`.
```
{"err":"builder: I/O error\n\nCaused by:\n   0: rpc error\n   1: server error: module: consensus code: 3 message: consensus: version not found\n, ...}
```
With changes compute workers report error message `Not enough trust to accept new chain context` when there is not enough trust to do the transition
```
{"level":"info","log_event":"consensus/tendermint/verifier/chain_context/no_trust","module":"runtime/consensus/tendermint/verifier","msg":"Not enough trust to accept new chain context","runtime_id":"8000000000000000000000000000000000000000000000000000000000000000","runtime_name":"test-runtime","tally":"VotingPowerTally { total: 3, tallied: 2, trust_threshold: TrustThresholdFraction { numerator: 2, denominator: 3 } }","ts":"2022-08-24T04:30:43.604572699Z"}
```
or `Failed to accept new chain context` if new light blocks are invalid (e.g. invalid time, height, hash, ...).
```
{"error":"NonIncreasingHeight(NonIncreasingHeightSubdetail { got: block::Height(46), expected: block::Height(51) })","level":"info","log_event":"consensus/tendermint/verifier/chain_context/failed","module":"runtime/consensus/tendermint/verifier","msg":"Failed to accept new chain context","runtime_id":"8000000000000000000000000000000000000000000000000000000000000000","runtime_name":"test-runtime","ts":"2022-08-24T04:29:42.405580653Z"}
```