### PR TITLE
go/oasis-test-runner: Fix viper bug in metrics options

### DIFF
--- a/go/oasis-test-runner/cmd/cmp/cmp.go
+++ b/go/oasis-test-runner/cmd/cmp/cmp.go
@@ -528,6 +528,10 @@ func runCmp(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	// Workaround for viper bug: https://github.com/spf13/viper/issues/233
+	_ = viper.BindPFlag(cfgMetricsAddr, cmd.Flags().Lookup(cfgMetricsAddr))
+	_ = viper.BindPFlag(cfgMetricsLabels, cmd.Flags().Lookup(cfgMetricsLabels))
+
 	var err error
 	client, err = api.NewClient(api.Config{
 		Address: viper.GetString(cfgMetricsAddr),
@@ -676,7 +680,7 @@ func Register(parentCmd *cobra.Command) {
 	)
 	cmpFlags.String(cfgMetricsNetDevice, "lo", "network device traffic to compare")
 
-	cmpFlags.String(cfgMetricsAddr, "127.0.0.1:3000", "metrics pull address")
+	cmpFlags.String(cfgMetricsAddr, "http://127.0.0.1:3000", "metrics pull address")
 	cmpFlags.StringToString(cfgMetricsLabels, map[string]string{}, "metrics push instance label")
 
 	_ = viper.BindPFlags(cmpFlags)

--- a/go/oasis-test-runner/cmd/root.go
+++ b/go/oasis-test-runner/cmd/root.go
@@ -271,6 +271,10 @@ func initRootEnv(cmd *cobra.Command) (*env.Env, error) {
 func runRoot(cmd *cobra.Command, args []string) error { // nolint: gocyclo
 	cmd.SilenceUsage = true
 
+	// Workaround for viper bug: https://github.com/spf13/viper/issues/233
+	_ = viper.BindPFlag(cfgMetricsAddr, cmd.Flags().Lookup(cfgMetricsAddr))
+	_ = viper.BindPFlag(cfgMetricsLabels, cmd.Flags().Lookup(cfgMetricsLabels))
+
 	if viper.IsSet(cfgMetricsAddr) {
 		oasisTestRunnerOnce.Do(func() {
 			prometheus.MustRegister(oasisTestRunnerCollectors...)


### PR DESCRIPTION
This fixes the following bug: https://github.com/oasisprotocol/oasis-core/pull/5244#discussion_r1167569898