### PR TITLE
tendermint: GetEvents: return events in order

### DIFF
--- a/.changelog/5117.bugfix.md
+++ b/.changelog/5117.bugfix.md
@@ -1,0 +1,4 @@
+go/tendermint: Change order of events returned from GetEvents()
+
+The new order reflects the order in which the events were
+generated during block execution.

--- a/go/consensus/tendermint/governance/governance.go
+++ b/go/consensus/tendermint/governance/governance.go
@@ -115,14 +115,8 @@ func (sc *serviceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 	}
 
 	var events []*api.Event
-	// Decode events from block results.
+	// Decode events from block results (at the beginning of the block).
 	blockEvs, err := EventsFromTendermint(nil, results.Height, results.BeginBlockEvents)
-	if err != nil {
-		return nil, err
-	}
-	events = append(events, blockEvs...)
-
-	blockEvs, err = EventsFromTendermint(nil, results.Height, results.EndBlockEvents)
 	if err != nil {
 		return nil, err
 	}
@@ -139,6 +133,13 @@ func (sc *serviceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 		}
 		events = append(events, evs...)
 	}
+
+	// Decode events from block results (at the end of the block).
+	blockEvs, err = EventsFromTendermint(nil, results.Height, results.EndBlockEvents)
+	if err != nil {
+		return nil, err
+	}
+	events = append(events, blockEvs...)
 
 	return events, nil
 }

--- a/go/consensus/tendermint/registry/registry.go
+++ b/go/consensus/tendermint/registry/registry.go
@@ -191,14 +191,8 @@ func (sc *serviceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 	}
 
 	var events []*api.Event
-	// Decode events from block results.
+	// Decode events from block results (at the beginning of the block).
 	blockEvs, _, err := EventsFromTendermint(nil, results.Height, results.BeginBlockEvents)
-	if err != nil {
-		return nil, err
-	}
-	events = append(events, blockEvs...)
-
-	blockEvs, _, err = EventsFromTendermint(nil, results.Height, results.EndBlockEvents)
 	if err != nil {
 		return nil, err
 	}
@@ -215,6 +209,13 @@ func (sc *serviceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 		}
 		events = append(events, txEvs...)
 	}
+
+	// Decode events from block results (at the end of the block).
+	blockEvs, _, err = EventsFromTendermint(nil, results.Height, results.EndBlockEvents)
+	if err != nil {
+		return nil, err
+	}
+	events = append(events, blockEvs...)
 
 	return events, nil
 }

--- a/go/consensus/tendermint/staking/staking.go
+++ b/go/consensus/tendermint/staking/staking.go
@@ -233,14 +233,8 @@ func (sc *serviceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 	}
 
 	var events []*api.Event
-	// Decode events from block results.
+	// Decode events from block results (at the beginning of the block).
 	blockEvs, err := EventsFromTendermint(nil, results.Height, results.BeginBlockEvents)
-	if err != nil {
-		return nil, err
-	}
-	events = append(events, blockEvs...)
-
-	blockEvs, err = EventsFromTendermint(nil, results.Height, results.EndBlockEvents)
 	if err != nil {
 		return nil, err
 	}
@@ -257,6 +251,13 @@ func (sc *serviceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 		}
 		events = append(events, evs...)
 	}
+
+	// Decode events from block results (at the end of the block).
+	blockEvs, err = EventsFromTendermint(nil, results.Height, results.EndBlockEvents)
+	if err != nil {
+		return nil, err
+	}
+	events = append(events, blockEvs...)
 
 	return events, nil
 }


### PR DESCRIPTION
Currently consensus events (e.g. in various GetEvents RPCs) are returned in the following order:
- BeginBlock
- EndBlock
- DeliverTx

This PR switches all GetEvents RPCs to the more natural order:
- BeginBlock
- DeliverTx
- EndBlock

The motivation comes from oasis-indexer, where processing events in the order they were returned before this PR can lead to violated assumptions (e.g. "no account can ever have negative balance").