### PR TITLE
runtime/consensus/tendermint/verifier: Correctly compare headers

### DIFF
--- a/.changelog/5068.bugfix.md
+++ b/.changelog/5068.bugfix.md
@@ -1,0 +1,11 @@
+runtime/consensus/tendermint/verifier: Correctly compare headers
+
+Since the store may have an earlier (non-canonical, but valid) version
+of the block available, we need to only compare the actual header and
+not the commits/signatures.
+
+This is because it can happen that during the immediate sync the light
+block does not yet contain all of the commits (but only just enough to
+be valid, e.g. 2/3+) and this gets stored in the light block store.
+Later on (e.g. during a query) the presented light block may have the
+full set of commits.

--- a/go/.nancy-ignore
+++ b/go/.nancy-ignore
@@ -1,2 +1,3 @@
 CVE-2022-30591 # quic-go resource exhaustion through 0.27.0, 0.27.1 imported, false positive?
 CVE-2022-44797 # remove once tendermint uses btcd above or 0.23.2
+CVE-2022-39389 # can be ignored as we only use a few crypto libraries from btcd

--- a/runtime/src/consensus/tendermint/verifier/mod.rs
+++ b/runtime/src/consensus/tendermint/verifier/mod.rs
@@ -212,7 +212,7 @@ impl Verifier {
         let verified_block = self.verify_to_target(height, cache, instance)?;
 
         // Validate passed consensus block.
-        if untrusted_header != &verified_block.signed_header {
+        if untrusted_header.header() != verified_block.signed_header.header() {
             return Err(Error::VerificationFailed(anyhow!("header mismatch")));
         }
 
@@ -490,7 +490,7 @@ impl Verifier {
         let verified_block = self.verify_to_target(height, cache, instance)?;
 
         // Validate passed consensus block.
-        if untrusted_header != &verified_block.signed_header {
+        if untrusted_header.header() != verified_block.signed_header.header() {
             return Err(Error::VerificationFailed(anyhow!("header mismatch")));
         }
 


### PR DESCRIPTION
Since the store may have an earlier (non-canonical, but valid) version of the block available, we need to only compare the actual header and not the commits/signatures.

This is because it can happen that during the immediate sync the light block does not yet contain all of the commits (but only just enough to be valid, e.g. 2/3+) and this gets stored in the light block store. Later on (e.g. during a query) the presented light block may have the full set of commits.