### PR TITLE
keymanager: Add support for master secret generations

### DIFF
--- a/.changelog/5198.internal.md
+++ b/.changelog/5198.internal.md
@@ -1,0 +1,4 @@
+keymanager: Add support for master secret generations
+
+Refactored key manager's init method to be able to support multiple
+generations of the master secret.

--- a/keymanager/src/api/errors.rs
+++ b/keymanager/src/api/errors.rs
@@ -9,6 +9,10 @@ pub enum KeyManagerError {
     NotAuthorized,
     #[error("invalid epoch: expected {0}, got {1}")]
     InvalidEpoch(u64, u64),
+    #[error("invalid generation: expected {0}, got {1}")]
+    InvalidGeneration(u64, u64),
+    #[error("generation is in the future: expected max {0}, got {1}")]
+    GenerationFromFuture(u64, u64),
     #[error("height is not fresh")]
     HeightNotFresh,
     #[error("key manager is not initialized")]
@@ -33,6 +37,10 @@ pub enum KeyManagerError {
     REKNotPublished,
     #[error("signature verification failed: {0}")]
     InvalidSignature(anyhow::Error),
+    #[error("master secret generation {0} not found")]
+    MasterSecretNotFound(u64),
+    #[error("master secret generation {0} not replicated")]
+    MasterSecretNotReplicated(u64),
     #[error("ephemeral secret for epoch {0} not found")]
     EphemeralSecretNotFound(u64),
     #[error("ephemeral secret for epoch {0} not replicated")]
@@ -45,8 +53,8 @@ pub enum KeyManagerError {
     InvalidCiphertext,
     #[error("status not found")]
     StatusNotFound,
-    #[error("runtime not found")]
-    RuntimeNotFound,
+    #[error("runtime mismatch")]
+    RuntimeMismatch,
     #[error("active deployment not found")]
     ActiveDeploymentNotFound,
     #[error(transparent)]

--- a/keymanager/src/client/interface.rs
+++ b/keymanager/src/client/interface.rs
@@ -27,6 +27,7 @@ pub trait KeyManagerClient: Send + Sync {
         &self,
         ctx: Context,
         key_pair_id: KeyPairId,
+        generation: u64,
     ) -> BoxFuture<Result<KeyPair, KeyManagerError>>;
 
     /// Get long-term public key for a key pair id.
@@ -34,6 +35,7 @@ pub trait KeyManagerClient: Send + Sync {
         &self,
         ctx: Context,
         key_pair_id: KeyPairId,
+        generation: u64,
     ) -> BoxFuture<Result<SignedPublicKey, KeyManagerError>>;
 
     /// Get or create named ephemeral key pair for given epoch.
@@ -57,7 +59,11 @@ pub trait KeyManagerClient: Send + Sync {
     ) -> BoxFuture<Result<SignedPublicKey, KeyManagerError>>;
 
     /// Get a copy of the master secret for replication.
-    fn replicate_master_secret(&self, ctx: Context) -> BoxFuture<Result<Secret, KeyManagerError>>;
+    fn replicate_master_secret(
+        &self,
+        ctx: Context,
+        generation: u64,
+    ) -> BoxFuture<Result<Secret, KeyManagerError>>;
 
     /// Get a copy of the ephemeral secret for replication.
     fn replicate_ephemeral_secret(
@@ -76,16 +82,18 @@ impl<T: ?Sized + KeyManagerClient> KeyManagerClient for Arc<T> {
         &self,
         ctx: Context,
         key_pair_id: KeyPairId,
+        generation: u64,
     ) -> BoxFuture<Result<KeyPair, KeyManagerError>> {
-        KeyManagerClient::get_or_create_keys(&**self, ctx, key_pair_id)
+        KeyManagerClient::get_or_create_keys(&**self, ctx, key_pair_id, generation)
     }
 
     fn get_public_key(
         &self,
         ctx: Context,
         key_pair_id: KeyPairId,
+        generation: u64,
     ) -> BoxFuture<Result<SignedPublicKey, KeyManagerError>> {
-        KeyManagerClient::get_public_key(&**self, ctx, key_pair_id)
+        KeyManagerClient::get_public_key(&**self, ctx, key_pair_id, generation)
     }
 
     fn get_or_create_ephemeral_keys(
@@ -106,8 +114,12 @@ impl<T: ?Sized + KeyManagerClient> KeyManagerClient for Arc<T> {
         KeyManagerClient::get_public_ephemeral_key(&**self, ctx, key_pair_id, epoch)
     }
 
-    fn replicate_master_secret(&self, ctx: Context) -> BoxFuture<Result<Secret, KeyManagerError>> {
-        KeyManagerClient::replicate_master_secret(&**self, ctx)
+    fn replicate_master_secret(
+        &self,
+        ctx: Context,
+        generation: u64,
+    ) -> BoxFuture<Result<Secret, KeyManagerError>> {
+        KeyManagerClient::replicate_master_secret(&**self, ctx, generation)
     }
 
     fn replicate_ephemeral_secret(

--- a/keymanager/src/crypto/kdf.rs
+++ b/keymanager/src/crypto/kdf.rs
@@ -4,11 +4,9 @@ use std::{
     convert::TryInto,
     num::NonZeroUsize,
     sync::{Arc, RwLock},
-    vec,
 };
 
 use anyhow::Result;
-use io_context::Context as IoContext;
 use lazy_static::lazy_static;
 use lru::LruCache;
 use sgx_isa::Keypolicy;
@@ -18,35 +16,25 @@ use zeroize::Zeroize;
 use oasis_core_runtime::{
     common::{
         crypto::{
-            mrae::{
-                deoxysii::{DeoxysII, NONCE_SIZE, TAG_SIZE},
-                nonce::Nonce,
-            },
-            signature::{self, Signer},
+            mrae::{deoxysii::DeoxysII, nonce::Nonce},
+            signature::{self, PublicKey},
             x25519,
         },
         namespace::Namespace,
         sgx::egetkey::egetkey,
     },
     consensus::beacon::EpochTime,
-    enclave_rpc::Context as RpcContext,
-    runtime_context,
     storage::KeyValue,
     BUILD_INFO,
 };
 
 use crate::{
-    api::{InitRequest, InitResponse, KeyManagerError, SignedInitResponse},
-    client::{KeyManagerClient, RemoteClient},
-    crypto::{KeyPair, Secret, SignedPublicKey, StateKey},
-    policy::Policy,
-    runtime::context::Context as KmContext,
+    api::KeyManagerError,
+    crypto::{
+        pack_runtime_id_generation, unpack_encrypted_generation_nonce,
+        unpack_encrypted_secret_nonce, KeyPair, KeyPairId, Secret, SignedPublicKey, StateKey,
+    },
 };
-
-use super::KeyPairId;
-
-/// Context used for the init response signature.
-const INIT_RESPONSE_CONTEXT: &[u8] = b"oasis-core/keymanager: init response";
 
 lazy_static! {
     // Global KDF object.
@@ -109,10 +97,11 @@ lazy_static! {
     };
 }
 
-const MASTER_SECRET_STORAGE_KEY: &[u8] = b"keymanager_master_secret";
-const MASTER_SECRET_STORAGE_SIZE: usize = 32 + TAG_SIZE + NONCE_SIZE;
+const LATEST_GENERATION_STORAGE_KEY: &[u8] = b"keymanager_master_secret_generation";
+const MASTER_SECRET_STORAGE_KEY_PREFIX: &[u8] = b"keymanager_master_secret";
 const MASTER_SECRET_SEAL_CONTEXT: &[u8] = b"Ekiden Keymanager Seal master secret v0";
 
+const MASTER_SECRET_CACHE_SIZE: usize = 20;
 const EPHEMERAL_SECRET_CACHE_SIZE: usize = 20;
 
 /// Kdf, which derives key manager keys from a master secret.
@@ -121,31 +110,43 @@ pub struct Kdf {
 }
 
 struct Inner {
-    /// Master secret used to derive long-term runtime keys, RSK key, etc.
-    master_secret: Option<Secret>,
+    /// Generation of the last master secret.
+    generation: Option<u64>,
+    /// Master secrets used to derive long-term runtime keys, RSK keys, etc.
+    master_secrets: LruCache<u64, Secret>,
     // Ephemeral secrets used to derive ephemeral runtime keys.
     ephemeral_secrets: HashMap<EpochTime, Secret>,
     /// Checksum of the master secret and the key manager runtime ID.
     checksum: Option<Vec<u8>>,
     /// Key manager runtime ID.
     runtime_id: Option<Namespace>,
-    /// Key manager committee signer derived from the master secret and
-    /// the key manager runtime ID.
+    /// Key manager committee runtime signer derived from
+    /// the latest master secret and the key manager runtime ID.
     ///
     /// Used to sign derived long-term and ephemeral public runtime keys.
     signer: Option<Arc<dyn signature::Signer>>,
-    /// Cache for storing derived key pairs.
-    cache: LruCache<Vec<u8>, KeyPair>,
+    /// Key manager committee public runtime signing key derived from
+    /// the latest master secret and the key manager runtime ID.
+    ///
+    /// Used to verify derived long-term and ephemeral public runtime keys.
+    signing_key: Option<signature::PublicKey>,
+    /// Local cache for the long-term private keys.
+    longterm_keys: LruCache<(Vec<u8>, u64), KeyPair>,
+    /// Local cache for the ephemeral private keys.
+    ephemeral_keys: LruCache<(Vec<u8>, EpochTime), KeyPair>,
 }
 
 impl Inner {
     fn reset(&mut self) {
-        self.master_secret = None;
+        self.generation = None;
+        self.master_secrets.clear();
         self.ephemeral_secrets.clear();
         self.checksum = None;
         self.runtime_id = None;
         self.signer = None;
-        self.cache.clear();
+        self.signing_key = None;
+        self.longterm_keys.clear();
+        self.ephemeral_keys.clear();
     }
 
     // Derive ephemeral or long-term keys from the given secret.
@@ -187,10 +188,15 @@ impl Inner {
     }
 
     /// Derive long-term secret from the key manager's master secret.
-    fn derive_static_secret(&self, kdf_custom: &[u8], seed: &[u8]) -> Result<Secret> {
-        let secret = match self.master_secret.as_ref() {
+    fn derive_longterm_secret(
+        &mut self,
+        kdf_custom: &[u8],
+        seed: &[u8],
+        generation: u64,
+    ) -> Result<Secret> {
+        let secret = match self.master_secrets.get(&generation) {
             Some(secret) => secret,
-            None => return Err(KeyManagerError::NotInitialized.into()),
+            None => return Err(KeyManagerError::MasterSecretNotFound(generation).into()),
         };
 
         Self::derive_secret(secret, kdf_custom, seed)
@@ -213,18 +219,66 @@ impl Inner {
             None => Err(KeyManagerError::NotInitialized.into()),
         }
     }
+
+    fn get_generation(&self) -> Result<u64> {
+        match self.generation {
+            Some(generation) => Ok(generation),
+            None => Err(KeyManagerError::NotInitialized.into()),
+        }
+    }
+
+    fn get_signing_key(&self) -> Result<signature::PublicKey> {
+        match self.signing_key {
+            Some(signing_key) => Ok(signing_key),
+            None => Err(KeyManagerError::NotInitialized.into()),
+        }
+    }
+
+    fn get_next_generation(&self) -> u64 {
+        self.generation.map(|g| g + 1).unwrap_or_default()
+    }
+
+    fn get_runtime_id(&self) -> Result<Namespace> {
+        match self.runtime_id {
+            Some(runtime_id) => Ok(runtime_id),
+            None => Err(KeyManagerError::NotInitialized.into()),
+        }
+    }
+
+    fn verify_runtime_id(&self, runtime_id: &Namespace) -> Result<()> {
+        let id = self
+            .runtime_id
+            .as_ref()
+            .ok_or(KeyManagerError::NotInitialized)?;
+        if runtime_id != id {
+            return Err(KeyManagerError::RuntimeMismatch.into());
+        }
+        Ok(())
+    }
+
+    pub fn set_runtime_id(&mut self, runtime_id: Namespace) -> Result<()> {
+        match self.runtime_id {
+            Some(id) if id == runtime_id => (),
+            Some(_) => return Err(KeyManagerError::RuntimeMismatch.into()),
+            None => self.runtime_id = Some(runtime_id),
+        }
+        Ok(())
+    }
 }
 
 impl Kdf {
     fn new() -> Self {
         Self {
             inner: RwLock::new(Inner {
-                master_secret: None,
+                generation: None,
+                master_secrets: LruCache::new(NonZeroUsize::new(MASTER_SECRET_CACHE_SIZE).unwrap()),
                 ephemeral_secrets: HashMap::new(),
                 checksum: None,
                 runtime_id: None,
                 signer: None,
-                cache: LruCache::new(NonZeroUsize::new(1024).unwrap()),
+                signing_key: None,
+                longterm_keys: LruCache::new(NonZeroUsize::new(1024).unwrap()),
+                ephemeral_keys: LruCache::new(NonZeroUsize::new(128).unwrap()),
             }),
         }
     }
@@ -234,220 +288,156 @@ impl Kdf {
         &KDF
     }
 
+    /// Set the runtime ID if it is not already set.
+    ///
+    /// If the runtime ID changes, the internal state is reset and an error is returned.
+    pub fn set_runtime_id(&self, runtime_id: Namespace) -> Result<()> {
+        let mut inner = self.inner.write().unwrap();
+        inner.set_runtime_id(runtime_id).map_err(|_| {
+            // Whowa, the caller's idea of our runtime ID has changed,
+            // something really screwed up is going on.
+            inner.reset();
+            KeyManagerError::StateCorrupted.into()
+        })
+    }
+
     /// Key manager runtime ID.
     pub fn runtime_id(&self) -> Option<Namespace> {
         let inner = self.inner.read().unwrap();
         inner.runtime_id
     }
 
-    /// Initialize the KDF internal state.
-    #[cfg_attr(not(target_env = "sgx"), allow(unused))]
-    pub fn init(
-        &self,
-        req: &InitRequest,
-        ctx: &mut RpcContext,
-        policy_checksum: Vec<u8>,
-    ) -> Result<SignedInitResponse> {
-        let mut inner = self.inner.write().unwrap();
-
-        let rctx = runtime_context!(ctx, KmContext);
-        if inner.runtime_id.is_some() {
-            // Whowa, the caller's idea of our runtime ID has changed,
-            // something really screwed up is going on.
-            if rctx.runtime_id != inner.runtime_id.unwrap() {
-                inner.reset();
-                return Err(KeyManagerError::StateCorrupted.into());
-            }
-        } else {
-            inner.runtime_id = Some(rctx.runtime_id);
-        }
-
-        let km_runtime_id = inner.runtime_id.unwrap();
-
-        // How initialization proceeds depends on the state and the request.
-        //
-        // WARNING: Once a master secret has been persisted to disk, it is
-        // intended that manual intervention by the operator is required to
-        // remove/alter it.
-        if inner.master_secret.is_some() {
-            // A master secret is set.  This enclave has initialized successfully
-            // at least once.
-
-            let checksum = inner.get_checksum()?;
-            if !req.checksum.is_empty() && req.checksum != checksum {
-                // The init request provided a checksum and there was a mismatch.
-                // The global key manager state disagrees with the enclave state.
-                inner.reset();
-                return Err(KeyManagerError::StateCorrupted.into());
-            }
-        } else if !req.checksum.is_empty() {
-            // A master secret is not set, and there is a checksum in the
-            // request.  An enclave somewhere, has initialized at least
-            // once.
-
-            // Attempt to load the master secret.
-            let (master_secret, did_replicate) =
-                match Self::load_master_secret(ctx.untrusted_local_storage, &km_runtime_id) {
-                    Some(master_secret) => (master_secret, false),
-                    None => {
-                        // Couldn't load, fetch the master secret from another
-                        // enclave instance.
-
-                        let rctx = runtime_context!(ctx, KmContext);
-
-                        let km_client = RemoteClient::new_runtime_with_enclaves_and_policy(
-                            rctx.runtime_id,
-                            Some(rctx.runtime_id),
-                            Policy::global().may_replicate_from(),
-                            ctx.identity.quote_policy(),
-                            rctx.protocol.clone(),
-                            ctx.consensus_verifier.clone(),
-                            ctx.identity.clone(),
-                            1, // Not used, doesn't matter.
-                            vec![],
-                        );
-
-                        let result =
-                            km_client.replicate_master_secret(IoContext::create_child(&ctx.io_ctx));
-                        let master_secret = tokio::runtime::Handle::current().block_on(result)?;
-                        (master_secret, true)
-                    }
-                };
-
-            let checksum = Self::checksum_master_secret(&master_secret, &km_runtime_id);
-            if req.checksum != checksum {
-                // We either loaded or replicated something that does
-                // not match the rest of the world.
-                inner.reset();
-                return Err(KeyManagerError::StateCorrupted.into());
-            }
-
-            // The loaded/replicated master secret is consistent with the rest
-            // of the world.   Ok to proceed.
-            if did_replicate {
-                Self::save_master_secret(
-                    ctx.untrusted_local_storage,
-                    &master_secret,
-                    &km_runtime_id,
-                );
-            }
-            inner.master_secret = Some(master_secret);
-            inner.checksum = Some(checksum);
-        } else {
-            // A master secret is not set, and there is no checksum in the
-            // request. Either this key manager instance has never been
-            // initialized, or our view of the external state is not current.
-
-            // Attempt to load the master secret, the caller may just be
-            // behind the rest of the world.
-            let master_secret =
-                match Self::load_master_secret(ctx.untrusted_local_storage, &km_runtime_id) {
-                    Some(master_secret) => master_secret,
-                    None => {
-                        // Unable to load, perhaps we can generate?
-                        if !req.may_generate {
-                            return Err(KeyManagerError::ReplicationRequired.into());
-                        }
-
-                        // TODO: Support static keying for debugging.
-                        let master_secret = Secret::generate();
-
-                        Self::save_master_secret(
-                            ctx.untrusted_local_storage,
-                            &master_secret,
-                            &km_runtime_id,
-                        );
-
-                        master_secret
-                    }
-                };
-
-            // Loaded or generated a master secret.  There is no checksum to
-            // compare against, but that is expected when bootstrapping or
-            // lagging.
-            inner.checksum = Some(Self::checksum_master_secret(&master_secret, &km_runtime_id));
-            inner.master_secret = Some(master_secret);
-        }
-
-        // If we make it this far, we have a master secret and checksum
-        // that either matches the global state, will become the global
-        // state, or should become the global state (rare).
-        //
-        // It is ok to derive the signing key and generate a response.
-
-        // Derive signing key from the master secret.
-        let secret =
-            inner.derive_static_secret(&RUNTIME_SIGNING_KEY_CUSTOM, km_runtime_id.as_ref())?;
-        let sk = signature::PrivateKey::from_bytes(secret.0.to_vec());
-        let pk = sk.public_key();
-        inner.signer = Some(Arc::new(sk));
-
-        // Build the response and sign it with the RAK.
-        let init_response = InitResponse {
-            is_secure: BUILD_INFO.is_secure && !Policy::unsafe_skip(),
-            checksum: inner.checksum.as_ref().unwrap().clone(),
-            policy_checksum,
-            rsk: pk,
-        };
-
-        let body = cbor::to_vec(init_response.clone());
-        let signature = ctx.identity.sign(INIT_RESPONSE_CONTEXT, &body)?;
-
-        Ok(SignedInitResponse {
-            init_response,
-            signature,
-        })
+    /// Next generation of the key manager master secret.
+    pub fn next_generation(&self) -> u64 {
+        let inner = self.inner.read().unwrap();
+        inner.get_next_generation()
     }
 
-    /// Get or create long-term or ephemeral keys.
-    pub fn get_or_create_keys(
+    /// Status of the internal state, i.e. checksum and runtime signing key.
+    ///
+    /// If given checksum and generation don't match internal state,
+    /// the state is reset and an error is returned.
+    pub fn status(
         &self,
+        runtime_id: &Namespace,
+        checksum: Vec<u8>,
+        generation: u64,
+    ) -> Result<(Vec<u8>, PublicKey)> {
+        let mut inner = self.inner.write().unwrap();
+        inner.verify_runtime_id(runtime_id)?;
+
+        let local_checksum = inner.get_checksum()?;
+        if !checksum.is_empty() && local_checksum != checksum {
+            // The caller provided a checksum and there was a mismatch.
+            // The global key manager state disagrees with the enclave state.
+            inner.reset();
+            return Err(KeyManagerError::StateCorrupted.into());
+        }
+
+        let last_generation = inner.get_generation()?;
+        if generation != last_generation {
+            return Err(KeyManagerError::InvalidGeneration(last_generation, generation).into());
+        }
+
+        let rsk = inner.get_signing_key()?;
+
+        Ok((local_checksum, rsk))
+    }
+
+    /// Get or create long-term keys.
+    pub fn get_or_create_longterm_keys(
+        &self,
+        storage: &dyn KeyValue,
         runtime_id: Namespace,
         key_pair_id: KeyPairId,
-        epoch: Option<EpochTime>,
+        generation: u64,
     ) -> Result<KeyPair> {
         // Construct a seed that must be unique for every key request.
         // Long-term keys: seed = runtime_id || key_pair_id
-        // Ephemeral keys: seed = runtime_id || key_pair_id || epoch
         let mut seed = runtime_id.as_ref().to_vec();
         seed.extend_from_slice(key_pair_id.as_ref());
-        if let Some(epoch) = epoch {
-            seed.extend_from_slice(epoch.to_be_bytes().as_ref());
-        }
 
         // Check to see if the cached value exists.
+        let id = (seed, generation);
         let mut inner = self.inner.write().unwrap();
-        if let Some(keys) = inner.cache.get(&seed) {
+        if let Some(keys) = inner.longterm_keys.get(&id) {
             return Ok(keys.clone());
         };
 
+        // Make sure the secret is loaded.
+        if !inner.master_secrets.contains(&generation) {
+            let secret = match Self::load_master_secret(storage, &runtime_id, generation) {
+                Some(secret) => secret,
+                None => {
+                    inner.reset();
+                    return Err(KeyManagerError::StateCorrupted.into());
+                }
+            };
+            inner.master_secrets.push(generation, secret);
+        }
+
         // Generate keys.
-        let keys = match epoch {
-            Some(epoch) => {
-                let secret = inner.derive_ephemeral_secret(&EPHEMERAL_KDF_CUSTOM, &seed, epoch)?;
-                inner.derive_keys(secret, &EPHEMERAL_XOF_CUSTOM)?
-            }
-            None => {
-                let secret = inner.derive_static_secret(&RUNTIME_KDF_CUSTOM, &seed)?;
-                // FIXME: Replace KDF custom with XOF custom when possible.
-                inner.derive_keys(secret, &RUNTIME_KDF_CUSTOM)?
-            }
-        };
+        let secret = inner.derive_longterm_secret(&RUNTIME_KDF_CUSTOM, &id.0, id.1)?;
+        // FIXME: Replace KDF custom with XOF custom when possible.
+        let keys = inner.derive_keys(secret, &RUNTIME_KDF_CUSTOM)?;
 
         // Insert into the cache.
-        inner.cache.put(seed, keys.clone());
+        inner.longterm_keys.put(id, keys.clone());
 
         Ok(keys)
     }
 
-    /// Get the public part of the key.
-    pub fn get_public_key(
+    /// Get or create ephemeral keys.
+    pub fn get_or_create_ephemeral_keys(
         &self,
         runtime_id: Namespace,
         key_pair_id: KeyPairId,
-        epoch: Option<EpochTime>,
+        epoch: EpochTime,
+    ) -> Result<KeyPair> {
+        // Construct a seed that must be unique for every key request.
+        // Ephemeral keys: seed = runtime_id || key_pair_id || epoch
+        let mut seed = runtime_id.as_ref().to_vec();
+        seed.extend_from_slice(key_pair_id.as_ref());
+        seed.extend_from_slice(epoch.to_be_bytes().as_ref()); // TODO: Remove once we transition to ephemeral secrets (how?)
+
+        // Check to see if the cached value exists.
+        let mut inner = self.inner.write().unwrap();
+        let id = (seed, epoch);
+        if let Some(keys) = inner.ephemeral_keys.get(&id) {
+            return Ok(keys.clone());
+        };
+
+        // Generate keys.
+        let secret = inner.derive_ephemeral_secret(&EPHEMERAL_KDF_CUSTOM, &id.0, id.1)?;
+        let keys = inner.derive_keys(secret, &EPHEMERAL_XOF_CUSTOM)?;
+
+        // Insert into the cache.
+        inner.ephemeral_keys.put(id, keys.clone());
+
+        Ok(keys)
+    }
+
+    /// Get the public part of the long-term key.
+    pub fn get_public_longterm_key(
+        &self,
+        storage: &dyn KeyValue,
+        runtime_id: Namespace,
+        key_pair_id: KeyPairId,
+        generation: u64,
     ) -> Result<x25519::PublicKey> {
-        let keys = self.get_or_create_keys(runtime_id, key_pair_id, epoch)?;
+        let keys =
+            self.get_or_create_longterm_keys(storage, runtime_id, key_pair_id, generation)?;
+        Ok(keys.input_keypair.pk)
+    }
+
+    /// Get the public part of the ephemeral key.
+    pub fn get_public_ephemeral_key(
+        &self,
+        runtime_id: Namespace,
+        key_pair_id: KeyPairId,
+        epoch: EpochTime,
+    ) -> Result<x25519::PublicKey> {
+        let keys = self.get_or_create_ephemeral_keys(runtime_id, key_pair_id, epoch)?;
         Ok(keys.input_keypair.pk)
     }
 
@@ -470,14 +460,35 @@ impl Kdf {
     }
 
     /// Replicate master secret.
-    pub fn replicate_master_secret(&self) -> Result<Secret> {
-        let inner = self.inner.read().unwrap();
+    pub fn replicate_master_secret(
+        &self,
+        storage: &dyn KeyValue,
+        generation: u64,
+    ) -> Result<Secret> {
+        let mut inner = self.inner.write().unwrap();
 
-        let secret = inner
-            .master_secret
-            .as_ref()
-            .cloned()
-            .ok_or(KeyManagerError::NotInitialized)?;
+        // Replicate only generations we know.
+        let last_generation = inner.get_generation()?;
+        if generation > last_generation {
+            return Err(KeyManagerError::GenerationFromFuture(last_generation, generation).into());
+        }
+
+        // First check the cache.
+        if let Some(secret) = inner.master_secrets.get(&generation).cloned() {
+            return Ok(secret);
+        }
+
+        // Then try to load it from the storage.
+        // Don't update the cache as someone could be replicating old secrets.
+        let runtime_id = inner.get_runtime_id()?;
+        let secret = match Self::load_master_secret(storage, &runtime_id, generation) {
+            Some(secret) => secret,
+            None => {
+                inner.reset();
+                return Err(KeyManagerError::StateCorrupted.into());
+            }
+        };
+
         Ok(secret)
     }
 
@@ -493,8 +504,64 @@ impl Kdf {
         Ok(secret)
     }
 
+    /// Save master secret to the local cache.
+    fn save_master_secret(
+        &self,
+        runtime_id: &Namespace,
+        secret: Secret,
+        generation: u64,
+    ) -> Result<()> {
+        let mut inner = self.inner.write().unwrap();
+        inner.verify_runtime_id(runtime_id)?;
+
+        // Master secrets need to be added in sequential order.
+        let next_generation = inner.get_next_generation();
+        if generation != next_generation {
+            return Err(KeyManagerError::InvalidGeneration(next_generation, generation).into());
+        }
+
+        // Compute next checksum.
+        let last_checksum = inner.get_checksum().unwrap_or(runtime_id.as_ref().to_vec());
+        let checksum = Self::checksum_master_secret(&secret, &last_checksum);
+
+        // Derive signing key from the latest secret.
+        let rsk_secret =
+            Inner::derive_secret(&secret, &RUNTIME_SIGNING_KEY_CUSTOM, runtime_id.as_ref())?;
+        let sk = signature::PrivateKey::from_bytes(rsk_secret.0.to_vec());
+        let pk = sk.public_key();
+
+        // Update state.
+        inner.generation = Some(generation);
+        inner.checksum = Some(checksum);
+        inner.signing_key = Some(pk);
+        inner.signer = Some(Arc::new(sk));
+        inner.master_secrets.push(generation, secret);
+
+        Ok(())
+    }
+
+    /// Add master secret to the local cache and store it encrypted to untrusted local storage.
+    pub fn add_master_secret(
+        &self,
+        storage: &dyn KeyValue,
+        runtime_id: &Namespace,
+        secret: Secret,
+        generation: u64,
+    ) -> Result<()> {
+        // Add to the cache before storing locally to make sure that secrets are added
+        // in sequential order.
+        self.save_master_secret(runtime_id, secret.clone(), generation)?;
+
+        // Update the last generation after the secret is stored to avoid problems
+        // if we panic in between.
+        Self::store_master_secret(storage, runtime_id, &secret, generation);
+        Self::store_last_generation(storage, runtime_id, generation);
+
+        Ok(())
+    }
+
     /// Add ephemeral secret to the local cache.
-    pub fn add_ephemeral_secret(&self, epoch: EpochTime, secret: Secret) {
+    pub fn add_ephemeral_secret(&self, secret: Secret, epoch: EpochTime) {
         let mut inner = self.inner.write().unwrap();
         inner.ephemeral_secrets.insert(epoch, Secret(secret.0));
 
@@ -509,65 +576,168 @@ impl Kdf {
         }
     }
 
+    /// Load master secrets from untrusted local storage, if not loaded already.
+    pub fn load_master_secrets(
+        &self,
+        storage: &dyn KeyValue,
+        runtime_id: &Namespace,
+    ) -> Result<()> {
+        if self.next_generation() != 0 {
+            return Ok(());
+        }
+
+        // Fetch the last generation number.
+        let last_generation = match Self::load_last_generation(storage, runtime_id) {
+            Some(generation) => generation,
+            None => {
+                // Empty storage, nothing to load.
+                return Ok(());
+            }
+        };
+
+        // Fetch secrets and add them to the cache.
+        for generation in 0..=last_generation {
+            let secret = match Kdf::load_master_secret(storage, runtime_id, generation) {
+                Some(secret) => secret,
+                None => {
+                    // We could stop here and let the caller replicate other secrets,
+                    // but we won't as this looks like a state corruption.
+                    let mut inner = self.inner.write().unwrap();
+                    inner.reset();
+                    return Err(KeyManagerError::StateCorrupted.into());
+                }
+            };
+
+            self.save_master_secret(runtime_id, secret, generation)?;
+        }
+
+        Ok(())
+    }
+
+    /// Load master secret from untrusted local storage.
+    ///
+    /// Loaded secrets are authenticated so there is no need to calculate and verify the checksum
+    /// again. The Deoxys-II AEAD algorithm ensures that the secrets belong to the correct runtime
+    /// and generation, while the consensus layer guarantees uniqueness, i.e. only one generation
+    /// of the master secret can be published per key manager runtime.
     fn load_master_secret(
         untrusted_local: &dyn KeyValue,
         runtime_id: &Namespace,
+        generation: u64,
     ) -> Option<Secret> {
-        let ciphertext = untrusted_local
-            .get(MASTER_SECRET_STORAGE_KEY.to_vec())
-            .unwrap();
+        // Fetch the encrypted master secret if it exists.
+        let mut key = MASTER_SECRET_STORAGE_KEY_PREFIX.to_vec();
+        key.extend(generation.to_le_bytes());
 
-        match ciphertext.len() {
-            0 => return None,
-            MASTER_SECRET_STORAGE_SIZE => (),
-            _ => {
-                panic!("persisted state is corrupted, invalid size");
-            }
+        let ciphertext = untrusted_local.get(key).unwrap();
+        if ciphertext.is_empty() {
+            return None;
         }
 
-        // Split the ciphertext || tag || nonce.
-        let mut nonce = [0u8; NONCE_SIZE];
-        nonce.copy_from_slice(&ciphertext[32 + TAG_SIZE..]);
-        let ciphertext = &ciphertext[..32 + TAG_SIZE];
+        let (ciphertext, nonce) = unpack_encrypted_secret_nonce(&ciphertext)
+            .expect("persisted state is corrupted, invalid size");
+        let additional_data = pack_runtime_id_generation(runtime_id, generation);
 
         // Decrypt the persisted master secret.
         let d2 = Self::new_d2();
         let plaintext = d2
-            .open(&nonce, ciphertext.to_vec(), runtime_id.as_ref())
+            .open(&nonce, ciphertext.to_vec(), additional_data)
             .expect("persisted state is corrupted");
 
         Some(Secret(plaintext.try_into().unwrap()))
     }
 
-    fn save_master_secret(
-        untrusted_local: &dyn KeyValue,
-        master_secret: &Secret,
+    /// Encrypt and store the master secret to untrusted local storage.
+    ///
+    /// WARNING: To ensure uniqueness always verify that the master secret has been published
+    /// in the consensus layer!!!
+    fn store_master_secret(
+        storage: &dyn KeyValue,
         runtime_id: &Namespace,
+        secret: &Secret,
+        generation: u64,
     ) {
+        // Every secret is stored under its own key.
+        let mut key = MASTER_SECRET_STORAGE_KEY_PREFIX.to_vec();
+        key.extend(generation.to_le_bytes());
+
         // Encrypt the master secret.
         let nonce = Nonce::generate();
+        let additional_data = pack_runtime_id_generation(runtime_id, generation);
         let d2 = Self::new_d2();
-        let mut ciphertext = d2.seal(&nonce, master_secret.as_ref(), runtime_id.as_ref());
+        let mut ciphertext = d2.seal(&nonce, secret.as_ref(), additional_data);
         ciphertext.extend_from_slice(&nonce.to_vec());
 
         // Persist the encrypted master secret.
-        untrusted_local
-            .insert(MASTER_SECRET_STORAGE_KEY.to_vec(), ciphertext)
+        storage
+            .insert(key, ciphertext)
             .expect("failed to persist master secret");
     }
 
-    fn checksum_master_secret(master_secret: &Secret, runtime_id: &Namespace) -> Vec<u8> {
+    /// Load the generation of the last stored master secret from untrusted local storage.
+    fn load_last_generation(untrusted_local: &dyn KeyValue, runtime_id: &Namespace) -> Option<u64> {
+        // Fetch the encrypted generation if it exists.
+        let key = LATEST_GENERATION_STORAGE_KEY.to_vec();
+        let ciphertext = untrusted_local.get(key).unwrap();
+        if ciphertext.is_empty() {
+            return None;
+        }
+
+        let (ciphertext, nonce) = unpack_encrypted_generation_nonce(&ciphertext)
+            .expect("persisted state is corrupted, invalid size");
+
+        // Decrypt the persisted generation.
+        let d2 = Self::new_d2();
+        let plaintext = d2
+            .open(&nonce, ciphertext.to_vec(), runtime_id)
+            .expect("persisted state is corrupted");
+
+        Some(u64::from_le_bytes(plaintext.try_into().unwrap()))
+    }
+
+    /// Store the generation of the last master secret to untrusted local storage.
+    fn store_last_generation(
+        untrusted_local: &dyn KeyValue,
+        runtime_id: &Namespace,
+        generation: u64,
+    ) {
+        // We only store the latest generation.
+        let key = LATEST_GENERATION_STORAGE_KEY.to_vec();
+
+        // Encrypt the generation.
+        let nonce = Nonce::generate();
+        let d2 = Self::new_d2();
+        let mut ciphertext = d2.seal(&nonce, generation.to_le_bytes(), runtime_id);
+        ciphertext.extend_from_slice(&nonce.to_vec());
+
+        // Persist the encrypted generation.
+        untrusted_local
+            .insert(key, ciphertext)
+            .expect("failed to persist master secret generation");
+    }
+
+    /// Compute the checksum of the master secret.
+    ///
+    /// The master secret checksum is computed by successively applying the KMAC algorithm
+    /// to the key manager's runtime ID, using master secret generations as the KMAC keys
+    /// at each step. The checksum calculation for the n-th generation can be expressed by
+    /// the formula: KMAC(gen_n, ... KMAC(gen_2, KMAC(gen_1, KMAC(gen_0, runtime_id)))).
+    fn checksum_master_secret(master_secret: &Secret, last_checksum: &Vec<u8>) -> Vec<u8> {
         let mut k = [0u8; 32];
 
-        // KMAC256(master_secret, kmRuntimeID, 32, "ekiden-checksum-master-secret")
+        // KMAC256(master_secret, last_checksum, 32, "ekiden-checksum-master-secret")
         let mut f = KMac::new_kmac256(master_secret.as_ref(), &CHECKSUM_MASTER_SECRET_CUSTOM);
-        f.update(runtime_id.as_ref());
+        f.update(last_checksum);
         f.finalize(&mut k);
 
         k.to_vec()
     }
 
     /// Compute the checksum of the ephemeral secret.
+    ///
+    /// The ephemeral secret checksum is computed by applying the KMAC algorithm to the
+    /// concatenation of the key manager's runtime ID and the epoch, using ephemeral secret
+    /// as the KMAC key.
     pub fn checksum_ephemeral_secret(
         ephemeral_secret: &Secret,
         runtime_id: &Namespace,
@@ -600,7 +770,8 @@ mod tests {
         collections::{HashMap, HashSet},
         convert::TryInto,
         num::NonZeroUsize,
-        sync::{Arc, RwLock},
+        panic,
+        sync::{Arc, Mutex, RwLock},
     };
 
     use lru::LruCache;
@@ -609,9 +780,11 @@ mod tests {
     use oasis_core_runtime::{
         common::{
             crypto::{signature::PrivateKey, x25519},
-            namespace::Namespace,
+            namespace::{Namespace, NAMESPACE_SIZE},
         },
         consensus::beacon::EpochTime,
+        storage::KeyValue,
+        types::Error,
     };
 
     use crate::crypto::{
@@ -629,44 +802,86 @@ mod tests {
 
     impl Kdf {
         fn clear_cache(&self) {
-            self.inner.write().unwrap().cache.clear();
+            let mut inner = self.inner.write().unwrap();
+            inner.longterm_keys.clear();
+            inner.ephemeral_keys.clear();
         }
     }
 
     impl Default for Kdf {
         fn default() -> Self {
+            let mut master_secrets = LruCache::new(NonZeroUsize::new(10).unwrap());
+            master_secrets.push(0, Secret([1u8; SECRET_SIZE]));
+            master_secrets.push(1, Secret([2u8; SECRET_SIZE]));
+
+            let ephemeral_secrets = HashMap::from([
+                (1, Secret([1u8; SECRET_SIZE])),
+                (2, Secret([2u8; SECRET_SIZE])),
+            ]);
+
             Self {
                 inner: RwLock::new(Inner {
-                    master_secret: Some(Secret([1u8; 32])),
+                    generation: Some(1),
+                    master_secrets,
+                    ephemeral_secrets,
                     checksum: Some(vec![2u8; 32]),
                     runtime_id: Some(Namespace([3u8; 32])),
                     signer: Some(Arc::new(PrivateKey::from_bytes(vec![4u8; 32]))),
-                    cache: LruCache::new(NonZeroUsize::new(1).unwrap()),
-                    ephemeral_secrets: HashMap::from([
-                        (1, Secret([1u8; SECRET_SIZE])),
-                        (2, Secret([2u8; SECRET_SIZE])),
-                    ]),
+                    signing_key: Some(PrivateKey::from_bytes(vec![4u8; 32]).public_key()),
+                    longterm_keys: LruCache::new(NonZeroUsize::new(1).unwrap()),
+                    ephemeral_keys: LruCache::new(NonZeroUsize::new(1).unwrap()),
                 }),
             }
+        }
+    }
+
+    /// Untrusted key/value store which stores arbitrary binary key/value pairs in memory.
+    pub struct InMemoryKeyValue {
+        store: Mutex<HashMap<Vec<u8>, Vec<u8>>>,
+    }
+
+    impl InMemoryKeyValue {
+        pub fn new() -> Self {
+            Self {
+                store: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl KeyValue for InMemoryKeyValue {
+        fn get(&self, key: Vec<u8>) -> Result<Vec<u8>, Error> {
+            // To mock the untrusted local key value store, we must return
+            // an empty vector if the key is not found.
+            let cache = self.store.lock().unwrap();
+            let value = cache.get(&key).cloned().unwrap_or_default();
+            Ok(value)
+        }
+
+        fn insert(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error> {
+            let mut cache = self.store.lock().unwrap();
+            cache.insert(key, value);
+            Ok(())
         }
     }
 
     #[test]
     fn key_generation_is_deterministic() {
         let kdf = Kdf::default();
+        let storage = InMemoryKeyValue::new();
         let runtime_id = Namespace::from(vec![1u8; 32]);
         let key_pair_id = KeyPairId::from(vec![2u8; 32]);
-        let epoch = Some(1);
+        let generation = 0;
+        let epoch = 1;
 
         // Long-term keys.
         kdf.clear_cache();
         let sk1 = kdf
-            .get_or_create_keys(runtime_id, key_pair_id, None)
+            .get_or_create_longterm_keys(&storage, runtime_id, key_pair_id, generation)
             .expect("private key should be created");
 
         kdf.clear_cache();
         let sk2 = kdf
-            .get_or_create_keys(runtime_id, key_pair_id, None)
+            .get_or_create_longterm_keys(&storage, runtime_id, key_pair_id, generation)
             .expect("private key should be created");
 
         assert_eq!(
@@ -678,12 +893,12 @@ mod tests {
         // Ephemeral keys.
         kdf.clear_cache();
         let sk1 = kdf
-            .get_or_create_keys(runtime_id, key_pair_id, epoch)
+            .get_or_create_ephemeral_keys(runtime_id, key_pair_id, epoch)
             .expect("private key should be created");
 
         kdf.clear_cache();
         let sk2 = kdf
-            .get_or_create_keys(runtime_id, key_pair_id, epoch)
+            .get_or_create_ephemeral_keys(runtime_id, key_pair_id, epoch)
             .expect("private key should be created");
 
         assert_eq!(
@@ -697,33 +912,35 @@ mod tests {
     fn private_keys_are_unique() {
         // Default values.
         let kdf = Kdf::default();
+        let storage = InMemoryKeyValue::new();
         let runtime_id = Namespace::from(vec![1u8; 32]);
         let key_pair_id = KeyPairId::from(vec![1u8; 32]);
-        let epoch = Some(1);
+        let generation = 0;
+        let epoch = 1;
 
         // Long-terms keys should depend on runtime_id and key_pair_id.
         let sk1 = kdf
-            .get_or_create_keys(runtime_id, key_pair_id, None)
+            .get_or_create_longterm_keys(&storage, runtime_id, key_pair_id, generation)
             .expect("private key should be created");
         let sk2 = kdf
-            .get_or_create_keys(vec![2u8; 32].into(), key_pair_id, None)
+            .get_or_create_longterm_keys(&storage, vec![2u8; 32].into(), key_pair_id, generation)
             .expect("private key should be created");
         let sk3 = kdf
-            .get_or_create_keys(runtime_id, vec![3u8; 32].into(), None)
+            .get_or_create_longterm_keys(&storage, runtime_id, vec![3u8; 32].into(), generation)
             .expect("private key should be created");
 
         // Ephemeral keys should depend on runtime_id, key_pair_id and epoch.
         let sk4 = kdf
-            .get_or_create_keys(runtime_id, key_pair_id, epoch)
+            .get_or_create_ephemeral_keys(runtime_id, key_pair_id, epoch)
             .expect("private key should be created");
         let sk5 = kdf
-            .get_or_create_keys(vec![2u8; 32].into(), key_pair_id, epoch)
+            .get_or_create_ephemeral_keys(vec![2u8; 32].into(), key_pair_id, epoch)
             .expect("private key should be created");
         let sk6 = kdf
-            .get_or_create_keys(runtime_id, vec![3u8; 32].into(), epoch)
+            .get_or_create_ephemeral_keys(runtime_id, vec![3u8; 32].into(), epoch)
             .expect("private key should be created");
         let sk7 = kdf
-            .get_or_create_keys(runtime_id, key_pair_id, Some(2))
+            .get_or_create_ephemeral_keys(runtime_id, key_pair_id, epoch + 1)
             .expect("private key should be created");
 
         let keys = HashSet::from(
@@ -735,23 +952,29 @@ mod tests {
     #[test]
     fn private_and_public_key_match() {
         let kdf = Kdf::default();
+        let storage = InMemoryKeyValue::new();
         let runtime_id = Namespace::from(vec![1u8; 32]);
         let key_pair_id = KeyPairId::from(vec![2u8; 32]);
-        let epoch = Some(1);
+        let generation = 0;
+        let epoch = 1;
 
         // Long-term keys.
         let sk = kdf
-            .get_or_create_keys(runtime_id, key_pair_id, None)
+            .get_or_create_longterm_keys(&storage, runtime_id, key_pair_id, generation)
             .expect("private key should be created");
-        let pk = kdf.get_public_key(runtime_id, key_pair_id, None).unwrap();
+        let pk = kdf
+            .get_public_longterm_key(&storage, runtime_id, key_pair_id, generation)
+            .unwrap();
 
         assert_eq!(sk.input_keypair.pk, pk);
 
         // Ephemeral keys.
         let sk = kdf
-            .get_or_create_keys(runtime_id, key_pair_id, epoch)
+            .get_or_create_ephemeral_keys(runtime_id, key_pair_id, epoch)
             .expect("private key should be created");
-        let pk = kdf.get_public_key(runtime_id, key_pair_id, epoch).unwrap();
+        let pk = kdf
+            .get_public_ephemeral_key(runtime_id, key_pair_id, epoch)
+            .unwrap();
 
         assert_eq!(sk.input_keypair.pk, pk);
     }
@@ -782,12 +1005,47 @@ mod tests {
     #[test]
     fn master_secret_can_be_replicated() {
         let kdf = Kdf::default();
-        let secret = kdf
-            .replicate_master_secret()
-            .expect("master secret should be replicated");
-        let inner = kdf.inner.into_inner().unwrap();
+        let storage = InMemoryKeyValue::new();
 
-        assert_eq!(secret.0, inner.master_secret.unwrap().0);
+        // Happy path.
+        let generation = 1;
+        let secret = kdf
+            .replicate_master_secret(&storage, generation)
+            .expect("master secret should be replicated");
+        {
+            let mut inner = kdf.inner.write().unwrap();
+            assert_eq!(secret.0, inner.master_secrets.get(&generation).unwrap().0);
+        }
+
+        // Generation in the future.
+        let generation = 2;
+        let result = kdf
+            .replicate_master_secret(&storage, generation)
+            .map(|s| s.0);
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "generation is in the future: expected max 1, got 2"
+        );
+
+        // Secret loaded from the storage.
+        let generation = kdf.next_generation();
+        let new_secret = Secret([3u8; SECRET_SIZE]);
+        {
+            let mut inner = kdf.inner.write().unwrap();
+            inner.generation = Some(generation);
+            assert!(inner.master_secrets.get(&generation).is_none());
+        }
+        Kdf::store_master_secret(
+            &storage,
+            &kdf.runtime_id().unwrap(),
+            &new_secret,
+            generation,
+        );
+
+        let secret = kdf
+            .replicate_master_secret(&storage, generation)
+            .expect("master secret should be replicated");
+        assert_eq!(secret.0, new_secret.0);
     }
 
     #[test]
@@ -844,7 +1102,7 @@ mod tests {
 
         // Insert enough secrets so that the oldest one is removed.
         for epoch in 1..EPHEMERAL_SECRET_CACHE_SIZE + 2 {
-            kdf.add_ephemeral_secret(epoch.try_into().unwrap(), Secret([100; SECRET_SIZE]));
+            kdf.add_ephemeral_secret(Secret([100; SECRET_SIZE]), epoch.try_into().unwrap());
         }
 
         // Secret for epoch 1 should be removed.
@@ -901,6 +1159,7 @@ mod tests {
             ephemeral_secret: &'a str,
             runtime_id: &'a str,
             key_pair_id: &'a str,
+            generation: u64,
             epoch: EpochTime,
             lk_sk: &'a str,
             lk_pk: &'a str,
@@ -916,6 +1175,7 @@ mod tests {
                     "2a9d51ed0380d11b26255ecc894dfc3aa48196c9b0da463a3073ea820a65a090",
                 runtime_id: "c818f97228a53b201e2afa383b64199c732c7ba1a67ac55ea2cb3b8fba367740",
                 key_pair_id: "fb99076f6a5a8c52bcf562cae5152d0410f47a615fc7bc4966dc9a4f477bd217",
+                generation: 0,
                 epoch: 8935419451,
                 // FIXME: Replace the values when the long-term key derivation is fixed (see FIXME above).
                 lk_sk: "702c5a25ff1149591cf7bca763fbe647a43939f43330a8fd331305d73e489b7c",
@@ -932,6 +1192,7 @@ mod tests {
                     "b8092ab767ddc47cb56807d4d1fd0e66eae0b02e289d1e38d4dfa900619edc47",
                 runtime_id: "c818f97228a53b201e2afa383b64199c732c7ba1a67ac55ea2cb3b8fba367740",
                 key_pair_id: "fb99076f6a5a8c52bcf562cae5152d0410f47a615fc7bc4966dc9a4f477bd217",
+                generation: 0,
                 epoch: 8935419451,
                 // FIXME: Replace the values when the long-term key derivation is fixed (see FIXME above).
                 lk_sk: "5045ff4735a1fc7cbdb729d7cfb9349a11e664bf3198e78b9b714bf7dffe984e",
@@ -948,6 +1209,7 @@ mod tests {
                     "2a9d51ed0380d11b26255ecc894dfc3aa48196c9b0da463a3073ea820a65a090",
                 runtime_id: "1aa3e6d86c0779afde8a367dbbb025538fb77e410624ece8b25a6be9e1a5170d",
                 key_pair_id: "fb99076f6a5a8c52bcf562cae5152d0410f47a615fc7bc4966dc9a4f477bd217",
+                generation: 0,
                 epoch: 8935419451,
                 // FIXME: Replace the values when the long-term key derivation is fixed (see FIXME above).
                 lk_sk: "e03a8c8e86024934e84d61d789ae7b292a0124bd7cedb1ac740e750391936150",
@@ -964,6 +1226,7 @@ mod tests {
                     "2a9d51ed0380d11b26255ecc894dfc3aa48196c9b0da463a3073ea820a65a090",
                 runtime_id: "c818f97228a53b201e2afa383b64199c732c7ba1a67ac55ea2cb3b8fba367740",
                 key_pair_id: "18789f16d8a8fbd75f529f0a1de3e95469eb537c283dc66eb296a6681a46c066",
+                generation: 0,
                 epoch: 8935419451,
                 // FIXME: Replace the values when the long-term key derivation is fixed (see FIXME above).
                 lk_sk: "a82089503a2b9f2804ee61dcc8ddc3c52f49be9aa6545d235ede885597d12d7a",
@@ -980,6 +1243,7 @@ mod tests {
                     "2a9d51ed0380d11b26255ecc894dfc3aa48196c9b0da463a3073ea820a65a090",
                 runtime_id: "c818f97228a53b201e2afa383b64199c732c7ba1a67ac55ea2cb3b8fba367740",
                 key_pair_id: "fb99076f6a5a8c52bcf562cae5152d0410f47a615fc7bc4966dc9a4f477bd217",
+                generation: 0,
                 epoch: 943032087,
                 // FIXME: Replace the values when the long-term key derivation is fixed (see FIXME above).
                 lk_sk: "702c5a25ff1149591cf7bca763fbe647a43939f43330a8fd331305d73e489b7c",
@@ -998,41 +1262,54 @@ mod tests {
 
         // Test all vectors.
         for v in vectors {
+            let mut master_secrets = LruCache::new(NonZeroUsize::new(10).unwrap());
+            master_secrets.push(
+                v.generation,
+                Secret(
+                    v.master_secret
+                        .from_hex::<Vec<u8>>()
+                        .unwrap()
+                        .try_into()
+                        .unwrap(),
+                ),
+            );
+
+            let ephemeral_secrets = HashMap::from([(
+                v.epoch,
+                Secret(
+                    v.ephemeral_secret
+                        .from_hex::<Vec<u8>>()
+                        .unwrap()
+                        .try_into()
+                        .unwrap(),
+                ),
+            )]);
+
             let kdf = Kdf {
                 inner: RwLock::new(Inner {
-                    master_secret: Some(Secret(
-                        v.master_secret
-                            .from_hex::<Vec<u8>>()
-                            .unwrap()
-                            .try_into()
-                            .unwrap(),
-                    )),
-                    ephemeral_secrets: HashMap::from([(
-                        v.epoch,
-                        Secret(
-                            v.ephemeral_secret
-                                .from_hex::<Vec<u8>>()
-                                .unwrap()
-                                .try_into()
-                                .unwrap(),
-                        ),
-                    )]),
+                    generation: Some(v.generation),
+                    master_secrets,
+                    ephemeral_secrets,
                     checksum: Some(checksum.from_hex().unwrap()),
                     runtime_id: Some(Namespace::from(runtime_id)),
                     signer: Some(Arc::new(PrivateKey::from_bytes(signer.from_hex().unwrap()))),
-                    cache: LruCache::new(NonZeroUsize::new(1).unwrap()),
+                    signing_key: Some(
+                        PrivateKey::from_bytes(signer.from_hex().unwrap()).public_key(),
+                    ),
+                    longterm_keys: LruCache::new(NonZeroUsize::new(1).unwrap()),
+                    ephemeral_keys: LruCache::new(NonZeroUsize::new(1).unwrap()),
                 }),
             };
-
+            let storage = InMemoryKeyValue::new();
             let runtime_id = Namespace::from(v.runtime_id);
             let key_pair_id = KeyPairId::from(v.key_pair_id);
 
             let lk = kdf
-                .get_or_create_keys(runtime_id, key_pair_id, None)
+                .get_or_create_longterm_keys(&storage, runtime_id, key_pair_id, v.generation)
                 .expect("private key should be created");
 
             let ek = kdf
-                .get_or_create_keys(runtime_id, key_pair_id, Some(v.epoch))
+                .get_or_create_ephemeral_keys(runtime_id, key_pair_id, v.epoch)
                 .expect("private key should be created");
 
             assert_eq!(lk.input_keypair.sk.0.to_bytes().to_hex::<String>(), v.lk_sk);
@@ -1040,5 +1317,110 @@ mod tests {
             assert_eq!(ek.input_keypair.sk.0.to_bytes().to_hex::<String>(), v.ek_sk);
             assert_eq!(ek.input_keypair.pk.0.to_bytes().to_hex::<String>(), v.ek_pk);
         }
+    }
+
+    #[test]
+    fn generation_save_load() {
+        let storage = InMemoryKeyValue::new();
+        let generation = 1;
+        let runtime_id = Namespace([2; NAMESPACE_SIZE]);
+
+        // Empty storage.
+        let result = Kdf::load_last_generation(&storage, &runtime_id);
+        assert!(result.is_none());
+
+        // Happy path.
+        Kdf::store_last_generation(&storage, &runtime_id, generation);
+        let loaded =
+            Kdf::load_last_generation(&storage, &runtime_id).expect("generation should be loaded");
+        assert_eq!(generation, loaded);
+
+        // Decryption panics (invalid runtime ID).
+        let invalid_runtime_id = Namespace([3; NAMESPACE_SIZE]);
+        let result =
+            panic::catch_unwind(|| Kdf::load_last_generation(&storage, &invalid_runtime_id));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn master_secret_save_load() {
+        let storage = InMemoryKeyValue::new();
+        let secret = Secret([1; SECRET_SIZE]);
+        let runtime_id = Namespace([2; NAMESPACE_SIZE]);
+        let generation = 3;
+
+        // Empty storage.
+        let result = Kdf::load_master_secret(&storage, &runtime_id, generation);
+        assert!(result.is_none());
+
+        // Happy path.
+        Kdf::store_master_secret(&storage, &runtime_id, &secret, generation);
+        let loaded = Kdf::load_master_secret(&storage, &runtime_id, generation)
+            .expect("master secret should be loaded");
+        assert_eq!(secret.0, loaded.0);
+
+        // Decryption panics (invalid runtime ID).
+        let invalid_runtime_id = Namespace([3; NAMESPACE_SIZE]);
+        let result = panic::catch_unwind(|| {
+            Kdf::load_master_secret(&storage, &invalid_runtime_id, generation)
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn load_master_secrets() {
+        let runtime_id = Namespace([1; NAMESPACE_SIZE]);
+        let master_secrets = vec![
+            Secret([0; SECRET_SIZE]),
+            Secret([1; SECRET_SIZE]),
+            Secret([2; SECRET_SIZE]),
+        ];
+
+        let empty_storage = InMemoryKeyValue::new();
+        let full_storage = InMemoryKeyValue::new();
+
+        Kdf::store_last_generation(&full_storage, &runtime_id, 2);
+        for (generation, secret) in master_secrets.iter().enumerate() {
+            Kdf::store_master_secret(&full_storage, &runtime_id, secret, generation as u64);
+        }
+
+        // Happy path.
+        let kdf = Kdf::new();
+        kdf.set_runtime_id(runtime_id)
+            .expect("runtime id should not be set");
+
+        let result = kdf.load_master_secrets(&full_storage, &runtime_id);
+        assert!(result.is_ok());
+
+        let mut inner = kdf.inner.write().unwrap();
+        assert_eq!(inner.generation.unwrap(), 2);
+        assert_eq!(
+            inner.checksum.clone().unwrap().to_hex::<String>(),
+            "ca9b0c294056ef674c4266e267e8972df8c6b8b0b5a3a86e081ed24daf306abf"
+        );
+        assert_eq!(inner.master_secrets.len(), 3);
+        for (generation, secret) in master_secrets.iter().enumerate() {
+            let generation = generation as u64;
+            let loaded = inner.master_secrets.get(&generation).cloned();
+            assert_eq!(loaded.unwrap().0, secret.0);
+        }
+
+        // One master secret is missing.
+        Kdf::store_last_generation(&full_storage, &runtime_id, 3);
+
+        let kdf = Kdf::new();
+        kdf.set_runtime_id(runtime_id)
+            .expect("runtime id should not be set");
+
+        let result = kdf.load_master_secrets(&full_storage, &runtime_id);
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "key manager state corrupted"
+        );
+
+        // Empty store.
+        let kdf = Kdf::new();
+        let result = kdf.load_master_secrets(&empty_storage, &runtime_id);
+        assert!(result.is_ok());
     }
 }

--- a/keymanager/src/crypto/mod.rs
+++ b/keymanager/src/crypto/mod.rs
@@ -1,6 +1,7 @@
 //! Key manager crypto types and primitives.
 pub mod kdf;
+mod packing;
 mod types;
 
 // Re-exports.
-pub use self::types::*;
+pub use self::{packing::*, types::*};

--- a/keymanager/src/crypto/packing.rs
+++ b/keymanager/src/crypto/packing.rs
@@ -1,0 +1,238 @@
+//! Helper methods for packing and unpacking data.
+use std::convert::TryInto;
+
+use oasis_core_runtime::{
+    common::{
+        crypto::mrae::{
+            deoxysii::TAG_SIZE,
+            nonce::{Nonce, NONCE_SIZE},
+        },
+        namespace::{Namespace, NAMESPACE_SIZE},
+    },
+    consensus::beacon::EpochTime,
+};
+
+use super::SECRET_SIZE;
+
+/// The size of the epoch in bytes.
+const EPOCH_SIZE: usize = 8;
+/// The size of the generation in bytes.
+const GENERATION_SIZE: usize = 8;
+/// The size of an encrypted secret.
+const SECRET_STORAGE_SIZE: usize = SECRET_SIZE + TAG_SIZE + NONCE_SIZE;
+/// The size of an encrypted generation.
+const GENERATION_STORAGE_SIZE: usize = GENERATION_SIZE + TAG_SIZE + NONCE_SIZE;
+
+/// Concatenate runtime ID and epoch (runtime_id || epoch)
+/// into a byte vector using little-endian byte order.
+pub fn pack_runtime_id_epoch(runtime_id: &Namespace, epoch: EpochTime) -> Vec<u8> {
+    let mut additional_data = runtime_id.0.to_vec();
+    additional_data.extend(epoch.to_le_bytes());
+    additional_data
+}
+
+/// Unpack the concatenation of runtime ID and epoch (runtime_id || epoch).
+pub fn unpack_runtime_id_epoch(data: Vec<u8>) -> Option<(Namespace, EpochTime)> {
+    if data.len() != NAMESPACE_SIZE + EPOCH_SIZE {
+        return None;
+    }
+
+    let runtime_id: Namespace = data
+        .get(0..NAMESPACE_SIZE)
+        .unwrap()
+        .try_into()
+        .expect("slice with incorrect length");
+
+    let epoch = u64::from_le_bytes(
+        data.get(NAMESPACE_SIZE..)
+            .unwrap()
+            .try_into()
+            .expect("slice with incorrect length"),
+    );
+
+    Some((runtime_id, epoch))
+}
+
+/// Concatenate runtime ID and generation (runtime_id || generation)
+/// into a byte vector using little-endian byte order.
+pub fn pack_runtime_id_generation(runtime_id: &Namespace, generation: u64) -> Vec<u8> {
+    let mut data = runtime_id.0.to_vec();
+    data.extend(generation.to_le_bytes());
+    data
+}
+
+/// Unpack the concatenation of runtime ID and generation (runtime_id || generation).
+pub fn unpack_runtime_id_generation(data: Vec<u8>) -> Option<(Namespace, u64)> {
+    if data.len() != NAMESPACE_SIZE + GENERATION_SIZE {
+        return None;
+    }
+
+    let runtime_id: Namespace = data
+        .get(0..NAMESPACE_SIZE)
+        .unwrap()
+        .try_into()
+        .expect("slice with incorrect length");
+
+    let generation = u64::from_le_bytes(
+        data.get(NAMESPACE_SIZE..)
+            .unwrap()
+            .try_into()
+            .expect("slice with incorrect length"),
+    );
+
+    Some((runtime_id, generation))
+}
+
+/// Concatenate runtime ID, generation and epoch (runtime_id || generation || epoch)
+/// into a byte vector using little-endian byte order.
+pub fn pack_runtime_id_generation_epoch(
+    runtime_id: &Namespace,
+    generation: u64,
+    epoch: EpochTime,
+) -> Vec<u8> {
+    let mut additional_data = runtime_id.0.to_vec();
+    additional_data.extend(generation.to_le_bytes());
+    additional_data.extend(epoch.to_le_bytes());
+    additional_data
+}
+
+/// Unpack the concatenation of runtime ID, generation and epoch (runtime_id || generation || epoch).
+pub fn unpack_runtime_id_generation_epoch(data: Vec<u8>) -> Option<(Namespace, u64, EpochTime)> {
+    if data.len() != NAMESPACE_SIZE + GENERATION_SIZE + EPOCH_SIZE {
+        return None;
+    }
+
+    let runtime_id: Namespace = data
+        .get(0..NAMESPACE_SIZE)
+        .unwrap()
+        .try_into()
+        .expect("slice with incorrect length");
+
+    let generation = u64::from_le_bytes(
+        data.get(NAMESPACE_SIZE..NAMESPACE_SIZE + GENERATION_SIZE)
+            .unwrap()
+            .try_into()
+            .expect("slice with incorrect length"),
+    );
+
+    let epoch = u64::from_le_bytes(
+        data.get(NAMESPACE_SIZE + GENERATION_SIZE..)
+            .unwrap()
+            .try_into()
+            .expect("slice with incorrect length"),
+    );
+
+    Some((runtime_id, generation, epoch))
+}
+
+/// Concatenate ciphertext and nonce (ciphertext || nonce) into a byte vector.
+pub fn pack_ciphertext_nonce(ciphertext: &Vec<u8>, nonce: &Nonce) -> Vec<u8> {
+    let mut data = ciphertext.clone();
+    data.extend_from_slice(&nonce.to_vec());
+    data
+}
+
+/// Unpack the concatenation of encrypted secret and nonce (ciphertext || nonce).
+pub fn unpack_encrypted_secret_nonce(data: &Vec<u8>) -> Option<(Vec<u8>, [u8; NONCE_SIZE])> {
+    if data.len() != SECRET_STORAGE_SIZE {
+        return None;
+    }
+
+    let ciphertext = data
+        .get(..SECRET_STORAGE_SIZE - NONCE_SIZE)
+        .unwrap()
+        .to_vec();
+
+    let nonce: [u8; NONCE_SIZE] = data
+        .get(SECRET_STORAGE_SIZE - NONCE_SIZE..)
+        .unwrap()
+        .try_into()
+        .expect("slice with incorrect length");
+
+    Some((ciphertext, nonce))
+}
+
+/// Unpack the concatenation of encrypted generation and nonce (ciphertext || nonce).
+pub fn unpack_encrypted_generation_nonce(data: &Vec<u8>) -> Option<(Vec<u8>, [u8; NONCE_SIZE])> {
+    if data.len() != GENERATION_STORAGE_SIZE {
+        return None;
+    }
+
+    let ciphertext = data
+        .get(..GENERATION_STORAGE_SIZE - NONCE_SIZE)
+        .unwrap()
+        .to_vec();
+
+    let nonce: [u8; NONCE_SIZE] = data
+        .get(GENERATION_STORAGE_SIZE - NONCE_SIZE..)
+        .unwrap()
+        .try_into()
+        .expect("slice with incorrect length");
+
+    Some((ciphertext, nonce))
+}
+
+#[cfg(test)]
+mod test {
+    use oasis_core_runtime::{
+        common::{
+            crypto::mrae::{
+                deoxysii::{DeoxysII, KEY_SIZE},
+                nonce::{Nonce, NONCE_SIZE},
+            },
+            namespace::{Namespace, NAMESPACE_SIZE},
+        },
+        consensus::beacon::EpochTime,
+    };
+
+    use crate::crypto::{self, Secret, SECRET_SIZE};
+
+    #[test]
+    fn basic_operations() {
+        let runtime_id = Namespace([1; NAMESPACE_SIZE]);
+        let epoch: EpochTime = 2;
+        let generation: u64 = 3;
+        let nonce = [4; NONCE_SIZE];
+        let secret = Secret([5; SECRET_SIZE]);
+        let key = [6; KEY_SIZE];
+
+        let d2 = DeoxysII::new(&key);
+        let encrypted_secret = d2.seal(&nonce, secret, vec![]);
+        let encrypted_generation = d2.seal(&nonce, generation.to_le_bytes(), vec![]);
+
+        let data = crypto::pack_runtime_id_epoch(&runtime_id, epoch);
+        let res = crypto::unpack_runtime_id_epoch(data).expect("data should unpack");
+        assert_eq!((runtime_id, epoch), res);
+
+        let res = crypto::unpack_runtime_id_epoch(vec![1, 2, 3]);
+        assert_eq!(None, res);
+
+        let data = crypto::pack_runtime_id_generation(&runtime_id, generation);
+        let res = crypto::unpack_runtime_id_generation(data).expect("data should unpack");
+        assert_eq!((runtime_id, generation), res);
+
+        let res = crypto::unpack_runtime_id_generation(vec![1, 2, 3]);
+        assert_eq!(None, res);
+
+        let data = crypto::pack_runtime_id_generation_epoch(&runtime_id, generation, epoch);
+        let res = crypto::unpack_runtime_id_generation_epoch(data).expect("data should unpack");
+        assert_eq!((runtime_id, generation, epoch), res);
+
+        let res = crypto::unpack_runtime_id_generation_epoch(vec![1, 2, 3]);
+        assert_eq!(None, res);
+
+        let data = crypto::pack_ciphertext_nonce(&encrypted_secret, &Nonce::new(nonce));
+        let res = crypto::unpack_encrypted_secret_nonce(&data).expect("data should unpack");
+        assert_eq!((encrypted_secret, nonce), res);
+
+        let res = crypto::unpack_encrypted_secret_nonce(&vec![1, 2, 3]);
+        assert_eq!(None, res);
+
+        let data = crypto::pack_ciphertext_nonce(&encrypted_generation, &Nonce::new(nonce));
+        let res = crypto::unpack_encrypted_generation_nonce(&data).expect("data should unpack");
+        assert_eq!((encrypted_generation, nonce), res);
+
+        let res = crypto::unpack_encrypted_secret_nonce(&vec![1, 2, 3]);
+        assert_eq!(None, res);
+    }
+}

--- a/runtime/src/common/namespace.rs
+++ b/runtime/src/common/namespace.rs
@@ -1,3 +1,6 @@
 //! Chain namespace.
 
-impl_bytes!(Namespace, 32, "Chain namespace.");
+/// Size of the namespace in bytes.
+pub const NAMESPACE_SIZE: usize = 32;
+
+impl_bytes!(Namespace, NAMESPACE_SIZE, "Chain namespace.");

--- a/tests/runtimes/simple-keyvalue/src/methods.rs
+++ b/tests/runtimes/simple-keyvalue/src/methods.rs
@@ -286,12 +286,15 @@ impl Methods {
         // Derive key pair ID based on key.
         let key_pair_id = KeyPairId::from(Hash::digest_bytes(key).as_ref());
 
+        // Always use keys from generation 0.
+        let generation = 0;
+
         // Fetch encryption keys.
         let io_ctx = IoContext::create_child(&ctx.parent.core.io_ctx);
         let result = ctx
             .parent
             .key_manager
-            .get_or_create_keys(io_ctx, key_pair_id);
+            .get_or_create_keys(io_ctx, key_pair_id, generation);
         let key = tokio::runtime::Handle::current()
             .block_on(result)
             .map_err(|err| err.to_string())?;


### PR DESCRIPTION
Master secret rotation, 1st part:
- Refactor key manager's init method to be able to support multiple generations of the master secret.