### PR TITLE
go/scheduler: include entity IDs in consensus validators state

### DIFF
--- a/.changelog/5050.breaking.1.md
+++ b/.changelog/5050.breaking.1.md
@@ -1,0 +1,4 @@
+go/scheduler: include entity IDs in consensus validators state
+
+Validator lists in scheduler consensus state now include entity and node
+identifiers.

--- a/.changelog/5050.breaking.2.md
+++ b/.changelog/5050.breaking.2.md
@@ -1,0 +1,1 @@
+`EntityID` is added to items in scheduler `GetValidators` API response

--- a/go/consensus/tendermint/apps/scheduler/genesis.go
+++ b/go/consensus/tendermint/apps/scheduler/genesis.go
@@ -59,7 +59,7 @@ func (app *schedulerApplication) InitChain(ctx *abciAPI.Context, req types.Reque
 
 	// Assemble the list of the tendermint genesis validators, and do some
 	// sanity checking.
-	currentValidators := make(map[signature.PublicKey]int64)
+	currentValidators := make(map[signature.PublicKey]*scheduler.Validator)
 	for _, v := range req.Validators {
 		tmPk := v.GetPubKey()
 		pk := tmPk.GetEd25519()
@@ -144,7 +144,11 @@ func (app *schedulerApplication) InitChain(ctx *abciAPI.Context, req types.Reque
 		ctx.Logger().Debug("adding validator to current validator set",
 			"id", id,
 		)
-		currentValidators[n.Consensus.ID] = v.Power
+		currentValidators[n.Consensus.ID] = &scheduler.Validator{
+			ID:          n.ID,
+			EntityID:    n.EntityID,
+			VotingPower: v.Power,
+		}
 	}
 
 	// TODO/security: Enforce genesis validator staking thresholds.

--- a/go/consensus/tendermint/apps/scheduler/query.go
+++ b/go/consensus/tendermint/apps/scheduler/query.go
@@ -51,24 +51,8 @@ func (sq *schedulerQuerier) Validators(ctx context.Context) ([]*scheduler.Valida
 	}
 
 	ret := make([]*scheduler.Validator, 0, len(vals))
-	for v, power := range vals {
-		// The validator list uses consensus addresses, so convert them
-		// to node identifiers.
-		//
-		// This is probably better than switching the scheduler to use
-		// node identifiers for validators, because user queries are
-		// likely more infrequent than all the business of actually
-		// scheduling...
-		node, err := sq.regState.NodeBySubKey(ctx, v)
-		if err != nil {
-			// Should NEVER happen.
-			return nil, err
-		}
-
-		ret = append(ret, &scheduler.Validator{
-			ID:          node.ID,
-			VotingPower: power,
-		})
+	for _, v := range vals {
+		ret = append(ret, v)
 	}
 
 	return ret, nil

--- a/go/consensus/tendermint/apps/scheduler/scheduler_test.go
+++ b/go/consensus/tendermint/apps/scheduler/scheduler_test.go
@@ -24,16 +24,24 @@ import (
 
 func TestDiffValidators(t *testing.T) {
 	logger := logging.GetLogger("TestDiffValidators")
-	powerOne := map[signature.PublicKey]int64{
-		{}: 1,
+	powerOne := map[signature.PublicKey]*scheduler.Validator{
+		{}: {
+			ID:          signature.PublicKey{},
+			EntityID:    signature.PublicKey{},
+			VotingPower: 1,
+		},
 	}
-	powerTwo := map[signature.PublicKey]int64{
-		{}: 2,
+	powerTwo := map[signature.PublicKey]*scheduler.Validator{
+		{}: {
+			ID:          signature.PublicKey{},
+			EntityID:    signature.PublicKey{},
+			VotingPower: 2,
+		},
 	}
 	for _, tt := range []struct {
 		msg     string
-		current map[signature.PublicKey]int64
-		pending map[signature.PublicKey]int64
+		current map[signature.PublicKey]*scheduler.Validator
+		pending map[signature.PublicKey]*scheduler.Validator
 		result  []types.ValidatorUpdate
 	}{
 		{

--- a/go/consensus/tendermint/apps/scheduler/state/state.go
+++ b/go/consensus/tendermint/apps/scheduler/state/state.go
@@ -21,12 +21,12 @@ var (
 	// validatorsCurrentKeyFmt is the key format used for the current set of
 	// validators.
 	//
-	// Value is CBOR-serialized map of validator public keys to voting power.
+	// Value is CBOR-serialized map of validator node consensus public keys to validator entries.
 	validatorsCurrentKeyFmt = keyformat.New(0x61)
 	// validatorsPendingKeyFmt is the key format used for the pending set of
 	// validators.
 	//
-	// Value is CBOR-serialized map of validator public keys to voting power.
+	// Value is CBOR-serialized map of validator node consensus public keys to validator entries.
 	validatorsPendingKeyFmt = keyformat.New(0x62)
 	// parametersKeyFmt is the key format used for consensus parameters.
 	//
@@ -113,7 +113,7 @@ func (s *ImmutableState) KindsCommittees(ctx context.Context, kinds []api.Commit
 }
 
 // CurrentValidators returns a list of current validators.
-func (s *ImmutableState) CurrentValidators(ctx context.Context) (map[signature.PublicKey]int64, error) {
+func (s *ImmutableState) CurrentValidators(ctx context.Context) (map[signature.PublicKey]*api.Validator, error) {
 	raw, err := s.is.Get(ctx, validatorsCurrentKeyFmt.Encode())
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
@@ -122,7 +122,7 @@ func (s *ImmutableState) CurrentValidators(ctx context.Context) (map[signature.P
 		return nil, nil
 	}
 
-	var validators map[signature.PublicKey]int64
+	var validators map[signature.PublicKey]*api.Validator
 	if err = cbor.Unmarshal(raw, &validators); err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -130,7 +130,7 @@ func (s *ImmutableState) CurrentValidators(ctx context.Context) (map[signature.P
 }
 
 // PendingValidators returns a list of pending validators.
-func (s *ImmutableState) PendingValidators(ctx context.Context) (map[signature.PublicKey]int64, error) {
+func (s *ImmutableState) PendingValidators(ctx context.Context) (map[signature.PublicKey]*api.Validator, error) {
 	raw, err := s.is.Get(ctx, validatorsPendingKeyFmt.Encode())
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
@@ -139,7 +139,7 @@ func (s *ImmutableState) PendingValidators(ctx context.Context) (map[signature.P
 		return nil, nil
 	}
 
-	var validators map[signature.PublicKey]int64
+	var validators map[signature.PublicKey]*api.Validator
 	if err = cbor.Unmarshal(raw, &validators); err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -192,13 +192,13 @@ func (s *MutableState) DropCommittee(ctx context.Context, kind api.CommitteeKind
 }
 
 // PutCurrentValidators stores the current set of validators.
-func (s *MutableState) PutCurrentValidators(ctx context.Context, validators map[signature.PublicKey]int64) error {
+func (s *MutableState) PutCurrentValidators(ctx context.Context, validators map[signature.PublicKey]*api.Validator) error {
 	err := s.ms.Insert(ctx, validatorsCurrentKeyFmt.Encode(), cbor.Marshal(validators))
 	return abciAPI.UnavailableStateError(err)
 }
 
 // PutPendingValidators stores the pending set of validators.
-func (s *MutableState) PutPendingValidators(ctx context.Context, validators map[signature.PublicKey]int64) error {
+func (s *MutableState) PutPendingValidators(ctx context.Context, validators map[signature.PublicKey]*api.Validator) error {
 	if validators == nil {
 		err := s.ms.Remove(ctx, validatorsPendingKeyFmt.Encode())
 		return abciAPI.UnavailableStateError(err)

--- a/go/scheduler/api/api.go
+++ b/go/scheduler/api/api.go
@@ -208,6 +208,9 @@ type Validator struct {
 	// ID is the validator Oasis node identifier.
 	ID signature.PublicKey `json:"id"`
 
+	// EntityID is the validator entity identifier.
+	EntityID signature.PublicKey `json:"entity_id"`
+
 	// VotingPower is the validator's consensus voting power.
 	VotingPower int64 `json:"voting_power"`
 }


### PR DESCRIPTION
#5034 will need an efficient way to obtain a list of active validator entities