### PR TITLE
go/registry: validate SoftwareVersion field in node descriptor

### DIFF
--- a/.changelog/5012.breaking.md
+++ b/.changelog/5012.breaking.md
@@ -1,0 +1,1 @@
+go/registry: validate SoftwareVersion field in node descriptor

--- a/go/common/node/node_test.go
+++ b/go/common/node/node_test.go
@@ -3,6 +3,7 @@ package node
 import (
 	"encoding/base64"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -309,4 +310,17 @@ func TestNodeDeserialization(t *testing.T) {
 		require.NoError(err, "Unmarshal")
 		require.EqualValues(tc.expectedNode, dec, "Node serialization should round-trip")
 	}
+}
+
+func TestNodeSoftwareVersion(t *testing.T) {
+	require := require.New(t)
+
+	sw := SoftwareVersion("")
+	require.NoError(sw.ValidateBasic(), "empty software version is allowed")
+
+	sw = SoftwareVersion(version.SoftwareVersion)
+	require.NoError(sw.ValidateBasic(), "software version is allowed")
+
+	sw = SoftwareVersion(strings.Repeat("a", 1000))
+	require.Error(sw.ValidateBasic(), "invalid software version")
 }

--- a/go/oasis-node/cmd/debug/fixgenesis/fixgenesis.go
+++ b/go/oasis-node/cmd/debug/fixgenesis/fixgenesis.go
@@ -269,6 +269,13 @@ NodeLoop:
 			)
 			continue
 		}
+		if err = node.ValidateBasic(false); err != nil {
+			logger.Warn("removing node not passing basic validation check",
+				"err", err,
+				"node_id", node.ID,
+			)
+			continue
+		}
 		for _, rt := range node.Runtimes {
 			knownRt, exists := knownRuntimes[rt.ID]
 			if !exists {

--- a/go/oasis-node/cmd/registry/node/node.go
+++ b/go/oasis-node/cmd/registry/node/node.go
@@ -163,7 +163,7 @@ func doInit(cmd *cobra.Command, args []string) { // nolint: gocyclo
 		VRF: &node.VRFInfo{
 			ID: nodeIdentity.VRFSigner.Public(),
 		},
-		SoftwareVersion: version.SoftwareVersion,
+		SoftwareVersion: node.SoftwareVersion(version.SoftwareVersion),
 	}
 	if n.Roles, err = argsToRolesMask(); err != nil {
 		logger.Error("failed to parse node roles mask",

--- a/go/oasis-test-runner/scenario/e2e/registry_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/registry_cli.go
@@ -430,7 +430,7 @@ func (sc *registryCLIImpl) newTestNode(entityID signature.PublicKey) (*node.Node
 			},
 		},
 		Roles:           node.RoleValidator,
-		SoftwareVersion: version.SoftwareVersion,
+		SoftwareVersion: node.SoftwareVersion(version.SoftwareVersion),
 	}
 	_ = testNode.Runtimes[0].ID.UnmarshalHex("8000000000000000000000000000000000000000000000000000000000000000")
 

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -1001,7 +1001,7 @@ func (w *Worker) registerNode(epoch beacon.EpochTime, hook RegisterNodeHook) err
 		VRF: &node.VRFInfo{
 			ID: w.identity.VRFSigner.Public(),
 		},
-		SoftwareVersion: version.SoftwareVersion,
+		SoftwareVersion: node.SoftwareVersion(version.SoftwareVersion),
 	}
 
 	if err := hook(&nodeDesc); err != nil {


### PR DESCRIPTION
This PR adds basic validation checks to the Software Version field in node descriptor. As this is a human-readable version field, only a reasonable max length is enforced at this time.

Fix genesis is also updated to remove (and warn about) any registry nodes failing the basic descriptor validity checks. On most recent mainnet state, all nodes pass the (updated) validation checks.