### PR TITLE
go: Remove flatbuffers replace directive in go.mod file

### DIFF
--- a/.changelog/5273.internal.md
+++ b/.changelog/5273.internal.md
@@ -1,0 +1,4 @@
+go: Remove flatbuffers replace directive in go.mod file
+
+The replace directive for github.com/google/flatbuffers has been removed
+since the badger library version 3.2103.4 uses the same version 1.12.1.

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,12 +1,6 @@
 module github.com/oasisprotocol/oasis-core/go
 
 replace (
-	// Updates the version used by badgerdb, because some of the Go
-	// module caches apparently have a messed up copy that causes
-	// build failures.
-	// https://github.com/google/flatbuffers/issues/6466
-	github.com/google/flatbuffers => github.com/google/flatbuffers v1.12.1
-
 	// v1.5.0 has broken uint parsing, use my commit with fixes instead until
 	// the maintainers merge my PR: https://github.com/spf13/cast/pull/144
 	github.com/spf13/cast => github.com/oasisprotocol/cast v0.0.0-20220606122631-eba453e69641


### PR DESCRIPTION
The replace directive for github.com/google/flatbuffers has been removed since the badger library version 3.2103.4 uses the same version 1.12.1.

See https://github.com/dgraph-io/badger/blob/v3.2103.4/go.mod#L14.