### PR TITLE
go/runtime/host/sgx: Update QE target info during re-attestation

### DIFF
--- a/.changelog/5239.bugfix.md
+++ b/.changelog/5239.bugfix.md
@@ -1,0 +1,5 @@
+go/runtime/host/sgx: Update QE target info during re-attestation
+
+This allows the node to continue working in case aesmd is upgraded while
+the node is running. In this case the Quoting Enclave identity can
+change and this requires the target info to be updated.


### PR DESCRIPTION
Fixes #5238 

This allows the node to continue working in case aesmd is upgraded while the node is running. In this case the Quoting Enclave identity can change and this requires the target info to be updated.