### PR TITLE
go/p2p/rpc: Refactor rpc calls

### DIFF
--- a/.changelog/5007.bugfix.1.md
+++ b/.changelog/5007.bugfix.1.md
@@ -1,0 +1,4 @@
+go/p2p/rpc: Fix peer grading when context is canceled
+
+When method `CallMulti` finishes early, the requests in progress are canceled
+and unfairly recorded as failed.

--- a/.changelog/5007.bugfix.2.md
+++ b/.changelog/5007.bugfix.2.md
@@ -1,0 +1,4 @@
+go/p2p/rpc: Fix memory leak when RPC multi call finishes early
+
+When method `CallMulti` finishes early, the result channel is never cleared.
+Therefore, the channel never closes and leaves one go routine hanging.

--- a/.changelog/5007.internal.md
+++ b/.changelog/5007.internal.md
@@ -1,0 +1,4 @@
+go/p2p/rpc: Refactor RPC calls
+
+Peer manager and RPC client are too tightly coupled. The client also doesn't
+support simple RPC calls which call exactly one peer.

--- a/go/p2p/rpc/client_test.go
+++ b/go/p2p/rpc/client_test.go
@@ -1,0 +1,347 @@
+package rpc
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+)
+
+const (
+	testMethod   = "test"
+	testProtocol = core.ProtocolID("p2p/rpc/test/1.0.0")
+)
+
+type testRequest struct{}
+
+type testResponse struct {
+	ID int
+}
+
+type testService struct {
+	id int
+}
+
+func (s *testService) HandleRequest(ctx context.Context, method string, body cbor.RawMessage) (interface{}, error) {
+	if method != testMethod {
+		return nil, fmt.Errorf("unsupported method")
+	}
+	var req testRequest
+	if err := cbor.Unmarshal(body, &req); err != nil {
+		return nil, err
+	}
+	if s.id < 2 {
+		return nil, fmt.Errorf("first two servers are corrupted")
+	}
+	return &testResponse{ID: s.id}, nil
+}
+
+func (s *testService) Protocol() protocol.ID {
+	return testProtocol
+}
+
+type testListener struct {
+	mu        sync.Mutex
+	successes int
+	failures  int
+	badPeers  int
+}
+
+func (l *testListener) RecordSuccess(peerID core.PeerID, latency time.Duration) {
+	l.mu.Lock()
+	l.successes++
+	l.mu.Unlock()
+}
+
+func (l *testListener) RecordFailure(peerID core.PeerID, latency time.Duration) {
+	l.mu.Lock()
+	l.failures++
+	l.mu.Unlock()
+}
+
+func (l *testListener) RecordBadPeer(peerID core.PeerID) {
+	l.mu.Lock()
+	l.badPeers++
+	l.mu.Unlock()
+}
+
+type RPCTestSuite struct {
+	suite.Suite
+
+	servers     []Server
+	serverHosts []host.Host
+
+	client     Client
+	clientHost host.Host
+
+	listener *testListener
+}
+
+func TestRPCTestSuite(t *testing.T) {
+	suite.Run(t, new(RPCTestSuite))
+}
+
+func (s *RPCTestSuite) SetupSuite() {
+	require := require.New(s.T())
+
+	newHost := func() host.Host {
+		listenAddr, err := multiaddr.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
+		require.NoError(err, "NewMultiaddr failed")
+
+		host, err := libp2p.New(
+			libp2p.ListenAddrs(listenAddr),
+		)
+		require.NoError(err, "libp2p.New failed")
+
+		return host
+	}
+
+	// Prepare N servers.
+	n := 4
+
+	s.servers = make([]Server, 0, n)
+	for i := 0; i < n; i++ {
+		server := NewServer(testProtocol, &testService{id: i})
+		s.servers = append(s.servers, server)
+	}
+
+	s.serverHosts = make([]host.Host, 0, 5)
+	for _, server := range s.servers {
+		serverHost := newHost()
+		serverHost.SetStreamHandler(server.Protocol(), server.HandleStream)
+
+		s.serverHosts = append(s.serverHosts, serverHost)
+	}
+
+	// Prepare 1 client.
+	s.clientHost = newHost()
+	s.client = NewClient(s.clientHost, testProtocol)
+
+	// Prepare listener.
+	s.listener = &testListener{}
+	s.client.RegisterListener(s.listener)
+
+	// Connect client to all servers.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	for _, serverHost := range s.serverHosts {
+		err := s.clientHost.Connect(ctx, peer.AddrInfo{
+			ID:    serverHost.ID(),
+			Addrs: serverHost.Addrs(),
+		})
+		require.NoError(err)
+	}
+}
+
+func (s *RPCTestSuite) TearDownSuite() {
+	for _, h := range s.serverHosts {
+		h.Close()
+	}
+	s.clientHost.Close()
+}
+
+func (s *RPCTestSuite) SetupTest() {
+	s.listener.successes = 0
+	s.listener.failures = 0
+	s.listener.badPeers = 0
+}
+
+func (s *RPCTestSuite) TestCall() {
+	require := require.New(s.T())
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	s.Run("Happy path", func() {
+		peer := s.serverHosts[2].ID()
+		var rsp testResponse
+		pf, err := s.client.Call(ctx, peer, testMethod, &testRequest{}, &rsp)
+		require.NoError(err, "Call failed")
+		require.Equal(2, rsp.ID)
+		require.Equal(peer, pf.PeerID())
+
+		require.Equal(0, s.listener.successes)
+		require.Equal(0, s.listener.failures)
+		require.Equal(0, s.listener.badPeers)
+	})
+
+	s.Run("Peer returns an error", func() {
+		peer := s.serverHosts[3].ID()
+		var rsp testResponse
+		_, err := s.client.Call(ctx, peer, "404", &testRequest{}, &rsp)
+		require.Error(err, "Call did not fail")
+
+		require.Equal(0, s.listener.successes)
+		require.Equal(1, s.listener.failures)
+		require.Equal(0, s.listener.badPeers)
+	})
+}
+
+func (s *RPCTestSuite) TestCallOne() {
+	require := require.New(s.T())
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	s.Run("Happy path", func() {
+		peers := make([]peer.ID, 0, len(s.serverHosts))
+		for _, h := range s.serverHosts {
+			peers = append(peers, h.ID())
+		}
+		var rsp testResponse
+		pf, err := s.client.CallOne(ctx, peers, testMethod, &testRequest{}, &rsp)
+		require.NoError(err, "CallOne failed")
+		require.Equal(2, rsp.ID)
+		require.Equal(peers[2], pf.PeerID())
+
+		require.Equal(0, s.listener.successes)
+		require.Equal(2, s.listener.failures)
+		require.Equal(0, s.listener.badPeers)
+	})
+
+	s.Run("All peers return an error", func() {
+		peers := make([]peer.ID, 0, len(s.serverHosts))
+		for i, h := range s.serverHosts {
+			if i < 2 {
+				peers = append(peers, h.ID())
+			}
+		}
+		var rsp testResponse
+		_, err := s.client.CallOne(ctx, peers, testMethod, &testRequest{}, &rsp)
+		require.Error(err, "CallOne did not fail")
+
+		require.Equal(0, s.listener.successes)
+		require.Equal(4, s.listener.failures)
+		require.Equal(0, s.listener.badPeers)
+	})
+}
+
+func (s *RPCTestSuite) TestCallMulti() {
+	require := require.New(s.T())
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	s.Run("Happy path", func() {
+		peers := make([]peer.ID, 0, len(s.serverHosts))
+		for _, h := range s.serverHosts {
+			peers = append(peers, h.ID())
+		}
+		var rsp testResponse
+		rsps, pfs, err := s.client.CallMulti(ctx, peers, testMethod, &testRequest{}, &rsp)
+		require.NoError(err, "CallMulti failed")
+		require.Equal(2, len(rsps))
+		require.Equal(2, len(pfs))
+
+		require.Equal(0, s.listener.successes)
+		require.Equal(2, s.listener.failures)
+		require.Equal(0, s.listener.badPeers)
+	})
+
+	s.Run("All peers return an error", func() {
+		peers := make([]peer.ID, 0, len(s.serverHosts))
+		for i, h := range s.serverHosts {
+			if i < 2 {
+				peers = append(peers, h.ID())
+			}
+		}
+		var rsp testResponse
+		rsps, pfs, err := s.client.CallMulti(ctx, peers, testMethod, &testRequest{}, &rsp)
+		require.NoError(err, "CallMulti failed")
+		require.Equal(0, len(rsps))
+		require.Equal(0, len(pfs))
+
+		require.Equal(0, s.listener.successes)
+		require.Equal(4, s.listener.failures)
+		require.Equal(0, s.listener.badPeers)
+	})
+}
+
+func (s *RPCTestSuite) TestListener() {
+	require := require.New(s.T())
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	peer := s.serverHosts[2].ID()
+	var rsp testResponse
+	pf, err := s.client.Call(ctx, peer, testMethod, &testRequest{}, &rsp)
+	require.NoError(err, "Call failed")
+
+	test := func(l *testListener, s, f, b int) {
+		require.Equal(s, l.successes)
+		require.Equal(f, l.failures)
+		require.Equal(b, l.badPeers)
+	}
+
+	s.Run("Happy path", func() {
+		firstListener := testListener{}
+		test(&firstListener, 0, 0, 0)
+
+		secondListener := testListener{}
+		test(&secondListener, 0, 0, 0)
+
+		s.client.RegisterListener(&firstListener)
+		pf.RecordSuccess()
+		test(&firstListener, 1, 0, 0)
+		pf.RecordFailure()
+		test(&firstListener, 1, 1, 0)
+		pf.RecordBadPeer()
+		test(&firstListener, 1, 1, 1)
+		test(&secondListener, 0, 0, 0)
+
+		s.client.RegisterListener(&secondListener)
+		pf.RecordSuccess()
+		pf.RecordFailure()
+		pf.RecordBadPeer()
+		test(&firstListener, 2, 2, 2)
+		test(&secondListener, 1, 1, 1)
+
+		s.client.UnregisterListener(&firstListener)
+		pf.RecordSuccess()
+		pf.RecordFailure()
+		pf.RecordBadPeer()
+		test(&secondListener, 2, 2, 2)
+		test(&firstListener, 2, 2, 2)
+
+		s.client.UnregisterListener(&secondListener)
+		pf.RecordSuccess()
+		pf.RecordFailure()
+		pf.RecordBadPeer()
+		test(&secondListener, 2, 2, 2)
+		test(&firstListener, 2, 2, 2)
+	})
+
+	s.Run("Register/unregister multiple times", func() {
+		listener := testListener{}
+
+		for i := 0; i < 5; i++ {
+			s.client.RegisterListener(&listener)
+		}
+		pf.RecordSuccess()
+		test(&listener, 1, 0, 0)
+
+		for i := 0; i < 10; i++ {
+			s.client.UnregisterListener(&listener)
+		}
+		pf.RecordSuccess()
+		test(&listener, 1, 0, 0)
+
+		s.client.RegisterListener(&listener)
+		pf.RecordSuccess()
+		test(&listener, 2, 0, 0)
+	})
+}

--- a/go/p2p/rpc/nop.go
+++ b/go/p2p/rpc/nop.go
@@ -15,7 +15,7 @@ func (*nopPeerManager) AddPeer(peerID peer.ID) {
 }
 
 // Implements PeerManager.
-func (*nopPeerManager) GetBestPeers() []peer.ID {
+func (*nopPeerManager) GetBestPeers(opts ...BestPeersOption) []peer.ID {
 	return nil
 }
 
@@ -35,13 +35,12 @@ func (*nopPeerManager) RecordSuccess(peerID peer.ID, latency time.Duration) {
 func (*nopPeerManager) RemovePeer(peerID peer.ID) {
 }
 
-type nopClient struct {
-	*nopPeerManager
-}
+type nopClient struct{}
 
 // Implements Client.
 func (c *nopClient) Call(
 	ctx context.Context,
+	peers []peer.ID,
 	method string,
 	body, rsp interface{},
 	maxPeerResponseTime time.Duration,
@@ -53,6 +52,7 @@ func (c *nopClient) Call(
 // Implements Client.
 func (c *nopClient) CallMulti(
 	ctx context.Context,
+	peers []peer.ID,
 	method string,
 	body, rspTyp interface{},
 	maxPeerResponseTime time.Duration,
@@ -61,3 +61,9 @@ func (c *nopClient) CallMulti(
 ) ([]interface{}, []PeerFeedback, error) {
 	return nil, nil, fmt.Errorf("unsupported: p2p is disabled")
 }
+
+// Implements Client.
+func (c *nopClient) RegisterListener(l ClientListener) {}
+
+// Implements Client.
+func (c *nopClient) UnregisterListener(l ClientListener) {}

--- a/go/p2p/rpc/nop.go
+++ b/go/p2p/rpc/nop.go
@@ -40,6 +40,18 @@ type nopClient struct{}
 // Implements Client.
 func (c *nopClient) Call(
 	ctx context.Context,
+	peer peer.ID,
+	method string,
+	body, rsp interface{},
+	maxPeerResponseTime time.Duration,
+	opts ...CallOption,
+) (PeerFeedback, error) {
+	return nil, fmt.Errorf("unsupported: p2p is disabled")
+}
+
+// Implements Client.
+func (c *nopClient) CallOne(
+	ctx context.Context,
 	peers []peer.ID,
 	method string,
 	body, rsp interface{},

--- a/go/p2p/rpc/nop.go
+++ b/go/p2p/rpc/nop.go
@@ -43,7 +43,6 @@ func (c *nopClient) Call(
 	peer peer.ID,
 	method string,
 	body, rsp interface{},
-	maxPeerResponseTime time.Duration,
 	opts ...CallOption,
 ) (PeerFeedback, error) {
 	return nil, fmt.Errorf("unsupported: p2p is disabled")
@@ -55,7 +54,6 @@ func (c *nopClient) CallOne(
 	peers []peer.ID,
 	method string,
 	body, rsp interface{},
-	maxPeerResponseTime time.Duration,
 	opts ...CallOption,
 ) (PeerFeedback, error) {
 	return nil, fmt.Errorf("unsupported: p2p is disabled")
@@ -67,8 +65,6 @@ func (c *nopClient) CallMulti(
 	peers []peer.ID,
 	method string,
 	body, rspTyp interface{},
-	maxPeerResponseTime time.Duration,
-	maxParallelRequests uint,
 	opts ...CallMultiOption,
 ) ([]interface{}, []PeerFeedback, error) {
 	return nil, nil, fmt.Errorf("unsupported: p2p is disabled")

--- a/go/p2p/rpc/server.go
+++ b/go/p2p/rpc/server.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	RequestReadDeadline   = 5 * time.Second
 	RequestHandleTimeout  = 60 * time.Second
 	ResponseWriteDeadline = 60 * time.Second
 )

--- a/go/p2p/txsync/client.go
+++ b/go/p2p/txsync/client.go
@@ -31,7 +31,7 @@ func (c *client) GetTxs(ctx context.Context, request *GetTxsRequest) (*GetTxsRes
 	resultTxMap := make(map[hash.Hash][]byte)
 
 	var rsp GetTxsResponse
-	_, _, err := c.rc.CallMulti(ctx, c.mgr.GetBestPeers(), MethodGetTxs, request, rsp, MaxGetTxsResponseTime, MaxGetTxsParallelRequests,
+	_, _, err := c.rc.CallMulti(ctx, c.mgr.GetBestPeers(), MethodGetTxs, request, rsp,
 		rpc.WithAggregateFn(func(rawRsp interface{}, pf rpc.PeerFeedback) bool {
 			rsp := rawRsp.(*GetTxsResponse)
 

--- a/go/p2p/txsync/client.go
+++ b/go/p2p/txsync/client.go
@@ -15,7 +15,8 @@ type Client interface {
 }
 
 type client struct {
-	rc rpc.Client
+	rc  rpc.Client
+	mgr rpc.PeerManager
 }
 
 func (c *client) GetTxs(ctx context.Context, request *GetTxsRequest) (*GetTxsResponse, error) {
@@ -30,7 +31,7 @@ func (c *client) GetTxs(ctx context.Context, request *GetTxsRequest) (*GetTxsRes
 	resultTxMap := make(map[hash.Hash][]byte)
 
 	var rsp GetTxsResponse
-	_, _, err := c.rc.CallMulti(ctx, MethodGetTxs, request, rsp, MaxGetTxsResponseTime, MaxGetTxsParallelRequests,
+	_, _, err := c.rc.CallMulti(ctx, c.mgr.GetBestPeers(), MethodGetTxs, request, rsp, MaxGetTxsResponseTime, MaxGetTxsParallelRequests,
 		rpc.WithAggregateFn(func(rawRsp interface{}, pf rpc.PeerFeedback) bool {
 			rsp := rawRsp.(*GetTxsResponse)
 
@@ -71,7 +72,13 @@ func (c *client) GetTxs(ctx context.Context, request *GetTxsRequest) (*GetTxsRes
 
 // NewClient creates a new transaction sync protocol client.
 func NewClient(p2p rpc.P2P, runtimeID common.Namespace) Client {
+	pid := rpc.NewRuntimeProtocolID(runtimeID, TxSyncProtocolID, TxSyncProtocolVersion)
+	mgr := rpc.NewPeerManager(p2p, pid)
+	rc := rpc.NewClient(p2p.GetHost(), pid)
+	rc.RegisterListener(mgr)
+
 	return &client{
-		rc: rpc.NewClient(p2p, rpc.NewRuntimeProtocolID(runtimeID, TxSyncProtocolID, TxSyncProtocolVersion)),
+		rc:  rc,
+		mgr: mgr,
 	}
 }

--- a/go/p2p/txsync/protocol.go
+++ b/go/p2p/txsync/protocol.go
@@ -1,8 +1,6 @@
 package txsync
 
 import (
-	"time"
-
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 )
@@ -15,10 +13,8 @@ var TxSyncProtocolVersion = version.Version{Major: 1, Minor: 0, Patch: 0}
 
 // Constants related to the GetTxs method.
 const (
-	MethodGetTxs              = "GetTxs"
-	MaxGetTxsResponseTime     = 5 * time.Second
-	MaxGetTxsCount            = 128
-	MaxGetTxsParallelRequests = 5
+	MethodGetTxs   = "GetTxs"
+	MaxGetTxsCount = 128
 )
 
 // GetTxsRequest is a GetTxs request.

--- a/go/worker/keymanager/p2p/client.go
+++ b/go/worker/keymanager/p2p/client.go
@@ -36,9 +36,8 @@ type client struct {
 
 func (c *client) CallEnclave(ctx context.Context, request *CallEnclaveRequest) (*CallEnclaveResponse, rpc.PeerFeedback, error) {
 	var rsp CallEnclaveResponse
-	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(), MethodCallEnclave, request, &rsp, MaxCallEnclaveResponseTime,
+	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(), MethodCallEnclave, request, &rsp,
 		rpc.WithMaxRetries(MaxCallEnclaveRetries),
-		rpc.WithRetryInterval(CallEnclaveRetryInterval),
 	)
 	if err != nil {
 		return nil, nil, err

--- a/go/worker/keymanager/p2p/client.go
+++ b/go/worker/keymanager/p2p/client.go
@@ -36,7 +36,7 @@ type client struct {
 
 func (c *client) CallEnclave(ctx context.Context, request *CallEnclaveRequest) (*CallEnclaveResponse, rpc.PeerFeedback, error) {
 	var rsp CallEnclaveResponse
-	pf, err := c.rc.Call(ctx, c.mgr.GetBestPeers(), MethodCallEnclave, request, &rsp, MaxCallEnclaveResponseTime,
+	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(), MethodCallEnclave, request, &rsp, MaxCallEnclaveResponseTime,
 		rpc.WithMaxRetries(MaxCallEnclaveRetries),
 		rpc.WithRetryInterval(CallEnclaveRetryInterval),
 	)

--- a/go/worker/keymanager/p2p/protocol.go
+++ b/go/worker/keymanager/p2p/protocol.go
@@ -1,8 +1,6 @@
 package p2p
 
 import (
-	"time"
-
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 )
 
@@ -14,10 +12,8 @@ var KeyManagerProtocolVersion = version.Version{Major: 1, Minor: 0, Patch: 0}
 
 // Constants related to the GetDiff method.
 const (
-	MethodCallEnclave          = "CallEnclave"
-	MaxCallEnclaveResponseTime = 5 * time.Second
-	MaxCallEnclaveRetries      = 15
-	CallEnclaveRetryInterval   = 1 * time.Second
+	MethodCallEnclave     = "CallEnclave"
+	MaxCallEnclaveRetries = 15
 )
 
 // CallEnclaveRequest is a CallEnclave request.

--- a/go/worker/storage/p2p/pub/client.go
+++ b/go/worker/storage/p2p/pub/client.go
@@ -27,7 +27,7 @@ type client struct {
 
 func (c *client) Get(ctx context.Context, request *GetRequest) (*ProofResponse, rpc.PeerFeedback, error) {
 	var rsp ProofResponse
-	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(), MethodGet, request, &rsp, MaxGetResponseTime)
+	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(), MethodGet, request, &rsp)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -36,7 +36,7 @@ func (c *client) Get(ctx context.Context, request *GetRequest) (*ProofResponse, 
 
 func (c *client) GetPrefixes(ctx context.Context, request *GetPrefixesRequest) (*ProofResponse, rpc.PeerFeedback, error) {
 	var rsp ProofResponse
-	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(), MethodGetPrefixes, request, &rsp, MaxGetPrefixesResponseTime)
+	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(), MethodGetPrefixes, request, &rsp)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -45,7 +45,7 @@ func (c *client) GetPrefixes(ctx context.Context, request *GetPrefixesRequest) (
 
 func (c *client) Iterate(ctx context.Context, request *IterateRequest) (*ProofResponse, rpc.PeerFeedback, error) {
 	var rsp ProofResponse
-	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(), MethodIterate, request, &rsp, MaxIterateResponseTime)
+	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(), MethodIterate, request, &rsp)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/worker/storage/p2p/pub/client.go
+++ b/go/worker/storage/p2p/pub/client.go
@@ -27,7 +27,7 @@ type client struct {
 
 func (c *client) Get(ctx context.Context, request *GetRequest) (*ProofResponse, rpc.PeerFeedback, error) {
 	var rsp ProofResponse
-	pf, err := c.rc.Call(ctx, c.mgr.GetBestPeers(), MethodGet, request, &rsp, MaxGetResponseTime)
+	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(), MethodGet, request, &rsp, MaxGetResponseTime)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -36,7 +36,7 @@ func (c *client) Get(ctx context.Context, request *GetRequest) (*ProofResponse, 
 
 func (c *client) GetPrefixes(ctx context.Context, request *GetPrefixesRequest) (*ProofResponse, rpc.PeerFeedback, error) {
 	var rsp ProofResponse
-	pf, err := c.rc.Call(ctx, c.mgr.GetBestPeers(), MethodGetPrefixes, request, &rsp, MaxGetPrefixesResponseTime)
+	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(), MethodGetPrefixes, request, &rsp, MaxGetPrefixesResponseTime)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -45,7 +45,7 @@ func (c *client) GetPrefixes(ctx context.Context, request *GetPrefixesRequest) (
 
 func (c *client) Iterate(ctx context.Context, request *IterateRequest) (*ProofResponse, rpc.PeerFeedback, error) {
 	var rsp ProofResponse
-	pf, err := c.rc.Call(ctx, c.mgr.GetBestPeers(), MethodIterate, request, &rsp, MaxIterateResponseTime)
+	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(), MethodIterate, request, &rsp, MaxIterateResponseTime)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/worker/storage/p2p/pub/client.go
+++ b/go/worker/storage/p2p/pub/client.go
@@ -21,12 +21,13 @@ type Client interface {
 }
 
 type client struct {
-	rc rpc.Client
+	rc  rpc.Client
+	mgr rpc.PeerManager
 }
 
 func (c *client) Get(ctx context.Context, request *GetRequest) (*ProofResponse, rpc.PeerFeedback, error) {
 	var rsp ProofResponse
-	pf, err := c.rc.Call(ctx, MethodGet, request, &rsp, MaxGetResponseTime)
+	pf, err := c.rc.Call(ctx, c.mgr.GetBestPeers(), MethodGet, request, &rsp, MaxGetResponseTime)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -35,7 +36,7 @@ func (c *client) Get(ctx context.Context, request *GetRequest) (*ProofResponse, 
 
 func (c *client) GetPrefixes(ctx context.Context, request *GetPrefixesRequest) (*ProofResponse, rpc.PeerFeedback, error) {
 	var rsp ProofResponse
-	pf, err := c.rc.Call(ctx, MethodGetPrefixes, request, &rsp, MaxGetPrefixesResponseTime)
+	pf, err := c.rc.Call(ctx, c.mgr.GetBestPeers(), MethodGetPrefixes, request, &rsp, MaxGetPrefixesResponseTime)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -44,7 +45,7 @@ func (c *client) GetPrefixes(ctx context.Context, request *GetPrefixesRequest) (
 
 func (c *client) Iterate(ctx context.Context, request *IterateRequest) (*ProofResponse, rpc.PeerFeedback, error) {
 	var rsp ProofResponse
-	pf, err := c.rc.Call(ctx, MethodIterate, request, &rsp, MaxIterateResponseTime)
+	pf, err := c.rc.Call(ctx, c.mgr.GetBestPeers(), MethodIterate, request, &rsp, MaxIterateResponseTime)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -53,7 +54,13 @@ func (c *client) Iterate(ctx context.Context, request *IterateRequest) (*ProofRe
 
 // NewClient creates a new storage pub protocol client.
 func NewClient(p2p rpc.P2P, runtimeID common.Namespace) Client {
+	pid := rpc.NewRuntimeProtocolID(runtimeID, StoragePubProtocolID, StoragePubProtocolVersion)
+	mgr := rpc.NewPeerManager(p2p, pid)
+	rc := rpc.NewClient(p2p.GetHost(), pid)
+	rc.RegisterListener(mgr)
+
 	return &client{
-		rc: rpc.NewClient(p2p, rpc.NewRuntimeProtocolID(runtimeID, StoragePubProtocolID, StoragePubProtocolVersion)),
+		rc:  rc,
+		mgr: mgr,
 	}
 }

--- a/go/worker/storage/p2p/pub/protocol.go
+++ b/go/worker/storage/p2p/pub/protocol.go
@@ -1,8 +1,6 @@
 package pub
 
 import (
-	"time"
-
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/syncer"
 )
@@ -15,8 +13,7 @@ var StoragePubProtocolVersion = version.Version{Major: 1, Minor: 0, Patch: 0}
 
 // Constants related to the Get method.
 const (
-	MethodGet          = "Get"
-	MaxGetResponseTime = 5 * time.Second
+	MethodGet = "Get"
 )
 
 // GetRequest is a Get request.
@@ -27,8 +24,7 @@ type ProofResponse = syncer.ProofResponse
 
 // Constants related to the GetPrefixes method.
 const (
-	MethodGetPrefixes          = "GetPrefixes"
-	MaxGetPrefixesResponseTime = 5 * time.Second
+	MethodGetPrefixes = "GetPrefixes"
 )
 
 // GetPrefixesRequest is a GetPrefixes request.
@@ -36,8 +32,7 @@ type GetPrefixesRequest = syncer.GetPrefixesRequest
 
 // Constants related to the Iterate method.
 const (
-	MethodIterate          = "Iterate"
-	MaxIterateResponseTime = 5 * time.Second
+	MethodIterate = "Iterate"
 )
 
 // IterateRequest is an Iterate request.

--- a/go/worker/storage/p2p/sync/client.go
+++ b/go/worker/storage/p2p/sync/client.go
@@ -45,7 +45,7 @@ type client struct {
 
 func (c *client) GetDiff(ctx context.Context, request *GetDiffRequest) (*GetDiffResponse, rpc.PeerFeedback, error) {
 	var rsp GetDiffResponse
-	pf, err := c.rcD.Call(ctx, c.mgrD.GetBestPeers(), MethodGetDiff, request, &rsp, MaxGetDiffResponseTime)
+	pf, err := c.rcD.CallOne(ctx, c.mgrD.GetBestPeers(), MethodGetDiff, request, &rsp, MaxGetDiffResponseTime)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -106,7 +106,7 @@ func (c *client) GetCheckpointChunk(
 	}
 
 	var rsp GetCheckpointChunkResponse
-	pf, err := c.rcC.Call(ctx, c.mgrC.GetBestPeers(opts...), MethodGetCheckpointChunk, request, &rsp,
+	pf, err := c.rcC.CallOne(ctx, c.mgrC.GetBestPeers(opts...), MethodGetCheckpointChunk, request, &rsp,
 		MaxGetCheckpointChunkResponseTime,
 	)
 	if err != nil {

--- a/go/worker/storage/p2p/sync/client.go
+++ b/go/worker/storage/p2p/sync/client.go
@@ -45,7 +45,9 @@ type client struct {
 
 func (c *client) GetDiff(ctx context.Context, request *GetDiffRequest) (*GetDiffResponse, rpc.PeerFeedback, error) {
 	var rsp GetDiffResponse
-	pf, err := c.rcD.CallOne(ctx, c.mgrD.GetBestPeers(), MethodGetDiff, request, &rsp, MaxGetDiffResponseTime)
+	pf, err := c.rcD.CallOne(ctx, c.mgrD.GetBestPeers(), MethodGetDiff, request, &rsp,
+		rpc.WithMaxPeerResponseTime(MaxGetDiffResponseTime),
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -54,10 +56,7 @@ func (c *client) GetDiff(ctx context.Context, request *GetDiffRequest) (*GetDiff
 
 func (c *client) GetCheckpoints(ctx context.Context, request *GetCheckpointsRequest) ([]*Checkpoint, error) {
 	var rsp GetCheckpointsResponse
-	rsps, pfs, err := c.rcC.CallMulti(ctx, c.mgrC.GetBestPeers(), MethodGetCheckpoints, request, rsp,
-		MaxGetCheckpointsResponseTime,
-		MaxGetCheckpointsParallelRequests,
-	)
+	rsps, pfs, err := c.rcC.CallMulti(ctx, c.mgrC.GetBestPeers(), MethodGetCheckpoints, request, rsp)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +106,7 @@ func (c *client) GetCheckpointChunk(
 
 	var rsp GetCheckpointChunkResponse
 	pf, err := c.rcC.CallOne(ctx, c.mgrC.GetBestPeers(opts...), MethodGetCheckpointChunk, request, &rsp,
-		MaxGetCheckpointChunkResponseTime,
+		rpc.WithMaxPeerResponseTime(MaxGetCheckpointChunkResponseTime),
 	)
 	if err != nil {
 		return nil, nil, err

--- a/go/worker/storage/p2p/sync/protocol.go
+++ b/go/worker/storage/p2p/sync/protocol.go
@@ -34,9 +34,7 @@ type GetDiffResponse struct {
 
 // Constants related to the GetCheckpoints method.
 const (
-	MethodGetCheckpoints              = "GetCheckpoints"
-	MaxGetCheckpointsResponseTime     = 5 * time.Second
-	MaxGetCheckpointsParallelRequests = 5
+	MethodGetCheckpoints = "GetCheckpoints"
 )
 
 // GetCheckpointsRequest is a GetCheckpoints request.


### PR DESCRIPTION
Peer selection is very tightly coupled with RPC client as peer manager is constructed inside client's constructor. We also miss simple RPC calls which contact exactly one peer.

### Test
Memory leak was check with the following code, which prints 1 and 101, meaning that 100 go routines leaked.

```
package main

import (
	"fmt"
	"runtime"
	"time"

	"github.com/eapache/channels"
)

func main() {
	fmt.Println(runtime.NumGoroutine())
	for i := 0; i < 100; i++ {
		leak()
	}
	time.Sleep(time.Minute)
	fmt.Println(runtime.NumGoroutine())
}

func leak() {
	n := 10
	var chs []channels.SimpleOutChannel

	for i := 0; i < n; i++ {
		ch := channels.NewNativeChannel(channels.BufferCap(1))
		defer close(ch)

		chs = append(chs, ch)
		ch <- i
	}

	ch := channels.NewNativeChannel(channels.None)
	channels.Multiplex(ch, chs...)

	for v := range ch.Out() {
		if v.(int) < n/2 {
			break
		}
	}
}
```