### PR TITLE
go/common/node: Add runtime encryption key (REK)

### DIFF
--- a/.changelog/5125.feature.md
+++ b/.changelog/5125.feature.md
@@ -1,0 +1,4 @@
+go/common/node: Add runtime encryption key (REK)
+
+The new key allows enclaves to publish encrypted data on-chain to an enclave
+instance.

--- a/go/common/node/node_test.go
+++ b/go/common/node/node_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasisprotocol/curve25519-voi/primitives/x25519"
+
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
@@ -297,6 +299,52 @@ func TestNodeForTestSerializationV2(t *testing.T) {
 				},
 			},
 			"qmF2AmJpZFgg//////////////////////////////////////////BjcDJwomJpZFgg//////////////////////////////////////////VpYWRkcmVzc2Vz9mN0bHOjZ3B1Yl9rZXlYIP/////////////////////////////////////////yaWFkZHJlc3Nlc4GiZ2FkZHJlc3OjYklQUAAAAAAAAAAAAAD//38AAAFkUG9ydBh7ZFpvbmVgZ3B1Yl9rZXlYIP/////////////////////////////////////////0bG5leHRfcHViX2tleVgg//////////////////////////////////////////NjdnJmoWJpZFgg//////////////////////////////////////////dlcm9sZXMAaHJ1bnRpbWVzgqRiaWRYIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQZ3ZlcnNpb26hZXBhdGNoGQFBamV4dHJhX2luZm/2bGNhcGFiaWxpdGllc6CkYmlkWCCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEWd2ZXJzaW9uoWVwYXRjaBh7amV4dHJhX2luZm9EBQMCAWxjYXBhYmlsaXRpZXOhY3RlZaNjcmFrWCD/////////////////////////////////////////+GhoYXJkd2FyZQFrYXR0ZXN0YXRpb25GAAECAwQFaWNvbnNlbnN1c6JiaWRYIP/////////////////////////////////////////2aWFkZHJlc3Nlc4BpZW50aXR5X2lkWCD/////////////////////////////////////////8WpleHBpcmF0aW9uGCA=",
+		},
+		{
+			nodeV2{
+				Versioned:  cbor.NewVersioned(2),
+				ID:         signature.NewPublicKey("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0"),
+				EntityID:   signature.NewPublicKey("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1"),
+				Expiration: 32,
+				TLS: nodeV2TLSInfo{
+					PubKey:     signature.NewPublicKey("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff2"),
+					NextPubKey: signature.NewPublicKey("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3"),
+					DeprecatedAddresses: []TLSAddress{
+						{
+							PubKey:  signature.NewPublicKey("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4"),
+							Address: Address{IP: net.IPv4(127, 0, 0, 1), Port: 123},
+						},
+					},
+				},
+				P2P: P2PInfo{
+					ID: signature.NewPublicKey("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5"),
+				},
+				Consensus: ConsensusInfo{
+					ID:        signature.NewPublicKey("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6"),
+					Addresses: []ConsensusAddress{},
+				},
+				VRF: &VRFInfo{
+					ID: signature.NewPublicKey("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7"),
+				},
+				Runtimes: []*Runtime{
+					{
+						ID:      runtimeID,
+						Version: version.FromU64(321),
+					},
+					{
+						ID:      runtimeID2,
+						Version: version.FromU64(123),
+						Capabilities: Capabilities{TEE: &CapabilityTEE{
+							Hardware:    TEEHardwareIntelSGX,
+							RAK:         signature.NewPublicKey("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8"),
+							REK:         &x25519.PublicKey{},
+							Attestation: []byte{0, 1, 2, 3, 4, 5},
+						}},
+						ExtraInfo: []byte{5, 3, 2, 1},
+					},
+				},
+			},
+			"qmF2AmJpZFgg//////////////////////////////////////////BjcDJwomJpZFgg//////////////////////////////////////////VpYWRkcmVzc2Vz9mN0bHOjZ3B1Yl9rZXlYIP/////////////////////////////////////////yaWFkZHJlc3Nlc4GiZ2FkZHJlc3OjYklQUAAAAAAAAAAAAAD//38AAAFkUG9ydBh7ZFpvbmVgZ3B1Yl9rZXlYIP/////////////////////////////////////////0bG5leHRfcHViX2tleVgg//////////////////////////////////////////NjdnJmoWJpZFgg//////////////////////////////////////////dlcm9sZXMAaHJ1bnRpbWVzgqRiaWRYIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQZ3ZlcnNpb26hZXBhdGNoGQFBamV4dHJhX2luZm/2bGNhcGFiaWxpdGllc6CkYmlkWCCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEWd2ZXJzaW9uoWVwYXRjaBh7amV4dHJhX2luZm9EBQMCAWxjYXBhYmlsaXRpZXOhY3RlZaRjcmFrWCD/////////////////////////////////////////+GNyZWtYIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaGhhcmR3YXJlAWthdHRlc3RhdGlvbkYAAQIDBAVpY29uc2Vuc3VzomJpZFgg//////////////////////////////////////////ZpYWRkcmVzc2VzgGllbnRpdHlfaWRYIP/////////////////////////////////////////xamV4cGlyYXRpb24YIA==",
 		},
 	} {
 		enc := cbor.Marshal(tc.node)

--- a/go/common/node/sgx_test.go
+++ b/go/common/node/sgx_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasisprotocol/curve25519-voi/primitives/x25519"
+
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx"
@@ -118,9 +120,16 @@ func TestHashAttestation(t *testing.T) {
 
 	var nodeID signature.PublicKey
 	_ = nodeID.UnmarshalHex("47aadd91516ac548decdb436fde957992610facc09ba2f850da0fe1b2be96119")
-	h := HashAttestation([]byte("foo bar"), nodeID, 42)
-	hHex := hex.EncodeToString(h)
-	require.EqualValues("0f01a5084bbf432427873cbce5f8c3bff76bc22b9d1e0674b852e43698abb195", hHex)
+
+	rekRaw, _ := hex.DecodeString("7992610facc09ba2f850da0fe1b2be9611947aadd91516ac548decdb436fde95")
+	var rek x25519.PublicKey
+	copy(rek[:], rekRaw)
+
+	h := HashAttestation([]byte("foo bar"), nodeID, 42, nil)
+	require.EqualValues("0f01a5084bbf432427873cbce5f8c3bff76bc22b9d1e0674b852e43698abb195", hex.EncodeToString(h))
+
+	h = HashAttestation([]byte("foo bar"), nodeID, 42, &rek)
+	require.EqualValues("9a288bd33ba7a4c2eefdee68e4c08c1a34c369302ef8176a3bfdb4fedcec333e", hex.EncodeToString(h))
 }
 
 func FuzzSGXConstraints(f *testing.F) {

--- a/go/consensus/tendermint/apps/registry/state/interop/interop.go
+++ b/go/consensus/tendermint/apps/registry/state/interop/interop.go
@@ -81,6 +81,7 @@ func InitializeTestRegistryState(ctx context.Context, mkvs mkvs.Tree) error {
 						Capabilities: node.Capabilities{TEE: &node.CapabilityTEE{
 							Hardware:    node.TEEHardwareIntelSGX,
 							RAK:         signature.NewPublicKey("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8"),
+							REK:         nil,
 							Attestation: []byte{0, 1, 2, 3, 4, 5},
 						}},
 						ExtraInfo: []byte{5, 3, 2, 1},

--- a/go/consensus/tendermint/apps/scheduler/scheduler.go
+++ b/go/consensus/tendermint/apps/scheduler/scheduler.go
@@ -386,7 +386,7 @@ func (app *schedulerApplication) isSuitableExecutorWorker(
 				activeDeployment.TEE,
 				n.node.ID,
 			); err != nil {
-				ctx.Logger().Warn("failed to verify node TEE attestaion",
+				ctx.Logger().Warn("failed to verify node TEE attestation",
 					"err", err,
 					"node_id", n.node.ID,
 					"timestamp", ctx.Now(),

--- a/go/oasis-node/cmd/debug/byzantine/steps.go
+++ b/go/oasis-node/cmd/debug/byzantine/steps.go
@@ -83,7 +83,7 @@ func initFakeCapabilitiesSGX(nodeID signature.PublicKey) (signature.Signer, *nod
 	})
 
 	// Generate attestation signature.
-	h := node.HashAttestation(quote.Report.ReportData[:], nodeID, 1)
+	h := node.HashAttestation(quote.Report.ReportData[:], nodeID, 1, nil)
 	attestationSig, err := signature.Sign(fr, node.AttestationSignatureContext, h)
 	if err != nil {
 		return nil, nil, err

--- a/go/roothash/api/commitment/txnscheduler.go
+++ b/go/roothash/api/commitment/txnscheduler.go
@@ -106,7 +106,7 @@ func GetTransactionScheduler(committee *scheduler.Committee, round uint64) (*sch
 	workers := committee.Workers()
 	numNodes := uint64(len(workers))
 	if numNodes == 0 {
-		return nil, fmt.Errorf("GetTransactionScheduler: no workers in commmittee")
+		return nil, fmt.Errorf("GetTransactionScheduler: no workers in committee")
 	}
 	schedulerIdx := round % numNodes
 	return workers[schedulerIdx], nil

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/oasisprotocol/curve25519-voi/primitives/x25519"
+
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
@@ -216,6 +218,7 @@ type RuntimeCapabilityTEERakInitRequest struct {
 // RuntimeCapabilityTEERakReportResponse is a worker RFC 0009 CapabilityTEE RAK response message body.
 type RuntimeCapabilityTEERakReportResponse struct {
 	RakPub signature.PublicKey `json:"rak_pub"`
+	RekPub *x25519.PublicKey   `json:"rek_pub,omitempty"`
 	Report []byte              `json:"report"`
 	Nonce  string              `json:"nonce"`
 }

--- a/go/runtime/host/sgx/sgx.go
+++ b/go/runtime/host/sgx/sgx.go
@@ -330,6 +330,7 @@ func (s *sgxProvisioner) updateCapabilityTEE(ctx context.Context, logger *loggin
 		return nil, fmt.Errorf("error while requesting worker quote and public RAK: %w", err)
 	}
 	rakPub := rakQuoteRes.RuntimeCapabilityTEERakReportResponse.RakPub
+	rekPub := rakQuoteRes.RuntimeCapabilityTEERakReportResponse.RekPub
 	report := rakQuoteRes.RuntimeCapabilityTEERakReportResponse.Report
 	nonce := rakQuoteRes.RuntimeCapabilityTEERakReportResponse.Nonce
 
@@ -341,6 +342,7 @@ func (s *sgxProvisioner) updateCapabilityTEE(ctx context.Context, logger *loggin
 	capabilityTEE := &node.CapabilityTEE{
 		Hardware:    node.TEEHardwareIntelSGX,
 		RAK:         rakPub,
+		REK:         rekPub,
 		Attestation: attestation,
 	}
 

--- a/runtime/src/consensus/state/registry.rs
+++ b/runtime/src/consensus/state/registry.rs
@@ -112,7 +112,7 @@ mod test {
 
     use crate::{
         common::{
-            crypto::{hash::Hash, signature::PublicKey},
+            crypto::{hash::Hash, signature},
             namespace::Namespace,
         },
         consensus::registry::{
@@ -163,27 +163,27 @@ mod test {
         let expected_nodes = vec![
                 Node{
                     v: 3,
-                    id: PublicKey::from("43e5aaee54c768867718837ef4f6a6161e0615da0fcf8da394e5c8b7a0d54c18"),
-                    entity_id: PublicKey::from("761950dfe65936f6e9d06a0124bc930f7d5b1812ceefdfb2cae0ef5841291531"),
+                    id: signature::PublicKey::from("43e5aaee54c768867718837ef4f6a6161e0615da0fcf8da394e5c8b7a0d54c18"),
+                    entity_id: signature::PublicKey::from("761950dfe65936f6e9d06a0124bc930f7d5b1812ceefdfb2cae0ef5841291531"),
                     expiration: 32,
                     ..Default::default()
                 },
                 Node{
                     v: 3,
-                    id: PublicKey::from("f43c3559658f76b85d0630f56dc75d603807ac60be0ca3aada66799289066758"),
-                    entity_id: PublicKey::from("761950dfe65936f6e9d06a0124bc930f7d5b1812ceefdfb2cae0ef5841291531"),
+                    id: signature::PublicKey::from("f43c3559658f76b85d0630f56dc75d603807ac60be0ca3aada66799289066758"),
+                    entity_id: signature::PublicKey::from("761950dfe65936f6e9d06a0124bc930f7d5b1812ceefdfb2cae0ef5841291531"),
                     expiration: 32,
                     tls: TLSInfo{
-                        pub_key: PublicKey::from("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0"),
-                        next_pub_key: PublicKey::from("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1"),
+                        pub_key: signature::PublicKey::from("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0"),
+                        next_pub_key: signature::PublicKey::from("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1"),
                         ..Default::default()
                     },
                     p2p: P2PInfo{
-                        id: PublicKey::from("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3"),
+                        id: signature::PublicKey::from("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3"),
                         addresses: Some(Vec::new()),
                     },
                     consensus: ConsensusInfo{
-                        id: PublicKey::from("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4"),
+                        id: signature::PublicKey::from("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4"),
                         addresses: Some(Vec::new()),
                     },
                     vrf: VRFInfo{
@@ -201,8 +201,9 @@ mod test {
                             capabilities: Capabilities{
                                tee: Some(CapabilityTEE{
                                    hardware: TEEHardware::TEEHardwareIntelSGX,
-                                    rak: PublicKey::from("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8"),
+                                    rak: signature::PublicKey::from("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8"),
                                     attestation: vec![0, 1,2,3,4,5],
+                                    ..Default::default()
                                }),
                             },
                             extra_info: Some(vec![5,3,2,1]),
@@ -224,7 +225,7 @@ mod test {
         let node = registry_state
             .node(
                 Context::create_child(&ctx),
-                &PublicKey::from(
+                &signature::PublicKey::from(
                     "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 ),
             )
@@ -237,7 +238,7 @@ mod test {
                 id: Namespace::from(
                     "8000000000000000000000000000000000000000000000000000000000000010",
                 ),
-                entity_id: PublicKey::from(
+                entity_id: signature::PublicKey::from(
                     "761950dfe65936f6e9d06a0124bc930f7d5b1812ceefdfb2cae0ef5841291531",
                 ),
                 kind: RuntimeKind::KindCompute,
@@ -261,7 +262,7 @@ mod test {
                 id: Namespace::from(
                     "8000000000000000000000000000000000000000000000000000000000000011",
                 ),
-                entity_id: PublicKey::from(
+                entity_id: signature::PublicKey::from(
                     "761950dfe65936f6e9d06a0124bc930f7d5b1812ceefdfb2cae0ef5841291531",
                 ),
                 kind: RuntimeKind::KindCompute,

--- a/runtime/src/dispatcher.rs
+++ b/runtime/src/dispatcher.rs
@@ -738,7 +738,7 @@ impl Dispatcher {
             "in_msgs_hash" => ?header.in_msgs_hash,
         );
 
-        let rak_sig = if self.rak.public_key().is_some() {
+        let rak_sig = if self.rak.public_rak().is_some() {
             self.rak
                 .sign(
                     COMPUTE_RESULTS_HEADER_CONTEXT,

--- a/runtime/src/enclave_rpc/session.rs
+++ b/runtime/src/enclave_rpc/session.rs
@@ -178,11 +178,11 @@ impl Session {
     fn get_rak_binding(&self) -> Vec<u8> {
         match self.rak {
             Some(ref rak) => {
-                if rak.public_key().is_none() || rak.quote().is_none() {
+                if rak.public_rak().is_none() || rak.quote().is_none() {
                     return vec![];
                 }
 
-                let rak_pub = rak.public_key().expect("RAK is configured");
+                let rak_pub = rak.public_rak().expect("RAK is configured");
                 let quote = rak.quote().expect("quote is configured");
                 let binding = rak
                     .sign(&RAK_SESSION_BINDING_CONTEXT, &self.local_static_pub)

--- a/runtime/src/protocol.rs
+++ b/runtime/src/protocol.rs
@@ -142,7 +142,7 @@ impl Protocol {
 
     /// The runtime attestation key.
     pub fn get_rak(&self) -> Option<&Arc<RAK>> {
-        if self.rak.public_key().is_none() || self.rak.quote().is_none() {
+        if self.rak.public_rak().is_none() || self.rak.quote().is_none() {
             return None;
         }
 

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -7,7 +7,8 @@ use crate::{
     common::{
         crypto::{
             hash::Hash,
-            signature::{PublicKey, Signature},
+            signature::{self, Signature},
+            x25519,
         },
         namespace::Namespace,
         sgx::{ias::AVR, Quote, QuotePolicy},
@@ -125,7 +126,8 @@ pub enum Body {
     RuntimeCapabilityTEERakInitResponse {},
     RuntimeCapabilityTEERakReportRequest {},
     RuntimeCapabilityTEERakReportResponse {
-        rak_pub: PublicKey,
+        rak_pub: signature::PublicKey,
+        rek_pub: x25519::PublicKey,
         report: Vec<u8>,
         nonce: String,
     },
@@ -265,7 +267,7 @@ pub enum Body {
     },
     HostIdentityRequest {},
     HostIdentityResponse {
-        node_id: PublicKey,
+        node_id: signature::PublicKey,
     },
 }
 


### PR DESCRIPTION
Used attestation signature to authenticate the REK. When computing the signature the new version hashes also REK.

Next (optional) step would be to:
- move `height` and `signature` to `CapabilitiesTEE`,
- define custom CBOR marshalling which would copy those two fields from the `SGXAttestation` v2, and 
- move signature verification to `CapabilitiesTEE`.

We would probably also need to introduce versioning for `CapabilitiesTEE`. As this step is more complicated and not needed,  I decided to skip it.