### PR TITLE
go/consensus/supplementarysanity: Fix checks for legacy validators

### DIFF
--- a/.changelog/5168.internal.md
+++ b/.changelog/5168.internal.md
@@ -1,0 +1,1 @@
+go/consensus/supplementarysanity: Fix checks for legacy validators

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -62,7 +62,7 @@ const (
 	LatestNodeDescriptorVersion = 3
 
 	// Minimum and maximum descriptor versions that are allowed.
-	minNodeDescriptorVersion = 2
+	minNodeDescriptorVersion = 3
 	maxNodeDescriptorVersion = LatestNodeDescriptorVersion
 
 	nodeSoftwareVersionMaxLength = 128

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -706,9 +706,10 @@ func VerifyRegisterNodeArgs( // nolint: gocyclo
 	}
 	expectedSigners = append(expectedSigners, n.P2P.ID)
 	p2pAddressRequired := n.HasRoles(P2PAddressRequiredRoles)
-	switch isGenesis {
+	switch isGenesis || isSanityCheck {
 	case true:
 		// Allow legacy descriptor with optional p2p address for validator.
+		// XXX: Remove this after 23.0.x.
 		if n.HasRoles(node.RoleValidator) {
 			p2pAddressRequired = false
 		}


### PR DESCRIPTION
Before, when upgrading from 22.2.x the supplementary-sanity checks would fail for validator nodes that did not yet re-register with added P2P address.

(Unrelated change) update `minNodeDescriptorVersion` to 3, because V2 descriptors are automatically migrated to V3 in deserialization, so no need to allow V2 descriptors.