### PR TITLE
go/registry: Add optional bundle checksum to runtime deployments

### DIFF
--- a/.changelog/5112.breaking.md
+++ b/.changelog/5112.breaking.md
@@ -1,0 +1,1 @@
+go/registry: Add optional bundle checksum to runtime deployments

--- a/go/consensus/tendermint/apps/registry/state/interop/interop.go
+++ b/go/consensus/tendermint/apps/registry/state/interop/interop.go
@@ -1,6 +1,7 @@
 package interop
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -137,9 +138,10 @@ func InitializeTestRegistryState(ctx context.Context, mkvs mkvs.Tree) error {
 				},
 				Deployments: []*registry.VersionInfo{
 					{
-						Version:   version.FromU64(123),
-						ValidFrom: 42,
-						TEE:       []byte{1, 2, 3, 4, 5},
+						Version:        version.FromU64(123),
+						ValidFrom:      42,
+						TEE:            []byte{1, 2, 3, 4, 5},
+						BundleChecksum: bytes.Repeat([]byte{0x05}, 32),
 					},
 					{
 						Version:   version.FromU64(120),

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -599,6 +599,11 @@ func (r *Runtime) ValidateDeployments(now beacon.EpochTime, params *ConsensusPar
 		default:
 			return fmt.Errorf("%w: invalid TEE hardware", ErrInvalidArgument)
 		}
+
+		// BundleChecksum should be a SHA256 hash if present.
+		if len(deployment.BundleChecksum) > 0 && len(deployment.BundleChecksum) != 32 {
+			return fmt.Errorf("%w: invalid bundle checksum", ErrInvalidArgument)
+		}
 	}
 	if numFuture > 1 {
 		return fmt.Errorf("%w: more than one future deployment", ErrInvalidArgument)
@@ -644,6 +649,9 @@ type VersionInfo struct {
 	// TEE is the enclave version information, in an enclave provider specific
 	// format if any.
 	TEE []byte `json:"tee,omitempty"`
+
+	// BundleChecksum is the SHA256 hash of the runtime bundle (optional).
+	BundleChecksum []byte `json:"bundle_checksum,omitempty"`
 }
 
 // Equal compares vs another VersionInfo for equality.
@@ -661,6 +669,9 @@ func (vi *VersionInfo) Equal(cmp *VersionInfo) bool {
 		return false
 	}
 	if !bytes.Equal(vi.TEE, cmp.TEE) {
+		return false
+	}
+	if !bytes.Equal(vi.BundleChecksum, cmp.BundleChecksum) {
 		return false
 	}
 	return true

--- a/go/registry/api/runtime_test.go
+++ b/go/registry/api/runtime_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -83,7 +84,8 @@ func TestRuntimeSerialization(t *testing.T) {
 						Minor: 0,
 						Patch: 1,
 					},
-					TEE: []byte("version tee"),
+					TEE:            []byte("version tee"),
+					BundleChecksum: bytes.Repeat([]byte{0x01}, 32),
 				},
 			},
 			KeyManager: &keymanagerID,
@@ -142,7 +144,7 @@ func TestRuntimeSerialization(t *testing.T) {
 				RewardSlashEquvocationRuntimePercent: 0,
 				MinInMessageFee:                      quantity.Quantity{},
 			},
-		}, "r2F2GCpiaWRYIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZGtpbmQCZ2dlbmVzaXOiZXJvdW5kGCtqc3RhdGVfcm9vdFggseUhAZ+3vd413IH+55BlYQy937jvXCXihJg2aBkqbQ1nc3Rha2luZ6FycmV3YXJkX2JhZF9yZXN1bHRzCmdzdG9yYWdlo3NjaGVja3BvaW50X2ludGVydmFsGCFzY2hlY2twb2ludF9udW1fa2VwdAZ1Y2hlY2twb2ludF9jaHVua19zaXplGGVoZXhlY3V0b3Koamdyb3VwX3NpemUJbG1heF9tZXNzYWdlcwVtcm91bmRfdGltZW91dAZxZ3JvdXBfYmFja3VwX3NpemUIcmFsbG93ZWRfc3RyYWdnbGVycwdybWF4X2xpdmVuZXNzX2ZhaWxzAnRtaW5fbGl2ZV9yb3VuZHNfZXZhbAN3bWluX2xpdmVfcm91bmRzX3BlcmNlbnQEaWVudGl0eV9pZFggEjRWeJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABrY29uc3RyYWludHOhAaEBo2ltYXhfbm9kZXOhZWxpbWl0Cm1taW5fcG9vbF9zaXploWVsaW1pdAVtdmFsaWRhdG9yX3NldKBrZGVwbG95bWVudHOBo2N0ZWVLdmVyc2lvbiB0ZWVndmVyc2lvbqJlbWFqb3IYLGVwYXRjaAFqdmFsaWRfZnJvbQBra2V5X21hbmFnZXJYIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABbHRlZV9oYXJkd2FyZQFtdHhuX3NjaGVkdWxlcqVubWF4X2JhdGNoX3NpemUZJxBvbWF4X2luX21lc3NhZ2VzGCBzYmF0Y2hfZmx1c2hfdGltZW91dBo7msoAdG1heF9iYXRjaF9zaXplX2J5dGVzGgCYloB1cHJvcG9zZV9iYXRjaF90aW1lb3V0AXBhZG1pc3Npb25fcG9saWN5oXBlbnRpdHlfd2hpdGVsaXN0oWhlbnRpdGllc6FYIBI0VniQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoWltYXhfbm9kZXOiAQMEAXBnb3Zlcm5hbmNlX21vZGVsAw=="},
+		}, "r2F2GCpiaWRYIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZGtpbmQCZ2dlbmVzaXOiZXJvdW5kGCtqc3RhdGVfcm9vdFggseUhAZ+3vd413IH+55BlYQy937jvXCXihJg2aBkqbQ1nc3Rha2luZ6FycmV3YXJkX2JhZF9yZXN1bHRzCmdzdG9yYWdlo3NjaGVja3BvaW50X2ludGVydmFsGCFzY2hlY2twb2ludF9udW1fa2VwdAZ1Y2hlY2twb2ludF9jaHVua19zaXplGGVoZXhlY3V0b3Koamdyb3VwX3NpemUJbG1heF9tZXNzYWdlcwVtcm91bmRfdGltZW91dAZxZ3JvdXBfYmFja3VwX3NpemUIcmFsbG93ZWRfc3RyYWdnbGVycwdybWF4X2xpdmVuZXNzX2ZhaWxzAnRtaW5fbGl2ZV9yb3VuZHNfZXZhbAN3bWluX2xpdmVfcm91bmRzX3BlcmNlbnQEaWVudGl0eV9pZFggEjRWeJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABrY29uc3RyYWludHOhAaEBo2ltYXhfbm9kZXOhZWxpbWl0Cm1taW5fcG9vbF9zaXploWVsaW1pdAVtdmFsaWRhdG9yX3NldKBrZGVwbG95bWVudHOBpGN0ZWVLdmVyc2lvbiB0ZWVndmVyc2lvbqJlbWFqb3IYLGVwYXRjaAFqdmFsaWRfZnJvbQBvYnVuZGxlX2NoZWNrc3VtWCABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAWtrZXlfbWFuYWdlclgggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFsdGVlX2hhcmR3YXJlAW10eG5fc2NoZWR1bGVypW5tYXhfYmF0Y2hfc2l6ZRknEG9tYXhfaW5fbWVzc2FnZXMYIHNiYXRjaF9mbHVzaF90aW1lb3V0GjuaygB0bWF4X2JhdGNoX3NpemVfYnl0ZXMaAJiWgHVwcm9wb3NlX2JhdGNoX3RpbWVvdXQBcGFkbWlzc2lvbl9wb2xpY3mhcGVudGl0eV93aGl0ZWxpc3ShaGVudGl0aWVzoVggEjRWeJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAChaW1heF9ub2Rlc6IBAwQBcGdvdmVybmFuY2VfbW9kZWwD"},
 	} {
 		enc := cbor.Marshal(tc.rr)
 		require.Equal(tc.expectedBase64, base64.StdEncoding.EncodeToString(enc), "serialization should match")
@@ -465,7 +467,110 @@ func TestVerifyRuntime(t *testing.T) {
 							Minor: 0,
 							Patch: 3,
 						},
-						ValidFrom: 2,
+						ValidFrom:      2,
+						BundleChecksum: []byte{1, 2, 3, 4, 5, 6, 7},
+					},
+				},
+				KeyManager: &keymanagerID,
+				Executor: ExecutorParameters{
+					GroupSize:                  9,
+					GroupBackupSize:            8,
+					AllowedStragglers:          7,
+					RoundTimeout:               6,
+					MaxMessages:                5,
+					MinLiveRoundsPercent:       4,
+					MinLiveRoundsForEvaluation: 3,
+					MaxLivenessFailures:        2,
+				},
+				TxnScheduler: TxnSchedulerParameters{
+					BatchFlushTimeout: 1 * time.Second,
+					MaxBatchSize:      10_000,
+					MaxBatchSizeBytes: 10_000_000,
+					MaxInMessages:     32,
+					ProposerTimeout:   2,
+				},
+				Storage: StorageParameters{
+					CheckpointInterval:  33,
+					CheckpointNumKept:   6,
+					CheckpointChunkSize: 1_000_000_000,
+				},
+				AdmissionPolicy: RuntimeAdmissionPolicy{
+					EntityWhitelist: &EntityWhitelistRuntimeAdmissionPolicy{
+						Entities: map[signature.PublicKey]EntityWhitelistConfig{
+							signature.NewPublicKey("1234567890000000000000000000000000000000000000000000000000000000"): {
+								MaxNodes: map[node.RolesMask]uint16{
+									node.RoleComputeWorker: 3,
+									node.RoleKeyManager:    1,
+								},
+							},
+						},
+					},
+				},
+				Constraints: map[api.CommitteeKind]map[api.Role]SchedulingConstraints{
+					api.KindComputeExecutor: {
+						api.RoleWorker: {
+							MaxNodes: &MaxNodesConstraint{
+								Limit: 10,
+							},
+							MinPoolSize: &MinPoolSizeConstraint{
+								Limit: 5,
+							},
+							ValidatorSet: &ValidatorSetConstraint{},
+						},
+					},
+				},
+				GovernanceModel: GovernanceConsensus,
+				Staking: RuntimeStakingParameters{
+					Thresholds:                           nil,
+					Slashing:                             nil,
+					RewardSlashBadResultsRuntimePercent:  10,
+					RewardSlashEquvocationRuntimePercent: 0,
+					MinInMessageFee:                      quantity.Quantity{},
+				},
+			},
+			func(cp *ConsensusParameters) {
+				// Increase the maximum number of allowed deployments.
+				cp.MaxRuntimeDeployments = 5
+			},
+			ErrInvalidArgument,
+			"invalid runtime (deployment with invalid checkusm)",
+		},
+		{
+			Runtime{
+				Versioned: cbor.NewVersioned(3),
+				EntityID:  signature.NewPublicKey("1234567890000000000000000000000000000000000000000000000000000000"),
+				ID:        runtimeID,
+				Genesis: RuntimeGenesis{
+					Round:     43,
+					StateRoot: h,
+				},
+				Kind:        KindCompute,
+				TEEHardware: node.TEEHardwareInvalid,
+				Deployments: []*VersionInfo{
+					{
+						Version: version.Version{
+							Major: 44,
+							Minor: 0,
+							Patch: 1,
+						},
+						ValidFrom: 0,
+					},
+					{
+						Version: version.Version{
+							Major: 44,
+							Minor: 0,
+							Patch: 2,
+						},
+						ValidFrom: 1,
+					},
+					{
+						Version: version.Version{
+							Major: 44,
+							Minor: 0,
+							Patch: 3,
+						},
+						ValidFrom:      2,
+						BundleChecksum: bytes.Repeat([]byte{0x01}, 32),
 					},
 				},
 				KeyManager: &keymanagerID,

--- a/runtime/src/consensus/registry.rs
+++ b/runtime/src/consensus/registry.rs
@@ -483,6 +483,9 @@ pub struct VersionInfo {
     /// Enclave version information, in an enclave provided specific format (if any).
     #[cbor(optional)]
     pub tee: Vec<u8>,
+    /// The SHA256 hash of the runtime bundle (optional).
+    #[cbor(optional)]
+    pub bundle_checksum: Vec<u8>,
 }
 
 impl VersionInfo {
@@ -751,7 +754,7 @@ mod tests {
                     },
                     ..Default::default()
                 }),
-		    ("r2F2GCpiaWRYIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZGtpbmQCZ2dlbmVzaXOiZXJvdW5kGCtqc3RhdGVfcm9vdFggseUhAZ+3vd413IH+55BlYQy937jvXCXihJg2aBkqbQ1nc3Rha2luZ6FycmV3YXJkX2JhZF9yZXN1bHRzCmdzdG9yYWdlo3NjaGVja3BvaW50X2ludGVydmFsGCFzY2hlY2twb2ludF9udW1fa2VwdAZ1Y2hlY2twb2ludF9jaHVua19zaXplGGVoZXhlY3V0b3Koamdyb3VwX3NpemUJbG1heF9tZXNzYWdlcwVtcm91bmRfdGltZW91dAZxZ3JvdXBfYmFja3VwX3NpemUIcmFsbG93ZWRfc3RyYWdnbGVycwdybWF4X2xpdmVuZXNzX2ZhaWxzAnRtaW5fbGl2ZV9yb3VuZHNfZXZhbAN3bWluX2xpdmVfcm91bmRzX3BlcmNlbnQEaWVudGl0eV9pZFggEjRWeJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABrY29uc3RyYWludHOhAaEBo2ltYXhfbm9kZXOhZWxpbWl0Cm1taW5fcG9vbF9zaXploWVsaW1pdAVtdmFsaWRhdG9yX3NldKBrZGVwbG95bWVudHOBo2N0ZWVLdmVyc2lvbiB0ZWVndmVyc2lvbqJlbWFqb3IYLGVwYXRjaAFqdmFsaWRfZnJvbQBra2V5X21hbmFnZXJYIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABbHRlZV9oYXJkd2FyZQFtdHhuX3NjaGVkdWxlcqVubWF4X2JhdGNoX3NpemUZJxBvbWF4X2luX21lc3NhZ2VzGCBzYmF0Y2hfZmx1c2hfdGltZW91dBo7msoAdG1heF9iYXRjaF9zaXplX2J5dGVzGgCYloB1cHJvcG9zZV9iYXRjaF90aW1lb3V0AXBhZG1pc3Npb25fcG9saWN5oXBlbnRpdHlfd2hpdGVsaXN0oWhlbnRpdGllc6FYIBI0VniQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoWltYXhfbm9kZXOiAQMEAXBnb3Zlcm5hbmNlX21vZGVsAw==",
+		    ("r2F2GCpiaWRYIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZGtpbmQCZ2dlbmVzaXOiZXJvdW5kGCtqc3RhdGVfcm9vdFggseUhAZ+3vd413IH+55BlYQy937jvXCXihJg2aBkqbQ1nc3Rha2luZ6FycmV3YXJkX2JhZF9yZXN1bHRzCmdzdG9yYWdlo3NjaGVja3BvaW50X2ludGVydmFsGCFzY2hlY2twb2ludF9udW1fa2VwdAZ1Y2hlY2twb2ludF9jaHVua19zaXplGGVoZXhlY3V0b3Koamdyb3VwX3NpemUJbG1heF9tZXNzYWdlcwVtcm91bmRfdGltZW91dAZxZ3JvdXBfYmFja3VwX3NpemUIcmFsbG93ZWRfc3RyYWdnbGVycwdybWF4X2xpdmVuZXNzX2ZhaWxzAnRtaW5fbGl2ZV9yb3VuZHNfZXZhbAN3bWluX2xpdmVfcm91bmRzX3BlcmNlbnQEaWVudGl0eV9pZFggEjRWeJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABrY29uc3RyYWludHOhAaEBo2ltYXhfbm9kZXOhZWxpbWl0Cm1taW5fcG9vbF9zaXploWVsaW1pdAVtdmFsaWRhdG9yX3NldKBrZGVwbG95bWVudHOBpGN0ZWVLdmVyc2lvbiB0ZWVndmVyc2lvbqJlbWFqb3IYLGVwYXRjaAFqdmFsaWRfZnJvbQBvYnVuZGxlX2NoZWNrc3VtWCABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAWtrZXlfbWFuYWdlclgggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFsdGVlX2hhcmR3YXJlAW10eG5fc2NoZWR1bGVypW5tYXhfYmF0Y2hfc2l6ZRknEG9tYXhfaW5fbWVzc2FnZXMYIHNiYXRjaF9mbHVzaF90aW1lb3V0GjuaygB0bWF4X2JhdGNoX3NpemVfYnl0ZXMaAJiWgHVwcm9wb3NlX2JhdGNoX3RpbWVvdXQBcGFkbWlzc2lvbl9wb2xpY3mhcGVudGl0eV93aGl0ZWxpc3ShaGVudGl0aWVzoVggEjRWeJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAChaW1heF9ub2Rlc6IBAwQBcGdvdmVybmFuY2VfbW9kZWwD",
                 Runtime {
                     v: 42,
                     id: Namespace::from("8000000000000000000000000000000000000000000000000000000000000000"),
@@ -767,6 +770,7 @@ mod tests {
                             version: Version { major: 44, minor: 0, patch: 1 },
                             valid_from: 0,
                             tee: b"version tee".to_vec(),
+                            bundle_checksum: vec![0x1; 32],
                         },
                     ],
                     key_manager: Some(

--- a/runtime/src/consensus/state/beacon.rs
+++ b/runtime/src/consensus/state/beacon.rs
@@ -169,7 +169,7 @@ mod test {
         let mock_consensus_root = Root {
             version: 1,
             root_type: RootType::State,
-            hash: Hash::from("e5b7e884e3233444ddce993426c25b80ca9bcb323388ec1308e50a7bd816084a"),
+            hash: Hash::from("00653d0a677ec3d058bce7889ca824f7d8d74db44fcaf966ef6d155794f9208d"),
             ..Default::default()
         };
         let mkvs = Tree::builder()

--- a/runtime/src/consensus/state/keymanager.rs
+++ b/runtime/src/consensus/state/keymanager.rs
@@ -112,7 +112,7 @@ mod test {
         let mock_consensus_root = Root {
             version: 1,
             root_type: RootType::State,
-            hash: Hash::from("e5b7e884e3233444ddce993426c25b80ca9bcb323388ec1308e50a7bd816084a"),
+            hash: Hash::from("00653d0a677ec3d058bce7889ca824f7d8d74db44fcaf966ef6d155794f9208d"),
             ..Default::default()
         };
         let mkvs = Tree::builder()

--- a/runtime/src/consensus/state/registry.rs
+++ b/runtime/src/consensus/state/registry.rs
@@ -139,7 +139,7 @@ mod test {
         let mock_consensus_root = Root {
             version: 1,
             root_type: RootType::State,
-            hash: Hash::from("e5b7e884e3233444ddce993426c25b80ca9bcb323388ec1308e50a7bd816084a"),
+            hash: Hash::from("00653d0a677ec3d058bce7889ca824f7d8d74db44fcaf966ef6d155794f9208d"),
             ..Default::default()
         };
         let mkvs = Tree::builder()
@@ -271,11 +271,13 @@ mod test {
                         version: Version::from(123),
                         valid_from: 42,
                         tee: vec![1, 2, 3, 4, 5],
+                        bundle_checksum: vec![0x5; 32],
                     },
                     VersionInfo {
                         version: Version::from(120),
                         valid_from: 10,
                         tee: vec![5, 4, 3, 2, 1],
+                        ..Default::default()
                     },
                 ],
                 ..Default::default()

--- a/runtime/src/consensus/state/staking.rs
+++ b/runtime/src/consensus/state/staking.rs
@@ -230,7 +230,7 @@ mod test {
         let mock_consensus_root = Root {
             version: 1,
             root_type: RootType::State,
-            hash: Hash::from("e5b7e884e3233444ddce993426c25b80ca9bcb323388ec1308e50a7bd816084a"),
+            hash: Hash::from("00653d0a677ec3d058bce7889ca824f7d8d74db44fcaf966ef6d155794f9208d"),
             ..Default::default()
         };
         let mkvs = Tree::builder()


### PR DESCRIPTION
Not used for anything at the moment, but can be used in future for verification of automatically distributed bundles.