### PR TITLE
go/keymanager/api: Move key manager gas costs

### DIFF
--- a/.changelog/5166.breaking.md
+++ b/.changelog/5166.breaking.md
@@ -1,0 +1,4 @@
+go/keymanager/api: Move key manager gas costs
+
+Consensus parameters were added to the key manager state and key manager gas
+costs were moved from the registry state to the key manager state.

--- a/go/consensus/tendermint/apps/keymanager/genesis.go
+++ b/go/consensus/tendermint/apps/keymanager/genesis.go
@@ -24,6 +24,12 @@ func (app *keymanagerApplication) InitChain(ctx *tmapi.Context, request types.Re
 		"state", string(b),
 	)
 
+	state := keymanagerState.NewMutableState(ctx.State())
+
+	if err := state.SetConsensusParameters(ctx, &st.Parameters); err != nil {
+		return fmt.Errorf("tendermint/keymanager: failed to set consensus parameters: %w", err)
+	}
+
 	epoch, err := app.state.GetCurrentEpoch(ctx)
 	if err != nil {
 		return fmt.Errorf("tendermint/keymanager: couldn't get current epoch: %w", err)
@@ -49,7 +55,6 @@ func (app *keymanagerApplication) InitChain(ctx *tmapi.Context, request types.Re
 	}
 
 	var toEmit []*keymanager.Status
-	state := keymanagerState.NewMutableState(ctx.State())
 	for i, v := range st.Statuses {
 		if v == nil {
 			return fmt.Errorf("InitChain: Status index %d is nil", i)

--- a/go/consensus/tendermint/apps/keymanager/messages.go
+++ b/go/consensus/tendermint/apps/keymanager/messages.go
@@ -1,0 +1,54 @@
+package keymanager
+
+import (
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	keymanagerState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/keymanager/state"
+	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
+	keymanager "github.com/oasisprotocol/oasis-core/go/keymanager/api"
+)
+
+func (app *keymanagerApplication) changeParameters(ctx *api.Context, msg interface{}, apply bool) (interface{}, error) {
+	// Unmarshal changes and check if they should be applied to this module.
+	proposal, ok := msg.(*governance.ChangeParametersProposal)
+	if !ok {
+		return nil, fmt.Errorf("keymanager: failed to type assert change parameters proposal")
+	}
+
+	if proposal.Module != keymanager.ModuleName {
+		return nil, nil
+	}
+
+	var changes keymanager.ConsensusParameterChanges
+	if err := cbor.Unmarshal(proposal.Changes, &changes); err != nil {
+		return nil, fmt.Errorf("keymanager: failed to unmarshal consensus parameter changes: %w", err)
+	}
+
+	// Validate changes against current parameters.
+	state := keymanagerState.NewMutableState(ctx.State())
+	params, err := state.ConsensusParameters(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("keymanager: failed to load consensus parameters: %w", err)
+	}
+	if err = changes.SanityCheck(); err != nil {
+		return nil, fmt.Errorf("keymanager: failed to validate consensus parameter changes: %w", err)
+	}
+	if err = changes.Apply(params); err != nil {
+		return nil, fmt.Errorf("keymanager: failed to apply consensus parameter changes: %w", err)
+	}
+	if err = params.SanityCheck(); err != nil {
+		return nil, fmt.Errorf("keymanager: failed to validate consensus parameters: %w", err)
+	}
+
+	// Apply changes.
+	if apply {
+		if err = state.SetConsensusParameters(ctx, params); err != nil {
+			return nil, fmt.Errorf("keymanager: failed to update consensus parameters: %w", err)
+		}
+	}
+
+	// Non-nil response signals that changes are valid and were successfully applied (if required).
+	return struct{}{}, nil
+}

--- a/go/consensus/tendermint/apps/keymanager/messages_test.go
+++ b/go/consensus/tendermint/apps/keymanager/messages_test.go
@@ -1,0 +1,89 @@
+package keymanager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
+	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	keymanagerState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/keymanager/state"
+	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
+	keymanager "github.com/oasisprotocol/oasis-core/go/keymanager/api"
+)
+
+func TestChangeParameters(t *testing.T) {
+	require := require.New(t)
+
+	// Prepare context.
+	now := time.Unix(1580461674, 0)
+	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
+	ctx := appState.NewContext(abciAPI.ContextEndBlock, now)
+	defer ctx.Close()
+
+	// Setup state.
+	state := keymanagerState.NewMutableState(ctx.State())
+	app := &keymanagerApplication{
+		state: appState,
+	}
+	params := &keymanager.ConsensusParameters{
+		GasCosts: transaction.Costs{
+			keymanager.GasOpUpdatePolicy: 1000,
+		},
+	}
+	err := state.SetConsensusParameters(ctx, params)
+	require.NoError(err, "setting consensus parameters should succeed")
+
+	// Prepare proposal.
+	gasCosts := transaction.Costs{
+		keymanager.GasOpUpdatePolicy: 2000,
+	}
+	changes := keymanager.ConsensusParameterChanges{
+		GasCosts: gasCosts,
+	}
+	proposal := governance.ChangeParametersProposal{
+		Module:  keymanager.ModuleName,
+		Changes: cbor.Marshal(changes),
+	}
+
+	// Run sub-tests.
+	t.Run("happy path - validate only", func(t *testing.T) {
+		res, err := app.changeParameters(ctx, &proposal, false)
+		require.NoError(err, "validation of consensus parameter changes should succeed")
+		require.Equal(struct{}{}, res)
+
+		state, err := state.ConsensusParameters(ctx)
+		require.NoError(err, "fetching consensus parameters should succeed")
+		require.Equal(params.GasCosts, state.GasCosts, "consensus parameters shouldn't change")
+	})
+	t.Run("happy path - apply changes", func(t *testing.T) {
+		res, err := app.changeParameters(ctx, &proposal, true)
+		require.NoError(err, "changing consensus parameters should succeed")
+		require.Equal(struct{}{}, res)
+
+		state, err := state.ConsensusParameters(ctx)
+		require.NoError(err, "fetching consensus parameters should succeed")
+		require.Equal(gasCosts, state.GasCosts, "consensus parameters should change")
+	})
+	t.Run("invalid proposal", func(t *testing.T) {
+		_, err := app.changeParameters(ctx, "proposal", true)
+		require.EqualError(err, "keymanager: failed to type assert change parameters proposal")
+	})
+	t.Run("different module", func(t *testing.T) {
+		proposal := governance.ChangeParametersProposal{
+			Module: "module",
+		}
+		res, err := app.changeParameters(ctx, &proposal, true)
+		require.Nil(res, "changes for other modules should be ignored")
+		require.NoError(err, "changes for other modules should be ignored without error")
+	})
+	t.Run("empty changes", func(t *testing.T) {
+		proposal := governance.ChangeParametersProposal{
+			Module: keymanager.ModuleName,
+		}
+		_, err := app.changeParameters(ctx, &proposal, true)
+		require.EqualError(err, "keymanager: failed to validate consensus parameter changes: consensus parameter changes should not be empty")
+	})
+}

--- a/go/consensus/tendermint/apps/keymanager/transactions.go
+++ b/go/consensus/tendermint/apps/keymanager/transactions.go
@@ -53,11 +53,11 @@ func (app *keymanagerApplication) updatePolicy(
 	}
 
 	// Charge gas for this operation.
-	regParams, err := regState.ConsensusParameters(ctx)
+	kmParams, err := state.ConsensusParameters(ctx)
 	if err != nil {
 		return err
 	}
-	if err = ctx.Gas().UseGas(1, registry.GasOpUpdateKeyManager, regParams.GasCosts); err != nil {
+	if err = ctx.Gas().UseGas(1, api.GasOpUpdatePolicy, kmParams.GasCosts); err != nil {
 		return err
 	}
 
@@ -78,6 +78,11 @@ func (app *keymanagerApplication) updatePolicy(
 	// node-reregistration, but I'm not sure how often the policy
 	// will get updated.
 	epoch, err := app.state.GetCurrentEpoch(ctx)
+	if err != nil {
+		return err
+	}
+
+	regParams, err := regState.ConsensusParameters(ctx)
 	if err != nil {
 		return err
 	}

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -137,7 +137,7 @@ func TestGenesisChainContext(t *testing.T) {
 
 	// Having to update this every single time the genesis structure
 	// changes isn't annoying at all.
-	require.Equal(t, "dfa431a32209f17f3fd9b5dddfce2bf2200eaca49c9f08abf2edeca79b800772", stableDoc.ChainContext())
+	require.Equal(t, "719f70522786e522c56e913cf3d31cf79d479dc0670ae048f2e476f732ac2990", stableDoc.ChainContext())
 }
 
 func TestGenesisSanityCheck(t *testing.T) {

--- a/go/keymanager/api/sanity_check.go
+++ b/go/keymanager/api/sanity_check.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"fmt"
+)
+
+// SanityCheckStatuses examines the statuses table.
+func SanityCheckStatuses(statuses []*Status) error {
+	for _, status := range statuses {
+		// Verify key manager runtime ID.
+		if !status.ID.IsKeyManager() {
+			return fmt.Errorf("keymanager: sanity check failed: key manager runtime ID %s is invalid", status.ID)
+		}
+
+		// Verify currently active key manager node IDs.
+		for _, node := range status.Nodes {
+			if !node.IsValid() {
+				return fmt.Errorf("keymanager: sanity check failed: key manager node ID %s is invalid", node.String())
+			}
+		}
+
+		// Verify SGX policy signatures if the policy exists.
+		if status.Policy != nil {
+			if err := SanityCheckSignedPolicySGX(nil, status.Policy); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// SanityCheck does basic sanity checking on the genesis state.
+func (g *Genesis) SanityCheck() error {
+	if err := g.Parameters.SanityCheck(); err != nil {
+		return fmt.Errorf("keymanager: sanity check failed: %w", err)
+	}
+
+	if err := SanityCheckStatuses(g.Statuses); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SanityCheck performs a sanity check on the consensus parameters.
+func (p *ConsensusParameters) SanityCheck() error {
+	return nil
+}
+
+// SanityCheck performs a sanity check on the consensus parameter changes.
+func (c *ConsensusParameterChanges) SanityCheck() error {
+	if c.GasCosts == nil {
+		return fmt.Errorf("consensus parameter changes should not be empty")
+	}
+	return nil
+}

--- a/go/oasis-node/cmd/debug/fixgenesis/fixgenesis.go
+++ b/go/oasis-node/cmd/debug/fixgenesis/fixgenesis.go
@@ -19,6 +19,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
+	keymanager "github.com/oasisprotocol/oasis-core/go/keymanager/api"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
@@ -308,6 +309,11 @@ NodeLoop:
 		}
 		newDoc.Registry.Nodes = append(newDoc.Registry.Nodes, sigNode)
 	}
+
+	// Move key manager gas costs from the registry to the key manager.
+	newDoc.KeyManager.Parameters.GasCosts = keymanager.DefaultGasCosts
+	newDoc.KeyManager.Parameters.GasCosts[keymanager.GasOpUpdatePolicy] = newDoc.Registry.Parameters.GasCosts["update_keymanager"]
+	delete(newDoc.Registry.Parameters.GasCosts, "update_keymanager")
 
 	return &newDoc, nil
 }

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -512,8 +512,7 @@ func AppendRootHashState(doc *genesis.Document, exports []string, l *logging.Log
 			DebugBypassStake:          viper.GetBool(cfgRoothashDebugBypassStake),
 			MaxRuntimeMessages:        viper.GetUint32(CfgRoothashMaxRuntimeMessages),
 			MaxInRuntimeMessages:      viper.GetUint32(CfgRoothashMaxInRuntimeMessages),
-			// TODO: Make these configurable.
-			GasCosts: roothash.DefaultGasCosts,
+			GasCosts:                  roothash.DefaultGasCosts, // TODO: Make these configurable.
 		},
 	}
 
@@ -557,7 +556,11 @@ func AppendRootHashState(doc *genesis.Document, exports []string, l *logging.Log
 // AppendKeyManagerState appends the key manager genesis state given a vector of
 // key manager statuses.
 func AppendKeyManagerState(doc *genesis.Document, statuses []string, l *logging.Logger) error {
-	var kmSt keymanager.Genesis
+	kmSt := keymanager.Genesis{
+		Parameters: keymanager.ConsensusParameters{
+			GasCosts: keymanager.DefaultGasCosts, // TODO: Make these configurable.
+		},
+	}
 
 	for _, v := range statuses {
 		b, err := os.ReadFile(v)

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -1496,9 +1496,6 @@ const (
 	// GasOpRuntimeEpochMaintenance is the gas operation identifier for per-epoch
 	// runtime maintenance costs.
 	GasOpRuntimeEpochMaintenance transaction.Op = "runtime_epoch_maintenance"
-	// GasOpUpdateKeyManager is the gas operation identifier for key manager
-	// policy updates costs.
-	GasOpUpdateKeyManager transaction.Op = "update_keymanager"
 	// GasOpProveFreshness is the gas operation identifier for freshness proofs.
 	GasOpProveFreshness transaction.Op = "prove_freshness"
 )
@@ -1513,7 +1510,6 @@ var DefaultGasCosts = transaction.Costs{
 	GasOpUnfreezeNode:            1000,
 	GasOpRegisterRuntime:         1000,
 	GasOpRuntimeEpochMaintenance: 1000,
-	GasOpUpdateKeyManager:        1000,
 	GasOpProveFreshness:          1000,
 }
 


### PR DESCRIPTION
Moving key manager gas costs from registry to key manager.