### PR TITLE
go/consensus: add missing 'IsSimulation' checks in some transactions

### DIFF
--- a/.changelog/5104.feature.md
+++ b/.changelog/5104.feature.md
@@ -1,0 +1,4 @@
+go/consensus: Add missing early exits when simulating transactions
+
+Some transactions were missing the early exit after gas accounting when
+simulating transactions.

--- a/go/consensus/tendermint/apps/governance/transactions.go
+++ b/go/consensus/tendermint/apps/governance/transactions.go
@@ -54,6 +54,11 @@ func (app *governanceApplication) submitProposal(
 		return nil, err
 	}
 
+	// Return early if simulating since this is just estimating gas.
+	if ctx.IsSimulation() {
+		return nil, nil
+	}
+
 	// Load submitter account.
 	submitterAddr := stakingAPI.NewAddress(ctx.TxSigner())
 	if !submitterAddr.IsValid() {
@@ -227,6 +232,11 @@ func (app *governanceApplication) castVote(
 	// Charge gas for this transaction.
 	if err = ctx.Gas().UseGas(1, governance.GasOpCastVote, params.GasCosts); err != nil {
 		return err
+	}
+
+	// Return early if simulating since this is just estimating gas.
+	if ctx.IsSimulation() {
+		return nil
 	}
 
 	submitterAddr := stakingAPI.NewAddress(ctx.TxSigner())

--- a/go/consensus/tendermint/apps/keymanager/transactions.go
+++ b/go/consensus/tendermint/apps/keymanager/transactions.go
@@ -61,6 +61,11 @@ func (app *keymanagerApplication) updatePolicy(
 		return err
 	}
 
+	// Return early if simulating since this is just estimating gas.
+	if ctx.IsSimulation() {
+		return nil
+	}
+
 	// Ok, as far as we can tell the new policy is valid, apply it.
 	//
 	// Note: The key manager cohort responsible for servicing this ID

--- a/go/consensus/tendermint/apps/registry/transactions.go
+++ b/go/consensus/tendermint/apps/registry/transactions.go
@@ -45,6 +45,11 @@ func (app *registryApplication) registerEntity(
 		return err
 	}
 
+	// Return early if simulating since this is just estimating gas.
+	if ctx.IsSimulation() {
+		return nil
+	}
+
 	// Make sure the signer of the transaction matches the signer of the entity.
 	// NOTE: If this is invoked during InitChain then there is no actual transaction
 	//       and thus no transaction signer so we must skip this check.
@@ -97,6 +102,11 @@ func (app *registryApplication) deregisterEntity(ctx *api.Context, state *regist
 	}
 	if err = ctx.Gas().UseGas(1, registry.GasOpDeregisterEntity, params.GasCosts); err != nil {
 		return err
+	}
+
+	// Return early if simulating since this is just estimating gas.
+	if ctx.IsSimulation() {
+		return nil
 	}
 
 	id := ctx.TxSigner()
@@ -560,6 +570,11 @@ func (app *registryApplication) unfreezeNode(
 		return err
 	}
 
+	// Return early if simulating since this is just estimating gas.
+	if ctx.IsSimulation() {
+		return nil
+	}
+
 	// Fetch node descriptor.
 	node, err := state.Node(ctx, unfreeze.NodeID)
 	if err != nil {
@@ -652,6 +667,11 @@ func (app *registryApplication) registerRuntime( // nolint: gocyclo
 	// Charge gas for this transaction.
 	if err = ctx.Gas().UseGas(1, registry.GasOpRegisterRuntime, params.GasCosts); err != nil {
 		return nil, err
+	}
+
+	// Return early if simulating since this is just estimating gas.
+	if ctx.IsSimulation() {
+		return nil, nil
 	}
 
 	// Make sure the runtime doesn't exist yet.


### PR DESCRIPTION
I think we can exit early in some places when estimating gas (all other transactions do already have this check after gas accounting is done).