### PR TITLE
go tendermint staking: reduce DelegationsTo scanning

### DIFF
--- a/.changelog/5011.feature.md
+++ b/.changelog/5011.feature.md
@@ -1,0 +1,1 @@
+go/consensus/tendermint/apps/staking: Reduce DelegationsTo scanning

--- a/go/consensus/tendermint/apps/staking/state/state.go
+++ b/go/consensus/tendermint/apps/staking/state/state.go
@@ -295,14 +295,14 @@ func (s *ImmutableState) DelegationsTo(
 	defer it.Close()
 
 	delegations := make(map[staking.Address]*staking.Delegation)
-	for it.Seek(delegationKeyFmt.Encode()); it.Valid(); it.Next() {
+	for it.Seek(delegationKeyFmt.Encode(destAddr)); it.Valid(); it.Next() {
 		var escrowAddr staking.Address
 		var delegatorAddr staking.Address
 		if !delegationKeyFmt.Decode(it.Key(), &escrowAddr, &delegatorAddr) {
 			break
 		}
 		if !escrowAddr.Equal(destAddr) {
-			continue
+			break
 		}
 
 		var del staking.Delegation


### PR DESCRIPTION
the escrow address is the first part of the key so we can seek to it