### PR TITLE
 keymanager/src/runtime: Remove legacy version of init request

### DIFF
--- a/.changelog/5205.internal.md
+++ b/.changelog/5205.internal.md
@@ -1,0 +1,1 @@
+keymanager/src/runtime: Remove legacy version of init request

--- a/go/keymanager/api/api.go
+++ b/go/keymanager/api/api.go
@@ -237,10 +237,7 @@ func NewPublishEphemeralSecretTx(nonce uint64, fee *transaction.Fee, sigSec *Sig
 // InitRequest is the initialization RPC request, sent to the key manager
 // enclave.
 type InitRequest struct {
-	Status      *Status `json:"status,omitempty"`       // TODO: Change in PR-5205.
-	Checksum    []byte  `json:"checksum,omitempty"`     // TODO: Remove in PR-5205.
-	Policy      []byte  `json:"policy,omitempty"`       // TODO: Remove in PR-5205.
-	MayGenerate bool    `json:"may_generate,omitempty"` // TODO: Remove in PR-5205.
+	Status Status `json:"status,omitempty"`
 }
 
 // InitResponse is the initialization RPC response, returned as part of a

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -345,9 +345,6 @@ pub struct Features {
     /// A feature specifying that the runtime supports updating key manager's status.
     #[cbor(optional)]
     pub key_manager_status_updates: bool,
-    /// A feature specifying that the runtime supports rotating key manager's master secret.
-    #[cbor(optional)]
-    pub key_manager_master_secret_rotation: bool,
 }
 
 impl Default for Features {
@@ -356,7 +353,6 @@ impl Default for Features {
             schedule_control: None,
             key_manager_quote_policy_updates: true,
             key_manager_status_updates: true,
-            key_manager_master_secret_rotation: false,
         }
     }
 }

--- a/tests/runtimes/simple-keymanager/src/main.rs
+++ b/tests/runtimes/simple-keymanager/src/main.rs
@@ -1,6 +1,6 @@
 use oasis_core_keymanager::runtime::init::new_keymanager;
 use oasis_core_runtime::{
-    common::version::Version, config::Config, consensus::verifier::TrustRoot, types::Features,
+    common::version::Version, config::Config, consensus::verifier::TrustRoot,
 };
 
 mod api;
@@ -29,10 +29,6 @@ pub fn main_with_version(version: Version) {
         Config {
             version,
             trust_root,
-            features: Some(Features {
-                key_manager_master_secret_rotation: true,
-                ..Default::default()
-            }),
             freshness_proofs: true,
             ..Default::default()
         },


### PR DESCRIPTION
Should be updated and merged after Oasis Core 23.0.x is released and all key managers support master secret rotation.
See also #5204.