### PR TITLE
go: Minor test case fixes

### DIFF
--- a/go/common/sync/sync_test.go
+++ b/go/common/sync/sync_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 func TestOne(t *testing.T) {
-	require := require.New(t)
-
 	noopFn := func(ctx context.Context) {}
 	blockFn := func(ctx context.Context) {
 		<-ctx.Done()
 	}
 
 	t.Run("Non-blocking function", func(t *testing.T) {
+		require := require.New(t)
+
 		one := NewOne()
 
 		// All functions should start and stop if there is big enough time gap
@@ -40,6 +40,8 @@ func TestOne(t *testing.T) {
 	})
 
 	t.Run("Blocking function", func(t *testing.T) {
+		require := require.New(t)
+
 		one := NewOne()
 
 		// First function should start, others not.

--- a/go/consensus/tendermint/apps/governance/messages_test.go
+++ b/go/consensus/tendermint/apps/governance/messages_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestChangeParameters(t *testing.T) {
-	require := require.New(t)
-
 	// Prepare context.
 	now := time.Unix(1580461674, 0)
 	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
@@ -34,7 +32,7 @@ func TestChangeParameters(t *testing.T) {
 		VotingPeriod:              beacon.EpochTime(50),
 	}
 	err := state.SetConsensusParameters(ctx, params)
-	require.NoError(err, "setting consensus parameters should succeed")
+	require.NoError(t, err, "setting consensus parameters should succeed")
 
 	// Prepare proposal.
 	votingPeriod := beacon.EpochTime(60)
@@ -48,6 +46,8 @@ func TestChangeParameters(t *testing.T) {
 
 	// Run sub-tests.
 	t.Run("happy path - validate only", func(t *testing.T) {
+		require := require.New(t)
+
 		res, err := app.changeParameters(ctx, &proposal, false)
 		require.NoError(err, "validation of consensus parameter changes should succeed")
 		require.Equal(struct{}{}, res)
@@ -57,6 +57,8 @@ func TestChangeParameters(t *testing.T) {
 		require.Equal(params.VotingPeriod, state.VotingPeriod, "consensus parameters shouldn't change")
 	})
 	t.Run("happy path - apply changes", func(t *testing.T) {
+		require := require.New(t)
+
 		res, err := app.changeParameters(ctx, &proposal, true)
 		require.NoError(err, "changing consensus parameters should succeed")
 		require.Equal(struct{}{}, res)
@@ -66,10 +68,14 @@ func TestChangeParameters(t *testing.T) {
 		require.Equal(votingPeriod, state.VotingPeriod, "consensus parameters should change")
 	})
 	t.Run("invalid proposal", func(t *testing.T) {
+		require := require.New(t)
+
 		_, err := app.changeParameters(ctx, "proposal", true)
 		require.EqualError(err, "tendermint/governance: failed to type assert change parameters proposal")
 	})
 	t.Run("different module", func(t *testing.T) {
+		require := require.New(t)
+
 		proposal := governance.ChangeParametersProposal{
 			Module: "module",
 		}
@@ -78,6 +84,8 @@ func TestChangeParameters(t *testing.T) {
 		require.NoError(err, "changes for other modules should be ignored without error")
 	})
 	t.Run("empty changes", func(t *testing.T) {
+		require := require.New(t)
+
 		proposal := governance.ChangeParametersProposal{
 			Module: governance.ModuleName,
 		}
@@ -85,6 +93,8 @@ func TestChangeParameters(t *testing.T) {
 		require.EqualError(err, "tendermint/governance: failed to validate consensus parameter changes: consensus parameter changes should not be empty")
 	})
 	t.Run("invalid changes", func(t *testing.T) {
+		require := require.New(t)
+
 		votingPeriod := beacon.EpochTime(100)
 		changes := governance.ConsensusParameterChanges{
 			VotingPeriod: &votingPeriod,

--- a/go/consensus/tendermint/apps/keymanager/keymanager_test.go
+++ b/go/consensus/tendermint/apps/keymanager/keymanager_test.go
@@ -20,8 +20,6 @@ import (
 )
 
 func TestGenerateStatus(t *testing.T) {
-	require := require.New(t)
-
 	// Prepare context.
 	now := time.Unix(1580461674, 0)
 	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
@@ -52,17 +50,17 @@ func TestGenerateStatus(t *testing.T) {
 		PolicyChecksum: policyChecksum[:],
 	}
 	sigInitResponse, err := api.SignInitResponse(rakSigner, &initResponse)
-	require.NoError(err, "SignInitResponse")
+	require.NoError(t, err, "SignInitResponse")
 
 	initResponse.IsSecure = false
 	sigInitResponseInsecure, err := api.SignInitResponse(rakSigner, &initResponse)
-	require.NoError(err, "SignInitResponse")
+	require.NoError(t, err, "SignInitResponse")
 
 	// Two key manager runtimes, one compute runtime.
 	runtimeIDs := make([]common.Namespace, 3)
-	require.NoError(runtimeIDs[0].UnmarshalHex("8000000000000000000000000000000000000000000000000000000000000000"), "runtime 0 (keymanager)")
-	require.NoError(runtimeIDs[1].UnmarshalHex("8000000000000000000000000000000000000000000000000000000000000001"), "runtime 1 (keymanager)")
-	require.NoError(runtimeIDs[2].UnmarshalHex("8000000000000000000000000000000000000000000000000000000000000002"), "runtime 2")
+	require.NoError(t, runtimeIDs[0].UnmarshalHex("8000000000000000000000000000000000000000000000000000000000000000"), "runtime 0 (keymanager)")
+	require.NoError(t, runtimeIDs[1].UnmarshalHex("8000000000000000000000000000000000000000000000000000000000000001"), "runtime 1 (keymanager)")
+	require.NoError(t, runtimeIDs[2].UnmarshalHex("8000000000000000000000000000000000000000000000000000000000000002"), "runtime 2")
 
 	// Initial key manager statuses.
 	initializedStatus := &api.Status{
@@ -196,6 +194,8 @@ func TestGenerateStatus(t *testing.T) {
 	}
 
 	t.Run("No nodes", func(t *testing.T) {
+		require := require.New(t)
+
 		newStatus := app.generateStatus(ctx, runtimes[0], uninitializedStatus, nodes[0:6], params, epoch)
 		require.Equal(uninitializedStatus, newStatus, "key manager committee should be empty")
 
@@ -204,6 +204,8 @@ func TestGenerateStatus(t *testing.T) {
 	})
 
 	t.Run("One node", func(t *testing.T) {
+		require := require.New(t)
+
 		// Node 6 (secure = false)
 		expStatus := &api.Status{
 			ID:            runtimeIDs[0],
@@ -226,6 +228,8 @@ func TestGenerateStatus(t *testing.T) {
 	})
 
 	t.Run("Multiple nodes", func(t *testing.T) {
+		require := require.New(t)
+
 		// The first node is the source of truth when constructing a committee. If the node 6 is
 		// processed before nodes 7 and 8, the latter won't be accepted as they are secure.
 		expStatus := &api.Status{

--- a/go/consensus/tendermint/apps/keymanager/messages_test.go
+++ b/go/consensus/tendermint/apps/keymanager/messages_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func TestChangeParameters(t *testing.T) {
-	require := require.New(t)
-
 	// Prepare context.
 	now := time.Unix(1580461674, 0)
 	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
@@ -34,7 +32,7 @@ func TestChangeParameters(t *testing.T) {
 		},
 	}
 	err := state.SetConsensusParameters(ctx, params)
-	require.NoError(err, "setting consensus parameters should succeed")
+	require.NoError(t, err, "setting consensus parameters should succeed")
 
 	// Prepare proposal.
 	gasCosts := transaction.Costs{
@@ -50,6 +48,8 @@ func TestChangeParameters(t *testing.T) {
 
 	// Run sub-tests.
 	t.Run("happy path - validate only", func(t *testing.T) {
+		require := require.New(t)
+
 		res, err := app.changeParameters(ctx, &proposal, false)
 		require.NoError(err, "validation of consensus parameter changes should succeed")
 		require.Equal(struct{}{}, res)
@@ -59,6 +59,8 @@ func TestChangeParameters(t *testing.T) {
 		require.Equal(params.GasCosts, state.GasCosts, "consensus parameters shouldn't change")
 	})
 	t.Run("happy path - apply changes", func(t *testing.T) {
+		require := require.New(t)
+
 		res, err := app.changeParameters(ctx, &proposal, true)
 		require.NoError(err, "changing consensus parameters should succeed")
 		require.Equal(struct{}{}, res)
@@ -68,10 +70,14 @@ func TestChangeParameters(t *testing.T) {
 		require.Equal(gasCosts, state.GasCosts, "consensus parameters should change")
 	})
 	t.Run("invalid proposal", func(t *testing.T) {
+		require := require.New(t)
+
 		_, err := app.changeParameters(ctx, "proposal", true)
 		require.EqualError(err, "keymanager: failed to type assert change parameters proposal")
 	})
 	t.Run("different module", func(t *testing.T) {
+		require := require.New(t)
+
 		proposal := governance.ChangeParametersProposal{
 			Module: "module",
 		}
@@ -80,6 +86,8 @@ func TestChangeParameters(t *testing.T) {
 		require.NoError(err, "changes for other modules should be ignored without error")
 	})
 	t.Run("empty changes", func(t *testing.T) {
+		require := require.New(t)
+
 		proposal := governance.ChangeParametersProposal{
 			Module: keymanager.ModuleName,
 		}

--- a/go/consensus/tendermint/apps/registry/messages_test.go
+++ b/go/consensus/tendermint/apps/registry/messages_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestChangeParameters(t *testing.T) {
-	require := require.New(t)
-
 	// Prepare context.
 	now := time.Unix(1580461674, 0)
 	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
@@ -31,7 +29,7 @@ func TestChangeParameters(t *testing.T) {
 		MaxNodeExpiration: 10,
 	}
 	err := state.SetConsensusParameters(ctx, params)
-	require.NoError(err, "setting consensus parameters should succeed")
+	require.NoError(t, err, "setting consensus parameters should succeed")
 
 	// Prepare proposal.
 	maxNodeExpiration := uint64(20)
@@ -45,6 +43,8 @@ func TestChangeParameters(t *testing.T) {
 
 	// Run sub-tests.
 	t.Run("happy path - validate only", func(t *testing.T) {
+		require := require.New(t)
+
 		res, err := app.changeParameters(ctx, &proposal, false)
 		require.NoError(err, "validation of consensus parameter changes should succeed")
 		require.Equal(struct{}{}, res)
@@ -54,6 +54,8 @@ func TestChangeParameters(t *testing.T) {
 		require.Equal(params.MaxNodeExpiration, state.MaxNodeExpiration, "consensus parameters shouldn't change")
 	})
 	t.Run("happy path - apply changes", func(t *testing.T) {
+		require := require.New(t)
+
 		res, err := app.changeParameters(ctx, &proposal, true)
 		require.NoError(err, "changing consensus parameters should succeed")
 		require.Equal(struct{}{}, res)
@@ -63,10 +65,14 @@ func TestChangeParameters(t *testing.T) {
 		require.Equal(maxNodeExpiration, state.MaxNodeExpiration, "consensus parameters should change")
 	})
 	t.Run("invalid proposal", func(t *testing.T) {
+		require := require.New(t)
+
 		_, err := app.changeParameters(ctx, "proposal", true)
 		require.EqualError(err, "registry: failed to type assert change parameters proposal")
 	})
 	t.Run("different module", func(t *testing.T) {
+		require := require.New(t)
+
 		proposal := governance.ChangeParametersProposal{
 			Module: "module",
 		}
@@ -75,6 +81,8 @@ func TestChangeParameters(t *testing.T) {
 		require.NoError(err, "changes for other modules should be ignored without error")
 	})
 	t.Run("empty changes", func(t *testing.T) {
+		require := require.New(t)
+
 		proposal := governance.ChangeParametersProposal{
 			Module: registry.ModuleName,
 		}
@@ -82,6 +90,8 @@ func TestChangeParameters(t *testing.T) {
 		require.EqualError(err, "registry: failed to validate consensus parameter changes: consensus parameter changes should not be empty")
 	})
 	t.Run("invalid changes", func(t *testing.T) {
+		require := require.New(t)
+
 		var maxNodeExpiration uint64
 		changes := registry.ConsensusParameterChanges{
 			MaxNodeExpiration: &maxNodeExpiration,

--- a/go/consensus/tendermint/apps/registry/transactions_test.go
+++ b/go/consensus/tendermint/apps/registry/transactions_test.go
@@ -688,8 +688,6 @@ func TestRegisterRuntime(t *testing.T) {
 }
 
 func TestProofFreshness(t *testing.T) {
-	require := requirePkg.New(t)
-
 	now := time.Unix(1580461674, 0)
 	cfg := abciAPI.MockApplicationStateConfig{}
 	appState := abciAPI.NewMockApplicationState(&cfg)
@@ -704,12 +702,14 @@ func TestProofFreshness(t *testing.T) {
 		err := state.SetConsensusParameters(ctx, &registry.ConsensusParameters{
 			TEEFeatures: TEEFeatures,
 		})
-		require.NoError(err, "registry.SetConsensusParameters")
+		requirePkg.NoError(t, err, "registry.SetConsensusParameters")
 	}
 
 	var blob [32]byte
 
 	t.Run("happy path", func(t *testing.T) {
+		require := requirePkg.New(t)
+
 		setTEEFeaturesFn(&node.TEEFeatures{FreshnessProofs: true})
 
 		err := app.proveFreshness(ctx, state, blob)
@@ -717,6 +717,8 @@ func TestProofFreshness(t *testing.T) {
 	})
 
 	t.Run("not enabled", func(t *testing.T) {
+		require := requirePkg.New(t)
+
 		// Freshness proofs disabled.
 		setTEEFeaturesFn(&node.TEEFeatures{FreshnessProofs: false})
 

--- a/go/consensus/tendermint/apps/roothash/messages_test.go
+++ b/go/consensus/tendermint/apps/roothash/messages_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestChangeParameters(t *testing.T) {
-	require := require.New(t)
-
 	// Prepare context.
 	now := time.Unix(1580461674, 0)
 	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
@@ -31,7 +29,7 @@ func TestChangeParameters(t *testing.T) {
 		MaxRuntimeMessages: 10,
 	}
 	err := state.SetConsensusParameters(ctx, params)
-	require.NoError(err, "setting consensus parameters should succeed")
+	require.NoError(t, err, "setting consensus parameters should succeed")
 
 	// Prepare proposal.
 	maxRuntimeMessages := uint32(20)
@@ -45,6 +43,8 @@ func TestChangeParameters(t *testing.T) {
 
 	// Run sub-tests.
 	t.Run("happy path - validate only", func(t *testing.T) {
+		require := require.New(t)
+
 		res, err := app.changeParameters(ctx, &proposal, false)
 		require.NoError(err, "validation of consensus parameter changes should succeed")
 		require.Equal(struct{}{}, res)
@@ -54,6 +54,8 @@ func TestChangeParameters(t *testing.T) {
 		require.Equal(params.MaxRuntimeMessages, state.MaxRuntimeMessages, "consensus parameters shouldn't change")
 	})
 	t.Run("happy path - apply changes", func(t *testing.T) {
+		require := require.New(t)
+
 		res, err := app.changeParameters(ctx, &proposal, true)
 		require.NoError(err, "changing consensus parameters should succeed")
 		require.Equal(struct{}{}, res)
@@ -63,10 +65,14 @@ func TestChangeParameters(t *testing.T) {
 		require.Equal(maxRuntimeMessages, state.MaxRuntimeMessages, "consensus parameters should change")
 	})
 	t.Run("invalid proposal", func(t *testing.T) {
+		require := require.New(t)
+
 		_, err := app.changeParameters(ctx, "proposal", true)
 		require.EqualError(err, "roothash: failed to type assert change parameters proposal")
 	})
 	t.Run("different module", func(t *testing.T) {
+		require := require.New(t)
+
 		proposal := governance.ChangeParametersProposal{
 			Module: "module",
 		}
@@ -75,6 +81,8 @@ func TestChangeParameters(t *testing.T) {
 		require.NoError(err, "changes for other modules should be ignored without error")
 	})
 	t.Run("empty changes", func(t *testing.T) {
+		require := require.New(t)
+
 		proposal := governance.ChangeParametersProposal{
 			Module: roothash.ModuleName,
 		}

--- a/go/consensus/tendermint/apps/scheduler/messages_test.go
+++ b/go/consensus/tendermint/apps/scheduler/messages_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestChangeParameters(t *testing.T) {
-	require := require.New(t)
-
 	// Prepare context.
 	now := time.Unix(1580461674, 0)
 	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
@@ -31,7 +29,7 @@ func TestChangeParameters(t *testing.T) {
 		MinValidators: 1,
 	}
 	err := state.SetConsensusParameters(ctx, params)
-	require.NoError(err, "setting consensus parameters should succeed")
+	require.NoError(t, err, "setting consensus parameters should succeed")
 
 	// Prepare proposal.
 	minValidators := 2
@@ -45,6 +43,8 @@ func TestChangeParameters(t *testing.T) {
 
 	// Run sub-tests.
 	t.Run("happy path - validate only", func(t *testing.T) {
+		require := require.New(t)
+
 		res, err := app.changeParameters(ctx, &proposal, false)
 		require.NoError(err, "validation of consensus parameter changes should succeed")
 		require.Equal(struct{}{}, res)
@@ -54,6 +54,8 @@ func TestChangeParameters(t *testing.T) {
 		require.Equal(params.MinValidators, state.MinValidators, "consensus parameters shouldn't change")
 	})
 	t.Run("happy path - apply changes", func(t *testing.T) {
+		require := require.New(t)
+
 		res, err := app.changeParameters(ctx, &proposal, true)
 		require.NoError(err, "changing consensus parameters should succeed")
 		require.Equal(struct{}{}, res)
@@ -63,10 +65,14 @@ func TestChangeParameters(t *testing.T) {
 		require.Equal(minValidators, state.MinValidators, "consensus parameters should change")
 	})
 	t.Run("invalid proposal", func(t *testing.T) {
+		require := require.New(t)
+
 		_, err := app.changeParameters(ctx, "proposal", true)
 		require.EqualError(err, "tendermint/scheduler: failed to type assert change parameters proposal")
 	})
 	t.Run("different module", func(t *testing.T) {
+		require := require.New(t)
+
 		proposal := governance.ChangeParametersProposal{
 			Module: "module",
 		}
@@ -75,6 +81,8 @@ func TestChangeParameters(t *testing.T) {
 		require.NoError(err, "changes for other modules should be ignored without error")
 	})
 	t.Run("empty changes", func(t *testing.T) {
+		require := require.New(t)
+
 		proposal := governance.ChangeParametersProposal{
 			Module: scheduler.ModuleName,
 		}

--- a/go/consensus/tendermint/apps/staking/messages_test.go
+++ b/go/consensus/tendermint/apps/staking/messages_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func TestChangeParameters(t *testing.T) {
-	require := require.New(t)
-
 	// Prepare context.
 	now := time.Unix(1580461674, 0)
 	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
@@ -40,7 +38,7 @@ func TestChangeParameters(t *testing.T) {
 		FeeSplitWeightVote: *quantity.NewFromUint64(1),
 	}
 	err := state.SetConsensusParameters(ctx, params)
-	require.NoError(err, "setting consensus parameters should succeed")
+	require.NoError(t, err, "setting consensus parameters should succeed")
 
 	// Prepare proposal.
 	feeSplitWeightVote := quantity.NewFromUint64(2)
@@ -54,6 +52,8 @@ func TestChangeParameters(t *testing.T) {
 
 	// Run sub-tests.
 	t.Run("happy path - validate only", func(t *testing.T) {
+		require := require.New(t)
+
 		res, err := app.changeParameters(ctx, &proposal, false)
 		require.NoError(err, "validation of consensus parameter changes should succeed")
 		require.Equal(struct{}{}, res)
@@ -63,6 +63,8 @@ func TestChangeParameters(t *testing.T) {
 		require.Equal(params.FeeSplitWeightVote, state.FeeSplitWeightVote, "consensus parameters shouldn't change")
 	})
 	t.Run("happy path - apply changes", func(t *testing.T) {
+		require := require.New(t)
+
 		res, err := app.changeParameters(ctx, &proposal, true)
 		require.NoError(err, "changing consensus parameters should succeed")
 		require.Equal(struct{}{}, res)
@@ -72,10 +74,14 @@ func TestChangeParameters(t *testing.T) {
 		require.Equal(*feeSplitWeightVote, state.FeeSplitWeightVote, "consensus parameters should change")
 	})
 	t.Run("invalid proposal", func(t *testing.T) {
+		require := require.New(t)
+
 		_, err := app.changeParameters(ctx, "proposal", true)
 		require.EqualError(err, "staking: failed to type assert change parameters proposal")
 	})
 	t.Run("different module", func(t *testing.T) {
+		require := require.New(t)
+
 		proposal := governance.ChangeParametersProposal{
 			Module: "module",
 		}
@@ -84,6 +90,8 @@ func TestChangeParameters(t *testing.T) {
 		require.NoError(err, "changes for other modules should be ignored without error")
 	})
 	t.Run("empty changes", func(t *testing.T) {
+		require := require.New(t)
+
 		proposal := governance.ChangeParametersProposal{
 			Module: staking.ModuleName,
 		}
@@ -91,6 +99,8 @@ func TestChangeParameters(t *testing.T) {
 		require.EqualError(err, "staking: failed to validate consensus parameter changes: consensus parameter changes should not be empty")
 	})
 	t.Run("invalid changes", func(t *testing.T) {
+		require := require.New(t)
+
 		var feeSplitWeightVote quantity.Quantity
 		changes := staking.ConsensusParameterChanges{
 			FeeSplitWeightVote: &feeSplitWeightVote,

--- a/go/p2p/backup/cstore_test.go
+++ b/go/p2p/backup/cstore_test.go
@@ -95,12 +95,12 @@ func (s *CommonStoreBackendTestSuite) TestDelete() {
 }
 
 func (s *CommonStoreBackendTestSuite) TestBackupRestore() {
-	require := require.New(s.T())
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	s.Run("No namespaces", func() {
+		require := require.New(s.T())
+
 		err := s.backend.Delete(ctx)
 		require.NoError(err, "Failed to delete the backup")
 
@@ -111,6 +111,8 @@ func (s *CommonStoreBackendTestSuite) TestBackupRestore() {
 	})
 
 	s.Run("No peers", func() {
+		require := require.New(s.T())
+
 		err := s.backend.Delete(ctx)
 		require.NoError(err, "Failed to delete the backup")
 
@@ -126,6 +128,8 @@ func (s *CommonStoreBackendTestSuite) TestBackupRestore() {
 	})
 
 	s.Run("No addrs", func() {
+		require := require.New(s.T())
+
 		err := s.backend.Backup(ctx, map[string][]peer.AddrInfo{
 			"ns-1": {
 				{
@@ -140,6 +144,8 @@ func (s *CommonStoreBackendTestSuite) TestBackupRestore() {
 	})
 
 	s.Run("One namespace", func() {
+		require := require.New(s.T())
+
 		peers := map[string][]peer.AddrInfo{
 			"ns-1": {s.addrs[0], s.addrs[1], s.addrs[2]},
 		}
@@ -154,6 +160,8 @@ func (s *CommonStoreBackendTestSuite) TestBackupRestore() {
 	})
 
 	s.Run("Many namespaces", func() {
+		require := require.New(s.T())
+
 		peers := map[string][]peer.AddrInfo{
 			"ns-1": {s.addrs[0], s.addrs[1], s.addrs[2]},
 			"ns-2": {s.addrs[2], s.addrs[3], s.addrs[4]},
@@ -173,6 +181,8 @@ func (s *CommonStoreBackendTestSuite) TestBackupRestore() {
 	})
 
 	s.Run("Many concurrent backups/restores", func() {
+		require := require.New(s.T())
+
 		peers := map[string][]peer.AddrInfo{
 			"ns-1": {s.addrs[0], s.addrs[1], s.addrs[2]},
 			"ns-2": {s.addrs[2], s.addrs[3], s.addrs[4]},
@@ -202,24 +212,28 @@ func (s *CommonStoreBackendTestSuite) TestBackupRestore() {
 }
 
 func (s *CommonStoreBackendTestSuite) TestNilCommonStore() {
-	require := require.New(s.T())
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	backup := NewCommonStoreBackend(nil, "bucket", "key")
 
 	s.Run("Delete", func() {
+		require := require.New(s.T())
+
 		err := backup.Delete(ctx)
 		require.NoError(err, "Failed to delete on nil common store")
 	})
 
 	s.Run("Backup", func() {
+		require := require.New(s.T())
+
 		err := backup.Backup(ctx, nil)
 		require.NoError(err, "Failed to backup on nil common store")
 	})
 
 	s.Run("Restore", func() {
+		require := require.New(s.T())
+
 		_, err := backup.Restore(ctx)
 		require.NoError(err, "Failed to restore on nil common store")
 	})

--- a/go/p2p/discovery/bootstrap/client_test.go
+++ b/go/p2p/discovery/bootstrap/client_test.go
@@ -115,24 +115,28 @@ func (s *BootstrapTestSuite) TearDownSuite() {
 }
 
 func (s *BootstrapTestSuite) TestAdvertise() {
-	require := require.New(s.T())
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	s.Run("Empty namespace", func() {
+		require := require.New(s.T())
+
 		ttl, err := s.peers[0].Advertise(ctx, "")
 		require.NoError(err, "Advertise failed")
 		require.Equal(peerstore.PeerRegistrationTTL, ttl)
 	})
 
 	s.Run("One namespace", func() {
+		require := require.New(s.T())
+
 		ttl, err := s.peers[0].Advertise(ctx, "ns-0")
 		require.NoError(err, "Advertise failed")
 		require.Equal(peerstore.PeerRegistrationTTL, ttl)
 	})
 
 	s.Run("Repeat advertisements", func() {
+		require := require.New(s.T())
+
 		for i := 0; i < 5; i++ {
 			ttl, err := s.peers[0].Advertise(ctx, "ns-1")
 			require.NoError(err, "Advertise failed")
@@ -142,14 +146,12 @@ func (s *BootstrapTestSuite) TestAdvertise() {
 }
 
 func (s *BootstrapTestSuite) TestDiscovery() {
-	require := require.New(s.T())
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	findPeers := func(d discovery.Discovery, ns string, limit int) int {
 		peers, err := d.FindPeers(ctx, ns, discovery.Limit(limit))
-		require.NoError(err, "FindPeers failed")
+		require.NoError(s.T(), err, "FindPeers failed")
 
 		n := 0
 		for range peers {
@@ -159,10 +161,14 @@ func (s *BootstrapTestSuite) TestDiscovery() {
 	}
 
 	s.Run("No peers", func() {
+		require := require.New(s.T())
+
 		require.Equal(0, findPeers(s.peers[0], "ns-404", 100))
 	})
 
 	s.Run("Many peers", func() {
+		require := require.New(s.T())
+
 		for _, peer := range s.peers {
 			_, err := peer.Advertise(ctx, "ns-2")
 			require.NoError(err, "Advertise failed")
@@ -171,6 +177,8 @@ func (s *BootstrapTestSuite) TestDiscovery() {
 	})
 
 	s.Run("Retention period", func() {
+		require := require.New(s.T())
+
 		n := 3
 
 		// Advertise only first 3 peers.
@@ -195,6 +203,8 @@ func (s *BootstrapTestSuite) TestDiscovery() {
 	})
 
 	s.Run("Peer limit", func() {
+		require := require.New(s.T())
+
 		for _, peer := range s.peers {
 			_, err := peer.Advertise(ctx, "ns-4")
 			require.NoError(err, "Advertise failed")
@@ -204,6 +214,8 @@ func (s *BootstrapTestSuite) TestDiscovery() {
 	})
 
 	s.Run("Malicious peer", func() {
+		require := require.New(s.T())
+
 		require.Equal(len(s.peers), findPeers(s.maliciousPeer, "limit", 100))
 
 		// Should not return any peers as malicious seed will return more than 1 peer.

--- a/go/p2p/discovery/peerstore/peerstore_test.go
+++ b/go/p2p/discovery/peerstore/peerstore_test.go
@@ -132,9 +132,9 @@ func (s *StoreTestSuite) TestPeers() {
 }
 
 func (s *StoreTestSuite) TestStoreOptions() {
-	require := require.New(s.T())
-
 	s.Run("Max peers", func() {
+		require := require.New(s.T())
+
 		store := NewStore(backup.NewInMemoryBackend(),
 			WithMaxPeers(2),
 		)
@@ -156,6 +156,8 @@ func (s *StoreTestSuite) TestStoreOptions() {
 	})
 
 	s.Run("Max namespace peers", func() {
+		require := require.New(s.T())
+
 		store := NewStore(backup.NewInMemoryBackend(),
 			WithMaxNamespacePeers(1),
 		)
@@ -177,6 +179,8 @@ func (s *StoreTestSuite) TestStoreOptions() {
 	})
 
 	s.Run("Max peer's namespaces", func() {
+		require := require.New(s.T())
+
 		store := NewStore(backup.NewInMemoryBackend(),
 			WithMaxPeerNamespaces(1),
 		)

--- a/go/p2p/peermgmt/backup_test.go
+++ b/go/p2p/peermgmt/backup_test.go
@@ -60,18 +60,18 @@ func (s *PeerstoreBackupTestSuite) SetupSuite() {
 }
 
 func (s *PeerstoreBackupTestSuite) TestBackupRestore() {
-	require := require.New(s.T())
-
-	clearStore := func() {
+	clearStore := func(t *testing.T) {
 		for _, p := range s.store.Peers() {
 			s.store.ClearAddrs(p)
 		}
-		require.Empty(s.store.PeersWithAddrs())
+		require.Empty(t, s.store.PeersWithAddrs())
 	}
 
 	s.Run("Empty store", func() {
+		require := require.New(s.T())
+
 		// Ensure that the store is empty.
-		clearStore()
+		clearStore(s.T())
 
 		// Store empty peerstore.
 		err := s.backup.backup(context.Background())
@@ -84,6 +84,8 @@ func (s *PeerstoreBackupTestSuite) TestBackupRestore() {
 	})
 
 	s.Run("One peer", func() {
+		require := require.New(s.T())
+
 		// Add one peer.
 		s.store.AddAddrs(s.infos[0].ID, s.infos[0].Addrs, peerstore.RecentlyConnectedAddrTTL)
 
@@ -92,7 +94,7 @@ func (s *PeerstoreBackupTestSuite) TestBackupRestore() {
 		require.NoError(err, "Backup failed")
 
 		// Ensure that the store is empty.
-		clearStore()
+		clearStore(s.T())
 
 		// Load one peer.
 		err = s.backup.restore(context.Background())
@@ -101,6 +103,8 @@ func (s *PeerstoreBackupTestSuite) TestBackupRestore() {
 	})
 
 	s.Run("Many peers", func() {
+		require := require.New(s.T())
+
 		// Add many peers.
 		for _, info := range s.infos {
 			s.store.AddAddrs(info.ID, info.Addrs, peerstore.RecentlyConnectedAddrTTL)
@@ -111,7 +115,7 @@ func (s *PeerstoreBackupTestSuite) TestBackupRestore() {
 		require.NoError(err, "Backup failed")
 
 		// Ensure that the store is empty.
-		clearStore()
+		clearStore(s.T())
 
 		// Load one peer.
 		err = s.backup.restore(context.Background())
@@ -120,6 +124,8 @@ func (s *PeerstoreBackupTestSuite) TestBackupRestore() {
 	})
 
 	s.Run("Many concurrent backups/restores", func() {
+		require := require.New(s.T())
+
 		// Many concurrent loads/saves.
 		var wg sync.WaitGroup
 		defer wg.Wait()

--- a/go/p2p/peermgmt/connector_test.go
+++ b/go/p2p/peermgmt/connector_test.go
@@ -87,12 +87,12 @@ func (s *ConnectorTestSuite) TearDownTest() {
 }
 
 func (s *ConnectorTestSuite) TestConnect() {
-	require := require.New(s.T())
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	s.Run("Blocked peer", func() {
+		require := require.New(s.T())
+
 		connected := s.connector.connect(ctx, s.blocked[0])
 		require.False(connected)
 
@@ -100,6 +100,8 @@ func (s *ConnectorTestSuite) TestConnect() {
 	})
 
 	s.Run("Empty address", func() {
+		require := require.New(s.T())
+
 		info := peer.AddrInfo{}
 		connected := s.connector.connect(ctx, info)
 		require.False(connected)
@@ -108,6 +110,8 @@ func (s *ConnectorTestSuite) TestConnect() {
 	})
 
 	s.Run("Host not allowed", func() {
+		require := require.New(s.T())
+
 		info := peer.AddrInfo{
 			ID:    s.host.ID(),
 			Addrs: s.host.Addrs(),
@@ -119,6 +123,8 @@ func (s *ConnectorTestSuite) TestConnect() {
 	})
 
 	s.Run("Canceled context", func() {
+		require := require.New(s.T())
+
 		ctx2, cancel2 := context.WithCancel(ctx)
 		cancel2()
 
@@ -129,6 +135,8 @@ func (s *ConnectorTestSuite) TestConnect() {
 	})
 
 	s.Run("Happy path", func() {
+		require := require.New(s.T())
+
 		connected := s.connector.connect(ctx, s.allowed[0])
 		require.True(connected)
 
@@ -136,6 +144,8 @@ func (s *ConnectorTestSuite) TestConnect() {
 	})
 
 	s.Run("DoS", func() {
+		require := require.New(s.T())
+
 		var wg sync.WaitGroup
 		wg.Add(100)
 		for i := 0; i < 100; i++ {
@@ -152,7 +162,6 @@ func (s *ConnectorTestSuite) TestConnect() {
 
 func (s *ConnectorTestSuite) TestConnectMany() {
 	time.Sleep(time.Second)
-	require := require.New(s.T())
 
 	sendToCh := func(peers []peer.AddrInfo) <-chan peer.AddrInfo {
 		peerCh := make(chan peer.AddrInfo, len(peers))
@@ -167,6 +176,8 @@ func (s *ConnectorTestSuite) TestConnectMany() {
 	defer cancel()
 
 	s.Run("No peers", func() {
+		require := require.New(s.T())
+
 		s.connector.connectMany(ctx, sendToCh(nil), 1000)
 		require.Equal(0, len(s.host.Network().Peers()))
 
@@ -175,6 +186,8 @@ func (s *ConnectorTestSuite) TestConnectMany() {
 	})
 
 	s.Run("Canceled ctx", func() {
+		require := require.New(s.T())
+
 		ctx2, cancel2 := context.WithCancel(ctx)
 		cancel2()
 
@@ -183,11 +196,15 @@ func (s *ConnectorTestSuite) TestConnectMany() {
 	})
 
 	s.Run("Happy path - limited", func() {
+		require := require.New(s.T())
+
 		s.connector.connectMany(ctx, sendToCh(s.all), 2)
 		require.Equal(2, len(s.host.Network().Peers()))
 	})
 
 	s.Run("Happy path - unlimited", func() {
+		require := require.New(s.T())
+
 		s.connector.connectMany(ctx, sendToCh(s.all), 100)
 		require.Equal(len(s.allowed), len(s.host.Network().Peers()))
 	})

--- a/go/p2p/peermgmt/discovery_test.go
+++ b/go/p2p/peermgmt/discovery_test.go
@@ -45,18 +45,20 @@ func (s *DiscoveryTestSuite) TestStartStop() {
 }
 
 func (s *DiscoveryTestSuite) TestFindPeers() {
-	require := require.New(s.T())
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	s.Run("Happy path", func() {
+		require := require.New(s.T())
+
 		peers := s.discovery.findPeers(ctx, "ns-1")
 		require.Equal(3, len(peers))
 		require.Equal(1, s.discoveryCount())
 	})
 
 	s.Run("Errors", func() {
+		require := require.New(s.T())
+
 		// Should try all seeds.
 		peers := s.discovery.findPeers(ctx, "ns-0")
 		require.Equal(0, len(peers))
@@ -65,12 +67,10 @@ func (s *DiscoveryTestSuite) TestFindPeers() {
 }
 
 func (s *DiscoveryTestSuite) TestAdvertise() {
-	require := require.New(s.T())
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	checkAdvertiseCounter := func(expected int) {
+	checkAdvertiseCounter := func(t *testing.T, expected int) {
 		for {
 			select {
 			case <-time.After(time.Microsecond):
@@ -78,7 +78,7 @@ func (s *DiscoveryTestSuite) TestAdvertise() {
 					return
 				}
 			case <-ctx.Done():
-				require.Equal(expected, s.advertiseCount())
+				require.Equal(s.T(), expected, s.advertiseCount())
 				return
 			}
 		}
@@ -91,13 +91,13 @@ func (s *DiscoveryTestSuite) TestAdvertise() {
 
 		time.Sleep(10 * time.Millisecond)
 
-		checkAdvertiseCounter(0)
+		checkAdvertiseCounter(s.T(), 0)
 	})
 
 	s.discovery.start()
 
 	s.Run("Startup", func() {
-		checkAdvertiseCounter(6)
+		checkAdvertiseCounter(s.T(), 6)
 	})
 
 	s.Run("Running", func() {
@@ -107,7 +107,7 @@ func (s *DiscoveryTestSuite) TestAdvertise() {
 
 		time.Sleep(10 * time.Millisecond)
 
-		checkAdvertiseCounter(9)
+		checkAdvertiseCounter(s.T(), 9)
 	})
 
 	s.Run("Error", func() {
@@ -115,14 +115,14 @@ func (s *DiscoveryTestSuite) TestAdvertise() {
 
 		time.Sleep(10 * time.Millisecond)
 
-		checkAdvertiseCounter(9)
+		checkAdvertiseCounter(s.T(), 9)
 	})
 
 	s.discovery.stop()
 	s.discovery.start()
 
 	s.Run("Restart", func() {
-		checkAdvertiseCounter(18)
+		checkAdvertiseCounter(s.T(), 18)
 	})
 
 	s.discovery.stop()

--- a/go/p2p/peermgmt/peermgr_test.go
+++ b/go/p2p/peermgmt/peermgr_test.go
@@ -185,12 +185,12 @@ func (s *PeerManagerTestSuite) TestUnregisterTopic() {
 }
 
 func (s *PeerManagerTestSuite) TestProtocolTracking() {
-	require := require.New(s.T())
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	s.Run("One peer", func() {
+		require := require.New(s.T())
+
 		err := s.host.Connect(ctx, *s.infos[0])
 		require.NoError(err, "Connect failed")
 		require.Equal(1, s.manager.NumProtocolPeers(s.protocols[0]))
@@ -201,6 +201,8 @@ func (s *PeerManagerTestSuite) TestProtocolTracking() {
 	})
 
 	s.Run("Many peers", func() {
+		require := require.New(s.T())
+
 		for _, info := range s.infos {
 			err := s.host.Connect(ctx, *info)
 			require.NoError(err, "Connect failed")
@@ -211,6 +213,8 @@ func (s *PeerManagerTestSuite) TestProtocolTracking() {
 	})
 
 	s.Run("Disconnect few peers", func() {
+		require := require.New(s.T())
+
 		n := len(s.infos) / 2
 		for _, info := range s.infos[:n] {
 			err := s.host.Network().ClosePeer(info.ID)

--- a/go/p2p/protocol/protocol_test.go
+++ b/go/p2p/protocol/protocol_test.go
@@ -12,12 +12,12 @@ import (
 )
 
 func TestProtocolID(t *testing.T) {
-	require := require.New(t)
-
 	chainContext := "d19ea2397fde0eba4b429f05443cced640c1f866c6df43f07132f1cdf6516c84"
 	version := version.Version{Major: 1, Minor: 2, Patch: 3}
 
 	t.Run("NewProtocolID", func(t *testing.T) {
+		require := require.New(t)
+
 		protocolID := "consensus"
 		expected := protocol.ID(
 			"/oasis/d19ea2397fde0eba4b429f05443cced640c1f866c6df43f07132f1cdf6516c84/consensus/1.0.0",
@@ -27,6 +27,8 @@ func TestProtocolID(t *testing.T) {
 	})
 
 	t.Run("NewRuntimeProtocolID", func(t *testing.T) {
+		require := require.New(t)
+
 		protocolID := "runtime"
 
 		var runtimeID common.Namespace
@@ -41,6 +43,8 @@ func TestProtocolID(t *testing.T) {
 	})
 
 	t.Run("NewTopicIDForRuntime", func(t *testing.T) {
+		require := require.New(t)
+
 		kind := api.TopicKind("topic")
 
 		var runtimeID common.Namespace

--- a/go/p2p/rpc/client_test.go
+++ b/go/p2p/rpc/client_test.go
@@ -160,12 +160,12 @@ func (s *RPCTestSuite) SetupTest() {
 }
 
 func (s *RPCTestSuite) TestCall() {
-	require := require.New(s.T())
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	s.Run("Happy path", func() {
+		require := require.New(s.T())
+
 		peer := s.serverHosts[2].ID()
 		var rsp testResponse
 		pf, err := s.client.Call(ctx, peer, testMethod, &testRequest{}, &rsp)
@@ -179,6 +179,8 @@ func (s *RPCTestSuite) TestCall() {
 	})
 
 	s.Run("Peer returns an error", func() {
+		require := require.New(s.T())
+
 		peer := s.serverHosts[3].ID()
 		var rsp testResponse
 		_, err := s.client.Call(ctx, peer, "404", &testRequest{}, &rsp)
@@ -191,12 +193,12 @@ func (s *RPCTestSuite) TestCall() {
 }
 
 func (s *RPCTestSuite) TestCallOne() {
-	require := require.New(s.T())
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	s.Run("Happy path", func() {
+		require := require.New(s.T())
+
 		peers := make([]peer.ID, 0, len(s.serverHosts))
 		for _, h := range s.serverHosts {
 			peers = append(peers, h.ID())
@@ -213,6 +215,8 @@ func (s *RPCTestSuite) TestCallOne() {
 	})
 
 	s.Run("All peers return an error", func() {
+		require := require.New(s.T())
+
 		peers := make([]peer.ID, 0, len(s.serverHosts))
 		for i, h := range s.serverHosts {
 			if i < 2 {
@@ -230,12 +234,12 @@ func (s *RPCTestSuite) TestCallOne() {
 }
 
 func (s *RPCTestSuite) TestCallMulti() {
-	require := require.New(s.T())
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	s.Run("Happy path", func() {
+		require := require.New(s.T())
+
 		peers := make([]peer.ID, 0, len(s.serverHosts))
 		for _, h := range s.serverHosts {
 			peers = append(peers, h.ID())
@@ -252,6 +256,8 @@ func (s *RPCTestSuite) TestCallMulti() {
 	})
 
 	s.Run("All peers return an error", func() {
+		require := require.New(s.T())
+
 		peers := make([]peer.ID, 0, len(s.serverHosts))
 		for i, h := range s.serverHosts {
 			if i < 2 {
@@ -271,58 +277,56 @@ func (s *RPCTestSuite) TestCallMulti() {
 }
 
 func (s *RPCTestSuite) TestListener() {
-	require := require.New(s.T())
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	peer := s.serverHosts[2].ID()
 	var rsp testResponse
 	pf, err := s.client.Call(ctx, peer, testMethod, &testRequest{}, &rsp)
-	require.NoError(err, "Call failed")
+	require.NoError(s.T(), err, "Call failed")
 
-	test := func(l *testListener, s, f, b int) {
-		require.Equal(s, l.successes)
-		require.Equal(f, l.failures)
-		require.Equal(b, l.badPeers)
+	test := func(t *testing.T, l *testListener, s, f, b int) {
+		require.Equal(t, s, l.successes)
+		require.Equal(t, f, l.failures)
+		require.Equal(t, b, l.badPeers)
 	}
 
 	s.Run("Happy path", func() {
 		firstListener := testListener{}
-		test(&firstListener, 0, 0, 0)
+		test(s.T(), &firstListener, 0, 0, 0)
 
 		secondListener := testListener{}
-		test(&secondListener, 0, 0, 0)
+		test(s.T(), &secondListener, 0, 0, 0)
 
 		s.client.RegisterListener(&firstListener)
 		pf.RecordSuccess()
-		test(&firstListener, 1, 0, 0)
+		test(s.T(), &firstListener, 1, 0, 0)
 		pf.RecordFailure()
-		test(&firstListener, 1, 1, 0)
+		test(s.T(), &firstListener, 1, 1, 0)
 		pf.RecordBadPeer()
-		test(&firstListener, 1, 1, 1)
-		test(&secondListener, 0, 0, 0)
+		test(s.T(), &firstListener, 1, 1, 1)
+		test(s.T(), &secondListener, 0, 0, 0)
 
 		s.client.RegisterListener(&secondListener)
 		pf.RecordSuccess()
 		pf.RecordFailure()
 		pf.RecordBadPeer()
-		test(&firstListener, 2, 2, 2)
-		test(&secondListener, 1, 1, 1)
+		test(s.T(), &firstListener, 2, 2, 2)
+		test(s.T(), &secondListener, 1, 1, 1)
 
 		s.client.UnregisterListener(&firstListener)
 		pf.RecordSuccess()
 		pf.RecordFailure()
 		pf.RecordBadPeer()
-		test(&secondListener, 2, 2, 2)
-		test(&firstListener, 2, 2, 2)
+		test(s.T(), &secondListener, 2, 2, 2)
+		test(s.T(), &firstListener, 2, 2, 2)
 
 		s.client.UnregisterListener(&secondListener)
 		pf.RecordSuccess()
 		pf.RecordFailure()
 		pf.RecordBadPeer()
-		test(&secondListener, 2, 2, 2)
-		test(&firstListener, 2, 2, 2)
+		test(s.T(), &secondListener, 2, 2, 2)
+		test(s.T(), &firstListener, 2, 2, 2)
 	})
 
 	s.Run("Register/unregister multiple times", func() {
@@ -332,16 +336,16 @@ func (s *RPCTestSuite) TestListener() {
 			s.client.RegisterListener(&listener)
 		}
 		pf.RecordSuccess()
-		test(&listener, 1, 0, 0)
+		test(s.T(), &listener, 1, 0, 0)
 
 		for i := 0; i < 10; i++ {
 			s.client.UnregisterListener(&listener)
 		}
 		pf.RecordSuccess()
-		test(&listener, 1, 0, 0)
+		test(s.T(), &listener, 1, 0, 0)
 
 		s.client.RegisterListener(&listener)
 		pf.RecordSuccess()
-		test(&listener, 2, 0, 0)
+		test(s.T(), &listener, 2, 0, 0)
 	})
 }

--- a/go/storage/mkvs/overlay_test.go
+++ b/go/storage/mkvs/overlay_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestOverlay(t *testing.T) {
-	require := require.New(t)
 	ctx := context.Background()
 
 	// Generate some items.
@@ -44,7 +43,7 @@ func TestOverlay(t *testing.T) {
 	overlay := NewOverlay(tree)
 	for _, item := range items {
 		err := overlay.Insert(ctx, item.Key, item.Value)
-		require.NoError(err, "Insert")
+		require.NoError(t, err, "Insert")
 	}
 
 	// Test that an overlay-only iterator works correctly.
@@ -57,13 +56,15 @@ func TestOverlay(t *testing.T) {
 
 	// Insert some items into the underlying tree.
 	err := tree.ApplyWriteLog(ctx, writelog.NewStaticIterator(items))
-	require.NoError(err, "ApplyWriteLog")
+	require.NoError(t, err, "ApplyWriteLog")
 
 	// Create an overlay.
 	overlay = NewOverlay(tree)
 
 	// Test that all keys can be fetched from an empty overlay.
 	t.Run("EmptyOverlay/Get", func(t *testing.T) {
+		require := require.New(t)
+
 		for _, item := range items {
 			var value []byte
 			value, err = overlay.Get(ctx, item.Key)
@@ -83,16 +84,18 @@ func TestOverlay(t *testing.T) {
 
 	// Add some updates to the overlay.
 	err = overlay.Remove(ctx, []byte("key 2"))
-	require.NoError(err, "Remove")
+	require.NoError(t, err, "Remove")
 	err = overlay.Insert(ctx, []byte("key 7"), []byte("seven"))
-	require.NoError(err, "Insert")
+	require.NoError(t, err, "Insert")
 	err = overlay.Remove(ctx, []byte("key 5"))
-	require.NoError(err, "Remove")
+	require.NoError(t, err, "Remove")
 	err = overlay.Insert(ctx, []byte("key 5"), []byte("fivey"))
-	require.NoError(err, "Insert")
+	require.NoError(t, err, "Insert")
 
 	// Make sure updates did not propagate to the inner tree.
 	t.Run("Updates/NoPropagation", func(t *testing.T) {
+		require := require.New(t)
+
 		var value []byte
 		value, err = tree.Get(ctx, []byte("key 2"))
 		require.NoError(err, "Get")
@@ -127,6 +130,8 @@ func TestOverlay(t *testing.T) {
 
 	// Test that all keys can be fetched from an updated overlay.
 	t.Run("Updates/Get", func(t *testing.T) {
+		require := require.New(t)
+
 		for _, item := range items {
 			var value []byte
 			value, err = overlay.Get(ctx, item.Key)
@@ -145,10 +150,12 @@ func TestOverlay(t *testing.T) {
 
 	// Commit the overlay.
 	err = overlay.Commit(ctx)
-	require.NoError(err, "Commit")
+	require.NoError(t, err, "Commit")
 
 	// Test that all keys can be fetched from an updated tree.
 	t.Run("Committed/Get", func(t *testing.T) {
+		require := require.New(t)
+
 		for _, item := range items {
 			var value []byte
 			value, err = tree.Get(ctx, item.Key)
@@ -168,5 +175,5 @@ func TestOverlay(t *testing.T) {
 	// Make sure that closing the overlay does not close the inner tree.
 	overlay.Close()
 	_, err = tree.Get(ctx, []byte("key"))
-	require.NoError(err, "Get")
+	require.NoError(t, err, "Get")
 }


### PR DESCRIPTION
Solves the following problem when test fails:
```
.../oasis-core/go/common/sync/testing.go:1343: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
```