### PR TITLE
go/p2p: Include chain context in p2p protocol names

### DIFF
--- a/.changelog/4996.cfg.md
+++ b/.changelog/4996.cfg.md
@@ -6,7 +6,7 @@ up in the hierarchy and rename its configuration flags.
 
 The following configuration changes were made to the p2p config flags:
 
-- Prefix `wroker.` was dropped.
+- Prefix `worker.` was dropped.
 
 - Flags for the same feature were grouped under the same prefix.
 

--- a/.changelog/5025.breaking.md
+++ b/.changelog/5025.breaking.md
@@ -1,0 +1,6 @@
+go/p2p: Include chain context in p2p protocol names
+
+Chain context was included in p2p protocol and topic names as until now
+it was impossible to distinguish mainnet and testnet names from each other.
+Unique names will also ease peer discovery as now we can use one seed node
+for multiple nets.

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -135,7 +135,7 @@ var (
 
 	// RuntimeCommitteeProtocol versions the P2P protocol used by the runtime
 	// committee members.
-	RuntimeCommitteeProtocol = Version{Major: 4, Minor: 0, Patch: 0}
+	RuntimeCommitteeProtocol = Version{Major: 5, Minor: 0, Patch: 0}
 
 	// TendermintAppVersion is Tendermint ABCI application's version computed by
 	// masking non-major consensus protocol version segments to 0 to be

--- a/go/oasis-node/cmd/debug/byzantine/byzantine.go
+++ b/go/oasis-node/cmd/debug/byzantine/byzantine.go
@@ -158,7 +158,7 @@ func doExecutorScenario(cmd *cobra.Command, args []string) { //nolint: gocyclo
 		return
 	}
 
-	cbc := newComputeBatchContext(runtimeID)
+	cbc := newComputeBatchContext(b.chainContext, runtimeID)
 	switch isTxScheduler {
 	case true:
 		// If we are the transaction scheduler, we wait for transactions and schedule them.

--- a/go/oasis-node/cmd/debug/byzantine/p2p.go
+++ b/go/oasis-node/cmd/debug/byzantine/p2p.go
@@ -10,6 +10,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
 	"github.com/oasisprotocol/oasis-core/go/p2p"
 	p2pAPI "github.com/oasisprotocol/oasis-core/go/p2p/api"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 )
 
 type p2pReqRes struct {
@@ -90,7 +91,7 @@ func (h *committeeMsgHandler) HandleMessage(ctx context.Context, peerID signatur
 	return <-responseCh
 }
 
-func (ph *p2pHandle) start(ht *honestTendermint, id *identity.Identity, runtimeID common.Namespace) error {
+func (ph *p2pHandle) start(ht *honestTendermint, id *identity.Identity, chainContext string, runtimeID common.Namespace) error {
 	if ph.service != nil {
 		return fmt.Errorf("P2P service already started")
 	}
@@ -101,8 +102,11 @@ func (ph *p2pHandle) start(ht *honestTendermint, id *identity.Identity, runtimeI
 		return fmt.Errorf("P2P service New: %w", err)
 	}
 
-	ph.service.RegisterHandler(runtimeID, p2pAPI.TopicKindTx, &txMsgHandler{ph})
-	ph.service.RegisterHandler(runtimeID, p2pAPI.TopicKindCommittee, &committeeMsgHandler{ph})
+	txTopic := protocol.NewTopicKindTxID(chainContext, runtimeID)
+	ph.service.RegisterHandler(txTopic, &txMsgHandler{ph})
+
+	committeeTopic := protocol.NewTopicKindCommitteeID(chainContext, runtimeID)
+	ph.service.RegisterHandler(committeeTopic, &committeeMsgHandler{ph})
 
 	return nil
 }

--- a/go/p2p/api/api.go
+++ b/go/p2p/api/api.go
@@ -63,14 +63,11 @@ type Service interface {
 	// Peers returns a list of connected P2P peers for the given runtime.
 	Peers(runtimeID common.Namespace) []string
 
-	// PublishCommittee publishes a committee message.
-	PublishCommittee(ctx context.Context, runtimeID common.Namespace, msg *CommitteeMessage)
-
-	// PublishTx publishes a transaction message.
-	PublishTx(ctx context.Context, runtimeID common.Namespace, msg TxMessage)
+	// Publish publishes the given message to the given topic.
+	Publish(ctx context.Context, topic string, msg interface{})
 
 	// RegisterHandler registers a message handler for the specified runtime and topic kind.
-	RegisterHandler(runtimeID common.Namespace, kind TopicKind, handler Handler)
+	RegisterHandler(topic string, handler Handler)
 
 	// BlockPeer blocks a specific peer from being used by the local node.
 	BlockPeer(peerID core.PeerID)

--- a/go/p2p/api/convert.go
+++ b/go/p2p/api/convert.go
@@ -1,14 +1,10 @@
 package api
 
 import (
-	"fmt"
-
 	"github.com/libp2p/go-libp2p/core"
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
-	"github.com/oasisprotocol/oasis-core/go/common/version"
 )
 
 // PublicKeyToPeerID converts a public key to a peer identifier.
@@ -37,14 +33,4 @@ func PublicKeyMapToPeerIDs(pks map[signature.PublicKey]bool) ([]core.PeerID, err
 		ids = append(ids, id)
 	}
 	return ids, nil
-}
-
-// NewTopicIDForRuntime constructs topic id from the given parameters.
-func NewTopicIDForRuntime(chainContext string, runtimeID common.Namespace, kind TopicKind) string {
-	return fmt.Sprintf("%s/%d/%s/%s",
-		chainContext,
-		version.RuntimeCommitteeProtocol.Major,
-		runtimeID.String(),
-		kind,
-	)
 }

--- a/go/p2p/dispatch.go
+++ b/go/p2p/dispatch.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/p2p/api"
 	p2pError "github.com/oasisprotocol/oasis-core/go/p2p/error"
 	"github.com/oasisprotocol/oasis-core/go/p2p/peermgmt"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 )
 
 const (
@@ -297,8 +298,8 @@ func init() {
 
 			topics := make([]string, 2*len(n.Runtimes))
 			for i, rt := range n.Runtimes {
-				topics[2*i] = api.NewTopicIDForRuntime(chainContext, rt.ID, api.TopicKindCommittee)
-				topics[2*i+1] = api.NewTopicIDForRuntime(chainContext, rt.ID, api.TopicKindTx)
+				topics[2*i] = protocol.NewTopicKindCommitteeID(chainContext, rt.ID)
+				topics[2*i+1] = protocol.NewTopicKindTxID(chainContext, rt.ID)
 			}
 
 			return topics

--- a/go/p2p/nop.go
+++ b/go/p2p/nop.go
@@ -56,15 +56,11 @@ func (p *nopP2P) Peers(runtimeID common.Namespace) []string {
 }
 
 // Implements api.Service.
-func (p *nopP2P) PublishCommittee(ctx context.Context, runtimeID common.Namespace, msg *api.CommitteeMessage) {
+func (p *nopP2P) Publish(ctx context.Context, topic string, msg interface{}) {
 }
 
 // Implements api.Service.
-func (p *nopP2P) PublishTx(ctx context.Context, runtimeID common.Namespace, msg api.TxMessage) {
-}
-
-// Implements api.Service.
-func (p *nopP2P) RegisterHandler(runtimeID common.Namespace, kind api.TopicKind, handler api.Handler) {
+func (p *nopP2P) RegisterHandler(topic string, handler api.Handler) {
 }
 
 // Implements api.Service.

--- a/go/p2p/protocol/protocol.go
+++ b/go/p2p/protocol/protocol.go
@@ -1,0 +1,69 @@
+package protocol
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/libp2p/go-libp2p/core"
+	"github.com/libp2p/go-libp2p/core/protocol"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
+	"github.com/oasisprotocol/oasis-core/go/p2p/api"
+)
+
+type protocolRegistry struct {
+	mu        sync.Mutex
+	protocols map[core.ProtocolID]struct{}
+}
+
+func newProtocolRegistry() *protocolRegistry {
+	return &protocolRegistry{
+		protocols: make(map[core.ProtocolID]struct{}),
+	}
+}
+
+var registry = newProtocolRegistry()
+
+// ValidateProtocolID panics if the protocol id is not unique.
+func ValidateProtocolID(p core.ProtocolID) {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+
+	if _, ok := registry.protocols[p]; ok {
+		panic(fmt.Sprintf("p2p/protocol: protocol or topic with name '%s' already exists", p))
+	}
+	registry.protocols[p] = struct{}{}
+}
+
+// ValidateTopicID panics if the topic id is not unique.
+func ValidateTopicID(topic string) {
+	ValidateProtocolID(core.ProtocolID(topic))
+}
+
+// NewProtocolID generates a protocol identifier for a consensus P2P protocol.
+func NewProtocolID(chainContext string, protocolID string, version version.Version) protocol.ID {
+	return protocol.ID(fmt.Sprintf("/oasis/%s/%s/%s", chainContext, protocolID, version.MaskNonMajor()))
+}
+
+// NewRuntimeProtocolID generates a protocol identifier for a protocol supported for a specific
+// runtime. This makes it so that one doesn't need additional checks to ensure that a peer supports
+// the given protocol for the given runtime.
+func NewRuntimeProtocolID(chainContext string, runtimeID common.Namespace, protocolID string, version version.Version) protocol.ID {
+	return protocol.ID(fmt.Sprintf("/oasis/%s/%s/%s/%s", chainContext, protocolID, runtimeID.Hex(), version.MaskNonMajor()))
+}
+
+// NewTopicIDForRuntime constructs topic id from the given parameters.
+func NewTopicIDForRuntime(chainContext string, runtimeID common.Namespace, kind api.TopicKind, version version.Version) string {
+	return fmt.Sprintf("oasis/%s/%s/%s/%s", chainContext, kind, runtimeID.String(), version.MaskNonMajor())
+}
+
+// NewTopicKindTxID constructs topic id from the given parameters.
+func NewTopicKindTxID(chainContext string, runtimeID common.Namespace) string {
+	return NewTopicIDForRuntime(chainContext, runtimeID, api.TopicKindTx, version.RuntimeCommitteeProtocol)
+}
+
+// NewTopicKindCommitteeID constructs topic id from the given parameters.
+func NewTopicKindCommitteeID(chainContext string, runtimeID common.Namespace) string {
+	return NewTopicIDForRuntime(chainContext, runtimeID, api.TopicKindCommittee, version.RuntimeCommitteeProtocol)
+}

--- a/go/p2p/rpc/rpc.go
+++ b/go/p2p/rpc/rpc.go
@@ -3,13 +3,8 @@ package rpc
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/libp2p/go-libp2p/core"
-	"github.com/libp2p/go-libp2p/core/protocol"
-
-	"github.com/oasisprotocol/oasis-core/go/common"
-	"github.com/oasisprotocol/oasis-core/go/common/version"
 )
 
 const codecModuleName = "p2p/rpc"
@@ -24,18 +19,6 @@ type P2P interface {
 
 	// Host returns the P2P host.
 	Host() core.Host
-}
-
-// NewProtocolID generates a protocol identifier for a consensus P2P protocol.
-func NewProtocolID(protocolID string, version version.Version) protocol.ID {
-	return protocol.ID(fmt.Sprintf("/oasis/%s/%s", protocolID, version.MaskNonMajor()))
-}
-
-// NewRuntimeProtocolID generates a protocol identifier for a protocol supported for a specific
-// runtime. This makes it so that one doesn't need additional checks to ensure that a peer supports
-// the given protocol for the given runtime.
-func NewRuntimeProtocolID(runtimeID common.Namespace, protocolID string, version version.Version) protocol.ID {
-	return protocol.ID(fmt.Sprintf("/oasis/%s/%s/%s", protocolID, runtimeID.Hex(), version.MaskNonMajor()))
 }
 
 // contextKeyPeerID is the context key used for storing the peer ID.

--- a/go/worker/client/stateless.go
+++ b/go/worker/client/stateless.go
@@ -53,8 +53,8 @@ func (s *statelessStorage) Initialized() <-chan struct{} {
 
 // NewStatelessStorage creates a stateless storage backend that uses the P2P transport and the
 // storagepub protocol to query storage state.
-func NewStatelessStorage(p2p rpc.P2P, runtimeID common.Namespace) storage.Backend {
+func NewStatelessStorage(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) storage.Backend {
 	return &statelessStorage{
-		rpc: storagePub.NewClient(p2p, runtimeID),
+		rpc: storagePub.NewClient(p2p, chainContext, runtimeID),
 	}
 }

--- a/go/worker/client/worker.go
+++ b/go/worker/client/worker.go
@@ -132,7 +132,7 @@ func (w *Worker) registerRuntime(commonNode *committeeCommon.Node) error {
 
 	// If we are running in stateless client mode, register remote storage.
 	if w.commonWorker.RuntimeRegistry.Mode() == runtimeRegistry.RuntimeModeClientStateless {
-		commonNode.Runtime.RegisterStorage(NewStatelessStorage(commonNode.P2P, id))
+		commonNode.Runtime.RegisterStorage(NewStatelessStorage(commonNode.P2P, w.commonWorker.ChainContext, id))
 	}
 
 	commonNode.AddHooks(node)

--- a/go/worker/common/committee/keymanager.go
+++ b/go/worker/common/committee/keymanager.go
@@ -21,11 +21,12 @@ import (
 type KeyManagerClientWrapper struct {
 	l sync.Mutex
 
-	id        *common.Namespace
-	p2p       p2p.Service
-	consensus consensus.Backend
-	cli       keymanagerP2P.Client
-	logger    *logging.Logger
+	id           *common.Namespace
+	p2p          p2p.Service
+	consensus    consensus.Backend
+	chainContext string
+	cli          keymanagerP2P.Client
+	logger       *logging.Logger
 
 	lastPeerFeedback rpc.PeerFeedback
 }
@@ -66,7 +67,7 @@ func (km *KeyManagerClientWrapper) SetKeyManagerID(id *common.Namespace) {
 	}
 
 	if id != nil {
-		km.cli = keymanagerP2P.NewClient(km.p2p, km.consensus, *id)
+		km.cli = keymanagerP2P.NewClient(km.p2p, km.consensus, km.chainContext, *id)
 	}
 
 	km.lastPeerFeedback = nil
@@ -128,10 +129,11 @@ func (km *KeyManagerClientWrapper) CallEnclave(
 }
 
 // NewKeyManagerClientWrapper creates a new key manager client wrapper.
-func NewKeyManagerClientWrapper(p2p p2p.Service, consensus consensus.Backend, logger *logging.Logger) *KeyManagerClientWrapper {
+func NewKeyManagerClientWrapper(p2p p2p.Service, consensus consensus.Backend, chainContext string, logger *logging.Logger) *KeyManagerClientWrapper {
 	return &KeyManagerClientWrapper{
-		p2p:       p2p,
-		consensus: consensus,
-		logger:    logger,
+		p2p:          p2p,
+		consensus:    consensus,
+		chainContext: chainContext,
+		logger:       logger,
 	}
 }

--- a/go/worker/common/committee/p2p.go
+++ b/go/worker/common/committee/p2p.go
@@ -63,7 +63,7 @@ func (h *txMsgHandler) HandleMessage(ctx context.Context, peerID signature.Publi
 
 // PublishTx publishes a transaction via P2P gossipsub.
 func (n *Node) PublishTx(ctx context.Context, tx []byte) error {
-	n.P2P.PublishTx(ctx, n.Runtime.ID(), tx)
+	n.P2P.Publish(ctx, n.txTopic, tx)
 	return nil
 }
 

--- a/go/worker/common/p2p/txsync/client.go
+++ b/go/worker/common/p2p/txsync/client.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 )
 
@@ -80,8 +81,8 @@ func (c *client) GetTxs(ctx context.Context, request *GetTxsRequest) (*GetTxsRes
 }
 
 // NewClient creates a new transaction sync protocol client.
-func NewClient(p2p rpc.P2P, runtimeID common.Namespace) Client {
-	pid := rpc.NewRuntimeProtocolID(runtimeID, TxSyncProtocolID, TxSyncProtocolVersion)
+func NewClient(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) Client {
+	pid := protocol.NewRuntimeProtocolID(chainContext, runtimeID, TxSyncProtocolID, TxSyncProtocolVersion)
 	mgr := rpc.NewPeerManager(p2p, pid)
 	rc := rpc.NewClient(p2p.Host(), pid)
 	rc.RegisterListener(mgr)

--- a/go/worker/common/p2p/txsync/protocol.go
+++ b/go/worker/common/p2p/txsync/protocol.go
@@ -7,14 +7,14 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/p2p/peermgmt"
-	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 )
 
 // TxSyncProtocolID is a unique protocol identifier for the transaction sync protocol.
 const TxSyncProtocolID = "txsync"
 
 // TxSyncProtocolVersion is the supported version of the transaction sync protocol.
-var TxSyncProtocolVersion = version.Version{Major: 1, Minor: 0, Patch: 0}
+var TxSyncProtocolVersion = version.Version{Major: 2, Minor: 0, Patch: 0}
 
 // Constants related to the GetTxs method.
 const (
@@ -41,7 +41,7 @@ func init() {
 
 			protocols := make([]core.ProtocolID, len(n.Runtimes))
 			for i, rt := range n.Runtimes {
-				protocols[i] = rpc.NewRuntimeProtocolID(rt.ID, TxSyncProtocolID, TxSyncProtocolVersion)
+				protocols[i] = protocol.NewRuntimeProtocolID(chainContext, rt.ID, TxSyncProtocolID, TxSyncProtocolVersion)
 			}
 
 			return protocols

--- a/go/worker/common/p2p/txsync/server.go
+++ b/go/worker/common/p2p/txsync/server.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 	"github.com/oasisprotocol/oasis-core/go/runtime/txpool"
 )
@@ -50,6 +51,6 @@ func (s *service) handleGetTxs(ctx context.Context, request *GetTxsRequest) (*Ge
 }
 
 // NewServer creates a new transaction sync protocol server.
-func NewServer(runtimeID common.Namespace, txPool txpool.TransactionPool) rpc.Server {
-	return rpc.NewServer(rpc.NewRuntimeProtocolID(runtimeID, TxSyncProtocolID, TxSyncProtocolVersion), &service{txPool})
+func NewServer(chainContext string, runtimeID common.Namespace, txPool txpool.TransactionPool) rpc.Server {
+	return rpc.NewServer(protocol.NewRuntimeProtocolID(chainContext, runtimeID, TxSyncProtocolID, TxSyncProtocolVersion), &service{txPool})
 }

--- a/go/worker/common/worker.go
+++ b/go/worker/common/worker.go
@@ -26,6 +26,7 @@ type Worker struct {
 
 	HostNode          control.NodeController
 	DataDir           string
+	ChainContext      string
 	Identity          *identity.Identity
 	Consensus         consensus.Backend
 	Grpc              *grpc.Server
@@ -162,6 +163,7 @@ func (w *Worker) registerRuntime(runtime runtimeRegistry.Runtime) error {
 	)
 
 	node, err := committee.NewNode(
+		w.ChainContext,
 		w.HostNode,
 		runtime,
 		w.Identity,
@@ -187,6 +189,7 @@ func newWorker(
 	cancelCtx context.CancelFunc,
 	hostNode control.NodeController,
 	dataDir string,
+	chainContext string,
 	identity *identity.Identity,
 	consensus consensus.Backend,
 	grpc *grpc.Server,
@@ -211,6 +214,7 @@ func newWorker(
 		cfg:               cfg,
 		HostNode:          hostNode,
 		DataDir:           dataDir,
+		ChainContext:      chainContext,
 		Identity:          identity,
 		Consensus:         consensus,
 		Grpc:              grpc,
@@ -245,6 +249,7 @@ func newWorker(
 func New(
 	hostNode control.NodeController,
 	dataDir string,
+	chainContext string,
 	identity *identity.Identity,
 	consensus consensus.Backend,
 	p2p p2p.Service,
@@ -276,6 +281,7 @@ func New(
 		cancelCtx,
 		hostNode,
 		dataDir,
+		chainContext,
 		identity,
 		consensus,
 		grpc,

--- a/go/worker/keymanager/handler.go
+++ b/go/worker/keymanager/handler.go
@@ -46,7 +46,7 @@ func (env *workerEnvironment) GetNodeIdentity(ctx context.Context) (*identity.Id
 
 // NewRuntimeHostHandler implements workerCommon.RuntimeHostHandlerFactory.
 func (w *Worker) NewRuntimeHostHandler() protocol.Handler {
-	kmCli := committeeCommon.NewKeyManagerClientWrapper(w.commonWorker.P2P, w.commonWorker.Consensus, w.logger)
+	kmCli := committeeCommon.NewKeyManagerClientWrapper(w.commonWorker.P2P, w.commonWorker.Consensus, w.commonWorker.ChainContext, w.logger)
 	runtimeID := w.runtime.ID()
 	kmCli.SetKeyManagerID(&runtimeID)
 

--- a/go/worker/keymanager/init.go
+++ b/go/worker/keymanager/init.go
@@ -37,7 +37,6 @@ var Flags = flag.NewFlagSet("", flag.ContinueOnError)
 
 // New constructs a new key manager worker.
 func New(
-	dataDir string,
 	commonWorker *workerCommon.Worker,
 	ias ias.Endpoint,
 	r *registration.Worker,
@@ -120,7 +119,7 @@ func New(
 	}
 
 	// Register keymanager service.
-	commonWorker.P2P.RegisterProtocolServer(p2p.NewServer(runtimeID, w))
+	commonWorker.P2P.RegisterProtocolServer(p2p.NewServer(commonWorker.ChainContext, runtimeID, w))
 
 	return w, nil
 }

--- a/go/worker/keymanager/p2p/client.go
+++ b/go/worker/keymanager/p2p/client.go
@@ -12,6 +12,7 @@ import (
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	keymanager "github.com/oasisprotocol/oasis-core/go/keymanager/api"
 	p2p "github.com/oasisprotocol/oasis-core/go/p2p/api"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 )
@@ -167,7 +168,7 @@ func (nt *nodeTracker) trackKeymanagerNodes() {
 }
 
 // NewClient creates a new keymanager protocol client.
-func NewClient(p2p p2p.Service, consensus consensus.Backend, keymanagerID common.Namespace) Client {
+func NewClient(p2p p2p.Service, consensus consensus.Backend, chainContext string, keymanagerID common.Namespace) Client {
 	// Create a peer filter as we want the client to only talk to known key manager nodes.
 	nt := &nodeTracker{
 		p2p:          p2p,
@@ -179,7 +180,7 @@ func NewClient(p2p p2p.Service, consensus consensus.Backend, keymanagerID common
 	}
 	go nt.trackKeymanagerNodes()
 
-	pid := rpc.NewRuntimeProtocolID(keymanagerID, KeyManagerProtocolID, KeyManagerProtocolVersion)
+	pid := protocol.NewRuntimeProtocolID(chainContext, keymanagerID, KeyManagerProtocolID, KeyManagerProtocolVersion)
 	mgr := rpc.NewPeerManager(p2p, pid, rpc.WithStickyPeers(true), rpc.WithPeerFilter(nt))
 	rc := rpc.NewClient(p2p.Host(), pid)
 	rc.RegisterListener(mgr)

--- a/go/worker/keymanager/p2p/protocol.go
+++ b/go/worker/keymanager/p2p/protocol.go
@@ -6,14 +6,14 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/p2p/peermgmt"
-	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 )
 
 // KeyManagerProtocolID is a unique protocol identifier for the keymanager protocol.
 const KeyManagerProtocolID = "keymanager"
 
 // KeyManagerProtocolVersion is the supported version of the keymanager protocol.
-var KeyManagerProtocolVersion = version.Version{Major: 1, Minor: 0, Patch: 0}
+var KeyManagerProtocolVersion = version.Version{Major: 2, Minor: 0, Patch: 0}
 
 // Constants related to the GetDiff method.
 const (
@@ -40,7 +40,7 @@ func init() {
 
 			protocols := make([]core.ProtocolID, len(n.Runtimes))
 			for i, rt := range n.Runtimes {
-				protocols[i] = rpc.NewRuntimeProtocolID(rt.ID, KeyManagerProtocolID, KeyManagerProtocolVersion)
+				protocols[i] = protocol.NewRuntimeProtocolID(chainContext, rt.ID, KeyManagerProtocolID, KeyManagerProtocolVersion)
 			}
 
 			return protocols

--- a/go/worker/keymanager/p2p/server.go
+++ b/go/worker/keymanager/p2p/server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 )
 
@@ -47,8 +48,8 @@ func (s *service) handleCallEnclave(ctx context.Context, request *CallEnclaveReq
 }
 
 // NewServer creates a new keymanager protocol server.
-func NewServer(runtimeID common.Namespace, km KeyManager) rpc.Server {
+func NewServer(chainContext string, runtimeID common.Namespace, km KeyManager) rpc.Server {
 	initMetrics()
 
-	return rpc.NewServer(rpc.NewRuntimeProtocolID(runtimeID, KeyManagerProtocolID, KeyManagerProtocolVersion), &service{km})
+	return rpc.NewServer(protocol.NewRuntimeProtocolID(chainContext, runtimeID, KeyManagerProtocolID, KeyManagerProtocolVersion), &service{km})
 }

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -250,12 +250,12 @@ func NewNode(
 	})
 
 	// Register storage sync service.
-	commonNode.P2P.RegisterProtocolServer(storageSync.NewServer(commonNode.Runtime.ID(), localStorage))
-	n.storageSync = storageSync.NewClient(commonNode.P2P, commonNode.Runtime.ID())
+	commonNode.P2P.RegisterProtocolServer(storageSync.NewServer(commonNode.ChainContext, commonNode.Runtime.ID(), localStorage))
+	n.storageSync = storageSync.NewClient(commonNode.P2P, commonNode.ChainContext, commonNode.Runtime.ID())
 
 	// Register storage pub service if configured.
 	if rpcRoleProvider != nil {
-		commonNode.P2P.RegisterProtocolServer(storagePub.NewServer(commonNode.Runtime.ID(), localStorage))
+		commonNode.P2P.RegisterProtocolServer(storagePub.NewServer(commonNode.ChainContext, commonNode.Runtime.ID(), localStorage))
 	}
 
 	return n, nil

--- a/go/worker/storage/p2p/pub/client.go
+++ b/go/worker/storage/p2p/pub/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 )
 
@@ -62,8 +63,8 @@ func (c *client) Iterate(ctx context.Context, request *IterateRequest) (*ProofRe
 }
 
 // NewClient creates a new storage pub protocol client.
-func NewClient(p2p rpc.P2P, runtimeID common.Namespace) Client {
-	pid := rpc.NewRuntimeProtocolID(runtimeID, StoragePubProtocolID, StoragePubProtocolVersion)
+func NewClient(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) Client {
+	pid := protocol.NewRuntimeProtocolID(chainContext, runtimeID, StoragePubProtocolID, StoragePubProtocolVersion)
 	mgr := rpc.NewPeerManager(p2p, pid)
 	rc := rpc.NewClient(p2p.Host(), pid)
 	rc.RegisterListener(mgr)

--- a/go/worker/storage/p2p/pub/protocol.go
+++ b/go/worker/storage/p2p/pub/protocol.go
@@ -6,7 +6,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/p2p/peermgmt"
-	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/syncer"
 )
 
@@ -14,7 +14,7 @@ import (
 const StoragePubProtocolID = "storagepub"
 
 // StoragePubProtocolVersion is the supported version of the storage pub protocol.
-var StoragePubProtocolVersion = version.Version{Major: 1, Minor: 0, Patch: 0}
+var StoragePubProtocolVersion = version.Version{Major: 2, Minor: 0, Patch: 0}
 
 // Constants related to the Get method.
 const (
@@ -52,7 +52,7 @@ func init() {
 
 			protocols := make([]core.ProtocolID, len(n.Runtimes))
 			for i, rt := range n.Runtimes {
-				protocols[i] = rpc.NewRuntimeProtocolID(rt.ID, StoragePubProtocolID, StoragePubProtocolVersion)
+				protocols[i] = protocol.NewRuntimeProtocolID(chainContext, rt.ID, StoragePubProtocolID, StoragePubProtocolVersion)
 			}
 
 			return protocols

--- a/go/worker/storage/p2p/pub/server.go
+++ b/go/worker/storage/p2p/pub/server.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
 )
@@ -42,6 +43,6 @@ func (s *service) HandleRequest(ctx context.Context, method string, body cbor.Ra
 }
 
 // NewServer creates a new storage pub protocol server.
-func NewServer(runtimeID common.Namespace, backend storage.Backend) rpc.Server {
-	return rpc.NewServer(rpc.NewRuntimeProtocolID(runtimeID, StoragePubProtocolID, StoragePubProtocolVersion), &service{backend})
+func NewServer(chainContext string, runtimeID common.Namespace, backend storage.Backend) rpc.Server {
+	return rpc.NewServer(protocol.NewRuntimeProtocolID(chainContext, runtimeID, StoragePubProtocolID, StoragePubProtocolVersion), &service{backend})
 }

--- a/go/worker/storage/p2p/sync/client.go
+++ b/go/worker/storage/p2p/sync/client.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
 )
@@ -124,11 +125,11 @@ func (c *client) GetCheckpointChunk(
 }
 
 // NewClient creates a new storage sync protocol client.
-func NewClient(p2p rpc.P2P, runtimeID common.Namespace) Client {
+func NewClient(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) Client {
 	// Use two separate clients and managers for the same protocol. This is to make sure that peers
 	// are scored differently between the two use cases (syncing diffs vs. syncing checkpoints). We
 	// could consider separating this into two protocols in the future.
-	pid := rpc.NewRuntimeProtocolID(runtimeID, StorageSyncProtocolID, StorageSyncProtocolVersion)
+	pid := protocol.NewRuntimeProtocolID(chainContext, runtimeID, StorageSyncProtocolID, StorageSyncProtocolVersion)
 
 	rcC := rpc.NewClient(p2p.Host(), pid)
 	mgrC := rpc.NewPeerManager(p2p, pid)

--- a/go/worker/storage/p2p/sync/protocol.go
+++ b/go/worker/storage/p2p/sync/protocol.go
@@ -9,7 +9,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/p2p/peermgmt"
-	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
 )
@@ -18,7 +18,7 @@ import (
 const StorageSyncProtocolID = "storagesync"
 
 // StorageSyncProtocolVersion is the supported version of the storage sync protocol.
-var StorageSyncProtocolVersion = version.Version{Major: 1, Minor: 0, Patch: 0}
+var StorageSyncProtocolVersion = version.Version{Major: 2, Minor: 0, Patch: 0}
 
 // Constants related to the GetDiff method.
 const (
@@ -80,7 +80,7 @@ func init() {
 
 			protocols := make([]core.ProtocolID, len(n.Runtimes))
 			for i, rt := range n.Runtimes {
-				protocols[i] = rpc.NewRuntimeProtocolID(rt.ID, StorageSyncProtocolID, StorageSyncProtocolVersion)
+				protocols[i] = protocol.NewRuntimeProtocolID(chainContext, rt.ID, StorageSyncProtocolID, StorageSyncProtocolVersion)
 			}
 
 			return protocols

--- a/go/worker/storage/p2p/sync/server.go
+++ b/go/worker/storage/p2p/sync/server.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
@@ -103,6 +104,6 @@ func (s *service) handleGetCheckpointChunk(ctx context.Context, request *GetChec
 }
 
 // NewServer creates a new storage sync protocol server.
-func NewServer(runtimeID common.Namespace, backend storage.Backend) rpc.Server {
-	return rpc.NewServer(rpc.NewRuntimeProtocolID(runtimeID, StorageSyncProtocolID, StorageSyncProtocolVersion), &service{backend})
+func NewServer(chainContext string, runtimeID common.Namespace, backend storage.Backend) rpc.Server {
+	return rpc.NewServer(protocol.NewRuntimeProtocolID(chainContext, runtimeID, StorageSyncProtocolID, StorageSyncProtocolVersion), &service{backend})
 }


### PR DESCRIPTION
Added chain context to the `Node`, `CommonWorker` and to the `committee.Node`, so they are aware on which chain they are working on. Not sure if we need the second commit, though.

### Test
Before & After
```
"protocols": {
    "/oasis/storagesync/8000000000000000000000000000000000000000000000000000000000000000/1.0.0": 0,
    "/oasis/txsync/8000000000000000000000000000000000000000000000000000000000000000/1.0.0": 0
},
"topics": {
    "340244480b3b5a5483ee97d882b568d48945fc0352d320af6b7153a5a0f9925a/4/8000000000000000000000000000000000000000000000000000000000000000/committee": 0,
    "340244480b3b5a5483ee97d882b568d48945fc0352d320af6b7153a5a0f9925a/4/8000000000000000000000000000000000000000000000000000000000000000/tx": 0
}
```
```
"protocols": {
    "/oasis/6128404930947419c626e0b6c3efcbadf7382e8d54b742adbd989548082ae3c0/keymanager/c000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff/1.0.0": 1,
    "/oasis/6128404930947419c626e0b6c3efcbadf7382e8d54b742adbd989548082ae3c0/storagesync/8000000000000000000000000000000000000000000000000000000000000000/1.0.0": 0,
    "/oasis/6128404930947419c626e0b6c3efcbadf7382e8d54b742adbd989548082ae3c0/txsync/8000000000000000000000000000000000000000000000000000000000000000/1.0.0": 0
},
"topics": {
    "oasis/6128404930947419c626e0b6c3efcbadf7382e8d54b742adbd989548082ae3c0/committee/8000000000000000000000000000000000000000000000000000000000000000/4.0.0": 0,
    "oasis/6128404930947419c626e0b6c3efcbadf7382e8d54b742adbd989548082ae3c0/tx/8000000000000000000000000000000000000000000000000000000000000000/4.0.0": 0
}
```