### PR TITLE
keymanager/src/runtime: Verify and modify init request

### DIFF
--- a/.changelog/5204.feature.md
+++ b/.changelog/5204.feature.md
@@ -1,0 +1,6 @@
+keymanager/src/runtime: Verify and modify init request
+
+The init request was never verified against the consensus layer state and,
+therefore, was not trustworthy. To make this request more informative and
+easily verifiable against consensus, it was extended to include all key
+manager status fields.

--- a/go/keymanager/api/api.go
+++ b/go/keymanager/api/api.go
@@ -169,9 +169,10 @@ func NewPublishEphemeralSecretTx(nonce uint64, fee *transaction.Fee, sigEnt *Sig
 // InitRequest is the initialization RPC request, sent to the key manager
 // enclave.
 type InitRequest struct {
-	Checksum    []byte `json:"checksum"`
-	Policy      []byte `json:"policy"`
-	MayGenerate bool   `json:"may_generate"`
+	Status      *Status `json:"status,omitempty"`   // TODO: Change in PR-5205.
+	Checksum    []byte  `json:"checksum,omitempty"` // TODO: Remove in PR-5205.
+	Policy      []byte  `json:"policy,omitempty"`   // TODO: Remove in PR-5205.
+	MayGenerate bool    `json:"may_generate"`
 }
 
 // InitResponse is the initialization RPC response, returned as part of a

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -182,6 +182,9 @@ type Features struct {
 	// KeyManagerStatusUpdates is a feature specifying that the runtime supports updating
 	// key manager's status.
 	KeyManagerStatusUpdates bool `json:"key_manager_status_updates,omitempty"`
+	// KeyManagerMasterSecretRotation is a feature specifying that the runtime supports rotating
+	// key manager's master secret.
+	KeyManagerMasterSecretRotation bool `json:"key_manager_master_secret_rotation,omitempty"`
 }
 
 // HasScheduleControl returns true when the runtime supports the schedule control feature.

--- a/keymanager/src/api/errors.rs
+++ b/keymanager/src/api/errors.rs
@@ -21,6 +21,8 @@ pub enum KeyManagerError {
     StateCorrupted,
     #[error("key manager replication required")]
     ReplicationRequired,
+    #[error("policy required")]
+    PolicyRequired,
     #[error("policy rollback")]
     PolicyRollback,
     #[error("policy alteration, without serial increment")]

--- a/keymanager/src/api/requests.rs
+++ b/keymanager/src/api/requests.rs
@@ -7,7 +7,9 @@ use oasis_core_runtime::{
         crypto::signature::{self, Signature, Signer},
         namespace::Namespace,
     },
-    consensus::{beacon::EpochTime, keymanager::SignedEncryptedEphemeralSecret},
+    consensus::{
+        beacon::EpochTime, keymanager::SignedEncryptedEphemeralSecret, state::keymanager::Status,
+    },
 };
 
 use crate::crypto::{KeyPairId, Secret};
@@ -18,12 +20,8 @@ const INIT_RESPONSE_CONTEXT: &[u8] = b"oasis-core/keymanager: init response";
 /// Key manager initialization request.
 #[derive(Clone, Default, cbor::Encode, cbor::Decode)]
 pub struct InitRequest {
-    /// Generation of the latest master secret.
-    pub generation: u64,
-    /// Checksum for validating replication.
-    pub checksum: Vec<u8>,
-    /// Policy for queries/replication.
-    pub policy: Vec<u8>,
+    /// Key manager status.
+    pub status: Status,
     /// True iff the enclave may generate a new master secret.
     pub may_generate: bool,
 }

--- a/runtime/src/consensus/state/keymanager.rs
+++ b/runtime/src/consensus/state/keymanager.rs
@@ -41,6 +41,8 @@ pub struct Status {
     pub is_initialized: bool,
     /// True iff the key manager is secure.
     pub is_secure: bool,
+    /// Generation of the latest master secret.
+    pub generation: u64,
     /// Key manager master secret verification checksum.
     pub checksum: Vec<u8>,
     /// List of currently active key manager node IDs.
@@ -201,6 +203,7 @@ mod test {
                 id: keymanager1,
                 is_initialized: false,
                 is_secure: false,
+                generation: 0,
                 checksum: vec![],
                 nodes: vec![],
                 policy: None,
@@ -210,6 +213,7 @@ mod test {
                 id: keymanager2,
                 is_initialized: true,
                 is_secure: true,
+                generation: 0,
                 checksum: checksum,
                 nodes: vec![signer1, signer2],
                 policy: Some(SignedPolicySGX {

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -338,6 +338,9 @@ pub struct Features {
     /// A feature specifying that the runtime supports updating key manager's status.
     #[cbor(optional)]
     pub key_manager_status_updates: bool,
+    /// A feature specifying that the runtime supports rotating key manager's master secret.
+    #[cbor(optional)]
+    pub key_manager_master_secret_rotation: bool,
 }
 
 impl Default for Features {
@@ -346,6 +349,7 @@ impl Default for Features {
             schedule_control: None,
             key_manager_quote_policy_updates: true,
             key_manager_status_updates: true,
+            key_manager_master_secret_rotation: false,
         }
     }
 }

--- a/tests/runtimes/simple-keymanager/src/main.rs
+++ b/tests/runtimes/simple-keymanager/src/main.rs
@@ -1,5 +1,5 @@
 use oasis_core_keymanager::runtime::init::new_keymanager;
-use oasis_core_runtime::{common::version::Version, config::Config};
+use oasis_core_runtime::{common::version::Version, config::Config, types::Features};
 
 mod api;
 
@@ -9,6 +9,10 @@ pub fn main_with_version(version: Version) {
         init,
         Config {
             version,
+            features: Some(Features {
+                key_manager_master_secret_rotation: true,
+                ..Default::default()
+            }),
             ..Default::default()
         },
     );


### PR DESCRIPTION
The init request was never verified against the consensus layer state and, therefore, was not trustworthy. To make this request more informative and easily verifiable against consensus, it was extended to include all key manager status fields.