### PR TITLE
go/control/api: Improve node registration status clarity

### DIFF
--- a/.changelog/5256.feature.md
+++ b/.changelog/5256.feature.md
@@ -1,0 +1,13 @@
+go/control/api: Improve node registration status clarity
+
+Three new fields have been added to the node's control status output
+under the registration status section:
+
+- `last_attempt_successful` - true if the last registration attempt
+succeeded.
+- `last_attempt_error_message` - error message if the last registration
+attempt failed.
+- `last_attempt` - time of the last registration attempt.
+
+Also, if the registration descriptor is expired, it is no longer
+shown in the output.

--- a/go/control/api/api.go
+++ b/go/control/api/api.go
@@ -124,6 +124,18 @@ type IdentityStatus struct {
 
 // RegistrationStatus is the node registration status.
 type RegistrationStatus struct {
+	// LastAttemptSuccessful is true if the last registration attempt has been
+	// successful.
+	LastAttemptSuccessful bool `json:"last_attempt_successful"`
+
+	// LastAttemptErrorMessage contains the error message if the last
+	// registration attempt has not been successful.
+	LastAttemptErrorMessage string `json:"last_attempt_error_message,omitempty"`
+
+	// LastAttempt is the time of the last registration attempt.
+	// In case the node did not successfully register yet, it will be the zero timestamp.
+	LastAttempt time.Time `json:"last_attempt"`
+
 	// LastRegistration is the time of the last successful registration with the consensus registry
 	// service. In case the node did not successfully register yet, it will be the zero timestamp.
 	LastRegistration time.Time `json:"last_registration"`

--- a/go/oasis-test-runner/scenario/e2e/runtime/node_shutdown.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/node_shutdown.go
@@ -95,6 +95,9 @@ func (sc *nodeShutdownImpl) Run(childEnv *env.Env) error { //nolint: gocyclo
 	if status.Registration.Descriptor == nil {
 		return fmt.Errorf("node has not registered")
 	}
+	if !status.Registration.LastAttemptSuccessful || status.Registration.LastAttemptErrorMessage != "" {
+		return fmt.Errorf("node registration was not successful")
+	}
 
 	sc.Logger.Info("requesting node shutdown")
 	args := []string{


### PR DESCRIPTION
This PR adds three new fields to the node's `control status` output under the registration status section:

- `last_attempt_successful` - true if the last registration attempt succeeded.
- `last_attempt_error_message` - error message if the last registration attempt failed.
- `last_attempt` - time of the last registration attempt.

Also, if the registration descriptor is expired, it is no longer shown in the output.