### PR TITLE
.buildkite: Download Buildkite artifact only if checksum changed

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -16,7 +16,9 @@ download_artifact() {
     mkdir -p ${dst_dir}
 
     pushd ${ARTIFACTS_TEMPORARY_DIR}
-        buildkite-agent artifact download ${name} .
+        # download only if checksum changed
+        (echo "$(buildkite-agent artifact shasum ${name})  ${name}" | sha1sum -c) \
+            || buildkite-agent artifact download ${name} .
     popd
     cp ${ARTIFACTS_TEMPORARY_DIR}/${name} ${dst_dir}/${name}
     chmod ${mode} ${dst_dir}/${name}


### PR DESCRIPTION
The command `buildkite-agent artifact download` always re-downloads Buildkite artifacts, even if they are already present. With this PR it first checks its SHA-1 checksum (SHA-256 is not available for all artifacts). This should speed-up most E2E tests by ~1.5-3 minutes.