### PR TITLE
[BACKPORT/22.1.x] go/runtime/registry: allow client nodes to run SGX

### DIFF
--- a/.changelog/4832.feature.md
+++ b/.changelog/4832.feature.md
@@ -1,0 +1,4 @@
+go/runtime/registry: allow client nodes to run sgx runtimes
+
+Client nodes can now run runtimes in SGX, which enables them to execute
+signed queries if peered with a keymanager.


### PR DESCRIPTION
This PR backports 8a220c68f, which will (hopefully) allow client nodes to run SGX runtimes.