### PR TITLE
go/worker/client: Ensure block round is synced to storage

### DIFF
--- a/.changelog/5160.bugfix.md
+++ b/.changelog/5160.bugfix.md
@@ -1,0 +1,4 @@
+go/worker/client: Ensure block round is synced to storage
+
+Previously the transaction inclusion checks could attempt to inspect a
+block that the node has not yet synced, triggering an error.


### PR DESCRIPTION
Previously the transaction inclusion checks could attempt to inspect a block that the node has not yet synced, triggering an error.