### PR TITLE
keymanager: Verify that policy was published in the consensus layer

### DIFF
--- a/.changelog/4925.feature.md
+++ b/.changelog/4925.feature.md
@@ -1,0 +1,1 @@
+keymanager: Verify that policy was published in the consensus layer

--- a/go/consensus/tendermint/apps/keymanager/state/interop/interop.go
+++ b/go/consensus/tendermint/apps/keymanager/state/interop/interop.go
@@ -1,0 +1,126 @@
+package interop
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
+	"github.com/oasisprotocol/oasis-core/go/common/sgx"
+	kmState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/keymanager/state"
+	kmApi "github.com/oasisprotocol/oasis-core/go/keymanager/api"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs"
+)
+
+// InitializeTestKeyManagerState must be kept in sync with tests in runtimes/consensus/state/keymanager.rs.
+func InitializeTestKeyManagerState(ctx context.Context, mkvs mkvs.Tree) error {
+	state := kmState.NewMutableState(mkvs)
+
+	// One runtime, two key manager runtimes.
+	var runtime, keymanager1, keymanager2 common.Namespace
+	if err := runtime.UnmarshalHex("8000000000000000000000000000000000000000000000000000000000000000"); err != nil {
+		return err
+	}
+	if err := keymanager1.UnmarshalHex("c000000000000000fffffffffffffffffffffffffffffffffffffffffffffffe"); err != nil {
+		return err
+	}
+	if err := keymanager2.UnmarshalHex("c000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff"); err != nil {
+		return err
+	}
+
+	// Three enclave identities.
+	var runtimeEnclave, keymanagerEnclave1, keymanagerEnclave2 sgx.EnclaveIdentity
+	if err := runtimeEnclave.MrEnclave.UnmarshalHex("18256f783c071521be2da041cd9347b5bdb5a8ef58fb34658571a6e14cf1fcb0"); err != nil {
+		return err
+	}
+	if err := runtimeEnclave.MrSigner.UnmarshalHex("e48049d1de0eb333523991671a6c93b97dd65bcf09273d5b6bfe8262dc968ec7"); err != nil {
+		return err
+	}
+	if err := keymanagerEnclave1.MrEnclave.UnmarshalHex("c9a589851b1f35627177fd70378ed778170f737611e4dfbf0b6d25bdff55b474"); err != nil {
+		return err
+	}
+	if err := keymanagerEnclave1.MrSigner.UnmarshalHex("7d310664780931ae103ab30a90171c201af385a72757bb4683578fdebde9adf5"); err != nil {
+		return err
+	}
+	if err := keymanagerEnclave2.MrEnclave.UnmarshalHex("756eaf76f5482c5345808b1eaccdd5c60f864bb2aa2d2b870df00ce435af4e23"); err != nil {
+		return err
+	}
+	if err := keymanagerEnclave2.MrSigner.UnmarshalHex("3597a2ff0743016f28e5d7e129304ee1c43dbdae3dba94e19cee3549038a5a32"); err != nil {
+		return err
+	}
+
+	// Signed policy.
+	enclavePolicySGX := kmApi.EnclavePolicySGX{
+		MayQuery: map[common.Namespace][]sgx.EnclaveIdentity{
+			runtime: {
+				runtimeEnclave,
+			},
+		},
+		MayReplicate: []sgx.EnclaveIdentity{
+			keymanagerEnclave2,
+		},
+	}
+	policy := kmApi.PolicySGX{
+		Serial: 1,
+		ID:     keymanager2,
+		Enclaves: map[sgx.EnclaveIdentity]*kmApi.EnclavePolicySGX{
+			keymanagerEnclave1: &enclavePolicySGX,
+		},
+	}
+	sigPolicy := kmApi.SignedPolicySGX{
+		Policy:     policy,
+		Signatures: []signature.Signature{},
+	}
+
+	// Two signers.
+	signers := []signature.Signer{
+		memorySigner.NewTestSigner("first signer"),
+		memorySigner.NewTestSigner("second signer"),
+	}
+
+	for _, signer := range signers {
+		sig, err := signature.Sign(signer, kmApi.PolicySGXSignatureContext, cbor.Marshal(policy))
+		if err != nil {
+			return fmt.Errorf("failed to sign policy: %w", err)
+		}
+		sigPolicy.Signatures = append(sigPolicy.Signatures, *sig)
+	}
+
+	// Random checksum.
+	checksum, err := hex.DecodeString("1bff211fae98c88ba82388ae954b88a71d3bbe327e162e9fa711fe7a1b759c3e")
+	if err != nil {
+		return err
+	}
+
+	// Add two statuses.
+	for _, status := range []*kmApi.Status{
+		{
+			ID:            keymanager1,
+			IsInitialized: false,
+			IsSecure:      false,
+			Checksum:      nil,
+			Nodes:         nil,
+			Policy:        nil,
+		},
+		{
+			ID:            keymanager2,
+			IsInitialized: true,
+			IsSecure:      true,
+			Checksum:      checksum,
+			Nodes: []signature.PublicKey{
+				signers[0].Public(),
+				signers[1].Public(),
+			},
+			Policy: &sigPolicy,
+		},
+	} {
+		if err := state.SetStatus(ctx, status); err != nil {
+			return fmt.Errorf("setting key manager status: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/go/storage/mkvs/interop/fixtures/consensus_mock.go
+++ b/go/storage/mkvs/interop/fixtures/consensus_mock.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	beaconInterop "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/beacon/state/interop"
+	keymanagerInterop "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/keymanager/state/interop"
 	registryInterop "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry/state/interop"
 	stakingInterop "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/staking/state/interop"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
@@ -40,6 +41,9 @@ func (c *consensusMock) Populate(ctx context.Context, ndb db.NodeDB) (*node.Root
 	}
 	if err = registryInterop.InitializeTestRegistryState(ctx, mkvsTree); err != nil {
 		return nil, fmt.Errorf("consensus-mock: failed to initialize registry state: %w", err)
+	}
+	if err = keymanagerInterop.InitializeTestKeyManagerState(ctx, mkvsTree); err != nil {
+		return nil, fmt.Errorf("consensus-mock: failed to initialize key manager state: %w", err)
 	}
 	_, testRoot.Hash, err = mkvsTree.Commit(ctx, common.Namespace{}, 1)
 	if err != nil {

--- a/runtime/src/common/crypto/signature.rs
+++ b/runtime/src/common/crypto/signature.rs
@@ -192,7 +192,7 @@ pub struct MultiSigned {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, cbor::Encode, cbor::Decode)]
 pub struct SignatureBundle {
     /// Public key that produced the signature.
-    pub public_key: Option<PublicKey>,
+    pub public_key: PublicKey,
     /// Actual signature.
     pub signature: Signature,
 }

--- a/runtime/src/consensus/keymanager.rs
+++ b/runtime/src/consensus/keymanager.rs
@@ -1,0 +1,52 @@
+use std::{collections::HashMap, default::Default};
+
+use thiserror::Error;
+
+use crate::common::{
+    crypto::signature::SignatureBundle, namespace::Namespace, sgx::EnclaveIdentity,
+};
+
+const POLICY_SIGN_CONTEXT: &[u8] = b"oasis-core/keymanager: policy";
+
+/// Errors emitted by the key manager module.
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("invalid signature")]
+    InvalidSignature,
+}
+
+/// Key manager access control policy.
+#[derive(Clone, Debug, Default, PartialEq, Eq, cbor::Encode, cbor::Decode)]
+pub struct PolicySGX {
+    pub serial: u32,
+    pub id: Namespace,
+    pub enclaves: HashMap<EnclaveIdentity, EnclavePolicySGX>,
+}
+
+/// Per enclave key manager access control policy.
+#[derive(Clone, Debug, Default, PartialEq, Eq, cbor::Encode, cbor::Decode)]
+pub struct EnclavePolicySGX {
+    pub may_query: HashMap<Namespace, Vec<EnclaveIdentity>>,
+    pub may_replicate: Vec<EnclaveIdentity>,
+}
+
+/// Signed key manager access control policy.
+#[derive(Clone, Debug, Default, PartialEq, Eq, cbor::Encode, cbor::Decode)]
+pub struct SignedPolicySGX {
+    pub policy: PolicySGX,
+    pub signatures: Vec<SignatureBundle>,
+}
+
+impl SignedPolicySGX {
+    /// Verify the signatures.
+    pub fn verify(&self) -> Result<&PolicySGX, Error> {
+        let raw_policy = cbor::to_vec(self.policy.clone());
+        for sig in &self.signatures {
+            sig.signature
+                .verify(&sig.public_key, POLICY_SIGN_CONTEXT, &raw_policy)
+                .map_err(|_| Error::InvalidSignature)?;
+        }
+
+        Ok(&self.policy)
+    }
+}

--- a/runtime/src/consensus/mod.rs
+++ b/runtime/src/consensus/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod address;
 pub mod beacon;
+pub mod keymanager;
 pub mod registry;
 pub mod roothash;
 pub mod scheduler;

--- a/runtime/src/consensus/state/beacon.rs
+++ b/runtime/src/consensus/state/beacon.rs
@@ -169,7 +169,7 @@ mod test {
         let mock_consensus_root = Root {
             version: 1,
             root_type: RootType::State,
-            hash: Hash::from("9fd36f15cd4ff0b856de1606ddda9a08eeb14d73346b7b3a9e0f36e853b02a1e"),
+            hash: Hash::from("f62f1f313de3833830a48b742f144fba542412e7ec65705d83f71a5e6e99bb2b"),
             ..Default::default()
         };
         let mkvs = Tree::builder()

--- a/runtime/src/consensus/state/keymanager.rs
+++ b/runtime/src/consensus/state/keymanager.rs
@@ -1,0 +1,231 @@
+//! Key manager state in the consensus layer.
+use std::default::Default;
+
+use anyhow::anyhow;
+use io_context::Context;
+
+use crate::{
+    common::{
+        crypto::{hash::Hash, signature::PublicKey},
+        key_format::{KeyFormat, KeyFormatAtom},
+        namespace::Namespace,
+    },
+    consensus::{keymanager::SignedPolicySGX, state::StateError},
+    key_format,
+    storage::mkvs::ImmutableMKVS,
+};
+
+/// Consensus key manager state wrapper.
+pub struct ImmutableState<'a, T: ImmutableMKVS> {
+    mkvs: &'a T,
+}
+
+impl<'a, T: ImmutableMKVS> ImmutableState<'a, T> {
+    /// Constructs a new ImmutableMKVS.
+    pub fn new(mkvs: &'a T) -> ImmutableState<'a, T> {
+        ImmutableState { mkvs }
+    }
+}
+
+key_format!(StatusKeyFmt, 0x70, Hash);
+
+/// Current key manager status.
+#[derive(Clone, Debug, Default, PartialEq, Eq, cbor::Decode, cbor::Encode)]
+pub struct Status {
+    /// Runtime ID of the key manager.
+    pub id: Namespace,
+    /// True iff the key manager is done initializing.
+    pub is_initialized: bool,
+    /// True iff the key manager is secure.
+    pub is_secure: bool,
+    /// Key manager master secret verification checksum.
+    pub checksum: Vec<u8>,
+    /// List of currently active key manager node IDs.
+    pub nodes: Vec<PublicKey>,
+    /// Key manager policy.
+    pub policy: Option<SignedPolicySGX>,
+}
+
+impl<'a, T: ImmutableMKVS> ImmutableState<'a, T> {
+    /// Looks up a specific key manager status by its namespace identifier.
+    pub fn status(&self, ctx: Context, id: Namespace) -> Result<Option<Status>, StateError> {
+        let h = Hash::digest_bytes(id.as_ref());
+        match self.mkvs.get(ctx, &StatusKeyFmt(h).encode()) {
+            Ok(Some(b)) => Ok(Some(self.decode_status(&b)?)),
+            Ok(None) => Ok(None),
+            Err(err) => Err(StateError::Unavailable(anyhow!(err))),
+        }
+    }
+
+    /// Returns the list of all key manager statuses.
+    pub fn statuses(&self, ctx: Context) -> Result<Vec<Status>, StateError> {
+        let mut it = self.mkvs.iter(ctx);
+        it.seek(&StatusKeyFmt::default().encode_partial(0));
+
+        let mut result: Vec<Status> = Vec::new();
+
+        while let Some(value) = it
+            .next()
+            .and_then(|(key, value)| StatusKeyFmt::decode(&key).map(|_| value))
+        {
+            result.push(self.decode_status(&value)?)
+        }
+
+        Ok(result)
+    }
+
+    fn decode_status(&self, data: &[u8]) -> Result<Status, StateError> {
+        cbor::from_slice(data).map_err(|err| StateError::Unavailable(anyhow!(err)))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{collections::HashMap, default::Default, sync::Arc, vec};
+
+    use io_context::Context;
+    use rustc_hex::FromHex;
+
+    use super::*;
+    use crate::{
+        common::{
+            crypto::{
+                hash::Hash,
+                signature::{Signature, SignatureBundle},
+            },
+            namespace::Namespace,
+            sgx::{EnclaveIdentity, MrEnclave, MrSigner},
+        },
+        consensus::keymanager::{EnclavePolicySGX, PolicySGX},
+        storage::mkvs::{
+            interop::{Fixture, ProtocolServer},
+            Root, RootType, Tree,
+        },
+    };
+
+    #[test]
+    fn test_keymanager_state_interop() {
+        // Keep in sync with go/consensus/tendermint/apps/keymanager/state/interop/interop.go.
+        // If mock consensus state changes, update the root hash bellow.
+        // See protocol server stdout for hash.
+
+        // Setup protocol server with initialized mock consensus state.
+        let server = ProtocolServer::new(Fixture::ConsensusMock.into());
+        let mock_consensus_root = Root {
+            version: 1,
+            root_type: RootType::State,
+            hash: Hash::from("f62f1f313de3833830a48b742f144fba542412e7ec65705d83f71a5e6e99bb2b"),
+            ..Default::default()
+        };
+        let mkvs = Tree::builder()
+            .with_capacity(100_000, 10_000_000)
+            .with_root(mock_consensus_root)
+            .build(server.read_sync());
+        let keymanager_state = ImmutableState::new(&mkvs);
+
+        let ctx = Arc::new(Context::background());
+
+        // Prepare expected results.
+        let runtime =
+            Namespace::from("8000000000000000000000000000000000000000000000000000000000000000");
+        let keymanager1 =
+            Namespace::from("c000000000000000fffffffffffffffffffffffffffffffffffffffffffffffe");
+        let keymanager2 =
+            Namespace::from("c000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff");
+        let runtime_enclave = EnclaveIdentity {
+            mr_enclave: MrEnclave::from(
+                "18256f783c071521be2da041cd9347b5bdb5a8ef58fb34658571a6e14cf1fcb0",
+            ),
+            mr_signer: MrSigner::from(
+                "e48049d1de0eb333523991671a6c93b97dd65bcf09273d5b6bfe8262dc968ec7",
+            ),
+        };
+        let keymanager_enclave1 = EnclaveIdentity {
+            mr_enclave: MrEnclave::from(
+                "c9a589851b1f35627177fd70378ed778170f737611e4dfbf0b6d25bdff55b474",
+            ),
+            mr_signer: MrSigner::from(
+                "7d310664780931ae103ab30a90171c201af385a72757bb4683578fdebde9adf5",
+            ),
+        };
+        let keymanager_enclave2 = EnclaveIdentity {
+            mr_enclave: MrEnclave::from(
+                "756eaf76f5482c5345808b1eaccdd5c60f864bb2aa2d2b870df00ce435af4e23",
+            ),
+            mr_signer: MrSigner::from(
+                "3597a2ff0743016f28e5d7e129304ee1c43dbdae3dba94e19cee3549038a5a32",
+            ),
+        };
+        let signer1 =
+            PublicKey::from("96533c123a6f4d33c68357109c2eb7c6e6a0f947be3ae1e320d153f561523ff2");
+        let signer2 =
+            PublicKey::from("4b97bfd95e829d5838131492b5c133e66ac6ef0db414c0be6207ec78c12d2b17");
+        let sig1 = Signature::from("37d04567456cab63004d54acacc60afb9d2315d5890401080d60b059cdd9088af5441974d0f53c2fca628877f0721780d8b79b66e92440ad120b44a5fce7be05");
+        let sig2 = Signature::from("7d76c6d0914f32f3abd33db51d95ca13c03c9313f4eb84bbecc4c5571ff51373d65b774bafae3e82677a6d4dd35f30b1d6751db0b3acc5e1b2c7811b67bf9801");
+        let checksum = "1bff211fae98c88ba82388ae954b88a71d3bbe327e162e9fa711fe7a1b759c3e"
+            .from_hex()
+            .unwrap();
+
+        let expected_statuses = vec![
+            Status {
+                id: keymanager1,
+                is_initialized: false,
+                is_secure: false,
+                checksum: vec![],
+                nodes: vec![],
+                policy: None,
+            },
+            Status {
+                id: keymanager2,
+                is_initialized: true,
+                is_secure: true,
+                checksum: checksum,
+                nodes: vec![signer1, signer2],
+                policy: Some(SignedPolicySGX {
+                    policy: PolicySGX {
+                        serial: 1,
+                        id: keymanager2,
+                        enclaves: HashMap::from([(
+                            keymanager_enclave1,
+                            EnclavePolicySGX {
+                                may_query: HashMap::from([(runtime, vec![runtime_enclave])]),
+                                may_replicate: vec![keymanager_enclave2],
+                            },
+                        )]),
+                    },
+                    signatures: vec![
+                        SignatureBundle {
+                            public_key: signer1,
+                            signature: sig1,
+                        },
+                        SignatureBundle {
+                            public_key: signer2,
+                            signature: sig2,
+                        },
+                    ],
+                }),
+            },
+        ];
+
+        // Test statuses.
+        let mut statuses = keymanager_state
+            .statuses(Context::create_child(&ctx))
+            .expect("statuses query should work");
+        statuses.sort_by(|a, b| a.id.partial_cmp(&b.id).unwrap());
+        assert_eq!(statuses, expected_statuses, "invalid statuses");
+
+        // Test status.
+        let status = keymanager_state
+            .status(Context::create_child(&ctx), expected_statuses[1].id)
+            .expect("status query should work")
+            .expect("status query should return a result");
+        assert_eq!(status, expected_statuses[1], "invalid status");
+
+        let id =
+            Namespace::from("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        let status = keymanager_state
+            .status(Context::create_child(&ctx), id)
+            .expect("status query should work");
+        assert_eq!(status, None, "invalid status");
+    }
+}

--- a/runtime/src/consensus/state/mod.rs
+++ b/runtime/src/consensus/state/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 
 pub mod beacon;
+pub mod keymanager;
 pub mod registry;
 pub mod roothash;
 pub mod staking;

--- a/runtime/src/consensus/state/registry.rs
+++ b/runtime/src/consensus/state/registry.rs
@@ -139,7 +139,7 @@ mod test {
         let mock_consensus_root = Root {
             version: 1,
             root_type: RootType::State,
-            hash: Hash::from("9fd36f15cd4ff0b856de1606ddda9a08eeb14d73346b7b3a9e0f36e853b02a1e"),
+            hash: Hash::from("f62f1f313de3833830a48b742f144fba542412e7ec65705d83f71a5e6e99bb2b"),
             ..Default::default()
         };
         let mkvs = Tree::builder()

--- a/runtime/src/consensus/state/staking.rs
+++ b/runtime/src/consensus/state/staking.rs
@@ -230,7 +230,7 @@ mod test {
         let mock_consensus_root = Root {
             version: 1,
             root_type: RootType::State,
-            hash: Hash::from("9fd36f15cd4ff0b856de1606ddda9a08eeb14d73346b7b3a9e0f36e853b02a1e"),
+            hash: Hash::from("f62f1f313de3833830a48b742f144fba542412e7ec65705d83f71a5e6e99bb2b"),
             ..Default::default()
         };
         let mkvs = Tree::builder()


### PR DESCRIPTION
### Force on-chain publication of key manager policies
When the key manager policy is updated, the runtime should check whether this policy has actually been published in the consensus layer by using the light client verifier.

This will require adding the Rust implementation of the consensus state accessor for the key manager service. Then one can fetch the corresponding key manager Status and check that the correct policy has been published there.

### Test
Happy path is already tested in `trust-root/simple` scenario. Unhappy path tested locally, the key manager doesn't update policy and constantly throws the following error:
```{"caller":"worker.go:737","err":"worker/keymanager: failed to extract rpc response payload: rpc failure: 'policy hasn't been published'","level":"error","module":"worker/keymanager","msg":"failed to handle status update","ts":"2022-09-08T22:56:44.214990354Z"}```