### PR TITLE
go/runtime: Fix configuring the SGX-based provisioner

### DIFF
--- a/.changelog/4960.bugfix.md
+++ b/.changelog/4960.bugfix.md
@@ -1,0 +1,9 @@
+go/runtime: Fix configuring the SGX-based provisioner
+
+Previously there was an edge case when the SGX loader was configured and
+remapping to non-SGX was forced (e.g. on client nodes). This would result in
+an invalid SGX configuration that resulted in a strange error message about a
+missing SIGSTRUCT.
+
+This has now been changed so that remapping happens independent of whether an
+SGX loader is configured or not.

--- a/go/runtime/host/sgx/sgx.go
+++ b/go/runtime/host/sgx/sgx.go
@@ -382,6 +382,11 @@ func (s *sgxProvisioner) attestationWorker(ts *teeState, p process.Process, conn
 
 // Implements host.Provisioner.
 func (s *sgxProvisioner) NewRuntime(ctx context.Context, cfg host.Config) (host.Runtime, error) {
+	// Make sure to return an error early if the SGX runtime loader is not configured.
+	if s.cfg.LoaderPath == "" {
+		return nil, fmt.Errorf("SGX loader binary path is not configured")
+	}
+
 	return s.sandbox.NewRuntime(ctx, cfg)
 }
 


### PR DESCRIPTION
Previously there was an edge case when the SGX loader was configured and remapping to non-SGX was forced (e.g. on client nodes). This would result in an invalid SGX configuration that resulted in a strange error message about a missing SIGSTRUCT.

This has now been changed so that remapping happens independent of whether an SGX loader is configured or not.