### PR TITLE
go/control: Include node's P2P addresses in control status

### DIFF
--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -314,9 +314,6 @@ type Status struct { // nolint: maligned
 	// Features are the indicated consensus backend features.
 	Features FeatureMask `json:"features"`
 
-	// NodePeers is a list of node's peers.
-	NodePeers []string `json:"node_peers"`
-
 	// LatestHeight is the height of the latest block.
 	LatestHeight int64 `json:"latest_height"`
 	// LatestHash is the hash of the latest block.
@@ -343,6 +340,24 @@ type Status struct { // nolint: maligned
 
 	// IsValidator returns whether the current node is part of the validator set.
 	IsValidator bool `json:"is_validator"`
+
+	// P2P is the P2P status of the node.
+	P2P *P2PStatus `json:"p2p,omitempty"`
+}
+
+// P2PStatus is the P2P status of a node.
+type P2PStatus struct {
+	// PubKey is the public key used for consensus P2P communication.
+	PubKey signature.PublicKey `json:"pub_key"`
+
+	// PeerID is the peer ID derived by hashing peer's public key.
+	PeerID string `json:"peer_id"`
+
+	// Addresses is a list of configured P2P addresses used when registering the node.
+	Addresses []node.ConsensusAddress `json:"addresses"`
+
+	// Peers is a list of node's peers.
+	Peers []string `json:"peers"`
 }
 
 // Backend is an interface that a consensus backend must provide.

--- a/go/consensus/tendermint/full/full.go
+++ b/go/consensus/tendermint/full/full.go
@@ -455,6 +455,12 @@ func (t *fullService) GetStatus(ctx context.Context) (*consensusAPI.Status, erro
 	status.Status = consensusAPI.StatusStateSyncing
 	status.Mode = consensusAPI.ModeFull
 
+	status.P2P = &consensusAPI.P2PStatus{}
+	status.P2P.PubKey = t.identity.P2PSigner.Public()
+	if status.P2P.Addresses, err = t.GetAddresses(); err != nil {
+		return nil, err
+	}
+
 	if t.started() {
 		// Check if node is synced.
 		select {
@@ -472,7 +478,9 @@ func (t *fullService) GetStatus(ctx context.Context) (*consensusAPI.Status, erro
 			p := string(tmpeer.ID()) + "@" + tmpeer.RemoteAddr().String()
 			peers = append(peers, p)
 		}
-		status.NodePeers = peers
+
+		status.P2P.Peers = peers
+		status.P2P.PeerID = string(t.node.NodeInfo().ID())
 	}
 
 	return status, nil

--- a/go/control/api/api.go
+++ b/go/control/api/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	p2p "github.com/oasisprotocol/oasis-core/go/p2p/api"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	block "github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
@@ -86,6 +87,9 @@ type Status struct {
 	// PendingUpgrades are the node's pending upgrades.
 	PendingUpgrades []*upgrade.PendingUpgrade `json:"pending_upgrades,omitempty"`
 
+	// P2P is the P2P status of the node.
+	P2P *p2p.Status `json:"p2p,omitempty"`
+
 	// Seed is the seed node status if the node is a seed node.
 	Seed *SeedStatus `json:"seed,omitempty"`
 }
@@ -107,9 +111,6 @@ type DebugStatus struct {
 type IdentityStatus struct {
 	// Node is the node identity public key.
 	Node signature.PublicKey `json:"node"`
-
-	// P2P is the public key used for p2p communication.
-	P2P signature.PublicKey `json:"p2p"`
 
 	// Consensus is the consensus public key.
 	Consensus signature.PublicKey `json:"consensus"`

--- a/go/oasis-node/cmd/node/seed_control.go
+++ b/go/oasis-node/cmd/node/seed_control.go
@@ -62,7 +62,6 @@ func (n *SeedNode) GetStatus(ctx context.Context) (*control.Status, error) {
 
 	identity := control.IdentityStatus{
 		Node:      n.identity.NodeSigner.Public(),
-		P2P:       n.identity.P2PSigner.Public(),
 		Consensus: n.identity.ConsensusSigner.Public(),
 		TLS:       n.identity.GetTLSPubKeys(),
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/archive_api.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/archive_api.go
@@ -92,8 +92,8 @@ func (sc *archiveAPI) testArchiveAPI(ctx context.Context, archiveCtrl *oasis.Con
 	if status.Consensus.LatestHeight == int64(0) {
 		return fmt.Errorf("archive node latest height should not be 0")
 	}
-	if len(status.Consensus.NodePeers) != 0 {
-		return fmt.Errorf("archive should not have any peers")
+	if status.Consensus.P2P != nil {
+		return fmt.Errorf("archive should not be included in the P2P network")
 	}
 	if p := status.PendingUpgrades; len(p) != 0 {
 		return fmt.Errorf("unexpected pending upgrades: %v", p)

--- a/go/oasis-test-runner/scenario/e2e/runtime/sentry.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/sentry.go
@@ -345,7 +345,7 @@ func loadSentryNodeInfo(s *oasis.Sentry) (*oasis.Sentry, string, string, signatu
 }
 
 func consensusTendermintAddrs(status *control.Status) (consensusPeers []string) {
-	for _, np := range status.Consensus.NodePeers {
+	for _, np := range status.Consensus.P2P.Peers {
 		consensusPeers = append(consensusPeers, strings.Split(np, "@")[0])
 	}
 	return

--- a/go/p2p/api/api.go
+++ b/go/p2p/api/api.go
@@ -27,9 +27,30 @@ const (
 	TopicKindTx TopicKind = "tx"
 )
 
+// Status is the P2P status of a node.
+type Status struct {
+	// PubKey is the public key used for P2P communication.
+	PubKey signature.PublicKey `json:"pub_key"`
+
+	// PeerID is the peer ID derived by hashing peer's public key.
+	PeerID peer.ID `json:"peer_id"`
+
+	// Addresses is a list of configured P2P addresses used when registering the node.
+	Addresses []node.Address `json:"addresses"`
+
+	// NumPeers is the number of connected peers.
+	NumPeers int `json:"num_peers"`
+
+	// NumConnections is the number of peer connections.
+	NumConnections int `json:"num_connections"`
+}
+
 // Service is a P2P node service interface.
 type Service interface {
 	service.BackgroundService
+
+	// GetStatus returns the P2P status of the node.
+	GetStatus() *Status
 
 	// Addresses returns the P2P addresses of the node.
 	Addresses() []node.Address

--- a/go/p2p/nop.go
+++ b/go/p2p/nop.go
@@ -46,6 +46,11 @@ func (p *nopP2P) Quit() <-chan struct{} {
 }
 
 // Implements api.Service.
+func (p *nopP2P) GetStatus() *api.Status {
+	return nil
+}
+
+// Implements api.Service.
 func (p *nopP2P) Addresses() []node.Address {
 	return nil
 }


### PR DESCRIPTION
### Task
Move P2P related status information including node's P2P addresses under P2P section of the control status.

### Test
Note that the data is duplicated if the node is registered (e.g. validators, compute nodes, key managers, but not clients).
```
➜  validator-0 oasis-node control status
{
  "consensus": {
   "p2p": {
      "pub_key": "8EBdmxYwjz9bLreogzNEFuoLPQfci5pRjvHbYHIC/1Q=",
      "peer_id": "21bd3dc64c88cb14ee0d4d5bb8964adc3febdd1b",
      "addresses": [
        "8EBdmxYwjz9bLreogzNEFuoLPQfci5pRjvHbYHIC/1Q=@127.0.0.1:20001"
      ],
      "peers": [
        "78ec9c69741d2a05dd479096d3adcc7c20ab6832@127.0.0.1:20004",
        "a42258a7ecdadfe1f917f737033de17aead2e19a@127.0.0.1:46008",
        "0d57061f4a1b293a8a10f46435eb29055627ee4e@127.0.0.1:46020",
        "ec41b7af0c5522114d5d2d406586e635ceb648a5@127.0.0.1:46036",
        "cfb3f1f210aeb832cd088cd5f6503e5fb820b874@127.0.0.1:46048",
        "02d4b70f0d8afe16a17d298fdaa57dc45b69cf8c@127.0.0.1:46054"
      ]
    }
},
{
  "p2p": {
    "pub_key": "8EBdmxYwjz9bLreogzNEFuoLPQfci5pRjvHbYHIC/1Q=",
    "peer_id": "12D3KooWRzCwZirVmeHqFoA1mruUfTtTQeXrLiz9rzojyAQsjSa7",
    "addresses": [
      "192.168.64.107:20003",
      "127.0.0.1:20003"
    ],
    "num_peers": 6,
    "num_connections": 8
  }
}
```