### PR TITLE
go/worker/keymanager: Show current key manager policy in the node status

### DIFF
--- a/.changelog/5079.feature.md
+++ b/.changelog/5079.feature.md
@@ -1,0 +1,1 @@
+go/worker/keymanager: Show current key manager policy in the node status

--- a/go/worker/keymanager/api/api.go
+++ b/go/worker/keymanager/api/api.go
@@ -6,6 +6,7 @@ import (
 	"github.com/libp2p/go-libp2p/core"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/keymanager/api"
 )
 
 // StatusState is the concise status state of the key manager worker.
@@ -97,4 +98,9 @@ type Status struct {
 	AccessList []RuntimeAccessList `json:"access_list"`
 	// PrivatePeers is a list of peers that are always allowed to call protected methods.
 	PrivatePeers []core.PeerID `json:"private_peers"`
+
+	// Policy is the key manager policy.
+	Policy *api.SignedPolicySGX `json:"signed_policy"`
+	// PolicyChecksum is the checksum of the key manager policy.
+	PolicyChecksum []byte `json:"policy_checksum"`
 }

--- a/go/worker/keymanager/status.go
+++ b/go/worker/keymanager/status.go
@@ -70,5 +70,7 @@ func (w *Worker) GetStatus(ctx context.Context) (*api.Status, error) {
 		ClientRuntimes: rts,
 		AccessList:     al,
 		PrivatePeers:   ps,
+		Policy:         w.policy,
+		PolicyChecksum: w.policyChecksum,
 	}, nil
 }

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -87,6 +87,9 @@ type Worker struct { // nolint: maligned
 	enclaveStatus *api.SignedInitResponse
 	backend       api.Backend
 
+	policy         *api.SignedPolicySGX
+	policyChecksum []byte
+
 	enabled     bool
 	mayGenerate bool
 }
@@ -338,11 +341,13 @@ func (w *Worker) updateStatus(status *api.Status, runtimeStatus *runtimeStatus) 
 		return nil
 	})
 
-	// Cache the key manager enclave status.
+	// Cache the key manager enclave status and the currently active policy.
 	w.Lock()
 	defer w.Unlock()
 
 	w.enclaveStatus = &signedInitResp
+	w.policy = status.Policy
+	w.policyChecksum = signedInitResp.InitResponse.PolicyChecksum
 
 	return nil
 }


### PR DESCRIPTION
Before first init request:
```
> keymanager-0 oasis-node control status
{
  "keymanager": {
    "signed_policy": null,
    "policy_checksum": null
  }
}
```
After first init request:
```
> keymanager-0 oasis-node control status
{
  "keymanager": {
    "signed_policy": null,
    "policy_checksum": ""
  }
}
```
With (sample) policy:
```
> keymanager-0 oasis-node control status
{
  "keymanager": {
    "signed_policy": {
      "policy": {
        "serial": 1,
        "id": "c000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff",
        "enclaves": {
          "yaWJhRsfNWJxd/1wN47XeBcPc3YR5N+/C20lvf9VtHR9MQZkeAkxrhA6swqQFxwgGvOFpydXu0aDV4/evemt9Q==": {
            "may_query": {
              "8000000000000000000000000000000000000000000000000000000000000000": [
                "GCVveDwHFSG+LaBBzZNHtb21qO9Y+zRlhXGm4Uzx/LDkgEnR3g6zM1I5kWcabJO5fdZbzwknPVtr/oJi3JaOxw=="
              ]
            },
            "may_replicate": [
              "dW6vdvVILFNFgIserM3Vxg+GS7KqLSuHDfAM5DWvTiM1l6L/B0MBbyjl1+EpME7hxD29rj26lOGc7jVJA4paMg=="
            ]
          }
        }
      },
      "signatures": []
    },
    "policy_checksum": "BR0LqY6VQbk/xGezjRGk+tnb8gsGZT5wK24OkXlZmAE="
  }
}
```