### PR TITLE
rust: Bump tempfile to 3.4.0

### DIFF
--- a/.changelog/5213.internal.md
+++ b/.changelog/5213.internal.md
@@ -1,0 +1,1 @@
+rust: Bump tempfile to 3.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,15 +2620,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "rs-libc"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3101,16 +3092,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi 0.3.9",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -67,7 +67,7 @@ features = ["full"]
 [dev-dependencies]
 # For storage interoperability tests only.
 jsonrpc = { version = "0.13.0", features = ["simple_uds"] }
-tempfile = "3.3.0"
+tempfile = "3.4.0"
 tendermint-testgen = "0.29.0"
 
 [[bin]]


### PR DESCRIPTION
Crate:     remove_dir_all
--
  | Version:   0.5.3
  | Title:     Race Condition Enabling Link Following and Time-of-check Time-of-use (TOCTOU)
  | Date:      2023-02-24
  | ID:        RUSTSEC-2023-0018
  | URL:       https://rustsec.org/advisories/RUSTSEC-2023-0018
  | Solution:  Upgrade to >=0.8.0

