### PR TITLE
go/registry: Support changing a runtime's owner

### DIFF
--- a/.changelog/5114.breaking.md
+++ b/.changelog/5114.breaking.md
@@ -1,0 +1,1 @@
+go/registry: Support changing a runtime's owner

--- a/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
@@ -257,8 +257,16 @@ func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
 			FeeSplitWeightVote:        *quantity.NewFromUint64(1),
 			FeeSplitWeightNextPropose: *quantity.NewFromUint64(1),
 			AllowEscrowMessages:       true,
+			Thresholds: map[staking.ThresholdKind]quantity.Quantity{
+				staking.KindEntity:            *quantity.NewFromUint64(0),
+				staking.KindNodeValidator:     *quantity.NewFromUint64(0),
+				staking.KindNodeCompute:       *quantity.NewFromUint64(0),
+				staking.KindNodeKeyManager:    *quantity.NewFromUint64(0),
+				staking.KindRuntimeCompute:    *quantity.NewFromUint64(100),
+				staking.KindRuntimeKeyManager: *quantity.NewFromUint64(100),
+			},
 		},
-		TotalSupply: *quantity.NewFromUint64(150000000400),
+		TotalSupply: *quantity.NewFromUint64(150000001400),
 		Ledger: map[staking.Address]*staking.Account{
 			e2e.DeterministicValidator0: {
 				General: staking.GeneralAccount{
@@ -369,6 +377,15 @@ func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
 					},
 				},
 			},
+			// Ensure test entity has enough stake to register runtimes.
+			e2e.TestEntityAccount: {
+				Escrow: staking.EscrowAccount{
+					Active: staking.SharePool{
+						Balance:     *quantity.NewFromUint64(1000),
+						TotalShares: *quantity.NewFromUint64(100),
+					},
+				},
+			},
 		},
 		Delegations: map[staking.Address]map[staking.Address]*staking.Delegation{
 			e2e.DeterministicEntity1: {
@@ -388,6 +405,11 @@ func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
 			},
 			e2e.DeterministicEntity4: {
 				e2e.DeterministicEntity4: &staking.Delegation{
+					Shares: *quantity.NewFromUint64(100),
+				},
+			},
+			e2e.TestEntityAccount: {
+				e2e.TestEntityAccount: &staking.Delegation{
 					Shares: *quantity.NewFromUint64(100),
 				},
 			},

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -1231,13 +1231,6 @@ func VerifyRuntimeUpdate(
 	now beacon.EpochTime,
 	params *ConsensusParameters,
 ) error {
-	if !currentRt.EntityID.Equal(newRt.EntityID) {
-		logger.Error("RegisterRuntime: trying to change runtime owner",
-			"current_owner", currentRt.EntityID,
-			"new_owner", newRt.EntityID,
-		)
-		return ErrRuntimeUpdateNotAllowed
-	}
 	if !currentRt.ID.Equal(&newRt.ID) {
 		logger.Error("RegisterRuntime: trying to update runtime ID",
 			"current_id", currentRt.ID.String(),

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -45,7 +45,8 @@ const (
 )
 
 var (
-	entityNodeSeed = []byte("testRegistryEntityNodes")
+	entityNodeSeed    = []byte("testRegistryEntityNodes")
+	entityRuntimeSeed = []byte("testRegistryEntityRuntime")
 
 	invalidPK = signature.NewBlacklistedPublicKey("0000000000000000000000000000000000000000000000000000000000000000")
 )
@@ -985,6 +986,11 @@ func testRegistryRuntime(t *testing.T, backend api.Backend, consensus consensusA
 	re, err = NewTestRuntime([]byte("Runtime re-registration test 2"), entity, true)
 	require.NoError(err, "NewTestRuntime (re-registration test 2)")
 	re.Runtime.Kind = api.KindKeyManager
+	re.MustRegister(t, backend, consensus)
+	// Changing the owning entity should work.
+	entities, err := NewTestEntities(entityRuntimeSeed, 1)
+	require.NoError(err, "NewTestEntities")
+	re.Runtime.EntityID = entities[0].Entity.ID
 	re.MustRegister(t, backend, consensus)
 	// Non-compute runtimes cannot transition to runtime governance.
 	re.Runtime.GovernanceModel = api.GovernanceRuntime


### PR DESCRIPTION
This existing code ensures that the new entity actually exists and has the required stake:
https://github.com/oasisprotocol/oasis-core/blob/2680a6e97f0ebf2ffa892c72cbaf7289e85f3938/go/consensus/tendermint/apps/registry/transactions.go#L749-L775

However, in the existing registry node tests `params.DebugBypassStake` is used, so this cannot really be tested there. That's why I added a separate unit test suite for register runtime (with is currently only testing the updating entity owner behavior).
