### PR TITLE
go/oasis-node: Fix graceful termination

### DIFF
--- a/go/oasis-node/cmd/ias/proxy.go
+++ b/go/oasis-node/cmd/ias/proxy.go
@@ -141,7 +141,7 @@ func doProxy(cmd *cobra.Command, args []string) {
 	env.svcMgr.Register(metrics)
 
 	// Initialize the profiling server.
-	profiling, err := pprof.New(env.svcMgr.Ctx)
+	profiling, err := pprof.New()
 	if err != nil {
 		logger.Error("failed to initialize pprof server",
 			"err", err,

--- a/go/oasis-node/cmd/node/init.go
+++ b/go/oasis-node/cmd/node/init.go
@@ -130,7 +130,7 @@ func startMetricServer(svcMgr *background.ServiceManager, logger *logging.Logger
 // startProfilingServer initializes and starts the profiling server.
 func startProfilingServer(svcMgr *background.ServiceManager, logger *logging.Logger) (service.BackgroundService, error) {
 	// Initialize the profiling server.
-	profiling, err := pprof.New(svcMgr.Ctx)
+	profiling, err := pprof.New()
 	if err != nil {
 		logger.Error("failed to initialize pprof server",
 			"err", err,

--- a/go/oasis-test-runner/env/env.go
+++ b/go/oasis-test-runner/env/env.go
@@ -192,8 +192,11 @@ func (env *Env) Cleanup() {
 	}
 
 	// Tear down this environment's commands.
-	for _, v := range env.cleanupCmds {
-		v.termOrKill()
+	for _, m := range env.cleanupCmds {
+		go m.termOrKill()
+	}
+	for _, m := range env.cleanupCmds {
+		<-m.doneCh
 	}
 
 	// Do the cleanup for this environment.


### PR DESCRIPTION
This should speed up the runtime integration tests by more than half a minute (5s for every termination).