### PR TITLE
[BACKPORT/22.2.x] buildkite: Shorten the timeout duration for test jobs

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -201,10 +201,7 @@ steps:
       - "build-rust-runtime-loader"
       - "build-rust-runtimes"
     parallelism: 30
-    # TODO: Temporary workaround to prevent timeouts during artifact downloading.
-    #       The timeout should be changed back to 15 minutes once we transition
-    #       to S3 or find a more efficient solution (see #5276).
-    timeout_in_minutes: 60
+    timeout_in_minutes: 15
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
       - .buildkite/scripts/test_e2e.sh
@@ -230,10 +227,7 @@ steps:
       - "build-go"
       - "build-rust-runtime-loader"
       - "build-rust-runtimes"
-    # TODO: Temporary workaround to prevent timeouts during artifact downloading.
-    #       The timeout should be changed back to 15 minutes once we transition
-    #       to S3 or find a more efficient solution (see #5276).
-    timeout_in_minutes: 60
+    timeout_in_minutes: 15
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
       - .buildkite/scripts/test_e2e.sh --scenario e2e/runtime/txsource-multi-short
@@ -262,10 +256,7 @@ steps:
       - "build-rust-runtimes"
     branches: "!master !stable/*"
     parallelism: 2
-    # TODO: Temporary workaround to prevent timeouts during artifact downloading.
-    #       The timeout should be changed back to 20 minutes once we transition
-    #       to S3 or find a more efficient solution (see #5276).
-    timeout_in_minutes: 60
+    timeout_in_minutes: 20
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
       # Needed as the trust-root test rebuilds the enclave with embedded trust root data.


### PR DESCRIPTION
The test job timeout needs to be reverted to 15/20 minutes, to undo the changes made in [5266](https://github.com/oasisprotocol/oasis-core/pull/5266) commit 5c0e0d3549d0a464609df531ac2e44c07e677e17.

Merged once we switch to S3 or find a more efficient solution for artifact downloading timeout.