### PR TITLE
runtime/src/protocol: Deserialize unknown rhp messages as invalid

### DIFF
--- a/.changelog/5094.internal.md
+++ b/.changelog/5094.internal.md
@@ -1,0 +1,6 @@
+runtime/src/protocol: Deserialize unknown rhp messages as invalid
+
+Runtime-host protocol terminated the reader thread when failed to deserialize
+a runtime message on the Rust side (e.g. when `Body` enum contained an unknown
+field). Decoding is now more robust as these messages are deserialized as
+invalid and latter discarded and logged as malformed by the handler.


### PR DESCRIPTION
Before:
```
{"err":"unknown field","level":"error","module":"runtime/protocol","msg":"Failed to handle message","runtime_id":"c000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff","runtime_name":"test-runtime","ts":"2022-12-10T14:02:38.449464523Z"}
{"level":"info","module":"runtime/protocol","msg":"Protocol reader thread is terminating","runtime_id":"c000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff","runtime_name":"test-runtime","ts":"2022-12-10T14:02:38.449491013Z"}
```
After:
```
{"err":"unknown field","level":"warn","module":"runtime/protocol","msg":"Unable to decode message","runtime_id":"c000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff","runtime_name":"test-runtime","ts":"2022-12-10T13:59:20.76384491Z"}
{"bytes":"[163, 98, 105, 100, 2, 100, 98, 111, 100, 121, 161, 120, 26, 82, 117, 110, 116, 105, 109, 101, 76, 111, 99, 97, 108, 82, 80, 67, 67, 97, 108, 108, 82, 101, 11
3, 117, 101, 115, 116, 161, 103, 114, 101, 113, 117, 101, 115, 116, 88, 51, 162, 100, 97, 114, 103, 115, 163, 102, 112, 111, 108, 105, 99, 121, 64, 104, 99, 104, 101, 9
9, 107, 115, 117, 109, 64, 108, 109, 97, 121, 95, 103, 101, 110, 101, 114, 97, 116, 101, 245, 102, 109, 101, 116, 104, 111, 100, 100, 105, 110, 105, 116, 108, 109, 101,
 115, 115, 97, 103, 101, 95, 116, 121, 112, 101, 1]","level":"debug","module":"runtime/protocol","msg":"Malformed message","runtime_id":"c000000000000000fffffffffffffffff
fffffffffffffffffffffffffffffff","runtime_name":"test-runtime","ts":"2022-12-10T13:59:20.76387489Z"}
{"level":"warn","module":"runtime/protocol","msg":"Received a malformed message","runtime_id":"c000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff","runtime_name":"test-runtime","ts":"2022-12-10T13:59:20.763938823Z"}
```