### PR TITLE
go/worker/compute: Only process keymanager client initialization once

### DIFF
--- a/.changelog/4962.bugfix.md
+++ b/.changelog/4962.bugfix.md
@@ -1,0 +1,1 @@
+go/worker/compute: Only process keymanager client initialization once


### PR DESCRIPTION
Before, the `nudgeAvailabilityLocked` was constantly executed once keymanager client was initialized since the channel is closed.