### PR TITLE
runtime/src/enclave_rpc: Support insecure key manager RPC requests

### DIFF
--- a/.changelog/5075.internal.md
+++ b/.changelog/5075.internal.md
@@ -1,0 +1,13 @@
+runtime/src/enclave_rpc: Add support for insecure key manager RPC requests
+
+The key manager uses encrypted sessions to authenticate clients and protect
+sensitive data. The number of sessions is limited, thus susceptible to DoS
+attacks. A malicious client can establish multiple sessions in parallel,
+preventing other clients from making requests. Furthermore, since each
+session is encrypted, the exchanged messages cannot be read or modified.
+For public key requests this is not ideal as one would want to cache the
+responses locally and serve them to other clients to unburden the manager.
+Large quotes also cannot be removed from the exchanged messages if we are
+sure that the recipient can obtain them through some other means. Supporting
+insecure key manager RPC requests solves some of the before mentioned problems
+and leaves space for further optimizations.

--- a/go/runtime/enclaverpc/api/api.go
+++ b/go/runtime/enclaverpc/api/api.go
@@ -1,6 +1,16 @@
 // Package api defines the EnclaveRPC interface.
 package api
 
+// Kind is the RPC call kind.
+type Kind uint8
+
+// Supported RPC call kinds.
+const (
+	KindNoiseSession  Kind = 0
+	KindInsecureQuery Kind = 1
+	KindLocalQuery    Kind = 2
+)
+
 // Frame is an EnclaveRPC frame.
 //
 // It is the Go analog of the Rust RPC frame defined in runtime/src/enclave_rpc/types.rs.

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -238,6 +238,8 @@ type RuntimeCapabilityTEERakQuoteResponse struct {
 type RuntimeRPCCallRequest struct {
 	// Request.
 	Request []byte `json:"request"`
+	// Kind is the type of RPC call.
+	Kind enclaverpc.Kind `json:"kind,omitempty"`
 }
 
 // RuntimeRPCCallResponse is a worker RPC call response message body.
@@ -442,8 +444,9 @@ type RuntimeConsensusSyncRequest struct {
 
 // HostRPCCallRequest is a host RPC call request message body.
 type HostRPCCallRequest struct {
-	Endpoint string `json:"endpoint"`
-	Request  []byte `json:"request"`
+	Endpoint string          `json:"endpoint"`
+	Request  []byte          `json:"request"`
+	Kind     enclaverpc.Kind `json:"kind,omitempty"`
 
 	// PeerFeedback contains optional peer feedback for the last RPC call under the given endpoint.
 	//

--- a/go/runtime/keymanager/api/api.go
+++ b/go/runtime/keymanager/api/api.go
@@ -16,5 +16,5 @@ type Client interface {
 	//
 	// The provided peer feedback is optional feedback on the peer that handled the last EnclaveRPC
 	// request (if any) which may be used to inform the routing decision.
-	CallEnclave(ctx context.Context, data []byte, pf *enclaverpc.PeerFeedback) ([]byte, error)
+	CallEnclave(ctx context.Context, data []byte, kind enclaverpc.Kind, pf *enclaverpc.PeerFeedback) ([]byte, error)
 }

--- a/go/runtime/registry/host.go
+++ b/go/runtime/registry/host.go
@@ -180,7 +180,7 @@ func (h *runtimeHostHandler) handleHostRPCCall(
 		if err != nil {
 			return nil, err
 		}
-		res, err := kmCli.CallEnclave(ctx, rq.Request, rq.PeerFeedback)
+		res, err := kmCli.CallEnclave(ctx, rq.Request, rq.Kind, rq.PeerFeedback)
 		if err != nil {
 			return nil, err
 		}

--- a/go/worker/common/committee/keymanager.go
+++ b/go/worker/common/committee/keymanager.go
@@ -77,6 +77,7 @@ func (km *KeyManagerClientWrapper) SetKeyManagerID(id *common.Namespace) {
 func (km *KeyManagerClientWrapper) CallEnclave(
 	ctx context.Context,
 	data []byte,
+	kind enclaverpc.Kind,
 	pf *enclaverpc.PeerFeedback,
 ) ([]byte, error) {
 	km.l.Lock()
@@ -113,6 +114,7 @@ func (km *KeyManagerClientWrapper) CallEnclave(
 
 	rsp, nextPf, err := cli.CallEnclave(ctx, &keymanagerP2P.CallEnclaveRequest{
 		Data: data,
+		Kind: kind,
 	})
 	if err != nil {
 		return nil, err

--- a/go/worker/keymanager/p2p/protocol.go
+++ b/go/worker/keymanager/p2p/protocol.go
@@ -7,6 +7,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/p2p/peermgmt"
 	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
+	enclaverpc "github.com/oasisprotocol/oasis-core/go/runtime/enclaverpc/api"
 )
 
 // KeyManagerProtocolID is a unique protocol identifier for the keymanager protocol.
@@ -23,7 +24,8 @@ const (
 
 // CallEnclaveRequest is a CallEnclave request.
 type CallEnclaveRequest struct {
-	Data []byte `json:"data"`
+	Data []byte          `json:"data"`
+	Kind enclaverpc.Kind `json:"kind,omitempty"`
 }
 
 // CallEnclaveResponse is a response to a CallEnclave request.

--- a/go/worker/keymanager/p2p/server.go
+++ b/go/worker/keymanager/p2p/server.go
@@ -9,12 +9,13 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+	enclaverpc "github.com/oasisprotocol/oasis-core/go/runtime/enclaverpc/api"
 )
 
 // KeyManager is the keymanager service interface.
 type KeyManager interface {
 	// CallEnclave calls the keymanager enclave with the provided data.
-	CallEnclave(ctx context.Context, data []byte) ([]byte, error)
+	CallEnclave(ctx context.Context, data []byte, kind enclaverpc.Kind) ([]byte, error)
 }
 
 type service struct {
@@ -38,7 +39,7 @@ func (s *service) HandleRequest(ctx context.Context, method string, body cbor.Ra
 }
 
 func (s *service) handleCallEnclave(ctx context.Context, request *CallEnclaveRequest) (*CallEnclaveResponse, error) {
-	data, err := s.km.CallEnclave(ctx, request.Data)
+	data, err := s.km.CallEnclave(ctx, request.Data, request.Kind)
 	if err != nil {
 		return nil, err
 	}

--- a/keymanager/src/client/remote.rs
+++ b/keymanager/src/client/remote.rs
@@ -202,7 +202,7 @@ impl KeyManagerClient for RemoteClient {
 
             let keys: KeyPair = inner
                 .rpc_client
-                .call(
+                .secure_call(
                     ctx,
                     METHOD_GET_OR_CREATE_KEYS,
                     LongTermKeyRequest::new(Some(height), inner.runtime_id, key_pair_id),
@@ -238,7 +238,7 @@ impl KeyManagerClient for RemoteClient {
 
             let key: SignedPublicKey = inner
                 .rpc_client
-                .call(
+                .secure_call(
                     ctx,
                     METHOD_GET_PUBLIC_KEY,
                     LongTermKeyRequest::new(Some(height), inner.runtime_id, key_pair_id),
@@ -275,7 +275,7 @@ impl KeyManagerClient for RemoteClient {
 
             let keys: KeyPair = inner
                 .rpc_client
-                .call(
+                .secure_call(
                     ctx,
                     METHOD_GET_OR_CREATE_EPHEMERAL_KEYS,
                     EphemeralKeyRequest::new(Some(height), inner.runtime_id, key_pair_id, epoch),
@@ -312,7 +312,7 @@ impl KeyManagerClient for RemoteClient {
 
             let key: SignedPublicKey = inner
                 .rpc_client
-                .call(
+                .secure_call(
                     ctx,
                     METHOD_GET_PUBLIC_EPHEMERAL_KEY,
                     EphemeralKeyRequest::new(Some(height), inner.runtime_id, key_pair_id, epoch),
@@ -341,7 +341,7 @@ impl KeyManagerClient for RemoteClient {
 
             let rsp: ReplicateResponse = inner
                 .rpc_client
-                .call(
+                .secure_call(
                     ctx,
                     METHOD_REPLICATE_MASTER_SECRET,
                     ReplicateRequest::new(Some(height)),

--- a/keymanager/src/runtime/init.rs
+++ b/keymanager/src/runtime/init.rs
@@ -4,6 +4,7 @@ use oasis_core_runtime::{
     dispatcher::{Initializer, PostInitState, PreInitState},
     enclave_rpc::{
         dispatcher::{Method as RpcMethod, MethodDescriptor as RpcMethodDescriptor},
+        types::Kind as RpcKind,
         Context as RpcContext,
     },
 };
@@ -34,62 +35,50 @@ pub fn new_keymanager(signers: TrustedPolicySigners) -> Box<dyn Initializer> {
         set_trusted_policy_signers(signers.clone());
 
         // Register RPC methods exposed via EnclaveRPC to remote clients.
-        state.rpc_dispatcher.add_method(
-            RpcMethod::new(
-                RpcMethodDescriptor {
-                    name: METHOD_GET_OR_CREATE_KEYS.to_string(),
-                },
-                methods::get_or_create_keys,
-            ),
-            false,
-        );
-        state.rpc_dispatcher.add_method(
-            RpcMethod::new(
-                RpcMethodDescriptor {
-                    name: METHOD_GET_PUBLIC_KEY.to_string(),
-                },
-                methods::get_public_key,
-            ),
-            false,
-        );
-        state.rpc_dispatcher.add_method(
-            RpcMethod::new(
-                RpcMethodDescriptor {
-                    name: METHOD_GET_OR_CREATE_EPHEMERAL_KEYS.to_string(),
-                },
-                methods::get_or_create_ephemeral_keys,
-            ),
-            false,
-        );
-        state.rpc_dispatcher.add_method(
-            RpcMethod::new(
-                RpcMethodDescriptor {
-                    name: METHOD_GET_PUBLIC_EPHEMERAL_KEY.to_string(),
-                },
-                methods::get_public_ephemeral_key,
-            ),
-            false,
-        );
-        state.rpc_dispatcher.add_method(
-            RpcMethod::new(
-                RpcMethodDescriptor {
-                    name: METHOD_REPLICATE_MASTER_SECRET.to_string(),
-                },
-                methods::replicate_master_secret,
-            ),
-            false,
-        );
+        state.rpc_dispatcher.add_method(RpcMethod::new(
+            RpcMethodDescriptor {
+                name: METHOD_GET_OR_CREATE_KEYS.to_string(),
+                kind: RpcKind::NoiseSession,
+            },
+            methods::get_or_create_keys,
+        ));
+        state.rpc_dispatcher.add_method(RpcMethod::new(
+            RpcMethodDescriptor {
+                name: METHOD_GET_PUBLIC_KEY.to_string(),
+                kind: RpcKind::InsecureQuery,
+            },
+            methods::get_public_key,
+        ));
+        state.rpc_dispatcher.add_method(RpcMethod::new(
+            RpcMethodDescriptor {
+                name: METHOD_GET_OR_CREATE_EPHEMERAL_KEYS.to_string(),
+                kind: RpcKind::NoiseSession,
+            },
+            methods::get_or_create_ephemeral_keys,
+        ));
+        state.rpc_dispatcher.add_method(RpcMethod::new(
+            RpcMethodDescriptor {
+                name: METHOD_GET_PUBLIC_EPHEMERAL_KEY.to_string(),
+                kind: RpcKind::InsecureQuery,
+            },
+            methods::get_public_ephemeral_key,
+        ));
+        state.rpc_dispatcher.add_method(RpcMethod::new(
+            RpcMethodDescriptor {
+                name: METHOD_REPLICATE_MASTER_SECRET.to_string(),
+                kind: RpcKind::NoiseSession,
+            },
+            methods::replicate_master_secret,
+        ));
 
         // Register local methods, for use by the node key manager component.
-        state.rpc_dispatcher.add_method(
-            RpcMethod::new(
-                RpcMethodDescriptor {
-                    name: LOCAL_METHOD_INIT.to_string(),
-                },
-                init_kdf,
-            ),
-            true,
-        );
+        state.rpc_dispatcher.add_method(RpcMethod::new(
+            RpcMethodDescriptor {
+                name: LOCAL_METHOD_INIT.to_string(),
+                kind: RpcKind::LocalQuery,
+            },
+            init_kdf,
+        ));
 
         let runtime_id = state.protocol.get_runtime_id();
         let protocol = state.protocol.clone(); // Shut up the borrow checker.

--- a/runtime/src/enclave_rpc/types.rs
+++ b/runtime/src/enclave_rpc/types.rs
@@ -19,6 +19,25 @@ impl SessionID {
     }
 }
 
+/// RPC call kind.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, cbor::Encode, cbor::Decode)]
+#[cbor(with_default)]
+#[repr(u8)]
+pub enum Kind {
+    /// A secure RPC call using an encrypted and authenticated Noise session.
+    NoiseSession = 0,
+    /// An insecure RPC call where messages are sent in plain text.
+    InsecureQuery = 1,
+    /// A local RPC call.
+    LocalQuery = 2,
+}
+
+impl Default for Kind {
+    fn default() -> Self {
+        Self::NoiseSession
+    }
+}
+
 /// Frame.
 #[derive(Clone, Debug, Default, cbor::Encode, cbor::Decode)]
 pub struct Frame {

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -141,6 +141,7 @@ pub enum Body {
     },
     RuntimeRPCCallRequest {
         request: Vec<u8>,
+        kind: enclave_rpc::types::Kind,
     },
     RuntimeRPCCallResponse {
         response: Vec<u8>,
@@ -213,6 +214,7 @@ pub enum Body {
     HostRPCCallRequest {
         endpoint: String,
         request: Vec<u8>,
+        kind: enclave_rpc::types::Kind,
         #[cbor(optional, rename = "pf")]
         peer_feedback: Option<enclave_rpc::types::PeerFeedback>,
     },


### PR DESCRIPTION
Create a new simpler, session-less, RPC request/response protocol to be used when dealing with public keys.