### PR TITLE
[STABLE/22.2.x] ci: Use Ubuntu 20.04 for release builds

### DIFF
--- a/.changelog/5130.bugfix.md
+++ b/.changelog/5130.bugfix.md
@@ -1,0 +1,5 @@
+ci: Use Ubuntu 20.04 for release builds
+
+This was automatically changed when `ubuntu-latest` was switched to
+Ubuntu 22.04. We should use the same build environment for all of the patch
+releases (22.2.4 is an exception as we didn't see this earlier).

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -21,7 +21,7 @@ env:
 jobs:
 
   prepare-dev-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ env:
 jobs:
 
   prepare-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
This was automatically changed when `ubuntu-latest` was switched to Ubuntu 22.04. We should use the same build environment for all of the patch releases (22.2.4 is an exception as we didn't see this earlier).