### PR TITLE
ci: Explicitly use Ubuntu 22.04 for release builds

### DIFF
--- a/.changelog/5131.internal.md
+++ b/.changelog/5131.internal.md
@@ -1,0 +1,4 @@
+ci: Explicitly use Ubuntu 22.04 for release builds
+
+This avoids the situation when ubuntu-latest gets changed to something
+else, possibly imposing a different set of dependencies.

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -21,7 +21,7 @@ env:
 jobs:
 
   prepare-dev-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ env:
 jobs:
 
   prepare-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
This avoids the situation when ubuntu-latest gets changed to something else, possibly imposing a different set of dependencies.