### PR TITLE
makefile: Exit with an error if go mod tidy fails

### DIFF
--- a/.changelog/5270.internal.md
+++ b/.changelog/5270.internal.md
@@ -1,0 +1,1 @@
+makefile: Exit with an error if go mod tidy fails

--- a/common.mk
+++ b/common.mk
@@ -166,7 +166,7 @@ endef
 # NOTE: go mod tidy doesn't implement a check mode yet.
 # For more details, see: https://github.com/golang/go/issues/27005.
 define CHECK_GO_MOD_TIDY =
-    $(GO) mod tidy; \
+    $(GO) mod tidy && \
     if [[ ! -z `git status --porcelain go.mod go.sum` ]]; then \
         $(ECHO) "$(RED)Error: The following changes detected after running 'go mod tidy':$(OFF)"; \
         git diff go.mod go.sum; \

--- a/go/Makefile
+++ b/go/Makefile
@@ -105,7 +105,7 @@ clean:
 	generate $(go-binaries) $(go-plugins) build \
 	$(test-helpers) build-helpers \
 	$(test-vectors-targets) \
-	fmt lint \
+	fmt lint lint-mod-tidy \
 	$(test-targets) test force-test \
 	clean all
 


### PR DESCRIPTION
Merge after `github.com/btcsuite/btcd/chaincfg/chainhash: ambiguous import` error is resolved.