### PR TITLE
go: Remove timecache replace directive in go.mod file

### DIFF
--- a/.changelog/5272.internal.md
+++ b/.changelog/5272.internal.md
@@ -1,0 +1,4 @@
+go: Remove timecache replace directive in go.mod file
+
+The replace directive for github.com/whyrusleeping/timecache has been removed
+since the go-libp2p-pubsub library version 0.9.3 no longer utilizes it.

--- a/go/go.mod
+++ b/go/go.mod
@@ -13,9 +13,6 @@ replace (
 
 	github.com/tendermint/tendermint => github.com/oasisprotocol/cometbft v0.34.27-oasis1
 
-	// Required because of https://github.com/libp2p/go-libp2p-pubsub/issues/467.
-	github.com/whyrusleeping/timecache => github.com/oasisprotocol/timecache v0.0.0-20220102191729-558b1c931038
-
 	golang.org/x/crypto/curve25519 => github.com/oasisprotocol/curve25519-voi/primitives/x25519 v0.0.0-20210505121811-294cf0fbfb43
 	golang.org/x/crypto/ed25519 => github.com/oasisprotocol/curve25519-voi/primitives/ed25519 v0.0.0-20210505121811-294cf0fbfb43
 )


### PR DESCRIPTION
The replace directive for github.com/whyrusleeping/timecache has been removed since the go-libp2p-pubsub library version 0.9.3 no longer utilizes it.

@kostko Was problem [#467](https://github.com/libp2p/go-libp2p-pubsub/issues/467) fixed in https://github.com/libp2p/go-libp2p-pubsub/tree/master/timecache?