### PR TITLE
meta: Mark #5016 as breaking

### DIFF
--- a/.changelog/5016.breaking.md
+++ b/.changelog/5016.breaking.md
@@ -1,0 +1,4 @@
+staking: specify slashed debonding amount in TakeEscrowEvent
+
+The event contains a new field; clients that do not need it
+can safely ignore it.


### PR DESCRIPTION
After discussing with @kostko on Slack, marking #5016 as breaking because some clients (notably, our go client) error on receiving an event with a new field, as pointed out in the description of #5016.