### PR TITLE
buildkite: Start intel sgx e2e test jobs sooner

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -192,60 +192,6 @@ steps:
     plugins:
       <<: *docker_plugin
 
-  ###############
-  # E2E test jobs
-  ###############
-  - label: E2E tests
-    depends_on:
-      - "build-go"
-      - "build-rust-runtime-loader"
-      - "build-rust-runtimes"
-    parallelism: 30
-    timeout_in_minutes: 15
-    command:
-      - .buildkite/scripts/download_e2e_test_artifacts.sh
-      - .buildkite/scripts/test_e2e.sh
-    artifact_paths:
-      - coverage-merged-e2e-*.txt
-      - /tmp/e2e/**/*.log
-      - /tmp/e2e/**/genesis.json
-      - /tmp/e2e/**/runtime_genesis.json
-    env:
-      OASIS_E2E_COVERAGE: enable
-      # Since the trust-root scenarios are tested in SGX mode (for which they are actually relevant)
-      # no need to also test them in non-SGX mode in CI. Also exclude txsource-multi-short so that
-      # we ensure it runs only on non-SGX agents.
-      OASIS_EXCLUDE_E2E: e2e/runtime/trust-root/simple,e2e/runtime/trust-root/change,e2e/runtime/trust-root/change-fails,e2e/runtime/txsource-multi-short
-      TEST_BASE_DIR: /tmp
-    retry:
-      <<: *retry_agent_failure
-    plugins:
-      <<: *docker_plugin
-
-  - label: E2E tests (txsource-multi-short)
-    depends_on:
-      - "build-go"
-      - "build-rust-runtime-loader"
-      - "build-rust-runtimes"
-    timeout_in_minutes: 15
-    command:
-      - .buildkite/scripts/download_e2e_test_artifacts.sh
-      - .buildkite/scripts/test_e2e.sh --scenario e2e/runtime/txsource-multi-short
-    artifact_paths:
-      - coverage-merged-e2e-*.txt
-      - /tmp/e2e/**/*.log
-      - /tmp/e2e/**/genesis.json
-      - /tmp/e2e/**/runtime_genesis.json
-    env:
-      OASIS_E2E_COVERAGE: enable
-      TEST_BASE_DIR: /tmp
-    agents:
-      buildkite_agent_class: ephemeral # XXX: Use a dedicated tag instead.
-    retry:
-      <<: *retry_agent_failure
-    plugins:
-      <<: *docker_plugin
-
   ###########################
   # E2E test jobs - intel-sgx
   ###########################
@@ -313,6 +259,60 @@ steps:
       <<: *retry_agent_failure
     plugins:
       <<: *docker_plugin_sgx
+
+  ###############
+  # E2E test jobs
+  ###############
+  - label: E2E tests
+    depends_on:
+      - "build-go"
+      - "build-rust-runtime-loader"
+      - "build-rust-runtimes"
+    parallelism: 30
+    timeout_in_minutes: 15
+    command:
+      - .buildkite/scripts/download_e2e_test_artifacts.sh
+      - .buildkite/scripts/test_e2e.sh
+    artifact_paths:
+      - coverage-merged-e2e-*.txt
+      - /tmp/e2e/**/*.log
+      - /tmp/e2e/**/genesis.json
+      - /tmp/e2e/**/runtime_genesis.json
+    env:
+      OASIS_E2E_COVERAGE: enable
+      # Since the trust-root scenarios are tested in SGX mode (for which they are actually relevant)
+      # no need to also test them in non-SGX mode in CI. Also exclude txsource-multi-short so that
+      # we ensure it runs only on non-SGX agents.
+      OASIS_EXCLUDE_E2E: e2e/runtime/trust-root/simple,e2e/runtime/trust-root/change,e2e/runtime/trust-root/change-fails,e2e/runtime/txsource-multi-short
+      TEST_BASE_DIR: /tmp
+    retry:
+      <<: *retry_agent_failure
+    plugins:
+      <<: *docker_plugin
+
+  - label: E2E tests (txsource-multi-short)
+    depends_on:
+      - "build-go"
+      - "build-rust-runtime-loader"
+      - "build-rust-runtimes"
+    timeout_in_minutes: 15
+    command:
+      - .buildkite/scripts/download_e2e_test_artifacts.sh
+      - .buildkite/scripts/test_e2e.sh --scenario e2e/runtime/txsource-multi-short
+    artifact_paths:
+      - coverage-merged-e2e-*.txt
+      - /tmp/e2e/**/*.log
+      - /tmp/e2e/**/genesis.json
+      - /tmp/e2e/**/runtime_genesis.json
+    env:
+      OASIS_E2E_COVERAGE: enable
+      TEST_BASE_DIR: /tmp
+    agents:
+      buildkite_agent_class: ephemeral # XXX: Use a dedicated tag instead.
+    retry:
+      <<: *retry_agent_failure
+    plugins:
+      <<: *docker_plugin
 
   ################################################
   # E2E test - intel-sgx with IAS (only on master)


### PR DESCRIPTION
Moving sgx e2e tests higher up the ladder to discover failed tests/bugs sooner as those tests cannot be run locally on non-sgx platforms.