### PR TITLE
keymanager/src/runtime: Remove redundant public key options

### DIFF
--- a/keymanager/src/client/interface.rs
+++ b/keymanager/src/client/interface.rs
@@ -34,7 +34,7 @@ pub trait KeyManagerClient: Send + Sync {
         &self,
         ctx: Context,
         key_pair_id: KeyPairId,
-    ) -> BoxFuture<Result<Option<SignedPublicKey>, KeyManagerError>>;
+    ) -> BoxFuture<Result<SignedPublicKey, KeyManagerError>>;
 
     /// Get or create named ephemeral key pair for given epoch.
     ///
@@ -54,7 +54,7 @@ pub trait KeyManagerClient: Send + Sync {
         ctx: Context,
         key_pair_id: KeyPairId,
         epoch: EpochTime,
-    ) -> BoxFuture<Result<Option<SignedPublicKey>, KeyManagerError>>;
+    ) -> BoxFuture<Result<SignedPublicKey, KeyManagerError>>;
 
     /// Get a copy of the master secret for replication.
     fn replicate_master_secret(
@@ -80,7 +80,7 @@ impl<T: ?Sized + KeyManagerClient> KeyManagerClient for Arc<T> {
         &self,
         ctx: Context,
         key_pair_id: KeyPairId,
-    ) -> BoxFuture<Result<Option<SignedPublicKey>, KeyManagerError>> {
+    ) -> BoxFuture<Result<SignedPublicKey, KeyManagerError>> {
         KeyManagerClient::get_public_key(&**self, ctx, key_pair_id)
     }
 
@@ -98,7 +98,7 @@ impl<T: ?Sized + KeyManagerClient> KeyManagerClient for Arc<T> {
         ctx: Context,
         key_pair_id: KeyPairId,
         epoch: EpochTime,
-    ) -> BoxFuture<Result<Option<SignedPublicKey>, KeyManagerError>> {
+    ) -> BoxFuture<Result<SignedPublicKey, KeyManagerError>> {
         KeyManagerClient::get_public_ephemeral_key(&**self, ctx, key_pair_id, epoch)
     }
 

--- a/keymanager/src/client/mock.rs
+++ b/keymanager/src/client/mock.rs
@@ -52,13 +52,13 @@ impl KeyManagerClient for MockClient {
         &self,
         ctx: Context,
         key_pair_id: KeyPairId,
-    ) -> BoxFuture<Result<Option<SignedPublicKey>, KeyManagerError>> {
+    ) -> BoxFuture<Result<SignedPublicKey, KeyManagerError>> {
         Box::pin(self.get_or_create_keys(ctx, key_pair_id).and_then(|ck| {
-            future::ok(Some(SignedPublicKey {
+            future::ok(SignedPublicKey {
                 key: ck.input_keypair.pk,
                 checksum: vec![],
                 signature: Signature::default(),
-            }))
+            })
         }))
     }
 
@@ -82,15 +82,15 @@ impl KeyManagerClient for MockClient {
         ctx: Context,
         key_pair_id: KeyPairId,
         epoch: EpochTime,
-    ) -> BoxFuture<Result<Option<SignedPublicKey>, KeyManagerError>> {
+    ) -> BoxFuture<Result<SignedPublicKey, KeyManagerError>> {
         Box::pin(
             self.get_or_create_ephemeral_keys(ctx, key_pair_id, epoch)
                 .and_then(|ck| {
-                    future::ok(Some(SignedPublicKey {
+                    future::ok(SignedPublicKey {
                         key: ck.input_keypair.pk,
                         checksum: vec![],
                         signature: Signature::default(),
-                    }))
+                    })
                 }),
         )
     }

--- a/keymanager/src/client/remote.rs
+++ b/keymanager/src/client/remote.rs
@@ -222,10 +222,10 @@ impl KeyManagerClient for RemoteClient {
         &self,
         ctx: Context,
         key_pair_id: KeyPairId,
-    ) -> BoxFuture<Result<Option<SignedPublicKey>, KeyManagerError>> {
+    ) -> BoxFuture<Result<SignedPublicKey, KeyManagerError>> {
         let mut cache = self.inner.public_key_cache.write().unwrap();
         if let Some(key) = cache.get(&(key_pair_id, None)) {
-            return Box::pin(future::ok(Some(key.clone())));
+            return Box::pin(future::ok(key.clone()));
         }
 
         // No entry in cache, fetch from key manager.
@@ -236,7 +236,7 @@ impl KeyManagerClient for RemoteClient {
                 .latest_height()
                 .map_err(|err| KeyManagerError::Other(err.into()))?;
 
-            let key: Option<SignedPublicKey> = inner
+            let key: SignedPublicKey = inner
                 .rpc_client
                 .call(
                     ctx,
@@ -246,16 +246,11 @@ impl KeyManagerClient for RemoteClient {
                 .await
                 .map_err(|err| KeyManagerError::Other(err.into()))?;
 
-            match key {
-                Some(key) => {
-                    // Cache key.
-                    let mut cache = inner.public_key_cache.write().unwrap();
-                    cache.put((key_pair_id, None), key.clone());
+            // Cache key.
+            let mut cache = inner.public_key_cache.write().unwrap();
+            cache.put((key_pair_id, None), key.clone());
 
-                    Ok(Some(key))
-                }
-                None => Ok(None),
-            }
+            Ok(key)
         })
     }
 
@@ -301,10 +296,10 @@ impl KeyManagerClient for RemoteClient {
         ctx: Context,
         key_pair_id: KeyPairId,
         epoch: EpochTime,
-    ) -> BoxFuture<Result<Option<SignedPublicKey>, KeyManagerError>> {
+    ) -> BoxFuture<Result<SignedPublicKey, KeyManagerError>> {
         let mut cache = self.inner.public_key_cache.write().unwrap();
         if let Some(key) = cache.get(&(key_pair_id, Some(epoch))) {
-            return Box::pin(future::ok(Some(key.clone())));
+            return Box::pin(future::ok(key.clone()));
         }
 
         // No entry in cache, fetch from key manager.
@@ -315,7 +310,7 @@ impl KeyManagerClient for RemoteClient {
                 .latest_height()
                 .map_err(|err| KeyManagerError::Other(err.into()))?;
 
-            let key: Option<SignedPublicKey> = inner
+            let key: SignedPublicKey = inner
                 .rpc_client
                 .call(
                     ctx,
@@ -325,16 +320,11 @@ impl KeyManagerClient for RemoteClient {
                 .await
                 .map_err(|err| KeyManagerError::Other(err.into()))?;
 
-            match key {
-                Some(key) => {
-                    // Cache key.
-                    let mut cache = inner.public_key_cache.write().unwrap();
-                    cache.put((key_pair_id, Some(epoch)), key.clone());
+            // Cache key.
+            let mut cache = inner.public_key_cache.write().unwrap();
+            cache.put((key_pair_id, Some(epoch)), key.clone());
 
-                    Ok(Some(key))
-                }
-                None => Ok(None),
-            }
+            Ok(key)
         })
     }
 

--- a/keymanager/src/crypto/kdf.rs
+++ b/keymanager/src/crypto/kdf.rs
@@ -420,9 +420,9 @@ impl Kdf {
     }
 
     /// Get the public part of the key.
-    pub fn get_public_key(&self, req: &impl KeyRequest) -> Result<Option<PublicKey>> {
+    pub fn get_public_key(&self, req: &impl KeyRequest) -> Result<PublicKey> {
         let keys = self.get_or_create_keys(req)?;
-        Ok(Some(keys.input_keypair.pk))
+        Ok(keys.input_keypair.pk)
     }
 
     /// Signs the public key using the key manager key.
@@ -656,10 +656,7 @@ mod tests {
             .get_or_create_keys(&req)
             .expect("private key should be created");
 
-        let pk = kdf
-            .get_public_key(&req)
-            .unwrap()
-            .expect("public key should be fetched");
+        let pk = kdf.get_public_key(&req).unwrap();
 
         assert_eq!(sk.input_keypair.pk, pk);
     }

--- a/keymanager/src/runtime/methods.rs
+++ b/keymanager/src/runtime/methods.rs
@@ -34,16 +34,14 @@ pub fn get_or_create_keys(req: &LongTermKeyRequest, ctx: &mut RpcContext) -> Res
 }
 
 /// See `Kdf::get_public_key`.
-pub fn get_public_key(
-    req: &LongTermKeyRequest,
-    _ctx: &mut RpcContext,
-) -> Result<Option<SignedPublicKey>> {
+pub fn get_public_key(req: &LongTermKeyRequest, _ctx: &mut RpcContext) -> Result<SignedPublicKey> {
     // No authentication or authorization.
     // Absolutely anyone is allowed to query public long-term keys.
 
     let kdf = Kdf::global();
     let pk = kdf.get_public_key(req)?;
-    pk.map_or(Ok(None), |pk| Ok(Some(kdf.sign_public_key(pk)?)))
+    let sig = kdf.sign_public_key(pk)?;
+    Ok(sig)
 }
 
 /// See `Kdf::get_or_create_keys`.
@@ -62,14 +60,15 @@ pub fn get_or_create_ephemeral_keys(
 pub fn get_public_ephemeral_key(
     req: &EphemeralKeyRequest,
     ctx: &mut RpcContext,
-) -> Result<Option<SignedPublicKey>> {
+) -> Result<SignedPublicKey> {
     // No authentication or authorization.
     // Absolutely anyone is allowed to query public ephemeral keys.
     validate_epoch(req.epoch, ctx)?;
 
     let kdf = Kdf::global();
     let pk = kdf.get_public_key(req)?;
-    pk.map_or(Ok(None), |pk| Ok(Some(kdf.sign_public_key(pk)?)))
+    let sig = kdf.sign_public_key(pk)?;
+    Ok(sig)
 }
 
 /// See `Kdf::replicate_master_secret`.

--- a/tests/runtimes/simple-keyvalue/src/methods.rs
+++ b/tests/runtimes/simple-keyvalue/src/methods.rs
@@ -374,8 +374,7 @@ impl Methods {
                 .get_public_ephemeral_key(io_ctx, key_pair_id, args.epoch);
         let long_term_pk = tokio::runtime::Handle::current()
             .block_on(result)
-            .map_err(|err| err.to_string())?
-            .ok_or("public ephemeral key not available")?;
+            .map_err(|err| err.to_string())?;
 
         // Generate ephemeral key. Not secure, but good enough for testing purposes.
         let ephemeral_sk = x25519_dalek::StaticSecret::from(hash);


### PR DESCRIPTION
Unwrapping public key from key manager requests.