### PR TITLE
[BACKPORT/22.2.x] go/runtime/registry: Fix watching policy updates

### DIFF
--- a/.changelog/5092.bugfix.md
+++ b/.changelog/5092.bugfix.md
@@ -1,0 +1,5 @@
+go/runtime/registry: Fix watching policy updates
+
+When multiple key managers were running, the last known status of the
+runtime's key manager was overwritten with each status update. On runtime
+(re)starts, this resulted in the wrong policy being set.

--- a/go/runtime/registry/host.go
+++ b/go/runtime/registry/host.go
@@ -491,12 +491,13 @@ func (n *runtimeHostNotifier) watchPolicyUpdates() {
 				)
 				continue
 			}
-		case st = <-stCh:
+		case newSt := <-stCh:
 			// Ignore status updates if key manager is not yet known (is nil)
 			// or if the status update is for a different key manager.
-			if rtDsc == nil || !st.ID.Equal(rtDsc.KeyManager) {
+			if rtDsc == nil || !newSt.ID.Equal(rtDsc.KeyManager) {
 				continue
 			}
+			st = newSt
 		case ev := <-evCh:
 			// Runtime host changes, make sure to update the policy if runtime is restarted.
 			if ev.Started == nil && ev.Updated == nil {


### PR DESCRIPTION
Backport of https://github.com/oasisprotocol/oasis-core/pull/5092 (bugfix commit).