### PR TITLE
[BACKPORT/22.2.x] runtime/src/protocol: Remove consensus version compatibility check

### DIFF
--- a/.changelog/5135.internal.md
+++ b/.changelog/5135.internal.md
@@ -1,0 +1,6 @@
+runtime/src/protocol: Remove consensus version compatibility check
+
+Consensus version check was a sanity check which didn't allow dump-restore
+upgrades. The removal did no harm as the consensus version was never
+authenticated and light clients use the verifier to check state compatibility
+and authenticity.

--- a/runtime/src/common/version.rs
+++ b/runtime/src/common/version.rs
@@ -68,14 +68,6 @@ pub const PROTOCOL_VERSION: Version = Version {
     patch: 0,
 };
 
-// Version of the consensus protocol runtime code works with. This version MUST
-// be compatible with the one supported by the worker host.
-pub const CONSENSUS_VERSION: Version = Version {
-    major: 6,
-    minor: 0,
-    patch: 0,
-};
-
 #[cfg(test)]
 mod test {
     use super::Version;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -37,7 +37,7 @@ pub mod storage;
 pub mod transaction;
 pub mod types;
 
-use crate::common::version::{Version, CONSENSUS_VERSION, PROTOCOL_VERSION};
+use crate::common::version::{Version, PROTOCOL_VERSION};
 
 #[cfg(target_env = "sgx")]
 use self::common::sgx::{EnclaveIdentity, MrSigner};
@@ -81,7 +81,6 @@ lazy_static! {
 
         BuildInfo {
             protocol_version: PROTOCOL_VERSION,
-            consensus_version: CONSENSUS_VERSION,
             is_secure,
         }
     };
@@ -91,8 +90,6 @@ lazy_static! {
 pub struct BuildInfo {
     /// Supported runtime protocol version.
     pub protocol_version: Version,
-    /// Supported consensus protocol version.
-    pub consensus_version: Version,
     /// True iff the build can provide integrity and confidentiality.
     pub is_secure: bool,
 }

--- a/runtime/src/protocol.rs
+++ b/runtime/src/protocol.rs
@@ -409,12 +409,6 @@ impl Protocol {
         if tendermint::BACKEND_NAME != host_info.consensus_backend {
             return Err(ProtocolError::IncompatibleConsensusBackend.into());
         }
-        if !BUILD_INFO
-            .consensus_version
-            .is_compatible_with(&host_info.consensus_protocol_version)
-        {
-            return Err(ProtocolError::IncompatibleConsensusBackend.into());
-        }
         let mut local_host_info = self.host_info.lock().unwrap();
         if local_host_info.is_some() {
             return Err(ProtocolError::AlreadyInitialized.into());


### PR DESCRIPTION
Backport https://github.com/oasisprotocol/oasis-core/pull/5135.