### PR TITLE
docs: Update Tendermint Core metrics link

### DIFF
--- a/docs/oasis-node/metrics.md
+++ b/docs/oasis-node/metrics.md
@@ -125,4 +125,4 @@ Tendermint metrics are also reported. Consult
 [tendermint-core documentation][2] for a list of reported by Tendermint.
 
 [1]: ../consensus/README.md#tendermint
-[2]: https://docs.tendermint.com/master/nodes/metrics.html
+[2]: https://docs.tendermint.com/main/tendermint-core/metrics.html

--- a/docs/oasis-node/metrics.md.tpl
+++ b/docs/oasis-node/metrics.md.tpl
@@ -49,4 +49,4 @@ Tendermint metrics are also reported. Consult
 [tendermint-core documentation][2] for a list of reported by Tendermint.
 
 [1]: ../consensus/README.md#tendermint
-[2]: https://docs.tendermint.com/master/nodes/metrics.html
+[2]: https://docs.tendermint.com/main/tendermint-core/metrics.html


### PR DESCRIPTION
At Tendermint Core they reorganized their docs, but forgot to put redirects for old links in place.