### PR TITLE
Config migration improvements

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -13,6 +13,7 @@ import (
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/config"
 	ias "github.com/oasisprotocol/oasis-core/go/ias/config"
 	common "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/config"
+	metrics "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/metrics/config"
 	pprof "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/pprof/config"
 	p2p "github.com/oasisprotocol/oasis-core/go/p2p/config"
 	runtime "github.com/oasisprotocol/oasis-core/go/runtime/config"
@@ -76,6 +77,7 @@ type Config struct {
 	P2P       p2p.Config     `yaml:"p2p"`
 	IAS       ias.Config     `yaml:"ias,omitempty"`
 	Pprof     pprof.Config   `yaml:"pprof,omitempty"`
+	Metrics   metrics.Config `yaml:"metrics,omitempty"`
 
 	Registration workerRegistration.Config `yaml:"registration,omitempty"`
 	Keymanager   workerKM.Config           `yaml:"keymanager,omitempty"`
@@ -132,6 +134,9 @@ func (c *Config) Validate() error {
 	if err = c.Pprof.Validate(); err != nil {
 		return fmt.Errorf("pprof: %w", err)
 	}
+	if err = c.Metrics.Validate(); err != nil {
+		return fmt.Errorf("metrics: %w", err)
+	}
 
 	return nil
 }
@@ -151,6 +156,7 @@ func DefaultConfig() Config {
 		Sentry:       workerSentry.DefaultConfig(),
 		IAS:          ias.DefaultConfig(),
 		Pprof:        pprof.DefaultConfig(),
+		Metrics:      metrics.DefaultConfig(),
 	}
 }
 

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -2,7 +2,9 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 
 	"github.com/a8m/envsubst"
 	"gopkg.in/yaml.v3"
@@ -161,9 +163,12 @@ func InitConfig(cfgFile string) error {
 	}
 
 	// Reset the global config and apply changes from the config file.
+	// Report error if any of the fields from the input file are unknown.
 	GlobalConfig = DefaultConfig()
-	err = yaml.Unmarshal(cfg, &GlobalConfig)
-	if err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(cfg))
+	dec.KnownFields(true)
+	err = dec.Decode(&GlobalConfig)
+	if err != nil && err != io.EOF {
 		return fmt.Errorf("failed to load config file '%s': %w", cfgFile, err)
 	}
 

--- a/go/oasis-node/cmd/common/metrics/config/config.go
+++ b/go/oasis-node/cmd/common/metrics/config/config.go
@@ -1,0 +1,61 @@
+// Package config implements global metrics configuration options.
+package config
+
+import (
+	"fmt"
+	"time"
+)
+
+// Config is the metrics configuration structure.
+type Config struct {
+	// Metrics mode (none, pull, push).
+	Mode string `yaml:"mode"`
+	// Metrics pull address.
+	Address string `yaml:"address"`
+
+	// Metrics push job name (debug-only).
+	JobName string `yaml:"job_name,omitempty"`
+	// Metrics push instance labels (debug-only).
+	Labels map[string]string `yaml:"labels,omitempty"`
+	// Metrics push interval (debug-only).
+	Interval time.Duration `yaml:"interval,omitempty"`
+}
+
+// Validate validates the configuration settings.
+func (c *Config) Validate() error {
+	switch c.Mode {
+	case "none":
+	case "pull":
+		if len(c.Address) == 0 {
+			return fmt.Errorf("missing address in pull mode")
+		}
+	case "push":
+		if len(c.Address) == 0 {
+			return fmt.Errorf("missing address in push mode")
+		}
+		if len(c.JobName) == 0 {
+			return fmt.Errorf("missing job_name in push mode")
+		}
+		if len(c.Labels) == 0 {
+			return fmt.Errorf("missing labels in push mode")
+		}
+		if c.Interval == 0 {
+			return fmt.Errorf("missing interval in push mode")
+		}
+	default:
+		return fmt.Errorf("unknown metrics mode: %s", c.Mode)
+	}
+
+	return nil
+}
+
+// DefaultConfig returns the default configuration settings.
+func DefaultConfig() Config {
+	return Config{
+		Mode:     "none",
+		Address:  "127.0.0.1:3000",
+		JobName:  "",
+		Labels:   map[string]string{},
+		Interval: 5 * time.Second,
+	}
+}

--- a/go/oasis-node/cmd/config/migrate/migrate.go
+++ b/go/oasis-node/cmd/config/migrate/migrate.go
@@ -3,7 +3,9 @@
 package migrate
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"strings"
@@ -681,8 +683,10 @@ func doMigrateConfig(cmd *cobra.Command, args []string) {
 	// Validate new config.
 	logger.Info("validating migrated config file")
 	newCfgStruct := config.DefaultConfig()
-	err = yaml.Unmarshal(newCfgRaw, &newCfgStruct)
-	if err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(newCfgRaw))
+	dec.KnownFields(true)
+	err = dec.Decode(&newCfgStruct)
+	if err != nil && err != io.EOF {
 		logger.Error("failed to parse config file after migration (this might be normal if you're using environment variable substitutions in your original config file)", "err", err)
 		os.Exit(1)
 	}

--- a/go/oasis-node/cmd/config/migrate/migrate.go
+++ b/go/oasis-node/cmd/config/migrate/migrate.go
@@ -634,6 +634,13 @@ func doMigrateConfig(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	metrics, ok := oldCfg["metrics"]
+	if ok {
+		mkSubMap(newCfg, "metrics")
+		newCfg["metrics"] = metrics
+		delete(oldCfg, "metrics")
+	}
+
 	// If we deleted any keys, make sure we don't retain empty structures.
 	pruneEmptyMaps(oldCfg)
 	// Also prune new config.
@@ -645,9 +652,6 @@ func doMigrateConfig(cmd *cobra.Command, args []string) {
 	}
 	if _, ok = oldCfg["grpc"]; ok {
 		logger.Warn("note that grpc.* options are from now on only available on the command-line")
-	}
-	if _, ok = oldCfg["metrics"]; ok {
-		logger.Warn("note that metrics.* options are from now on only available on the command-line")
 	}
 
 	logger.Info("config file migration completed")

--- a/go/oasis-node/cmd/config/migrate/migrate_test.go
+++ b/go/oasis-node/cmd/config/migrate/migrate_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
@@ -141,6 +142,15 @@ runtime:
 # Profiling.
 pprof:
   bind: 0.0.0.0:6666
+
+# Metrics.
+metrics:
+  mode: pull
+  address: 0.0.0.0:9101
+  job_name: node-mainnet
+  interval: 10s
+  labels:
+    instance: asdf-instance-0
 `
 
 // Keymanager test configuration file.
@@ -482,6 +492,11 @@ func TestConfigMigrationComplex(t *testing.T) {
 	require.Equal(newConfig.Storage.CheckpointSyncDisabled, true)
 	require.Equal(newConfig.Storage.Checkpointer.Enabled, true)
 	require.Equal(newConfig.Registration.Entity, "/storage/node/entity/entity.json")
+	require.Equal(newConfig.Metrics.Mode, "pull")
+	require.Equal(newConfig.Metrics.Address, "0.0.0.0:9101")
+	require.Equal(newConfig.Metrics.JobName, "node-mainnet")
+	require.Equal(newConfig.Metrics.Interval, 10*time.Second)
+	require.Equal(newConfig.Metrics.Labels["instance"], "asdf-instance-0")
 }
 
 func TestConfigMigrationKM(t *testing.T) {

--- a/go/oasis-node/cmd/config/migrate/migrate_test.go
+++ b/go/oasis-node/cmd/config/migrate/migrate_test.go
@@ -113,10 +113,13 @@ consensus:
     p2p:
       # Seed node setup.
       seed:
-        - "E27F6B7A350B4CC2B48A6CBE94B0A02B0DCB0BF3@35.199.49.168:26656"
+        - "53572F689E5BACDD3C6527E6594EC49C8F3093F6@34.86.165.6:26656"
 
       persistent_peer:
         - "asdf@1.2.3.4:5678"
+
+      unconditional_peer:
+        - "53572F689E5BACDD3C6527E6594EC49C8F3093F6@34.86.165.6:26656"
 
       disable_peer_exchange: true
 
@@ -434,6 +437,7 @@ func TestConfigMigrationSimple(t *testing.T) {
 	require.Equal(newConfig.Common.Log.Level["tendermint"], "debug")
 	require.Equal(newConfig.Common.Log.Level["tendermint/context"], "error")
 	require.Equal(newConfig.Genesis.File, "/node/etc/genesis.json")
+	require.Equal(newConfig.P2P.Seeds[0], "H6u9MtuoWRKn5DKSgarj/dzr2Z9BsjuRHgRAoXITOcU=@35.199.49.168:26656")
 	require.Equal(newConfig.Runtime.Paths[0], "/node/runtime/cipher-paratime-2.6.2.orc")
 	require.Equal(newConfig.Runtime.Paths[1], "/node/runtime/emerald-paratime-10.0.0.orc")
 	require.Equal(newConfig.Runtime.Paths[2], "/node/runtime/sapphire-paratime-0.4.0.orc")
@@ -454,6 +458,10 @@ func TestConfigMigrationComplex(t *testing.T) {
 	require.Equal(newConfig.Common.Log.Level["tendermint/context"], "error")
 	require.Equal(newConfig.Genesis.File, "/storage/node/genesis.json")
 	require.Equal(newConfig.P2P.Port, uint16(9002))
+	require.Equal(newConfig.P2P.Seeds[0], "HcDFrTp/MqRHtju5bCx6TIhIMd6X/0ZQ3lUG73q5898=@34.86.165.6:26656")
+	require.Equal(newConfig.Consensus.P2P.PersistentPeer[0], "INSERT_P2P_PUBKEY_HERE@1.2.3.4:5678")
+	require.Equal(newConfig.Consensus.P2P.UnconditionalPeer[0], "HcDFrTp/MqRHtju5bCx6TIhIMd6X/0ZQ3lUG73q5898=@34.86.165.6:26656")
+	require.Equal(newConfig.Consensus.SentryUpstreamAddresses[0], "INSERT_P2P_PUBKEY_HERE@1.2.3.4:5678")
 	require.Equal(newConfig.IAS.ProxyAddress, []string{"qwerty@1.2.3.4:4321"})
 	require.Equal(newConfig.Pprof.BindAddress, "0.0.0.0:6666")
 	require.Equal(newConfig.Runtime.Environment, rtConfig.RuntimeEnvironmentSGX)
@@ -487,6 +495,7 @@ func TestConfigMigrationKM(t *testing.T) {
 	require.Equal(newConfig.Common.Log.Level["default"], "debug")
 	require.Equal(newConfig.Genesis.File, "/km/etc/genesis.json")
 	require.Equal(newConfig.P2P.Port, uint16(1234))
+	require.Equal(newConfig.P2P.Seeds[0], "INSERT_P2P_PUBKEY_HERE@1.2.3.4:26656")
 	require.Equal(newConfig.P2P.Registration.Addresses[0], "4.3.2.1:26656")
 	require.Equal(newConfig.Registration.Entity, "/km/etc/entity/entity.json")
 	require.Equal(newConfig.IAS.ProxyAddress, []string{"foo@1.2.3.4:5678"})
@@ -511,6 +520,7 @@ func TestConfigMigrationDocsNonValidator(t *testing.T) {
 	require.Equal(newConfig.Common.Log.Level["tendermint"], "info")
 	require.Equal(newConfig.Common.Log.Level["tendermint/context"], "error")
 	require.Equal(newConfig.Genesis.File, "/node/etc/genesis.json")
+	require.Equal(newConfig.P2P.Seeds[0], "H6u9MtuoWRKn5DKSgarj/dzr2Z9BsjuRHgRAoXITOcU=@35.199.49.168:26656")
 	require.Equal(newConfig.Consensus.Validator, false)
 }
 
@@ -558,6 +568,7 @@ func TestConfigMigrationDocsParaTime(t *testing.T) {
 	require.Equal(newConfig.Genesis.File, "/node/etc/genesis.json")
 	require.Equal(newConfig.P2P.Port, uint16(30002))
 	require.Equal(newConfig.P2P.Registration.Addresses[0], "1.2.3.4:30002")
+	require.Equal(newConfig.P2P.Seeds[0], "H6u9MtuoWRKn5DKSgarj/dzr2Z9BsjuRHgRAoXITOcU=@35.199.49.168:26656")
 	require.Equal(newConfig.Registration.Entity, "/node/entity/entity.json")
 	require.Equal(newConfig.IAS.ProxyAddress, []string{"asdf@5.4.3.2:1234"})
 	require.Equal(newConfig.Runtime.SGXLoader, "/node/bin/oasis-core-runtime-loader")
@@ -579,6 +590,7 @@ func TestConfigMigrationDocsParaTimeClient(t *testing.T) {
 	require.Equal(newConfig.Common.Log.Level["tendermint"], "info")
 	require.Equal(newConfig.Common.Log.Level["tendermint/context"], "error")
 	require.Equal(newConfig.Genesis.File, "/node/etc/genesis.json")
+	require.Equal(newConfig.P2P.Seeds[0], "H6u9MtuoWRKn5DKSgarj/dzr2Z9BsjuRHgRAoXITOcU=@35.199.49.168:26656")
 	require.Equal(newConfig.Runtime.Paths[0], "/node/runtimes/test.orc")
 }
 
@@ -601,4 +613,6 @@ func TestConfigMigrationDocsSentry(t *testing.T) {
 	require.Equal(newConfig.Sentry.Enabled, true)
 	require.Equal(newConfig.Sentry.Control.Port, uint16(9009))
 	require.Equal(newConfig.Sentry.Control.AuthorizedPubkeys[0], "asdf")
+	require.Equal(newConfig.P2P.Seeds[0], "H6u9MtuoWRKn5DKSgarj/dzr2Z9BsjuRHgRAoXITOcU=@35.199.49.168:26656")
+	require.Equal(newConfig.Consensus.SentryUpstreamAddresses[0], "INSERT_P2P_PUBKEY_HERE@1.2.3.4:26656")
 }

--- a/go/oasis-node/cmd/debug/byzantine/byzantine.go
+++ b/go/oasis-node/cmd/debug/byzantine/byzantine.go
@@ -16,7 +16,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/sgx/ias"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/grpc"
-	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/metrics"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
 	"github.com/oasisprotocol/oasis-core/go/runtime/transaction"
@@ -303,7 +302,6 @@ func init() {
 	_ = viper.BindPFlags(storageFlags)
 	byzantineCmd.PersistentFlags().AddFlagSet(storageFlags)
 
-	byzantineCmd.PersistentFlags().AddFlagSet(metrics.Flags)
 	byzantineCmd.PersistentFlags().AddFlagSet(flags.GenesisFileFlags)
 	byzantineCmd.PersistentFlags().AddFlagSet(flags.DebugDontBlameOasisFlag)
 	byzantineCmd.PersistentFlags().AddFlagSet(flags.DebugTestEntityFlags)

--- a/go/oasis-node/cmd/ias/proxy.go
+++ b/go/oasis-node/cmd/ias/proxy.go
@@ -263,7 +263,6 @@ func init() {
 	_ = viper.BindEnv(cfgSPID, envSPID)
 
 	_ = viper.BindPFlags(proxyFlags)
-	proxyFlags.AddFlagSet(metrics.Flags)
 	proxyFlags.AddFlagSet(cmdGrpc.ServerLocalFlags)
 	proxyFlags.AddFlagSet(cmdGrpc.ServerTCPFlags)
 	proxyFlags.AddFlagSet(cmdGrpc.ClientFlags)

--- a/go/oasis-node/cmd/node/flags.go
+++ b/go/oasis-node/cmd/node/flags.go
@@ -8,7 +8,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crash"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	cmdGrpc "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/grpc"
-	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/metrics"
 	cmdSigner "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/signer"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	workerStorage "github.com/oasisprotocol/oasis-core/go/worker/storage"
@@ -37,7 +36,6 @@ func init() {
 
 	// Backend initialization flags.
 	for _, v := range []*flag.FlagSet{
-		metrics.Flags,
 		cmdGrpc.ServerLocalFlags,
 		cmdSigner.Flags,
 		runtimeRegistry.Flags,

--- a/go/oasis-test-runner/cmd/cmp/cmp.go
+++ b/go/oasis-test-runner/cmd/cmp/cmp.go
@@ -21,6 +21,8 @@ import (
 
 const (
 	cfgMetrics                = "metrics"
+	cfgMetricsAddr            = "metrics.address"
+	cfgMetricsLabels          = "metrics.labels"
 	cfgMetricsP               = "m"
 	cfgMetricsTargetGitBranch = "metrics.target.git_branch"
 	cfgMetricsSourceGitBranch = "metrics.source.git_branch"
@@ -528,7 +530,7 @@ func runCmp(cmd *cobra.Command, args []string) {
 
 	var err error
 	client, err = api.NewClient(api.Config{
-		Address: viper.GetString(metrics.CfgMetricsAddr),
+		Address: viper.GetString(cfgMetricsAddr),
 	})
 	if err != nil {
 		cmpLogger.Error("error creating client", "err", err)
@@ -555,7 +557,7 @@ func runCmp(cmd *cobra.Command, args []string) {
 		// Set other required Prometheus labels, if passed.
 		// TODO: Integrate scenario parameters and parameter set combinations if
 		// multiple values are provided like we do in oasis-test-runner.
-		for k, v := range viper.GetStringMapString(metrics.CfgMetricsLabels) {
+		for k, v := range viper.GetStringMapString(cfgMetricsLabels) {
 			srcLabels[k] = v
 			tgtLabels[k] = v
 		}
@@ -673,6 +675,9 @@ func Register(parentCmd *cobra.Command) {
 		"(optional) git_branch label for the target benchmark instance",
 	)
 	cmpFlags.String(cfgMetricsNetDevice, "lo", "network device traffic to compare")
+
+	cmpFlags.String(cfgMetricsAddr, "127.0.0.1:3000", "metrics pull address")
+	cmpFlags.StringToString(cfgMetricsLabels, map[string]string{}, "metrics push instance label")
 
 	_ = viper.BindPFlags(cmpFlags)
 	cmpCmd.Flags().AddFlagSet(cmpFlags)

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -4,9 +4,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strconv"
-	"strings"
-
-	"github.com/spf13/viper"
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
@@ -15,7 +12,6 @@ import (
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/grpc"
-	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/metrics"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/debug/byzantine"
 )
 
@@ -137,29 +133,6 @@ func (args *argBuilder) configureDebugCrashPoints(prob float64) *argBuilder {
 
 func (args *argBuilder) appendDebugTestEntity() *argBuilder {
 	args.vec = append(args.vec, Argument{Name: flags.CfgDebugTestEntity})
-	return args
-}
-
-func (args *argBuilder) appendNodeMetrics(node *Node) *argBuilder {
-	args.vec = append(args.vec, []Argument{
-		{metrics.CfgMetricsMode, []string{metrics.MetricsModePush}, false},
-		{metrics.CfgMetricsAddr, []string{viper.GetString(metrics.CfgMetricsAddr)}, false},
-		{metrics.CfgMetricsInterval, []string{viper.GetString(metrics.CfgMetricsInterval)}, false},
-		{metrics.CfgMetricsJobName, []string{node.Name}, false},
-	}...)
-
-	// Append labels.
-	ti := node.net.env.ScenarioInfo()
-	labels := metrics.GetDefaultPushLabels(ti)
-	var l []string
-	for k, v := range labels {
-		l = append(l, k+"="+v)
-	}
-	args.vec = append(args.vec, Argument{
-		Name:   metrics.CfgMetricsLabels,
-		Values: []string{strings.Join(l, ",")},
-	})
-
 	return args
 }
 


### PR DESCRIPTION
- [X] Always print the node mode at the top of the migrated config file.
- [X] Automatically migrate known P2P addresses from the old format to the new (for now implemented only for the mainnet and testnet seed nodes).
- [X] Migrate other P2P addresses as well, but replace the old ID with `INSERT_P2P_PUBKEY_HERE` to make it more obvious to the user that manual changes are required.
- [X] Instruct the user to run `oasis-node control status` to get the P2P public keys for new addresses.
- [x] Add `metrics.*` settings to the config structure.
- [x] Maybe figure out a way to print parts of the YAML config file that don't get deserialized into any structures instead of silently ignoring them when loading the config.