### PR TITLE
go/governance: Add change parameters proposal

### DIFF
--- a/.changelog/4938.feature.md
+++ b/.changelog/4938.feature.md
@@ -1,0 +1,5 @@
+go/governance: Add change parameters proposal
+
+Introducing a new governance proposal for changing consensus parameters.
+Until now, this was possible only with an upgrade governance proposal
+which was not very efficient.

--- a/go/beacon/api/api.go
+++ b/go/beacon/api/api.go
@@ -3,11 +3,9 @@ package api
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
-	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 )
 
 const (
@@ -131,7 +129,7 @@ type ConsensusParameters struct {
 	// InsecureParameters are the beacon parameters for the insecure backend.
 	InsecureParameters *InsecureParameters `json:"insecure_parameters,omitempty"`
 
-	// VRFParamenters are the beacon parameters for the VRF backend.
+	// VRFParameters are the beacon parameters for the VRF backend.
 	VRFParameters *VRFParameters `json:"vrf_parameters,omitempty"`
 }
 
@@ -139,52 +137,6 @@ type ConsensusParameters struct {
 type InsecureParameters struct {
 	// Interval is the epoch interval (in blocks).
 	Interval int64 `json:"interval,omitempty"`
-}
-
-// SanityCheck does basic sanity checking on the genesis state.
-func (g *Genesis) SanityCheck() error {
-	switch g.Parameters.Backend {
-	case BackendInsecure:
-		params := g.Parameters.InsecureParameters
-		if params == nil {
-			return fmt.Errorf("beacon: sanity check failed: insecure backend not configured")
-		}
-
-		if params.Interval <= 0 && !g.Parameters.DebugMockBackend {
-			return fmt.Errorf("beacon: sanity check failed: epoch interval must be > 0")
-		}
-	case BackendVRF:
-		params := g.Parameters.VRFParameters
-		if params == nil {
-			return fmt.Errorf("beacon: sanity check failed: VRF backend not configured")
-		}
-
-		if params.AlphaHighQualityThreshold == 0 {
-			return fmt.Errorf("beacon: sanity check failed: alpha threshold must be > 0")
-		}
-		if params.Interval <= 0 {
-			return fmt.Errorf("beacon: sanity check failed: epoch interval must be > 0")
-		}
-		if params.ProofSubmissionDelay <= 0 {
-			return fmt.Errorf("beacon: sanity check failed: submission delay must be > 0")
-		}
-		if params.ProofSubmissionDelay >= params.Interval {
-			return fmt.Errorf("beacon: sanity check failed: submission delay must be < epoch interval")
-		}
-	default:
-		return fmt.Errorf("beacon: sanity check failed: unknown backend: '%s'", g.Parameters.Backend)
-	}
-
-	unsafeFlags := g.Parameters.DebugMockBackend
-	if unsafeFlags && !flags.DebugDontBlameOasis() {
-		return fmt.Errorf("beacon: sanity check failed: one or more unsafe debug flags set")
-	}
-
-	if g.Base == EpochInvalid {
-		return fmt.Errorf("beacon: sanity check failed: starting epoch is invalid")
-	}
-
-	return nil
 }
 
 // EpochEvent is the epoch event.

--- a/go/beacon/api/sanity_check.go
+++ b/go/beacon/api/sanity_check.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
+)
+
+// SanityCheck does basic sanity checking on the genesis state.
+func (g *Genesis) SanityCheck() error {
+	if err := g.Parameters.SanityCheck(); err != nil {
+		return fmt.Errorf("beacon: sanity check failed: %w", err)
+	}
+
+	if g.Base == EpochInvalid {
+		return fmt.Errorf("beacon: sanity check failed: starting epoch is invalid")
+	}
+
+	return nil
+}
+
+// SanityCheck performs a sanity check on the consensus parameters.
+func (p *ConsensusParameters) SanityCheck() error {
+	switch p.Backend {
+	case BackendInsecure:
+		params := p.InsecureParameters
+		if params == nil {
+			return fmt.Errorf("insecure backend not configured")
+		}
+
+		if params.Interval <= 0 && !p.DebugMockBackend {
+			return fmt.Errorf("epoch interval must be > 0")
+		}
+	case BackendVRF:
+		params := p.VRFParameters
+		if params == nil {
+			return fmt.Errorf("VRF backend not configured")
+		}
+
+		if params.AlphaHighQualityThreshold == 0 {
+			return fmt.Errorf("alpha threshold must be > 0")
+		}
+		if params.Interval <= 0 {
+			return fmt.Errorf("epoch interval must be > 0")
+		}
+		if params.ProofSubmissionDelay <= 0 {
+			return fmt.Errorf("submission delay must be > 0")
+		}
+		if params.ProofSubmissionDelay >= params.Interval {
+			return fmt.Errorf("submission delay must be < epoch interval")
+		}
+	default:
+		return fmt.Errorf("unknown backend: '%s'", p.Backend)
+	}
+
+	unsafeFlags := p.DebugMockBackend
+	if unsafeFlags && !flags.DebugDontBlameOasis() {
+		return fmt.Errorf("one or more unsafe debug flags set")
+	}
+
+	return nil
+}

--- a/go/consensus/tendermint/apps/governance/api/api.go
+++ b/go/consensus/tendermint/apps/governance/api/api.go
@@ -1,0 +1,15 @@
+// Package api defines the governance application API for other applications.
+package api
+
+type messageKind uint8
+
+// MessageChangeParameters is the message kind for when the change parameters proposal closes
+// as accepted. The message is the change parameters proposal.
+var MessageChangeParameters = messageKind(0)
+
+// MessageValidateParameterChanges is the message kind for when the change parameters proposal's
+// changes should be validated. The message is the change parameters proposal. Consensus module
+// to which changes should be applied should respond with an empty struct if validation is
+// successful and with error otherwise. Other modules should ignore the message and return a nil
+// response.
+var MessageValidateParameterChanges = messageKind(1)

--- a/go/consensus/tendermint/apps/governance/messages.go
+++ b/go/consensus/tendermint/apps/governance/messages.go
@@ -1,0 +1,80 @@
+package governance
+
+import (
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	governanceState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/governance/state"
+	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
+	upgrade "github.com/oasisprotocol/oasis-core/go/upgrade/api"
+)
+
+func (app *governanceApplication) completeStateSync(ctx *api.Context) (interface{}, error) {
+	// State sync has just completed, check whether there are any pending upgrades to make
+	// sure we don't miss them after the sync.
+	state := governanceState.NewMutableState(ctx.State())
+	pendingUpgrades, err := state.PendingUpgrades(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("tendermint/governance: couldn't get pending upgrades: %w", err)
+	}
+
+	// Apply all pending upgrades locally.
+	if upgrader := ctx.AppState().Upgrader(); upgrader != nil {
+		for _, pu := range pendingUpgrades {
+			switch err = upgrader.SubmitDescriptor(ctx, pu); err {
+			case nil, upgrade.ErrAlreadyPending:
+			default:
+				ctx.Logger().Error("failed to locally apply the upgrade descriptor",
+					"err", err,
+					"descriptor", pu,
+				)
+			}
+		}
+	}
+	// No execute message results at this time.
+	return nil, nil
+}
+
+func (app *governanceApplication) changeParameters(ctx *api.Context, msg interface{}, apply bool) (interface{}, error) {
+	// Unmarshal changes and check if they should be applied to this module.
+	proposal, ok := msg.(*governance.ChangeParametersProposal)
+	if !ok {
+		return nil, fmt.Errorf("tendermint/governance: failed to type assert change parameters proposal")
+	}
+
+	if proposal.Module != governance.ModuleName {
+		return nil, nil
+	}
+
+	var changes governance.ConsensusParameterChanges
+	if err := cbor.Unmarshal(proposal.Changes, &changes); err != nil {
+		return nil, fmt.Errorf("tendermint/governance: failed to unmarshal consensus parameter changes: %w", err)
+	}
+
+	// Validate changes against current parameters.
+	state := governanceState.NewMutableState(ctx.State())
+	params, err := state.ConsensusParameters(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("tendermint/governance: failed to load consensus parameters: %w", err)
+	}
+	if err = changes.SanityCheck(); err != nil {
+		return nil, fmt.Errorf("tendermint/governance: failed to validate consensus parameter changes: %w", err)
+	}
+	if err = changes.Apply(params); err != nil {
+		return nil, fmt.Errorf("tendermint/governance: failed to apply consensus parameter changes: %w", err)
+	}
+	if err = params.SanityCheck(); err != nil {
+		return nil, fmt.Errorf("tendermint/governance: failed to validate consensus parameters: %w", err)
+	}
+
+	// Apply changes.
+	if apply {
+		if err = state.SetConsensusParameters(ctx, params); err != nil {
+			return nil, fmt.Errorf("tendermint/governance: failed to update consensus parameters: %w", err)
+		}
+	}
+
+	// Non-nil response signals that changes are valid and were successfully applied (if required).
+	return struct{}{}, nil
+}

--- a/go/consensus/tendermint/apps/governance/messages_test.go
+++ b/go/consensus/tendermint/apps/governance/messages_test.go
@@ -1,0 +1,99 @@
+package governance
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	governanceState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/governance/state"
+	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
+)
+
+func TestChangeParameters(t *testing.T) {
+	require := require.New(t)
+
+	// Prepare context.
+	now := time.Unix(1580461674, 0)
+	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
+	ctx := appState.NewContext(abciAPI.ContextEndBlock, now)
+	defer ctx.Close()
+
+	// Setup state.
+	state := governanceState.NewMutableState(ctx.State())
+	app := &governanceApplication{
+		state: appState,
+	}
+	params := &governance.ConsensusParameters{
+		StakeThreshold:            90,
+		UpgradeCancelMinEpochDiff: beacon.EpochTime(100),
+		UpgradeMinEpochDiff:       beacon.EpochTime(100),
+		VotingPeriod:              beacon.EpochTime(50),
+	}
+	err := state.SetConsensusParameters(ctx, params)
+	require.NoError(err, "setting consensus parameters should succeed")
+
+	// Prepare proposal.
+	votingPeriod := beacon.EpochTime(60)
+	changes := governance.ConsensusParameterChanges{
+		VotingPeriod: &votingPeriod,
+	}
+	proposal := governance.ChangeParametersProposal{
+		Module:  governance.ModuleName,
+		Changes: cbor.Marshal(changes),
+	}
+
+	// Run sub-tests.
+	t.Run("happy path - validate only", func(t *testing.T) {
+		res, err := app.changeParameters(ctx, &proposal, false)
+		require.NoError(err, "validation of consensus parameter changes should succeed")
+		require.Equal(struct{}{}, res)
+
+		state, err := state.ConsensusParameters(ctx)
+		require.NoError(err, "fetching consensus parameters should succeed")
+		require.Equal(params.VotingPeriod, state.VotingPeriod, "consensus parameters shouldn't change")
+	})
+	t.Run("happy path - apply changes", func(t *testing.T) {
+		res, err := app.changeParameters(ctx, &proposal, true)
+		require.NoError(err, "changing consensus parameters should succeed")
+		require.Equal(struct{}{}, res)
+
+		state, err := state.ConsensusParameters(ctx)
+		require.NoError(err, "fetching consensus parameters should succeed")
+		require.Equal(votingPeriod, state.VotingPeriod, "consensus parameters should change")
+	})
+	t.Run("invalid proposal", func(t *testing.T) {
+		_, err := app.changeParameters(ctx, "proposal", true)
+		require.EqualError(err, "tendermint/governance: failed to type assert change parameters proposal")
+	})
+	t.Run("different module", func(t *testing.T) {
+		proposal := governance.ChangeParametersProposal{
+			Module: "module",
+		}
+		res, err := app.changeParameters(ctx, &proposal, true)
+		require.Nil(res, "changes for other modules should be ignored")
+		require.NoError(err, "changes for other modules should be ignored without error")
+	})
+	t.Run("empty changes", func(t *testing.T) {
+		proposal := governance.ChangeParametersProposal{
+			Module: governance.ModuleName,
+		}
+		_, err := app.changeParameters(ctx, &proposal, true)
+		require.EqualError(err, "tendermint/governance: failed to validate consensus parameter changes: consensus parameter changes should not be empty")
+	})
+	t.Run("invalid changes", func(t *testing.T) {
+		votingPeriod := beacon.EpochTime(100)
+		changes := governance.ConsensusParameterChanges{
+			VotingPeriod: &votingPeriod,
+		}
+		proposal := governance.ChangeParametersProposal{
+			Module:  governance.ModuleName,
+			Changes: cbor.Marshal(changes),
+		}
+		_, err := app.changeParameters(ctx, &proposal, true)
+		require.EqualError(err, "tendermint/governance: failed to validate consensus parameters: voting_period should be less than upgrade_min_epoch_diff")
+	})
+}

--- a/go/consensus/tendermint/apps/registry/messages.go
+++ b/go/consensus/tendermint/apps/registry/messages.go
@@ -1,0 +1,54 @@
+package registry
+
+import (
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	registryState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry/state"
+	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+)
+
+func (app *registryApplication) changeParameters(ctx *api.Context, msg interface{}, apply bool) (interface{}, error) {
+	// Unmarshal changes and check if they should be applied to this module.
+	proposal, ok := msg.(*governance.ChangeParametersProposal)
+	if !ok {
+		return nil, fmt.Errorf("registry: failed to type assert change parameters proposal")
+	}
+
+	if proposal.Module != registry.ModuleName {
+		return nil, nil
+	}
+
+	var changes registry.ConsensusParameterChanges
+	if err := cbor.Unmarshal(proposal.Changes, &changes); err != nil {
+		return nil, fmt.Errorf("registry: failed to unmarshal consensus parameter changes: %w", err)
+	}
+
+	// Validate changes against current parameters.
+	state := registryState.NewMutableState(ctx.State())
+	params, err := state.ConsensusParameters(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("registry: failed to load consensus parameters: %w", err)
+	}
+	if err = changes.SanityCheck(); err != nil {
+		return nil, fmt.Errorf("registry: failed to validate consensus parameter changes: %w", err)
+	}
+	if err = changes.Apply(params); err != nil {
+		return nil, fmt.Errorf("registry: failed to apply consensus parameter changes: %w", err)
+	}
+	if err = params.SanityCheck(); err != nil {
+		return nil, fmt.Errorf("registry: failed to validate consensus parameters: %w", err)
+	}
+
+	// Apply changes.
+	if apply {
+		if err = state.SetConsensusParameters(ctx, params); err != nil {
+			return nil, fmt.Errorf("registry: failed to update consensus parameters: %w", err)
+		}
+	}
+
+	// Non-nil response signals that changes are valid and were successfully applied (if required).
+	return struct{}{}, nil
+}

--- a/go/consensus/tendermint/apps/registry/messages_test.go
+++ b/go/consensus/tendermint/apps/registry/messages_test.go
@@ -1,0 +1,96 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	registryState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry/state"
+	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+)
+
+func TestChangeParameters(t *testing.T) {
+	require := require.New(t)
+
+	// Prepare context.
+	now := time.Unix(1580461674, 0)
+	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
+	ctx := appState.NewContext(abciAPI.ContextEndBlock, now)
+	defer ctx.Close()
+
+	// Setup state.
+	state := registryState.NewMutableState(ctx.State())
+	app := &registryApplication{
+		state: appState,
+	}
+	params := &registry.ConsensusParameters{
+		MaxNodeExpiration: 10,
+	}
+	err := state.SetConsensusParameters(ctx, params)
+	require.NoError(err, "setting consensus parameters should succeed")
+
+	// Prepare proposal.
+	maxNodeExpiration := uint64(20)
+	changes := registry.ConsensusParameterChanges{
+		MaxNodeExpiration: &maxNodeExpiration,
+	}
+	proposal := governance.ChangeParametersProposal{
+		Module:  registry.ModuleName,
+		Changes: cbor.Marshal(changes),
+	}
+
+	// Run sub-tests.
+	t.Run("happy path - validate only", func(t *testing.T) {
+		res, err := app.changeParameters(ctx, &proposal, false)
+		require.NoError(err, "validation of consensus parameter changes should succeed")
+		require.Equal(struct{}{}, res)
+
+		state, err := state.ConsensusParameters(ctx)
+		require.NoError(err, "fetching consensus parameters should succeed")
+		require.Equal(params.MaxNodeExpiration, state.MaxNodeExpiration, "consensus parameters shouldn't change")
+	})
+	t.Run("happy path - apply changes", func(t *testing.T) {
+		res, err := app.changeParameters(ctx, &proposal, true)
+		require.NoError(err, "changing consensus parameters should succeed")
+		require.Equal(struct{}{}, res)
+
+		state, err := state.ConsensusParameters(ctx)
+		require.NoError(err, "fetching consensus parameters should succeed")
+		require.Equal(maxNodeExpiration, state.MaxNodeExpiration, "consensus parameters should change")
+	})
+	t.Run("invalid proposal", func(t *testing.T) {
+		_, err := app.changeParameters(ctx, "proposal", true)
+		require.EqualError(err, "registry: failed to type assert change parameters proposal")
+	})
+	t.Run("different module", func(t *testing.T) {
+		proposal := governance.ChangeParametersProposal{
+			Module: "module",
+		}
+		res, err := app.changeParameters(ctx, &proposal, true)
+		require.Nil(res, "changes for other modules should be ignored")
+		require.NoError(err, "changes for other modules should be ignored without error")
+	})
+	t.Run("empty changes", func(t *testing.T) {
+		proposal := governance.ChangeParametersProposal{
+			Module: registry.ModuleName,
+		}
+		_, err := app.changeParameters(ctx, &proposal, true)
+		require.EqualError(err, "registry: failed to validate consensus parameter changes: consensus parameter changes should not be empty")
+	})
+	t.Run("invalid changes", func(t *testing.T) {
+		var maxNodeExpiration uint64
+		changes := registry.ConsensusParameterChanges{
+			MaxNodeExpiration: &maxNodeExpiration,
+		}
+		proposal := governance.ChangeParametersProposal{
+			Module:  registry.ModuleName,
+			Changes: cbor.Marshal(changes),
+		}
+		_, err := app.changeParameters(ctx, &proposal, true)
+		require.EqualError(err, "registry: failed to validate consensus parameters: maximum node expiration not specified")
+	})
+}

--- a/go/consensus/tendermint/apps/roothash/messages.go
+++ b/go/consensus/tendermint/apps/roothash/messages.go
@@ -1,10 +1,17 @@
 package roothash
 
 import (
+	"fmt"
+
+	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
+	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
 	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	registryState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry/state"
 	roothashApi "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/roothash/api"
+	roothashState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/roothash/state"
+	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/message"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
@@ -71,4 +78,74 @@ func (app *rootHashApplication) processRuntimeMessages(
 		})
 	}
 	return events, nil
+}
+
+func (app *rootHashApplication) doBeforeSchedule(ctx *api.Context, msg interface{}) (interface{}, error) {
+	epoch := msg.(beacon.EpochTime)
+
+	ctx.Logger().Debug("processing liveness statistics before scheduling",
+		"epoch", epoch,
+	)
+
+	state := roothashState.NewMutableState(ctx.State())
+	regState := registryState.NewMutableState(ctx.State())
+	runtimes, _ := regState.Runtimes(ctx)
+
+	for _, rt := range runtimes {
+		if !rt.IsCompute() {
+			continue
+		}
+
+		rtState, err := state.RuntimeState(ctx, rt.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch runtime state: %w", err)
+		}
+		if err = processLivenessStatistics(ctx, epoch, rtState); err != nil {
+			return nil, fmt.Errorf("failed to process liveness statistics for %s: %w", rt.ID, err)
+		}
+	}
+	return nil, nil
+}
+
+func (app *rootHashApplication) changeParameters(ctx *api.Context, msg interface{}, apply bool) (interface{}, error) {
+	// Unmarshal changes and check if they should be applied to this module.
+	proposal, ok := msg.(*governance.ChangeParametersProposal)
+	if !ok {
+		return nil, fmt.Errorf("roothash: failed to type assert change parameters proposal")
+	}
+
+	if proposal.Module != roothash.ModuleName {
+		return nil, nil
+	}
+
+	var changes roothash.ConsensusParameterChanges
+	if err := cbor.Unmarshal(proposal.Changes, &changes); err != nil {
+		return nil, fmt.Errorf("roothash: failed to unmarshal consensus parameter changes: %w", err)
+	}
+
+	// Validate changes against current parameters.
+	state := roothashState.NewMutableState(ctx.State())
+	params, err := state.ConsensusParameters(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("roothash: failed to load consensus parameters: %w", err)
+	}
+	if err = changes.SanityCheck(); err != nil {
+		return nil, fmt.Errorf("roothash: failed to validate consensus parameter changes: %w", err)
+	}
+	if err = changes.Apply(params); err != nil {
+		return nil, fmt.Errorf("roothash: failed to apply consensus parameter changes: %w", err)
+	}
+	if err = params.SanityCheck(); err != nil {
+		return nil, fmt.Errorf("roothash: failed to validate consensus parameters: %w", err)
+	}
+
+	// Apply changes.
+	if apply {
+		if err = state.SetConsensusParameters(ctx, params); err != nil {
+			return nil, fmt.Errorf("roothash: failed to update consensus parameters: %w", err)
+		}
+	}
+
+	// Non-nil response signals that changes are valid and were successfully applied (if required).
+	return struct{}{}, nil
 }

--- a/go/consensus/tendermint/apps/roothash/messages_test.go
+++ b/go/consensus/tendermint/apps/roothash/messages_test.go
@@ -1,0 +1,84 @@
+package roothash
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	roothashState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/roothash/state"
+	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
+)
+
+func TestChangeParameters(t *testing.T) {
+	require := require.New(t)
+
+	// Prepare context.
+	now := time.Unix(1580461674, 0)
+	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
+	ctx := appState.NewContext(abciAPI.ContextEndBlock, now)
+	defer ctx.Close()
+
+	// Setup state.
+	state := roothashState.NewMutableState(ctx.State())
+	app := &rootHashApplication{
+		state: appState,
+	}
+	params := &roothash.ConsensusParameters{
+		MaxRuntimeMessages: 10,
+	}
+	err := state.SetConsensusParameters(ctx, params)
+	require.NoError(err, "setting consensus parameters should succeed")
+
+	// Prepare proposal.
+	maxRuntimeMessages := uint32(20)
+	changes := roothash.ConsensusParameterChanges{
+		MaxRuntimeMessages: &maxRuntimeMessages,
+	}
+	proposal := governance.ChangeParametersProposal{
+		Module:  roothash.ModuleName,
+		Changes: cbor.Marshal(changes),
+	}
+
+	// Run sub-tests.
+	t.Run("happy path - validate only", func(t *testing.T) {
+		res, err := app.changeParameters(ctx, &proposal, false)
+		require.NoError(err, "validation of consensus parameter changes should succeed")
+		require.Equal(struct{}{}, res)
+
+		state, err := state.ConsensusParameters(ctx)
+		require.NoError(err, "fetching consensus parameters should succeed")
+		require.Equal(params.MaxRuntimeMessages, state.MaxRuntimeMessages, "consensus parameters shouldn't change")
+	})
+	t.Run("happy path - apply changes", func(t *testing.T) {
+		res, err := app.changeParameters(ctx, &proposal, true)
+		require.NoError(err, "changing consensus parameters should succeed")
+		require.Equal(struct{}{}, res)
+
+		state, err := state.ConsensusParameters(ctx)
+		require.NoError(err, "fetching consensus parameters should succeed")
+		require.Equal(maxRuntimeMessages, state.MaxRuntimeMessages, "consensus parameters should change")
+	})
+	t.Run("invalid proposal", func(t *testing.T) {
+		_, err := app.changeParameters(ctx, "proposal", true)
+		require.EqualError(err, "roothash: failed to type assert change parameters proposal")
+	})
+	t.Run("different module", func(t *testing.T) {
+		proposal := governance.ChangeParametersProposal{
+			Module: "module",
+		}
+		res, err := app.changeParameters(ctx, &proposal, true)
+		require.Nil(res, "changes for other modules should be ignored")
+		require.NoError(err, "changes for other modules should be ignored without error")
+	})
+	t.Run("empty changes", func(t *testing.T) {
+		proposal := governance.ChangeParametersProposal{
+			Module: roothash.ModuleName,
+		}
+		_, err := app.changeParameters(ctx, &proposal, true)
+		require.EqualError(err, "roothash: failed to validate consensus parameter changes: consensus parameter changes should not be empty")
+	})
+}

--- a/go/consensus/tendermint/apps/scheduler/messages.go
+++ b/go/consensus/tendermint/apps/scheduler/messages.go
@@ -1,0 +1,54 @@
+package scheduler
+
+import (
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	schedulerState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/scheduler/state"
+	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
+	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
+)
+
+func (app *schedulerApplication) changeParameters(ctx *api.Context, msg interface{}, apply bool) (interface{}, error) {
+	// Unmarshal changes and check if they should be applied to this module.
+	proposal, ok := msg.(*governance.ChangeParametersProposal)
+	if !ok {
+		return nil, fmt.Errorf("tendermint/scheduler: failed to type assert change parameters proposal")
+	}
+
+	if proposal.Module != scheduler.ModuleName {
+		return nil, nil
+	}
+
+	var changes scheduler.ConsensusParameterChanges
+	if err := cbor.Unmarshal(proposal.Changes, &changes); err != nil {
+		return nil, fmt.Errorf("tendermint/scheduler: failed to unmarshal consensus parameter changes: %w", err)
+	}
+
+	// Validate changes against current parameters.
+	state := schedulerState.NewMutableState(ctx.State())
+	params, err := state.ConsensusParameters(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("tendermint/scheduler: failed to load consensus parameters: %w", err)
+	}
+	if err = changes.SanityCheck(); err != nil {
+		return nil, fmt.Errorf("tendermint/scheduler: failed to validate consensus parameter changes: %w", err)
+	}
+	if err = changes.Apply(params); err != nil {
+		return nil, fmt.Errorf("tendermint/scheduler: failed to apply consensus parameter changes: %w", err)
+	}
+	if err = params.SanityCheck(); err != nil {
+		return nil, fmt.Errorf("tendermint/scheduler: failed to validate consensus parameters: %w", err)
+	}
+
+	// Apply changes.
+	if apply {
+		if err = state.SetConsensusParameters(ctx, params); err != nil {
+			return nil, fmt.Errorf("tendermint/scheduler: failed to update consensus parameters: %w", err)
+		}
+	}
+
+	// Non-nil response signals that changes are valid and were successfully applied (if required).
+	return struct{}{}, nil
+}

--- a/go/consensus/tendermint/apps/scheduler/messages_test.go
+++ b/go/consensus/tendermint/apps/scheduler/messages_test.go
@@ -1,0 +1,84 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	schedulerState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/scheduler/state"
+	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
+	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
+)
+
+func TestChangeParameters(t *testing.T) {
+	require := require.New(t)
+
+	// Prepare context.
+	now := time.Unix(1580461674, 0)
+	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
+	ctx := appState.NewContext(abciAPI.ContextEndBlock, now)
+	defer ctx.Close()
+
+	// Setup state.
+	state := schedulerState.NewMutableState(ctx.State())
+	app := &schedulerApplication{
+		state: appState,
+	}
+	params := &scheduler.ConsensusParameters{
+		MinValidators: 1,
+	}
+	err := state.SetConsensusParameters(ctx, params)
+	require.NoError(err, "setting consensus parameters should succeed")
+
+	// Prepare proposal.
+	minValidators := 2
+	changes := scheduler.ConsensusParameterChanges{
+		MinValidators: &minValidators,
+	}
+	proposal := governance.ChangeParametersProposal{
+		Module:  scheduler.ModuleName,
+		Changes: cbor.Marshal(changes),
+	}
+
+	// Run sub-tests.
+	t.Run("happy path - validate only", func(t *testing.T) {
+		res, err := app.changeParameters(ctx, &proposal, false)
+		require.NoError(err, "validation of consensus parameter changes should succeed")
+		require.Equal(struct{}{}, res)
+
+		state, err := state.ConsensusParameters(ctx)
+		require.NoError(err, "fetching consensus parameters should succeed")
+		require.Equal(params.MinValidators, state.MinValidators, "consensus parameters shouldn't change")
+	})
+	t.Run("happy path - apply changes", func(t *testing.T) {
+		res, err := app.changeParameters(ctx, &proposal, true)
+		require.NoError(err, "changing consensus parameters should succeed")
+		require.Equal(struct{}{}, res)
+
+		state, err := state.ConsensusParameters(ctx)
+		require.NoError(err, "fetching consensus parameters should succeed")
+		require.Equal(minValidators, state.MinValidators, "consensus parameters should change")
+	})
+	t.Run("invalid proposal", func(t *testing.T) {
+		_, err := app.changeParameters(ctx, "proposal", true)
+		require.EqualError(err, "tendermint/scheduler: failed to type assert change parameters proposal")
+	})
+	t.Run("different module", func(t *testing.T) {
+		proposal := governance.ChangeParametersProposal{
+			Module: "module",
+		}
+		res, err := app.changeParameters(ctx, &proposal, true)
+		require.Nil(res, "changes for other modules should be ignored")
+		require.NoError(err, "changes for other modules should be ignored without error")
+	})
+	t.Run("empty changes", func(t *testing.T) {
+		proposal := governance.ChangeParametersProposal{
+			Module: scheduler.ModuleName,
+		}
+		_, err := app.changeParameters(ctx, &proposal, true)
+		require.EqualError(err, "tendermint/scheduler: failed to validate consensus parameter changes: consensus parameter changes should not be empty")
+	})
+}

--- a/go/consensus/tendermint/apps/staking/messages.go
+++ b/go/consensus/tendermint/apps/staking/messages.go
@@ -1,0 +1,53 @@
+package staking
+
+import (
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	stakingState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/staking/state"
+	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
+	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
+)
+
+func (app *stakingApplication) changeParameters(ctx *api.Context, msg interface{}, apply bool) (interface{}, error) {
+	proposal, ok := msg.(*governance.ChangeParametersProposal)
+	if !ok {
+		return nil, fmt.Errorf("staking: failed to type assert change parameters proposal")
+	}
+
+	if proposal.Module != staking.ModuleName {
+		return nil, nil
+	}
+
+	var changes staking.ConsensusParameterChanges
+	if err := cbor.Unmarshal(proposal.Changes, &changes); err != nil {
+		return nil, fmt.Errorf("staking: failed to unmarshal consensus parameter changes: %w", err)
+	}
+
+	// Validate and apply changes to the parameters.
+	state := stakingState.NewMutableState(ctx.State())
+	params, err := state.ConsensusParameters(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("staking: failed to load consensus parameters: %w", err)
+	}
+	if err = changes.SanityCheck(); err != nil {
+		return nil, fmt.Errorf("staking: failed to validate consensus parameter changes: %w", err)
+	}
+	if err = changes.Apply(params); err != nil {
+		return nil, fmt.Errorf("staking: failed to apply consensus parameter changes: %w", err)
+	}
+	if err = params.SanityCheck(); err != nil {
+		return nil, fmt.Errorf("staking: failed to validate consensus parameters: %w", err)
+	}
+
+	// Apply changes.
+	if apply {
+		if err = state.SetConsensusParameters(ctx, params); err != nil {
+			return nil, fmt.Errorf("staking: failed to update consensus parameters: %w", err)
+		}
+	}
+
+	// Non-nil response signals that changes are valid and were successfully applied (if required).
+	return struct{}{}, nil
+}

--- a/go/consensus/tendermint/apps/staking/messages_test.go
+++ b/go/consensus/tendermint/apps/staking/messages_test.go
@@ -1,0 +1,105 @@
+package staking
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	stakingState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/staking/state"
+	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
+	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
+)
+
+func TestChangeParameters(t *testing.T) {
+	require := require.New(t)
+
+	// Prepare context.
+	now := time.Unix(1580461674, 0)
+	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
+	ctx := appState.NewContext(abciAPI.ContextEndBlock, now)
+	defer ctx.Close()
+
+	// Setup state.
+	state := stakingState.NewMutableState(ctx.State())
+	app := &stakingApplication{
+		state: appState,
+	}
+	params := &staking.ConsensusParameters{
+		Thresholds: map[staking.ThresholdKind]quantity.Quantity{
+			staking.KindEntity:            *quantity.NewFromUint64(1),
+			staking.KindNodeValidator:     *quantity.NewFromUint64(1),
+			staking.KindNodeCompute:       *quantity.NewFromUint64(1),
+			staking.KindNodeKeyManager:    *quantity.NewFromUint64(1),
+			staking.KindRuntimeCompute:    *quantity.NewFromUint64(1),
+			staking.KindRuntimeKeyManager: *quantity.NewFromUint64(1),
+		},
+		FeeSplitWeightVote: *quantity.NewFromUint64(1),
+	}
+	err := state.SetConsensusParameters(ctx, params)
+	require.NoError(err, "setting consensus parameters should succeed")
+
+	// Prepare proposal.
+	feeSplitWeightVote := quantity.NewFromUint64(2)
+	changes := staking.ConsensusParameterChanges{
+		FeeSplitWeightVote: feeSplitWeightVote,
+	}
+	proposal := governance.ChangeParametersProposal{
+		Module:  staking.ModuleName,
+		Changes: cbor.Marshal(changes),
+	}
+
+	// Run sub-tests.
+	t.Run("happy path - validate only", func(t *testing.T) {
+		res, err := app.changeParameters(ctx, &proposal, false)
+		require.NoError(err, "validation of consensus parameter changes should succeed")
+		require.Equal(struct{}{}, res)
+
+		state, err := state.ConsensusParameters(ctx)
+		require.NoError(err, "fetching consensus parameters should succeed")
+		require.Equal(params.FeeSplitWeightVote, state.FeeSplitWeightVote, "consensus parameters shouldn't change")
+	})
+	t.Run("happy path - apply changes", func(t *testing.T) {
+		res, err := app.changeParameters(ctx, &proposal, true)
+		require.NoError(err, "changing consensus parameters should succeed")
+		require.Equal(struct{}{}, res)
+
+		state, err := state.ConsensusParameters(ctx)
+		require.NoError(err, "fetching consensus parameters should succeed")
+		require.Equal(*feeSplitWeightVote, state.FeeSplitWeightVote, "consensus parameters should change")
+	})
+	t.Run("invalid proposal", func(t *testing.T) {
+		_, err := app.changeParameters(ctx, "proposal", true)
+		require.EqualError(err, "staking: failed to type assert change parameters proposal")
+	})
+	t.Run("different module", func(t *testing.T) {
+		proposal := governance.ChangeParametersProposal{
+			Module: "module",
+		}
+		res, err := app.changeParameters(ctx, &proposal, true)
+		require.Nil(res, "changes for other modules should be ignored")
+		require.NoError(err, "changes for other modules should be ignored without error")
+	})
+	t.Run("empty changes", func(t *testing.T) {
+		proposal := governance.ChangeParametersProposal{
+			Module: staking.ModuleName,
+		}
+		_, err := app.changeParameters(ctx, &proposal, true)
+		require.EqualError(err, "staking: failed to validate consensus parameter changes: consensus parameter changes should not be empty")
+	})
+	t.Run("invalid changes", func(t *testing.T) {
+		var feeSplitWeightVote quantity.Quantity
+		changes := staking.ConsensusParameterChanges{
+			FeeSplitWeightVote: &feeSplitWeightVote,
+		}
+		proposal := governance.ChangeParametersProposal{
+			Module:  staking.ModuleName,
+			Changes: cbor.Marshal(changes),
+		}
+		_, err := app.changeParameters(ctx, &proposal, true)
+		require.EqualError(err, "staking: failed to validate consensus parameters: fee split proportions are all zero")
+	})
+}

--- a/go/consensus/tendermint/tests/genesis/genesis.go
+++ b/go/consensus/tendermint/tests/genesis/genesis.go
@@ -93,11 +93,12 @@ func NewTestNodeGenesisProvider(identity *identity.Identity, ent *entity.Entity,
 		},
 		Governance: governance.Genesis{
 			Parameters: governance.ConsensusParameters{
-				StakeThreshold:            90,
-				UpgradeCancelMinEpochDiff: 20,
-				UpgradeMinEpochDiff:       20,
-				VotingPeriod:              10,
-				MinProposalDeposit:        *quantity.NewFromUint64(100),
+				StakeThreshold:                 90,
+				UpgradeCancelMinEpochDiff:      20,
+				UpgradeMinEpochDiff:            20,
+				VotingPeriod:                   10,
+				MinProposalDeposit:             *quantity.NewFromUint64(100),
+				EnableChangeParametersProposal: true,
 			},
 		},
 		RootHash: roothash.Genesis{

--- a/go/governance/api/sanity_check.go
+++ b/go/governance/api/sanity_check.go
@@ -33,6 +33,20 @@ func (p *ConsensusParameters) SanityCheck() error {
 	return nil
 }
 
+// SanityCheck performs a sanity check on the consensus parameter changes.
+func (c *ConsensusParameterChanges) SanityCheck() error {
+	if c.GasCosts == nil &&
+		c.MinProposalDeposit == nil &&
+		c.VotingPeriod == nil &&
+		c.StakeThreshold == nil &&
+		c.UpgradeMinEpochDiff == nil &&
+		c.UpgradeCancelMinEpochDiff == nil &&
+		c.EnableChangeParametersProposal == nil {
+		return fmt.Errorf("consensus parameter changes should not be empty")
+	}
+	return nil
+}
+
 // SanityCheckProposals sanity checks proposals.
 func SanityCheckProposals(proposals []*Proposal, epoch beacon.EpochTime, governanceDeposit *quantity.Quantity) error {
 	activeProposalDeposits := quantity.NewFromUint64(0)

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -77,11 +77,12 @@ const (
 	CfgSchedulerDebugAllowWeakAlpha    = "scheduler.debug.allow_weak_alpha"
 
 	// Governance config flags.
-	CfgGovernanceMinProposalDeposit        = "governance.min_proposal_deposit"
-	CfgGovernanceStakeThreshold            = "governance.stake_threshold"
-	CfgGovernanceUpgradeCancelMinEpochDiff = "governance.upgrade_cancel_min_epoch_diff"
-	CfgGovernanceUpgradeMinEpochDiff       = "governance.upgrade_min_epoch_diff"
-	CfgGovernanceVotingPeriod              = "governance.voting_period"
+	CfgGovernanceMinProposalDeposit             = "governance.min_proposal_deposit"
+	CfgGovernanceStakeThreshold                 = "governance.stake_threshold"
+	CfgGovernanceUpgradeCancelMinEpochDiff      = "governance.upgrade_cancel_min_epoch_diff"
+	CfgGovernanceUpgradeMinEpochDiff            = "governance.upgrade_min_epoch_diff"
+	CfgGovernanceVotingPeriod                   = "governance.voting_period"
+	CfgGovernanceEnableChangeParametersProposal = "governance.enable_change_parameters_proposal"
 
 	// Beacon config flags.
 	CfgBeaconBackend                    = "beacon.backend"
@@ -241,12 +242,13 @@ func doInitGenesis(cmd *cobra.Command, args []string) {
 
 	doc.Governance = governance.Genesis{
 		Parameters: governance.ConsensusParameters{
-			GasCosts:                  governance.DefaultGasCosts, // TODO: configurable.
-			MinProposalDeposit:        *quantity.NewFromUint64(viper.GetUint64(CfgGovernanceMinProposalDeposit)),
-			StakeThreshold:            uint8(viper.GetInt(CfgGovernanceStakeThreshold)),
-			UpgradeCancelMinEpochDiff: beacon.EpochTime(viper.GetUint64(CfgGovernanceUpgradeCancelMinEpochDiff)),
-			UpgradeMinEpochDiff:       beacon.EpochTime(viper.GetUint64(CfgGovernanceUpgradeMinEpochDiff)),
-			VotingPeriod:              beacon.EpochTime(viper.GetUint64(CfgGovernanceVotingPeriod)),
+			GasCosts:                       governance.DefaultGasCosts, // TODO: configurable.
+			MinProposalDeposit:             *quantity.NewFromUint64(viper.GetUint64(CfgGovernanceMinProposalDeposit)),
+			StakeThreshold:                 uint8(viper.GetInt(CfgGovernanceStakeThreshold)),
+			UpgradeCancelMinEpochDiff:      beacon.EpochTime(viper.GetUint64(CfgGovernanceUpgradeCancelMinEpochDiff)),
+			UpgradeMinEpochDiff:            beacon.EpochTime(viper.GetUint64(CfgGovernanceUpgradeMinEpochDiff)),
+			VotingPeriod:                   beacon.EpochTime(viper.GetUint64(CfgGovernanceVotingPeriod)),
+			EnableChangeParametersProposal: viper.GetBool(CfgGovernanceEnableChangeParametersProposal),
 		},
 	}
 
@@ -815,6 +817,7 @@ func init() {
 	initGenesisFlags.Uint64(CfgGovernanceUpgradeCancelMinEpochDiff, 300, "minimum number of epochs in advance for canceling proposals")
 	initGenesisFlags.Uint64(CfgGovernanceUpgradeMinEpochDiff, 300, "minimum number of epochs the upgrade needs to be scheduled in advance")
 	initGenesisFlags.Uint64(CfgGovernanceVotingPeriod, 100, "voting period (in epochs)")
+	initGenesisFlags.Bool(CfgGovernanceEnableChangeParametersProposal, true, "enable change parameters proposals")
 
 	// Beacon config flags.
 	initGenesisFlags.String(CfgBeaconBackend, "insecure", "beacon backend")

--- a/go/oasis-test-runner/oasis/network.go
+++ b/go/oasis-test-runner/oasis/network.go
@@ -744,6 +744,7 @@ func (net *Network) MakeGenesis() error {
 			"--" + genesis.CfgGovernanceUpgradeCancelMinEpochDiff, strconv.FormatUint(uint64(cfg.UpgradeCancelMinEpochDiff), 10),
 			"--" + genesis.CfgGovernanceUpgradeMinEpochDiff, strconv.FormatUint(uint64(cfg.UpgradeMinEpochDiff), 10),
 			"--" + genesis.CfgGovernanceVotingPeriod, strconv.FormatUint(uint64(cfg.VotingPeriod), 10),
+			"--" + genesis.CfgGovernanceEnableChangeParametersProposal, strconv.FormatBool(cfg.EnableChangeParametersProposal),
 		}...)
 	}
 	if cfg := net.cfg.RoothashParameters; cfg != nil {

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -1408,7 +1408,7 @@ type Genesis struct {
 // ConsensusParameters are the registry consensus parameters.
 type ConsensusParameters struct {
 	// DebugAllowUnroutableAddresses is true iff node registration should
-	// allow unroutable addreses.
+	// allow unroutable addresses.
 	DebugAllowUnroutableAddresses bool `json:"debug_allow_unroutable_addresses,omitempty"`
 
 	// DebugAllowTestRuntimes is true iff test runtimes should be allowed to
@@ -1427,7 +1427,7 @@ type ConsensusParameters struct {
 	// disabled outside of the genesis block.
 	DisableRuntimeRegistration bool `json:"disable_runtime_registration,omitempty"`
 
-	// DisableRuntimeRegistration is true iff key manager runtime registration should be
+	// DisableKeyManagerRuntimeRegistration is true iff key manager runtime registration should be
 	// disabled outside of the genesis block.
 	DisableKeyManagerRuntimeRegistration bool `json:"disable_km_runtime_registration,omitempty"`
 
@@ -1443,6 +1443,50 @@ type ConsensusParameters struct {
 
 	// TEEFeatures contains the configuration of supported TEE features.
 	TEEFeatures *node.TEEFeatures `json:"tee_features,omitempty"`
+}
+
+// ConsensusParameterChanges are allowed registry consensus parameter changes.
+type ConsensusParameterChanges struct {
+	// DisableRuntimeRegistration is the new disable runtime registration flag.
+	DisableRuntimeRegistration *bool `json:"disable_runtime_registration,omitempty"`
+
+	// DisableKeyManagerRuntimeRegistration the new disable key manager runtime registration flag.
+	DisableKeyManagerRuntimeRegistration *bool `json:"disable_km_runtime_registration,omitempty"`
+
+	// GasCosts are the new gas costs.
+	GasCosts transaction.Costs `json:"gas_costs,omitempty"`
+
+	// MaxNodeExpiration is the maximum node expiration.
+	MaxNodeExpiration *uint64 `json:"max_node_expiration,omitempty"`
+
+	// EnableRuntimeGovernanceModels are the new enabled runtime governance models.
+	EnableRuntimeGovernanceModels map[RuntimeGovernanceModel]bool `json:"enable_runtime_governance_models,omitempty"`
+
+	// TEEFeatures are the new TEE features.
+	TEEFeatures **node.TEEFeatures `json:"tee_features,omitempty"`
+}
+
+// Apply applies changes to the given consensus parameters.
+func (c *ConsensusParameterChanges) Apply(params *ConsensusParameters) error {
+	if c.DisableRuntimeRegistration != nil {
+		params.DisableRuntimeRegistration = *c.DisableRuntimeRegistration
+	}
+	if c.DisableKeyManagerRuntimeRegistration != nil {
+		params.DisableKeyManagerRuntimeRegistration = *c.DisableKeyManagerRuntimeRegistration
+	}
+	if c.GasCosts != nil {
+		params.GasCosts = c.GasCosts
+	}
+	if c.MaxNodeExpiration != nil {
+		params.MaxNodeExpiration = *c.MaxNodeExpiration
+	}
+	if c.EnableRuntimeGovernanceModels != nil {
+		params.EnableRuntimeGovernanceModels = c.EnableRuntimeGovernanceModels
+	}
+	if c.TEEFeatures != nil {
+		params.TEEFeatures = *c.TEEFeatures
+	}
+	return nil
 }
 
 const (

--- a/go/roothash/api/sanity_check.go
+++ b/go/roothash/api/sanity_check.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
+)
+
+// SanityCheckBlocks examines the blocks table.
+func SanityCheckBlocks(blocks map[common.Namespace]*block.Block) error {
+	for _, blk := range blocks {
+		hdr := blk.Header
+
+		if hdr.Timestamp > block.Timestamp(time.Now().Unix()+61*60) {
+			return fmt.Errorf("roothash: sanity check failed: block header timestamp is more than 1h1m in the future")
+		}
+	}
+	return nil
+}
+
+// SanityCheck does basic sanity checking on the genesis state.
+func (g *Genesis) SanityCheck() error {
+	if err := g.Parameters.SanityCheck(); err != nil {
+		return fmt.Errorf("roothash: sanity check failed: %w", err)
+	}
+
+	// Check blocks.
+	for _, rtg := range g.RuntimeStates {
+		if err := rtg.SanityCheck(true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SanityCheck performs a sanity check on the consensus parameters.
+func (p *ConsensusParameters) SanityCheck() error {
+	unsafeFlags := p.DebugDoNotSuspendRuntimes || p.DebugBypassStake
+	if unsafeFlags && !flags.DebugDontBlameOasis() {
+		return fmt.Errorf("one or more unsafe debug flags set")
+	}
+	return nil
+}
+
+// SanityCheck performs a sanity check on the consensus parameter changes.
+func (c *ConsensusParameterChanges) SanityCheck() error {
+	if c.GasCosts == nil &&
+		c.MaxRuntimeMessages == nil &&
+		c.MaxInRuntimeMessages == nil &&
+		c.MaxEvidenceAge == nil {
+		return fmt.Errorf("consensus parameter changes should not be empty")
+	}
+	return nil
+}

--- a/go/scheduler/api/sanity_check.go
+++ b/go/scheduler/api/sanity_check.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
+)
+
+// SanityCheck does basic sanity checking on the genesis state.
+func (g *Genesis) SanityCheck(stakingTotalSupply *quantity.Quantity) error {
+	if err := g.Parameters.SanityCheck(); err != nil {
+		return fmt.Errorf("scheduler: sanity check failed: %w", err)
+	}
+
+	if !g.Parameters.DebugBypassStake {
+		supplyPower, err := VotingPowerFromStake(stakingTotalSupply)
+		if err != nil {
+			return fmt.Errorf("scheduler: sanity check failed: total supply would break voting power computation: %w", err)
+		}
+		// I've been advised not to import implementation details.
+		// Instead, here's our own number that satisfies all current implementations' limits.
+		maxTotalVotingPower := int64(math.MaxInt64) / 8
+		if supplyPower > maxTotalVotingPower {
+			return fmt.Errorf("init chain: total supply power %d exceeds Tendermint voting power limit %d", supplyPower, maxTotalVotingPower)
+		}
+	}
+
+	return nil
+}
+
+// SanityCheck performs a sanity check on the consensus parameters.
+func (p *ConsensusParameters) SanityCheck() error {
+	unsafeFlags := p.DebugBypassStake || p.DebugAllowWeakAlpha || p.DebugForceElect != nil
+	if unsafeFlags && !flags.DebugDontBlameOasis() {
+		return fmt.Errorf("one or more unsafe debug flags set")
+	}
+	return nil
+}
+
+// SanityCheck performs a sanity check on the consensus parameter changes.
+func (c *ConsensusParameterChanges) SanityCheck() error {
+	if c.MinValidators == nil &&
+		c.MaxValidators == nil {
+		return fmt.Errorf("consensus parameter changes should not be empty")
+	}
+	return nil
+}

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -1137,6 +1137,92 @@ type ConsensusParameters struct { // nolint: maligned
 	RewardFactorBlockProposed quantity.Quantity `json:"reward_factor_block_proposed"`
 }
 
+// ConsensusParameterChanges are allowed staking consensus parameter changes.
+type ConsensusParameterChanges struct {
+	// DebondingInterval is the new debonding interval.
+	DebondingInterval *beacon.EpochTime `json:"debonding_interval,omitempty"`
+
+	// GasCosts are the new gas costs.
+	GasCosts transaction.Costs `json:"gas_costs,omitempty"`
+
+	// MinDelegationAmount is the new minimum delegation amount.
+	MinDelegationAmount *quantity.Quantity `json:"min_delegation"`
+	// MinTransferAmount is the new minimum transfer amount.
+	MinTransferAmount *quantity.Quantity `json:"min_transfer"`
+	// MinTransactBalance is the new minimum transact balance.
+	MinTransactBalance *quantity.Quantity `json:"min_transact_balance"`
+
+	// DisableTransfers is the new disable transfers flag.
+	DisableTransfers *bool `json:"disable_transfers,omitempty"`
+	// DisableDelegation is the new disable delegation flag.
+	DisableDelegation *bool `json:"disable_delegation,omitempty"`
+
+	// AllowEscrowMessages is the new allow escrow messages flag.
+	AllowEscrowMessages *bool `json:"allow_escrow_messages,omitempty"`
+
+	// MaxAllowances is the new maximum number of allowances.
+	MaxAllowances *uint32 `json:"max_allowances,omitempty"`
+
+	// FeeSplitWeightPropose is the new propose fee split weight.
+	FeeSplitWeightPropose *quantity.Quantity `json:"fee_split_weight_propose"`
+	// FeeSplitWeightVote is the new vote fee split weight.
+	FeeSplitWeightVote *quantity.Quantity `json:"fee_split_weight_vote"`
+	// FeeSplitWeightNextPropose is the new next propose fee split weight.
+	FeeSplitWeightNextPropose *quantity.Quantity `json:"fee_split_weight_next_propose"`
+
+	// RewardFactorEpochSigned is the new epoch signed reward factor.
+	RewardFactorEpochSigned *quantity.Quantity `json:"reward_factor_epoch_signed"`
+	// RewardFactorBlockProposed is the new block proposed reward factor.
+	RewardFactorBlockProposed *quantity.Quantity `json:"reward_factor_block_proposed"`
+}
+
+// Apply applies changes to the given consensus parameters.
+func (c *ConsensusParameterChanges) Apply(params *ConsensusParameters) error {
+	if c.DebondingInterval != nil {
+		params.DebondingInterval = *c.DebondingInterval
+	}
+	if c.GasCosts != nil {
+		params.GasCosts = c.GasCosts
+	}
+	if c.MinDelegationAmount != nil {
+		params.MinDelegationAmount = *c.MinDelegationAmount
+	}
+	if c.MinTransferAmount != nil {
+		params.MinTransferAmount = *c.MinTransferAmount
+	}
+	if c.MinTransactBalance != nil {
+		params.MinTransactBalance = *c.MinTransactBalance
+	}
+	if c.DisableTransfers != nil {
+		params.DisableTransfers = *c.DisableTransfers
+	}
+	if c.DisableDelegation != nil {
+		params.DisableDelegation = *c.DisableDelegation
+	}
+	if c.AllowEscrowMessages != nil {
+		params.AllowEscrowMessages = *c.AllowEscrowMessages
+	}
+	if c.MaxAllowances != nil {
+		params.MaxAllowances = *c.MaxAllowances
+	}
+	if c.FeeSplitWeightPropose != nil {
+		params.FeeSplitWeightPropose = *c.FeeSplitWeightPropose
+	}
+	if c.FeeSplitWeightVote != nil {
+		params.FeeSplitWeightVote = *c.FeeSplitWeightVote
+	}
+	if c.FeeSplitWeightNextPropose != nil {
+		params.FeeSplitWeightNextPropose = *c.FeeSplitWeightNextPropose
+	}
+	if c.RewardFactorEpochSigned != nil {
+		params.RewardFactorEpochSigned = *c.RewardFactorEpochSigned
+	}
+	if c.RewardFactorBlockProposed != nil {
+		params.RewardFactorBlockProposed = *c.RewardFactorBlockProposed
+	}
+	return nil
+}
+
 const (
 	// GasOpTransfer is the gas operation identifier for transfer.
 	GasOpTransfer transaction.Op = "transfer"

--- a/go/staking/api/sanity_check.go
+++ b/go/staking/api/sanity_check.go
@@ -40,6 +40,27 @@ func (p *ConsensusParameters) SanityCheck() error {
 	return nil
 }
 
+// SanityCheck performs a sanity check on the consensus parameter changes.
+func (c *ConsensusParameterChanges) SanityCheck() error {
+	if c.DebondingInterval == nil &&
+		c.GasCosts == nil &&
+		c.MinDelegationAmount == nil &&
+		c.MinTransferAmount == nil &&
+		c.MinTransactBalance == nil &&
+		c.DisableTransfers == nil &&
+		c.DisableDelegation == nil &&
+		c.AllowEscrowMessages == nil &&
+		c.MaxAllowances == nil &&
+		c.FeeSplitWeightPropose == nil &&
+		c.FeeSplitWeightVote == nil &&
+		c.FeeSplitWeightNextPropose == nil &&
+		c.RewardFactorEpochSigned == nil &&
+		c.RewardFactorBlockProposed == nil {
+		return fmt.Errorf("consensus parameter changes should not be empty")
+	}
+	return nil
+}
+
 // SanityCheckAccount examines an account's balances.
 // Adds the balances to a running total `total`.
 func SanityCheckAccount(

--- a/go/upgrade/api/api.go
+++ b/go/upgrade/api/api.go
@@ -116,6 +116,12 @@ type Descriptor struct { // nolint: maligned
 
 // Equals compares descriptors for equality.
 func (d *Descriptor) Equals(other *Descriptor) bool {
+	if d == other {
+		return true
+	}
+	if d == nil || other == nil {
+		return false
+	}
 	if d.V != other.V {
 		return false
 	}

--- a/go/upgrade/migrations/consensus_change_parameters.go
+++ b/go/upgrade/migrations/consensus_change_parameters.go
@@ -1,0 +1,51 @@
+package migrations
+
+import (
+	"fmt"
+
+	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	governanceState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/governance/state"
+)
+
+const (
+	// ChangeParametersProposalHandler is the name of the upgrade that enables change
+	// parameters proposal.
+	ChangeParametersProposalHandler = "change-parameters-proposal"
+)
+
+var _ Handler = (*changeParametersProposalHandler)(nil)
+
+type changeParametersProposalHandler struct{}
+
+func (h *changeParametersProposalHandler) StartupUpgrade(ctx *Context) error {
+	return nil
+}
+
+func (h *changeParametersProposalHandler) ConsensusUpgrade(ctx *Context, privateCtx interface{}) error {
+	abciCtx := privateCtx.(*abciAPI.Context)
+	switch abciCtx.Mode() {
+	case abciAPI.ContextBeginBlock:
+		// Nothing to do during begin block.
+	case abciAPI.ContextEndBlock:
+		// Update a consensus parameter during EndBlock.
+		state := governanceState.NewMutableState(abciCtx.State())
+
+		params, err := state.ConsensusParameters(abciCtx)
+		if err != nil {
+			return fmt.Errorf("unable to load governance consensus parameters: %w", err)
+		}
+
+		params.EnableChangeParametersProposal = true
+
+		if err = state.SetConsensusParameters(abciCtx, params); err != nil {
+			return fmt.Errorf("failed to update governance consensus parameters: %w", err)
+		}
+	default:
+		return fmt.Errorf("upgrade handler called in unexpected context: %s", abciCtx.Mode())
+	}
+	return nil
+}
+
+func init() {
+	Register(ChangeParametersProposalHandler, &changeParametersProposalHandler{})
+}


### PR DESCRIPTION
We should add a governance proposal that allows changing parameters. The parameter change would be described by a CBOR document containing the following:
- Name of the consensus app/service that the parameter change applies to.
- Parameter change that can be applied to the app's `ConsensusParameters` structure.

To execute a parameter change proposal, the governance module would submit a message (using the existing message dispatch mechanism) to the given application containing the details of the proposal. Executing the parameter change would be up to the application and each application should carefully scope what is allowed to be changed.

This functionality should be parameter-gated behind a governance consensus parameter to be enabled in an upgrade handler.