### PR TITLE
[BACKPORT/22.2.x] runtime: Bump oasis-cbor to 0.5.1

### DIFF
--- a/.changelog/5024.internal.md
+++ b/.changelog/5024.internal.md
@@ -1,0 +1,1 @@
+go: Ignore CVE-2022-44797 until tendermint uses newer btcd

--- a/.changelog/5035.internal.md
+++ b/.changelog/5035.internal.md
@@ -1,0 +1,1 @@
+runtime: Bump oasis-cbor to 0.5.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "oasis-cbor"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae5d03ada3f2f496b1505477e91b32b9bccf1d21a8527a84b73567133c05165"
+checksum = "937dd928dca340f29f67f096760ccec7853e60ebc156175aadfc8eb203eed37d"
 dependencies = [
  "impl-trait-for-tuples",
  "oasis-cbor-derive",
@@ -1835,9 +1835,9 @@ dependencies = [
 
 [[package]]
 name = "oasis-cbor-derive"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe7107f968c18b1f384d4d92d7f5a40b655c6ae1262954b3d552b140cef8391"
+checksum = "b593c6ebad6e6429a8d1dac3509555da30311f0e6fdf93b96475bce895abef6d"
 dependencies = [
  "darling",
  "oasis-cbor-value",
@@ -1849,9 +1849,9 @@ dependencies = [
 
 [[package]]
 name = "oasis-cbor-value"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbeffe8aae62d42a39195627a3f3741c0cb3679c0d3ebb87a724ceb4624374e0"
+checksum = "5fe0d7f5a7c55eba7e8e845046c6c81332f4fa4997f0ed497b9f44db1d7f2050"
 
 [[package]]
 name = "oasis-core-keymanager"

--- a/go/.nancy-ignore
+++ b/go/.nancy-ignore
@@ -1,2 +1,2 @@
 CVE-2022-30591 # quic-go resource exhaustion through 0.27.0, 0.27.1 imported, false positive?
-sonatype-2022-3945 # remove after upgrade to go-libp2p 0.21.0
+CVE-2022-44797 # remove once tendermint uses btcd above or 0.23.2

--- a/keymanager/Cargo.toml
+++ b/keymanager/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 oasis-core-runtime = { path = "../runtime" }
-cbor = { version = "0.5.0", package = "oasis-cbor" }
+cbor = { version = "0.5.1", package = "oasis-cbor" }
 
 # Third party.
 anyhow = "1.0"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Oasis Protocol Foundation <info@oasisprotocol.org>"]
 edition = "2018"
 
 [dependencies]
-cbor = { version = "0.5.0", package = "oasis-cbor" }
+cbor = { version = "0.5.1", package = "oasis-cbor" }
 
 # Third party.
 log = "0.4"

--- a/tests/runtimes/simple-keyvalue/Cargo.toml
+++ b/tests/runtimes/simple-keyvalue/Cargo.toml
@@ -20,7 +20,7 @@ stack-size = 2097152
 threads = 6
 
 [dependencies]
-cbor = { version = "0.5.0", package = "oasis-cbor" }
+cbor = { version = "0.5.1", package = "oasis-cbor" }
 oasis-core-runtime = { path = "../../../runtime" }
 oasis-core-keymanager = { path = "../../../keymanager" }
 simple-keymanager = { path = "../simple-keymanager" }


### PR DESCRIPTION
Backport of #5035 