### PR TITLE
[BACKPORT/22.2.x] Fix Discord links to use static custom URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ to contribute, and this document should not be considered encompassing.
 
 If you have a general question on how to use and deploy our software, please
 read our [General Documentation](https://docs.oasis.io) or join our
-[Oasis Network Community server on Discord](https://discord.gg/RwNTK8t).
+[Oasis Network Community server on Discord](https://discord.gg/oasisprotocol).
 
 For concrete feature requests and/or bug reports, please file an issue in this
 repository as described below.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -45,7 +45,7 @@ on Discord]. They submit changes to the project itself via pull requests, which
 will be considered for inclusion in the project by existing committers (see
 next section).
 
-[Oasis Network Community server on Discord]: https://discord.gg/RwNTK8t
+[Oasis Network Community server on Discord]: https://discord.gg/oasisprotocol
 
 ### Committers
 


### PR DESCRIPTION
Backport of #5252 