### PR TITLE
go/common/dynlib: Handle Devuan in tests

### DIFF
--- a/go/common/dynlib/cache.go
+++ b/go/common/dynlib/cache.go
@@ -537,6 +537,7 @@ func archDepsMusl() (elf.Machine, []string, error) {
 			"/lib64",
 			"/usr/lib64",
 			"/usr/lib/x86_64-linux-gnu",
+			"/lib/x86_64-linux-gnu", // Devuan (and others)
 		}
 	default:
 		return elf.EM_NONE, nil, errUnsupported


### PR DESCRIPTION
Devuan puts libc in a somewhat odd place, and doesn't have enough backward compatibility symlinks, so the fallback test fails.

Resolve this by adding a special case for where Devuan sticks shared libraries.  Note that most sensible systems will only ever exercise the fallback path when running unit tests.