### PR TITLE
go/runtime/txpool: Add block propagation delay before tx publish

### DIFF
--- a/.changelog/4959.bugfix.md
+++ b/.changelog/4959.bugfix.md
@@ -1,0 +1,1 @@
+go/runtime/txpool: Add block propagation delay before tx publish


### PR DESCRIPTION
After processing a new block locally, make sure that any transactions that are checked against that block are only propagated after waiting for the `newBlockPublishDelay` to increase probability that peers are up to date with the new block.

Obviously a better way would be to check the current round of each peer (e.g., via a p2p update protocol), but such filtering is unfortunately not possible to do with the current go-libp2p-pubsub implementation.