### PR TITLE
go/worker/compute/executor: Do not propose batch on epoch transition

### DIFF
--- a/.changelog/5260.bugfix.md
+++ b/.changelog/5260.bugfix.md
@@ -1,0 +1,5 @@
+go/worker/compute/executor: Do not propose batch on epoch transition
+
+Previously a compute node could propose a new batch just before the
+epoch transition happened, resulting in computation that will be
+discarded anyway.


### PR DESCRIPTION
Previously a compute node could propose a new batch just before the epoch transition happened, resulting in computation that will be discarded anyway.