### PR TITLE
[BACKPORT/22.2.x] go/worker/client: Better handle latest round queries with verification

### DIFF
--- a/.changelog/5120.internal.md
+++ b/.changelog/5120.internal.md
@@ -1,0 +1,1 @@
+rust: Bump tokio from 1.21.2 to 1.24.1

--- a/.changelog/5123.bugfix.md
+++ b/.changelog/5123.bugfix.md
@@ -1,0 +1,6 @@
+go/worker/client: Better handle latest round queries with verification
+
+When a query is requesting to be executed against the latest round and
+the runtime reports a consensus verifier error, use an earlier round
+instead as the latest round may not yet be verifiable by the light
+client as it needs to wait for the validator signatures.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,7 +1570,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1871,7 +1871,7 @@ dependencies = [
  "sp800-185",
  "thiserror",
  "tiny-keccak 2.0.2",
- "tokio 1.21.2",
+ "tokio 1.24.1",
  "x25519-dalek",
  "zeroize",
 ]
@@ -1929,7 +1929,7 @@ dependencies = [
  "tendermint-rpc",
  "thiserror",
  "tiny-keccak 2.0.2",
- "tokio 1.21.2",
+ "tokio 1.24.1",
  "x25519-dalek",
  "x509-parser",
  "yasna 0.5.0",
@@ -2056,7 +2056,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -2691,7 +2691,7 @@ dependencies = [
  "oasis-core-tools",
  "simple-keymanager",
  "thiserror",
- "tokio 1.21.2",
+ "tokio 1.24.1",
  "x25519-dalek",
 ]
 
@@ -3129,9 +3129,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes 1.2.1",
@@ -3144,7 +3144,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros 1.8.0",
- "winapi 0.3.9",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3446,12 +3446,33 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3460,10 +3481,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3472,16 +3505,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "ws2_32-sys"

--- a/go/runtime/host/protocol/errors.go
+++ b/go/runtime/host/protocol/errors.go
@@ -1,0 +1,12 @@
+package protocol
+
+import (
+	"github.com/oasisprotocol/oasis-core/go/common/errors"
+)
+
+// ModuleVerifierName is the name of the consensus verifier module inside the runtime.
+const ModuleVerifierName = "verifier"
+
+// ErrVerifierVerificationFailed is the error returned when consensus verifier fails to verify the
+// passed consensus light block.
+var ErrVerifierVerificationFailed = errors.New(ModuleVerifierName, 2, "verifier: light block verification failed")

--- a/go/worker/client/committee/node.go
+++ b/go/worker/client/committee/node.go
@@ -11,6 +11,7 @@ import (
 
 	cmnBackoff "github.com/oasisprotocol/oasis-core/go/common/backoff"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/common/errors"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
@@ -149,22 +150,52 @@ func (n *Node) Query(ctx context.Context, round uint64, method string, args []by
 	}
 	maxMessages := dsc.Executor.MaxMessages
 
-	annBlk, err := n.commonNode.Runtime.History().GetAnnotatedBlock(ctx, round)
-	if err != nil {
-		return nil, fmt.Errorf("client: failed to fetch annotated block from history: %w", err)
+	var resolvedRound uint64
+	queryFn := func(round uint64) ([]byte, error) {
+		annBlk, err := n.commonNode.Runtime.History().GetAnnotatedBlock(ctx, round)
+		if err != nil {
+			return nil, fmt.Errorf("client: failed to fetch annotated block from history: %w", err)
+		}
+		resolvedRound = annBlk.Block.Header.Round
+
+		// Get consensus light block for state after executing block at given height.
+		lb, err := n.commonNode.Consensus.GetLightBlockForState(ctx, annBlk.Height)
+		if err != nil {
+			return nil, fmt.Errorf("client: failed to get light block at height %d: %w", annBlk.Height, err)
+		}
+		epoch, err := n.commonNode.Consensus.Beacon().GetEpoch(ctx, annBlk.Height)
+		if err != nil {
+			return nil, fmt.Errorf("client: failed to get epoch at height %d: %w", annBlk.Height, err)
+		}
+
+		return hrt.Query(ctx, annBlk.Block, lb, epoch, maxMessages, method, args)
 	}
 
-	// Get consensus light block for state after executing block at given height.
-	lb, err := n.commonNode.Consensus.GetLightBlockForState(ctx, annBlk.Height)
-	if err != nil {
-		return nil, fmt.Errorf("client: failed to get light block at height %d: %w", annBlk.Height, err)
-	}
-	epoch, err := n.commonNode.Consensus.Beacon().GetEpoch(ctx, annBlk.Height)
-	if err != nil {
-		return nil, fmt.Errorf("client: failed to get epoch at height %d: %w", annBlk.Height, err)
-	}
+	data, err := queryFn(round)
+	if errors.Is(err, protocol.ErrVerifierVerificationFailed) {
+		// The query failed due to the runtime's consensus verifier failing to verify the given
+		// header. We assume that this is because a finalized header is not yet available for the
+		// given round.
+		switch round {
+		case api.RoundLatest:
+			// Since we are allowed to decide what we see as the latest round, use an earlier one.
+			n.logger.Debug("runtime's consensus verifier reports failure, retrying",
+				"method", method,
+				"target_round", resolvedRound,
+			)
 
-	return hrt.Query(ctx, annBlk.Block, lb, epoch, maxMessages, method, args)
+			data, err = queryFn(resolvedRound - 1)
+		default:
+			// A specific round was given so this query is not yet possible.
+			n.logger.Debug("runtime's consensus verifier reports failure",
+				"method", method,
+				"target_round", round,
+			)
+
+			return nil, roothash.ErrNotFound
+		}
+	}
+	return data, err
 }
 
 func (n *Node) checkBlock(ctx context.Context, blk *block.Block, pending map[hash.Hash]*pendingTx) error {

--- a/keymanager/Cargo.toml
+++ b/keymanager/Cargo.toml
@@ -22,5 +22,5 @@ sp800-185 = "0.2.0"
 thiserror = "1.0"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 x25519-dalek = "1.1.0"
-tokio = { version = "~1.21.1", features = ["rt"] }
+tokio = { version = "~1.24.1", features = ["rt"] }
 zeroize = "1.4.2"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -32,7 +32,7 @@ base64 = "0.13.0"
 rustc-hex = "2.0.1"
 rand = "0.7.3"
 futures = "0.3.17"
-tokio = { version = "~1.21.1", features = ["rt", "sync"] }
+tokio = { version = "~1.24.1", features = ["rt", "sync"] }
 tendermint = "0.25.0"
 tendermint-proto = "0.25.0"
 tendermint-light-client = { version = "0.25.0", default-features = false }

--- a/tests/runtimes/simple-keyvalue/Cargo.toml
+++ b/tests/runtimes/simple-keyvalue/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = "1.0"
 io-context = "0.2.0"
 byteorder = "1.4.3"
 x25519-dalek = "1.1.0"
-tokio = { version = "~1.21.1", features = ["rt"] }
+tokio = { version = "~1.24.1", features = ["rt"] }
 
 [build-dependencies]
 oasis-core-tools = { path = "../../../tools" }


### PR DESCRIPTION
Backport of #5123 