### PR TITLE
go/common/workerpool: Fix memory leak when workerpool is stopped early

### DIFF
--- a/.changelog/5008.bugfix.md
+++ b/.changelog/5008.bugfix.md
@@ -1,0 +1,5 @@
+go/common/workerpool: Fix memory leak when workerpool is stopped early
+
+When workerpool si stopped, the job channel might still contain jobs which
+haven't been processed. Therefore, the channel never closes and leaves one
+go routine hanging.

--- a/go/common/workerpool/workerpool.go
+++ b/go/common/workerpool/workerpool.go
@@ -79,6 +79,10 @@ func (p *Pool) Stop() {
 	p.stopOnce.Do(func() {
 		close(p.stopCh)
 	})
+
+	for range p.jobCh.Out() {
+		// Clear the channel to close all go routines and prevent memory leaks.
+	}
 }
 
 // Quit returns a channel that will be closed when the pool stops.


### PR DESCRIPTION
When workerpool si stopped, the job channel might still contain jobs which haven't been processed. Therefore, the channel never closes and leaves one go routine hanging.

### Test
Tested with the following code. Before the code printed 1/101, afterwards 1/1.

```
package main

import (
	"fmt"
	"runtime"
	"time"

	"github.com/oasisprotocol/oasis-core/go/common/workerpool"
)

func main() {
	fmt.Println(runtime.NumGoroutine())
	for i := 0; i < 100; i++ {
		leak()
	}
	time.Sleep(time.Minute)
	fmt.Println(runtime.NumGoroutine())
}

func leak() {
	pool := workerpool.New("p2p/rpc")
	pool.Resize(10)
	defer pool.Stop()

	for i := 0; i < 100; i++ {
		pool.Submit(func() {
			time.Sleep(time.Millisecond)
		})
	}
}
```