### PR TITLE
registry: Add ProveFreshness consensus layer transaction

### DIFF
--- a/.changelog/4916.feature.md
+++ b/.changelog/4916.feature.md
@@ -1,0 +1,6 @@
+registry: Add ProveFreshness consensus layer transaction
+
+Introducing new transaction that accepts a fixed-size binary blob of 32 bytes
+and always succeeds without doing any processing or state changes. Transaction
+is needed for client node TEE freshness verification and enabled via
+freshness_proofs parameter located in tee_features consensus parameter group.

--- a/go/common/node/tee.go
+++ b/go/common/node/tee.go
@@ -6,6 +6,10 @@ import "github.com/oasisprotocol/oasis-core/go/common/sgx/quote"
 type TEEFeatures struct {
 	// SGX contains the supported TEE features for Intel SGX.
 	SGX TEEFeaturesSGX `json:"sgx"`
+
+	// FreshnessProofs is a feature flag specifying whether ProveFreshness transactions are
+	// supported and processed, or ignored and handled as non-existing transactions.
+	FreshnessProofs bool `json:"freshness_proofs"`
 }
 
 // TEEFeaturesSGX are the supported Intel SGX-specific TEE features.

--- a/go/consensus/tendermint/apps/registry/registry.go
+++ b/go/consensus/tendermint/apps/registry/registry.go
@@ -94,24 +94,25 @@ func (app *registryApplication) ExecuteTx(ctx *api.Context, tx *transaction.Tran
 		if err := cbor.Unmarshal(tx.Body, &sigEnt); err != nil {
 			return err
 		}
-
 		return app.registerEntity(ctx, state, &sigEnt)
+
 	case registry.MethodDeregisterEntity:
 		return app.deregisterEntity(ctx, state)
+
 	case registry.MethodRegisterNode:
 		var sigNode node.MultiSignedNode
 		if err := cbor.Unmarshal(tx.Body, &sigNode); err != nil {
 			return err
 		}
-
 		return app.registerNode(ctx, state, &sigNode)
+
 	case registry.MethodUnfreezeNode:
 		var unfreeze registry.UnfreezeNode
 		if err := cbor.Unmarshal(tx.Body, &unfreeze); err != nil {
 			return err
 		}
-
 		return app.unfreezeNode(ctx, state, &unfreeze)
+
 	case registry.MethodRegisterRuntime:
 		var rt registry.Runtime
 		if err := cbor.Unmarshal(tx.Body, &rt); err != nil {
@@ -121,6 +122,20 @@ func (app *registryApplication) ExecuteTx(ctx *api.Context, tx *transaction.Tran
 			return err
 		}
 		return nil
+
+	case registry.MethodProveFreshness:
+		var blob [32]byte
+		if err := cbor.Unmarshal(tx.Body, &blob); err != nil {
+			ctx.Logger().Error("ExecuteTx: failed to unmarshal blob for freshness proof",
+				"err", err,
+			)
+			return registry.ErrInvalidArgument
+		}
+		if err := app.proveFreshness(ctx, state, blob); err != nil {
+			return err
+		}
+		return nil
+
 	default:
 		return registry.ErrInvalidArgument
 	}

--- a/go/consensus/tendermint/tests/genesis/genesis.go
+++ b/go/consensus/tendermint/tests/genesis/genesis.go
@@ -75,6 +75,12 @@ func NewTestNodeGenesisProvider(identity *identity.Identity, ent *entity.Entity,
 					registry.GovernanceEntity:  true,
 					registry.GovernanceRuntime: true,
 				},
+				TEEFeatures: &node.TEEFeatures{
+					SGX: node.TEEFeaturesSGX{
+						PCS: true,
+					},
+					FreshnessProofs: true,
+				},
 			},
 		},
 		Scheduler: scheduler.Genesis{

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -65,6 +65,7 @@ const (
 	cfgRegistryDebugBypassStake              = "registry.debug.bypass_stake" // nolint: gosec
 	cfgRegistryEnableRuntimeGovernanceModels = "registry.enable_runtime_governance_models"
 	CfgRegistryTEEFeaturesSGXPCS             = "registry.tee_features.sgx.pcs"
+	CfgRegistryTEEFeaturesFreshnessProofs    = "registry.tee_features.freshness_proofs"
 
 	// Scheduler config flags.
 	cfgSchedulerMinValidators          = "scheduler.min_validators"
@@ -345,11 +346,17 @@ func AppendRegistryState(doc *genesis.Document, entities, runtimes, nodes []stri
 	}
 
 	if viper.GetBool(CfgRegistryTEEFeaturesSGXPCS) {
-		regSt.Parameters.TEEFeatures = &node.TEEFeatures{
-			SGX: node.TEEFeaturesSGX{
-				PCS: true,
-			},
+		if regSt.Parameters.TEEFeatures == nil {
+			regSt.Parameters.TEEFeatures = &node.TEEFeatures{}
 		}
+		regSt.Parameters.TEEFeatures.SGX = node.TEEFeaturesSGX{PCS: true}
+	}
+
+	if viper.GetBool(CfgRegistryTEEFeaturesFreshnessProofs) {
+		if regSt.Parameters.TEEFeatures == nil {
+			regSt.Parameters.TEEFeatures = &node.TEEFeatures{}
+		}
+		regSt.Parameters.TEEFeatures.FreshnessProofs = true
 	}
 
 	for _, gmStr := range viper.GetStringSlice(cfgRegistryEnableRuntimeGovernanceModels) {
@@ -776,6 +783,7 @@ func init() {
 	initGenesisFlags.Bool(cfgRegistryDebugBypassStake, false, "bypass all stake checks and operations (UNSAFE)")
 	initGenesisFlags.StringSlice(cfgRegistryEnableRuntimeGovernanceModels, []string{"entity"}, "set of enabled runtime governance models")
 	initGenesisFlags.Bool(CfgRegistryTEEFeaturesSGXPCS, true, "enable PCS support for SGX TEEs")
+	initGenesisFlags.Bool(CfgRegistryTEEFeaturesFreshnessProofs, true, "enable freshness proofs")
 	_ = initGenesisFlags.MarkHidden(cfgRegistryDebugAllowUnroutableAddresses)
 	_ = initGenesisFlags.MarkHidden(CfgRegistryDebugAllowTestRuntimes)
 	_ = initGenesisFlags.MarkHidden(cfgRegistryDebugBypassStake)

--- a/go/oasis-test-runner/scenario/e2e/upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/upgrade.go
@@ -98,6 +98,12 @@ func (n *upgradeTeePcsChecker) PostUpgradeFn(ctx context.Context, ctrl *oasis.Co
 	if !registryParams.TEEFeatures.SGX.PCS {
 		return fmt.Errorf("PCS SGX TEE feature is disabled")
 	}
+	if !registryParams.TEEFeatures.FreshnessProofs {
+		return fmt.Errorf("freshness proofs TEE feature is disabled")
+	}
+	if registryParams.GasCosts[registry.GasOpProveFreshness] != registry.DefaultGasCosts[registry.GasOpProveFreshness] {
+		return fmt.Errorf("default gas cost for freshness proofs is not set")
+	}
 
 	return nil
 }

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -130,6 +130,8 @@ var (
 	MethodUnfreezeNode = transaction.NewMethodName(ModuleName, "UnfreezeNode", UnfreezeNode{})
 	// MethodRegisterRuntime is the method name for registering runtimes.
 	MethodRegisterRuntime = transaction.NewMethodName(ModuleName, "RegisterRuntime", Runtime{})
+	// MethodProveFreshness is the method name for freshness proofs.
+	MethodProveFreshness = transaction.NewMethodName(ModuleName, "ProveFreshness", Runtime{})
 
 	// Methods is the list of all methods supported by the registry backend.
 	Methods = []transaction.MethodName{
@@ -138,6 +140,7 @@ var (
 		MethodRegisterNode,
 		MethodUnfreezeNode,
 		MethodRegisterRuntime,
+		MethodProveFreshness,
 	}
 
 	// RuntimesRequiredRoles are the Node roles that require runtimes.
@@ -284,6 +287,11 @@ func NewUnfreezeNodeTx(nonce uint64, fee *transaction.Fee, unfreeze *UnfreezeNod
 // NewRegisterRuntimeTx creates a new register runtime transaction.
 func NewRegisterRuntimeTx(nonce uint64, fee *transaction.Fee, rt *Runtime) *transaction.Transaction {
 	return transaction.NewTransaction(nonce, fee, MethodRegisterRuntime, rt)
+}
+
+// NewProveFreshnessTx creates a new prove freshness transaction.
+func NewProveFreshnessTx(nonce uint64, fee *transaction.Fee, blob [32]byte) *transaction.Transaction {
+	return transaction.NewTransaction(nonce, fee, MethodProveFreshness, blob)
 }
 
 // EntityEvent is the event that is returned via WatchEntities to signify
@@ -1451,6 +1459,8 @@ const (
 	// GasOpUpdateKeyManager is the gas operation identifier for key manager
 	// policy updates costs.
 	GasOpUpdateKeyManager transaction.Op = "update_keymanager"
+	// GasOpProveFreshness is the gas operation identifier for freshness proofs.
+	GasOpProveFreshness transaction.Op = "prove_freshness"
 )
 
 // XXX: Define reasonable default gas costs.
@@ -1464,6 +1474,7 @@ var DefaultGasCosts = transaction.Costs{
 	GasOpRegisterRuntime:         1000,
 	GasOpRuntimeEpochMaintenance: 1000,
 	GasOpUpdateKeyManager:        1000,
+	GasOpProveFreshness:          1000,
 }
 
 const (

--- a/go/upgrade/migrations/consensus_tee_pcs.go
+++ b/go/upgrade/migrations/consensus_tee_pcs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
 	registryState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry/state"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 )
 
 const (
@@ -40,7 +41,11 @@ func (th *teePcsHandler) ConsensusUpgrade(ctx *Context, privateCtx interface{}) 
 			SGX: node.TEEFeaturesSGX{
 				PCS: true,
 			},
+			FreshnessProofs: true,
 		}
+
+		// Configure the default gas cost for freshness proofs.
+		params.GasCosts[registry.GasOpProveFreshness] = registry.DefaultGasCosts[registry.GasOpProveFreshness]
 
 		if err = state.SetConsensusParameters(abciCtx, params); err != nil {
 			return fmt.Errorf("failed to update registry consensus parameters: %w", err)


### PR DESCRIPTION
### Add ProveFreshness consensus layer transaction

This is needed for `Client node TEE freshness verification` and should be implemented in the following manner.

We can add a (carefully parameter-gated) new transaction (e.g. `registry.ProveFreshness`) that accepts a fixed-size binary blob of 32 bytes and always succeeds without doing any processing or state changes. It should cost a reasonable amount of gas.

The enablement parameter should be part of the existing `tee_features` consensus parameter group and be a boolean called `freshness_proofs`. If it is set to true the new transaction is processed otherwise it is handled as a non-existing transaction (e.g. exactly as currently to avoid breaking consensus before the activation proposal passes).

The existing `consensus-tee-pcs` migration should be updated to enable the `freshness_proofs` feature and configure the default gas cost.

### Test
Tested locally (sub-command `gen_prove_freshness` will be added latter to the CLI repository).
```
oasis-node registry node gen_prove_freshness \
  --transaction.fee.gas 1000 \
  --transaction.fee.amount 0 \
  --transaction.file=tx.txt \
  --genesis.file ../genesis.json \
  --debug.dont_blame_oasis \
  --debug.allow_test_keys \
  --log.level=DEBUG \
  --assume_yes

oasis-node consensus submit_tx --transaction.file tx.txt
```
If proofs are not enabled, I get the following error.
```
level=error ts=2022-08-31T06:55:44.773530442Z caller=grpc.go:242 module=grpc/client msg="request failed" method=/oasis-core.Consensus/SubmitTx req_seq=1 rsp=null err="registry: invalid argument"
level=error ts=2022-08-31T06:55:44.773585673Z caller=consensus.go:129 module=cmd/consensus msg="failed to submit transaction" err="registry: invalid argument"
```