### PR TITLE
go/worker/keymanager: Show global key manager status in node status

### DIFF
--- a/.changelog/5080.feature.md
+++ b/.changelog/5080.feature.md
@@ -1,0 +1,1 @@
+go/worker/keymanager: Show global key manager status in node status

--- a/go/worker/keymanager/api/api.go
+++ b/go/worker/keymanager/api/api.go
@@ -81,8 +81,17 @@ type RuntimeAccessList struct {
 	Peers []core.PeerID `json:"peers"`
 }
 
-// Status is the key manager worker status.
+// Status is the key manager global and worker status.
 type Status struct {
+	// GlobalStatus is the global key manager committee status.
+	GlobalStatus *api.Status `json:"global"`
+
+	// WorkerStatus is the key manager worker status.
+	WorkerStatus WorkerStatus `json:"worker"`
+}
+
+// WorkerStatus is the key manager worker status.
+type WorkerStatus struct {
 	// Status is a concise status of the key manager worker.
 	Status StatusState `json:"status"`
 
@@ -100,7 +109,7 @@ type Status struct {
 	PrivatePeers []core.PeerID `json:"private_peers"`
 
 	// Policy is the key manager policy.
-	Policy *api.SignedPolicySGX `json:"signed_policy"`
+	Policy *api.SignedPolicySGX `json:"policy"`
 	// PolicyChecksum is the checksum of the key manager policy.
 	PolicyChecksum []byte `json:"policy_checksum"`
 }

--- a/go/worker/keymanager/status.go
+++ b/go/worker/keymanager/status.go
@@ -35,12 +35,6 @@ func (w *Worker) GetStatus(ctx context.Context) (*api.Status, error) {
 		ss = api.StatusStateStarting
 	}
 
-	var rid *common.Namespace
-	if w.runtime != nil {
-		id := w.runtime.ID()
-		rid = &id
-	}
-
 	ps := make([]peer.ID, 0, len(w.privatePeers))
 	for p := range w.privatePeers {
 		ps = append(ps, p)
@@ -63,14 +57,19 @@ func (w *Worker) GetStatus(ctx context.Context) (*api.Status, error) {
 		al = append(al, ral)
 	}
 
-	return &api.Status{
+	gs := w.globalStatus
+	ws := api.WorkerStatus{
 		Status:         ss,
 		MayGenerate:    w.mayGenerate,
-		RuntimeID:      rid,
 		ClientRuntimes: rts,
 		AccessList:     al,
 		PrivatePeers:   ps,
 		Policy:         w.policy,
 		PolicyChecksum: w.policyChecksum,
+	}
+
+	return &api.Status{
+		GlobalStatus: gs,
+		WorkerStatus: ws,
 	}, nil
 }


### PR DESCRIPTION
Not sure if we need two polices, one from the registry and one from the enclave. If things go sideways, those two could differ.
```
➜  keymanager-0 oasis-node control status
{
   "keymanager": {
    "global": {
      "id": "c000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff",
      "is_initialized": true,
      "is_secure": false,
      "checksum": "Um8OfhUNj0qWPP4+Jrp5byV90xKkpFVK37myBmk5FcI=",
      "nodes": [
        "lw6q22vpk3KEG4n4tB/jUNBJhbyRYoxK9QRfRYJUXZQ=",
        "46AhhHHegX40j/XSK2b5LEXOOisG2xgnjJohTG7BRTQ="
      ],
      "policy": null
    },
    "worker": {
      "status": "ready",
      "may_generate": true,
      "runtime_id": null,
      "client_runtimes": [
        "8000000000000000000000000000000000000000000000000000000000000000"
      ],
      "access_list": [
        {
          "runtime_id": "c000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff",
          "peers": [
            "12D3KooWAVrvjLQjBwfA9kwFMm5N3nDwVEptzTGTbHkrbsGMqb7g",
            "12D3KooWKmqj5e26wzKNDdygQXx9tsWPhi1Y4p2bt7A6fHqjB7Zq"
          ]
        },
        {
          "runtime_id": "8000000000000000000000000000000000000000000000000000000000000000",
          "peers": [
            "12D3KooWMLPrLv9kXUaXuZeM9uxMkZ49xr9hexZprUgqQyQMq48f",
            "12D3KooWGvNqQbwYgUjkqux8Y5ev5cpX56QemgkccUFdypVa5n8B"
          ]
        }
      ],
      "private_peers": [
        "12D3KooWLGerSQABvFxSboPVRGZ795qBAB5nndr5WGXM9wK9Gc13",
        "12D3KooWN2bT2FfVH1UcStQakR6dTdfxQRxw2THt4LWr432hQgBH"
      ],
      "policy": null,
      "policy_checksum": ""
    }
  },
}
```