### PR TITLE
go: Fix nil pointer error and remove exploded bundles 

### DIFF
--- a/go/oasis-test-runner/oasis/client.go
+++ b/go/oasis-test-runner/oasis/client.go
@@ -2,9 +2,11 @@ package oasis
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/oasisprotocol/oasis-core/go/config"
+	"github.com/oasisprotocol/oasis-core/go/runtime/bundle"
 	runtimeConfig "github.com/oasisprotocol/oasis-core/go/runtime/config"
 )
 
@@ -92,6 +94,11 @@ func (net *Network) NewClient(cfg *ClientCfg) (*Client, error) {
 		consensusPort:      host.getProvisionedPort(nodePortConsensus),
 		p2pPort:            host.getProvisionedPort(nodePortP2P),
 	}
+
+	// Remove any exploded bundles on cleanup.
+	net.env.AddOnCleanup(func() {
+		_ = os.RemoveAll(bundle.ExplodedPath(client.dir.String()))
+	})
 
 	net.clients = append(net.clients, client)
 	host.features = append(host.features, client)

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -3,6 +3,7 @@ package oasis
 import (
 	"crypto/ed25519"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 
@@ -14,6 +15,7 @@ import (
 	kmCmd "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/keymanager"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+	"github.com/oasisprotocol/oasis-core/go/runtime/bundle"
 	runtimeConfig "github.com/oasisprotocol/oasis-core/go/runtime/config"
 )
 
@@ -351,6 +353,11 @@ func (net *Network) NewKeymanager(cfg *KeymanagerCfg) (*Keymanager, error) {
 		mayGenerate:        len(net.keymanagers) == 0,
 		privatePeerPubKeys: cfg.PrivatePeerPubKeys,
 	}
+
+	// Remove any exploded bundles on cleanup.
+	net.env.AddOnCleanup(func() {
+		_ = os.RemoveAll(bundle.ExplodedPath(km.dir.String()))
+	})
 
 	net.keymanagers = append(net.keymanagers, km)
 	host.features = append(host.features, km)

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -320,7 +320,7 @@ func (w *Worker) initEnclave(kmStatus *api.Status, rtStatus *runtimeStatus) (*ap
 
 	// Initialize the key manager.
 	var args api.InitRequest
-	if rtInfo.Features.KeyManagerMasterSecretRotation {
+	if rtInfo.Features != nil && rtInfo.Features.KeyManagerMasterSecretRotation {
 		args = api.InitRequest{
 			Status:      kmStatus,
 			MayGenerate: w.mayGenerate,


### PR DESCRIPTION
Nil pointer error shows up if you try to run the latest stable test runtimes on a key manager node from the master branch.
Exploded bundles can be removed on cleanup on client, compute and key manager nodes.