### PR TITLE
runtime: Clear verification trace after block verification

### DIFF
--- a/.changelog/5148.bugfix.md
+++ b/.changelog/5148.bugfix.md
@@ -1,0 +1,1 @@
+runtime: Clear verification trace after block verification

--- a/runtime/src/consensus/tendermint/verifier/mod.rs
+++ b/runtime/src/consensus/tendermint/verifier/mod.rs
@@ -143,6 +143,9 @@ impl Verifier {
         }
         .map_err(|err| Error::VerificationFailed(err.into()))?;
 
+        // Clear verification trace as it could otherwise lead to infinite memory growth.
+        instance.state.verification_trace.clear();
+
         cache.update_verified_block(&verified_block);
         self.update_insecure_posix_time(&verified_block);
 


### PR DESCRIPTION
Thanks to @ptrus for flagging this.