### PR TITLE
go: always return `ErrInvalidArgument` on tx deserialization failure

### DIFF
--- a/.changelog/5055.breaking.md
+++ b/.changelog/5055.breaking.md
@@ -1,0 +1,4 @@
+go/consensus: Always return ErrInvalidArgument on tx deserialization failures
+
+Before, some modules were returning non-specific errors on tx deserialization
+failures, which resulted in them being assigned to module "unknown", code 1.

--- a/go/beacon/api/api.go
+++ b/go/beacon/api/api.go
@@ -25,9 +25,14 @@ const (
 	BackendVRF = "vrf"
 )
 
-// ErrBeaconNotAvailable is the error returned when a beacon is not
-// available for the requested height for any reason.
-var ErrBeaconNotAvailable = errors.New(ModuleName, 1, "beacon: random beacon not available")
+var (
+	// ErrInvalidArgument is the error returned on malformed argument(s).
+	ErrInvalidArgument = errors.New(ModuleName, 1, "beacon: invalid argument")
+
+	// ErrBeaconNotAvailable is the error returned when a beacon is not
+	// available for the requested height for any reason.
+	ErrBeaconNotAvailable = errors.New(ModuleName, 2, "beacon: random beacon not available")
+)
 
 // EpochTime is the number of intervals (epochs) since a fixed instant
 // in time/block height (epoch date/height).

--- a/go/consensus/tendermint/apps/beacon/backend_vrf.go
+++ b/go/consensus/tendermint/apps/beacon/backend_vrf.go
@@ -297,7 +297,7 @@ func (impl *backendVRF) doProveTx(
 	// Deserialize the tx.
 	var proveTx beacon.VRFProve
 	if err = cbor.Unmarshal(tx.Body, &proveTx); err != nil {
-		return fmt.Errorf("beacon: failed to deserialize prove tx: %w", err)
+		return beacon.ErrInvalidArgument
 	}
 	if proveTx.Epoch != vrfState.Epoch {
 		return fmt.Errorf("beacon: proof for invalid epoch: %d", proveTx.Epoch)

--- a/go/consensus/tendermint/apps/keymanager/keymanager.go
+++ b/go/consensus/tendermint/apps/keymanager/keymanager.go
@@ -73,7 +73,7 @@ func (app *keymanagerApplication) ExecuteTx(ctx *tmapi.Context, tx *transaction.
 	case api.MethodUpdatePolicy:
 		var sigPol api.SignedPolicySGX
 		if err := cbor.Unmarshal(tx.Body, &sigPol); err != nil {
-			return err
+			return api.ErrInvalidArgument
 		}
 		return app.updatePolicy(ctx, state, &sigPol)
 	default:

--- a/go/consensus/tendermint/apps/registry/registry.go
+++ b/go/consensus/tendermint/apps/registry/registry.go
@@ -103,7 +103,7 @@ func (app *registryApplication) ExecuteTx(ctx *api.Context, tx *transaction.Tran
 	case registry.MethodRegisterEntity:
 		var sigEnt entity.SignedEntity
 		if err := cbor.Unmarshal(tx.Body, &sigEnt); err != nil {
-			return err
+			return registry.ErrInvalidArgument
 		}
 		return app.registerEntity(ctx, state, &sigEnt)
 
@@ -113,7 +113,7 @@ func (app *registryApplication) ExecuteTx(ctx *api.Context, tx *transaction.Tran
 	case registry.MethodRegisterNode:
 		var sigNode node.MultiSignedNode
 		if err := cbor.Unmarshal(tx.Body, &sigNode); err != nil {
-			return err
+			return registry.ErrInvalidArgument
 		}
 		ctx.SetPriority(AppPriority + 10000)
 		return app.registerNode(ctx, state, &sigNode)
@@ -121,14 +121,14 @@ func (app *registryApplication) ExecuteTx(ctx *api.Context, tx *transaction.Tran
 	case registry.MethodUnfreezeNode:
 		var unfreeze registry.UnfreezeNode
 		if err := cbor.Unmarshal(tx.Body, &unfreeze); err != nil {
-			return err
+			return registry.ErrInvalidArgument
 		}
 		return app.unfreezeNode(ctx, state, &unfreeze)
 
 	case registry.MethodRegisterRuntime:
 		var rt registry.Runtime
 		if err := cbor.Unmarshal(tx.Body, &rt); err != nil {
-			return err
+			return registry.ErrInvalidArgument
 		}
 		if _, err := app.registerRuntime(ctx, state, &rt); err != nil {
 			return err

--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -369,28 +369,28 @@ func (app *rootHashApplication) ExecuteTx(ctx *tmapi.Context, tx *transaction.Tr
 	case roothash.MethodExecutorCommit:
 		var xc roothash.ExecutorCommit
 		if err := cbor.Unmarshal(tx.Body, &xc); err != nil {
-			return err
+			return roothash.ErrInvalidArgument
 		}
 
 		return app.executorCommit(ctx, state, &xc)
 	case roothash.MethodExecutorProposerTimeout:
 		var xc roothash.ExecutorProposerTimeoutRequest
 		if err := cbor.Unmarshal(tx.Body, &xc); err != nil {
-			return err
+			return roothash.ErrInvalidArgument
 		}
 
 		return app.executorProposerTimeout(ctx, state, &xc)
 	case roothash.MethodEvidence:
 		var ev roothash.Evidence
 		if err := cbor.Unmarshal(tx.Body, &ev); err != nil {
-			return err
+			return roothash.ErrInvalidArgument
 		}
 
 		return app.submitEvidence(ctx, state, &ev)
 	case roothash.MethodSubmitMsg:
 		var msg roothash.SubmitMsg
 		if err := cbor.Unmarshal(tx.Body, &msg); err != nil {
-			return err
+			return roothash.ErrInvalidArgument
 		}
 
 		return app.submitMsg(ctx, state, &msg)

--- a/go/consensus/tendermint/apps/staking/staking.go
+++ b/go/consensus/tendermint/apps/staking/staking.go
@@ -156,7 +156,7 @@ func (app *stakingApplication) ExecuteTx(ctx *api.Context, tx *transaction.Trans
 	case staking.MethodTransfer:
 		var xfer staking.Transfer
 		if err := cbor.Unmarshal(tx.Body, &xfer); err != nil {
-			return err
+			return staking.ErrInvalidArgument
 		}
 
 		_, err := app.transfer(ctx, state, &xfer)
@@ -164,14 +164,14 @@ func (app *stakingApplication) ExecuteTx(ctx *api.Context, tx *transaction.Trans
 	case staking.MethodBurn:
 		var burn staking.Burn
 		if err := cbor.Unmarshal(tx.Body, &burn); err != nil {
-			return err
+			return staking.ErrInvalidArgument
 		}
 
 		return app.burn(ctx, state, &burn)
 	case staking.MethodAddEscrow:
 		var escrow staking.Escrow
 		if err := cbor.Unmarshal(tx.Body, &escrow); err != nil {
-			return err
+			return staking.ErrInvalidArgument
 		}
 
 		_, err := app.addEscrow(ctx, state, &escrow)
@@ -179,7 +179,7 @@ func (app *stakingApplication) ExecuteTx(ctx *api.Context, tx *transaction.Trans
 	case staking.MethodReclaimEscrow:
 		var reclaim staking.ReclaimEscrow
 		if err := cbor.Unmarshal(tx.Body, &reclaim); err != nil {
-			return err
+			return staking.ErrInvalidArgument
 		}
 
 		_, err := app.reclaimEscrow(ctx, state, &reclaim)
@@ -187,21 +187,21 @@ func (app *stakingApplication) ExecuteTx(ctx *api.Context, tx *transaction.Trans
 	case staking.MethodAmendCommissionSchedule:
 		var amend staking.AmendCommissionSchedule
 		if err := cbor.Unmarshal(tx.Body, &amend); err != nil {
-			return err
+			return staking.ErrInvalidArgument
 		}
 
 		return app.amendCommissionSchedule(ctx, state, &amend)
 	case staking.MethodAllow:
 		var allow staking.Allow
 		if err := cbor.Unmarshal(tx.Body, &allow); err != nil {
-			return err
+			return staking.ErrInvalidArgument
 		}
 
 		return app.allow(ctx, state, &allow)
 	case staking.MethodWithdraw:
 		var withdraw staking.Withdraw
 		if err := cbor.Unmarshal(tx.Body, &withdraw); err != nil {
-			return err
+			return staking.ErrInvalidArgument
 		}
 
 		_, err := app.withdraw(ctx, state, &withdraw)

--- a/go/keymanager/api/api.go
+++ b/go/keymanager/api/api.go
@@ -27,9 +27,12 @@ const (
 )
 
 var (
+	// ErrInvalidArgument is the error returned on malformed arguments.
+	ErrInvalidArgument = errors.New(ModuleName, 1, "keymanager: invalid argument")
+
 	// ErrNoSuchStatus is the error returned when a key manager status does not
 	// exist.
-	ErrNoSuchStatus = errors.New(ModuleName, 1, "keymanager: no such status")
+	ErrNoSuchStatus = errors.New(ModuleName, 2, "keymanager: no such status")
 
 	// MethodUpdatePolicy is the method name for policy updates.
 	MethodUpdatePolicy = transaction.NewMethodName(ModuleName, "UpdatePolicy", SignedPolicySGX{})


### PR DESCRIPTION
Currently, some modules are returning non-specific errros on tx deserialization failures which results in them being assigned to module "unknown", code 1. It would be more correct to always return the corresponding ErrInvalidArgument error for all deserialization failures.