### PR TITLE
mkvs/proof: Make sure that all entries in the proof have been used

### DIFF
--- a/.changelog/4973.internal.md
+++ b/.changelog/4973.internal.md
@@ -1,0 +1,9 @@
+mkvs/proof: Make sure that all entries in the proof have been used
+
+Note that this does not impact verification correctness as only visited
+nodes are part of the proof computation and the verified tree returned
+by the verifier.
+
+But in case future code may want to do something with raw entries of a
+verified proof this removes a possible footgun where unverified entries
+could be considered.

--- a/go/storage/mkvs/syncer/proof.go
+++ b/go/storage/mkvs/syncer/proof.go
@@ -181,9 +181,14 @@ func (pv *ProofVerifier) VerifyProof(ctx context.Context, root hash.Hash, proof 
 		return nil, errors.New("verifier: empty proof")
 	}
 
-	_, rootNode, err := pv.verifyProof(ctx, proof, 0)
+	idx, rootNode, err := pv.verifyProof(ctx, proof, 0)
 	if err != nil {
 		return nil, err
+	}
+	// Make sure that all of the entries in the proof have been used. The returned index should
+	// point to just beyond the last element.
+	if idx != len(proof.Entries) {
+		return nil, fmt.Errorf("verifier: unused entries in proof")
 	}
 	rootNodeHash := rootNode.GetHash()
 	if rootNodeHash.IsEmpty() {

--- a/go/storage/mkvs/syncer/proof_test.go
+++ b/go/storage/mkvs/syncer/proof_test.go
@@ -5,8 +5,37 @@ import (
 	"encoding/base64"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 )
+
+func TestProofExtraNodes(t *testing.T) {
+	require := require.New(t)
+
+	var rootHash hash.Hash
+	err := rootHash.UnmarshalHex("59e67c2fdc08b8e10dd08bb6b8efe614fcc965ecb89625f97f17f87f07104613")
+	require.NoError(err)
+	rawProof, _ := base64.StdEncoding.DecodeString("omdlbnRyaWVzhUoBASQAa2V5IDACRgEBAQAAAlghAsFltYRhD4dAwHOdOmEigY1r02pJH6InhiibKlh9neYlWCECpsJnkjOnIgc4+yfvpsqCcIYHh5eld1hNMWTT7arAfHFYIQLhNTLWRbks1RBf52ulnlOTO+7D5EZNMYFzTx8U46sCnm51bnRydXN0ZWRfcm9vdFggWeZ8L9wIuOEN0Iu2uO/mFPzJZey4liX5fxf4fwcQRhM=")
+
+	var proof Proof
+	err = cbor.Unmarshal(rawProof, &proof)
+	if err != nil {
+		panic(err)
+	}
+
+	// Verify the proof as a sanity check.
+	var verifier ProofVerifier
+	_, err = verifier.VerifyProof(context.Background(), rootHash, &proof)
+	require.NoError(err)
+
+	// Duplicate some nodes and add them to the end.
+	proof.Entries = append(proof.Entries, proof.Entries[0])
+
+	_, err = verifier.VerifyProof(context.Background(), rootHash, &proof)
+	require.Error(err, "proof with extra data should fail to validate")
+}
 
 func FuzzProof(f *testing.F) {
 	// Seed corpus.


### PR DESCRIPTION
Note that this does not impact verification correctness as only visited nodes are part of the proof computation and the verified tree returned by the verifier.

But in case future code may want to do something with raw entries of a verified proof this removes a possible footgun where unverified entries could be considered.