### PR TITLE
[STABLE/22.2.x] oasis-net-runner: add some useful configuration options

### DIFF
--- a/.changelog/5193.internal.md
+++ b/.changelog/5193.internal.md
@@ -1,0 +1,4 @@
+oasis-net-runner: add some useful configuration options
+
+Adds support for disabling debug test entity, configuring epochtime interval
+and governance parameters to the `oasis-net-runner` default fixture.

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -16,9 +16,11 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	consensusGenesis "github.com/oasisprotocol/oasis-core/go/consensus/genesis"
+	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
@@ -30,29 +32,36 @@ import (
 )
 
 const (
-	cfgDeterministicIdentities = "fixture.default.deterministic_entities"
-	cfgFundEntities            = "fixture.default.fund_entities"
-	cfgEpochtimeMock           = "fixture.default.epochtime_mock"
-	cfgHaltEpoch               = "fixture.default.halt_epoch"
-	cfgKeymanagerBinary        = "fixture.default.keymanager.binary"
-	cfgNodeBinary              = "fixture.default.node.binary"
-	cfgNumEntities             = "fixture.default.num_entities"
-	cfgRuntimeID               = "fixture.default.runtime.id"
-	cfgRuntimeBinary           = "fixture.default.runtime.binary"
-	cfgRuntimeVersion          = "fixture.default.runtime.version"
-	cfgRuntimeStatePath        = "fixture.default.runtime.state_path"
-	cfgRuntimeProvisioner      = "fixture.default.runtime.provisioner"
-	cfgRuntimeLoader           = "fixture.default.runtime.loader"
-	cfgSetupRuntimes           = "fixture.default.setup_runtimes"
-	cfgTEEHardware             = "fixture.default.tee_hardware"
-	cfgInitialHeight           = "fixture.default.initial_height"
-	cfgStakingGenesis          = "fixture.default.staking_genesis"
+	cfgDebugTestEntity                     = "fixture.default.debug_test_entity"
+	cfgDeterministicIdentities             = "fixture.default.deterministic_entities"
+	cfgFundEntities                        = "fixture.default.fund_entities"
+	cfgEpochtimeMock                       = "fixture.default.epochtime_mock"
+	cfgEpochtimeInterval                   = "fixture.default.epochtime_interval"
+	cfgHaltEpoch                           = "fixture.default.halt_epoch"
+	cfgKeymanagerBinary                    = "fixture.default.keymanager.binary"
+	cfgNodeBinary                          = "fixture.default.node.binary"
+	cfgNumEntities                         = "fixture.default.num_entities"
+	cfgRuntimeID                           = "fixture.default.runtime.id"
+	cfgRuntimeBinary                       = "fixture.default.runtime.binary"
+	cfgRuntimeVersion                      = "fixture.default.runtime.version"
+	cfgRuntimeStatePath                    = "fixture.default.runtime.state_path"
+	cfgRuntimeProvisioner                  = "fixture.default.runtime.provisioner"
+	cfgRuntimeLoader                       = "fixture.default.runtime.loader"
+	cfgGovernanceUpgradeMinEpochDiff       = "fixture.default.governance.upgrade_min_epoch_diff"
+	cfgGovernanceUpgradeCancelMinEpochDiff = "fixture.default.governance.upgrade_cancel_min_epoch_diff"
+	cfgGovernanceVotingPeriod              = "fixture.default.governance.voting_period"
+	cfgGovernanceStakeThreshold            = "fixture.default.governance.stake_threshold"
+	cfgGovernanceMinProposalDeposit        = "fixture.default.governance.min_proposal_deposit"
+	cfgSetupRuntimes                       = "fixture.default.setup_runtimes"
+	cfgTEEHardware                         = "fixture.default.tee_hardware"
+	cfgInitialHeight                       = "fixture.default.initial_height"
+	cfgStakingGenesis                      = "fixture.default.staking_genesis"
 )
 
 var keymanagerID common.Namespace
 
 // newDefaultFixture returns a default network fixture.
-func newDefaultFixture() (*oasis.NetworkFixture, error) {
+func newDefaultFixture() (*oasis.NetworkFixture, error) { // nolint: gocyclo
 	var tee node.TEEHardware
 	err := tee.FromString(viper.GetString(cfgTEEHardware))
 	if err != nil {
@@ -81,6 +90,11 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 		}
 	}
 
+	govStakeThreshold := viper.GetUint(cfgGovernanceStakeThreshold)
+	if govStakeThreshold > 100 {
+		return nil, fmt.Errorf("governance stake threshold must not be greater than 100")
+	}
+
 	fixture := &oasis.NetworkFixture{
 		TEE: oasis.TEEFixture{
 			Hardware: tee,
@@ -97,6 +111,13 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 			Beacon: beacon.ConsensusParameters{
 				Backend: beacon.BackendInsecure,
 			},
+			GovernanceParameters: &governance.ConsensusParameters{
+				UpgradeMinEpochDiff:       beacon.EpochTime(viper.GetUint64(cfgGovernanceUpgradeMinEpochDiff)),
+				VotingPeriod:              beacon.EpochTime(viper.GetUint64(cfgGovernanceVotingPeriod)),
+				UpgradeCancelMinEpochDiff: beacon.EpochTime(viper.GetUint64(cfgGovernanceUpgradeCancelMinEpochDiff)),
+				StakeThreshold:            uint8(govStakeThreshold),
+				MinProposalDeposit:        *quantity.NewFromUint64(viper.GetUint64(cfgGovernanceMinProposalDeposit)),
+			},
 			InitialHeight: viper.GetInt64(cfgInitialHeight),
 			HaltEpoch:     viper.GetUint64(cfgHaltEpoch),
 			IAS: oasis.IASCfg{
@@ -106,16 +127,22 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 			FundEntities:            viper.GetBool(cfgFundEntities),
 			StakingGenesis:          &stakingGenesis,
 		},
-		Entities: []oasis.EntityCfg{
-			{IsDebugTestEntity: true},
-		},
+		Entities: []oasis.EntityCfg{},
 		Validators: []oasis.ValidatorFixture{
 			{Entity: 1, Consensus: oasis.ConsensusFixture{SupplementarySanityInterval: 1}},
 		},
 		Seeds: []oasis.SeedFixture{{}},
 	}
+	if viper.GetBool(cfgDebugTestEntity) {
+		fixture.Entities = append(fixture.Entities, oasis.EntityCfg{IsDebugTestEntity: true})
+	}
 	if viper.GetBool(cfgEpochtimeMock) {
 		fixture.Network.SetMockEpoch()
+	}
+	if interval := viper.GetInt64(cfgEpochtimeInterval); interval > 0 {
+		fixture.Network.Beacon.InsecureParameters = &beacon.InsecureParameters{
+			Interval: interval,
+		}
 	}
 
 	for i := 0; i < viper.GetInt(cfgNumEntities); i++ {
@@ -307,9 +334,11 @@ func getLatestVersionAndStateRoot(db mkvsAPI.NodeDB) (uint64, *hash.Hash, error)
 }
 
 func init() {
+	DefaultFixtureFlags.Bool(cfgDebugTestEntity, true, "include the debug test entity in genesis")
 	DefaultFixtureFlags.Bool(cfgDeterministicIdentities, false, "generate nodes with deterministic identities")
 	DefaultFixtureFlags.Bool(cfgFundEntities, false, "fund all entities in genesis")
 	DefaultFixtureFlags.Bool(cfgEpochtimeMock, false, "use mock epochtime")
+	DefaultFixtureFlags.Uint64(cfgEpochtimeInterval, 0, "epochtime interval")
 	DefaultFixtureFlags.Bool(cfgSetupRuntimes, true, "initialize the network with runtimes and runtime nodes")
 	DefaultFixtureFlags.Int(cfgNumEntities, 1, "number of (non debug) entities in genesis")
 	DefaultFixtureFlags.String(cfgKeymanagerBinary, "simple-keymanager", "path to the keymanager runtime")
@@ -320,6 +349,11 @@ func init() {
 	DefaultFixtureFlags.StringSlice(cfgRuntimeStatePath, []string{""}, "runtime state path to initialize the runtime (and nodes) with")
 	DefaultFixtureFlags.String(cfgRuntimeProvisioner, "sandboxed", "the runtime provisioner: mock, unconfined, or sandboxed")
 	DefaultFixtureFlags.String(cfgRuntimeLoader, "oasis-core-runtime-loader", "path to the runtime loader")
+	DefaultFixtureFlags.Uint64(cfgGovernanceUpgradeMinEpochDiff, 100, "minimum epoch difference for upgrade proposals")
+	DefaultFixtureFlags.Uint64(cfgGovernanceUpgradeCancelMinEpochDiff, 70, "minimum epoch difference for cancel upgrade proposals")
+	DefaultFixtureFlags.Uint64(cfgGovernanceVotingPeriod, 20, "voting period for governance proposals")
+	DefaultFixtureFlags.Uint8(cfgGovernanceStakeThreshold, 90, "stake threshold for governance proposals")
+	DefaultFixtureFlags.Uint64(cfgGovernanceMinProposalDeposit, 100, "minimum proposal deposit for governance proposals")
 	DefaultFixtureFlags.String(cfgTEEHardware, "", "TEE hardware to use")
 	DefaultFixtureFlags.Uint64(cfgHaltEpoch, math.MaxUint64, "halt epoch height")
 	DefaultFixtureFlags.Int64(cfgInitialHeight, 1, "initial block height")

--- a/go/oasis-test-runner/oasis/entity.go
+++ b/go/oasis-test-runner/oasis/entity.go
@@ -18,7 +18,6 @@ import (
 const entityIdentitySeedTemplate = "oasis entity %d"
 
 var entityArgsDebugTest = []string{
-	"--" + flags.CfgDebugDontBlameOasis,
 	"--" + flags.CfgDebugTestEntity,
 	"--" + common.CfgDebugAllowTestKeys,
 }

--- a/go/oasis-test-runner/oasis/network.go
+++ b/go/oasis-test-runner/oasis/network.go
@@ -33,6 +33,7 @@ import (
 	genesisTestHelpers "github.com/oasisprotocol/oasis-core/go/genesis/tests"
 	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
+	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/metrics"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/genesis"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
@@ -704,6 +705,7 @@ func (net *Network) MakeGenesis() error {
 		"--consensus.backend", net.cfg.Consensus.Backend,
 		"--consensus.tendermint.timeout_commit", net.cfg.Consensus.Parameters.TimeoutCommit.String(),
 		"--registry.enable_runtime_governance_models", "entity,runtime",
+		"--" + flags.CfgDebugDontBlameOasis,
 		"--registry.debug.allow_unroutable_addresses", "true",
 		"--" + genesis.CfgRegistryDebugAllowTestRuntimes, "true",
 		"--scheduler.max_validators_per_entity", strconv.Itoa(len(net.Validators())),


### PR DESCRIPTION
Adds support for disabling debug test entity, configuring epochtime interval and governance parameters to the `oasis-net-runner`.

These are useful/needed for implementing: `22.2.x` -> `master` E2E network upgrade tests.