### PR TITLE
go/p2p: Bootstrap libp2p peers

### DIFF
--- a/.changelog/4981.feature.md
+++ b/.changelog/4981.feature.md
@@ -1,0 +1,9 @@
+go/p2p: Bootstrap libp2p peers using seed nodes
+
+Seed nodes can now bootstrap libp2p peers. Bootstrapping can be enabled or
+disabled using a new configuration setting named
+`p2p.discovery.bootstrap.enable`
+which can be used on seed nodes as well as non-seed nodes (e.g. clients,
+key managers). The latter can also configure how frequently peers are fetched
+from the seed nodes with
+`p2p.discovery.bootstrap.retention_period`.

--- a/go/common/persistent/persistent.go
+++ b/go/common/persistent/persistent.go
@@ -40,12 +40,11 @@ func (cs *CommonStore) Close() {
 }
 
 // GetServiceStore returns a handle to a per-service bucket for the given service.
-func (cs *CommonStore) GetServiceStore(name string) (*ServiceStore, error) {
-	ss := &ServiceStore{
+func (cs *CommonStore) GetServiceStore(name string) *ServiceStore {
+	return &ServiceStore{
 		store: cs,
 		name:  []byte(name),
 	}
-	return ss, nil
 }
 
 // NewCommonStore opens the default common node storage and returns a handle.

--- a/go/common/persistent/persistent_test.go
+++ b/go/common/persistent/persistent_test.go
@@ -15,8 +15,7 @@ func TestPersistent(t *testing.T) {
 	common, err := NewCommonStore(dir)
 	assert.NoError(t, err, "NewCommonStore")
 
-	svc, err := common.GetServiceStore("persistent_test")
-	assert.NoError(t, err, "GetServiceStore")
+	svc := common.GetServiceStore("persistent_test")
 
 	key := []byte("foo")
 	val := "bar"

--- a/go/common/scheduling/fixed_rate.go
+++ b/go/common/scheduling/fixed_rate.go
@@ -1,0 +1,108 @@
+package scheduling
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	cmSync "github.com/oasisprotocol/oasis-core/go/common/sync"
+)
+
+type fixedRateTask struct {
+	name string
+	fn   func(ctx context.Context) error
+}
+
+var _ Scheduler = (*fixedRateScheduler)(nil)
+
+// fixedRateScheduler executes tasks consecutively after an initial delay, and repeats them
+// at regular intervals.
+type fixedRateScheduler struct {
+	logger *logging.Logger
+
+	delay    time.Duration // Initial time delay before first execution.
+	interval time.Duration // Time interval between repetitions.
+
+	startOne cmSync.One // Allows running scheduler only once at a time.
+
+	mu    sync.Mutex
+	tasks []*fixedRateTask
+}
+
+// NewFixedRateScheduler creates a new fixed rate scheduler.
+//
+// The interval must be greater than zero; if not, the scheduler will panic.
+func NewFixedRateScheduler(delay time.Duration, interval time.Duration) Scheduler {
+	l := logging.GetLogger("scheduler/fixed-rate")
+
+	return &fixedRateScheduler{
+		logger:   l,
+		delay:    delay,
+		interval: interval,
+		startOne: cmSync.NewOne(),
+		tasks:    make([]*fixedRateTask, 0),
+	}
+}
+
+// AddTask implements Scheduler.
+func (s *fixedRateScheduler) AddTask(name string, fn func(ctx context.Context) error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.tasks = append(s.tasks, &fixedRateTask{
+		name: name,
+		fn:   fn,
+	})
+}
+
+// Start implements Scheduler.
+func (s *fixedRateScheduler) Start() {
+	s.startOne.TryStart(s.run)
+}
+
+// Stop implements Scheduler.
+func (s *fixedRateScheduler) Stop() {
+	s.startOne.TryStop()
+}
+
+func (s *fixedRateScheduler) run(ctx context.Context) {
+	select {
+	case <-time.After(s.delay):
+	case <-ctx.Done():
+		return
+	}
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	tasks := make([]*fixedRateTask, 0)
+
+	for {
+		// Add new tasks, if any.
+		func() {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+
+			for i := len(tasks); i < len(s.tasks); i++ {
+				tasks = append(tasks, s.tasks[i])
+			}
+		}()
+
+		// Execute tasks consecutively.
+		for _, task := range tasks {
+			if err := task.fn(ctx); err != nil {
+				s.logger.Error("failed to execute task",
+					"err", err,
+					"task", task.name,
+				)
+			}
+		}
+
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/go/common/scheduling/fixed_rate_test.go
+++ b/go/common/scheduling/fixed_rate_test.go
@@ -1,0 +1,129 @@
+package scheduling
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type FixedRateSchedulerTestSuite struct {
+	suite.Suite
+}
+
+func TestFixedRateScheduler(t *testing.T) {
+	require := require.New(t)
+
+	t.Run("No tasks", func(t *testing.T) {
+		scheduler := NewFixedRateScheduler(time.Millisecond, time.Millisecond)
+		scheduler.Start()
+		time.Sleep(5 * time.Millisecond)
+		scheduler.Stop()
+	})
+
+	t.Run("Many tasks", func(t *testing.T) {
+		n1, n2 := 0, 0
+		t1 := func(ctx context.Context) error { n1++; return nil }
+		t2 := func(ctx context.Context) error { n2++; return nil }
+
+		scheduler := NewFixedRateScheduler(time.Millisecond, time.Millisecond)
+		scheduler.AddTask("t1", t1)
+		scheduler.AddTask("t2", t2)
+
+		scheduler.Start()
+		time.Sleep(5 * time.Millisecond)
+		scheduler.Stop()
+
+		require.Positive(n1)
+		require.Positive(n2)
+		require.Equal(n1, n2)
+	})
+
+	t.Run("New task while running", func(t *testing.T) {
+		n1, n2 := 0, 0
+		t1 := func(ctx context.Context) error { n1++; return nil }
+		t2 := func(ctx context.Context) error { n2++; return nil }
+
+		scheduler := NewFixedRateScheduler(time.Millisecond, time.Millisecond)
+		scheduler.AddTask("t1", t1)
+
+		scheduler.Start()
+		time.Sleep(5 * time.Millisecond)
+		scheduler.AddTask("t2", t2)
+		time.Sleep(5 * time.Millisecond)
+		scheduler.Stop()
+
+		require.Positive(n1)
+		require.Positive(n2)
+		require.Greater(n1, n2)
+	})
+
+	t.Run("Stopped during initial delay", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		doneCh := make(chan struct{})
+
+		go func() {
+			scheduler := NewFixedRateScheduler(time.Hour, time.Millisecond)
+			scheduler.Start()
+			scheduler.Stop()
+			close(doneCh)
+		}()
+
+		select {
+		case <-ctx.Done():
+			require.Fail("Scheduler should stop during initial delay")
+		case <-doneCh:
+		}
+	})
+
+	t.Run("Stopped between repetitions", func(t *testing.T) {
+		scheduler := NewFixedRateScheduler(0, time.Millisecond)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		doneCh := make(chan struct{})
+
+		go func() {
+			scheduler.Start()
+			time.Sleep(time.Millisecond)
+			scheduler.Stop()
+			close(doneCh)
+		}()
+
+		select {
+		case <-ctx.Done():
+			require.Fail("Scheduler should stop between repetitions")
+		case <-doneCh:
+		}
+	})
+
+	t.Run("Stopped during task execution", func(t *testing.T) {
+		t1 := func(ctx context.Context) error { <-ctx.Done(); return nil }
+
+		scheduler := NewFixedRateScheduler(0, time.Millisecond)
+		scheduler.AddTask("t1", t1)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		doneCh := make(chan struct{})
+
+		go func() {
+			scheduler.Start()
+			time.Sleep(time.Millisecond)
+			scheduler.Stop()
+			close(doneCh)
+		}()
+
+		select {
+		case <-ctx.Done():
+			require.Fail("Scheduler should stop during task execution")
+		case <-doneCh:
+		}
+	})
+}

--- a/go/common/scheduling/scheduler.go
+++ b/go/common/scheduling/scheduler.go
@@ -1,0 +1,19 @@
+// Package scheduling provides tools for scheduling tasks.
+package scheduling
+
+import (
+	"context"
+)
+
+// Scheduler is an interface for scheduling tasks.
+type Scheduler interface {
+	// AddTask adds given task to the scheduler.
+	AddTask(name string, fn func(ctx context.Context) error)
+
+	// Start starts executing tasks in the background. If the scheduler is already running, this is
+	// a noop operation.
+	Start()
+
+	// Stop stops executing tasks. If the scheduler is not running, this is a noop operation.
+	Stop()
+}

--- a/go/control/api/api.go
+++ b/go/control/api/api.go
@@ -171,8 +171,8 @@ type SeedStatus struct {
 	// ChainContext is the chain domain separation context.
 	ChainContext string `json:"chain_context"`
 
-	// Addresses is a list of configured external consensus addresses.
-	Addresses []node.ConsensusAddress `json:"addresses"`
+	// Addresses is a list of seed node's addresses.
+	Addresses []string `json:"addresses"`
 
 	// NodePeers is a list of peers that are connected to the node.
 	NodePeers []string `json:"node_peers"`

--- a/go/oasis-node/cmd/control/control.go
+++ b/go/oasis-node/cmd/control/control.go
@@ -186,13 +186,7 @@ func doClearDeregister(cmd *cobra.Command, args []string) {
 	}
 	defer commonStore.Close()
 
-	serviceStore, err := commonStore.GetServiceStore(registration.DBBucketName)
-	if err != nil {
-		logger.Error("failed to get registration worker service store",
-			"err", err,
-		)
-		os.Exit(1)
-	}
+	serviceStore := commonStore.GetServiceStore(registration.DBBucketName)
 
 	if err = registration.SetForcedDeregister(serviceStore, false); err != nil {
 		logger.Error("failed to clear persisted forced-deregister",

--- a/go/oasis-node/cmd/node/seed_control.go
+++ b/go/oasis-node/cmd/node/seed_control.go
@@ -49,14 +49,21 @@ func (n *SeedNode) CancelUpgrade(ctx context.Context, descriptor *upgrade.Descri
 
 // GetStatus implements control.NodeController.
 func (n *SeedNode) GetStatus(ctx context.Context) (*control.Status, error) {
-	addresses, err := n.tendermintSeed.GetAddresses()
+	tmAddresses, err := n.tendermintSeed.GetAddresses()
 	if err != nil {
 		return nil, err
 	}
+	libAddresses := n.libp2pSeed.Addresses()
+
+	addresses := make([]string, 0)
+	for _, addr := range tmAddresses {
+		addresses = append(addresses, addr.String())
+	}
+	addresses = append(addresses, libAddresses...)
 
 	seedStatus := control.SeedStatus{
 		ChainContext: n.tendermintSeed.GetChainContext(),
-		NodePeers:    n.tendermintSeed.GetPeers(),
+		NodePeers:    append(n.tendermintSeed.GetPeers(), n.libp2pSeed.Peers()...),
 		Addresses:    addresses,
 	}
 

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -611,16 +611,24 @@ func (args *argBuilder) addSentryKeymanagerWorkers(keymanagerWorkers []*Keymanag
 
 func (args *argBuilder) appendSeedNodes(seeds []*Seed) *argBuilder {
 	for _, seed := range seeds {
-		addr := commonNode.ConsensusAddress{
+		tendermintSeed := commonNode.ConsensusAddress{
 			ID: seed.p2pSigner,
 			Address: commonNode.Address{
 				IP:   net.ParseIP("127.0.0.1"),
 				Port: int64(seed.consensusPort),
 			},
 		}
+		libp2pSeed := commonNode.ConsensusAddress{
+			ID: seed.p2pSigner,
+			Address: commonNode.Address{
+				IP:   net.ParseIP("127.0.0.1"),
+				Port: int64(seed.libp2pSeedPort),
+			},
+		}
+		seeds := []string{tendermintSeed.String(), libp2pSeed.String()}
 		args.vec = append(args.vec, Argument{
 			Name:        p2p.CfgSeeds,
-			Values:      []string{addr.String()},
+			Values:      []string{strings.Join(seeds, ",")},
 			MultiValued: true,
 		})
 	}

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -49,6 +49,7 @@ const (
 	nodePortConsensus = "consensus"
 	nodePortClient    = "client"
 	nodePortP2P       = "p2p"
+	nodePortP2PSeed   = "p2p-seed"
 	nodePortPprof     = "pprof"
 )
 

--- a/go/oasis-test-runner/oasis/seed.go
+++ b/go/oasis-test-runner/oasis/seed.go
@@ -20,7 +20,8 @@ type Seed struct { // nolint: maligned
 
 	disableAddrBookFromGenesis bool
 
-	consensusPort uint16
+	consensusPort  uint16
+	libp2pSeedPort uint16
 }
 
 func (seed *Seed) AddArgs(args *argBuilder) error {
@@ -38,6 +39,7 @@ func (seed *Seed) AddArgs(args *argBuilder) error {
 		debugSetRlimit().
 		workerCertificateRotation(true).
 		tendermintCoreAddress(seed.consensusPort).
+		workerP2pPort(seed.libp2pSeedPort).
 		appendSeedNodes(otherSeeds).
 		seedMode()
 
@@ -73,6 +75,7 @@ func (net *Network) NewSeed(cfg *SeedCfg) (*Seed, error) {
 		Node:                       host,
 		disableAddrBookFromGenesis: cfg.DisableAddrBookFromGenesis,
 		consensusPort:              host.getProvisionedPort(nodePortConsensus),
+		libp2pSeedPort:             host.getProvisionedPort(nodePortP2PSeed),
 	}
 	net.seeds = append(net.seeds, seedNode)
 	host.features = append(host.features, seedNode)

--- a/go/oasis-test-runner/scenario/e2e/upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/upgrade.go
@@ -373,11 +373,7 @@ func (sc *nodeUpgradeImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 	if err != nil {
 		return fmt.Errorf("can't open upgraded node's persistent store: %w", err)
 	}
-	svcStore, err := store.GetServiceStore("upgrade")
-	if err != nil {
-		store.Close()
-		return fmt.Errorf("can't open upgraded node's upgrade module storage: %w", err)
-	}
+	svcStore := store.GetServiceStore("upgrade")
 	if err = svcStore.Delete([]byte("descriptors")); err != nil {
 		svcStore.Close()
 		store.Close()

--- a/go/p2p/api/api.go
+++ b/go/p2p/api/api.go
@@ -134,3 +134,14 @@ type PeerTagger interface {
 	// This makes it less likely for those peers to be pruned.
 	SetPeerImportance(kind ImportanceKind, runtimeID common.Namespace, pids []peer.ID)
 }
+
+// SeedService is a P2P node service interface.
+type SeedService interface {
+	service.BackgroundService
+
+	// Addresses returns the listen addresses of the host.
+	Addresses() []string
+
+	// Peers returns a list of peers located in the peer store.
+	Peers() []string
+}

--- a/go/p2p/api/convert.go
+++ b/go/p2p/api/convert.go
@@ -1,10 +1,14 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/libp2p/go-libp2p/core"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
 )
 
 // PublicKeyToPeerID converts a public key to a peer identifier.
@@ -33,4 +37,61 @@ func PublicKeyMapToPeerIDs(pks map[signature.PublicKey]bool) ([]core.PeerID, err
 		ids = append(ids, id)
 	}
 	return ids, nil
+}
+
+// AddrInfosFromConsensusAddrs converts string consensus addresses to addr infos.
+func AddrInfosFromConsensusAddrs(addrs []string) ([]peer.AddrInfo, error) {
+	peerMap := make(map[core.PeerID]*peer.AddrInfo)
+	for _, s := range addrs {
+		// Peer addresses are in the format pubkey@IP:port, because we use a similar format
+		// elsewhere and it's easier for users to understand than a multiaddr.
+		var addr node.ConsensusAddress
+		if err := addr.UnmarshalText([]byte(s)); err != nil {
+			return nil, fmt.Errorf("malformed address (expected pubkey@IP:port): %w", err)
+		}
+
+		pid, err := PublicKeyToPeerID(addr.ID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid public key (%s): %w", addr.ID, err)
+		}
+
+		ma, err := addr.Address.MultiAddress()
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert address to multi address (%s): %w", addr, err)
+		}
+
+		// If we already have this peer ID, append to its addresses.
+		if info, ok := peerMap[pid]; ok {
+			info.Addrs = append(info.Addrs, ma)
+			continue
+		}
+
+		// Fresh entry.
+		info := peer.AddrInfo{
+			ID:    pid,
+			Addrs: []multiaddr.Multiaddr{ma},
+		}
+		peerMap[pid] = &info
+	}
+
+	peers := make([]peer.AddrInfo, 0, len(peerMap))
+	for _, info := range peerMap {
+		peers = append(peers, *info)
+	}
+
+	return peers, nil
+}
+
+// AddrInfoToString converts AddressInfo to a list of p2p string multiaddresses.
+//
+// For example, an address info with ID 1234 and multiaddresses /ip4/127.0.0.1/tcp/8080 and
+// /ip6/::1/tcp/8080 would be converted to a list ["/ip4/127.0.0.1/tcp/8080/p2p/1234",
+// "/ip6/::1/tcp/8080/p2p/1234"].
+func AddrInfoToString(info peer.AddrInfo) []string {
+	id := info.ID.Pretty()
+	addrs := make([]string, len(info.Addrs))
+	for i, a := range info.Addrs {
+		addrs[i] = fmt.Sprintf("%s/p2p/%s", a.String(), id)
+	}
+	return addrs
 }

--- a/go/p2p/backup/backup.go
+++ b/go/p2p/backup/backup.go
@@ -1,0 +1,20 @@
+// Package backup provides tools for backing up peers.
+package backup
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// Backend is an interface used to backup and restore peer identities and addresses.
+type Backend interface {
+	// Delete permanently removes all peers from the backup.
+	Delete(ctx context.Context) error
+
+	// Backup stores gives peers possibly overwriting the last backup.
+	Backup(ctx context.Context, nsPeers map[string][]peer.AddrInfo) error
+
+	// Restore returns peers from the last backup.
+	Restore(ctx context.Context) (map[string][]peer.AddrInfo, error)
+}

--- a/go/p2p/backup/cstore.go
+++ b/go/p2p/backup/cstore.go
@@ -1,0 +1,120 @@
+package backup
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/common/persistent"
+)
+
+var _ Backend = (*commonStoreBackend)(nil)
+
+// commonStoreBackend uses the common store to backup and restore peers.
+type commonStoreBackend struct {
+	logger *logging.Logger
+
+	bucket *persistent.ServiceStore // A handle to a bucket where peers are stored.
+	key    string                   // A key under which peers are stored in the bucket.
+}
+
+// NewCommonStoreBackend creates a new common store backend.
+//
+// The name of the bucket and the key under which peers are stored should be unique to avoid
+// backups to be overwritten.
+func NewCommonStoreBackend(cs *persistent.CommonStore, bucket string, key string) Backend {
+	l := logging.GetLogger("p2p/backup/common-store-backend")
+
+	var b *persistent.ServiceStore
+	if cs != nil {
+		b = cs.GetServiceStore(bucket)
+	}
+
+	return &commonStoreBackend{
+		logger: l,
+		bucket: b,
+		key:    key,
+	}
+}
+
+// Delete implements PeerBackup.
+func (b *commonStoreBackend) Delete(ctx context.Context) error {
+	if b.bucket == nil {
+		return nil
+	}
+
+	return b.bucket.Delete([]byte(b.key))
+}
+
+// Backup implements PeerBackup.
+func (b *commonStoreBackend) Backup(ctx context.Context, nsPeers map[string][]peer.AddrInfo) error {
+	if b.bucket == nil {
+		return nil
+	}
+
+	// Convert addresses to json, skipping empty ones.
+	data := make(map[string][][]byte)
+	for ns, infos := range nsPeers {
+		jsons := make([][]byte, 0, len(infos))
+		for _, info := range infos {
+			if len(info.Addrs) == 0 {
+				continue
+			}
+			json, err := info.MarshalJSON()
+			if err != nil {
+				return err
+			}
+			jsons = append(jsons, json)
+		}
+		if len(jsons) == 0 {
+			continue
+		}
+		data[ns] = jsons
+	}
+
+	// Don't override the last backup if not needed.
+	if len(data) == 0 {
+		return nil
+	}
+
+	// Store addresses.
+	if err := b.bucket.PutCBOR([]byte(b.key), data); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Restore implements PeerBackup.
+func (b *commonStoreBackend) Restore(ctx context.Context) (map[string][]peer.AddrInfo, error) {
+	if b.bucket == nil {
+		return map[string][]peer.AddrInfo{}, nil
+	}
+
+	// Restore addresses.
+	data := make(map[string][][]byte)
+	if err := b.bucket.GetCBOR([]byte(b.key), &data); err != nil {
+		switch err {
+		case persistent.ErrNotFound:
+			return map[string][]peer.AddrInfo{}, nil
+		default:
+			return nil, err
+		}
+	}
+
+	// Convert them from json.
+	nsPeers := make(map[string][]peer.AddrInfo)
+	for ns, jsons := range data {
+		infos := make([]peer.AddrInfo, len(jsons))
+		for i := range jsons {
+			err := infos[i].UnmarshalJSON(jsons[i])
+			if err != nil {
+				return nil, err
+			}
+		}
+		nsPeers[ns] = infos
+	}
+
+	return nsPeers, nil
+}

--- a/go/p2p/backup/cstore_test.go
+++ b/go/p2p/backup/cstore_test.go
@@ -1,0 +1,234 @@
+package backup
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/oasisprotocol/oasis-core/go/common/persistent"
+)
+
+type CommonStoreBackendTestSuite struct {
+	suite.Suite
+
+	dir     string
+	store   *persistent.CommonStore
+	backend Backend
+
+	addrs []peer.AddrInfo
+}
+
+func TestCommonStoreBackendTestSuite(t *testing.T) {
+	suite.Run(t, new(CommonStoreBackendTestSuite))
+}
+
+func (s *CommonStoreBackendTestSuite) SetupSuite() {
+	require := require.New(s.T())
+
+	var err error
+	s.dir, err = os.MkdirTemp("", "oasis-p2p-backup-test_")
+	require.NoError(err, "TempDir failed")
+
+	s.store, err = persistent.NewCommonStore(s.dir)
+	require.NoError(err, "NewCommonStore failed")
+
+	s.backend = NewCommonStoreBackend(s.store, "bucket", "key")
+
+	s.addrs = make([]peer.AddrInfo, 5)
+	for i := 0; i < len(s.addrs); i++ {
+		_, pk, err := crypto.GenerateKeyPair(crypto.Ed25519, 0)
+		require.NoError(err, "GenerateKeyPair failed")
+
+		id, err := peer.IDFromPublicKey(pk)
+		require.NoError(err, "IDFromPublicKey failed")
+
+		addr, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d/", 8000+i))
+		require.NoError(err, "NewMultiaddr failed")
+
+		s.addrs[i] = peer.AddrInfo{
+			ID:    id,
+			Addrs: []multiaddr.Multiaddr{addr},
+		}
+	}
+}
+
+func (s *CommonStoreBackendTestSuite) TearDownSuite() {
+	require := require.New(s.T())
+
+	if s.dir != "" {
+		err := os.RemoveAll(s.dir)
+		require.NoError(err, "RemoveAll failed")
+	}
+}
+
+func (s *CommonStoreBackendTestSuite) TestDelete() {
+	require := require.New(s.T())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	peers := map[string][]peer.AddrInfo{
+		"ns-1": {s.addrs[0], s.addrs[1], s.addrs[2]},
+	}
+
+	err := s.backend.Backup(ctx, peers)
+	require.NoError(err, "Failed to backup peers")
+
+	restored, err := s.backend.Restore(ctx)
+	require.NoError(err, "Failed to restore peers")
+
+	require.True(reflect.DeepEqual(peers, restored), "Restored peers to not match")
+
+	err = s.backend.Delete(ctx)
+	require.NoError(err, "Failed to delete the backup")
+
+	s.testEmpty(ctx)
+}
+
+func (s *CommonStoreBackendTestSuite) TestBackupRestore() {
+	require := require.New(s.T())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s.Run("No namespaces", func() {
+		err := s.backend.Delete(ctx)
+		require.NoError(err, "Failed to delete the backup")
+
+		err = s.backend.Backup(ctx, nil)
+		require.NoError(err, "Failed to backup nil map of peers")
+
+		s.testEmpty(ctx)
+	})
+
+	s.Run("No peers", func() {
+		err := s.backend.Delete(ctx)
+		require.NoError(err, "Failed to delete the backup")
+
+		err = s.backend.Backup(ctx, map[string][]peer.AddrInfo{})
+		require.NoError(err, "Failed to backup empty map of peers")
+
+		s.testEmpty(ctx)
+
+		err = s.backend.Backup(ctx, map[string][]peer.AddrInfo{"ns-1": nil})
+		require.NoError(err, "Failed to backup map with empty list of peers")
+
+		s.testEmpty(ctx)
+	})
+
+	s.Run("No addrs", func() {
+		err := s.backend.Backup(ctx, map[string][]peer.AddrInfo{
+			"ns-1": {
+				{
+					ID:    s.addrs[0].ID,
+					Addrs: []multiaddr.Multiaddr{},
+				},
+			},
+		})
+		require.NoError(err, "Failed to backup map of empty addrs")
+
+		s.testEmpty(ctx)
+	})
+
+	s.Run("One namespace", func() {
+		peers := map[string][]peer.AddrInfo{
+			"ns-1": {s.addrs[0], s.addrs[1], s.addrs[2]},
+		}
+
+		err := s.backend.Backup(ctx, peers)
+		require.NoError(err, "Failed to backup one namespace")
+
+		restored, err := s.backend.Restore(ctx)
+		require.NoError(err, "Failed to restore one namespace")
+
+		require.True(reflect.DeepEqual(peers, restored), "Restored peers to not match")
+	})
+
+	s.Run("Many namespaces", func() {
+		peers := map[string][]peer.AddrInfo{
+			"ns-1": {s.addrs[0], s.addrs[1], s.addrs[2]},
+			"ns-2": {s.addrs[2], s.addrs[3], s.addrs[4]},
+			"ns-3": {s.addrs[0]},
+			"ns-4": {},
+		}
+
+		err := s.backend.Backup(ctx, peers)
+		require.NoError(err, "Failed to backup many namespaces")
+
+		restored, err := s.backend.Restore(ctx)
+		require.NoError(err, "Failed to restore many namespaces")
+
+		delete(peers, "ns-4")
+
+		require.True(reflect.DeepEqual(peers, restored), "Restored peers do not match")
+	})
+
+	s.Run("Many concurrent backups/restores", func() {
+		peers := map[string][]peer.AddrInfo{
+			"ns-1": {s.addrs[0], s.addrs[1], s.addrs[2]},
+			"ns-2": {s.addrs[2], s.addrs[3], s.addrs[4]},
+			"ns-3": {s.addrs[0]},
+		}
+
+		var wg sync.WaitGroup
+		defer wg.Wait()
+
+		n := 50
+		wg.Add(n * 2)
+		for i := 0; i < n; i++ {
+			go func() {
+				defer wg.Done()
+				err := s.backend.Backup(ctx, peers)
+				require.NoError(err, "Failed to backup peers")
+			}()
+
+			go func() {
+				defer wg.Done()
+				restored, err := s.backend.Restore(ctx)
+				require.NoError(err, "Failed to restore peers")
+				require.True(reflect.DeepEqual(peers, restored), "Restored peers do not match")
+			}()
+		}
+	})
+}
+
+func (s *CommonStoreBackendTestSuite) TestNilCommonStore() {
+	require := require.New(s.T())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	backup := NewCommonStoreBackend(nil, "bucket", "key")
+
+	s.Run("Delete", func() {
+		err := backup.Delete(ctx)
+		require.NoError(err, "Failed to delete on nil common store")
+	})
+
+	s.Run("Backup", func() {
+		err := backup.Backup(ctx, nil)
+		require.NoError(err, "Failed to backup on nil common store")
+	})
+
+	s.Run("Restore", func() {
+		_, err := backup.Restore(ctx)
+		require.NoError(err, "Failed to restore on nil common store")
+	})
+}
+
+func (s *CommonStoreBackendTestSuite) testEmpty(ctx context.Context) {
+	require := require.New(s.T())
+
+	peers, err := s.backend.Restore(ctx)
+	require.NoError(err, "Failed to restore from empty store")
+	require.Empty(peers, "There should be no peers restored from an empty store")
+}

--- a/go/p2p/backup/memory.go
+++ b/go/p2p/backup/memory.go
@@ -1,0 +1,50 @@
+package backup
+
+import (
+	"context"
+	"sync"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+var _ Backend = (*commonStoreBackend)(nil)
+
+// InMemoryBackend uses memory to backup and restore peers. This backend is not persistent and
+// intended for testing purposes only.
+type InMemoryBackend struct {
+	mu      sync.Mutex
+	nsPeers map[string][]peer.AddrInfo
+}
+
+// NewInMemoryBackend creates a new in-memory backend.
+func NewInMemoryBackend() *InMemoryBackend {
+	return &InMemoryBackend{
+		nsPeers: make(map[string][]peer.AddrInfo),
+	}
+}
+
+// Delete implements PeerBackup.
+func (b *InMemoryBackend) Delete(ctx context.Context) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.nsPeers = make(map[string][]peer.AddrInfo)
+	return nil
+}
+
+// Backup implements PeerBackup.
+func (b *InMemoryBackend) Backup(ctx context.Context, nsPeers map[string][]peer.AddrInfo) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.nsPeers = nsPeers
+	return nil
+}
+
+// Restore implements PeerBackup.
+func (b *InMemoryBackend) Restore(ctx context.Context) (map[string][]peer.AddrInfo, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.nsPeers, nil
+}

--- a/go/p2p/discovery/bootstrap/client.go
+++ b/go/p2p/discovery/bootstrap/client.go
@@ -1,0 +1,258 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/libp2p/go-libp2p/core/discovery"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+
+	cmnBackoff "github.com/oasisprotocol/oasis-core/go/common/backoff"
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+)
+
+const (
+	// defaultRetentionPeriod is the default peer retention period.
+	defaultRetentionPeriod = time.Hour
+
+	// discoveryBackOffInitialInterval is the initial time interval for the exponential back-off
+	// used between failed discoveries.
+	discoveryBackOffInitialInterval = time.Minute
+
+	// discoveryBackOffMaxInterval is the maximum time interval for the exponential back-off
+	// used between failed discoveries.
+	discoveryBackOffMaxInterval = time.Hour
+
+	// maliciousSeedBackOff is the time interval during which no peers will be returned if the seed
+	// has behaved maliciously.
+	maliciousSeedBackOff = 24 * time.Hour
+)
+
+// ClientOptions are client's peer discovery options.
+type ClientOptions struct {
+	retentionPeriod time.Duration
+}
+
+// ClientOption is a client peer discovery option setter.
+type ClientOption func(opts *ClientOptions)
+
+// WithRetentionPeriod configures peer retention period.
+func WithRetentionPeriod(retentionPeriod time.Duration) ClientOption {
+	return func(opts *ClientOptions) {
+		opts.retentionPeriod = retentionPeriod
+	}
+}
+
+// DefaultClientOptions returns the default client options.
+func DefaultClientOptions() *ClientOptions {
+	return &ClientOptions{
+		retentionPeriod: defaultRetentionPeriod,
+	}
+}
+
+type discoveryCache struct {
+	peers   []peer.AddrInfo
+	expires time.Time
+	limit   int
+}
+
+// client is an implementation of a peer discovery that fetches peers from the seed node and
+// advertises services.
+type client struct {
+	logger *logging.Logger
+
+	host host.Host
+	rc   rpc.Client
+
+	seed            peer.AddrInfo
+	retentionPeriod time.Duration
+
+	mu            sync.Mutex
+	nextDiscovery time.Time
+	backoff       *backoff.ExponentialBackOff
+	cache         map[string]*discoveryCache
+}
+
+// NewClient creates a new bootstrap protocol client.
+func NewClient(h host.Host, seed peer.AddrInfo, opts ...ClientOption) discovery.Discovery {
+	l := logging.GetLogger("p2p/discovery/bootstrap").With(
+		"seed_id", seed.ID,
+		"seed_addrs", seed.Addrs,
+	)
+
+	cos := DefaultClientOptions()
+	for _, opt := range opts {
+		opt(cos)
+	}
+
+	// Add the seed to the peer store so that libp2p knows how to contact it.
+	h.Peerstore().AddAddrs(seed.ID, seed.Addrs, peerstore.PermanentAddrTTL)
+
+	rc := rpc.NewClient(h, ProtocolID())
+
+	bo := cmnBackoff.NewExponentialBackOff()
+	bo.InitialInterval = discoveryBackOffInitialInterval
+	bo.MaxInterval = discoveryBackOffMaxInterval
+	bo.Reset()
+
+	return &client{
+		logger:          l,
+		host:            h,
+		rc:              rc,
+		seed:            seed,
+		retentionPeriod: cos.retentionPeriod,
+		nextDiscovery:   time.Now(),
+		backoff:         bo,
+		cache:           make(map[string]*discoveryCache),
+	}
+}
+
+// Advertise implements discovery.Advertiser and discovery.Discovery.
+func (c *client) Advertise(ctx context.Context, ns string, opts ...discovery.Option) (time.Duration, error) {
+	req := AdvertiseRequest{
+		Namespace: ns,
+	}
+	var res AdvertiseResponse
+
+	pf, err := c.rc.Call(ctx, c.seed.ID, MethodAdvertise, req, &res)
+	if err != nil {
+		pf.RecordFailure()
+
+		c.logger.Error("failed to advertise",
+			"err", err,
+		)
+		return 0, fmt.Errorf("failed to advertise: %w", err)
+	}
+
+	pf.RecordSuccess()
+
+	return res.TTL, nil
+}
+
+// FindPeers implements discovery.Discoverer and discovery.Discovery.
+func (c *client) FindPeers(ctx context.Context, ns string, opts ...discovery.Option) (<-chan peer.AddrInfo, error) {
+	// Check how many peers we need to fetch.
+	var options discovery.Options
+	err := options.Apply(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply options: %w", err)
+	}
+	limit := options.Limit
+
+	// Fetch peers and flush them down the channel.
+	ch := make(chan peer.AddrInfo)
+	go func() {
+		defer close(ch)
+		peers := c.fetchPeers(ctx, ns, limit)
+		sendPeers(ctx, ch, peers, limit)
+	}()
+
+	return ch, nil
+}
+
+func (c *client) fetchPeers(ctx context.Context, ns string, limit int) []peer.AddrInfo {
+	// Allow only one fetch request at a time. No need for parallelism here as speed is not
+	// crucial and the number of requests should be low anyway.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	cache, ok := c.cache[ns]
+	if !ok {
+		cache = &discoveryCache{}
+		c.cache[ns] = cache
+	}
+
+	now := time.Now()
+	if c.nextDiscovery.After(now) {
+		return cache.peers
+	}
+	if cache.expires.After(now) && (cache.limit == 0 || cache.limit >= limit && limit != 0) {
+		return cache.peers
+	}
+
+	peers, pf, err := func() ([]peer.AddrInfo, rpc.PeerFeedback, error) {
+		req := DiscoverRequest{
+			Namespace: ns,
+			Limit:     limit,
+		}
+		var rsp DiscoverResponse
+
+		pf, err := c.rc.Call(ctx, c.seed.ID, MethodDiscover, req, &rsp)
+		if err != nil {
+			c.logger.Error("failed to call seed node",
+				"err", err,
+			)
+			return nil, pf, err
+		}
+
+		if limit != 0 && len(rsp.Peers) > limit {
+			c.logger.Debug("seed node returned too many peers",
+				"limit", limit,
+				"received", len(rsp.Peers),
+			)
+			return nil, pf, ErrMaliciousSeed
+		}
+
+		peers := make([]peer.AddrInfo, len(rsp.Peers))
+		for i, json := range rsp.Peers {
+			err := peers[i].UnmarshalJSON(json)
+			if err != nil {
+				c.logger.Debug("failed to unmarshal addr info",
+					"err", err,
+				)
+				return nil, pf, ErrMaliciousSeed
+			}
+		}
+
+		return peers, pf, nil
+	}()
+
+	switch err {
+	case nil:
+		// All good. Start serving new peers.
+		cache.peers = peers
+		cache.limit = limit
+		cache.expires = now.Add(c.retentionPeriod)
+
+		c.backoff.Reset()
+		pf.RecordSuccess()
+
+	case ErrMaliciousSeed:
+		// Return no peers while the seed is marked as malicious.
+		cache.peers = nil
+		cache.limit = 0
+		cache.expires = now.Add(maliciousSeedBackOff)
+
+		pf.RecordFailure()
+		pf.RecordBadPeer()
+	default:
+		// Keep serving peers from the cache if something went wrong.
+		c.nextDiscovery = now.Add(c.backoff.NextBackOff())
+
+		pf.RecordFailure()
+	}
+
+	return cache.peers
+}
+
+func sendPeers(ctx context.Context, peerCh chan<- peer.AddrInfo, peers []peer.AddrInfo, limit int) {
+	if limit == 0 || limit > len(peers) {
+		limit = len(peers)
+	}
+
+	order := rand.Perm(len(peers))[:limit]
+	for _, i := range order {
+		select {
+		case peerCh <- peers[i]:
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/go/p2p/discovery/bootstrap/client_test.go
+++ b/go/p2p/discovery/bootstrap/client_test.go
@@ -1,0 +1,250 @@
+package bootstrap
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/discovery"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
+	"github.com/oasisprotocol/oasis-core/go/p2p/api"
+	"github.com/oasisprotocol/oasis-core/go/p2p/backup"
+	"github.com/oasisprotocol/oasis-core/go/p2p/discovery/peerstore"
+	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+)
+
+type BootstrapTestSuite struct {
+	suite.Suite
+
+	seedHost  host.Host
+	peerHosts []host.Host
+	peers     []discovery.Discovery
+
+	maliciousSeedHost host.Host
+	maliciousPeerHost host.Host
+	maliciousPeer     discovery.Discovery
+}
+
+func TestBootstrapTestSuite(t *testing.T) {
+	suite.Run(t, new(BootstrapTestSuite))
+}
+
+func (s *BootstrapTestSuite) SetupSuite() {
+	require := require.New(s.T())
+
+	newHost := func() host.Host {
+		signer, err := memory.NewFactory().Generate(signature.SignerP2P, rand.Reader)
+		require.NoError(err, "Generate failed")
+
+		listenAddr, err := multiaddr.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
+		require.NoError(err, "NewMultiaddr failed")
+
+		host, err := libp2p.New(
+			libp2p.ListenAddrs(listenAddr),
+			libp2p.Identity(api.SignerToPrivKey(signer)),
+		)
+		require.NoError(err, "libp2p.New failed")
+
+		return host
+	}
+
+	newSeed := func() rpc.Server {
+		store := peerstore.NewStore(backup.NewInMemoryBackend())
+		srv := NewServer(store)
+
+		return srv
+	}
+
+	// Prepare a seed node.
+	s.seedHost = newHost()
+	seedSrv := newSeed()
+	s.seedHost.SetStreamHandler(ProtocolID(), seedSrv.HandleStream)
+
+	// Prepare seed address for the peers.
+	ma := fmt.Sprintf("%s/p2p/%s", s.seedHost.Addrs()[0], s.seedHost.ID())
+	seedAddr, err := peer.AddrInfoFromString(ma)
+	require.NoError(err, "AddrInfoFromString failed")
+
+	// Prepare few peers.
+	numPeers := 10
+	s.peerHosts = make([]host.Host, numPeers)
+	s.peers = make([]discovery.Discovery, numPeers)
+	for i := 0; i < numPeers; i++ {
+		opts := []ClientOption{}
+		if i > 0 {
+			opts = append(opts, WithRetentionPeriod(time.Duration(0)))
+		}
+		s.peerHosts[i] = newHost()
+		s.peers[i] = NewClient(s.peerHosts[i], *seedAddr, opts...)
+	}
+
+	// Prepare a malicious seed node.
+	s.maliciousSeedHost = newHost()
+	maliciousSrv := rpc.NewServer(ProtocolID(), s)
+	s.maliciousSeedHost.SetStreamHandler(ProtocolID(), maliciousSrv.HandleStream)
+
+	ma = fmt.Sprintf("%s/p2p/%s", s.maliciousSeedHost.Addrs()[0], s.maliciousSeedHost.ID())
+	maliciousSeedAddr, err := peer.AddrInfoFromString(ma)
+	require.NoError(err, "AddrInfoFromString failed")
+
+	// Prepare a peer that communicates with malicious seed.
+	s.maliciousPeerHost = newHost()
+	s.maliciousPeer = NewClient(s.maliciousPeerHost, *maliciousSeedAddr, WithRetentionPeriod(time.Duration(0)))
+}
+
+func (s *BootstrapTestSuite) TearDownSuite() {
+	// Stop everything.
+	for _, h := range s.peerHosts {
+		h.Close()
+	}
+	s.seedHost.Close()
+
+	s.maliciousPeerHost.Close()
+	s.maliciousSeedHost.Close()
+}
+
+func (s *BootstrapTestSuite) TestAdvertise() {
+	require := require.New(s.T())
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	s.Run("Empty namespace", func() {
+		ttl, err := s.peers[0].Advertise(ctx, "")
+		require.NoError(err, "Advertise failed")
+		require.Equal(peerstore.PeerRegistrationTTL, ttl)
+	})
+
+	s.Run("One namespace", func() {
+		ttl, err := s.peers[0].Advertise(ctx, "ns-0")
+		require.NoError(err, "Advertise failed")
+		require.Equal(peerstore.PeerRegistrationTTL, ttl)
+	})
+
+	s.Run("Repeat advertisements", func() {
+		for i := 0; i < 5; i++ {
+			ttl, err := s.peers[0].Advertise(ctx, "ns-1")
+			require.NoError(err, "Advertise failed")
+			require.Equal(peerstore.PeerRegistrationTTL, ttl)
+		}
+	})
+}
+
+func (s *BootstrapTestSuite) TestDiscovery() {
+	require := require.New(s.T())
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	findPeers := func(d discovery.Discovery, ns string, limit int) int {
+		peers, err := d.FindPeers(ctx, ns, discovery.Limit(limit))
+		require.NoError(err, "FindPeers failed")
+
+		n := 0
+		for range peers {
+			n++
+		}
+		return n
+	}
+
+	s.Run("No peers", func() {
+		require.Equal(0, findPeers(s.peers[0], "ns-404", 100))
+	})
+
+	s.Run("Many peers", func() {
+		for _, peer := range s.peers {
+			_, err := peer.Advertise(ctx, "ns-2")
+			require.NoError(err, "Advertise failed")
+		}
+		require.Equal(len(s.peers), findPeers(s.peers[0], "ns-2", 100))
+	})
+
+	s.Run("Retention period", func() {
+		n := 3
+
+		// Advertise only first 3 peers.
+		for _, peer := range s.peers[:n] {
+			_, err := peer.Advertise(ctx, "ns-3")
+			require.NoError(err, "Advertise failed")
+		}
+
+		require.Equal(n, findPeers(s.peers[0], "ns-3", 100))
+		require.Equal(n, findPeers(s.peers[1], "ns-3", 100))
+
+		// Advertise the rest. Note that peer 0 has retention period set and will return peers from
+		// its cache.
+		for _, peer := range s.peers[n:] {
+			_, err := peer.Advertise(ctx, "ns-3")
+			require.NoError(err, "Advertise failed")
+		}
+
+		require.Equal(n, findPeers(s.peers[0], "ns-3", 100))
+		require.Equal(len(s.peers), findPeers(s.peers[1], "ns-3", 100))
+		require.NotEqual(n, len(s.peers))
+	})
+
+	s.Run("Peer limit", func() {
+		for _, peer := range s.peers {
+			_, err := peer.Advertise(ctx, "ns-4")
+			require.NoError(err, "Advertise failed")
+		}
+		require.Equal(1, findPeers(s.peers[1], "ns-4", 1))
+		require.Equal(len(s.peers), findPeers(s.peers[1], "ns-4", 100))
+	})
+
+	s.Run("Malicious peer", func() {
+		require.Equal(len(s.peers), findPeers(s.maliciousPeer, "limit", 100))
+
+		// Should not return any peers as malicious seed will return more than 1 peer.
+		require.Equal(0, findPeers(s.maliciousPeer, "limit", 1))
+
+		// Should not return any peers as malicious seed will return 1 peer with invalid addr info.
+		require.Equal(0, findPeers(s.maliciousPeer, "json", 100))
+	})
+}
+
+// HandleRequest is a malicious seed which doesn't respect the protocol.
+func (s *BootstrapTestSuite) HandleRequest(ctx context.Context, method string, body cbor.RawMessage) (interface{}, error) {
+	var req DiscoverRequest
+	if err := cbor.Unmarshal(body, &req); err != nil {
+		return nil, ErrBadRequest
+	}
+
+	switch req.Namespace {
+	case "limit":
+		jsons := make([][]byte, 0, len(s.peers))
+		for _, h := range s.peerHosts {
+			addr := peer.AddrInfo{
+				ID:    h.ID(),
+				Addrs: h.Addrs(),
+			}
+			json, err := addr.MarshalJSON()
+			if err != nil {
+				return nil, err
+			}
+			jsons = append(jsons, json)
+		}
+
+		return &DiscoverResponse{
+			Peers: jsons,
+		}, nil
+
+	case "json":
+		return &DiscoverResponse{
+			Peers: [][]byte{{1, 2, 3}},
+		}, nil
+	}
+
+	return nil, nil
+}

--- a/go/p2p/discovery/bootstrap/messages.go
+++ b/go/p2p/discovery/bootstrap/messages.go
@@ -1,0 +1,26 @@
+package bootstrap
+
+import (
+	"time"
+)
+
+// AdvertiseRequest is a message requesting seed to register the peer.
+type AdvertiseRequest struct {
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// AdvertiseResponse is a message response with a deadline for the next registration.
+type AdvertiseResponse struct {
+	TTL time.Duration `json:"ttl,omitempty"`
+}
+
+// DiscoverRequest is a message requesting peers.
+type DiscoverRequest struct {
+	Namespace string `json:"namespace,omitempty"`
+	Limit     int    `json:"limit,omitempty"`
+}
+
+// DiscoverResponse is a message response with a list of json encoded peer addresses.
+type DiscoverResponse struct {
+	Peers [][]byte `json:"peers,omitempty"`
+}

--- a/go/p2p/discovery/bootstrap/params.go
+++ b/go/p2p/discovery/bootstrap/params.go
@@ -1,0 +1,49 @@
+package bootstrap
+
+import (
+	"fmt"
+
+	"github.com/libp2p/go-libp2p/core/protocol"
+
+	"github.com/oasisprotocol/oasis-core/go/common/errors"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
+)
+
+const (
+	// ModuleName is a unique module name for the bootstrap discovery module.
+	ModuleName = "p2p/discovery/bootstrap"
+
+	// BootstrapProtocolName is the name for the bootstrap protocol.
+	BootstrapProtocolName = "bootstrap"
+
+	// MethodDiscover is the method name for the peer discovery handler.
+	MethodDiscover = "discover"
+
+	// MethodAdvertise is the method name for the service advertisement handler.
+	MethodAdvertise = "advertise"
+
+	// MaxPeers is the maximum number of peers the seed node will return.
+	MaxPeers = 100
+)
+
+var (
+	// ErrMethodNotSupported is an error raised when a given method is not supported.
+	ErrMethodNotSupported = errors.New(ModuleName, 1, "bootstrap: method not supported")
+
+	// ErrBadRequest is an error raised when a given request is malformed.
+	ErrBadRequest = errors.New(ModuleName, 2, "bootstrap: bad request")
+
+	// ErrMaliciousSeed is an error raised when a seed doesn't follow the bootstrap protocol.
+	ErrMaliciousSeed = errors.New(ModuleName, 3, "bootstrap: malicious seed")
+
+	// BootstrapProtocolVersion is the supported version of the bootstrap protocol.
+	BootstrapProtocolVersion = version.Version{Major: 1, Minor: 0, Patch: 0}
+)
+
+// ProtocolID is a unique protocol identifier for the bootstrap protocol.
+func ProtocolID() protocol.ID {
+	return protocol.ID(fmt.Sprintf("/oasis/%s/%s",
+		BootstrapProtocolName,
+		BootstrapProtocolVersion.MaskNonMajor(),
+	))
+}

--- a/go/p2p/discovery/bootstrap/server.go
+++ b/go/p2p/discovery/bootstrap/server.go
@@ -1,0 +1,98 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/p2p/discovery/peerstore"
+	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+)
+
+// service handles requests for service advertisement and peer discovery.
+type service struct {
+	logger *logging.Logger
+
+	store *peerstore.Store
+}
+
+// newSeedService creates a new seed node service.
+func newSeedService(s *peerstore.Store) rpc.Service {
+	l := logging.GetLogger("p2p/discovery/bootstrap")
+
+	srv := service{
+		logger: l,
+		store:  s,
+	}
+
+	return &srv
+}
+
+// HandleRequest implements rpc.Service.
+func (s *service) HandleRequest(ctx context.Context, method string, body cbor.RawMessage) (interface{}, error) {
+	switch method {
+	case MethodAdvertise:
+		addr, ok := rpc.PeerAddrInfoFromContext(ctx)
+		if !ok {
+			return nil, fmt.Errorf("failed to read peer's addr info from ctx")
+		}
+
+		var req AdvertiseRequest
+		if err := cbor.Unmarshal(body, &req); err != nil {
+			return nil, ErrBadRequest
+		}
+
+		return s.handleAdvertise(&req, addr)
+
+	case MethodDiscover:
+		var req DiscoverRequest
+		if err := cbor.Unmarshal(body, &req); err != nil {
+			return nil, ErrBadRequest
+		}
+
+		return s.handleDiscovery(&req)
+	}
+
+	return nil, ErrMethodNotSupported
+}
+
+func (s *service) handleAdvertise(req *AdvertiseRequest, info peer.AddrInfo) (*AdvertiseResponse, error) {
+	ttl, err := s.store.Add(req.Namespace, info)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add peer to the store: %w", err)
+	}
+
+	return &AdvertiseResponse{
+		TTL: ttl,
+	}, nil
+}
+
+func (s *service) handleDiscovery(req *DiscoverRequest) (*DiscoverResponse, error) {
+	limit := MaxPeers
+	if req.Limit > 0 && req.Limit < MaxPeers {
+		limit = req.Limit
+	}
+
+	peers := s.store.NamespacePeers(req.Namespace, limit)
+
+	jsons := make([][]byte, 0, len(peers))
+	for _, info := range peers {
+		json, err := info.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		jsons = append(jsons, json)
+	}
+
+	return &DiscoverResponse{
+		Peers: jsons,
+	}, nil
+}
+
+// NewServer creates a new bootstrap protocol server.
+func NewServer(s *peerstore.Store) rpc.Server {
+	return rpc.NewServer(ProtocolID(), newSeedService(s))
+}

--- a/go/p2p/discovery/peerstore/peerstore.go
+++ b/go/p2p/discovery/peerstore/peerstore.go
@@ -1,0 +1,397 @@
+package peerstore
+
+import (
+	"container/list"
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/common/scheduling"
+	"github.com/oasisprotocol/oasis-core/go/p2p/backup"
+)
+
+const (
+	// PeerRegistrationTTL is a deadline for the next registration.
+	PeerRegistrationTTL = time.Hour
+
+	// backupTaskName is the name of the task responsible for periodical backups.
+	backupTaskName = "peerstore-backup"
+
+	// backupDelay is the initial time delay for backups.
+	backupDelay = 15 * time.Minute
+
+	// backupInterval is the time interval between backups.
+	backupInterval = 15 * time.Minute
+
+	// cleanupTaskName is the name of the task responsible for periodical cleanups.
+	cleanupTaskName = "peerstore-cleanup"
+
+	// cleanupInterval is the interval for periodic store cleanup.
+	cleanupInterval = time.Minute
+
+	// defaultMaxPeers is the default maximum number of peers the store will hold before starting
+	// to reject new registration requests.
+	defaultMaxPeers = 10_000
+
+	// defaultMaxNamespacePeers is the default maximum number of peers the store will register
+	// for a namespace before starting to reject new registration requests for the namespace.
+	defaultMaxNamespacePeers = 1_000
+
+	// defaultMaxPeerNamespaces is the default maximum number of namespaces a peer can be
+	// registered for.
+	defaultMaxPeerNamespaces = 20
+)
+
+// StoreOptions are store options.
+type StoreOptions struct {
+	maxPeers   int
+	maxNsPeers int
+	maxPeerNs  int
+}
+
+// StoreOption is a store option setter.
+type StoreOption func(opts *StoreOptions)
+
+// WithMaxPeers configures maximum number of peers.
+func WithMaxPeers(max int) StoreOption {
+	return func(opts *StoreOptions) {
+		opts.maxPeers = max
+	}
+}
+
+// WithMaxNamespacePeers configures maximum number of peers in a namespace.
+func WithMaxNamespacePeers(max int) StoreOption {
+	return func(opts *StoreOptions) {
+		opts.maxNsPeers = max
+	}
+}
+
+// WithMaxPeerNamespaces configures maximum number of peer's namespaces.
+func WithMaxPeerNamespaces(max int) StoreOption {
+	return func(opts *StoreOptions) {
+		opts.maxPeerNs = max
+	}
+}
+
+// DefaultStoreOptions returns the default store options.
+func DefaultStoreOptions() *StoreOptions {
+	return &StoreOptions{
+		maxPeers:   defaultMaxPeers,
+		maxNsPeers: defaultMaxNamespacePeers,
+		maxPeerNs:  defaultMaxPeerNamespaces,
+	}
+}
+
+type registration struct {
+	ns      string
+	info    peer.AddrInfo
+	expires time.Time
+
+	expirationPos *list.Element
+}
+
+// Store is an in-memory data structure for storing peers' data.
+type Store struct {
+	logger *logging.Logger
+
+	maxPeers   int
+	maxNsPeers int
+	maxPeerNs  int
+
+	mu             sync.RWMutex
+	peerNamespaces map[peer.ID]map[string]struct{}
+	registrations  map[string]map[peer.ID]*registration
+	expirations    *list.List
+
+	backup           backup.Backend
+	backupScheduler  scheduling.Scheduler
+	cleanupScheduler scheduling.Scheduler
+}
+
+// NewStore creates a new peer store.
+func NewStore(b backup.Backend, opts ...StoreOption) *Store {
+	so := DefaultStoreOptions()
+	for _, opt := range opts {
+		opt(so)
+	}
+
+	l := logging.GetLogger("p2p/discovery/peerstore")
+
+	store := Store{
+		logger:         l,
+		backup:         b,
+		maxPeers:       so.maxPeers,
+		maxNsPeers:     so.maxNsPeers,
+		maxPeerNs:      so.maxPeerNs,
+		peerNamespaces: make(map[peer.ID]map[string]struct{}),
+		registrations:  make(map[string]map[peer.ID]*registration),
+		expirations:    list.New(),
+	}
+
+	store.backupScheduler = scheduling.NewFixedRateScheduler(backupDelay, backupInterval)
+	store.backupScheduler.AddTask(backupTaskName, store.Backup)
+
+	store.cleanupScheduler = scheduling.NewFixedRateScheduler(0, cleanupInterval)
+	store.cleanupScheduler.AddTask(cleanupTaskName, store.cleanup)
+
+	return &store
+}
+
+// Add inserts the given peer address into the store under the given namespace.
+func (s *Store) Add(ns string, info peer.AddrInfo) (time.Duration, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	nsPeers, ok := s.registrations[ns]
+	if !ok {
+		nsPeers = make(map[peer.ID]*registration)
+		s.registrations[ns] = nsPeers
+	}
+
+	// Extend/update registration.
+	reg, ok := nsPeers[info.ID]
+	if ok {
+		reg.info = info
+		reg.expires = time.Now().Add(PeerRegistrationTTL)
+		s.expirations.MoveToBack(reg.expirationPos)
+
+		return PeerRegistrationTTL, nil
+	}
+
+	// Or add a new one.
+	if len(s.peerNamespaces) >= s.maxPeers {
+		return 0, fmt.Errorf("too many peers")
+	}
+
+	if len(nsPeers) >= s.maxNsPeers {
+		return 0, fmt.Errorf("too many peers registered for the namespace")
+	}
+
+	peerNs, ok := s.peerNamespaces[info.ID]
+	if !ok {
+		peerNs = make(map[string]struct{})
+		s.peerNamespaces[info.ID] = peerNs
+	}
+	if len(peerNs) >= s.maxPeerNs {
+		return 0, fmt.Errorf("peer registered too many namespaces")
+	}
+
+	reg = &registration{
+		ns:      ns,
+		info:    info,
+		expires: time.Now().Add(PeerRegistrationTTL),
+	}
+	reg.expirationPos = s.expirations.PushBack(reg)
+
+	nsPeers[info.ID] = reg
+	peerNs[ns] = struct{}{}
+
+	return PeerRegistrationTTL, nil
+}
+
+// Remove removes the peer from the given namespace.
+func (s *Store) Remove(ns string, pid peer.ID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	peers, ok := s.registrations[ns]
+	if !ok {
+		return
+	}
+
+	reg, ok := peers[pid]
+	if !ok {
+		return
+	}
+
+	delete(peers, pid)
+
+	if len(s.registrations[ns]) == 0 {
+		delete(s.registrations, ns)
+	}
+	s.expirations.Remove(reg.expirationPos)
+
+	delete(s.peerNamespaces[pid], ns)
+	if len(s.peerNamespaces[pid]) == 0 {
+		delete(s.peerNamespaces, pid)
+	}
+}
+
+// NamespacePeers returns a random selection of peers from the given namespace.
+func (s *Store) NamespacePeers(ns string, limit int) []peer.AddrInfo {
+	if limit <= 0 {
+		return []peer.AddrInfo{}
+	}
+
+	now := time.Now()
+
+	peers := func() []peer.AddrInfo {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+
+		peerMap, ok := s.registrations[ns]
+		if !ok {
+			return []peer.AddrInfo{}
+		}
+
+		// A more advanced store should optimize this.
+		peers := make([]peer.AddrInfo, 0, len(peerMap))
+		for _, reg := range peerMap {
+			if reg.expires.Before(now) {
+				continue
+			}
+			peers = append(peers, reg.info)
+		}
+
+		return peers
+	}()
+
+	if limit > len(peers) {
+		return peers
+	}
+
+	// Shuffle only first few peers.
+	for i := 0; i < limit; i++ {
+		j := i + rand.Intn(len(peers)-i)
+		peers[i], peers[j] = peers[j], peers[i]
+	}
+
+	return peers[:limit]
+}
+
+// Peers returns peers from all namespaces without duplicates.
+func (s *Store) Peers() []peer.AddrInfo {
+	now := time.Now()
+
+	peerMap := make(map[peer.ID]peer.AddrInfo)
+	func() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+
+		for _, regs := range s.registrations {
+			for _, reg := range regs {
+				if reg.expires.Before(now) {
+					continue
+				}
+				peerMap[reg.info.ID] = reg.info
+			}
+		}
+	}()
+
+	peers := make([]peer.AddrInfo, 0, len(peerMap))
+	for _, peer := range peerMap {
+		peers = append(peers, peer)
+	}
+
+	return peers
+}
+
+// Restore loads peers from the backup.
+func (s *Store) Restore(ctx context.Context) error {
+	nsPeers, err := s.backup.Restore(ctx)
+	if err != nil {
+		s.logger.Error("failed to restore peers from the backup",
+			"err", err,
+		)
+		return err
+	}
+
+	for ns, peers := range nsPeers {
+		for _, peer := range peers {
+			_, err = s.Add(ns, peer)
+			if err != nil {
+				s.logger.Error("failed to add peer to the store",
+					"err", err,
+				)
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Backup persists peers to the backup.
+func (s *Store) Backup(ctx context.Context) error {
+	nsPeers := make(map[string][]peer.AddrInfo)
+
+	func() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+
+		for ns, regs := range s.registrations {
+			peers := make([]peer.AddrInfo, 0, len(regs))
+			for _, reg := range regs {
+				peers = append(peers, reg.info)
+			}
+			nsPeers[ns] = peers
+		}
+	}()
+
+	return s.backup.Backup(ctx, nsPeers)
+}
+
+// Start starts background services which periodically backup and clean the store.
+func (s *Store) Start() {
+	s.backupScheduler.Start()
+	s.cleanupScheduler.Start()
+}
+
+// Stop stops all background services. This method blocks until all services are stopped.
+func (s *Store) Stop() {
+	s.backupScheduler.Stop()
+	s.cleanupScheduler.Stop()
+}
+
+// cleanup removes peers which registration expired.
+func (s *Store) cleanup(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for e := s.expirations.Front(); e != nil; {
+		reg, ok := e.Value.(*registration)
+		if !ok {
+			panic("failed to cast registration")
+		}
+		if reg.expires.After(time.Now()) {
+			break
+		}
+
+		next := e.Next()
+		s.expirations.Remove(e)
+		e = next
+
+		delete(s.registrations[reg.ns], reg.info.ID)
+		if len(s.registrations[reg.ns]) == 0 {
+			delete(s.registrations, reg.ns)
+		}
+	}
+
+	return nil
+}
+
+// total returns the number of peers in all namespaces counting duplicates twice.
+func (s *Store) total() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	total := 0
+	for _, ns := range s.registrations {
+		total += len(ns)
+	}
+
+	return total
+}
+
+// size returns the number of peers in the given namespace.
+func (s *Store) size(ns string) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return len(s.registrations[ns])
+}

--- a/go/p2p/discovery/peerstore/peerstore_test.go
+++ b/go/p2p/discovery/peerstore/peerstore_test.go
@@ -1,0 +1,234 @@
+package peerstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/oasisprotocol/oasis-core/go/p2p/backup"
+)
+
+type StoreTestSuite struct {
+	suite.Suite
+
+	store *Store
+	infos []peer.AddrInfo
+}
+
+func (s *StoreTestSuite) SetupSuite() {
+	require := require.New(s.T())
+
+	s.infos = make([]peer.AddrInfo, 5)
+	for i := 0; i < len(s.infos); i++ {
+		_, pk, err := crypto.GenerateKeyPair(crypto.Ed25519, 0)
+		require.NoError(err)
+
+		id, err := peer.IDFromPublicKey(pk)
+		require.NoError(err)
+
+		s.infos[i] = peer.AddrInfo{
+			ID:    id,
+			Addrs: make([]multiaddr.Multiaddr, 0),
+		}
+	}
+}
+
+func (s *StoreTestSuite) SetupTest() {
+	require := require.New(s.T())
+
+	// Prepare store with few entries.
+	s.store = NewStore(backup.NewInMemoryBackend())
+
+	_, err := s.store.Add("ns-1", s.infos[0])
+	require.NoError(err)
+	_, err = s.store.Add("ns-1", s.infos[1])
+	require.NoError(err)
+	_, err = s.store.Add("ns-1", s.infos[2])
+	require.NoError(err)
+
+	_, err = s.store.Add("ns-2", s.infos[0])
+	require.NoError(err)
+	_, err = s.store.Add("ns-2", s.infos[3])
+	require.NoError(err)
+}
+
+func (s *StoreTestSuite) TestNewStore() {
+	require := require.New(s.T())
+
+	store := NewStore(backup.NewInMemoryBackend())
+	require.NotNil(store.logger, "logger should be initialized")
+	require.NotNil(store.registrations, "registrations should be initialized")
+	require.NotNil(store.expirations, "expirations should be initialized")
+}
+
+func (s *StoreTestSuite) TestAdd() {
+	require := require.New(s.T())
+
+	// Happy path.
+	require.Equal(3, s.store.size("ns-1"))
+	require.Equal(2, s.store.size("ns-2"))
+	require.Equal(5, s.store.total())
+
+	// Add few existing.
+	_, err := s.store.Add("ns-1", s.infos[0])
+	require.NoError(err)
+	_, err = s.store.Add("ns-1", s.infos[1])
+	require.NoError(err)
+
+	// Numbers should not change.
+	require.Equal(3, s.store.size("ns-1"))
+	require.Equal(2, s.store.size("ns-2"))
+	require.Equal(5, s.store.total())
+}
+
+func (s *StoreTestSuite) TestRemove() {
+	require := require.New(s.T())
+
+	// Remove few.
+	s.store.Remove("ns-1", s.infos[0].ID)
+	s.store.Remove("ns-2", s.infos[3].ID)
+
+	// Remove non-existing.
+	s.store.Remove("ns-1", s.infos[4].ID)
+	s.store.Remove("ns-404", s.infos[0].ID)
+	s.store.Remove("ns-404", s.infos[4].ID)
+
+	require.Equal(2, s.store.size("ns-1"))
+	require.Equal(1, s.store.size("ns-2"))
+	require.Equal(3, s.store.total())
+}
+
+func (s *StoreTestSuite) TestNamespacePeers() {
+	require := require.New(s.T())
+
+	require.Equal(3, s.store.size("ns-1"))
+	require.Equal(2, s.store.size("ns-2"))
+
+	// Non-existing namespace.
+	peers := s.store.NamespacePeers("ns-404", 10)
+	require.Empty(peers)
+
+	// Happy path.
+	peers = s.store.NamespacePeers("ns-1", 10)
+	require.Len(peers, 3)
+
+	// With limit.
+	peers = s.store.NamespacePeers("ns-2", 1)
+	require.Len(peers, 1)
+}
+
+func (s *StoreTestSuite) TestPeers() {
+	require := require.New(s.T())
+
+	// Happy path.
+	peers := s.store.Peers()
+	require.Len(peers, 4)
+}
+
+func (s *StoreTestSuite) TestStoreOptions() {
+	require := require.New(s.T())
+
+	s.Run("Max peers", func() {
+		store := NewStore(backup.NewInMemoryBackend(),
+			WithMaxPeers(2),
+		)
+
+		// Add two peers.
+		_, err := store.Add("ns-1", s.infos[0])
+		require.NoError(err)
+		_, err = store.Add("ns-2", s.infos[1])
+		require.NoError(err)
+
+		// Third addition should fail.
+		_, err = store.Add("ns-3", s.infos[2])
+		require.Error(err)
+
+		// But if we remove one we can add another one.
+		store.Remove("ns-2", s.infos[1].ID)
+		_, err = store.Add("ns-3", s.infos[2])
+		require.NoError(err)
+	})
+
+	s.Run("Max namespace peers", func() {
+		store := NewStore(backup.NewInMemoryBackend(),
+			WithMaxNamespacePeers(1),
+		)
+
+		// Add one twice.
+		_, err := store.Add("ns-1", s.infos[0])
+		require.NoError(err)
+		_, err = store.Add("ns-1", s.infos[0])
+		require.NoError(err)
+
+		// Add a second one and reach max number of peers in namespace ns-1.
+		_, err = store.Add("ns-1", s.infos[1])
+		require.Error(err)
+
+		// Remove one and test if we can add again.
+		store.Remove("ns-1", s.infos[0].ID)
+		_, err = store.Add("ns-1", s.infos[1])
+		require.NoError(err)
+	})
+
+	s.Run("Max peer's namespaces", func() {
+		store := NewStore(backup.NewInMemoryBackend(),
+			WithMaxPeerNamespaces(1),
+		)
+
+		_, err := store.Add("ns-1", s.infos[0])
+		require.NoError(err)
+		_, err = store.Add("ns-2", s.infos[0])
+		require.Error(err)
+	})
+}
+
+func (s *StoreTestSuite) TestBackupRestore() {
+	require := require.New(s.T())
+
+	// Backup and restore to a different store.
+	err := s.store.Backup(context.Background())
+	require.NoError(err)
+
+	store := NewStore(s.store.backup)
+	err = store.Restore(context.Background())
+	require.NoError(err)
+
+	// Numbers should not change.
+	require.Equal(3, store.size("ns-1"))
+	require.Equal(2, store.size("ns-2"))
+	require.Equal(5, store.total())
+}
+
+func (s *StoreTestSuite) TestStartStop() {
+	s.store.Start()
+	s.store.Stop()
+}
+
+func (s *StoreTestSuite) TestClean() {
+	require := require.New(s.T())
+
+	require.Equal(3, s.store.size("ns-1"))
+	require.Equal(2, s.store.size("ns-2"))
+	require.Equal(5, s.store.expirations.Len())
+
+	// Fake expirations of the first two in line.
+	s.store.registrations["ns-1"][s.infos[0].ID].expires = time.Now()
+	s.store.registrations["ns-1"][s.infos[1].ID].expires = time.Now()
+
+	err := s.store.cleanup(context.Background())
+	require.NoError(err)
+
+	require.Equal(1, s.store.size("ns-1"))
+	require.Equal(2, s.store.size("ns-2"))
+	require.Equal(3, s.store.expirations.Len())
+}
+
+func TestStoreTestSuite(t *testing.T) {
+	suite.Run(t, new(StoreTestSuite))
+}

--- a/go/p2p/flags.go
+++ b/go/p2p/flags.go
@@ -41,6 +41,11 @@ const (
 
 	// CfgSeeds configures seed node(s).
 	CfgSeeds = "p2p.seeds"
+
+	// CfgBootstrapEnable enables bootstrap discovery protocol.
+	CfgBootstrapEnable = "p2p.discovery.bootstrap.enable"
+	// CfgBootstrapRetentionPeriod is the retention period for peers discovered through seed nodes.
+	CfgBootstrapRetentionPeriod = "p2p.discovery.bootstrap.retention_period"
 )
 
 // Flags has the configuration flags.
@@ -59,6 +64,8 @@ func init() {
 	Flags.StringSlice(CfgConnGaterBlockedPeerIPs, []string{}, "List of blocked peer IPs")
 	Flags.StringSlice(CfgConnMgrPersistentPeers, []string{}, "List of persistent peer node addresses in format P2Ppubkey@IP:port")
 	Flags.StringSlice(CfgSeeds, []string{}, "Seed node(s) of the form pubkey@IP:port")
+	Flags.Bool(CfgBootstrapEnable, true, "Enable bootstrap discovery protocol")
+	Flags.Duration(CfgBootstrapRetentionPeriod, time.Hour, "Retention period for peers discovered through seed nodes")
 
 	_ = viper.BindPFlags(Flags)
 }

--- a/go/p2p/host.go
+++ b/go/p2p/host.go
@@ -1,0 +1,199 @@
+package p2p
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/net/conngater"
+	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/spf13/viper"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
+	"github.com/oasisprotocol/oasis-core/go/p2p/api"
+)
+
+// HostConfig describes a set of settings for a host.
+type HostConfig struct {
+	Signer signature.Signer
+
+	UserAgent  string
+	ListenAddr multiaddr.Multiaddr
+	Port       uint16
+
+	ConnManagerConfig
+	ConnGaterConfig
+}
+
+// NewHost constructs a new libp2p host.
+func NewHost(cfg *HostConfig) (host.Host, *conngater.BasicConnectionGater, error) {
+	id := api.SignerToPrivKey(cfg.Signer)
+
+	// Set up a connection manager so we can limit the number of connections.
+	cm, err := NewConnManager(&cfg.ConnManagerConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Set up a connection gater so we can block peers.
+	cg, err := NewConnGater(&cfg.ConnGaterConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	host, err := libp2p.New(
+		libp2p.UserAgent(cfg.UserAgent),
+		libp2p.ListenAddrs(cfg.ListenAddr),
+		libp2p.Identity(id),
+		libp2p.ConnectionManager(cm),
+		libp2p.ConnectionGater(cg),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// We need to return the gater as it is not accessible via the host.
+	return host, cg, nil
+}
+
+// NewHost constructs a new libp2p host.
+func (cfg *HostConfig) NewHost() (host.Host, *conngater.BasicConnectionGater, error) {
+	return NewHost(cfg)
+}
+
+// Load loads host configuration.
+func (cfg *HostConfig) Load() error {
+	userAgent := fmt.Sprintf("oasis-core/%s", version.SoftwareVersion)
+	port := viper.GetUint16(CfgHostPort)
+
+	// Listen for connections on all interfaces.
+	listenAddr, err := multiaddr.NewMultiaddr(
+		fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", port),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create multiaddress: %w", err)
+	}
+
+	var cmCfg ConnManagerConfig
+	if err = cmCfg.Load(); err != nil {
+		return fmt.Errorf("failed to load connection manager config: %w", err)
+	}
+
+	var cgCfg ConnGaterConfig
+	if err = cgCfg.Load(); err != nil {
+		return fmt.Errorf("failed to load connection gater config: %w", err)
+	}
+
+	cfg.UserAgent = userAgent
+	cfg.Port = port
+	cfg.ListenAddr = listenAddr
+	cfg.ConnManagerConfig = cmCfg
+	cfg.ConnGaterConfig = cgCfg
+
+	return nil
+}
+
+// ConnManagerConfig describes a set of settings for a connection manager.
+type ConnManagerConfig struct {
+	MinPeers        int
+	MaxPeers        int
+	GracePeriod     time.Duration
+	PersistentPeers []peer.ID
+}
+
+// NewConnManager constructs a new connection manager.
+func NewConnManager(cfg *ConnManagerConfig) (*connmgr.BasicConnMgr, error) {
+	gracePeriod := connmgr.WithGracePeriod(cfg.GracePeriod)
+	cm, err := connmgr.NewConnManager(cfg.MinPeers, cfg.MaxPeers, gracePeriod)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create connection manager: %w", err)
+	}
+	for _, pid := range cfg.PersistentPeers {
+		cm.Protect(pid, "")
+	}
+	return cm, nil
+}
+
+// NewConnManager constructs a new connection manager.
+func (cfg *ConnManagerConfig) NewConnManager() (*connmgr.BasicConnMgr, error) {
+	return NewConnManager(cfg)
+}
+
+// Load loads connection manager configuration.
+func (cfg *ConnManagerConfig) Load() error {
+	persistentPeersMap := make(map[core.PeerID]struct{})
+	for _, pp := range viper.GetStringSlice(CfgConnMgrPersistentPeers) {
+		var addr node.ConsensusAddress
+		if err := addr.UnmarshalText([]byte(pp)); err != nil {
+			return fmt.Errorf("malformed address (expected pubkey@IP:port): %w", err)
+		}
+
+		pid, err := api.PublicKeyToPeerID(addr.ID)
+		if err != nil {
+			return fmt.Errorf("invalid public key (%s): %w", addr.ID, err)
+		}
+
+		persistentPeersMap[pid] = struct{}{}
+	}
+
+	persistentPeers := make([]peer.ID, 0)
+	for pid := range persistentPeersMap {
+		persistentPeers = append(persistentPeers, pid)
+	}
+
+	cfg.MinPeers = viper.GetInt(CfgConnMgrMaxNumPeers)
+	cfg.MaxPeers = cfg.MinPeers + peersHighWatermarkDelta
+	cfg.GracePeriod = viper.GetDuration(CfgConnMgrPeerGracePeriod)
+	cfg.PersistentPeers = persistentPeers
+
+	return nil
+}
+
+// ConnGaterConfig describes a set of settings for a connection gater.
+type ConnGaterConfig struct {
+	BlockedPeers []net.IP
+}
+
+// NewConnGater constructs a new connection gater.
+func NewConnGater(cfg *ConnGaterConfig) (*conngater.BasicConnectionGater, error) {
+	// Set up a connection gater and block blacklisted peers.
+	cg, err := conngater.NewBasicConnectionGater(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create connection gater: %w", err)
+	}
+
+	for _, ip := range cfg.BlockedPeers {
+		if err = cg.BlockAddr(ip); err != nil {
+			return nil, fmt.Errorf("connection gater failed to block IP (%s): %w", ip, err)
+		}
+	}
+	return cg, nil
+}
+
+// NewConnGater constructs a new connection gater.
+func (cfg *ConnGaterConfig) NewConnGater() (*conngater.BasicConnectionGater, error) {
+	return NewConnGater(cfg)
+}
+
+// Load loads connection gater configuration.
+func (cfg *ConnGaterConfig) Load() error {
+	blockedPeers := make([]net.IP, 0)
+	for _, blockedIP := range viper.GetStringSlice(CfgConnGaterBlockedPeerIPs) {
+		parsedIP := net.ParseIP(blockedIP)
+		if parsedIP == nil {
+			return fmt.Errorf("malformed blocked IP: %s", blockedIP)
+		}
+		blockedPeers = append(blockedPeers, parsedIP)
+	}
+
+	cfg.BlockedPeers = blockedPeers
+
+	return nil
+}

--- a/go/p2p/peermgmt/backoff.go
+++ b/go/p2p/peermgmt/backoff.go
@@ -1,0 +1,39 @@
+package peermgmt
+
+import (
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+
+	cmnBackoff "github.com/oasisprotocol/oasis-core/go/common/backoff"
+)
+
+type backOff struct {
+	bo      *backoff.ExponentialBackOff
+	nextTry time.Time
+}
+
+func newBackOff(nextTry time.Time, initialInterval time.Duration, maxInterval time.Duration) *backOff {
+	bo := cmnBackoff.NewExponentialBackOff()
+	bo.InitialInterval = initialInterval
+	bo.MaxInterval = maxInterval
+	bo.Reset()
+
+	return &backOff{
+		bo:      bo,
+		nextTry: nextTry,
+	}
+}
+
+func (b *backOff) check(t time.Time) bool {
+	return !t.Before(b.nextTry)
+}
+
+func (b *backOff) extend() {
+	b.nextTry = time.Now().Add(b.bo.NextBackOff())
+}
+
+func (b *backOff) reset() {
+	b.bo.Reset()
+	b.nextTry = time.Now()
+}

--- a/go/p2p/peermgmt/backup.go
+++ b/go/p2p/peermgmt/backup.go
@@ -2,197 +2,104 @@ package peermgmt
 
 import (
 	"context"
-	"math/rand"
 	"time"
 
-	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
 
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
-	"github.com/oasisprotocol/oasis-core/go/common/persistent"
-	cmSync "github.com/oasisprotocol/oasis-core/go/common/sync"
+	"github.com/oasisprotocol/oasis-core/go/common/scheduling"
+	"github.com/oasisprotocol/oasis-core/go/p2p/backup"
 )
 
 const (
-	// storeBucketName is the name of the bucket in which backup data is stored.
-	storeBucketName = "p2p/peer_manager"
+	// peerstoreBucketName is the name of the bucket in which backup data is stored.
+	peerstoreBucketName = "p2p/peer_manager/peerstore"
 
-	// storePeerstoreKey is the bucket key under which peers from the peerstore are stored.
-	storePeerstoreKey = "peerstore"
+	// peerstoreBucketKey is the bucket key under which peers from the peerstore are stored.
+	peerstoreBucketKey = "peers"
 
-	// backupStartupDelay is the startup time delay for backups.
-	backupStartupDelay = 15 * time.Minute
+	// peerstoreBackupTaskName is the name of the task responsible for periodical backups.
+	peerstoreBackupTaskName = "peerstore-backup"
+
+	// peerstoreNamespace is the namespace under which peers are stored in the backup.
+	peerstoreNamespace = ""
+
+	// backupDelay is the initial time delay for backups.
+	backupDelay = 15 * time.Minute
 
 	// backupInterval is the time interval between backups.
 	backupInterval = 15 * time.Minute
-
-	// maxRestorePeers is the maximum number of peers connected on startup from the backup.
-	maxRestorePeers = 100
 )
 
 type peerstoreBackup struct {
 	logger *logging.Logger
 
-	host host.Host
-
-	store   *persistent.CommonStore
-	storeCh chan struct{}
-
-	startOne cmSync.One
+	store           peerstore.Peerstore
+	backupBackend   backup.Backend
+	backupScheduler scheduling.Scheduler
 }
 
-func newPeerstoreBackup(h host.Host, cs *persistent.CommonStore) *peerstoreBackup {
+func newPeerstoreBackup(ps peerstore.Peerstore, b backup.Backend) *peerstoreBackup {
 	l := logging.GetLogger("p2p/peer-manager/backup")
 
-	return &peerstoreBackup{
-		logger:   l,
-		host:     h,
-		store:    cs,
-		storeCh:  make(chan struct{}, 1),
-		startOne: cmSync.NewOne(),
+	pb := peerstoreBackup{
+		logger:        l,
+		store:         ps,
+		backupBackend: b,
 	}
+
+	pb.backupScheduler = scheduling.NewFixedRateScheduler(backupDelay, backupInterval)
+	pb.backupScheduler.AddTask(peerstoreBackupTaskName, pb.backup)
+
+	return &pb
 }
 
-// save persists peers to the store.
-func (b *peerstoreBackup) save() error {
-	if b.store == nil {
-		return nil
-	}
+func (b *peerstoreBackup) backup(ctx context.Context) error {
+	b.logger.Debug("backing up peers")
 
-	// Allow only one save/load at a time.
-	b.storeCh <- struct{}{}
-	defer func() { <-b.storeCh }()
-
-	// Save only connected peers.
-	peers := b.host.Network().Peers()
-
-	if len(peers) == 0 {
-		return nil
-	}
-
-	b.logger.Debug("storing peers",
-		"count", len(peers),
-	)
-
-	infos := make([][]byte, 0, len(peers))
+	peers := b.store.PeersWithAddrs()
+	infos := make([]peer.AddrInfo, 0, len(peers))
 	for _, p := range peers {
-		info := b.host.Peerstore().PeerInfo(p)
-		if len(info.Addrs) == 0 {
-			continue
-		}
-
-		json, err := info.MarshalJSON()
-		if err != nil {
-			return err
-		}
-
-		infos = append(infos, json)
+		infos = append(infos, b.store.PeerInfo(p))
+	}
+	nsPeers := map[string][]peer.AddrInfo{
+		peerstoreNamespace: infos,
 	}
 
-	// Persist addresses.
-	bucket, err := b.store.GetServiceStore(storeBucketName)
+	err := b.backupBackend.Backup(ctx, nsPeers)
 	if err != nil {
-		return err
-	}
-	if err = bucket.PutCBOR([]byte(storePeerstoreKey), infos); err != nil {
+		b.logger.Error("failed to backup peers",
+			"err", err,
+		)
 		return err
 	}
 
 	return nil
 }
 
-// load loads peers from the store.
-func (b *peerstoreBackup) load() ([]*peer.AddrInfo, error) {
-	if b.store == nil {
-		return []*peer.AddrInfo{}, nil
-	}
+func (b *peerstoreBackup) restore(ctx context.Context) error {
+	b.logger.Debug("restoring peers")
 
-	// Allow only one save/load at a time.
-	b.storeCh <- struct{}{}
-	defer func() { <-b.storeCh }()
-
-	b.logger.Debug("loading peers")
-
-	// Load addresses in json form.
-	bucket, err := b.store.GetServiceStore(storeBucketName)
+	peers, err := b.backupBackend.Restore(ctx)
 	if err != nil {
-		return nil, err
-	}
-	var jsons [][]byte
-	if err = bucket.GetCBOR([]byte(storePeerstoreKey), &jsons); err != nil {
-		return nil, err
-	}
-
-	// Convert them.
-	infos := make([]*peer.AddrInfo, len(jsons))
-	for i, json := range jsons {
-		var info peer.AddrInfo
-		if err = info.UnmarshalJSON(json); err != nil {
-			return nil, err
-		}
-		infos[i] = &info
-	}
-
-	return infos, nil
-}
-
-// start starts a background task which periodically backups peers to the store. If a backup
-// is already in progress, this is a noop operation.
-func (b *peerstoreBackup) start() {
-	b.startOne.TryStart(b.run)
-}
-
-// stop stops the backup service, if one is running.
-func (b *peerstoreBackup) stop() {
-	b.startOne.TryStop()
-}
-
-// run periodically backups peers to the store. If a backup is already in progress, this method will
-// wait for it to finish.
-func (b *peerstoreBackup) run(ctx context.Context) {
-	select {
-	case <-time.After(backupStartupDelay):
-	case <-ctx.Done():
-		return
-	}
-
-	ticker := time.NewTicker(backupInterval)
-	defer ticker.Stop()
-
-	for {
-		if err := b.save(); err != nil {
-			b.logger.Error("failed to backup peers",
-				"err", err,
-			)
-		}
-
-		select {
-		case <-ticker.C:
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-// restore loads peers from the backup and connects to few of them.
-func (b *peerstoreBackup) restore(ctx context.Context, c *peerConnector) {
-	infos, err := b.load()
-	if err != nil {
-		b.logger.Error("failed to load peers from the backup",
+		b.logger.Error("failed to restore peers",
 			"err", err,
 		)
-		return
+		return err
 	}
 
-	b.logger.Debug("connecting to peers from the backup",
-		"count", len(infos),
-		"limit", maxRestorePeers,
-	)
+	for _, info := range peers[peerstoreNamespace] {
+		b.store.SetAddrs(info.ID, info.Addrs, peerstore.RecentlyConnectedAddrTTL)
+	}
 
-	// Connect to a random subset.
-	rand.Shuffle(len(infos), func(i, j int) {
-		infos[i], infos[j] = infos[j], infos[i]
-	})
+	return nil
+}
 
-	c.connectMany(ctx, infos, maxRestorePeers)
+func (b *peerstoreBackup) start() {
+	b.backupScheduler.Start()
+}
+
+func (b *peerstoreBackup) stop() {
+	b.backupScheduler.Stop()
 }

--- a/go/p2p/peermgmt/backup_test.go
+++ b/go/p2p/peermgmt/backup_test.go
@@ -2,173 +2,147 @@ package peermgmt
 
 import (
 	"context"
-	"os"
+	"fmt"
 	"sync"
 	"testing"
-	"time"
 
-	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-libp2p/p2p/net/conngater"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/oasisprotocol/oasis-core/go/common/persistent"
+	"github.com/oasisprotocol/oasis-core/go/p2p/backup"
 )
 
-type BackupTestSuite struct {
+type PeerstoreBackupTestSuite struct {
 	suite.Suite
 
-	dir   string
-	store *persistent.CommonStore
+	store   peerstore.Peerstore
+	backup  *peerstoreBackup
+	backend backup.Backend
 
-	host  host.Host
-	peers []host.Host
-	infos []*peer.AddrInfo
-
-	backup *peerstoreBackup
+	infos []peer.AddrInfo
 }
 
-func TestBackupTestSuite(t *testing.T) {
-	suite.Run(t, new(BackupTestSuite))
+func TestPeerstoreBackupTestSuite(t *testing.T) {
+	suite.Run(t, new(PeerstoreBackupTestSuite))
 }
 
-func (s *BackupTestSuite) SetupSuite() {
+func (s *PeerstoreBackupTestSuite) SetupSuite() {
 	require := require.New(s.T())
+
+	s.infos = make([]peer.AddrInfo, 5)
+	for i := 0; i < len(s.infos); i++ {
+		_, pk, err := crypto.GenerateKeyPair(crypto.Ed25519, 0)
+		require.NoError(err, "GenerateKeyPair failed")
+
+		id, err := peer.IDFromPublicKey(pk)
+		require.NoError(err, "IDFromPublicKey failed")
+
+		addr, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d/", 8000+i))
+		require.NoError(err, "NewMultiaddr failed")
+
+		s.infos[i] = peer.AddrInfo{
+			ID:    id,
+			Addrs: []multiaddr.Multiaddr{addr},
+		}
+	}
 
 	var err error
-	s.dir, err = os.MkdirTemp("", "oasis-p2p-backup-test_")
-	require.NoError(err, "TempDir failed")
+	s.store, err = pstoremem.NewPeerstore()
+	require.NoError(err, "NewPeerstore failed")
 
-	s.store, err = persistent.NewCommonStore(s.dir)
-	require.NoError(err, "NewCommonStore failed")
+	s.backend = backup.NewInMemoryBackend()
+	s.backup = newPeerstoreBackup(s.store, s.backend)
+}
 
-	// One host.
-	s.host, err = newTestHost()
-	require.NoError(err, "newTestHost failed")
+func (s *PeerstoreBackupTestSuite) TestBackupRestore() {
+	require := require.New(s.T())
 
-	// Few peers.
-	n := 10
-	s.peers = make([]host.Host, 0, n)
-	for i := 0; i < n; i++ {
-		host, err := newTestHost()
-		require.NoError(err, "newTestHost failed")
-
-		s.peers = append(s.peers, host)
-	}
-
-	s.infos = make([]*peer.AddrInfo, 0, len(s.peers))
-	for _, p := range s.peers {
-		info := peer.AddrInfo{
-			ID:    p.ID(),
-			Addrs: p.Addrs(),
+	clearStore := func() {
+		for _, p := range s.store.Peers() {
+			s.store.ClearAddrs(p)
 		}
-		s.infos = append(s.infos, &info)
+		require.Empty(s.store.PeersWithAddrs())
 	}
-
-	// One backup to play with.
-	s.backup = newPeerstoreBackup(s.host, s.store)
-}
-
-func (s *BackupTestSuite) TearDownSuite() {
-	require := require.New(s.T())
-
-	for _, p := range s.peers {
-		err := p.Close()
-		require.NoError(err, "Peer Close failed")
-	}
-
-	err := s.host.Close()
-	require.NoError(err, "Host Close failed")
-
-	if s.dir != "" {
-		os.RemoveAll(s.dir)
-	}
-}
-
-func (s *BackupTestSuite) TestStoreLoad() {
-	require := require.New(s.T())
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
 	s.Run("Empty store", func() {
-		// Make sure no one is connected.
-		require.Equal(0, len(s.host.Network().Peers()))
-
-		// Clear store.
-		db, err := s.store.GetServiceStore(storeBucketName)
-		require.NoError(err, "GetServiceStore failed")
-
-		err = db.Delete([]byte(storePeerstoreKey))
-		require.NoError(err, "Delete failed")
+		// Ensure that the store is empty.
+		clearStore()
 
 		// Store empty peerstore.
-		err = s.backup.save()
-		require.NoError(err, "Store failed on empty peerstore")
+		err := s.backup.backup(context.Background())
+		require.NoError(err, "Backup failed on empty peerstore")
 
 		// Load empty db.
-		_, err = s.backup.load()
-		require.Error(err, "Load should fail on empty db")
+		err = s.backup.restore(context.Background())
+		require.NoError(err, "Restore failed on empty db")
+		require.Empty(s.store.PeersWithAddrs())
 	})
 
 	s.Run("One peer", func() {
-		// Connect one peer.
-		err := s.host.Connect(ctx, *s.infos[0])
-		require.NoError(err, "Connect failed")
+		// Add one peer.
+		s.store.AddAddrs(s.infos[0].ID, s.infos[0].Addrs, peerstore.RecentlyConnectedAddrTTL)
 
 		// Store peerstore with one peer.
-		err = s.backup.save()
-		require.NoError(err, "Store failed")
+		err := s.backup.backup(context.Background())
+		require.NoError(err, "Backup failed")
 
-		// Load db.
-		peers, err := s.backup.load()
-		require.NoError(err, "Load failed")
-		require.Len(peers, 1)
+		// Ensure that the store is empty.
+		clearStore()
+
+		// Load one peer.
+		err = s.backup.restore(context.Background())
+		require.NoError(err, "Restore failed")
+		require.Len(s.store.PeersWithAddrs(), 1)
 	})
 
 	s.Run("Many peers", func() {
-		// Connect many peers.
+		// Add many peers.
 		for _, info := range s.infos {
-			err := s.host.Connect(ctx, *info)
-			require.NoError(err, "Connect failed")
+			s.store.AddAddrs(info.ID, info.Addrs, peerstore.RecentlyConnectedAddrTTL)
 		}
 
-		// Store peerstore with many peers.
-		err := s.backup.save()
-		require.NoError(err, "Store failed")
+		// Store peerstore with one peer.
+		err := s.backup.backup(context.Background())
+		require.NoError(err, "Backup failed")
 
-		// Load db.
-		peers, err := s.backup.load()
-		require.NoError(err, "Load failed")
-		require.Len(peers, len(s.infos))
+		// Ensure that the store is empty.
+		clearStore()
+
+		// Load one peer.
+		err = s.backup.restore(context.Background())
+		require.NoError(err, "Restore failed")
+		require.Len(s.store.PeersWithAddrs(), len(s.infos))
 	})
 
-	s.Run("Concurrency", func() {
+	s.Run("Many concurrent backups/restores", func() {
 		// Many concurrent loads/saves.
 		var wg sync.WaitGroup
 		defer wg.Wait()
 
-		n := 10
+		n := 50
 		wg.Add(n * 2)
 		for i := 0; i < n; i++ {
 			go func() {
 				defer wg.Done()
-				err := s.backup.save()
-				require.NoError(err, "Store failed")
+				err := s.backup.backup(context.Background())
+				require.NoError(err, "Backup failed")
 			}()
 
 			go func() {
 				defer wg.Done()
-				peers, err := s.backup.load()
-				require.NoError(err, "Load failed")
-				require.Len(peers, len(s.infos))
+				err := s.backup.restore(context.Background())
+				require.NoError(err, "Restore failed")
 			}()
 		}
 	})
 }
 
-func (s *BackupTestSuite) TestStartStop() {
+func (s *PeerstoreBackupTestSuite) TestStartStop() {
 	s.Run("Backup stops", func() {
 		s.backup.start()
 		s.backup.stop()
@@ -186,46 +160,5 @@ func (s *BackupTestSuite) TestStartStop() {
 				s.backup.stop()
 			}()
 		}
-	})
-}
-
-func (s *BackupTestSuite) TestRestore() {
-	require := require.New(s.T())
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	s.Run("Happy path", func() {
-		// Connect all peers.
-		for _, info := range s.infos {
-			err := s.host.Connect(ctx, *info)
-			require.NoError(err, "Connect failed")
-		}
-
-		// Store peerstore with one peer.
-		err := s.backup.save()
-		require.NoError(err, "Store failed")
-
-		// Disconnect all peers.
-		for _, info := range s.infos {
-			err = s.host.Network().ClosePeer(info.ID)
-			require.NoError(err, "ClosePeer failed")
-		}
-		require.Equal(0, len(s.host.Network().Peers()))
-
-		// Do restore and check if everyone is connected.
-		gater, err := conngater.NewBasicConnectionGater(nil)
-		require.NoError(err, "NewBasicConnectionGater failed")
-		connector := newPeerConnector(s.host, gater)
-		s.backup.restore(ctx, connector)
-
-		require.Equal(len(s.infos), len(s.host.Network().Peers()))
-
-		// Reset.
-		for _, info := range s.infos {
-			err := s.host.Network().ClosePeer(info.ID)
-			require.NoError(err, "ClosePeer failed")
-		}
-		require.Equal(0, len(s.host.Network().Peers()))
 	})
 }

--- a/go/p2p/peermgmt/discovery.go
+++ b/go/p2p/peermgmt/discovery.go
@@ -1,0 +1,225 @@
+package peermgmt
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/discovery"
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	cmnBackoff "github.com/oasisprotocol/oasis-core/go/common/backoff"
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	cmSync "github.com/oasisprotocol/oasis-core/go/common/sync"
+)
+
+const (
+	// advertiseBackOffInitialInterval is the initial time interval for the exponential back-off
+	// used between failed advertisements.
+	advertiseBackOffInitialInterval = time.Minute
+
+	// advertiseBackOffMaxInterval is the maximum time interval for the exponential back-off
+	// used between failed advertisements.
+	advertiseBackOffMaxInterval = time.Hour
+)
+
+type peerDiscovery struct {
+	logger *logging.Logger
+
+	seeds []discovery.Discovery
+
+	mu          sync.Mutex
+	advertising map[string]struct{}
+
+	advCh chan struct{}
+
+	startOne cmSync.One
+}
+
+func newPeerDiscovery(seeds []discovery.Discovery) *peerDiscovery {
+	l := logging.GetLogger("p2p/peer-manager/discovery")
+
+	return &peerDiscovery{
+		logger:      l,
+		seeds:       seeds,
+		advertising: make(map[string]struct{}),
+		advCh:       make(chan struct{}, 1),
+		startOne:    cmSync.NewOne(),
+	}
+}
+
+// start starts advertising services to seed nodes.
+func (d *peerDiscovery) start() {
+	d.startOne.TryStart(d.run)
+}
+
+// stop stops advertising services to seed nodes.
+func (d *peerDiscovery) stop() {
+	d.startOne.TryStop()
+}
+
+// findPeers tries to discover peers for the given namespace.
+func (d *peerDiscovery) findPeers(ctx context.Context, ns string) <-chan peer.AddrInfo {
+	// Select seeds at random until one responds.
+	for _, pos := range rand.Perm(len(d.seeds)) {
+		peerCh, err := d.seeds[pos].FindPeers(ctx, ns)
+		if err != nil {
+			d.logger.Error("failed to find peers",
+				"err", err,
+				"namespace", ns,
+			)
+			if ctx.Err() != nil {
+				break
+			}
+			continue
+		}
+
+		return peerCh
+	}
+
+	// If no one responds, just return a closed channel.
+	peerCh := make(chan peer.AddrInfo)
+	close(peerCh)
+
+	return peerCh
+}
+
+// startAdvertising starts advertising the given namespace. Advertisements are done only when
+// the discovery is running.
+func (d *peerDiscovery) startAdvertising(ns string) {
+	if len(d.seeds) == 0 {
+		return
+	}
+
+	d.mu.Lock()
+	d.advertising[ns] = struct{}{}
+	d.mu.Unlock()
+
+	select {
+	case d.advCh <- struct{}{}:
+	default:
+	}
+}
+
+// stopAdvertising stops advertising the given namespace.
+func (d *peerDiscovery) stopAdvertising(ns string) {
+	if len(d.seeds) == 0 {
+		return
+	}
+
+	d.mu.Lock()
+	delete(d.advertising, ns)
+	d.mu.Unlock()
+
+	select {
+	case d.advCh <- struct{}{}:
+	default:
+	}
+}
+
+func (d *peerDiscovery) run(ctx context.Context) {
+	if len(d.seeds) == 0 {
+		return
+	}
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	// Force advertise check at startup.
+	select {
+	case d.advCh <- struct{}{}:
+	default:
+	}
+
+	// Handle advertise start/stop requests.
+	ongoing := make(map[string]context.CancelFunc)
+
+	for {
+		select {
+		case <-d.advCh:
+		case <-ctx.Done():
+			return
+		}
+
+		// Something has changed. Check which namespaces where added or removed.
+		func() {
+			d.mu.Lock()
+			defer d.mu.Unlock()
+
+			// Stop advertising removed ones.
+			for ns, cancel := range ongoing {
+				if _, ok := d.advertising[ns]; ok {
+					continue
+				}
+
+				delete(ongoing, ns)
+				cancel()
+
+				d.logger.Info("stopped advertising",
+					"namespace", ns,
+				)
+			}
+
+			// Start advertising added ones.
+			for ns := range d.advertising {
+				if _, ok := ongoing[ns]; ok {
+					continue
+				}
+
+				advCtx, advCancel := context.WithCancel(ctx)
+				ongoing[ns] = advCancel
+
+				wg.Add(len(d.seeds))
+				for _, seed := range d.seeds {
+					go func(seed discovery.Discovery, ns string) {
+						defer wg.Done()
+						d.advertise(advCtx, seed, ns)
+					}(seed, ns)
+				}
+
+				d.logger.Info("started advertising",
+					"namespace", ns,
+				)
+			}
+		}()
+	}
+}
+
+func (d *peerDiscovery) advertise(ctx context.Context, seed discovery.Advertiser, namespace string) {
+	bo := cmnBackoff.NewExponentialBackOff()
+	bo.InitialInterval = advertiseBackOffInitialInterval
+	bo.MaxInterval = advertiseBackOffMaxInterval
+	bo.Reset()
+
+	for {
+		ttl, err := seed.Advertise(ctx, namespace)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+
+			d.logger.Debug("failed to advertise",
+				"err", err,
+				"namespace", namespace,
+			)
+
+			// Retry if failed.
+			select {
+			case <-time.After(bo.NextBackOff()):
+				continue
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		// Advertise before the deadline.
+		select {
+		case <-time.After(ttl * 7 / 8):
+		case <-ctx.Done():
+			return
+		}
+
+		bo.Reset()
+	}
+}

--- a/go/p2p/peermgmt/discovery_test.go
+++ b/go/p2p/peermgmt/discovery_test.go
@@ -1,0 +1,173 @@
+package peermgmt
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/discovery"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type DiscoveryTestSuite struct {
+	suite.Suite
+
+	mu               sync.Mutex
+	discoveryCounter int
+	advertiseCounter int
+
+	discovery *peerDiscovery
+}
+
+func TestDiscoveryTestSuite(t *testing.T) {
+	suite.Run(t, new(DiscoveryTestSuite))
+}
+
+func (s *DiscoveryTestSuite) SetupSuite() {
+	numSeeds := 3
+	seeds := make([]discovery.Discovery, 0, numSeeds)
+	for i := 0; i < numSeeds; i++ {
+		seeds = append(seeds, s)
+	}
+
+	s.discovery = newPeerDiscovery(seeds)
+}
+
+func (s *DiscoveryTestSuite) TestStartStop() {
+	for i := 0; i < 5; i++ {
+		s.discovery.start()
+		s.discovery.stop()
+	}
+}
+
+func (s *DiscoveryTestSuite) TestFindPeers() {
+	require := require.New(s.T())
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	s.Run("Happy path", func() {
+		peers := s.discovery.findPeers(ctx, "ns-1")
+		require.Equal(3, len(peers))
+		require.Equal(1, s.discoveryCount())
+	})
+
+	s.Run("Errors", func() {
+		// Should try all seeds.
+		peers := s.discovery.findPeers(ctx, "ns-0")
+		require.Equal(0, len(peers))
+		require.Equal(4, s.discoveryCount())
+	})
+}
+
+func (s *DiscoveryTestSuite) TestAdvertise() {
+	require := require.New(s.T())
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	checkAdvertiseCounter := func(expected int) {
+		for {
+			select {
+			case <-time.After(time.Microsecond):
+				if expected == s.advertiseCount() {
+					return
+				}
+			case <-ctx.Done():
+				require.Equal(expected, s.advertiseCount())
+				return
+			}
+		}
+	}
+
+	s.Run("Not running", func() {
+		s.discovery.startAdvertising("ns-1")
+		s.discovery.startAdvertising("ns-1")
+		s.discovery.startAdvertising("ns-2")
+
+		time.Sleep(10 * time.Millisecond)
+
+		checkAdvertiseCounter(0)
+	})
+
+	s.discovery.start()
+
+	s.Run("Startup", func() {
+		checkAdvertiseCounter(6)
+	})
+
+	s.Run("Running", func() {
+		s.discovery.startAdvertising("ns-1")
+		s.discovery.startAdvertising("ns-2")
+		s.discovery.startAdvertising("ns-3")
+
+		time.Sleep(10 * time.Millisecond)
+
+		checkAdvertiseCounter(9)
+	})
+
+	s.Run("Error", func() {
+		s.discovery.startAdvertising("ns-0")
+
+		time.Sleep(10 * time.Millisecond)
+
+		checkAdvertiseCounter(9)
+	})
+
+	s.discovery.stop()
+	s.discovery.start()
+
+	s.Run("Restart", func() {
+		checkAdvertiseCounter(18)
+	})
+
+	s.discovery.stop()
+}
+
+func (s *DiscoveryTestSuite) advertiseCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.advertiseCounter
+}
+
+func (s *DiscoveryTestSuite) discoveryCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.discoveryCounter
+}
+
+func (s *DiscoveryTestSuite) FindPeers(ctx context.Context, ns string, opts ...discovery.Option) (<-chan peer.AddrInfo, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.discoveryCounter++
+
+	if ns == "ns-0" {
+		return nil, fmt.Errorf("broken seed")
+	}
+
+	ch := make(chan peer.AddrInfo, 3)
+	for i := 0; i < 3; i++ {
+		ch <- peer.AddrInfo{}
+	}
+	close(ch)
+
+	return ch, nil
+}
+
+func (s *DiscoveryTestSuite) Advertise(ctx context.Context, ns string, opts ...discovery.Option) (time.Duration, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if ns == "ns-0" {
+		return 0, fmt.Errorf("broken seed")
+	}
+
+	s.advertiseCounter++
+
+	return time.Hour, nil
+}

--- a/go/p2p/rpc/client.go
+++ b/go/p2p/rpc/client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/libp2p/go-libp2p/core"
 	"github.com/libp2p/go-libp2p/core/host"
-	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/protocol"
 
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
@@ -473,7 +472,7 @@ func (c *client) call(
 ) error {
 	// Attempt to open stream to the given peer.
 	stream, err := c.host.NewStream(
-		network.WithNoDial(ctx, "should already have connection"),
+		ctx,
 		peerID,
 		c.protocolID,
 	)

--- a/go/p2p/rpc/rpc.go
+++ b/go/p2p/rpc/rpc.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/libp2p/go-libp2p/core"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 const codecModuleName = "p2p/rpc"
@@ -21,16 +22,25 @@ type P2P interface {
 	Host() core.Host
 }
 
-// contextKeyPeerID is the context key used for storing the peer ID.
-type contextKeyPeerID struct{}
+// contextKeyPeerAddrInfo is the context key used for storing the peer addr info.
+type contextKeyPeerAddrInfo struct{}
 
-// WithPeerID creates a new context with the peer ID value set.
-func WithPeerID(parent context.Context, peerID core.PeerID) context.Context {
-	return context.WithValue(parent, contextKeyPeerID{}, peerID)
+// WithPeerAddrInfo creates a new context with the peer addr info value set.
+func WithPeerAddrInfo(parent context.Context, peerAddrInfo peer.AddrInfo) context.Context {
+	return context.WithValue(parent, contextKeyPeerAddrInfo{}, peerAddrInfo)
 }
 
 // PeerIDFromContext looks up the peer ID value in the given context.
 func PeerIDFromContext(ctx context.Context) (core.PeerID, bool) {
-	peerID, ok := ctx.Value(contextKeyPeerID{}).(core.PeerID)
-	return peerID, ok
+	peerAddrInfo, ok := ctx.Value(contextKeyPeerAddrInfo{}).(peer.AddrInfo)
+	if !ok {
+		return "", false
+	}
+	return peerAddrInfo.ID, true
+}
+
+// PeerAddrInfoFromContext looks up the peer addr info value in the given context.
+func PeerAddrInfoFromContext(ctx context.Context) (peer.AddrInfo, bool) {
+	peerAddrInfo, ok := ctx.Value(contextKeyPeerAddrInfo{}).(peer.AddrInfo)
+	return peerAddrInfo, ok
 }

--- a/go/p2p/seed.go
+++ b/go/p2p/seed.go
@@ -1,0 +1,180 @@
+package p2p
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/common/persistent"
+	"github.com/oasisprotocol/oasis-core/go/p2p/api"
+	"github.com/oasisprotocol/oasis-core/go/p2p/backup"
+	"github.com/oasisprotocol/oasis-core/go/p2p/discovery/bootstrap"
+	"github.com/oasisprotocol/oasis-core/go/p2p/discovery/peerstore"
+	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+)
+
+const (
+	// peerstoreBucketName is the name of the bucket in which peers from the peerstore are stored.
+	peerstoreBucketName = "p2p/seed/peerstore"
+
+	// peerstoreBucketKey is the bucket key under which peers from the peerstore are stored.
+	peerstoreBucketKey = "peers"
+)
+
+// seedNode is a P2P seed node which serves information about other peers in the network.
+type seedNode struct {
+	logger *logging.Logger
+
+	host  host.Host
+	store *peerstore.Store
+
+	bootSrv rpc.Server
+
+	quitCh chan struct{}
+}
+
+// NewSeedNode creates a new P2P seed node service.
+func NewSeedNode(cfg *SeedConfig) (api.SeedService, error) {
+	logger := logging.GetLogger("p2p/seed")
+
+	host, _, err := NewHost(&cfg.HostConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	backup := backup.NewCommonStoreBackend(cfg.CommonStore, peerstoreBucketName, peerstoreBucketKey)
+	store := peerstore.NewStore(backup)
+
+	var bootSrv rpc.Server
+	if cfg.BootstrapDiscoveryConfig.Enable {
+		bootSrv = bootstrap.NewServer(store)
+	}
+
+	return &seedNode{
+		logger:  logger,
+		host:    host,
+		store:   store,
+		bootSrv: bootSrv,
+		quitCh:  make(chan struct{}),
+	}, nil
+}
+
+// Cleanup implements service.BackgroundService.
+func (s *seedNode) Cleanup() {
+}
+
+// Name implements service.BackgroundService.
+func (s *seedNode) Name() string {
+	return "libp2p/seed"
+}
+
+// Start implements service.BackgroundService.
+func (s *seedNode) Start() error {
+	if err := s.store.Restore(context.TODO()); err != nil {
+		s.logger.Debug("failed to restore peer store",
+			"err", err,
+		)
+	}
+	s.store.Start()
+
+	if s.bootSrv != nil {
+		s.registerProtocolServer(s.bootSrv)
+	}
+
+	return nil
+}
+
+// Stop implements service.BackgroundService.
+func (s *seedNode) Stop() {
+	defer close(s.quitCh)
+
+	// Some blocking services can be stopped concurrently.
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		if err := s.host.Close(); err != nil {
+			s.logger.Debug("failed to stop host",
+				"err", err,
+			)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		s.store.Stop()
+	}()
+}
+
+// Quit implements service.BackgroundService.
+func (s *seedNode) Quit() <-chan struct{} {
+	return s.quitCh
+}
+
+// Peers implements api.SeedService.
+func (s *seedNode) Peers() []string {
+	peers := s.store.Peers()
+	encoded := make([]string, 0, len(peers))
+	for _, info := range peers {
+		encoded = append(encoded, api.AddrInfoToString(info)...)
+	}
+	sort.Strings(encoded)
+	return encoded
+}
+
+// Addresses implements api.SeedService.
+func (s *seedNode) Addresses() []string {
+	info := peer.AddrInfo{
+		ID:    s.host.ID(),
+		Addrs: s.host.Addrs(),
+	}
+
+	return []string{info.String()}
+}
+
+func (s *seedNode) registerProtocolServer(srv rpc.Server) {
+	s.host.SetStreamHandler(srv.Protocol(), srv.HandleStream)
+
+	s.logger.Info("registered protocol server",
+		"protocol_id", srv.Protocol(),
+	)
+}
+
+// SeedConfig describes a set of settings for a seed.
+type SeedConfig struct {
+	CommonStore *persistent.CommonStore
+
+	HostConfig
+	BootstrapDiscoveryConfig
+}
+
+// NewSeed creates a new P2P seed node service.
+func (cfg *SeedConfig) NewSeed() (api.SeedService, error) {
+	return NewSeedNode(cfg)
+}
+
+// Load loads seed configuration.
+func (cfg *SeedConfig) Load() error {
+	var hostCfg HostConfig
+	if err := hostCfg.Load(); err != nil {
+		return fmt.Errorf("failed to load host config: %w", err)
+	}
+
+	var bootstrapCfg BootstrapDiscoveryConfig
+	if err := bootstrapCfg.Load(); err != nil {
+		return fmt.Errorf("failed to load bootstrap config: %w", err)
+	}
+
+	cfg.HostConfig = hostCfg
+	cfg.BootstrapDiscoveryConfig = bootstrapCfg
+
+	return nil
+}

--- a/go/upgrade/upgrade.go
+++ b/go/upgrade/upgrade.go
@@ -318,10 +318,8 @@ func (u *upgradeManager) Close() {
 // pending upgrade descriptors; if this node is not the one intended to be run according
 // to the loaded descriptor, New will return an error.
 func New(store *persistent.CommonStore, dataDir string, checkStatus bool) (api.Backend, error) {
-	svcStore, err := store.GetServiceStore(api.ModuleName)
-	if err != nil {
-		return nil, err
-	}
+	svcStore := store.GetServiceStore(api.ModuleName)
+
 	upgrader := &upgradeManager{
 		store:   svcStore,
 		dataDir: dataDir,

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -1210,13 +1210,7 @@ func New(
 ) (*Worker, error) {
 	logger := logging.GetLogger("worker/registration")
 
-	serviceStore, err := store.GetServiceStore(DBBucketName)
-	if err != nil {
-		logger.Error("can't get registration worker store bucket",
-			"err", err,
-		)
-		return nil, err
-	}
+	serviceStore := store.GetServiceStore(DBBucketName)
 
 	entityID, registrationSigner, err := GetRegistrationSigner(logger, dataDir, identity)
 	if err != nil {


### PR DESCRIPTION
### Task

Add libp2p seed node which can bootstrap libp2p peers.

Notes:
- Rate limiter was not added. Peer store is simple without peer scoring, advanced peer selection, etc. This can/should be added in separate PRs.

### Configuration

Libp2p seed node can be configured using the following settings:
```
# Host
p2p.port

# Connection manager
p2p.max_num_peers
p2p.peer_grace_period
p2p.persistent_peers

# Connection gater
p2p.blocked_peers

# Discovery
p2p.discovery.bootstrap.enable
p2p.discovery.bootstrap.retention_period
```

Peers still configure seeds using the following setting:
```
p2p.seeds
```
As we currently run 2 seed nodes on one address but on different ports, 2 seeds need to be configured.
```
p2p.seeds:
 - pubkey@IP:consensus-port
 - pubkey@IP:libp2p-port
```

### Test
Tested locally. If we disable registry discovery (e.g. comment `connectRegisteredPeers` in `PeerManager`), the peer nodes still connect.

```
"runtimes": {
  "8000000000000000000000000000000000000000000000000000000000000000": {
    "committee": {
      "peers": [
          "/ip4/192.168.0.2/tcp/20017/p2p/12D3KooWP2DNWFz7ivdpENeQirCkPTwCJ762EKChdKHCNEuAxUVC",
          "/ip4/192.168.0.2/tcp/20014/p2p/12D3KooWGe86FFdDn3vZtEupwTM55LjsL2WVGfM1jtrhEaGdgh7X",
          "/ip4/192.168.0.2/tcp/20019/p2p/12D3KooWD8gjDP1pxqhpjy2ZkPguWVKSMBu26mJXwridnoAynhxM"
      ],
    },
  },
}
```
Seed node now shows addresses and peers from both seed nodes (Tendermint, libp2p).
```
➜  seed-0 oasis-node control status 
{
  "seed": {
    "addresses": [
      // Tendermint address.
      "mbqm2wnNxSgsm8OSyCT+fYo1JuQU1tJWU9wVz8vv1Cs=@127.0.0.1:20000",
      // Libp2p address.
      "{12D3KooWALMXUq9y2BwY6VgEdJyVDcmWrdQsJ6LJth7eoCcRhheN: [/ip4/192.168.64.107/tcp/20001 /ip4/127.0.0.1/tcp/20001]}"
    ],
    "node_peers": [
      // Tendermint peers.
      "4533c1467e52281edcc866176cb0cc2e968880c5@127.0.0.1:20006",
      "45a2a3e75e00a2a10d3dfba5e0b6ca8a5dd91848@127.0.0.1:20015",
      "9ee8d0a7ff2c20db17f25f39a17a548e6582af4e@127.0.0.1:20009",
      "b9cec91ce2fa349f318f7a28e2fc739d79c05a5e@127.0.0.1:20012",
      "762d91e3e0ddd029d6342d18f9f6690cf4755274@127.0.0.1:20018",
      "75fc1446e282ca226958c47f68620318a78e73c5@127.0.0.1:20002",
      "0566341e8963c12a73f730b8872f30dffad27d7c@127.0.0.1:20004",
      // Libp2p peers.
      "/ip4/127.0.0.1/tcp/20008/p2p/12D3KooWCv1cFd8k1MhxaKU2LKuCanPLx8sYym6bz2qQWoPkhVsW",
      "/ip4/127.0.0.1/tcp/20011/p2p/12D3KooWEDUkJKh4xRnjrfA6iNQZCKCDvnrLrb6tZfhV9Kkm9gG4",
      "/ip4/127.0.0.1/tcp/20014/p2p/12D3KooWGe86FFdDn3vZtEupwTM55LjsL2WVGfM1jtrhEaGdgh7X",
      "/ip4/127.0.0.1/tcp/20017/p2p/12D3KooWP2DNWFz7ivdpENeQirCkPTwCJ762EKChdKHCNEuAxUVC",
      "/ip4/127.0.0.1/tcp/20019/p2p/12D3KooWD8gjDP1pxqhpjy2ZkPguWVKSMBu26mJXwridnoAynhxM"
    ]
  }
}
```
