### PR TITLE
go/staking: efficient DelegationsFor query

### DIFF
--- a/.changelog/5023.breaking.md
+++ b/.changelog/5023.breaking.md
@@ -1,0 +1,4 @@
+go/staking: efficient `DelegationsFor` query
+
+A reverse delegation mapping is added to the staking state that makes
+querying outgoing delegations efficient.

--- a/runtime/src/consensus/state/beacon.rs
+++ b/runtime/src/consensus/state/beacon.rs
@@ -169,7 +169,7 @@ mod test {
         let mock_consensus_root = Root {
             version: 1,
             root_type: RootType::State,
-            hash: Hash::from("f62f1f313de3833830a48b742f144fba542412e7ec65705d83f71a5e6e99bb2b"),
+            hash: Hash::from("8f6760fe2b547a823f71df7510272d3c932874e6dc5cc6e2df0588bad917e90f"),
             ..Default::default()
         };
         let mkvs = Tree::builder()

--- a/runtime/src/consensus/state/keymanager.rs
+++ b/runtime/src/consensus/state/keymanager.rs
@@ -112,7 +112,7 @@ mod test {
         let mock_consensus_root = Root {
             version: 1,
             root_type: RootType::State,
-            hash: Hash::from("f62f1f313de3833830a48b742f144fba542412e7ec65705d83f71a5e6e99bb2b"),
+            hash: Hash::from("8f6760fe2b547a823f71df7510272d3c932874e6dc5cc6e2df0588bad917e90f"),
             ..Default::default()
         };
         let mkvs = Tree::builder()

--- a/runtime/src/consensus/state/registry.rs
+++ b/runtime/src/consensus/state/registry.rs
@@ -139,7 +139,7 @@ mod test {
         let mock_consensus_root = Root {
             version: 1,
             root_type: RootType::State,
-            hash: Hash::from("f62f1f313de3833830a48b742f144fba542412e7ec65705d83f71a5e6e99bb2b"),
+            hash: Hash::from("8f6760fe2b547a823f71df7510272d3c932874e6dc5cc6e2df0588bad917e90f"),
             ..Default::default()
         };
         let mkvs = Tree::builder()

--- a/runtime/src/consensus/state/staking.rs
+++ b/runtime/src/consensus/state/staking.rs
@@ -230,7 +230,7 @@ mod test {
         let mock_consensus_root = Root {
             version: 1,
             root_type: RootType::State,
-            hash: Hash::from("f62f1f313de3833830a48b742f144fba542412e7ec65705d83f71a5e6e99bb2b"),
+            hash: Hash::from("8f6760fe2b547a823f71df7510272d3c932874e6dc5cc6e2df0588bad917e90f"),
             ..Default::default()
         };
         let mkvs = Tree::builder()


### PR DESCRIPTION
An efficient `DelegationsFor` query will be needed for implementing [ADR-0020](https://github.com/oasisprotocol/adrs/blob/main/0020-governance-delegator-votes.md). If desired, could do a similar change for `DebonidngDelegationsTo` to optimize the query for it. 

No fix-genesis updates needed, since on `InitChain` all the delegations are inserted via the updated `SetDelegation` function.