### PR TITLE
go/consensus, go/registry: Reduce amount of error logs (2nd iteration)

### DIFF
--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -764,7 +764,7 @@ func (app *rootHashApplication) tryFinalizeExecutorCommits( //nolint: gocyclo
 	}
 
 	// Something else went wrong, emit empty error block.
-	ctx.Logger().Error("round failed",
+	ctx.Logger().Debug("round failed",
 		"round", round,
 		"err", err,
 		logging.LogEvent, roothash.LogEventRoundFailed,

--- a/go/consensus/tendermint/apps/roothash/transactions.go
+++ b/go/consensus/tendermint/apps/roothash/transactions.go
@@ -87,7 +87,7 @@ func (app *rootHashApplication) executorProposerTimeout(
 
 	// Ensure request is valid.
 	if err = rtState.ExecutorPool.CheckProposerTimeout(ctx, rtState.CurrentBlock, nl, ctx.TxSigner(), rpt.Round); err != nil {
-		ctx.Logger().Error("failed requesting proposer round timeout",
+		ctx.Logger().Debug("failed requesting proposer round timeout",
 			"err", err,
 			"round", rtState.CurrentBlock.Header.Round,
 			"request", rpt,
@@ -96,7 +96,7 @@ func (app *rootHashApplication) executorProposerTimeout(
 	}
 
 	// Timeout triggered by executor node, emit empty error block.
-	ctx.Logger().Error("proposer round timeout",
+	ctx.Logger().Debug("proposer round timeout",
 		"round", rpt.Round,
 		"err", err,
 		logging.LogEvent, roothash.LogEventRoundFailed,
@@ -157,7 +157,7 @@ func (app *rootHashApplication) executorCommit(
 			&commit, // nolint: gosec
 			msgGasAccountant,
 		); err != nil {
-			ctx.Logger().Error("failed to add compute commitment to round",
+			ctx.Logger().Debug("failed to add compute commitment to round",
 				"err", err,
 				"round", rtState.CurrentBlock.Header.Round,
 			)

--- a/go/consensus/tendermint/apps/staking/transactions.go
+++ b/go/consensus/tendermint/apps/staking/transactions.go
@@ -76,7 +76,7 @@ func (app *stakingApplication) transfer(ctx *api.Context, state *stakingState.Mu
 			return nil, fmt.Errorf("failed to fetch account: %w", err)
 		}
 		if err = quantity.Move(&to.General.Balance, &from.General.Balance, &xfer.Amount); err != nil {
-			ctx.Logger().Error("Transfer: failed to move balance",
+			ctx.Logger().Debug("Transfer: failed to move balance",
 				"err", err,
 				"from", fromAddr,
 				"to", xfer.To,
@@ -275,7 +275,7 @@ func (app *stakingApplication) addEscrow(ctx *api.Context, state *stakingState.M
 
 	obtainedShares, err := to.Escrow.Active.Deposit(&delegation.Shares, &from.General.Balance, &escrow.Amount)
 	if err != nil {
-		ctx.Logger().Error("AddEscrow: failed to escrow stake",
+		ctx.Logger().Debug("AddEscrow: failed to escrow stake",
 			"err", err,
 			"from", fromAddr,
 			"to", escrow.Account,
@@ -412,7 +412,7 @@ func (app *stakingApplication) reclaimEscrow(ctx *api.Context, state *stakingSta
 	var baseUnits quantity.Quantity
 
 	if err = from.Escrow.Active.Withdraw(&baseUnits, &delegation.Shares, &reclaim.Shares); err != nil {
-		ctx.Logger().Error("ReclaimEscrow: failed to redeem escrow shares",
+		ctx.Logger().Debug("ReclaimEscrow: failed to redeem escrow shares",
 			"err", err,
 			"to", toAddr,
 			"from", reclaim.Account,
@@ -424,7 +424,7 @@ func (app *stakingApplication) reclaimEscrow(ctx *api.Context, state *stakingSta
 
 	var debondingShares *quantity.Quantity
 	if debondingShares, err = from.Escrow.Debonding.Deposit(&deb.Shares, &baseUnits, stakeAmount); err != nil {
-		ctx.Logger().Error("ReclaimEscrow: failed to debond shares",
+		ctx.Logger().Debug("ReclaimEscrow: failed to debond shares",
 			"err", err,
 			"to", toAddr,
 			"from", reclaim.Account,
@@ -435,7 +435,7 @@ func (app *stakingApplication) reclaimEscrow(ctx *api.Context, state *stakingSta
 	}
 
 	if !baseUnits.IsZero() {
-		ctx.Logger().Error("ReclaimEscrow: inconsistency in transferring stake from active escrow to debonding",
+		ctx.Logger().Debug("ReclaimEscrow: inconsistency in transferring stake from active escrow to debonding",
 			"remaining_base_units", baseUnits,
 		)
 		return nil, staking.ErrInvalidArgument

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -522,7 +522,7 @@ func VerifyRegisterNodeArgs( // nolint: gocyclo
 	// Descriptors will always be signed by the node identity key.
 	var expectedSigners []signature.PublicKey
 	if !sigNode.MultiSigned.IsSignedBy(n.ID) {
-		logger.Error("RegisterNode: registration not signed by node identity",
+		logger.Debug("RegisterNode: registration not signed by node identity",
 			"signed_node", sigNode,
 			"node", n,
 		)
@@ -530,7 +530,7 @@ func VerifyRegisterNodeArgs( // nolint: gocyclo
 	}
 	expectedSigners = append(expectedSigners, n.ID)
 	if !entity.HasNode(n.ID) && (!isSanityCheck || isGenesis) {
-		logger.Error("RegisterNode: node public key not found in entity's node list",
+		logger.Debug("RegisterNode: node public key not found in entity's node list",
 			"signed_node", sigNode,
 			"node", n,
 		)


### PR DESCRIPTION
See #4196 for motivation.

#4759 already downgraded most extraneous error logs, but I found some more when syncing a node from scratch. This PR removes the logs that appeared with frequency of more than one per 100k blocks.