### PR TITLE
go/runtime/registry: Fix key manager (quote) policy updates

### DIFF
--- a/.changelog/5111.bugfix.md
+++ b/.changelog/5111.bugfix.md
@@ -1,0 +1,6 @@
+go/runtime/registry: Fix key manager (quote) policy updates
+
+When a key manager (quote) policy update fails, the host should retry the
+update until the policy is updated. For example, when using Tendermint as
+a backend service, the first update will always fail because the consensus
+verifier sees new blocks with a one-block delay.

--- a/keymanager/src/policy/cached.rs
+++ b/keymanager/src/policy/cached.rs
@@ -80,7 +80,6 @@ impl Policy {
             ioctx,
             untrusted_policy,
             key_manager,
-            false,
         )?;
         let new_policy = CachedPolicy::parse(published_policy, policy_raw)?;
 

--- a/runtime/src/attestation.rs
+++ b/runtime/src/attestation.rs
@@ -112,7 +112,6 @@ impl Handler {
                 ctx,
                 &self.runtime_id,
                 version,
-                true,
             )?;
 
             self.rak.set_quote_policy(policy)?;

--- a/runtime/src/dispatcher.rs
+++ b/runtime/src/dispatcher.rs
@@ -1022,14 +1022,12 @@ impl Dispatcher {
         let runtime_id = state.protocol.get_host_info().runtime_id;
         let key_manager = state
             .policy_verifier
-            .key_manager(ctx.clone(), &runtime_id, true)?;
+            .key_manager(ctx.clone(), &runtime_id)?;
         let untrusted_policy = cbor::from_slice(&signed_policy_raw).map_err(|err| anyhow!(err))?;
-        let published_policy = state.policy_verifier.verify_key_manager_policy(
-            ctx,
-            untrusted_policy,
-            key_manager,
-            false,
-        )?;
+        let published_policy =
+            state
+                .policy_verifier
+                .verify_key_manager_policy(ctx, untrusted_policy, key_manager)?;
 
         // Dispatch the local RPC call.
         state
@@ -1058,14 +1056,11 @@ impl Dispatcher {
         let runtime_id = state.protocol.get_host_info().runtime_id;
         let key_manager = state
             .policy_verifier
-            .key_manager(ctx.clone(), &runtime_id, true)?;
-        let policy = state.policy_verifier.verify_quote_policy(
-            ctx,
-            quote_policy,
-            &key_manager,
-            None,
-            false,
-        )?;
+            .key_manager(ctx.clone(), &runtime_id)?;
+        let policy =
+            state
+                .policy_verifier
+                .verify_quote_policy(ctx, quote_policy, &key_manager, None)?;
 
         // Dispatch the local RPC call.
         state.rpc_dispatcher.handle_km_quote_policy_update(policy);


### PR DESCRIPTION
### Problems
- Key manager (quote) policy updates don't work as expected as the consensus verifier will reject policy updates as his view of the state is one block behind the host. This is Tendermint specific and we should retry the update if it fails.
- Runtime info was also not updated if the runtime upgraded to a new version. As a consequence the quote policy was never updated, even if the new version supported this feature.

### Test
Retries can be tested by running `.buildkite/scripts/test_e2e.sh -s=e2e.runtime.keymanager-upgrade` on an SGX instance.

Before:
```
// Status update (reason: policy change)
{... "msg":"got key manager policy update","policy":{"policy":{"serial":2,...}}"}
{... "msg":"key manager policy mismatch","published":"SignedPolicySGX { policy: PolicySGX { serial: 1,...}}","untrusted":"SignedPolicySGX { policy: PolicySGX { serial: 2,...}}"}
{... "err":"policy hasn't been published","msg":"failed dispatching key manager policy update to runtime",...}
// ...
// Status update (reason: a new key manager node was added to the status)
{... "msg":"got key manager policy update","policy":{"policy":{"serial":2,...}}"}
{... "msg":"key manager policy update dispatched",...} // Policy changed!
```

After:
```
// Status update (reason: policy change)
{... "msg":"got key manager policy update","policy":{"policy":{"serial":2,...}}"}
{... "msg":"key manager policy mismatch","published":"SignedPolicySGX { policy: PolicySGX { serial: 1,...}}","untrusted":"SignedPolicySGX { policy: PolicySGX { serial: 2,...}}"}
{... "err":"policy hasn't been published","msg":"failed dispatching key manager policy update to runtime",...}
// Retry.
{... "msg":"got key manager policy update","policy":{"policy":{"serial":2,...}}"}
{... "msg":"key manager policy mismatch","published":"SignedPolicySGX { policy: PolicySGX { serial: 1,...}}","untrusted":"SignedPolicySGX { policy: PolicySGX { serial: 2,...}}"}
{... "err":"policy hasn't been published","msg":"failed dispatching key manager policy update to runtime",...}
// Retry.
{... "msg":"got key manager policy update","policy":{"policy":{"serial":2,...}}"}
{... "msg":"key manager policy update dispatched",...} // Policy changed!
// ...
// Status update (reason: a new key manager node was added to the status)
{... "msg":"got key manager policy update","policy":{"policy":{"serial":2,...}}"}
{... "msg":"key manager policy update dispatched",...} // Policy changed (no effect as policy was already up-to-date)!
```