### PR TITLE
keymanager: Validate latest trust root height in key manager requests

### DIFF
--- a/.changelog/4910.feature.md
+++ b/.changelog/4910.feature.md
@@ -1,0 +1,1 @@
+keymanager: Validate latest trust root height in key manager requests

--- a/keymanager-api-common/src/api.rs
+++ b/keymanager-api-common/src/api.rs
@@ -88,7 +88,14 @@ pub struct SignedInitResponse {
 /// Key manager replication request.
 #[derive(Clone, Default, cbor::Encode, cbor::Decode)]
 pub struct ReplicateRequest {
-    // Empty.
+    /// Latest trust root height.
+    pub height: Option<u64>,
+}
+
+impl ReplicateRequest {
+    pub fn new(height: Option<u64>) -> Self {
+        Self { height }
+    }
 }
 
 /// Key manager replication response.
@@ -103,6 +110,8 @@ pub struct ReplicateResponse {
 /// from the master secret. They can be generated at any time.
 #[derive(Clone, Default, cbor::Encode, cbor::Decode)]
 pub struct LongTermKeyRequest {
+    /// Latest trust root height.
+    pub height: Option<u64>,
     /// Runtime ID.
     pub runtime_id: Namespace,
     /// Key pair ID.
@@ -110,8 +119,9 @@ pub struct LongTermKeyRequest {
 }
 
 impl LongTermKeyRequest {
-    pub fn new(runtime_id: Namespace, key_pair_id: KeyPairId) -> Self {
+    pub fn new(height: Option<u64>, runtime_id: Namespace, key_pair_id: KeyPairId) -> Self {
         Self {
+            height,
             runtime_id,
             key_pair_id,
         }
@@ -125,6 +135,8 @@ impl LongTermKeyRequest {
 /// for the past few epochs relative to the consensus layer state.
 #[derive(Clone, Default, cbor::Encode, cbor::Decode)]
 pub struct EphemeralKeyRequest {
+    /// Latest trust root height.
+    pub height: Option<u64>,
     /// Runtime ID.
     pub runtime_id: Namespace,
     /// Key pair ID.
@@ -134,8 +146,14 @@ pub struct EphemeralKeyRequest {
 }
 
 impl EphemeralKeyRequest {
-    pub fn new(runtime_id: Namespace, key_pair_id: KeyPairId, epoch: EpochTime) -> Self {
+    pub fn new(
+        height: Option<u64>,
+        runtime_id: Namespace,
+        key_pair_id: KeyPairId,
+        epoch: EpochTime,
+    ) -> Self {
         Self {
+            height,
             runtime_id,
             key_pair_id,
             epoch,
@@ -225,6 +243,8 @@ pub enum KeyManagerError {
     NotAuthorized,
     #[error("invalid epoch")]
     InvalidEpoch,
+    #[error("height is not fresh")]
+    HeightNotFresh,
     #[error("key manager is not initialized")]
     NotInitialized,
     #[error("key manager state corrupted")]

--- a/keymanager-lib/src/kdf.rs
+++ b/keymanager-lib/src/kdf.rs
@@ -292,6 +292,7 @@ impl Kdf {
                             rctx.runtime_id,
                             Policy::global().may_replicate_from(),
                             rctx.protocol.clone(),
+                            ctx.consensus_verifier.clone(),
                             ctx.rak.clone(),
                             1, // Not used, doesn't matter.
                         );
@@ -699,10 +700,12 @@ mod tests {
         let runtime_id = Namespace::from(vec![1u8; 32]);
         let key_pair_id = KeyPairId::from(vec![1u8; 32]);
         let epoch = 1;
+        let height = None;
 
         // LongTermKeyRequest's seed should depend on runtime_id and
         // key_pair_id.
         let req1 = LongTermKeyRequest {
+            height,
             runtime_id,
             key_pair_id,
         };
@@ -721,6 +724,7 @@ mod tests {
         // EphemeralKeyRequest's seed should depend on runtime_id, key_pair_id
         // and epoch.
         let req1 = EphemeralKeyRequest {
+            height,
             epoch,
             runtime_id,
             key_pair_id,

--- a/runtime/src/dispatcher.rs
+++ b/runtime/src/dispatcher.rs
@@ -126,7 +126,7 @@ struct TxDispatchState {
 /// State provided by the protocol upon successful initialization.
 struct ProtocolState {
     protocol: Arc<Protocol>,
-    consensus_verifier: Box<dyn Verifier>,
+    consensus_verifier: Arc<dyn Verifier>,
 }
 
 /// State held by the dispatcher, shared between all async tasks.
@@ -205,6 +205,7 @@ impl Dispatcher {
 
     /// Start the dispatcher.
     pub fn start(&self, protocol: Arc<Protocol>, consensus_verifier: Box<dyn Verifier>) {
+        let consensus_verifier = Arc::from(consensus_verifier);
         let mut s = self.state.lock().unwrap();
         *s = Some(ProtocolState {
             protocol,
@@ -249,7 +250,6 @@ impl Dispatcher {
         info!(self.logger, "Starting the runtime dispatcher");
         let mut rpc_demux = RpcDemux::new(self.rak.clone());
         let mut rpc_dispatcher = RpcDispatcher::default();
-        let consensus_verifier: Arc<dyn Verifier> = Arc::from(consensus_verifier);
         let pre_init_state = PreInitState {
             protocol: &protocol,
             rak: &self.rak,

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -358,6 +358,7 @@ pub fn main_with_version(version: Version) {
         let km_client = Arc::new(oasis_core_keymanager_client::RemoteClient::new_runtime(
             hi.runtime_id,
             state.protocol.clone(),
+            state.consensus_verifier.clone(),
             state.rak.clone(),
             1024,
             trusted_policy_signers(),


### PR DESCRIPTION
### Key manager requests should include latest consensus trust root
The key manager protocol should add the latest known trust root (or just the height) to (private key) EnclaveRPC requests. This would allow the key manager to detect whether the runtimes querying it have a fresh enough state (e.g. within 50 blocks) and reject operations if not.

Obviously the bad view can be either on the key manager side (Byzantine key manager operator) or the runtime side (Byzantine runtime operator). In case the key manager node is Byzantine the runtime can just switch to a different one (this already happens automatically when key manager requests fail).

This should be supported in a backwards compatible manner by making the new field optional.

### Test
Happy path is already covered with e2e tests. Unhappy path was tested locally.
- If key manager client is not up to date, `height` is not sent and after decoding takes a default value of `None`. Validation is skipped.
- If key manager client is up to date but `height` is lower than trust root's height, the client will receive an error, e.g. `private ephemeral key not available: call failed: height is not fresh`.
- If key manager is not up to date, the client will send `height` but it will not decode properly. The client will again receive an error, e.g. `private ephemeral key not available: call failed: unknown field`.
