### PR TITLE
go/runtime/host/sgx: Fix SGX device search order

### DIFF
--- a/.changelog/5098.trivial.md
+++ b/.changelog/5098.trivial.md
@@ -1,0 +1,1 @@
+go/runtime/host/sgx: Fix SGX device search order

--- a/go/runtime/host/sgx/sgx.go
+++ b/go/runtime/host/sgx/sgx.go
@@ -193,7 +193,7 @@ func (s *sgxProvisioner) loadEnclaveBinaries(rtCfg host.Config) ([]byte, []byte,
 func (s *sgxProvisioner) discoverSGXDevice() (string, error) {
 	// Different versions of Intel SGX drivers provide different names for
 	// the SGX device.  Autodetect which one actually exists.
-	sgxDevices := []string{"/dev/sgx", "/dev/sgx/enclave", "/dev/sgx_enclave", "/dev/isgx"}
+	sgxDevices := []string{"/dev/sgx_enclave", "/dev/sgx/enclave", "/dev/sgx", "/dev/isgx"}
 	for _, dev := range sgxDevices {
 		fi, err := os.Stat(dev)
 		if err != nil {


### PR DESCRIPTION
This changes the SGX device search order in the runtime host to prefer the latest mainline SGX driver.