### PR TITLE
go/p2p/PeerManager: support subscribing to peer updates

### DIFF
--- a/.changelog/5083.internal.md
+++ b/.changelog/5083.internal.md
@@ -1,0 +1,4 @@
+go/p2p/PeerManager: enable subscribing to peer updates
+
+Adds `WatchUpdates` method to the `PeerManager` which allows subscribing to
+peer updates (peers being added or removed).

--- a/go/p2p/rpc/nop.go
+++ b/go/p2p/rpc/nop.go
@@ -6,7 +6,11 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
 )
+
+var errUnsupported = fmt.Errorf("unsupported: p2p is disabled")
 
 type nopPeerManager struct{}
 
@@ -35,6 +39,11 @@ func (*nopPeerManager) RecordSuccess(peerID peer.ID, latency time.Duration) {
 func (*nopPeerManager) RemovePeer(peerID peer.ID) {
 }
 
+// Implements PeersUpdates.
+func (*nopPeerManager) WatchUpdates() (<-chan *PeerUpdate, pubsub.ClosableSubscription, error) {
+	return nil, nil, errUnsupported
+}
+
 type nopClient struct{}
 
 // Implements Client.
@@ -45,7 +54,7 @@ func (c *nopClient) Call(
 	body, rsp interface{},
 	opts ...CallOption,
 ) (PeerFeedback, error) {
-	return nil, fmt.Errorf("unsupported: p2p is disabled")
+	return nil, errUnsupported
 }
 
 // Implements Client.
@@ -56,7 +65,7 @@ func (c *nopClient) CallOne(
 	body, rsp interface{},
 	opts ...CallOption,
 ) (PeerFeedback, error) {
-	return nil, fmt.Errorf("unsupported: p2p is disabled")
+	return nil, errUnsupported
 }
 
 // Implements Client.
@@ -67,7 +76,7 @@ func (c *nopClient) CallMulti(
 	body, rspTyp interface{},
 	opts ...CallMultiOption,
 ) ([]interface{}, []PeerFeedback, error) {
-	return nil, nil, fmt.Errorf("unsupported: p2p is disabled")
+	return nil, nil, errUnsupported
 }
 
 // Implements Client.

--- a/go/p2p/rpc/peermgmt_test.go
+++ b/go/p2p/rpc/peermgmt_test.go
@@ -1,0 +1,93 @@
+package rpc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+type testP2P struct {
+	host host.Host
+}
+
+// BlockPeer implements P2P.
+func (*testP2P) BlockPeer(peerID peer.ID) {
+}
+
+// Host implements P2P.
+func (t *testP2P) Host() host.Host {
+	return t.host
+}
+
+// RegisterProtocol implements P2P.
+func (*testP2P) RegisterProtocol(p protocol.ID, min int, total int) {
+}
+
+func TestWatchUpdates(t *testing.T) {
+	require := require.New(t)
+
+	// Prepare a p2p host.
+	listenAddr, err := multiaddr.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
+	require.NoError(err, "NewMultiaddr failed")
+	host, err := libp2p.New(
+		libp2p.ListenAddrs(listenAddr),
+	)
+	require.NoError(err, "libp2p.New failed")
+	defer host.Close()
+
+	peerMgr := NewPeerManager(&testP2P{host}, testProtocol)
+
+	ch, sub, err := peerMgr.WatchUpdates()
+	require.NoError(err, "WatchUpdates")
+	defer sub.Close()
+
+	// No events expected.
+	select {
+	case ev := <-ch:
+		t.Fatalf("received unexpected event: %+v", ev)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	peer1, peer2, peer3 := core.PeerID("peer-1"), core.PeerID("peer-2"), core.PeerID("peer-3")
+
+	// Add/remove peers.
+	peerMgr.AddPeer(peer1)
+	peerMgr.AddPeer(peer2)
+	peerMgr.RecordBadPeer(peer1)
+	peerMgr.RecordBadPeer(peer1)
+	peerMgr.AddPeer(peer3)
+	peerMgr.AddPeer(peer3)
+	peerMgr.RemovePeer(peer2)
+	peerMgr.RemovePeer(peer2)
+
+	// Ensure expected events are received.
+	expectedEvents := []*PeerUpdate{
+		{ID: peer1, PeerAdded: &PeerAdded{}},
+		{ID: peer2, PeerAdded: &PeerAdded{}},
+		{ID: peer1, PeerRemoved: &PeerRemoved{BadPeer: true}},
+		{ID: peer3, PeerAdded: &PeerAdded{}},
+		{ID: peer2, PeerRemoved: &PeerRemoved{}},
+	}
+	for _, next := range expectedEvents {
+		select {
+		case ev := <-ch:
+			require.Equal(next, ev, "should receive expected event")
+		case <-time.After(2 * time.Second):
+			t.Fatalf("failed to receive expected event: %+v", next)
+		}
+	}
+
+	// No more events expected.
+	select {
+	case ev := <-ch:
+		t.Fatalf("received unexpected event: %+v", ev)
+	case <-time.After(100 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
Adds `WatchUpdates` method to the `PeerManager` which allows subscribing to peer updates (peers being added or removed).

This will be required by an upcoming Pull Request (consensus light-blocks protocol via libp2p), where Tendermint light client providers backed by P2P peers are implemented. In short: each provider is backed by a single P2P peer, and the provider needs to detect if the peer is removed, so it can switch to a new peer.