### PR TITLE
docs: Migrate docs.oasis.dev -> docs.oasis.io

### DIFF
--- a/.changelog/4929.trivial.md
+++ b/.changelog/4929.trivial.md
@@ -1,0 +1,1 @@
+docs: Migrate docs.oasis.dev -> docs.oasis.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,7 +150,7 @@ As of this version, this is no longer allowed and attempting to run the
 
   See [metrics documentation] for descriptions of metrics.
 
-  [metrics documentation]: https://docs.oasis.dev/oasis-core/oasis-node/metrics
+  [metrics documentation]: https://docs.oasis.io/core/oasis-node/metrics
 
 - go/oasis-node/cmd: Allow using non local gRPC connections
   ([#4617](https://github.com/oasisprotocol/oasis-core/issues/4617))
@@ -714,7 +714,7 @@ As of this version, this is no longer allowed and attempting to run the
 - Migrate [Oasis Core Docs] to Docusaurus
   ([#4501](https://github.com/oasisprotocol/oasis-core/issues/4501))
 
-  [Oasis Core Docs]: https://docs.oasis.dev/oasis-core/
+  [Oasis Core Docs]: https://docs.oasis.io/core/
 
 ### Internal Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to Oasis Core! There are many ways
 to contribute, and this document should not be considered encompassing.
 
 If you have a general question on how to use and deploy our software, please
-read our [General Documentation](https://docs.oasis.dev) or join our
+read our [General Documentation](https://docs.oasis.io) or join our
 [Oasis Network Community server on Discord](https://discord.gg/RwNTK8t).
 
 For concrete feature requests and/or bug reports, please file an issue in this

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ work around that and make the second (non-header) row also bold. -->
 [godev-badge]: https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white
 [godev-link]: https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go?tab=subdirectories
 [docusaurus-badge]: https://img.shields.io/badge/docusaurus-docs-007d9c?logo=read-the-docs&logoColor=white
-[docs-link]: https://docs.oasis.dev/oasis-core
+[docs-link]: https://docs.oasis.io/core
 <!-- markdownlint-enable line-length -->
 
 ## Note

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -1,7 +1,7 @@
 // Package version implements Oasis protocol and runtime versioning.
 //
 // For a more detailed explanation of Oasis Core's versioning, see:
-// https://docs.oasis.dev/oasis-core/processes/versioning.
+// https://docs.oasis.io/core/versioning.
 package version
 
 import (

--- a/go/oasis-test-runner/scenario/e2e/genesis_file.go
+++ b/go/oasis-test-runner/scenario/e2e/genesis_file.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	// Parameters from https://docs.oasis.dev/general/oasis-network/network-parameters.
+	// Parameters from https://docs.oasis.io/node/mainnet.
 	latestMainnetGenesisURL          = "https://github.com/oasisprotocol/mainnet-artifacts/releases/download/2022-04-11/genesis.json"
 	latestMainnetGenesisDocumentHash = "b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535"
 


### PR DESCRIPTION
Replaces docs.oasis.dev references with docs.oasis.io