### PR TITLE
runtime/src/enclave_rpc: Verify RPC quotes with key manager quote policy

### DIFF
--- a/.changelog/5092.bugfix.md
+++ b/.changelog/5092.bugfix.md
@@ -1,0 +1,5 @@
+go/runtime/registry: Fix watching policy updates
+
+When multiple key managers were running, the last known status of the
+runtime's key manager was overwritten with each status update. On runtime
+(re)starts, this resulted in the wrong policy being set.

--- a/.changelog/5092.feature.md
+++ b/.changelog/5092.feature.md
@@ -1,0 +1,1 @@
+runtime/src/enclave_rpc: Verify RPC quotes with key manager quote policy

--- a/go/common/namespace.go
+++ b/go/common/namespace.go
@@ -105,7 +105,10 @@ func (n *Namespace) UnmarshalBase64(text []byte) error {
 
 // Equal compares vs another namespace for equality.
 func (n *Namespace) Equal(cmp *Namespace) bool {
-	if cmp == nil {
+	if n == cmp {
+		return true
+	}
+	if n == nil || cmp == nil {
 		return false
 	}
 	return bytes.Equal(n[:], cmp[:])

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -648,6 +648,12 @@ type VersionInfo struct {
 
 // Equal compares vs another VersionInfo for equality.
 func (vi *VersionInfo) Equal(cmp *VersionInfo) bool {
+	if vi == cmp {
+		return true
+	}
+	if vi == nil || cmp == nil {
+		return false
+	}
 	if vi.Version.ToU64() != cmp.Version.ToU64() {
 		return false
 	}

--- a/go/runtime/host/multi/multi.go
+++ b/go/runtime/host/multi/multi.go
@@ -192,7 +192,7 @@ func (agg *Aggregate) SetVersion(ctx context.Context, version version.Version) e
 			return nil
 		}
 
-		// Otherwise tear it dow.
+		// Otherwise tear it down.
 		agg.stopActiveLocked()
 	}
 

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -171,6 +171,9 @@ type RuntimeInfoRequest struct {
 type Features struct {
 	// ScheduleControl is the schedule control feature.
 	ScheduleControl *FeatureScheduleControl `json:"schedule_control,omitempty"`
+	// KeyManagerQuotePolicyUpdates is a feature specifying that the runtime supports updating
+	// key manager's quote policy.
+	KeyManagerQuotePolicyUpdates bool `json:"key_manager_quote_policy_updates,omitempty"`
 }
 
 // HasScheduleControl returns true when the runtime supports the schedule control feature.

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -67,34 +67,36 @@ type Body struct {
 	Error *Error `json:",omitempty"`
 
 	// Runtime interface.
-	RuntimeInfoRequest                    *RuntimeInfoRequest                    `json:",omitempty"`
-	RuntimeInfoResponse                   *RuntimeInfoResponse                   `json:",omitempty"`
-	RuntimePingRequest                    *Empty                                 `json:",omitempty"`
-	RuntimeShutdownRequest                *Empty                                 `json:",omitempty"`
-	RuntimeCapabilityTEERakInitRequest    *RuntimeCapabilityTEERakInitRequest    `json:",omitempty"`
-	RuntimeCapabilityTEERakInitResponse   *Empty                                 `json:",omitempty"`
-	RuntimeCapabilityTEERakReportRequest  *Empty                                 `json:",omitempty"`
-	RuntimeCapabilityTEERakReportResponse *RuntimeCapabilityTEERakReportResponse `json:",omitempty"`
-	RuntimeCapabilityTEERakAvrRequest     *RuntimeCapabilityTEERakAvrRequest     `json:",omitempty"`
-	RuntimeCapabilityTEERakAvrResponse    *Empty                                 `json:",omitempty"`
-	RuntimeCapabilityTEERakQuoteRequest   *RuntimeCapabilityTEERakQuoteRequest   `json:",omitempty"`
-	RuntimeCapabilityTEERakQuoteResponse  *RuntimeCapabilityTEERakQuoteResponse  `json:",omitempty"`
-	RuntimeRPCCallRequest                 *RuntimeRPCCallRequest                 `json:",omitempty"`
-	RuntimeRPCCallResponse                *RuntimeRPCCallResponse                `json:",omitempty"`
-	RuntimeLocalRPCCallRequest            *RuntimeLocalRPCCallRequest            `json:",omitempty"`
-	RuntimeLocalRPCCallResponse           *RuntimeLocalRPCCallResponse           `json:",omitempty"`
-	RuntimeCheckTxBatchRequest            *RuntimeCheckTxBatchRequest            `json:",omitempty"`
-	RuntimeCheckTxBatchResponse           *RuntimeCheckTxBatchResponse           `json:",omitempty"`
-	RuntimeExecuteTxBatchRequest          *RuntimeExecuteTxBatchRequest          `json:",omitempty"`
-	RuntimeExecuteTxBatchResponse         *RuntimeExecuteTxBatchResponse         `json:",omitempty"`
-	RuntimeAbortRequest                   *Empty                                 `json:",omitempty"`
-	RuntimeAbortResponse                  *Empty                                 `json:",omitempty"`
-	RuntimeKeyManagerPolicyUpdateRequest  *RuntimeKeyManagerPolicyUpdateRequest  `json:",omitempty"`
-	RuntimeKeyManagerPolicyUpdateResponse *Empty                                 `json:",omitempty"`
-	RuntimeQueryRequest                   *RuntimeQueryRequest                   `json:",omitempty"`
-	RuntimeQueryResponse                  *RuntimeQueryResponse                  `json:",omitempty"`
-	RuntimeConsensusSyncRequest           *RuntimeConsensusSyncRequest           `json:",omitempty"`
-	RuntimeConsensusSyncResponse          *Empty                                 `json:",omitempty"`
+	RuntimeInfoRequest                         *RuntimeInfoRequest                        `json:",omitempty"`
+	RuntimeInfoResponse                        *RuntimeInfoResponse                       `json:",omitempty"`
+	RuntimePingRequest                         *Empty                                     `json:",omitempty"`
+	RuntimeShutdownRequest                     *Empty                                     `json:",omitempty"`
+	RuntimeCapabilityTEERakInitRequest         *RuntimeCapabilityTEERakInitRequest        `json:",omitempty"`
+	RuntimeCapabilityTEERakInitResponse        *Empty                                     `json:",omitempty"`
+	RuntimeCapabilityTEERakReportRequest       *Empty                                     `json:",omitempty"`
+	RuntimeCapabilityTEERakReportResponse      *RuntimeCapabilityTEERakReportResponse     `json:",omitempty"`
+	RuntimeCapabilityTEERakAvrRequest          *RuntimeCapabilityTEERakAvrRequest         `json:",omitempty"`
+	RuntimeCapabilityTEERakAvrResponse         *Empty                                     `json:",omitempty"`
+	RuntimeCapabilityTEERakQuoteRequest        *RuntimeCapabilityTEERakQuoteRequest       `json:",omitempty"`
+	RuntimeCapabilityTEERakQuoteResponse       *RuntimeCapabilityTEERakQuoteResponse      `json:",omitempty"`
+	RuntimeRPCCallRequest                      *RuntimeRPCCallRequest                     `json:",omitempty"`
+	RuntimeRPCCallResponse                     *RuntimeRPCCallResponse                    `json:",omitempty"`
+	RuntimeLocalRPCCallRequest                 *RuntimeLocalRPCCallRequest                `json:",omitempty"`
+	RuntimeLocalRPCCallResponse                *RuntimeLocalRPCCallResponse               `json:",omitempty"`
+	RuntimeCheckTxBatchRequest                 *RuntimeCheckTxBatchRequest                `json:",omitempty"`
+	RuntimeCheckTxBatchResponse                *RuntimeCheckTxBatchResponse               `json:",omitempty"`
+	RuntimeExecuteTxBatchRequest               *RuntimeExecuteTxBatchRequest              `json:",omitempty"`
+	RuntimeExecuteTxBatchResponse              *RuntimeExecuteTxBatchResponse             `json:",omitempty"`
+	RuntimeAbortRequest                        *Empty                                     `json:",omitempty"`
+	RuntimeAbortResponse                       *Empty                                     `json:",omitempty"`
+	RuntimeKeyManagerPolicyUpdateRequest       *RuntimeKeyManagerPolicyUpdateRequest      `json:",omitempty"`
+	RuntimeKeyManagerPolicyUpdateResponse      *Empty                                     `json:",omitempty"`
+	RuntimeKeyManagerQuotePolicyUpdateRequest  *RuntimeKeyManagerQuotePolicyUpdateRequest `json:",omitempty"`
+	RuntimeKeyManagerQuotePolicyUpdateResponse *Empty                                     `json:",omitempty"`
+	RuntimeQueryRequest                        *RuntimeQueryRequest                       `json:",omitempty"`
+	RuntimeQueryResponse                       *RuntimeQueryResponse                      `json:",omitempty"`
+	RuntimeConsensusSyncRequest                *RuntimeConsensusSyncRequest               `json:",omitempty"`
+	RuntimeConsensusSyncResponse               *Empty                                     `json:",omitempty"`
 
 	// Host interface.
 	HostRPCCallRequest               *HostRPCCallRequest               `json:",omitempty"`
@@ -395,10 +397,15 @@ type RuntimeExecuteTxBatchResponse struct {
 	Deprecated1 cbor.RawMessage `json:"batch_weight_limits,omitempty"`
 }
 
-// RuntimeKeyManagerPolicyUpdateRequest is a runtime key manager policy request
-// message body.
+// RuntimeKeyManagerPolicyUpdateRequest is a runtime key manager policy request message body.
 type RuntimeKeyManagerPolicyUpdateRequest struct {
 	SignedPolicyRaw []byte `json:"signed_policy_raw"`
+}
+
+// RuntimeKeyManagerQuotePolicyUpdateRequest is a runtime key manager quote policy request
+// message body.
+type RuntimeKeyManagerQuotePolicyUpdateRequest struct {
+	Policy quote.Policy `json:"policy"`
 }
 
 // RuntimeQueryRequest is a runtime query request message body.

--- a/go/runtime/registry/host.go
+++ b/go/runtime/registry/host.go
@@ -491,12 +491,13 @@ func (n *runtimeHostNotifier) watchPolicyUpdates() {
 				)
 				continue
 			}
-		case st = <-stCh:
+		case newSt := <-stCh:
 			// Ignore status updates if key manager is not yet known (is nil)
 			// or if the status update is for a different key manager.
-			if rtDsc == nil || !st.ID.Equal(rtDsc.KeyManager) {
+			if rtDsc == nil || !newSt.ID.Equal(rtDsc.KeyManager) {
 				continue
 			}
+			st = newSt
 		case ev := <-evCh:
 			// Runtime host changes, make sure to update the policy if runtime is restarted.
 			if ev.Started == nil && ev.Updated == nil {

--- a/keymanager/src/api/errors.rs
+++ b/keymanager/src/api/errors.rs
@@ -27,8 +27,6 @@ pub enum KeyManagerError {
     PolicyInvalid(#[from] anyhow::Error),
     #[error("policy has insufficient signatures")]
     PolicyInsufficientSignatures,
-    #[error("policy hasn't been published")]
-    PolicyNotPublished,
     #[error(transparent)]
     Other(anyhow::Error),
 }

--- a/keymanager/src/client/remote.rs
+++ b/keymanager/src/client/remote.rs
@@ -142,9 +142,7 @@ impl RemoteClient {
     }
 
     /// Set client allowed enclaves from key manager policy.
-    pub fn set_policy(&self, signed_policy_raw: Vec<u8>) -> Result<(), KeyManagerError> {
-        let untrusted_policy: SignedPolicySGX = cbor::from_slice(&signed_policy_raw)
-            .map_err(|err| KeyManagerError::PolicyInvalid(err.into()))?;
+    pub fn set_policy(&self, untrusted_policy: SignedPolicySGX) -> Result<(), KeyManagerError> {
         let policy = verify_policy_and_trusted_signers(&untrusted_policy)?;
 
         let policies: HashSet<EnclaveIdentity> =

--- a/keymanager/src/crypto/kdf.rs
+++ b/keymanager/src/crypto/kdf.rs
@@ -298,9 +298,10 @@ impl Kdf {
 
                         let rctx = runtime_context!(ctx, KmContext);
 
-                        let km_client = RemoteClient::new_runtime_with_enclave_identities(
+                        let km_client = RemoteClient::new_runtime_with_enclaves_and_policy(
                             rctx.runtime_id,
                             Policy::global().may_replicate_from(),
+                            ctx.rak.quote_policy(),
                             rctx.protocol.clone(),
                             ctx.consensus_verifier.clone(),
                             ctx.rak.clone(),

--- a/keymanager/src/policy/cached.rs
+++ b/keymanager/src/policy/cached.rs
@@ -199,10 +199,10 @@ impl Policy {
     fn save_raw_policy(untrusted_local: &dyn KeyValue, raw_policy: &[u8]) {
         let ciphertext = seal(Keypolicy::MRENCLAVE, POLICY_SEAL_CONTEXT, raw_policy);
 
-        // Persist the encrypted master secret.
+        // Persist the encrypted policy.
         untrusted_local
             .insert(POLICY_STORAGE_KEY.to_vec(), ciphertext)
-            .expect("failed to persist master secret");
+            .expect("failed to persist policy");
     }
 }
 

--- a/runtime/src/attestation.rs
+++ b/runtime/src/attestation.rs
@@ -104,36 +104,43 @@ impl Handler {
     }
 
     fn set_quote(&self, ctx: Context, quote: Quote) -> Result<Body> {
+        if self.rak.quote_policy().is_none() {
+            info!(self.logger, "Configuring quote policy");
+
+            // Obtain current quote policy from (verified) consensus state.
+            let ctx = ctx.freeze();
+            let consensus_state = self.consensus_verifier.latest_state()?;
+            let registry_state = RegistryState::new(&consensus_state);
+            let runtime = registry_state
+                .runtime(Context::create_child(&ctx), &self.runtime_id)?
+                .ok_or(anyhow!("missing runtime descriptor"))?;
+            let ad = runtime
+                .deployment_for_version(self.version)
+                .ok_or(anyhow!("no corresponding runtime deployment"))?;
+
+            let policy = match runtime.tee_hardware {
+                TEEHardware::TEEHardwareIntelSGX => {
+                    let sc: SGXConstraints = ad
+                        .try_decode_tee()
+                        .map_err(|_| anyhow!("bad TEE constraints"))?;
+                    sc.policy()
+                }
+                _ => bail!("configured runtime hardware mismatch"),
+            };
+
+            self.rak.set_quote_policy(policy)?;
+        }
+
         info!(
             self.logger,
             "Configuring quote for the runtime attestation key binding"
         );
 
-        // Obtain current quote policy from (verified) consensus state.
-        let ctx = ctx.freeze();
-        let consensus_state = self.consensus_verifier.latest_state()?;
-        let registry_state = RegistryState::new(&consensus_state);
-        let runtime = registry_state
-            .runtime(Context::create_child(&ctx), &self.runtime_id)?
-            .ok_or(anyhow!("missing runtime descriptor"))?;
-        let ad = runtime
-            .deployment_for_version(self.version)
-            .ok_or(anyhow!("no corresponding runtime deployment"))?;
-
-        let policy = match runtime.tee_hardware {
-            TEEHardware::TEEHardwareIntelSGX => {
-                let sc: SGXConstraints = ad
-                    .try_decode_tee()
-                    .map_err(|_| anyhow!("bad TEE constraints"))?;
-                sc.policy()
-            }
-            _ => bail!("configured runtime hardware mismatch"),
-        };
-
         // Configure the quote and policy on the RAK.
-        let verified_quote = self.rak.set_quote(quote, policy)?;
+        let verified_quote = self.rak.set_quote(quote)?;
 
         // Sign the report data, latest verified consensus height and host node ID.
+        let consensus_state = self.consensus_verifier.latest_state()?;
         let height = consensus_state.height();
         let node_id = self.host.identity()?;
         let h = SGXAttestation::hash(&verified_quote.report_data, node_id, height);

--- a/runtime/src/common/sgx/ias.rs
+++ b/runtime/src/common/sgx/ias.rs
@@ -116,7 +116,7 @@ lazy_static! {
 }
 
 /// Quote validity policy.
-#[derive(Clone, Debug, Default, cbor::Encode, cbor::Decode)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, cbor::Encode, cbor::Decode)]
 pub struct QuotePolicy {
     /// Whether IAS quotes are disabled and will always be rejected.
     #[cbor(optional)]

--- a/runtime/src/common/sgx/mod.rs
+++ b/runtime/src/common/sgx/mod.rs
@@ -96,7 +96,7 @@ impl Quote {
 }
 
 /// Quote validity policy.
-#[derive(Clone, Debug, Default, cbor::Encode, cbor::Decode)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, cbor::Encode, cbor::Decode)]
 pub struct QuotePolicy {
     #[cbor(rename = "ias")]
     pub ias: Option<ias::QuotePolicy>,

--- a/runtime/src/common/sgx/pcs.rs
+++ b/runtime/src/common/sgx/pcs.rs
@@ -97,7 +97,7 @@ pub enum Error {
 }
 
 /// Quote validity policy.
-#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
+#[derive(Clone, Debug, PartialEq, Eq, cbor::Encode, cbor::Decode)]
 pub struct QuotePolicy {
     /// Whether PCS quotes are disabled and will always be rejected.
     #[cbor(optional)]

--- a/runtime/src/enclave_rpc/demux.rs
+++ b/runtime/src/enclave_rpc/demux.rs
@@ -135,6 +135,7 @@ impl Demux {
             // Create a new session.
             if self.sessions.len() < self.max_concurrent_sessions {
                 let mut session = Builder::default()
+                    .quote_policy(self.rak.quote_policy())
                     .local_rak(self.rak.clone())
                     .build_responder();
                 let result = match session.process_data(frame.payload, writer).map(|m| {

--- a/runtime/src/enclave_rpc/dispatcher.rs
+++ b/runtime/src/enclave_rpc/dispatcher.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 use anyhow::Result;
 use thiserror::Error;
 
+use crate::consensus::keymanager::SignedPolicySGX;
+
 use super::{
     context::Context,
     types::{Body, Request, Response},
@@ -124,7 +126,7 @@ impl Method {
 }
 
 /// Key manager policy update handler callback.
-pub type KeyManagerPolicyHandler = dyn Fn(Vec<u8>) + Send + Sync;
+pub type KeyManagerPolicyHandler = dyn Fn(SignedPolicySGX) + Send + Sync;
 
 /// RPC call dispatcher.
 #[derive(Default)]
@@ -209,9 +211,9 @@ impl Dispatcher {
     }
 
     /// Handle key manager policy update.
-    pub fn handle_km_policy_update(&self, signed_policy_raw: Vec<u8>) {
+    pub fn handle_km_policy_update(&self, policy: SignedPolicySGX) {
         if let Some(handler) = self.km_policy_handler.as_ref() {
-            handler(signed_policy_raw)
+            handler(policy)
         }
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -31,6 +31,7 @@ pub mod enclave_rpc;
 pub mod host;
 pub mod init;
 pub mod macros;
+pub mod policy;
 pub mod protocol;
 pub mod rak;
 pub mod storage;

--- a/runtime/src/policy.rs
+++ b/runtime/src/policy.rs
@@ -104,6 +104,30 @@ impl PolicyVerifier {
         Ok(policy)
     }
 
+    /// Verify that runtime's quote policy has been published in the consensus layer.
+    pub fn verify_quote_policy(
+        &self,
+        ctx: Arc<Context>,
+        policy: QuotePolicy,
+        runtime_id: &Namespace,
+        version: Option<Version>,
+        use_latest_state: bool,
+    ) -> Result<QuotePolicy> {
+        let published_policy = self.quote_policy(ctx, runtime_id, version, use_latest_state)?;
+
+        if policy != published_policy {
+            debug!(
+                self.logger,
+                "quote policy mismatch";
+                "untrusted" => ?policy,
+                "published" => ?published_policy,
+            );
+            return Err(PolicyVerifierError::PolicyNotPublished.into());
+        }
+
+        Ok(published_policy)
+    }
+
     /// Fetch key manager's policy from the latest verified consensus layer state.
     pub fn key_manager_policy(
         &self,

--- a/runtime/src/policy.rs
+++ b/runtime/src/policy.rs
@@ -1,0 +1,152 @@
+//! Consensus SGX and quote policy handling.
+
+use std::sync::Arc;
+
+use anyhow::{bail, Result};
+use io_context::Context;
+use slog::{debug, Logger};
+use thiserror::Error;
+
+use crate::{
+    common::{logger::get_logger, namespace::Namespace, sgx::QuotePolicy, version::Version},
+    consensus::{
+        keymanager::SignedPolicySGX,
+        registry::{SGXConstraints, TEEHardware},
+        state::{
+            beacon::ImmutableState as BeaconState, keymanager::ImmutableState as KeyManagerState,
+            registry::ImmutableState as RegistryState,
+        },
+        verifier::Verifier,
+        HEIGHT_LATEST,
+    },
+};
+
+/// Policy verifier error.
+#[derive(Error, Debug)]
+pub enum PolicyVerifierError {
+    #[error("missing runtime descriptor")]
+    MissingRuntimeDescriptor,
+    #[error("no corresponding runtime deployment")]
+    NoDeployment,
+    #[error("bad TEE constraints")]
+    BadTEEConstraints,
+    #[error("policy hasn't been published")]
+    PolicyNotPublished,
+    #[error("configured runtime hardware mismatch")]
+    HardwareMismatch,
+}
+
+/// Consensus policy verifier.
+pub struct PolicyVerifier {
+    consensus_verifier: Arc<dyn Verifier>,
+    logger: Logger,
+}
+
+impl PolicyVerifier {
+    /// Create a new consensus policy verifier.
+    pub fn new(consensus_verifier: Arc<dyn Verifier>) -> Self {
+        let logger = get_logger("runtime/policy_verifier");
+        Self {
+            consensus_verifier,
+            logger,
+        }
+    }
+
+    /// Fetch runtime's quote policy from the latest verified consensus layer state.
+    ///
+    /// If the runtime version is not provided, the policy for the active deployment is returned.
+    pub fn quote_policy(
+        &self,
+        ctx: Arc<Context>,
+        runtime_id: &Namespace,
+        version: Option<Version>,
+        use_latest_state: bool,
+    ) -> Result<QuotePolicy> {
+        // Verify to the latest height, if needed.
+        let consensus_state = if use_latest_state {
+            self.consensus_verifier.latest_state()?
+        } else {
+            self.consensus_verifier.state_at(HEIGHT_LATEST)?
+        };
+
+        // Fetch quote policy from the consensus layer using the given or the active version.
+        let registry_state = RegistryState::new(&consensus_state);
+        let runtime = registry_state
+            .runtime(Context::create_child(&ctx), runtime_id)?
+            .ok_or(PolicyVerifierError::MissingRuntimeDescriptor)?;
+
+        let ad = match version {
+            Some(version) => runtime
+                .deployment_for_version(version)
+                .ok_or(PolicyVerifierError::NoDeployment)?,
+            None => {
+                let beacon_state = BeaconState::new(&consensus_state);
+                let epoch = beacon_state.epoch(Context::create_child(&ctx))?;
+
+                runtime
+                    .active_deployment(epoch)
+                    .ok_or(PolicyVerifierError::NoDeployment)?
+            }
+        };
+
+        let policy = match runtime.tee_hardware {
+            TEEHardware::TEEHardwareIntelSGX => {
+                let sc: SGXConstraints = ad
+                    .try_decode_tee()
+                    .map_err(|_| PolicyVerifierError::BadTEEConstraints)?;
+                sc.policy()
+            }
+            _ => bail!(PolicyVerifierError::HardwareMismatch),
+        };
+
+        Ok(policy)
+    }
+
+    /// Fetch key manager's policy from the latest verified consensus layer state.
+    pub fn key_manager_policy(
+        &self,
+        ctx: Arc<Context>,
+        key_manager: Namespace,
+        use_latest_state: bool,
+    ) -> Result<SignedPolicySGX> {
+        // Verify to the latest height, if needed.
+        let consensus_state = if use_latest_state {
+            self.consensus_verifier.latest_state()?
+        } else {
+            self.consensus_verifier.state_at(HEIGHT_LATEST)?
+        };
+
+        // Fetch policy from the consensus layer.
+        let km_state = KeyManagerState::new(&consensus_state);
+        let policy = km_state
+            .status(Context::create_child(&ctx), key_manager)?
+            .ok_or(PolicyVerifierError::PolicyNotPublished)?
+            .policy
+            .ok_or(PolicyVerifierError::PolicyNotPublished)?;
+
+        Ok(policy)
+    }
+
+    /// Verify that key manager's policy has been published in the consensus layer.
+    pub fn verify_key_manager_policy(
+        &self,
+        ctx: Arc<Context>,
+        policy: SignedPolicySGX,
+        key_manager: Namespace,
+        use_latest_state: bool,
+    ) -> Result<SignedPolicySGX> {
+        let published_policy = self.key_manager_policy(ctx, key_manager, use_latest_state)?;
+
+        if policy != published_policy {
+            debug!(
+                self.logger,
+                "key manager policy mismatch";
+                "untrusted" => ?policy,
+                "published" => ?published_policy,
+            );
+            return Err(PolicyVerifierError::PolicyNotPublished.into());
+        }
+
+        Ok(published_policy)
+    }
+}

--- a/runtime/src/protocol.rs
+++ b/runtime/src/protocol.rs
@@ -380,6 +380,7 @@ impl Protocol {
             | Body::RuntimeCheckTxBatchRequest { .. }
             | Body::RuntimeExecuteTxBatchRequest { .. }
             | Body::RuntimeKeyManagerPolicyUpdateRequest { .. }
+            | Body::RuntimeKeyManagerQuotePolicyUpdateRequest { .. }
             | Body::RuntimeQueryRequest { .. }
             | Body::RuntimeConsensusSyncRequest { .. } => {
                 self.ensure_initialized()?;

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -320,11 +320,23 @@ pub struct RuntimeInfoRequest {
 }
 
 /// Set of supported runtime features.
-#[derive(Clone, Debug, Default, cbor::Encode, cbor::Decode)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct Features {
     /// Schedule control feature.
     #[cbor(optional)]
     pub schedule_control: Option<FeatureScheduleControl>,
+    /// A feature specifying that the runtime supports updating key manager's quote policy.
+    #[cbor(optional)]
+    pub key_manager_quote_policy_updates: bool,
+}
+
+impl Default for Features {
+    fn default() -> Self {
+        Self {
+            schedule_control: None,
+            key_manager_quote_policy_updates: true,
+        }
+    }
 }
 
 /// A feature specifying that the runtime supports controlling the scheduling of batches. This means

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -10,7 +10,7 @@ use crate::{
             signature::{PublicKey, Signature},
         },
         namespace::Namespace,
-        sgx::{ias::AVR, Quote},
+        sgx::{ias::AVR, Quote, QuotePolicy},
         version::Version,
     },
     consensus::{
@@ -187,6 +187,10 @@ pub enum Body {
         signed_policy_raw: Vec<u8>,
     },
     RuntimeKeyManagerPolicyUpdateResponse {},
+    RuntimeKeyManagerQuotePolicyUpdateRequest {
+        policy: QuotePolicy,
+    },
+    RuntimeKeyManagerQuotePolicyUpdateResponse {},
     RuntimeQueryRequest {
         consensus_block: LightBlock,
         header: Header,

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -426,6 +426,7 @@ pub fn main_with_version(version: Version) {
                 schedule_control: Some(FeatureScheduleControl {
                     initial_batch_size: MAX_BATCH_SIZE.try_into().unwrap(),
                 }),
+                ..Default::default()
             }),
             freshness_proofs: true,
             ..Default::default()

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -380,9 +380,9 @@ pub fn main_with_version(version: Version) {
         #[cfg(target_env = "sgx")]
         state
             .rpc_dispatcher
-            .set_keymanager_policy_update_handler(Some(Box::new(move |raw_signed_policy| {
+            .set_keymanager_policy_update_handler(Some(Box::new(move |policy| {
                 key_manager
-                    .set_policy(raw_signed_policy)
+                    .set_policy(policy)
                     .expect("failed to update km client policy");
             })));
 

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -376,15 +376,23 @@ pub fn main_with_version(version: Version) {
         ));
 
         #[cfg(target_env = "sgx")]
-        let key_manager = km_client.clone();
-        #[cfg(target_env = "sgx")]
-        state
-            .rpc_dispatcher
-            .set_keymanager_policy_update_handler(Some(Box::new(move |policy| {
-                key_manager
-                    .set_policy(policy)
-                    .expect("failed to update km client policy");
-            })));
+        {
+            let key_manager = km_client.clone();
+            state
+                .rpc_dispatcher
+                .set_keymanager_policy_update_handler(Some(Box::new(move |policy| {
+                    key_manager
+                        .set_policy(policy)
+                        .expect("failed to update km client policy");
+                })));
+
+            let key_manager = km_client.clone();
+            state
+                .rpc_dispatcher
+                .set_keymanager_quote_policy_update_handler(Some(Box::new(move |policy| {
+                    key_manager.set_quote_policy(policy);
+                })));
+        }
 
         let dispatcher = Dispatcher::new(hi, km_client, state.consensus_verifier.clone());
 


### PR DESCRIPTION
Currently EnclaveRPC session establishment always uses the default quote verification policy to verify quotes. When the runtime is configured with a consensus layer trust root it could instead use the quote verification policy specified in the consensus layer for the key manager runtime.

How things work:
- RPC remote client starts with empty enclaves, without key manager quote policy and waits for them to be set and regularly updated via local rpc calls.
- Demux uses no enclaves (enclaves authorization is checked at the application level) and local RAK quote policy which might be empty until TEE attestation is finished. Note that compute runtimes use their own quote policy in the demux and not from the key manager, but that should be fine as they currently never use demux.