### PR TITLE
[BACKPORT/22.2.x] go/worker/client: Also treat literal latest round as latest

### DIFF
--- a/.changelog/5248.bugfix.md
+++ b/.changelog/5248.bugfix.md
@@ -1,0 +1,1 @@
+go/worker/client: Also treat literal latest round as latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,9 +2167,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.46"
+version = "0.10.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd2523381e46256e40930512c7fd25562b9eae4812cb52078f155e87217c9d1e"
+checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2193,11 +2193,10 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.81"
+version = "0.9.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176be2629957c157240f68f61f2d0053ad3a4ecfdd9ebf1e6521d18d9635cf67"
+checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "pkg-config",

--- a/go/worker/client/committee/node.go
+++ b/go/worker/client/committee/node.go
@@ -143,6 +143,7 @@ func (n *Node) Query(ctx context.Context, round uint64, method string, args []by
 	// Fetch the active descriptor so we can get the current message limits.
 	n.commonNode.CrossNode.Lock()
 	dsc := n.commonNode.CurrentDescriptor
+	latestRound := n.commonNode.CurrentBlock.Header.Round
 	n.commonNode.CrossNode.Unlock()
 
 	if dsc == nil {
@@ -177,7 +178,7 @@ func (n *Node) Query(ctx context.Context, round uint64, method string, args []by
 		// header. We assume that this is because a finalized header is not yet available for the
 		// given round.
 		switch round {
-		case api.RoundLatest:
+		case api.RoundLatest, latestRound:
 			// Since we are allowed to decide what we see as the latest round, use an earlier one.
 			n.logger.Debug("runtime's consensus verifier reports failure, retrying",
 				"method", method,


### PR DESCRIPTION
Backport of #5248 