### PR TITLE
keymanager/src/client: Fetch public keys using insecure RPC requests

### DIFF
--- a/.changelog/5101.feature.md
+++ b/.changelog/5101.feature.md
@@ -1,0 +1,1 @@
+keymanager/src/client: Fetch public keys using insecure RPC requests

--- a/go/consensus/tendermint/apps/keymanager/state/interop/interop.go
+++ b/go/consensus/tendermint/apps/keymanager/state/interop/interop.go
@@ -104,6 +104,7 @@ func InitializeTestKeyManagerState(ctx context.Context, mkvs mkvs.Tree) error {
 			Checksum:      nil,
 			Nodes:         nil,
 			Policy:        nil,
+			RSK:           nil,
 		},
 		{
 			ID:            keymanager2,
@@ -115,6 +116,7 @@ func InitializeTestKeyManagerState(ctx context.Context, mkvs mkvs.Tree) error {
 				signers[1].Public(),
 			},
 			Policy: &sigPolicy,
+			RSK:    nil,
 		},
 	} {
 		if err := state.SetStatus(ctx, status); err != nil {

--- a/go/keymanager/api/api.go
+++ b/go/keymanager/api/api.go
@@ -72,6 +72,9 @@ type Status struct {
 
 	// Policy is the key manager policy.
 	Policy *SignedPolicySGX `json:"policy"`
+
+	// RSK is the runtime signing key of the key manager.
+	RSK *signature.PublicKey `json:"rsk,omitempty"`
 }
 
 // Backend is a key manager management implementation.
@@ -100,9 +103,10 @@ func NewUpdatePolicyTx(nonce uint64, fee *transaction.Fee, sigPol *SignedPolicyS
 // InitResponse is the initialization RPC response, returned as part of a
 // SignedInitResponse from the key manager enclave.
 type InitResponse struct {
-	IsSecure       bool   `json:"is_secure"`
-	Checksum       []byte `json:"checksum"`
-	PolicyChecksum []byte `json:"policy_checksum"`
+	IsSecure       bool                 `json:"is_secure"`
+	Checksum       []byte               `json:"checksum"`
+	PolicyChecksum []byte               `json:"policy_checksum"`
+	RSK            *signature.PublicKey `json:"rsk,omitempty"`
 }
 
 // SignedInitResponse is the signed initialization RPC response, returned

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -16,6 +16,7 @@ import (
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	consensusTx "github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	consensusResults "github.com/oasisprotocol/oasis-core/go/consensus/api/transaction/results"
+	keymanager "github.com/oasisprotocol/oasis-core/go/keymanager/api"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
@@ -89,6 +90,8 @@ type Body struct {
 	RuntimeExecuteTxBatchResponse              *RuntimeExecuteTxBatchResponse             `json:",omitempty"`
 	RuntimeAbortRequest                        *Empty                                     `json:",omitempty"`
 	RuntimeAbortResponse                       *Empty                                     `json:",omitempty"`
+	RuntimeKeyManagerStatusUpdateRequest       *RuntimeKeyManagerStatusUpdateRequest      `json:",omitempty"`
+	RuntimeKeyManagerStatusUpdateResponse      *Empty                                     `json:",omitempty"`
 	RuntimeKeyManagerPolicyUpdateRequest       *RuntimeKeyManagerPolicyUpdateRequest      `json:",omitempty"`
 	RuntimeKeyManagerPolicyUpdateResponse      *Empty                                     `json:",omitempty"`
 	RuntimeKeyManagerQuotePolicyUpdateRequest  *RuntimeKeyManagerQuotePolicyUpdateRequest `json:",omitempty"`
@@ -174,6 +177,9 @@ type Features struct {
 	// KeyManagerQuotePolicyUpdates is a feature specifying that the runtime supports updating
 	// key manager's quote policy.
 	KeyManagerQuotePolicyUpdates bool `json:"key_manager_quote_policy_updates,omitempty"`
+	// KeyManagerStatusUpdates is a feature specifying that the runtime supports updating
+	// key manager's status.
+	KeyManagerStatusUpdates bool `json:"key_manager_status_updates,omitempty"`
 }
 
 // HasScheduleControl returns true when the runtime supports the schedule control feature.
@@ -402,12 +408,17 @@ type RuntimeExecuteTxBatchResponse struct {
 	Deprecated1 cbor.RawMessage `json:"batch_weight_limits,omitempty"`
 }
 
-// RuntimeKeyManagerPolicyUpdateRequest is a runtime key manager policy request message body.
+// RuntimeKeyManagerStatusUpdateRequest is a runtime key manager status update request message body.
+type RuntimeKeyManagerStatusUpdateRequest struct {
+	Status keymanager.Status `json:"status"`
+}
+
+// RuntimeKeyManagerPolicyUpdateRequest is a runtime key manager policy update request message body.
 type RuntimeKeyManagerPolicyUpdateRequest struct {
 	SignedPolicyRaw []byte `json:"signed_policy_raw"`
 }
 
-// RuntimeKeyManagerQuotePolicyUpdateRequest is a runtime key manager quote policy request
+// RuntimeKeyManagerQuotePolicyUpdateRequest is a runtime key manager quote policy update request
 // message body.
 type RuntimeKeyManagerQuotePolicyUpdateRequest struct {
 	Policy quote.Policy `json:"policy"`

--- a/keymanager/src/api/errors.rs
+++ b/keymanager/src/api/errors.rs
@@ -27,6 +27,10 @@ pub enum KeyManagerError {
     PolicyInvalid(#[from] anyhow::Error),
     #[error("policy has insufficient signatures")]
     PolicyInsufficientSignatures,
+    #[error("runtime signing key missing")]
+    RSKMissing,
+    #[error("signature verification failed: {0}")]
+    InvalidSignature(anyhow::Error),
     #[error(transparent)]
     Other(anyhow::Error),
 }

--- a/keymanager/src/api/requests.rs
+++ b/keymanager/src/api/requests.rs
@@ -1,5 +1,8 @@
 use oasis_core_runtime::{
-    common::{crypto::signature::Signature, namespace::Namespace},
+    common::{
+        crypto::signature::{PublicKey, Signature},
+        namespace::Namespace,
+    },
     consensus::beacon::EpochTime,
 };
 
@@ -17,7 +20,7 @@ pub struct InitRequest {
 }
 
 /// Key manager initialization response.
-#[derive(Clone, Default, cbor::Encode, cbor::Decode)]
+#[derive(Clone, Default, Debug, cbor::Encode, cbor::Decode)]
 pub struct InitResponse {
     /// True iff the key manager thinks it's running in a secure mode.
     pub is_secure: bool,
@@ -25,6 +28,8 @@ pub struct InitResponse {
     pub checksum: Vec<u8>,
     /// Checksum for identifying policy.
     pub policy_checksum: Vec<u8>,
+    /// Runtime signing key.
+    pub rsk: PublicKey,
 }
 
 /// Signed InitResponse.

--- a/keymanager/src/client/mock.rs
+++ b/keymanager/src/client/mock.rs
@@ -58,6 +58,7 @@ impl KeyManagerClient for MockClient {
                 key: ck.input_keypair.pk,
                 checksum: vec![],
                 signature: Signature::default(),
+                expiration: None,
             })
         }))
     }
@@ -90,6 +91,7 @@ impl KeyManagerClient for MockClient {
                         key: ck.input_keypair.pk,
                         checksum: vec![],
                         signature: Signature::default(),
+                        expiration: None,
                     })
                 }),
         )

--- a/runtime/src/consensus/state/keymanager.rs
+++ b/runtime/src/consensus/state/keymanager.rs
@@ -42,6 +42,8 @@ pub struct Status {
     pub nodes: Vec<PublicKey>,
     /// Key manager policy.
     pub policy: Option<SignedPolicySGX>,
+    /// Runtime signing key of the key manager.
+    pub rsk: Option<PublicKey>,
 }
 
 impl<'a, T: ImmutableMKVS> ImmutableState<'a, T> {
@@ -172,6 +174,7 @@ mod test {
                 checksum: vec![],
                 nodes: vec![],
                 policy: None,
+                rsk: None,
             },
             Status {
                 id: keymanager2,
@@ -202,6 +205,7 @@ mod test {
                         },
                     ],
                 }),
+                rsk: None,
             },
         ];
 

--- a/runtime/src/protocol.rs
+++ b/runtime/src/protocol.rs
@@ -379,7 +379,7 @@ impl Protocol {
             | Body::RuntimeLocalRPCCallRequest { .. }
             | Body::RuntimeCheckTxBatchRequest { .. }
             | Body::RuntimeExecuteTxBatchRequest { .. }
-            | Body::RuntimeKeyManagerPolicyUpdateRequest { .. }
+            | Body::RuntimeKeyManagerStatusUpdateRequest { .. }
             | Body::RuntimeKeyManagerQuotePolicyUpdateRequest { .. }
             | Body::RuntimeQueryRequest { .. }
             | Body::RuntimeConsensusSyncRequest { .. } => {

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -17,6 +17,7 @@ use crate::{
         self,
         beacon::EpochTime,
         roothash::{self, Block, ComputeResultsHeader, Header},
+        state::keymanager::Status as KeyManagerStatus,
         transaction::{Proof, SignedTransaction},
         LightBlock,
     },
@@ -184,10 +185,10 @@ pub enum Body {
         tx_input_root: Hash,
         tx_input_write_log: WriteLog,
     },
-    RuntimeKeyManagerPolicyUpdateRequest {
-        signed_policy_raw: Vec<u8>,
+    RuntimeKeyManagerStatusUpdateRequest {
+        status: KeyManagerStatus,
     },
-    RuntimeKeyManagerPolicyUpdateResponse {},
+    RuntimeKeyManagerStatusUpdateResponse {},
     RuntimeKeyManagerQuotePolicyUpdateRequest {
         policy: QuotePolicy,
     },
@@ -330,6 +331,9 @@ pub struct Features {
     /// A feature specifying that the runtime supports updating key manager's quote policy.
     #[cbor(optional)]
     pub key_manager_quote_policy_updates: bool,
+    /// A feature specifying that the runtime supports updating key manager's status.
+    #[cbor(optional)]
+    pub key_manager_status_updates: bool,
 }
 
 impl Default for Features {
@@ -337,6 +341,7 @@ impl Default for Features {
         Self {
             schedule_control: None,
             key_manager_quote_policy_updates: true,
+            key_manager_status_updates: true,
         }
     }
 }

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -375,17 +375,17 @@ pub fn main_with_version(version: Version) {
             trusted_policy_signers(),
         ));
 
+        let key_manager = km_client.clone();
+        state
+            .rpc_dispatcher
+            .set_keymanager_status_update_handler(Some(Box::new(move |status| {
+                key_manager
+                    .set_status(status)
+                    .expect("failed to update km client status");
+            })));
+
         #[cfg(target_env = "sgx")]
         {
-            let key_manager = km_client.clone();
-            state
-                .rpc_dispatcher
-                .set_keymanager_policy_update_handler(Some(Box::new(move |policy| {
-                    key_manager
-                        .set_policy(policy)
-                        .expect("failed to update km client policy");
-                })));
-
             let key_manager = km_client.clone();
             state
                 .rpc_dispatcher


### PR DESCRIPTION
### Task
Fetch and verify public long-term/ephemeral runtime keys through an insecure channel.
        
### Test
Key manager upgrade tested locally with e2e test. Upgrade works as we allow empty runtime signing keys. An alternative would be to be strict here, but then one key manager would not be included in the node list because of the `Runtime signing key mismatch for runtime` error. Not sure if this is a problem though, as the new manager will be added to the list as soon as the old one is deregistered.
