### PR TITLE
runtime: Add client node TEE freshness verification

### DIFF
--- a/.changelog/4922.feature.md
+++ b/.changelog/4922.feature.md
@@ -1,0 +1,1 @@
+runtime: Add client node TEE freshness verification

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -155,6 +155,10 @@ type ClientBackend interface {
 	// in a block. Use SubmitTxNoWait if you only need to broadcast the transaction.
 	SubmitTx(ctx context.Context, tx *transaction.SignedTransaction) error
 
+	// SubmitTxWithProof submits a signed consensus transaction, waits for the transaction to be
+	// included in a block and returns a proof of inclusion.
+	SubmitTxWithProof(ctx context.Context, tx *transaction.SignedTransaction) (*transaction.Proof, error)
+
 	// StateToGenesis returns the genesis state at the specified block height.
 	StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error)
 

--- a/go/consensus/api/transaction/transaction.go
+++ b/go/consensus/api/transaction/transaction.go
@@ -345,3 +345,12 @@ func NewMethodName(module, method string, bodyType interface{}) MethodName {
 
 	return MethodName(name)
 }
+
+// Proof is a proof of transaction inclusion in a block.
+type Proof struct {
+	// Height is the block height at which the transaction was published.
+	Height int64 `json:"height"`
+
+	// RawProof is the actual raw proof.
+	RawProof []byte `json:"raw_proof"`
+}

--- a/go/consensus/api/transaction/transaction.go
+++ b/go/consensus/api/transaction/transaction.go
@@ -164,7 +164,7 @@ type PrettyTransaction struct {
 	Body   interface{} `json:"body,omitempty"`
 }
 
-// SignedTransaction is a signed transaction.
+// SignedTransaction is a signed consensus transaction.
 type SignedTransaction struct {
 	signature.Signed
 }

--- a/go/consensus/tendermint/full/common.go
+++ b/go/consensus/tendermint/full/common.go
@@ -764,6 +764,11 @@ func (n *commonNode) SubmitTx(ctx context.Context, tx *transaction.SignedTransac
 }
 
 // Implements consensusAPI.Backend.
+func (n *commonNode) SubmitTxWithProof(ctx context.Context, tx *transaction.SignedTransaction) (*transaction.Proof, error) {
+	return nil, consensusAPI.ErrUnsupported
+}
+
+// Implements consensusAPI.Backend.
 func (n *commonNode) GetUnconfirmedTransactions(ctx context.Context) ([][]byte, error) {
 	return nil, consensusAPI.ErrUnsupported
 }

--- a/go/consensus/tendermint/seed/seed.go
+++ b/go/consensus/tendermint/seed/seed.go
@@ -202,6 +202,11 @@ func (srv *seedService) SubmitTx(ctx context.Context, tx *transaction.SignedTran
 }
 
 // Implements consensus.Backend.
+func (srv *seedService) SubmitTxWithProof(ctx context.Context, tx *transaction.SignedTransaction) (*transaction.Proof, error) {
+	return nil, consensus.ErrUnsupported
+}
+
+// Implements consensus.Backend.
 func (srv *seedService) StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error) {
 	return nil, consensus.ErrUnsupported
 }

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/sgx/quote"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	consensusTx "github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	consensusResults "github.com/oasisprotocol/oasis-core/go/consensus/api/transaction/results"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
@@ -112,6 +113,8 @@ type Body struct {
 	HostFetchTxBatchResponse         *HostFetchTxBatchResponse         `json:",omitempty"`
 	HostFetchGenesisHeightRequest    *HostFetchGenesisHeightRequest    `json:",omitempty"`
 	HostFetchGenesisHeightResponse   *HostFetchGenesisHeightResponse   `json:",omitempty"`
+	HostProveFreshnessRequest        *HostProveFreshnessRequest        `json:",omitempty"`
+	HostProveFreshnessResponse       *HostProveFreshnessResponse       `json:",omitempty"`
 }
 
 // Type returns the message type by determining the name of the first non-nil member.
@@ -529,4 +532,17 @@ type HostFetchTxBatchRequest struct {
 type HostFetchTxBatchResponse struct {
 	// Batch is a batch of transactions.
 	Batch [][]byte `json:"batch,omitempty"`
+}
+
+// HostProveFreshnessRequest is a request to host to prove state freshness.
+type HostProveFreshnessRequest struct {
+	Blob [32]byte `json:"blob"`
+}
+
+// HostProveFreshnessResponse is a response from host proving state freshness.
+type HostProveFreshnessResponse struct {
+	// SignedTx is a signed prove freshness transaction.
+	SignedTx *consensusTx.SignedTransaction `json:"signed_tx"`
+	// Proof of transaction inclusion in a block.
+	Proof *consensusTx.Proof `json:"proof"`
 }

--- a/go/worker/common/committee/runtime_host.go
+++ b/go/worker/common/committee/runtime_host.go
@@ -3,6 +3,7 @@ package committee
 import (
 	"context"
 
+	"github.com/oasisprotocol/oasis-core/go/common/identity"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
@@ -42,6 +43,11 @@ func (env *nodeEnvironment) GetKeyManagerClient(ctx context.Context) (runtimeKey
 // GetTxPool implements RuntimeHostHandlerEnvironment.
 func (env *nodeEnvironment) GetTxPool(ctx context.Context) (txpool.TransactionPool, error) {
 	return env.n.TxPool, nil
+}
+
+// GetIdentity implements RuntimeHostHandlerEnvironment.
+func (env *nodeEnvironment) GetNodeIdentity(ctx context.Context) (*identity.Identity, error) {
+	return env.n.Identity, nil
 }
 
 // NewRuntimeHostHandler implements RuntimeHostHandlerFactory.

--- a/runtime/src/common/crypto/signature.rs
+++ b/runtime/src/common/crypto/signature.rs
@@ -178,6 +178,16 @@ impl Signature {
     }
 }
 
+/// Blob signed with one public key.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, cbor::Encode, cbor::Decode)]
+pub struct Signed {
+    /// Signed blob.
+    #[cbor(rename = "untrusted_raw_value")]
+    pub blob: Vec<u8>,
+    /// Signature over the blob.
+    pub signature: SignatureBundle,
+}
+
 /// Blob signed by multiple public keys.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, cbor::Encode, cbor::Decode)]
 pub struct MultiSigned {

--- a/runtime/src/common/crypto/signature.rs
+++ b/runtime/src/common/crypto/signature.rs
@@ -207,6 +207,16 @@ pub struct SignatureBundle {
     pub signature: Signature,
 }
 
+impl SignatureBundle {
+    /// Verify returns true iff the signature is valid over the given context
+    /// and message.
+    pub fn verify(&self, context: &[u8], message: &[u8]) -> bool {
+        self.signature
+            .verify(&self.public_key, context, message)
+            .is_ok()
+    }
+}
+
 /// A abstract signer.
 pub trait Signer: Send + Sync {
     /// Generates a signature over the context and message.

--- a/runtime/src/config.rs
+++ b/runtime/src/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     /// Whether storage state should be persisted between transaction check invocations. The state
     /// is invalidated on the next round.
     pub persist_check_tx_state: bool,
+    /// Whether TEE freshness is verified with freshness proofs.
+    pub freshness_proofs: bool,
 }
 
 /// Storage-related configuration.

--- a/runtime/src/consensus/mod.rs
+++ b/runtime/src/consensus/mod.rs
@@ -9,6 +9,7 @@ pub mod scheduler;
 pub mod staking;
 pub mod state;
 pub mod tendermint;
+pub mod transaction;
 pub mod verifier;
 
 /// The height that represents the most recent block height.

--- a/runtime/src/consensus/tendermint/merkle.rs
+++ b/runtime/src/consensus/tendermint/merkle.rs
@@ -1,0 +1,185 @@
+//! Merkle proofs used in Tendermint networks
+//!
+//! Rewritten to Rust from:
+//! https://github.com/tendermint/tendermint/blob/main/crypto/merkle/proof.go
+//!
+//! Helper functions copied from:
+//! https://github.com/informalsystems/tendermint-rs/blob/main/tendermint/src/merkle.rs
+
+use std::cmp::Ordering;
+
+use anyhow::{anyhow, Result};
+use rustc_hex::ToHex;
+use sha2::{Digest, Sha256};
+
+use tendermint::merkle::{Hash, HASH_SIZE};
+
+/// Maximum number of aunts that can be included in a Proof.
+/// This corresponds to a tree of size 2^100, which should be sufficient for all conceivable purposes.
+/// This maximum helps prevent Denial-of-Service attacks by limiting the size of the proofs.
+pub const MAX_AUNTS: usize = 100;
+
+/// Proof represents a Merkle proof.
+///
+/// NOTE: The convention for proofs is to include leaf hashes but to
+/// exclude the root hash.
+/// This convention is implemented across IAVL range proofs as well.
+/// Keep this consistent unless there's a very good reason to change
+/// everything.  This also affects the generalized proof system as
+/// well.
+#[derive(Debug, Default, cbor::Encode, cbor::Decode)]
+pub struct Proof {
+    pub total: i64,       // Total number of items.
+    pub index: i64,       // Index of item to prove.
+    pub leaf_hash: Hash,  // Hash of item value.
+    pub aunts: Vec<Hash>, // Hashes from leaf's sibling to a root's child.
+}
+
+impl Proof {
+    /// Verify that the Proof proves the root hash.
+    /// Check index/total manually if needed.
+    pub fn verify(&self, root_hash: Hash, leaf: Hash) -> Result<()> {
+        if self.total < 0 {
+            return Err(anyhow!("proof total must be positive"));
+        }
+        if self.index < 0 {
+            return Err(anyhow!("proof index cannot be negative"));
+        }
+        if self.aunts.len() > MAX_AUNTS {
+            return Err(anyhow!(
+                "expected no more than {} aunts, got {}",
+                MAX_AUNTS,
+                self.aunts.len()
+            ));
+        }
+
+        let leaf_hash = leaf_hash(&leaf);
+        match self.leaf_hash.cmp(&leaf_hash) {
+            Ordering::Equal => (),
+            _ => {
+                return Err(anyhow!(
+                    "invalid leaf hash: wanted {} got {}",
+                    leaf_hash.to_hex::<String>(),
+                    self.leaf_hash.to_hex::<String>(),
+                ));
+            }
+        }
+
+        let computed_hash = self.compute_root_hash().ok_or_else(|| {
+            anyhow!(
+                "invalid root hash: wanted {} got None",
+                root_hash.to_hex::<String>()
+            )
+        })?;
+        match computed_hash.cmp(&root_hash) {
+            Ordering::Equal => (),
+            _ => {
+                return Err(anyhow!(
+                    "invalid root hash: wanted {} got {}",
+                    root_hash.to_hex::<String>(),
+                    computed_hash.to_hex::<String>(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Compute the root hash given a leaf hash. Does not verify the result.
+    pub fn compute_root_hash(&self) -> Option<Hash> {
+        Self::compute_hash_from_aunts(self.index, self.total, self.leaf_hash, &self.aunts)
+    }
+
+    /// Use the leaf_hash and inner_hashes to get the root merkle hash.
+    /// If the length of the inner_hashes slice isn't exactly correct, the result is None.
+    /// Recursive impl.
+    fn compute_hash_from_aunts(
+        index: i64,
+        total: i64,
+        leaf_hash: Hash,
+        inner_hashes: &[Hash],
+    ) -> Option<Hash> {
+        if index >= total || index < 0 || total <= 0 {
+            return None;
+        }
+        match total {
+            0 => unreachable!("cannot call compute_hash_from_aunts() with 0 total"), // Handled above.
+            1 => {
+                if !inner_hashes.is_empty() {
+                    return None;
+                }
+                Some(leaf_hash)
+            }
+            _ => {
+                if inner_hashes.is_empty() {
+                    return None;
+                }
+                let last_idx = inner_hashes.len() - 1;
+                let last_hash = inner_hashes[last_idx];
+                let inner_hashes = &inner_hashes[..last_idx];
+
+                let num_left = get_split_point(total as usize) as i64;
+                if index < num_left {
+                    if let Some(left_hash) =
+                        Self::compute_hash_from_aunts(index, num_left, leaf_hash, inner_hashes)
+                    {
+                        return Some(inner_hash(&left_hash, &last_hash));
+                    }
+                    return None;
+                }
+                if let Some(right_hash) = Self::compute_hash_from_aunts(
+                    index - num_left,
+                    total - num_left,
+                    leaf_hash,
+                    inner_hashes,
+                ) {
+                    return Some(inner_hash(&last_hash, &right_hash));
+                }
+                None
+            }
+        }
+    }
+}
+
+/// returns the largest power of 2 less than length
+fn get_split_point(length: usize) -> usize {
+    match length {
+        0 => panic!("tree is empty!"),
+        1 => panic!("tree has only one element!"),
+        2 => 1,
+        _ => length.next_power_of_two() / 2,
+    }
+}
+
+/// tmhash(0x00 || leaf)
+fn leaf_hash(bytes: &[u8]) -> Hash {
+    // make a new array starting with 0 and copy in the bytes
+    let mut leaf_bytes = Vec::with_capacity(bytes.len() + 1);
+    leaf_bytes.push(0x00);
+    leaf_bytes.extend_from_slice(bytes);
+
+    // hash it !
+    let digest = Sha256::digest(&leaf_bytes);
+
+    // copy the GenericArray out
+    let mut hash_bytes = [0u8; HASH_SIZE];
+    hash_bytes.copy_from_slice(&digest);
+    hash_bytes
+}
+
+/// tmhash(0x01 || left || right)
+fn inner_hash(left: &[u8], right: &[u8]) -> Hash {
+    // make a new array starting with 0x1 and copy in the bytes
+    let mut inner_bytes = Vec::with_capacity(left.len() + right.len() + 1);
+    inner_bytes.push(0x01);
+    inner_bytes.extend_from_slice(left);
+    inner_bytes.extend_from_slice(right);
+
+    // hash it !
+    let digest = Sha256::digest(&inner_bytes);
+
+    // copy the GenericArray out
+    let mut hash_bytes = [0u8; HASH_SIZE];
+    hash_bytes.copy_from_slice(&digest);
+    hash_bytes
+}

--- a/runtime/src/consensus/tendermint/mod.rs
+++ b/runtime/src/consensus/tendermint/mod.rs
@@ -1,5 +1,6 @@
 //! Tendermint consensus layer backend.
 
+pub mod merkle;
 mod store;
 pub mod verifier;
 

--- a/runtime/src/consensus/tendermint/verifier.rs
+++ b/runtime/src/consensus/tendermint/verifier.rs
@@ -368,7 +368,13 @@ impl Verifier {
             return Ok(None);
         };
 
-        verify_state_freshness(state, &self.trust_root, rak, &self.runtime_version, node_id)
+        verify_state_freshness(
+            state,
+            rak,
+            &self.trust_root.runtime_id,
+            &self.runtime_version,
+            node_id,
+        )
     }
 
     fn verify(

--- a/runtime/src/consensus/transaction.rs
+++ b/runtime/src/consensus/transaction.rs
@@ -1,0 +1,37 @@
+use crate::common::{crypto::signature::Signed, quantity::Quantity};
+
+pub const SIGNATURE_CONTEXT: &[u8] = b"oasis-core/consensus: tx for chain ";
+
+/// Unsigned consensus transaction.
+#[derive(Debug, cbor::Encode, cbor::Decode)]
+#[cbor(no_default)]
+pub struct Transaction {
+    /// Nonce to prevent replay.
+    pub nonce: u64,
+    /// Optional fee that the sender commits to pay to execute this transaction.
+    pub fee: Option<Fee>,
+
+    /// Method that should be called.
+    pub method: MethodName,
+    /// Method call body.
+    pub body: cbor::Value,
+}
+
+/// Signed consensus transaction.
+pub type SignedTransaction = Signed;
+
+/// Consensus transaction fee the sender wishes to pay for operations which
+/// require a fee to be paid to validators.
+#[derive(Debug, Default, cbor::Encode, cbor::Decode)]
+pub struct Fee {
+    /// Fee amount to be paid.
+    pub amount: Quantity,
+    /// Maximum gas that a transaction can use.
+    pub gas: Gas,
+}
+
+/// Consensus gas representation.
+pub type Gas = u64;
+
+/// Method name.
+pub type MethodName = String;

--- a/runtime/src/consensus/transaction.rs
+++ b/runtime/src/consensus/transaction.rs
@@ -35,3 +35,12 @@ pub type Gas = u64;
 
 /// Method name.
 pub type MethodName = String;
+
+/// Proof of transaction inclusion in a block.
+#[derive(Debug, Default, cbor::Encode, cbor::Decode)]
+pub struct Proof {
+    /// Block height at which the transaction was published.
+    pub height: u64,
+    /// Actual raw proof.
+    pub raw_proof: Vec<u8>,
+}

--- a/runtime/src/consensus/verifier.rs
+++ b/runtime/src/consensus/verifier.rs
@@ -31,6 +31,9 @@ pub enum Error {
     #[error("consensus chain context transition failed: {0}")]
     ChainContextTransitionFailed(#[source] anyhow::Error),
 
+    #[error("freshness verification: {0}")]
+    FreshnessVerificationFailed(#[source] anyhow::Error),
+
     #[error("internal consensus verifier error")]
     Internal,
 }
@@ -42,7 +45,8 @@ impl Error {
             Error::VerificationFailed(_) => 2,
             Error::TrustedStateLoadingFailed => 3,
             Error::ChainContextTransitionFailed(_) => 4,
-            Error::Internal => 5,
+            Error::FreshnessVerificationFailed(_) => 5,
+            Error::Internal => 6,
         }
     }
 }

--- a/runtime/src/consensus/verifier.rs
+++ b/runtime/src/consensus/verifier.rs
@@ -200,8 +200,8 @@ pub struct TrustedState {
 /// passed in order to optimize discovery for subsequent runs.
 pub fn verify_state_freshness(
     state: &ConsensusState,
-    trust_root: &TrustRoot,
     rak: &RAK,
+    runtime_id: &Namespace,
     version: &Version,
     node_id: &Option<PublicKey>,
 ) -> Result<Option<PublicKey>, Error> {
@@ -224,7 +224,7 @@ pub fn verify_state_freshness(
                     node_id,
                 ))
             })?;
-            if !node.has_tee(rak, &trust_root.runtime_id, version) {
+            if !node.has_tee(rak, runtime_id, version) {
                 return Err(Error::VerificationFailed(anyhow!(
                     "own RAK not found in registry state"
                 )));
@@ -242,7 +242,7 @@ pub fn verify_state_freshness(
             })?;
             let mut found_node: Option<PublicKey> = None;
             for node in nodes {
-                if node.has_tee(rak, &trust_root.runtime_id, version) {
+                if node.has_tee(rak, runtime_id, version) {
                     found_node = Some(node.id);
                     break;
                 }

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -17,6 +17,7 @@ use crate::{
         self,
         beacon::EpochTime,
         roothash::{self, Block, ComputeResultsHeader, Header},
+        transaction::{Proof, SignedTransaction},
         LightBlock,
     },
     enclave_rpc,
@@ -244,6 +245,13 @@ pub enum Body {
     HostFetchGenesisHeightRequest {},
     HostFetchGenesisHeightResponse {
         height: u64,
+    },
+    HostProveFreshnessRequest {
+        blob: Vec<u8>,
+    },
+    HostProveFreshnessResponse {
+        signed_tx: SignedTransaction,
+        proof: Proof,
     },
 }
 

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -419,6 +419,7 @@ pub fn main_with_version(version: Version) {
                     initial_batch_size: MAX_BATCH_SIZE.try_into().unwrap(),
                 }),
             }),
+            freshness_proofs: true,
             ..Default::default()
         },
     );


### PR DESCRIPTION
### Add client node TEE freshness verification
Executor and key manager TEE nodes currently use node registration (which includes the randomly generated Runtime Attestation Key and nonce) in order to establish consensus layer view freshness.

But this approach doesn’t work for client nodes. Since client nodes do not currently register, there is no way for TEE runtimes running on them to verify consensus layer freshness. There is however a need for client nodes to be able to execute signed queries and requiring an up-to-date consensus layer view is crucial for verifying quotes and policies.

To do this the runtime just needs to generate a transaction containing a nonce and that transaction must be published in a block, with the host node providing the height at which the transaction was published, its index and Merkle proof of inclusion. The runtime can then use the light client to verify the specified block header and the provided Merkle proof using the verified transaction root hash.

The newly added `registry.ProveFreshness` transaction that accepts a fixed-size binary blob of 32 bytes and always succeeds without doing any processing should be used for this purpose. The runtime host protocol should be extended to support this new flow, initiated by the consensus verifier in the runtime (immediately after initializing the light client in case enabled in the static runtime config), e.g. adding the `HostProveFreshness{Request,Response}` messages.

Note that this check can be used very early on as it doesn’t require the node to be registered.

### Test
Unhappy path tested locally. Happy path already included in trust root tests.