### PR TITLE
keymanager: Support policies in unsafe builds

### DIFF
--- a/.changelog/5215.internal.md
+++ b/.changelog/5215.internal.md
@@ -1,0 +1,1 @@
+keymanager: Support policies in unsafe builds

--- a/go/oasis-node/cmd/keymanager/keymanager.go
+++ b/go/oasis-node/cmd/keymanager/keymanager.go
@@ -45,7 +45,6 @@ const (
 	CfgStatusChecksum    = "keymanager.status.checksum"
 	CfgStatusRSK         = "keymanager.status.rsk"
 
-	policyFilename = "km_policy.cbor"
 	statusFilename = "km_status.json"
 )
 
@@ -639,8 +638,8 @@ func registerKMInitStatusFlags(cmd *cobra.Command) {
 
 // Register registers the keymanager sub-command and all of it's children.
 func Register(parentCmd *cobra.Command) {
-	policyFileFlag.String(CfgPolicyFile, policyFilename, "file name of policy in CBOR format")
-	policySigFileFlag.StringSlice(CfgPolicySigFile, []string{policyFilename + ".sign"}, "file name(s) containing policy signature")
+	policyFileFlag.String(CfgPolicyFile, "", "file name of policy in CBOR format")
+	policySigFileFlag.StringSlice(CfgPolicySigFile, []string{}, "file name(s) containing policy signature")
 
 	_ = viper.BindPFlags(policyFileFlag)
 	_ = viper.BindPFlags(policySigFileFlag)

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -303,9 +303,10 @@ func (f *KeymanagerPolicyFixture) Create(net *Network) (*KeymanagerPolicy, error
 type KeymanagerFixture struct {
 	NodeFixture
 
-	Runtime int `json:"runtime"`
-	Entity  int `json:"entity"`
-	Policy  int `json:"policy"`
+	Runtime    int  `json:"runtime"`
+	Entity     int  `json:"entity"`
+	Policy     int  `json:"policy"`
+	SkipPolicy bool `json:"skip_policy,omitempty"`
 
 	RuntimeProvisioner runtimeConfig.RuntimeProvisioner `json:"runtime_provisioner"`
 
@@ -336,9 +337,11 @@ func (f *KeymanagerFixture) Create(net *Network) (*Keymanager, error) {
 	if err != nil {
 		return nil, err
 	}
-	policy, err := resolveKMPolicy(net, f.Policy)
-	if err != nil {
-		return nil, err
+	var policy *KeymanagerPolicy
+	if !f.SkipPolicy {
+		if policy, err = resolveKMPolicy(net, f.Policy); err != nil {
+			return nil, err
+		}
 	}
 
 	return net.NewKeymanager(&KeymanagerCfg{

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -244,7 +244,7 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 			{Runtime: 0, Serial: 1},
 		},
 		Keymanagers: []oasis.KeymanagerFixture{
-			{Runtime: 0, Entity: 1},
+			{Runtime: 0, Entity: 1, Policy: 0, SkipPolicy: tee != node.TEEHardwareIntelSGX},
 		},
 		ComputeWorkers: []oasis.ComputeWorkerFixture{
 			{Entity: 1, Runtimes: []int{1}},

--- a/go/worker/keymanager/watcher.go
+++ b/go/worker/keymanager/watcher.go
@@ -83,7 +83,7 @@ func (knw *kmNodeWatcher) watchNodes() {
 			peers[n.P2P.ID] = true
 		}
 
-		knw.w.setAccessList(knw.w.runtime.ID(), nodes)
+		knw.w.setAccessList(knw.w.runtimeID, nodes)
 		if pm := knw.w.commonWorker.P2P.PeerManager(); pm != nil {
 			if pids, err := p2p.PublicKeyMapToPeerIDs(peers); err == nil {
 				pm.PeerTagger().SetPeerImportance(p2p.ImportantNodeKeyManager, knw.w.runtime.ID(), pids)
@@ -94,13 +94,12 @@ func (knw *kmNodeWatcher) watchNodes() {
 
 func (knw *kmNodeWatcher) rebuildActiveNodeIDs(nodeList []*node.Node) map[signature.PublicKey]bool {
 	m := make(map[signature.PublicKey]bool)
-	id := knw.w.runtime.ID()
 	for _, n := range nodeList {
 		if !n.HasRoles(node.RoleKeyManager) {
 			continue
 		}
 		for _, rt := range n.Runtimes {
-			if rt.ID.Equal(&id) {
+			if rt.ID.Equal(&knw.w.runtimeID) {
 				m[n.ID] = true
 				break
 			}


### PR DESCRIPTION
The key manager settings configured in the policy can now be tested on non-SGX builds as well. This will simplify tests, as default values can be configured in the test fixtures (e.g. master secret rotation period).