### PR TITLE
go: Add consensus transaction prioritization

### DIFF
--- a/.changelog/4911.internal.md
+++ b/.changelog/4911.internal.md
@@ -1,0 +1,1 @@
+go: Add consensus transaction prioritization

--- a/go/consensus/tendermint/abci/mux.go
+++ b/go/consensus/tendermint/abci/mux.go
@@ -710,6 +710,7 @@ func (mux *abciMux) CheckTx(req types.RequestCheckTx) types.ResponseCheckTx {
 		Code:      types.CodeTypeOK,
 		GasWanted: int64(ctx.Gas().GasWanted()),
 		GasUsed:   int64(ctx.Gas().GasUsed()),
+		Priority:  ctx.GetPriority(),
 	}
 }
 

--- a/go/consensus/tendermint/api/context.go
+++ b/go/consensus/tendermint/api/context.go
@@ -72,6 +72,7 @@ type Context struct { // nolint: maligned
 	data          interface{}
 	events        []types.Event
 	gasAccountant GasAccountant
+	priority      int64
 
 	txSigner      signature.PublicKey
 	callerAddress staking.Address
@@ -108,6 +109,7 @@ func NewContext(
 		mode:          mode,
 		currentTime:   currentTime,
 		gasAccountant: gasAccountant,
+		priority:      0,
 		appState:      appState,
 		state:         state,
 		blockHeight:   blockHeight,
@@ -401,6 +403,18 @@ func (c *Context) InitialHeight() int64 {
 // BlockHeight returns the current block height.
 func (c *Context) BlockHeight() int64 {
 	return c.blockHeight
+}
+
+// SetPriority sets the current priority.
+// Higher number means higher priority.
+func (c *Context) SetPriority(p int64) {
+	c.priority = p
+}
+
+// GetPriority returns the current priority.
+// Higher number means higher priority.
+func (c *Context) GetPriority() int64 {
+	return c.priority
 }
 
 // BlockContext returns the current block context.

--- a/go/consensus/tendermint/apps/beacon/api.go
+++ b/go/consensus/tendermint/apps/beacon/api.go
@@ -17,6 +17,9 @@ const (
 	// AppName is the ABCI application name.
 	// Run before all other applications.
 	AppName string = "000_beacon"
+
+	// AppPriority is the base priority for the app's transactions.
+	AppPriority int64 = 100000
 )
 
 var (

--- a/go/consensus/tendermint/apps/beacon/beacon.go
+++ b/go/consensus/tendermint/apps/beacon/beacon.go
@@ -81,6 +81,8 @@ func (app *beaconApplication) ExecuteTx(ctx *api.Context, tx *transaction.Transa
 		return fmt.Errorf("beacon: failed to query consensus parameters: %w", err)
 	}
 
+	ctx.SetPriority(AppPriority)
+
 	return app.backend.ExecuteTx(ctx, state, params, tx)
 }
 

--- a/go/consensus/tendermint/apps/governance/api.go
+++ b/go/consensus/tendermint/apps/governance/api.go
@@ -10,6 +10,9 @@ const (
 
 	// AppName is the ABCI application name.
 	AppName string = "300_governance"
+
+	// AppPriority is the base priority for the app's transactions.
+	AppPriority int64 = 25000
 )
 
 var (

--- a/go/consensus/tendermint/apps/governance/governance.go
+++ b/go/consensus/tendermint/apps/governance/governance.go
@@ -65,6 +65,8 @@ func (app *governanceApplication) ExecuteTx(ctx *api.Context, tx *transaction.Tr
 		"tx", tx,
 	)
 
+	ctx.SetPriority(AppPriority)
+
 	switch tx.Method {
 	case governance.MethodSubmitProposal:
 		var proposalContent governance.ProposalContent

--- a/go/consensus/tendermint/apps/keymanager/api.go
+++ b/go/consensus/tendermint/apps/keymanager/api.go
@@ -9,6 +9,9 @@ const (
 
 	// AppName is the ABCI application name.
 	AppName string = "999_keymanager"
+
+	// AppPriority is the base priority for the app's transactions.
+	AppPriority int64 = 50000
 )
 
 var (

--- a/go/consensus/tendermint/apps/keymanager/keymanager.go
+++ b/go/consensus/tendermint/apps/keymanager/keymanager.go
@@ -67,6 +67,8 @@ func (app *keymanagerApplication) ExecuteMessage(ctx *tmapi.Context, kind, msg i
 func (app *keymanagerApplication) ExecuteTx(ctx *tmapi.Context, tx *transaction.Transaction) error {
 	state := keymanagerState.NewMutableState(ctx.State())
 
+	ctx.SetPriority(AppPriority)
+
 	switch tx.Method {
 	case api.MethodUpdatePolicy:
 		var sigPol api.SignedPolicySGX

--- a/go/consensus/tendermint/apps/registry/api.go
+++ b/go/consensus/tendermint/apps/registry/api.go
@@ -10,6 +10,9 @@ const (
 
 	// AppName is the ABCI application name.
 	AppName string = "200_registry"
+
+	// AppPriority is the base priority for the app's transactions.
+	AppPriority int64 = 50000
 )
 
 var (

--- a/go/consensus/tendermint/apps/registry/registry.go
+++ b/go/consensus/tendermint/apps/registry/registry.go
@@ -88,6 +88,8 @@ func (app *registryApplication) ExecuteMessage(ctx *api.Context, kind, msg inter
 func (app *registryApplication) ExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {
 	state := registryState.NewMutableState(ctx.State())
 
+	ctx.SetPriority(AppPriority)
+
 	switch tx.Method {
 	case registry.MethodRegisterEntity:
 		var sigEnt entity.SignedEntity
@@ -104,6 +106,7 @@ func (app *registryApplication) ExecuteTx(ctx *api.Context, tx *transaction.Tran
 		if err := cbor.Unmarshal(tx.Body, &sigNode); err != nil {
 			return err
 		}
+		ctx.SetPriority(AppPriority + 10000)
 		return app.registerNode(ctx, state, &sigNode)
 
 	case registry.MethodUnfreezeNode:

--- a/go/consensus/tendermint/apps/roothash/api.go
+++ b/go/consensus/tendermint/apps/roothash/api.go
@@ -17,6 +17,9 @@ const (
 
 	// AppName is the ABCI application name.
 	AppName string = "999_roothash"
+
+	// AppPriority is the base priority for the app's transactions.
+	AppPriority int64 = 15000
 )
 
 var (

--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -376,6 +376,8 @@ func (app *rootHashApplication) verifyRuntimeUpdate(ctx *tmapi.Context, rt *regi
 func (app *rootHashApplication) ExecuteTx(ctx *tmapi.Context, tx *transaction.Transaction) error {
 	state := roothashState.NewMutableState(ctx.State())
 
+	ctx.SetPriority(AppPriority)
+
 	switch tx.Method {
 	case roothash.MethodExecutorCommit:
 		var xc roothash.ExecutorCommit

--- a/go/consensus/tendermint/apps/staking/api.go
+++ b/go/consensus/tendermint/apps/staking/api.go
@@ -8,6 +8,9 @@ import (
 const (
 	// AppID is the unique application identifier.
 	AppID uint8 = 0x05
+
+	// AppPriority is the base priority for the app's transactions.
+	AppPriority int64 = 1000
 )
 
 var (

--- a/go/consensus/tendermint/apps/staking/staking.go
+++ b/go/consensus/tendermint/apps/staking/staking.go
@@ -141,6 +141,8 @@ func (app *stakingApplication) ExecuteMessage(ctx *api.Context, kind, msg interf
 func (app *stakingApplication) ExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {
 	state := stakingState.NewMutableState(ctx.State())
 
+	ctx.SetPriority(AppPriority)
+
 	switch tx.Method {
 	case staking.MethodTransfer:
 		var xfer staking.Transfer

--- a/go/consensus/tendermint/full/full.go
+++ b/go/consensus/tendermint/full/full.go
@@ -611,6 +611,7 @@ func (t *fullService) lazyInit() error {
 	tenderConfig.Consensus.CreateEmptyBlocks = true
 	tenderConfig.Consensus.CreateEmptyBlocksInterval = emptyBlockInterval
 	tenderConfig.Consensus.DebugUnsafeReplayRecoverCorruptedWAL = viper.GetBool(CfgDebugUnsafeReplayRecoverCorruptedWAL) && cmflags.DebugDontBlameOasis()
+	tenderConfig.Mempool.Version = tmconfig.MempoolV1
 	tenderConfig.Instrumentation.Prometheus = true
 	tenderConfig.Instrumentation.PrometheusListenAddr = ""
 	tenderConfig.TxIndex.Indexer = "null"


### PR DESCRIPTION
This PR adds support for consensus transaction prioritization using the V1 tendermint mempool implementation.

Here are the base priorities for our consensus apps:
```
consensus/tendermint/apps/beacon/api.go:		AppPriority int64 = 100000
consensus/tendermint/apps/keymanager/api.go:		AppPriority int64 = 50000
consensus/tendermint/apps/registry/api.go:		AppPriority int64 = 50000
consensus/tendermint/apps/governance/api.go:		AppPriority int64 = 25000
consensus/tendermint/apps/roothash/api.go:		AppPriority int64 = 15000
consensus/tendermint/apps/staking/api.go:		AppPriority int64 = 1000
consensus/tendermint/apps/scheduler/api.go:		AppPriority int64 = 0
consensus/tendermint/apps/supplementarysanity/api.go:	AppPriority int64 = 0
```
The reason why the `scheduler` and `supplementarysanity` have a priority of 0 is that they have no transactions.
Node registrations have a slightly higher priority of 60000 instead of the base 50000 used for other registry transactions.

I also experimented a bit with bumping various priorities based on the transaction contents -- e.g. roothash executor commits and proposer timeouts based on runtime stake, but I don't think it's worth the extra complexity.
I suggest we first try the basic version as implemented in this PR and we can always add the extra priority fudging later, once we're sure this works as intended.

In case of errors, the returned priority is 0, which I think makes most sense, so people won't be able to submit faulty transactions to fill up the high-priority part of the queue.