### PR TITLE
ci: Fix Go version used in workflows

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -43,10 +43,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "12.x"
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: "1.17.x"
+          go-version: "1.18.x"
       - name: Set up Rust
         run: rustup show
       - name: Install dependencies

--- a/.github/workflows/ci-reproducibility.yml
+++ b/.github/workflows/ci-reproducibility.yml
@@ -37,10 +37,10 @@ jobs:
           # NOTE: We make a git checkout to a unique directory for each build to
           # catch reproducibility issues with code in different local paths.
           path: build${{ matrix.build_number }}
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: "1.17.x"
+          go-version: "1.18.x"
       - name: Set up Rust
         working-directory: build${{ matrix.build_number }}
         run: rustup show

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -33,10 +33,10 @@ jobs:
           # For more info, see:
           # https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
           fetch-depth: 0
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: "1.17.x"
+          go-version: "1.18.x"
       - name: Set up Rust
         run: rustup show
       - name: Install Oasis Node prerequisites

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,10 @@ jobs:
           # https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
           fetch-depth: 0
 
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: "1.17.x"
+          go-version: "1.18.x"
 
       - name: Set up Rust
         run: rustup show


### PR DESCRIPTION
When Go was bumped to 1.18 some of the CI workflows were not changed.