### PR TITLE
Optimize backup worker commit submission

### DIFF
--- a/.changelog/5264.feature.md
+++ b/.changelog/5264.feature.md
@@ -1,0 +1,4 @@
+go/worker/compute: Optimize backup worker commit submission
+
+Backup compute workers now observe any gossiped commitments and pre-empt
+consensus when it is obvious that there will be a discrepancy declared.

--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -12,6 +12,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
 	governanceApi "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/governance/api"
@@ -38,6 +39,8 @@ var _ tmapi.Application = (*rootHashApplication)(nil)
 type rootHashApplication struct {
 	state tmapi.ApplicationState
 	md    tmapi.MessageDispatcher
+
+	ecNotifier *pubsub.Broker
 }
 
 func (app *rootHashApplication) Name() string {
@@ -818,6 +821,8 @@ func (app *rootHashApplication) tryFinalizeBlock(
 }
 
 // New constructs a new roothash application instance.
-func New() tmapi.Application {
-	return &rootHashApplication{}
+func New(ecNotifier *pubsub.Broker) tmapi.Application {
+	return &rootHashApplication{
+		ecNotifier: ecNotifier,
+	}
 }

--- a/go/consensus/tendermint/apps/roothash/transactions.go
+++ b/go/consensus/tendermint/apps/roothash/transactions.go
@@ -119,6 +119,13 @@ func (app *rootHashApplication) executorCommit(
 	cc *roothash.ExecutorCommit,
 ) (err error) {
 	if ctx.IsCheckOnly() {
+		// In case an executor commit notifier has been set up, push all commits into channel.
+		if app.ecNotifier != nil {
+			for _, ec := range cc.Commits {
+				ec := ec
+				app.ecNotifier.Broadcast(&ec)
+			}
+		}
 		return nil
 	}
 

--- a/go/consensus/tendermint/apps/roothash/transactions_test.go
+++ b/go/consensus/tendermint/apps/roothash/transactions_test.go
@@ -132,7 +132,7 @@ func TestMessagesGasEstimation(t *testing.T) {
 
 	// Create a test message dispatcher that fakes gas estimation.
 	var md testMsgDispatcher
-	app := rootHashApplication{appState, &md}
+	app := rootHashApplication{appState, &md, nil}
 
 	// Generate a private key for the single node in this test.
 	sk, err := memorySigner.NewSigner(rand.Reader)
@@ -502,7 +502,7 @@ func TestEvidence(t *testing.T) {
 	err = expiredCommitment2.Sign(sk, runtime.ID)
 	require.NoError(err, "expiredCommitment2.Sign")
 	var md testMsgDispatcher
-	app := rootHashApplication{appState, &md}
+	app := rootHashApplication{appState, &md, nil}
 
 	ctx = appState.NewContext(abciAPI.ContextDeliverTx, now)
 	defer ctx.Close()
@@ -654,7 +654,7 @@ func TestSubmitMsg(t *testing.T) {
 	defer ctx.Close()
 
 	var md testMsgDispatcher
-	app := rootHashApplication{appState, &md}
+	app := rootHashApplication{appState, &md, nil}
 
 	// Generate a private key for the caller.
 	skCaller, err := memorySigner.NewSigner(rand.Reader)

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -143,6 +143,13 @@ type Backend interface {
 	// WatchEvents returns a stream of protocol events.
 	WatchEvents(ctx context.Context, runtimeID common.Namespace) (<-chan *Event, pubsub.ClosableSubscription, error)
 
+	// WatchExecutorCommitments returns a channel that produces a stream of executor commitments
+	// observed in the consensus layer P2P network.
+	//
+	// Note that these commitments may not have been processed by consensus, commitments may be
+	// received in any order and duplicates are possible.
+	WatchExecutorCommitments(ctx context.Context) (<-chan *commitment.ExecutorCommitment, pubsub.ClosableSubscription, error)
+
 	// TrackRuntime adds a runtime the history of which should be tracked.
 	TrackRuntime(ctx context.Context, history BlockHistory) error
 

--- a/go/worker/compute/executor/committee/discrepancy.go
+++ b/go/worker/compute/executor/committee/discrepancy.go
@@ -1,0 +1,115 @@
+package committee
+
+import (
+	"github.com/oasisprotocol/oasis-core/go/common/crash"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
+)
+
+func (n *Node) handleDiscrepancyLocked(height uint64) {
+	n.logger.Warn("execution discrepancy detected")
+
+	crash.Here(crashPointDiscrepancyDetectedAfter)
+
+	discrepancyDetectedCount.With(n.getMetricLabels()).Inc()
+
+	// If the node is not a backup worker in this epoch, no need to do anything. Also if the
+	// node is an executor worker in this epoch, then it has already processed and submitted
+	// a commitment, so no need to do anything.
+	epoch := n.commonNode.Group.GetEpochSnapshot()
+	if !epoch.IsExecutorBackupWorker() || epoch.IsExecutorWorker() {
+		return
+	}
+
+	// Make sure that the runtime has synced this consensus block.
+	if rt := n.commonNode.GetHostedRuntime(); rt != nil {
+		err := rt.ConsensusSync(n.roundCtx, height)
+		if err != nil {
+			n.logger.Warn("failed to ask the runtime to sync the latest consensus block",
+				"err", err,
+				"height", height,
+			)
+		}
+	}
+
+	var state StateWaitingForEvent
+	switch s := n.state.(type) {
+	case StateWaitingForBatch:
+		// Discrepancy detected event received before the batch. We need to remember that there was
+		// a discrepancy and keep waiting for the batch.
+		s.discrepancyDetected = true
+		n.transitionLocked(s)
+		return
+	case StateWaitingForEvent:
+		state = s
+	default:
+		n.logger.Warn("ignoring received discrepancy event in incorrect state",
+			"state", s,
+		)
+		return
+	}
+
+	// Backup worker, start processing a batch.
+	n.logger.Info("backup worker activating and processing batch")
+	n.startProcessingBatchLocked(state.batch)
+}
+
+// HandleNewEventLocked implements NodeHooks.
+// Guarded by n.commonNode.CrossNode.
+func (n *Node) HandleNewEventLocked(ev *roothash.Event) {
+	switch {
+	case ev.ExecutionDiscrepancyDetected != nil:
+		n.handleDiscrepancyLocked(uint64(ev.Height))
+	}
+}
+
+func (n *Node) handleObservedExecutorCommitment(ec *commitment.ExecutorCommitment) {
+	n.commonNode.CrossNode.Lock()
+	defer n.commonNode.CrossNode.Unlock()
+
+	// Don't do anything if we are not a backup worker or we are an executor worker.
+	es := n.commonNode.Group.GetEpochSnapshot()
+	if !es.IsExecutorBackupWorker() || es.IsExecutorWorker() {
+		return
+	}
+
+	n.logger.Debug("observed executor commitment",
+		"commitment", ec,
+	)
+
+	// Make sure the executor commitment is for the next round.
+	currentRound := n.commonNode.CurrentBlock.Header.Round
+	nextRound := currentRound + 1
+	if ec.Header.Round != nextRound {
+		n.logger.Debug("observed executor commitment is not for the next round",
+			"ec_round", ec.Header.Round,
+			"next_round", nextRound,
+		)
+		return
+	}
+
+	// Initialize the pool if needed.
+	if n.commitPool.Round != currentRound {
+		n.commitPool.Runtime = es.GetRuntime()
+		n.commitPool.Committee = es.GetExecutorCommittee().Committee
+		n.commitPool.ResetCommitments(currentRound)
+	}
+
+	// TODO: Handle equivocation detection.
+
+	err := n.commitPool.AddExecutorCommitment(n.ctx, n.commonNode.CurrentBlock, es, ec, nil)
+	if err != nil {
+		n.logger.Debug("ignoring bad observed executor commitment",
+			"err", err,
+			"node_id", ec.NodeID,
+		)
+		return
+	}
+
+	// In case observed commits indicate a discrepancy, preempt consensus and immediately handle.
+	if _, err = n.commitPool.ProcessCommitments(false); err == commitment.ErrDiscrepancyDetected {
+		n.logger.Warn("observed commitments indicate discrepancy")
+
+		n.handleDiscrepancyLocked(uint64(n.commonNode.CurrentBlockHeight))
+	}
+}

--- a/go/worker/compute/executor/committee/state.go
+++ b/go/worker/compute/executor/committee/state.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
-	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 	"github.com/oasisprotocol/oasis-core/go/runtime/transaction"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
@@ -109,9 +108,9 @@ func (s StateNotReady) String() string {
 
 // StateWaitingForBatch is the waiting for batch state.
 type StateWaitingForBatch struct {
-	// Pending execute discrepancy detected event in case the node is a
-	// backup worker and the event was received before the batch.
-	pendingEvent *roothash.ExecutionDiscrepancyDetectedEvent
+	// Whether a discrepancy has been detected in case the node is a backup worker and the event has
+	// been received before the batch.
+	discrepancyDetected bool
 }
 
 // Name returns the name of the state.


### PR DESCRIPTION
Backup compute workers now observe any gossiped commitments and pre-empt
consensus when it is obvious that there will be a discrepancy declared.