### PR TITLE
[BACKPORT/22.2.x] runtime/src/protocol: Deserialize unknown rhp messages as invalid

### DIFF
--- a/.changelog/5094.internal.md
+++ b/.changelog/5094.internal.md
@@ -1,0 +1,6 @@
+runtime/src/protocol: Deserialize unknown rhp messages as invalid
+
+Runtime-host protocol terminated the reader thread when failed to deserialize
+a runtime message on the Rust side (e.g. when `Body` enum contained an unknown
+field). Decoding is now more robust as these messages are deserialized as
+invalid and latter discarded and logged as malformed by the handler.


### PR DESCRIPTION
Backport [5094](https://github.com/oasisprotocol/oasis-core/pull/5094).