### PR TITLE
go/consensus: Ensure state has the correct chain context

### DIFF
--- a/.changelog/5107.bugfix.md
+++ b/.changelog/5107.bugfix.md
@@ -1,0 +1,7 @@
+go/consensus: Ensure state has the correct chain context
+
+Previously one could accidentally copy state from one network but use a
+genesis document from a different one, causing state corruption during
+Tendermint block replay.
+
+There is now a check to ensure we abort early.

--- a/go/consensus/tendermint/full/archive.go
+++ b/go/consensus/tendermint/full/archive.go
@@ -172,6 +172,7 @@ func NewArchive(
 		// ReadOnly should actually be preferable for archive but there is a badger issue with read-only:
 		// https://discuss.dgraph.io/t/read-only-log-truncate-required-to-run-db/16444/2
 		ReadOnlyStorage: false,
+		ChainContext:    srv.genesis.ChainContext(),
 	}
 	srv.mux, err = abci.NewApplicationServer(srv.ctx, nil, appConfig)
 	if err != nil {

--- a/go/consensus/tendermint/full/full.go
+++ b/go/consensus/tendermint/full/full.go
@@ -615,6 +615,7 @@ func (t *fullService) lazyInit() error { // nolint: gocyclo
 		DisableCheckpointer:       viper.GetBool(CfgCheckpointerDisabled),
 		CheckpointerCheckInterval: viper.GetDuration(CfgCheckpointerCheckInterval),
 		InitialHeight:             uint64(t.genesis.Height),
+		ChainContext:              t.genesis.ChainContext(),
 	}
 	t.mux, err = abci.NewApplicationServer(t.ctx, t.upgrader, appConfig)
 	if err != nil {

--- a/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
+++ b/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
@@ -110,6 +110,7 @@ func doDumpDB(cmd *cobra.Command, args []string) {
 			MemoryOnlyStorage:   false,
 			ReadOnlyStorage:     viper.GetBool(cfgDumpReadOnlyDB),
 			DisableCheckpointer: true,
+			ChainContext:        oldDoc.ChainContext(),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Previously one could accidentally copy state from one network but use a genesis document from a different one, causing state corruption during Tendermint block replay.

There is now a check to ensure we abort early.