### PR TITLE
go tendermint staking: specify slashed debonding amount in `TakeEscrowEvent`

### DIFF
--- a/.changelog/5016.feature.md
+++ b/.changelog/5016.feature.md
@@ -1,0 +1,5 @@
+staking: specify slashed debonding amount in TakeEscrowEvent
+
+The newly introduced field lets observers distinguish how much
+was slashed from the active escrow pool and how much from the
+debonding escrow pool.

--- a/docs/consensus/services/staking.md
+++ b/docs/consensus/services/staking.md
@@ -649,15 +649,19 @@ slashed for whatever reason.
 
 ```golang
 type TakeEscrowEvent struct {
-  Owner  Address           `json:"owner"`
-  Amount quantity.Quantity `json:"amount"`
+  Owner  Address                    `json:"owner"`
+  Amount quantity.Quantity          `json:"amount"`
+  DebondingAmount quantity.Quantity `json:"debonding_amount"`
 }
 ```
 
 **Fields:**
 
 * `owner` contains the address of the account escrow has been taken from.
-* `amount` contains the amount (in base units) taken.
+* `amount` contains the total amount (in base units) taken. The debonding and
+  active escrow balances are slashed in equal proportions.
+* `debonding_amount` contains the amount (in base units) taken from just the
+  debonding escrow balance.
 
 #### Reclaim Escrow Event
 

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -260,8 +260,11 @@ func (e *AddEscrowEvent) EventKind() string {
 // TakeEscrowEvent is the event emitted when stake is taken from an escrow
 // account (i.e. stake is slashed).
 type TakeEscrowEvent struct {
-	Owner  Address           `json:"owner"`
+	Owner Address `json:"owner"`
+	// The sum of amounts slashed from active and debonding escrow balances.
 	Amount quantity.Quantity `json:"amount"`
+	// The amount slashed from debonding escrow balances.
+	DebondingAmount quantity.Quantity `json:"debonding_amount"`
 }
 
 // EventKind returns a string representation of this event's kind.

--- a/go/staking/api/api_test.go
+++ b/go/staking/api/api_test.go
@@ -576,12 +576,13 @@ func TestEventsSerialization(t *testing.T) {
 				TxHash: txHash,
 				Escrow: &EscrowEvent{
 					Take: &TakeEscrowEvent{
-						Owner:  addr1,
-						Amount: mustInitQuantity(t, 100),
+						Owner:           addr1,
+						Amount:          mustInitQuantity(t, 100),
+						DebondingAmount: mustInitQuantity(t, 20),
 					},
 				},
 			},
-			"o2Zlc2Nyb3ehZHRha2WiZW93bmVyVQAgchQ0iT9hbAmBSOLPn5nj4oJuE2ZhbW91bnRBZGZoZWlnaHQYKmd0eF9oYXNoWCDGcrjR71btKKuHw2IsURQGm90617j5c3SY0MAezvCWeg==",
+			"o2Zlc2Nyb3ehZHRha2WjZW93bmVyVQAgchQ0iT9hbAmBSOLPn5nj4oJuE2ZhbW91bnRBZHBkZWJvbmRpbmdfYW1vdW50QRRmaGVpZ2h0GCpndHhfaGFzaFggxnK40e9W7Sirh8NiLFEUBpvdOte4+XN0mNDAHs7wlno=",
 		},
 		{
 			Event{

--- a/runtime/src/consensus/staking.rs
+++ b/runtime/src/consensus/staking.rs
@@ -276,7 +276,13 @@ pub enum EscrowEvent {
 
     /// Event emitted when stake is taken from an escrow account (i.e. stake is slashed).
     #[cbor(rename = "take")]
-    Take { owner: Address, amount: Quantity },
+    Take {
+        owner: Address,
+        // The sum of amounts slashed from active and debonding escrow balances.
+        amount: Quantity,
+        // The amount slashed from the debonding escrow balance.
+        debonding_amount: Quantity,
+    },
 
     /// Event emitted when the debonding process has started and the given number of active shares
     /// have been moved into the debonding pool and started debonding.
@@ -630,13 +636,14 @@ mod tests {
                 },
             ),
             (
-                "o2Zlc2Nyb3ehZHRha2WiZW93bmVyVQAgchQ0iT9hbAmBSOLPn5nj4oJuE2ZhbW91bnRBZGZoZWlnaHQYKmd0eF9oYXNoWCDGcrjR71btKKuHw2IsURQGm90617j5c3SY0MAezvCWeg==",
+                "o2Zlc2Nyb3ehZHRha2WjZW93bmVyVQAgchQ0iT9hbAmBSOLPn5nj4oJuE2ZhbW91bnRBZHBkZWJvbmRpbmdfYW1vdW50QRRmaGVpZ2h0GCpndHhfaGFzaFggxnK40e9W7Sirh8NiLFEUBpvdOte4+XN0mNDAHs7wlno=",
                 Event {
                     height: 42,
                     tx_hash,
                     escrow: Some(EscrowEvent::Take {
                         owner: addr1.clone(),
                         amount: 100u32.into(),
+                        debonding_amount: 20u32.into()
                     }),
                     ..Default::default()
                 },


### PR DESCRIPTION
**Motivation / Before this PR:** `TakeEscrowEvent` reports the [amount](https://github.com/oasisprotocol/oasis-core/blob/531421a928dc3450abd721c832d376549626a473/go/staking/api/api.go#L284) that was slashed. However, this total amount is taken proportionally from two separate sharepools: the active escrow and the debonding escrow.

Example: an account has 300 ROSE in active escrow and 100 ROSE in debonding escrow, and gets slashed by 40 ROSE. 30 ROSE will be slashed from active escrow, and 10 ROSE from debonding.

The event is thus not self-contained in that the 30 and the 10 from the example above cannot be derived from the event data (= 40) without knowing the balances in active and debonding escrow at the time the event was generated. This is inconsistent with other events, and awkward for external observers to track active vs debonding balances.

**This PR** adds a `debonding_amount` field which explicitly states the amount taken from the debonding sharepool. To keep the fields non-redundant, `active_amount` is not included; it can be trivially derived as `active_amount = amount - debonding_amount`.

**Change compatibility:** I tested our two major cbor libraries for backwards/forwards compatibility when adding a new field, as this PR does. Results:
- `from_cbor_value` in Rust (as implemented by `derive(cbor::Decode)`): Compatible both ways. Decoding a new-style message into an old-style type ignores the extra field. Decoding an old-style message into a new-style type silently defaults `debonding_delegations` to 0.
- `cbor.Unmarshal()` in Go: Backward compatible -- decoding an old-style message into a new-style type silently defaults `debonding_delegations` to 0. **NOT forward compatible** -- Decoding a new-style message into an old-style type returns an error (`"unknown field"`)