### PR TITLE
[BACKPORT/22.2.x] docs: Fix Tendermint URLs

### DIFF
--- a/.changelog/5032.trivial.md
+++ b/.changelog/5032.trivial.md
@@ -1,0 +1,1 @@
+docs: Fix broken link to tendermint transaction format

--- a/docs/consensus/README.md
+++ b/docs/consensus/README.md
@@ -172,6 +172,6 @@ application multiplexer mentioned above.
 
 <!-- markdownlint-disable line-length -->
 [serialized signed Oasis Core transaction]: transactions.md
-[Tendermint transaction]: https://docs.tendermint.com/v0.35/tendermint-core/using-tendermint.html#transactions
+[Tendermint transaction]: https://docs.tendermint.com/main/tendermint-core/using-tendermint.html#transactions
 [mempool]: https://github.com/tendermint/tendermint/blob/master/spec/abci/abci.md#mempool-connection
 <!-- markdownlint-enable line-length -->

--- a/docs/oasis-node/metrics.md
+++ b/docs/oasis-node/metrics.md
@@ -125,4 +125,4 @@ Tendermint metrics are also reported. Consult
 [tendermint-core documentation][2] for a list of reported by Tendermint.
 
 [1]: ../consensus/README.md#tendermint
-[2]: https://docs.tendermint.com/master/nodes/metrics.html
+[2]: https://docs.tendermint.com/main/tendermint-core/metrics.html

--- a/docs/oasis-node/metrics.md.tpl
+++ b/docs/oasis-node/metrics.md.tpl
@@ -49,4 +49,4 @@ Tendermint metrics are also reported. Consult
 [tendermint-core documentation][2] for a list of reported by Tendermint.
 
 [1]: ../consensus/README.md#tendermint
-[2]: https://docs.tendermint.com/master/nodes/metrics.html
+[2]: https://docs.tendermint.com/main/tendermint-core/metrics.html


### PR DESCRIPTION
Backport of #5032 and #5018.