### PR TITLE
.buildkite: Improve namespacing of CI caches and build artifacts

### DIFF
--- a/.buildkite/benchmarks.pipeline.yml
+++ b/.buildkite/benchmarks.pipeline.yml
@@ -6,20 +6,26 @@ docker_plugin_default_config: &docker_plugin_default_config
   volumes:
     - /var/lib/buildkite-agent/.coveralls:/root/.coveralls
     - /var/lib/buildkite-agent/.codecov:/root/.codecov
-    # Shared Rust incremental compile caches.
-    - /var/tmp/cargo_ic/debug:/var/tmp/artifacts/debug/incremental
-    - /var/tmp/cargo_ic/debug_sgx:/var/tmp/artifacts/x86_64-unknown-linux-sgx/debug/incremental
-    # Shared Rust package checkouts directory.
-    - /var/tmp/cargo_pkg/git:/root/.cargo/git
-    - /var/tmp/cargo_pkg/registry:/root/.cargo/registry
-    # Shared Rust SGX standard library artifacts cache.
-    - /var/tmp/xargo_cache:/root/.xargo
-    # Shared Go package checkouts directory.
-    - /var/tmp/go_pkg:/root/go/pkg
     # Intel SGX Application Enclave Services Manager (AESM) daemon running on
     # the Buildkite host.
     - /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket
-    - /var/tmp/benchmarks:/var/tmp/benchmarks
+    # Shared Go package checkouts directory.
+    - /storage/buildkite/global_cache/go_pkg:/root/go/pkg
+    # Shared Rust package checkouts directory.
+    - /storage/buildkite/global_cache/cargo_git:/root/.cargo/git
+    - /storage/buildkite/global_cache/cargo_registry:/root/.cargo/registry
+    # Shared Rust SGX standard library artifacts cache.
+    - /storage/buildkite/global_cache/xargo_cache:/root/.xargo
+    # Per-branch shared Rust incremental compile caches.
+    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/debug:/var/tmp/artifacts/default/debug/incremental
+    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/debug_sgx:/var/tmp/artifacts/sgx/x86_64-unknown-linux-sgx/debug/incremental
+    # Per-build shared downloaded Buildkite artifacts.
+    - /storage/buildkite/build_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BUILD_NUMBER}/artifacts:/tmp/artifacts
+    # Per-build shared benchmark tests.
+    - /storage/buildkite/build_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BUILD_NUMBER}/benchmarks:/var/tmp/benchmarks
+  tmpfs:
+    # Per-job tmpfs for E2E test nodes, Codecov, Coveralls...
+    - /tmp:exec
   environment:
     - "LC_ALL=C.UTF-8"
     - "LANG=C.UTF-8"
@@ -27,6 +33,13 @@ docker_plugin_default_config: &docker_plugin_default_config
     - "CARGO_INSTALL_ROOT=/root/.cargo"
     - "CARGO_INCREMENTAL=0"
     - "GOPROXY=https://proxy.golang.org/"
+    - "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"
+    - "BUILDKITE_S3_DEFAULT_REGION"
+    - "BUILDKITE_S3_ACL"
+    - "BUILDKITE_S3_SSE_ENABLED"
+    - "BUILDKITE_S3_ACCESS_KEY_ID"
+    - "BUILDKITE_S3_SECRET_ACCESS_KEY"
+    - "BUILDKITE_S3_SESSION_TOKEN"
     - "BUILDKITE_PIPELINE_NAME"
     - "BUILDKITE_BUILD_NUMBER"
     - "BUILDKITE_BUILD_URL"

--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -14,30 +14,40 @@ docker_plugin_default_config: &docker_plugin_default_config
     - /var/lib/buildkite-agent/.codecov:/root/.codecov
     # IAS Development API keys.
     - /var/lib/buildkite-agent/.oasis-ias:/root/.oasis-ias
-    # Shared Rust incremental compile caches.
-    - /var/tmp/cargo_ic/debug:/var/tmp/artifacts/default/debug/incremental
-    - /var/tmp/cargo_ic/debug_sgx:/var/tmp/artifacts/sgx/x86_64-unknown-linux-sgx/debug/incremental
-    # Shared Rust package checkouts directory.
-    - /var/tmp/cargo_pkg/git:/root/.cargo/git
-    - /var/tmp/cargo_pkg/registry:/root/.cargo/registry
-    # Shared Rust SGX standard library artifacts cache.
-    - /var/tmp/xargo_cache:/root/.xargo
-    # Shared Go package checkouts directory.
-    - /var/tmp/go_pkg:/root/go/pkg
     # Intel SGX Application Enclave Services Manager (AESM) daemon running on
     # the Buildkite host.
     - /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket
-    # Propapage the tmpfs mount.
-    - /tmp:/tmp
+    # Shared Go package checkouts directory.
+    - /storage/buildkite/global_cache/go_pkg:/root/go/pkg
+    # Shared Rust package checkouts directory.
+    - /storage/buildkite/global_cache/cargo_git:/root/.cargo/git
+    - /storage/buildkite/global_cache/cargo_registry:/root/.cargo/registry
+    # Shared Rust SGX standard library artifacts cache.
+    - /storage/buildkite/global_cache/xargo_cache:/root/.xargo
+    # Per-branch shared Rust incremental compile caches.
+    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/debug:/var/tmp/artifacts/default/debug/incremental
+    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/debug_sgx:/var/tmp/artifacts/sgx/x86_64-unknown-linux-sgx/debug/incremental
+    # Per-build shared downloaded Buildkite artifacts.
+    - /storage/buildkite/build_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BUILD_NUMBER}/artifacts:/tmp/artifacts
+  tmpfs:
+    # Per-job tmpfs for E2E test nodes, Codecov, Coveralls...
+    - /tmp:exec
+  environment:
     # NOTE: When changing the environment variables below, also copy the changes
     # to the docker_plugin_sgx1_config.
-  environment:
     - "LC_ALL=C.UTF-8"
     - "LANG=C.UTF-8"
     - "CARGO_TARGET_DIR=/var/tmp/artifacts"
     - "CARGO_INSTALL_ROOT=/root/.cargo"
     - "CARGO_INCREMENTAL=0"
     - "GOPROXY=https://proxy.golang.org/"
+    - "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"
+    - "BUILDKITE_S3_DEFAULT_REGION"
+    - "BUILDKITE_S3_ACL"
+    - "BUILDKITE_S3_SSE_ENABLED"
+    - "BUILDKITE_S3_ACCESS_KEY_ID"
+    - "BUILDKITE_S3_SECRET_ACCESS_KEY"
+    - "BUILDKITE_S3_SESSION_TOKEN"
   propagate-environment: true
   unconfined: true
 
@@ -55,6 +65,13 @@ docker_plugin_sgx1_config: &docker_plugin_sgx1_config
     - "CARGO_INSTALL_ROOT=/root/.cargo"
     - "CARGO_INCREMENTAL=0"
     - "GOPROXY=https://proxy.golang.org/"
+    - "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"
+    - "BUILDKITE_S3_DEFAULT_REGION"
+    - "BUILDKITE_S3_ACL"
+    - "BUILDKITE_S3_SSE_ENABLED"
+    - "BUILDKITE_S3_ACCESS_KEY_ID"
+    - "BUILDKITE_S3_SECRET_ACCESS_KEY"
+    - "BUILDKITE_S3_SESSION_TOKEN"
 
 docker_plugin: &docker_plugin
   oasislabs/docker#v3.0.1-oasis1:
@@ -269,7 +286,7 @@ steps:
       - "build-rust-runtime-loader"
       - "build-rust-runtimes"
     parallelism: 30
-    timeout_in_minutes: 15
+    timeout_in_minutes: 20
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
       - .buildkite/scripts/test_e2e.sh
@@ -295,7 +312,7 @@ steps:
       - "build-go"
       - "build-rust-runtime-loader"
       - "build-rust-runtimes"
-    timeout_in_minutes: 15
+    timeout_in_minutes: 20
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
       - .buildkite/scripts/test_e2e.sh --scenario e2e/runtime/txsource-multi-short
@@ -307,8 +324,6 @@ steps:
     env:
       OASIS_E2E_COVERAGE: enable
       TEST_BASE_DIR: /tmp
-    agents:
-      buildkite_agent_class: ephemeral # XXX: Use a dedicated tag instead.
     retry:
       <<: *retry_agent_failure
     plugins:
@@ -319,7 +334,7 @@ steps:
   ###########################################
   - label: E2E tests - sgx1 - IAS
     branches: master stable/*
-    timeout_in_minutes: 15
+    timeout_in_minutes: 20
     command:
       - .buildkite/scripts/sgx_ias_tests.sh
     # A unique string to identify the step. The value is available in the

--- a/.buildkite/longtests.pipeline.yml
+++ b/.buildkite/longtests.pipeline.yml
@@ -6,20 +6,26 @@ docker_plugin_default_config: &docker_plugin_default_config
   volumes:
     - /var/lib/buildkite-agent/.coveralls:/root/.coveralls
     - /var/lib/buildkite-agent/.codecov:/root/.codecov
-    # Shared Rust incremental compile caches.
-    - /var/tmp/cargo_ic/debug:/var/tmp/artifacts/default/debug/incremental
-    - /var/tmp/cargo_ic/debug_sgx:/var/tmp/artifacts/sgx/x86_64-unknown-linux-sgx/debug/incremental
-    # Shared Rust package checkouts directory.
-    - /var/tmp/cargo_pkg/git:/root/.cargo/git
-    - /var/tmp/cargo_pkg/registry:/root/.cargo/registry
-    # Shared Rust SGX standard library artifacts cache.
-    - /var/tmp/xargo_cache:/root/.xargo
-    # Shared Go package checkouts directory.
-    - /var/tmp/go_pkg:/root/go/pkg
     # Intel SGX Application Enclave Services Manager (AESM) daemon running on
     # the Buildkite host.
     - /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket
-    - /var/tmp/longtests:/var/tmp/longtests
+    # Shared Go package checkouts directory.
+    - /storage/buildkite/global_cache/go_pkg:/root/go/pkg
+    # Shared Rust package checkouts directory.
+    - /storage/buildkite/global_cache/cargo_git:/root/.cargo/git
+    - /storage/buildkite/global_cache/cargo_registry:/root/.cargo/registry
+    # Shared Rust SGX standard library artifacts cache.
+    - /storage/buildkite/global_cache/xargo_cache:/root/.xargo
+    # Per-branch shared Rust incremental compile caches.
+    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/debug:/var/tmp/artifacts/default/debug/incremental
+    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/debug_sgx:/var/tmp/artifacts/sgx/x86_64-unknown-linux-sgx/debug/incremental
+    # Per-build shared downloaded Buildkite artifacts.
+    - /storage/buildkite/build_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BUILD_NUMBER}/artifacts:/tmp/artifacts
+    # Per-build shared long tests.
+    - /storage/buildkite/build_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BUILD_NUMBER}/longtests:/var/tmp/longtests
+  tmpfs:
+    # Per-job tmpfs for E2E test nodes, Codecov, Coveralls...
+    - /tmp:exec
   environment:
     - "LC_ALL=C.UTF-8"
     - "LANG=C.UTF-8"
@@ -27,10 +33,17 @@ docker_plugin_default_config: &docker_plugin_default_config
     - "CARGO_INSTALL_ROOT=/root/.cargo"
     - "CARGO_INCREMENTAL=0"
     - "GOPROXY=https://proxy.golang.org/"
-    - "SLACK_WEBHOOK_URL"
-    - "METRICS_PUSH_ADDR"
+    - "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"
+    - "BUILDKITE_S3_DEFAULT_REGION"
+    - "BUILDKITE_S3_ACL"
+    - "BUILDKITE_S3_SSE_ENABLED"
+    - "BUILDKITE_S3_ACCESS_KEY_ID"
+    - "BUILDKITE_S3_SECRET_ACCESS_KEY"
+    - "BUILDKITE_S3_SESSION_TOKEN"
     - "BUILDKITE_PIPELINE_NAME"
     - "BUILDKITE_BUILD_NUMBER"
+    - "SLACK_WEBHOOK_URL"
+    - "METRICS_PUSH_ADDR"
   propagate-environment: true
   unconfined: true
 
@@ -89,7 +102,7 @@ steps:
     env:
       TEST_BASE_DIR: /var/tmp/longtests
     agents:
-      daily: true
+      queue: daily
     # NOTE: we actually don't want to retry, but this is the only way that we
     # can execute the notify step only if tests failed.
     retry:

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -82,6 +82,7 @@ if ! check_docker_ci_image_tag_exists "${docker_tag}"; then
 fi
 
 export DOCKER_OASIS_CORE_CI_BASE_TAG=${docker_tag}
+export BUILDKITE_BRANCH_SLUG=${BUILDKITE_BRANCH//\//-}
 
 # Decide which pipeline to use.
 pipeline=.buildkite/code.pipeline.yml
@@ -91,4 +92,3 @@ fi
 
 # Upload the selected pipeline.
 cat $pipeline | buildkite-agent pipeline upload
-


### PR DESCRIPTION
Experimental attempt to reorganize and improve namespacing of CI caches and build artifacts. By introducing explicit levels at which local caches and artifacts can be shared (`global_cache`, `branch_cache`, `build_cache`), we should be able to support multiple Buildkite agents per node and increase their utilization.