### PR TITLE
runtime/src/enclave_rpc: Support calls to explicit key manager members

### DIFF
--- a/.changelog/5156.feature.md
+++ b/.changelog/5156.feature.md
@@ -1,0 +1,7 @@
+runtime/src/enclave_rpc: Support calls to explicit key manager members
+
+Key manager enclaves can now request a host to talk not only to a randomly
+chosen key manager instance, but also to a specific instance. The identity
+of the remote node is verified only in Noise sessions. In these, the enclave
+obtains the other instance's trusted RAK from the consensus layer and compares
+it to the one used throughout the session.

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -462,6 +462,9 @@ type HostRPCCallRequest struct {
 	Request  []byte          `json:"request"`
 	Kind     enclaverpc.Kind `json:"kind,omitempty"`
 
+	// Nodes are optional node identities in case the request should be forwarded to specific
+	// node instances and not to randomly chosen ones as selected by the host.
+	Nodes []signature.PublicKey `json:"nodes,omitempty"`
 	// PeerFeedback contains optional peer feedback for the last RPC call under the given endpoint.
 	//
 	// This enables the runtime to notify the node whether the given peer should continue to be used
@@ -473,7 +476,10 @@ type HostRPCCallRequest struct {
 
 // HostRPCCallResponse is a host RPC call response message body.
 type HostRPCCallResponse struct {
+	// Response is a response to a HostRPCCallRequest.
 	Response []byte `json:"response"`
+	// Node is the identifier of the node that handled the request.
+	Node *signature.PublicKey `json:"node,omitempty"`
 }
 
 // HostStorageEndpoint is the host storage endpoint.

--- a/go/runtime/keymanager/api/api.go
+++ b/go/runtime/keymanager/api/api.go
@@ -4,6 +4,7 @@ package api
 import (
 	"context"
 
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	enclaverpc "github.com/oasisprotocol/oasis-core/go/runtime/enclaverpc/api"
 )
 
@@ -14,7 +15,10 @@ const EnclaveRPCEndpoint = "key-manager"
 type Client interface {
 	// CallEnclave calls the key manager via remote EnclaveRPC.
 	//
+	// The node to which the call will be routed is chosen at random from the key manager committee
+	// members. The latter can be restricted by specifying a non-empty list of allowed nodes.
+	//
 	// The provided peer feedback is optional feedback on the peer that handled the last EnclaveRPC
 	// request (if any) which may be used to inform the routing decision.
-	CallEnclave(ctx context.Context, data []byte, kind enclaverpc.Kind, pf *enclaverpc.PeerFeedback) ([]byte, error)
+	CallEnclave(ctx context.Context, data []byte, nodes []signature.PublicKey, kind enclaverpc.Kind, pf *enclaverpc.PeerFeedback) ([]byte, error)
 }

--- a/go/runtime/keymanager/api/api.go
+++ b/go/runtime/keymanager/api/api.go
@@ -20,5 +20,5 @@ type Client interface {
 	//
 	// The provided peer feedback is optional feedback on the peer that handled the last EnclaveRPC
 	// request (if any) which may be used to inform the routing decision.
-	CallEnclave(ctx context.Context, data []byte, nodes []signature.PublicKey, kind enclaverpc.Kind, pf *enclaverpc.PeerFeedback) ([]byte, error)
+	CallEnclave(ctx context.Context, data []byte, nodes []signature.PublicKey, kind enclaverpc.Kind, pf *enclaverpc.PeerFeedback) ([]byte, signature.PublicKey, error)
 }

--- a/go/runtime/registry/host.go
+++ b/go/runtime/registry/host.go
@@ -185,7 +185,7 @@ func (h *runtimeHostHandler) handleHostRPCCall(
 		if err != nil {
 			return nil, err
 		}
-		res, err := kmCli.CallEnclave(ctx, rq.Request, rq.Kind, rq.PeerFeedback)
+		res, err := kmCli.CallEnclave(ctx, rq.Request, nil, rq.Kind, rq.PeerFeedback)
 		if err != nil {
 			return nil, err
 		}

--- a/go/runtime/registry/host.go
+++ b/go/runtime/registry/host.go
@@ -185,12 +185,19 @@ func (h *runtimeHostHandler) handleHostRPCCall(
 		if err != nil {
 			return nil, err
 		}
-		res, err := kmCli.CallEnclave(ctx, rq.Request, nil, rq.Kind, rq.PeerFeedback)
+		res, node, err := kmCli.CallEnclave(ctx, rq.Request, rq.Nodes, rq.Kind, rq.PeerFeedback)
 		if err != nil {
 			return nil, err
 		}
+		// Don't send node identity if the runtime doesn't support explicit key manager RPC calls.
+		if rq.Nodes == nil {
+			return &protocol.HostRPCCallResponse{
+				Response: res,
+			}, nil
+		}
 		return &protocol.HostRPCCallResponse{
-			Response: cbor.FixSliceForSerde(res),
+			Response: res,
+			Node:     &node,
 		}, nil
 	default:
 		return nil, errEndpointNotSupported

--- a/go/worker/common/committee/keymanager.go
+++ b/go/worker/common/committee/keymanager.go
@@ -5,11 +5,17 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/libp2p/go-libp2p/core"
+
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	cmSync "github.com/oasisprotocol/oasis-core/go/common/sync"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	keymanager "github.com/oasisprotocol/oasis-core/go/keymanager/api"
 	p2p "github.com/oasisprotocol/oasis-core/go/p2p/api"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	enclaverpc "github.com/oasisprotocol/oasis-core/go/runtime/enclaverpc/api"
 	keymanagerP2P "github.com/oasisprotocol/oasis-core/go/worker/keymanager/p2p"
 )
@@ -26,6 +32,7 @@ type KeyManagerClientWrapper struct {
 	consensus    consensus.Backend
 	chainContext string
 	cli          keymanagerP2P.Client
+	nt           *nodeTracker
 	logger       *logging.Logger
 
 	lastPeerFeedback rpc.PeerFeedback
@@ -36,14 +43,14 @@ func (km *KeyManagerClientWrapper) Initialized() <-chan struct{} {
 	km.l.Lock()
 	defer km.l.Unlock()
 
-	// If no active key manager client, return a closed channel.
-	if km.cli == nil {
+	// If no active key manager client or node tracker, return a closed channel.
+	if km.cli == nil || km.nt == nil {
 		initCh := make(chan struct{})
 		close(initCh)
 		return initCh
 	}
 
-	return km.cli.Initialized()
+	return km.nt.Initialized()
 }
 
 // SetKeyManagerID configures the key manager runtime ID to use.
@@ -61,13 +68,18 @@ func (km *KeyManagerClientWrapper) SetKeyManagerID(id *common.Namespace) {
 	)
 	km.id = id
 
-	if km.cli != nil {
-		km.cli.Stop()
-		km.cli = nil
+	if km.nt != nil {
+		km.nt.Stop()
 	}
 
-	if id != nil {
+	switch id {
+	case nil:
+		km.cli = nil
+		km.nt = nil
+	default:
 		km.cli = keymanagerP2P.NewClient(km.p2p, km.consensus, km.chainContext, *id)
+		km.nt = newKeyManagerNodeTracker(km.p2p, km.consensus, *id)
+		km.nt.Start()
 	}
 
 	km.lastPeerFeedback = nil
@@ -77,6 +89,7 @@ func (km *KeyManagerClientWrapper) SetKeyManagerID(id *common.Namespace) {
 func (km *KeyManagerClientWrapper) CallEnclave(
 	ctx context.Context,
 	data []byte,
+	nodes []signature.PublicKey,
 	kind enclaverpc.Kind,
 	pf *enclaverpc.PeerFeedback,
 ) ([]byte, error) {
@@ -112,10 +125,19 @@ func (km *KeyManagerClientWrapper) CallEnclave(
 		}
 	}
 
-	rsp, nextPf, err := cli.CallEnclave(ctx, &keymanagerP2P.CallEnclaveRequest{
+	// Call only members of the key manager committee. If no nodes are given, use all members.
+	kmNodes := km.nt.Nodes(nodes)
+	peers := make([]core.PeerID, 0, len(kmNodes))
+	for p := range kmNodes {
+		peers = append(peers, p)
+	}
+
+	req := &keymanagerP2P.CallEnclaveRequest{
 		Data: data,
 		Kind: kind,
-	})
+	}
+
+	rsp, nextPf, err := cli.CallEnclave(ctx, req, peers)
 	if err != nil {
 		return nil, err
 	}
@@ -137,5 +159,153 @@ func NewKeyManagerClientWrapper(p2p p2p.Service, consensus consensus.Backend, ch
 		consensus:    consensus,
 		chainContext: chainContext,
 		logger:       logger,
+	}
+}
+
+type nodeTracker struct {
+	sync.Mutex
+
+	p2p          p2p.Service
+	consensus    consensus.Backend
+	keymanagerID common.Namespace
+
+	nodes map[signature.PublicKey]core.PeerID
+
+	initCh   chan struct{}
+	startOne cmSync.One
+
+	logger *logging.Logger
+}
+
+// Stop stops the node tracker if it is running.
+func (nt *nodeTracker) Stop() {
+	nt.startOne.TryStop()
+}
+
+// Start starts the node tracker if it is not running.
+func (nt *nodeTracker) Start() {
+	nt.startOne.TryStart(nt.trackKeymanagerNodes)
+}
+
+// Initialized returns a channel that closes when the tracker fetches nodes from the key manager
+// status for the first time.
+func (nt *nodeTracker) Initialized() <-chan struct{} {
+	return nt.initCh
+}
+
+// Nodes returns a map of key manager node IDs and their peer identities for the given list
+// of nodes. If no nodes given, all registered members of the key manager committee are returned.
+func (nt *nodeTracker) Nodes(nodes []signature.PublicKey) map[core.PeerID]signature.PublicKey {
+	nt.Lock()
+	defer nt.Unlock()
+
+	peers := make(map[core.PeerID]signature.PublicKey, len(nt.nodes))
+
+	switch len(nodes) {
+	case 0:
+		for n, p := range nt.nodes {
+			peers[p] = n
+		}
+	default:
+		for _, n := range nodes {
+			if p, ok := nt.nodes[n]; ok {
+				peers[p] = n
+			}
+		}
+	}
+
+	return peers
+}
+
+func (nt *nodeTracker) trackKeymanagerNodes(ctx context.Context) {
+	stCh, stSub := nt.consensus.KeyManager().WatchStatuses()
+	defer stSub.Close()
+
+	for {
+		var status *keymanager.Status
+		select {
+		case <-ctx.Done():
+			return
+		case st := <-stCh:
+			// Ignore status updates if key manager is not yet known (is nil) or if the status
+			// update is for a different key manager.
+			if !st.ID.Equal(&nt.keymanagerID) {
+				continue
+			}
+
+			status = st
+		}
+
+		// It's not possible to service requests for this key manager.
+		if !status.IsInitialized || len(status.Nodes) == 0 {
+			nt.logger.Warn("key manager not initialized or has no nodes",
+				"id", status.ID,
+				"status", status,
+			)
+			continue
+		}
+
+		// Fetch key manager nodes from the consensus layer.
+		nodes := make(map[signature.PublicKey]core.PeerID, len(status.Nodes))
+		peers := make([]core.PeerID, 0, len(status.Nodes))
+		for _, nodeID := range status.Nodes {
+			node, err := nt.consensus.Registry().GetNode(ctx, &registry.IDQuery{
+				ID:     nodeID,
+				Height: consensus.HeightLatest,
+			})
+			if err != nil {
+				nt.logger.Warn("failed to fetch node descriptor",
+					"err", err,
+					"node_id", nodeID,
+				)
+				continue
+			}
+
+			peerID, err := p2p.PublicKeyToPeerID(node.P2P.ID)
+			if err != nil {
+				nt.logger.Warn("failed to derive peer ID",
+					"err", err,
+					"node_id", nodeID,
+				)
+				continue
+			}
+
+			nodes[node.ID] = peerID
+			peers = append(peers, peerID)
+		}
+
+		// Mark them as important.
+		if pm := nt.p2p.PeerManager(); pm != nil {
+			pm.PeerTagger().SetPeerImportance(p2p.ImportantNodeKeyManager, nt.keymanagerID, peers)
+		}
+
+		// Update nodes.
+		nt.Lock()
+		nt.nodes = nodes
+		nt.Unlock()
+
+		// Signal initialization completed.
+		select {
+		case <-nt.initCh:
+		default:
+			nt.logger.Info("key manager is initialized",
+				"id", status.ID,
+				"status", status,
+			)
+			close(nt.initCh)
+		}
+	}
+}
+
+// newKeyManagerNodeTracker creates a new tracker that is responsible for keeping the list
+// of key manager nodes and their peer identities up-to-date.
+func newKeyManagerNodeTracker(p2p p2p.Service, consensus consensus.Backend, keymanagerID common.Namespace) *nodeTracker {
+	return &nodeTracker{
+		p2p:          p2p,
+		consensus:    consensus,
+		keymanagerID: keymanagerID,
+		initCh:       make(chan struct{}),
+		startOne:     cmSync.NewOne(),
+		logger:       logging.GetLogger("worker/common/committee/keymanager/nodetracker"),
 	}
 }

--- a/go/worker/keymanager/p2p/client.go
+++ b/go/worker/keymanager/p2p/client.go
@@ -2,19 +2,14 @@ package p2p
 
 import (
 	"context"
-	"sync"
 
 	"github.com/libp2p/go-libp2p/core"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
-	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
-	keymanager "github.com/oasisprotocol/oasis-core/go/keymanager/api"
 	p2p "github.com/oasisprotocol/oasis-core/go/p2p/api"
 	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
-	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 )
 
 const (
@@ -29,24 +24,19 @@ const (
 // Client is a keymanager protocol client.
 type Client interface {
 	// CallEnclave calls a key manager enclave with the provided data.
-	CallEnclave(ctx context.Context, request *CallEnclaveRequest) (*CallEnclaveResponse, rpc.PeerFeedback, error)
-
-	// Stop asks the client to stop.
-	Stop()
-
-	// Initialized returns a channel that gets closed when the client is initialized.
-	Initialized() <-chan struct{}
+	//
+	// The peer to which the call will be routed is chosen at random from the given list.
+	CallEnclave(ctx context.Context, request *CallEnclaveRequest, peers []core.PeerID) (*CallEnclaveResponse, rpc.PeerFeedback, error)
 }
 
 type client struct {
 	rc  rpc.Client
 	mgr rpc.PeerManager
-	nt  *nodeTracker
 }
 
-func (c *client) CallEnclave(ctx context.Context, request *CallEnclaveRequest) (*CallEnclaveResponse, rpc.PeerFeedback, error) {
+func (c *client) CallEnclave(ctx context.Context, request *CallEnclaveRequest, peers []core.PeerID) (*CallEnclaveResponse, rpc.PeerFeedback, error) {
 	var rsp CallEnclaveResponse
-	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(), MethodCallEnclave, request, &rsp,
+	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(rpc.WithLimitPeers(peers)), MethodCallEnclave, request, &rsp,
 		rpc.WithMaxRetries(MaxCallEnclaveRetries),
 	)
 	if err != nil {
@@ -55,133 +45,10 @@ func (c *client) CallEnclave(ctx context.Context, request *CallEnclaveRequest) (
 	return &rsp, pf, nil
 }
 
-func (c *client) Stop() {
-	close(c.nt.stopCh)
-}
-
-func (c *client) Initialized() <-chan struct{} {
-	return c.nt.initCh
-}
-
-type nodeTracker struct {
-	sync.Mutex
-
-	p2p          p2p.Service
-	consensus    consensus.Backend
-	keymanagerID common.Namespace
-
-	peers map[core.PeerID]bool
-
-	initCh chan struct{}
-	stopCh chan struct{}
-
-	logger *logging.Logger
-}
-
-// Implements rpc.PeerFilter.
-func (nt *nodeTracker) IsPeerAcceptable(peerID core.PeerID) bool {
-	nt.Lock()
-	defer nt.Unlock()
-
-	return nt.peers[peerID]
-}
-
-func (nt *nodeTracker) trackKeymanagerNodes() {
-	stCh, stSub := nt.consensus.KeyManager().WatchStatuses()
-	defer stSub.Close()
-
-	ctx := context.Background()
-
-	var initialized bool
-	for {
-		var status *keymanager.Status
-		select {
-		case <-nt.stopCh:
-			return
-		case st := <-stCh:
-			// Ignore status updates if key manager is not yet known (is nil) or if the status
-			// update is for a different key manager.
-			if !st.ID.Equal(&nt.keymanagerID) {
-				continue
-			}
-
-			status = st
-		}
-
-		// It's not possible to service requests for this key manager.
-		if !status.IsInitialized || len(status.Nodes) == 0 {
-			nt.logger.Warn("key manager not initialized or has no nodes",
-				"id", status.ID,
-				"status", status,
-			)
-			continue
-		}
-
-		// Clear peer map and add nodes to filter.
-		nt.Lock()
-		nt.peers = make(map[core.PeerID]bool)
-		peerKeys := make(map[signature.PublicKey]bool)
-		for _, nodeID := range status.Nodes {
-			node, err := nt.consensus.Registry().GetNode(ctx, &registry.IDQuery{
-				ID:     nodeID,
-				Height: consensus.HeightLatest,
-			})
-			if err != nil {
-				nt.logger.Warn("failed to fetch node descriptor",
-					"err", err,
-					"node_id", nodeID,
-				)
-				continue
-			}
-
-			peerID, err := p2p.PublicKeyToPeerID(node.P2P.ID)
-			if err != nil {
-				nt.logger.Warn("failed to derive peer ID",
-					"err", err,
-					"node_id", nodeID,
-				)
-				continue
-			}
-
-			nt.peers[peerID] = true
-			peerKeys[node.P2P.ID] = true
-		}
-		// Mark key manager nodes as important.
-		if pm := nt.p2p.PeerManager(); pm != nil {
-			if pids, err := p2p.PublicKeyMapToPeerIDs(peerKeys); err == nil {
-				pm.PeerTagger().SetPeerImportance(p2p.ImportantNodeKeyManager, nt.keymanagerID, pids)
-			}
-		}
-		nt.Unlock()
-
-		// Signal initialization completed.
-		if !initialized {
-			nt.logger.Info("key manager is initialized",
-				"id", status.ID,
-				"status", status,
-			)
-
-			close(nt.initCh)
-			initialized = true
-		}
-	}
-}
-
 // NewClient creates a new keymanager protocol client.
 func NewClient(p2p p2p.Service, consensus consensus.Backend, chainContext string, keymanagerID common.Namespace) Client {
-	// Create a peer filter as we want the client to only talk to known key manager nodes.
-	nt := &nodeTracker{
-		p2p:          p2p,
-		consensus:    consensus,
-		keymanagerID: keymanagerID,
-		initCh:       make(chan struct{}),
-		stopCh:       make(chan struct{}),
-		logger:       logging.GetLogger("worker/keymanager/p2p/nodetracker"),
-	}
-	go nt.trackKeymanagerNodes()
-
 	pid := protocol.NewRuntimeProtocolID(chainContext, keymanagerID, KeyManagerProtocolID, KeyManagerProtocolVersion)
-	mgr := rpc.NewPeerManager(p2p, pid, rpc.WithStickyPeers(true), rpc.WithPeerFilter(nt))
+	mgr := rpc.NewPeerManager(p2p, pid, rpc.WithStickyPeers(true))
 	rc := rpc.NewClient(p2p.Host(), pid)
 	rc.RegisterListener(mgr)
 
@@ -190,6 +57,5 @@ func NewClient(p2p p2p.Service, consensus consensus.Backend, chainContext string
 	return &client{
 		rc:  rc,
 		mgr: mgr,
-		nt:  nt,
 	}
 }

--- a/go/worker/storage/p2p/sync/client.go
+++ b/go/worker/storage/p2p/sync/client.go
@@ -107,9 +107,9 @@ func (c *client) GetCheckpointChunk(
 	// When a checkpoint is passed, we limit requests to only those peers that actually advertised
 	// having the checkpoint in question to avoid needless requests.
 	if cp != nil {
-		peers := make(map[core.PeerID]struct{})
+		peers := make([]core.PeerID, 0, len(cp.Peers))
 		for _, pf := range cp.Peers {
-			peers[pf.PeerID()] = struct{}{}
+			peers = append(peers, pf.PeerID())
 		}
 		opts = append(opts, rpc.WithLimitPeers(peers))
 	}

--- a/keymanager/src/crypto/kdf.rs
+++ b/keymanager/src/crypto/kdf.rs
@@ -305,12 +305,14 @@ impl Kdf {
 
                         let km_client = RemoteClient::new_runtime_with_enclaves_and_policy(
                             rctx.runtime_id,
+                            Some(rctx.runtime_id),
                             Policy::global().may_replicate_from(),
                             ctx.identity.quote_policy(),
                             rctx.protocol.clone(),
                             ctx.consensus_verifier.clone(),
                             ctx.identity.clone(),
                             1, // Not used, doesn't matter.
+                            vec![],
                         );
 
                         let result =

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -218,11 +218,13 @@ pub enum Body {
         endpoint: String,
         request: Vec<u8>,
         kind: enclave_rpc::types::Kind,
+        nodes: Vec<signature::PublicKey>,
         #[cbor(optional, rename = "pf")]
         peer_feedback: Option<enclave_rpc::types::PeerFeedback>,
     },
     HostRPCCallResponse {
         response: Vec<u8>,
+        node: signature::PublicKey,
     },
     HostStorageSyncRequest(StorageSyncRequestWithEndpoint),
     HostStorageSyncResponse(StorageSyncResponse),

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -373,6 +373,7 @@ pub fn main_with_version(version: Version) {
             state.identity.clone(),
             1024,
             trusted_policy_signers(),
+            vec![],
         ));
 
         let key_manager = km_client.clone();


### PR DESCRIPTION
### Task
Currently the EnclaveRPC clients can only talk to a randomly chosen remote key manager as selected by the host. It should be possible for the client to ask the host to talk to a specific key manager instance identifier by its (node ID, RAK) pair and its identity would be verified by using RAK (in addition to the remote attestation checks). The enclave can obtain a trusted RAK of other instances from the consensus layer registry service.

This would allow for later implementation of secret sharing schemes where communication with particular instances is required.