### PR TITLE
go/p2p/rpc: add support for consensus-wide libp2p protocols

### DIFF
--- a/.changelog/5000.feature.md
+++ b/.changelog/5000.feature.md
@@ -1,0 +1,1 @@
+go/p2p/rpc: add support for consensus-wide libp2p protocols

--- a/go/p2p/rpc/peermgmt.go
+++ b/go/p2p/rpc/peermgmt.go
@@ -335,7 +335,7 @@ func NewPeerManager(p2p P2P, protocolID protocol.ID, stickyPeers bool) PeerManag
 		peers:        make(map[core.PeerID]*peerStats),
 		ignoredPeers: make(map[core.PeerID]bool),
 		stickyPeers:  stickyPeers,
-		logger: logging.GetLogger("worker/common/p2p/rpc/peermgr").With(
+		logger: logging.GetLogger("p2p/rpc/peermgr").With(
 			"protocol_id", protocolID,
 		),
 	}

--- a/go/p2p/rpc/rpc.go
+++ b/go/p2p/rpc/rpc.go
@@ -23,6 +23,11 @@ type P2P interface {
 	GetHost() core.Host
 }
 
+// NewProtocolID generates a protocol identifier for a consensus P2P protocol.
+func NewProtocolID(protocolID string, version version.Version) protocol.ID {
+	return protocol.ID(fmt.Sprintf("/oasis/%s/%s", protocolID, version.MaskNonMajor()))
+}
+
 // NewRuntimeProtocolID generates a protocol identifier for a protocol supported for a specific
 // runtime. This makes it so that one doesn't need additional checks to ensure that a peer supports
 // the given protocol for the given runtime.

--- a/go/p2p/rpc/server.go
+++ b/go/p2p/rpc/server.go
@@ -7,11 +7,9 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/protocol"
 
-	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
-	"github.com/oasisprotocol/oasis-core/go/common/version"
 )
 
 const (
@@ -38,7 +36,6 @@ type Server interface {
 type server struct {
 	Service
 
-	runtimeID  common.Namespace
 	protocolID protocol.ID
 
 	logger *logging.Logger
@@ -106,16 +103,10 @@ func (s *server) HandleStream(stream network.Stream) {
 }
 
 // NewServer creates a new RPC server for the given protocol.
-func NewServer(runtimeID common.Namespace, protocolID string, version version.Version, srv Service) Server {
-	pid := NewRuntimeProtocolID(runtimeID, protocolID, version)
-
+func NewServer(protocolID protocol.ID, srv Service) Server {
 	return &server{
 		Service:    srv,
-		runtimeID:  runtimeID,
-		protocolID: pid,
-		logger: logging.GetLogger("worker/common/p2p/rpc/server").With(
-			"protocol", protocolID,
-			"runtime_id", runtimeID,
-		),
+		protocolID: protocolID,
+		logger:     logging.GetLogger("p2p/rpc/server").With("protocol", protocolID),
 	}
 }

--- a/go/p2p/txsync/client.go
+++ b/go/p2p/txsync/client.go
@@ -72,6 +72,6 @@ func (c *client) GetTxs(ctx context.Context, request *GetTxsRequest) (*GetTxsRes
 // NewClient creates a new transaction sync protocol client.
 func NewClient(p2p rpc.P2P, runtimeID common.Namespace) Client {
 	return &client{
-		rc: rpc.NewClient(p2p, runtimeID, TxSyncProtocolID, TxSyncProtocolVersion),
+		rc: rpc.NewClient(p2p, rpc.NewRuntimeProtocolID(runtimeID, TxSyncProtocolID, TxSyncProtocolVersion)),
 	}
 }

--- a/go/p2p/txsync/server.go
+++ b/go/p2p/txsync/server.go
@@ -51,5 +51,5 @@ func (s *service) handleGetTxs(ctx context.Context, request *GetTxsRequest) (*Ge
 
 // NewServer creates a new transaction sync protocol server.
 func NewServer(runtimeID common.Namespace, txPool txpool.TransactionPool) rpc.Server {
-	return rpc.NewServer(runtimeID, TxSyncProtocolID, TxSyncProtocolVersion, &service{txPool})
+	return rpc.NewServer(rpc.NewRuntimeProtocolID(runtimeID, TxSyncProtocolID, TxSyncProtocolVersion), &service{txPool})
 }

--- a/go/worker/keymanager/p2p/client.go
+++ b/go/worker/keymanager/p2p/client.go
@@ -167,7 +167,7 @@ func NewClient(p2p p2p.Service, consensus consensus.Backend, keymanagerID common
 	go nt.trackKeymanagerNodes()
 
 	return &client{
-		rc: rpc.NewClient(p2p, keymanagerID, KeyManagerProtocolID, KeyManagerProtocolVersion,
+		rc: rpc.NewClient(p2p, rpc.NewRuntimeProtocolID(keymanagerID, KeyManagerProtocolID, KeyManagerProtocolVersion),
 			rpc.WithStickyPeers(true),
 			rpc.WithPeerFilter(nt),
 		),

--- a/go/worker/keymanager/p2p/server.go
+++ b/go/worker/keymanager/p2p/server.go
@@ -50,5 +50,5 @@ func (s *service) handleCallEnclave(ctx context.Context, request *CallEnclaveReq
 func NewServer(runtimeID common.Namespace, km KeyManager) rpc.Server {
 	initMetrics()
 
-	return rpc.NewServer(runtimeID, KeyManagerProtocolID, KeyManagerProtocolVersion, &service{km})
+	return rpc.NewServer(rpc.NewRuntimeProtocolID(runtimeID, KeyManagerProtocolID, KeyManagerProtocolVersion), &service{km})
 }

--- a/go/worker/storage/p2p/pub/client.go
+++ b/go/worker/storage/p2p/pub/client.go
@@ -54,6 +54,6 @@ func (c *client) Iterate(ctx context.Context, request *IterateRequest) (*ProofRe
 // NewClient creates a new storage pub protocol client.
 func NewClient(p2p rpc.P2P, runtimeID common.Namespace) Client {
 	return &client{
-		rc: rpc.NewClient(p2p, runtimeID, StoragePubProtocolID, StoragePubProtocolVersion),
+		rc: rpc.NewClient(p2p, rpc.NewRuntimeProtocolID(runtimeID, StoragePubProtocolID, StoragePubProtocolVersion)),
 	}
 }

--- a/go/worker/storage/p2p/pub/server.go
+++ b/go/worker/storage/p2p/pub/server.go
@@ -43,5 +43,5 @@ func (s *service) HandleRequest(ctx context.Context, method string, body cbor.Ra
 
 // NewServer creates a new storage pub protocol server.
 func NewServer(runtimeID common.Namespace, backend storage.Backend) rpc.Server {
-	return rpc.NewServer(runtimeID, StoragePubProtocolID, StoragePubProtocolVersion, &service{backend})
+	return rpc.NewServer(rpc.NewRuntimeProtocolID(runtimeID, StoragePubProtocolID, StoragePubProtocolVersion), &service{backend})
 }

--- a/go/worker/storage/p2p/sync/client.go
+++ b/go/worker/storage/p2p/sync/client.go
@@ -114,7 +114,7 @@ func NewClient(p2p rpc.P2P, runtimeID common.Namespace) Client {
 		// Use two separate clients for the same protocol. This is to make sure that peers are
 		// scored differently between the two use cases (syncing diffs vs. syncing checkpoints). We
 		// could consider separating this into two protocols in the future.
-		rcDiff:        rpc.NewClient(p2p, runtimeID, StorageSyncProtocolID, StorageSyncProtocolVersion),
-		rcCheckpoints: rpc.NewClient(p2p, runtimeID, StorageSyncProtocolID, StorageSyncProtocolVersion),
+		rcDiff:        rpc.NewClient(p2p, rpc.NewRuntimeProtocolID(runtimeID, StorageSyncProtocolID, StorageSyncProtocolVersion)),
+		rcCheckpoints: rpc.NewClient(p2p, rpc.NewRuntimeProtocolID(runtimeID, StorageSyncProtocolID, StorageSyncProtocolVersion)),
 	}
 }

--- a/go/worker/storage/p2p/sync/server.go
+++ b/go/worker/storage/p2p/sync/server.go
@@ -104,5 +104,5 @@ func (s *service) handleGetCheckpointChunk(ctx context.Context, request *GetChec
 
 // NewServer creates a new storage sync protocol server.
 func NewServer(runtimeID common.Namespace, backend storage.Backend) rpc.Server {
-	return rpc.NewServer(runtimeID, StorageSyncProtocolID, StorageSyncProtocolVersion, &service{backend})
+	return rpc.NewServer(rpc.NewRuntimeProtocolID(runtimeID, StorageSyncProtocolID, StorageSyncProtocolVersion), &service{backend})
 }


### PR DESCRIPTION
This will be needed for adding a consensus-wide light-blocks libp2p protocol.