### PR TITLE
go/staking: reduce DebondingDelegationsFor scanning

### DIFF
--- a/.changelog/5022.feature.md
+++ b/.changelog/5022.feature.md
@@ -1,0 +1,1 @@
+go/staking: reduce DebondingDelegationsFor scanning

--- a/go/consensus/tendermint/apps/staking/state/state.go
+++ b/go/consensus/tendermint/apps/staking/state/state.go
@@ -383,7 +383,7 @@ func (s *ImmutableState) DebondingDelegationsFor(
 			break
 		}
 		if !decDelegatorAddr.Equal(delegatorAddr) {
-			continue
+			break
 		}
 
 		var deb staking.DebondingDelegation


### PR DESCRIPTION
`DebondingDelegationsFor` keys are ordered by `delegatorAddr`. Once past it, it doesn't need to scan further (analogous to `DelegationsTo` fixed in: https://github.com/oasisprotocol/oasis-core/pull/5011).

Seek query is already (correctly) prefixed with `delegatorAddr`.