### PR TITLE
grpc: Pretty-print response in logs

### DIFF
--- a/go/common/grpc/grpc.go
+++ b/go/common/grpc/grpc.go
@@ -221,7 +221,7 @@ func (l *grpcLogAdapter) unaryClientLogger(ctx context.Context,
 		l.reqLogger.Debug("request",
 			"method", method,
 			"req_seq", seq,
-			"req", req,
+			"req", fmt.Sprintf("%+v", req),
 		)
 	}
 
@@ -242,7 +242,8 @@ func (l *grpcLogAdapter) unaryClientLogger(ctx context.Context,
 		l.reqLogger.Error("request failed",
 			"method", method,
 			"req_seq", seq,
-			"rsp", rsp,
+			"req", fmt.Sprintf("%+v", req),
+			"rsp", fmt.Sprintf("%+v", rsp),
 			"err", err,
 		)
 		return err


### PR DESCRIPTION
When we log a GRPC error, we display the raw server response. Sometimes (most of the time?), the response is not auto-formattable by the logging library, so it is displayed as `unsupported value type`. This PR adds an explicit `Sprintf` to format the value.

Before (see the `rsp` field):
```
level=error caller=grpc.go:242 [...] rsp="unsupported value type" err="query aborted: Any { .. }"
```
After:
```
level=error caller=grpc.go:242 [...] rsp=&{Data:[]} err="query aborted: Any { .. }"
```
:roll_eyes: but hopefully it makes a difference in some other scenario

The PR makes the same change in a related logging statement that I noticed, and adds request logging in the error case for a more informative context.