### PR TITLE
runtime/consensus/roothash: Implement executor commitment structures 

### DIFF
--- a/.changelog/5282.breaking.md
+++ b/.changelog/5282.breaking.md
@@ -1,0 +1,3 @@
+go/roothash/commitment: Refactor executor commitment header
+
+The embedded compute results header struct has been changed to a field.

--- a/.changelog/5282.internal.md
+++ b/.changelog/5282.internal.md
@@ -1,0 +1,4 @@
+runtime/consensus/roothash: Implement executor commitment structures
+
+Structures and functions related to executor commitments were added
+in order to be used later for executor commitment verification.

--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -580,21 +580,21 @@ func (app *rootHashApplication) tryFinalizeExecutorCommits( //nolint: gocyclo
 		// Update the incoming message queue by removing processed messages. Do one final check to
 		// make sure that the processed messages actually correspond to the provided hash.
 		state := roothashState.NewMutableState(ctx.State())
-		if ec.Header.InMessagesCount > 0 {
+		if ec.Header.Header.InMessagesCount > 0 {
 			var meta *message.IncomingMessageQueueMeta
 			meta, err = state.IncomingMessageQueueMeta(ctx, rtState.Runtime.ID)
 			if err != nil {
 				return fmt.Errorf("failed to fetch incoming message queue metadata: %w", err)
 			}
 			var msgs []*message.IncomingMessage
-			msgs, err = state.IncomingMessageQueue(ctx, rtState.Runtime.ID, 0, ec.Header.InMessagesCount)
+			msgs, err = state.IncomingMessageQueue(ctx, rtState.Runtime.ID, 0, ec.Header.Header.InMessagesCount)
 			if err != nil {
 				return fmt.Errorf("failed to fetch incoming message queue: %w", err)
 			}
-			if inMsgsHash := message.InMessagesHash(msgs); !ec.Header.InMessagesHash.Equal(&inMsgsHash) {
+			if inMsgsHash := message.InMessagesHash(msgs); !ec.Header.Header.InMessagesHash.Equal(&inMsgsHash) {
 				ctx.Logger().Debug("finalized round contained invalid incoming message hash, failing instead",
 					"in_msgs_hash", inMsgsHash,
-					"ec_in_msgs_hash", *ec.Header.InMessagesHash,
+					"ec_in_msgs_hash", *ec.Header.Header.InMessagesHash,
 				)
 				// Make the round fail.
 				err = fmt.Errorf("finalized round contained invalid incoming message hash")
@@ -713,10 +713,10 @@ func (app *rootHashApplication) tryFinalizeExecutorCommits( //nolint: gocyclo
 
 		// Generate the final block.
 		blk := block.NewEmptyBlock(rtState.CurrentBlock, uint64(ctx.Now().Unix()), block.Normal)
-		blk.Header.IORoot = *ec.Header.IORoot
-		blk.Header.StateRoot = *ec.Header.StateRoot
-		blk.Header.MessagesHash = *ec.Header.MessagesHash
-		blk.Header.InMessagesHash = *ec.Header.InMessagesHash
+		blk.Header.IORoot = *ec.Header.Header.IORoot
+		blk.Header.StateRoot = *ec.Header.Header.StateRoot
+		blk.Header.MessagesHash = *ec.Header.Header.MessagesHash
+		blk.Header.InMessagesHash = *ec.Header.Header.InMessagesHash
 
 		// Timeout will be cleared by caller.
 		pool.ResetCommitments(blk.Header.Round)

--- a/go/consensus/tendermint/apps/roothash/transactions.go
+++ b/go/consensus/tendermint/apps/roothash/transactions.go
@@ -260,7 +260,7 @@ func (app *rootHashApplication) submitEvidence(
 	case evidence.EquivocationExecutor != nil:
 		commitA := evidence.EquivocationExecutor.CommitA
 
-		if commitA.Header.Round+params.MaxEvidenceAge < rtState.CurrentBlock.Header.Round {
+		if commitA.Header.Header.Round+params.MaxEvidenceAge < rtState.CurrentBlock.Header.Round {
 			ctx.Logger().Debug("Evidence: commitment equivocation evidence expired",
 				"evidence", evidence.EquivocationExecutor,
 				"current_round", rtState.CurrentBlock.Header.Round,
@@ -268,7 +268,7 @@ func (app *rootHashApplication) submitEvidence(
 			)
 			return fmt.Errorf("%w: equivocation evidence expired", roothash.ErrInvalidEvidence)
 		}
-		round = commitA.Header.Round
+		round = commitA.Header.Header.Round
 		pk = commitA.NodeID
 	case evidence.EquivocationProposal != nil:
 		proposalA := evidence.EquivocationProposal.ProposalA

--- a/go/consensus/tendermint/apps/roothash/transactions_test.go
+++ b/go/consensus/tendermint/apps/roothash/transactions_test.go
@@ -211,7 +211,7 @@ func TestMessagesGasEstimation(t *testing.T) {
 	ec := commitment.ExecutorCommitment{
 		NodeID: sk.Public(),
 		Header: commitment.ExecutorCommitmentHeader{
-			ComputeResultsHeader: commitment.ComputeResultsHeader{
+			Header: commitment.ComputeResultsHeader{
 				Round:          newBlk.Header.Round,
 				PreviousHash:   newBlk.Header.PreviousHash,
 				IORoot:         &newBlk.Header.IORoot,
@@ -442,7 +442,7 @@ func TestEvidence(t *testing.T) {
 	signedCommitment1 := commitment.ExecutorCommitment{
 		NodeID: sk.Public(),
 		Header: commitment.ExecutorCommitmentHeader{
-			ComputeResultsHeader: commitment.ComputeResultsHeader{
+			Header: commitment.ComputeResultsHeader{
 				Round:          blk.Header.Round,
 				PreviousHash:   blk.Header.PreviousHash,
 				IORoot:         &blk.Header.IORoot,
@@ -455,7 +455,7 @@ func TestEvidence(t *testing.T) {
 	err = signedCommitment1.Sign(sk, runtime.ID)
 	require.NoError(err, "signedCommitment1.Sign")
 	signedCommitment2 := signedCommitment1
-	signedCommitment2.Header.PreviousHash = hash.NewFromBytes([]byte("invalid ioroot"))
+	signedCommitment2.Header.Header.PreviousHash = hash.NewFromBytes([]byte("invalid ioroot"))
 	err = signedCommitment2.Sign(sk, runtime.ID)
 	require.NoError(err, "signedCommitment2.Sign")
 
@@ -485,7 +485,7 @@ func TestEvidence(t *testing.T) {
 	expiredCommitment1 := commitment.ExecutorCommitment{
 		NodeID: sk.Public(),
 		Header: commitment.ExecutorCommitmentHeader{
-			ComputeResultsHeader: commitment.ComputeResultsHeader{
+			Header: commitment.ComputeResultsHeader{
 				Round:          blk2.Header.Round,
 				PreviousHash:   blk2.Header.PreviousHash,
 				IORoot:         &blk2.Header.IORoot,
@@ -498,7 +498,7 @@ func TestEvidence(t *testing.T) {
 	err = expiredCommitment1.Sign(sk, runtime.ID)
 	require.NoError(err, "expiredCommitment1.Sign")
 	expiredCommitment2 := expiredCommitment1
-	expiredCommitment2.Header.PreviousHash = hash.NewFromBytes([]byte("invalid ioroot"))
+	expiredCommitment2.Header.Header.PreviousHash = hash.NewFromBytes([]byte("invalid ioroot"))
 	err = expiredCommitment2.Sign(sk, runtime.ID)
 	require.NoError(err, "expiredCommitment2.Sign")
 	var md testMsgDispatcher

--- a/go/oasis-node/cmd/control/runtime_stats.go
+++ b/go/oasis-node/cmd/control/runtime_stats.go
@@ -20,7 +20,6 @@ import (
 	registryAPI "github.com/oasisprotocol/oasis-core/go/registry/api"
 	roothashAPI "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
-	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
 	schedulerAPI "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 )
 
@@ -496,7 +495,7 @@ func doRuntimeStats(cmd *cobra.Command, args []string) { //nolint:gocyclo
 			}
 			// Set committee info.
 			currentCommittee = state.ExecutorPool.Committee
-			currentScheduler, err = commitment.GetTransactionScheduler(currentCommittee, currentRound)
+			currentScheduler, err = currentCommittee.TransactionScheduler(currentRound)
 			if err != nil {
 				logger.Error("failed to query transaction scheduler",
 					"err", err,

--- a/go/oasis-node/cmd/debug/byzantine/executor.go
+++ b/go/oasis-node/cmd/debug/byzantine/executor.go
@@ -318,7 +318,7 @@ func (cbc *computeBatchContext) createCommitment(
 	ec := &commitment.ExecutorCommitment{
 		NodeID: id.NodeSigner.Public(),
 		Header: commitment.ExecutorCommitmentHeader{
-			ComputeResultsHeader: header,
+			Header: header,
 		},
 	}
 	if rak != nil {

--- a/go/oasis-node/cmd/debug/byzantine/scheduler.go
+++ b/go/oasis-node/cmd/debug/byzantine/scheduler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
-	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 )
 
@@ -77,7 +76,7 @@ func schedulerCheckScheduled(committee *scheduler.Committee, nodeID signature.Pu
 }
 
 func schedulerCheckTxScheduler(committee *scheduler.Committee, nodeID signature.PublicKey, round uint64) bool {
-	scheduler, err := commitment.GetTransactionScheduler(committee, round)
+	scheduler, err := committee.TransactionScheduler(round)
 	if err != nil {
 		panic(err)
 	}

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -294,7 +294,7 @@ func (ev *EquivocationExecutorEvidence) ValidateBasic(id common.Namespace) error
 		return fmt.Errorf("equivocation executor evidence signature public keys don't match")
 	}
 
-	if ev.CommitA.Header.Round != ev.CommitB.Header.Round {
+	if ev.CommitA.Header.Header.Round != ev.CommitB.Header.Header.Round {
 		return fmt.Errorf("equivocation evidence commit headers not for same round")
 	}
 
@@ -315,10 +315,10 @@ func (ev *EquivocationExecutorEvidence) ValidateBasic(id common.Namespace) error
 	switch {
 	// Note: ValidateBasic checks above ensure that none of these fields are nil.
 	case a.Failure == commitment.FailureNone && b.Failure == commitment.FailureNone:
-		if a.PreviousHash.Equal(&b.PreviousHash) &&
-			a.IORoot.Equal(b.IORoot) &&
-			a.StateRoot.Equal(b.StateRoot) &&
-			a.MessagesHash.Equal(b.MessagesHash) {
+		if a.Header.PreviousHash.Equal(&b.Header.PreviousHash) &&
+			a.Header.IORoot.Equal(b.Header.IORoot) &&
+			a.Header.StateRoot.Equal(b.Header.StateRoot) &&
+			a.Header.MessagesHash.Equal(b.Header.MessagesHash) {
 			return fmt.Errorf("equivocation evidence commit headers match, no sign of equivocation")
 		}
 	default:

--- a/go/roothash/api/api_test.go
+++ b/go/roothash/api/api_test.go
@@ -66,7 +66,7 @@ func TestEvidenceHash(t *testing.T) {
 	ec := commitment.ExecutorCommitment{
 		NodeID: sk.Public(),
 		Header: commitment.ExecutorCommitmentHeader{
-			ComputeResultsHeader: commitment.ComputeResultsHeader{
+			Header: commitment.ComputeResultsHeader{
 				Round:        blk.Header.Round,
 				PreviousHash: blk.Header.PreviousHash,
 				IORoot:       &blk.Header.IORoot,
@@ -147,7 +147,7 @@ func TestEvidenceValidateBasic(t *testing.T) {
 	signedCommitment1 := commitment.ExecutorCommitment{
 		NodeID: sk.Public(),
 		Header: commitment.ExecutorCommitmentHeader{
-			ComputeResultsHeader: commitment.ComputeResultsHeader{
+			Header: commitment.ComputeResultsHeader{
 				Round:          rtBlk.Header.Round + 1,
 				PreviousHash:   rtBlk.Header.EncodedHash(),
 				IORoot:         &rtBlk.Header.IORoot,
@@ -161,7 +161,7 @@ func TestEvidenceValidateBasic(t *testing.T) {
 	require.NoError(err, "signedCommitment1.Sign")
 
 	signedCommitment2 := signedCommitment1
-	signedCommitment2.Header.PreviousHash = hash.NewFromBytes([]byte("invalid hash"))
+	signedCommitment2.Header.Header.PreviousHash = hash.NewFromBytes([]byte("invalid hash"))
 	err = signedCommitment2.Sign(sk, rtID)
 	require.NoError(err, "signedCommitment2.Sign")
 
@@ -445,7 +445,7 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 	signed1Commitment := commitment.ExecutorCommitment{
 		NodeID: sk.Public(),
 		Header: commitment.ExecutorCommitmentHeader{
-			ComputeResultsHeader: commitment.ComputeResultsHeader{
+			Header: commitment.ComputeResultsHeader{
 				Round:          rt1Blk2.Header.Round,
 				PreviousHash:   rt1Blk2.Header.PreviousHash,
 				IORoot:         &rt1Blk2.Header.IORoot,
@@ -465,7 +465,7 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 	signed1Commitment2 := commitment.ExecutorCommitment{
 		NodeID: sk.Public(),
 		Header: commitment.ExecutorCommitmentHeader{
-			ComputeResultsHeader: commitment.ComputeResultsHeader{
+			Header: commitment.ComputeResultsHeader{
 				Round:          rt1Blk2.Header.Round,
 				PreviousHash:   hash.NewFromBytes([]byte("invalid hash")),
 				IORoot:         &rt1Blk2.Header.IORoot,
@@ -482,7 +482,7 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 	signed1Commitment3 := commitment.ExecutorCommitment{
 		NodeID: sk.Public(),
 		Header: commitment.ExecutorCommitmentHeader{
-			ComputeResultsHeader: commitment.ComputeResultsHeader{
+			Header: commitment.ComputeResultsHeader{
 				Round:          rt1Blk2.Header.Round + 1,
 				PreviousHash:   hash.NewFromBytes([]byte("invalid hash")),
 				IORoot:         &rt1Blk2.Header.IORoot,
@@ -499,7 +499,7 @@ func TestEquivocationExecutorEvidenceValidateBasic(t *testing.T) {
 	signed1Invalid := commitment.ExecutorCommitment{
 		NodeID: sk.Public(),
 		Header: commitment.ExecutorCommitmentHeader{
-			ComputeResultsHeader: commitment.ComputeResultsHeader{
+			Header: commitment.ComputeResultsHeader{
 				Round:          rt1Blk2.Header.Round,
 				PreviousHash:   hash.NewFromBytes([]byte("invalid hash")),
 				IORoot:         nil,

--- a/go/roothash/api/block/block.go
+++ b/go/roothash/api/block/block.go
@@ -5,7 +5,7 @@ import "github.com/oasisprotocol/oasis-core/go/common"
 
 // Block is an Oasis block.
 //
-// Keep this in sync with /runtime/src/common/roothash.rs.
+// Keep this in sync with /runtime/src/consensus/roothash/block.rs.
 type Block struct {
 	// Header is the block header.
 	Header Header `json:"header"`

--- a/go/roothash/api/block/header.go
+++ b/go/roothash/api/block/header.go
@@ -65,7 +65,7 @@ const (
 
 // Header is a block header.
 //
-// Keep this in sync with /runtime/src/common/roothash.rs.
+// Keep this in sync with /runtime/src/consensus/roothash/block.rs.
 type Header struct { // nolint: maligned
 	// Version is the protocol version number.
 	Version uint16 `json:"version"`

--- a/go/roothash/api/commitment/executor.go
+++ b/go/roothash/api/commitment/executor.go
@@ -86,8 +86,10 @@ const (
 
 // ExecutorCommitmentHeader is the header of an executor commitment.
 type ExecutorCommitmentHeader struct {
-	ComputeResultsHeader
+	// Header is the compute results header.
+	Header ComputeResultsHeader `json:"header"`
 
+	// Failure is the executor commitment failure reason.
 	Failure ExecutorCommitmentFailure `json:"failure,omitempty"`
 
 	// Optional fields (may be absent for failure indication).
@@ -98,11 +100,11 @@ type ExecutorCommitmentHeader struct {
 // SetFailure sets failure reason and clears any fields that should be clear
 // in a failure indicating commitment.
 func (eh *ExecutorCommitmentHeader) SetFailure(failure ExecutorCommitmentFailure) {
-	eh.ComputeResultsHeader.IORoot = nil
-	eh.ComputeResultsHeader.StateRoot = nil
-	eh.ComputeResultsHeader.MessagesHash = nil
-	eh.ComputeResultsHeader.InMessagesHash = nil
-	eh.ComputeResultsHeader.InMessagesCount = 0
+	eh.Header.IORoot = nil
+	eh.Header.StateRoot = nil
+	eh.Header.MessagesHash = nil
+	eh.Header.InMessagesHash = nil
+	eh.Header.InMessagesCount = 0
 	eh.RAKSignature = nil
 	eh.Failure = failure
 }
@@ -126,7 +128,7 @@ func (eh *ExecutorCommitmentHeader) VerifyRAK(rak signature.PublicKey) error {
 	if eh.RAKSignature == nil {
 		return fmt.Errorf("missing RAK signature")
 	}
-	if !rak.Verify(ComputeResultsHeaderSignatureContext, cbor.Marshal(eh.ComputeResultsHeader), eh.RAKSignature[:]) {
+	if !rak.Verify(ComputeResultsHeaderSignatureContext, cbor.Marshal(eh.Header), eh.RAKSignature[:]) {
 		return fmt.Errorf("RAK signature verification failed")
 	}
 	return nil
@@ -139,8 +141,8 @@ func (eh *ExecutorCommitmentHeader) MostlyEqual(other *ExecutorCommitmentHeader)
 	if eh.Failure != other.Failure {
 		return false
 	}
-	h1 := eh.ComputeResultsHeader.EncodedHash()
-	h2 := other.ComputeResultsHeader.EncodedHash()
+	h1 := eh.Header.EncodedHash()
+	h2 := other.Header.EncodedHash()
 	return h1.Equal(&h2)
 }
 
@@ -191,7 +193,7 @@ func (c *ExecutorCommitment) Verify(runtimeID common.Namespace) error {
 
 // ValidateBasic performs basic executor commitment validity checks.
 func (c *ExecutorCommitment) ValidateBasic() error {
-	header := &c.Header.ComputeResultsHeader
+	header := &c.Header.Header
 	switch c.Header.Failure {
 	case FailureNone:
 		// Ensure header fields are present.
@@ -259,7 +261,7 @@ func (c *ExecutorCommitment) IsIndicatingFailure() bool {
 // ToVote returns a hash that represents a vote for this commitment as
 // per discrepancy resolution criteria.
 func (c *ExecutorCommitment) ToVote() hash.Hash {
-	return c.Header.ComputeResultsHeader.EncodedHash()
+	return c.Header.Header.EncodedHash()
 }
 
 // ToDDResult returns a commitment-specific result after discrepancy

--- a/go/roothash/api/commitment/executor.go
+++ b/go/roothash/api/commitment/executor.go
@@ -35,16 +35,22 @@ var (
 //
 // Keep the roothash RAK validation in sync with changes to this structure.
 type ComputeResultsHeader struct {
-	Round        uint64    `json:"round"`
+	// Round is the round number.
+	Round uint64 `json:"round"`
+
+	// PreviousHash is the hash of the previous block header this batch was computed against.
 	PreviousHash hash.Hash `json:"previous_hash"`
 
 	// Optional fields (may be absent for failure indication).
 
-	IORoot       *hash.Hash `json:"io_root,omitempty"`
-	StateRoot    *hash.Hash `json:"state_root,omitempty"`
+	// IORoot is the I/O merkle root.
+	IORoot *hash.Hash `json:"io_root,omitempty"`
+	// StateRoot is the root hash of the state after computing this batch.
+	StateRoot *hash.Hash `json:"state_root,omitempty"`
+	// MessagesHash is the hash of messages sent from this batch.
 	MessagesHash *hash.Hash `json:"messages_hash,omitempty"`
 
-	// InMessagesHash is the hash of processed incoming messages.
+	// InMessagesHash is hash of processed incoming messages.
 	InMessagesHash *hash.Hash `json:"in_msgs_hash,omitempty"`
 	// InMessagesCount is the number of processed incoming messages.
 	InMessagesCount uint32 `json:"in_msgs_count,omitempty"`
@@ -240,9 +246,9 @@ func (c *ExecutorCommitment) ValidateBasic() error {
 // MostlyEqual returns true if the commitment is mostly equal to another
 // specified commitment as per discrepancy detection criteria.
 func (c *ExecutorCommitment) MostlyEqual(other OpenCommitment) bool {
-	h := c.Header.ComputeResultsHeader.EncodedHash()
-	otherHash := other.(*ExecutorCommitment).Header.ComputeResultsHeader.EncodedHash()
-	return h.Equal(&otherHash)
+	h := c.ToVote()
+	otherH := other.ToVote()
+	return h.Equal(&otherH)
 }
 
 // IsIndicatingFailure returns true if this commitment indicates a failure.

--- a/go/roothash/api/commitment/executor_test.go
+++ b/go/roothash/api/commitment/executor_test.go
@@ -44,7 +44,7 @@ func TestValidateBasic(t *testing.T) {
 
 	body := ExecutorCommitment{
 		Header: ExecutorCommitmentHeader{
-			ComputeResultsHeader: ComputeResultsHeader{
+			Header: ComputeResultsHeader{
 				Round:          42,
 				PreviousHash:   emptyHeaderHash,
 				IORoot:         &emptyRoot,
@@ -70,7 +70,7 @@ func TestValidateBasic(t *testing.T) {
 		{
 			"Bad IORoot",
 			func(ec ExecutorCommitment) ExecutorCommitment {
-				ec.Header.IORoot = nil
+				ec.Header.Header.IORoot = nil
 				return ec
 			},
 			true,
@@ -78,7 +78,7 @@ func TestValidateBasic(t *testing.T) {
 		{
 			"Bad StateRoot",
 			func(ec ExecutorCommitment) ExecutorCommitment {
-				ec.Header.StateRoot = nil
+				ec.Header.Header.StateRoot = nil
 				return ec
 			},
 			true,
@@ -86,7 +86,7 @@ func TestValidateBasic(t *testing.T) {
 		{
 			"Bad MessagesHash",
 			func(ec ExecutorCommitment) ExecutorCommitment {
-				ec.Header.MessagesHash = nil
+				ec.Header.Header.MessagesHash = nil
 				return ec
 			},
 			true,
@@ -114,9 +114,9 @@ func TestValidateBasic(t *testing.T) {
 			func(ec ExecutorCommitment) ExecutorCommitment {
 				ec.Header.Failure = FailureUnknown
 				// ec.Header.IORoot is set.
-				ec.Header.StateRoot = nil
-				ec.Header.MessagesHash = nil
-				ec.Header.InMessagesHash = nil
+				ec.Header.Header.StateRoot = nil
+				ec.Header.Header.MessagesHash = nil
+				ec.Header.Header.InMessagesHash = nil
 				return ec
 			},
 			true,
@@ -125,10 +125,10 @@ func TestValidateBasic(t *testing.T) {
 			"Bad Failure (existing StateRoot)",
 			func(ec ExecutorCommitment) ExecutorCommitment {
 				ec.Header.Failure = FailureUnknown
-				ec.Header.IORoot = nil
+				ec.Header.Header.IORoot = nil
 				// ec.Header.StateRoot is set.
-				ec.Header.MessagesHash = nil
-				ec.Header.InMessagesHash = nil
+				ec.Header.Header.MessagesHash = nil
+				ec.Header.Header.InMessagesHash = nil
 				return ec
 			},
 			true,
@@ -137,10 +137,10 @@ func TestValidateBasic(t *testing.T) {
 			"Bad Failure (existing MessagesHash)",
 			func(ec ExecutorCommitment) ExecutorCommitment {
 				ec.Header.Failure = FailureUnknown
-				ec.Header.IORoot = nil
-				ec.Header.StateRoot = nil
+				ec.Header.Header.IORoot = nil
+				ec.Header.Header.StateRoot = nil
 				// ec.Header.MessagesHash is set.
-				ec.Header.InMessagesHash = nil
+				ec.Header.Header.InMessagesHash = nil
 				return ec
 			},
 			true,
@@ -149,9 +149,9 @@ func TestValidateBasic(t *testing.T) {
 			"Bad Failure (existing InMessagesHash)",
 			func(ec ExecutorCommitment) ExecutorCommitment {
 				ec.Header.Failure = FailureUnknown
-				ec.Header.IORoot = nil
-				ec.Header.StateRoot = nil
-				ec.Header.MessagesHash = nil
+				ec.Header.Header.IORoot = nil
+				ec.Header.Header.StateRoot = nil
+				ec.Header.Header.MessagesHash = nil
 				// ec.Header.InMessagesHash is set.
 				return ec
 			},

--- a/go/roothash/api/commitment/executor_test.go
+++ b/go/roothash/api/commitment/executor_test.go
@@ -36,6 +36,7 @@ func TestConsistentHash(t *testing.T) {
 }
 
 func TestValidateBasic(t *testing.T) {
+	// NOTE: These hashes MUST be synced with runtime/src/common/roothash/commitment/executor.rs.
 	var emptyRoot hash.Hash
 	emptyRoot.Empty()
 

--- a/go/roothash/api/commitment/executor_test.go
+++ b/go/roothash/api/commitment/executor_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestConsistentHash(t *testing.T) {
-	// NOTE: These hashes MUST be synced with runtime/src/common/roothash.rs.
+	// NOTE: These hashes MUST be synced with runtime/src/common/roothash/commitment/executor.rs.
 	var emptyHeaderHash hash.Hash
 	_ = emptyHeaderHash.UnmarshalHex("57d73e02609a00fcf4ca43cbf8c9f12867c46942d246fb2b0bce42cbdb8db844")
 

--- a/go/roothash/api/commitment/pool.go
+++ b/go/roothash/api/commitment/pool.go
@@ -196,11 +196,11 @@ func (p *Pool) addVerifiedExecutorCommitment( // nolint: gocyclo
 	}
 
 	// Check if the block is based on the previous block.
-	if !commit.Header.IsParentOf(&blk.Header) {
+	if !commit.Header.Header.IsParentOf(&blk.Header) {
 		logger.Debug("executor commitment is not based on correct block",
 			"node_id", commit.NodeID,
 			"expected_previous_hash", blk.Header.EncodedHash(),
-			"previous_hash", commit.Header.PreviousHash,
+			"previous_hash", commit.Header.Header.PreviousHash,
 		)
 		return ErrNotBasedOnCorrectBlock
 	}
@@ -277,11 +277,11 @@ func (p *Pool) addVerifiedExecutorCommitment( // nolint: gocyclo
 				)
 				return ErrInvalidMessages
 			}
-			if h := message.MessagesHash(commit.Messages); !h.Equal(commit.Header.MessagesHash) {
+			if h := message.MessagesHash(commit.Messages); !h.Equal(commit.Header.Header.MessagesHash) {
 				logger.Debug("executor commitment from scheduler has invalid messages hash",
 					"node_id", commit.NodeID,
 					"expected_hash", h,
-					"messages_hash", commit.Header.MessagesHash,
+					"messages_hash", commit.Header.Header.MessagesHash,
 				)
 				return ErrInvalidMessages
 			}

--- a/go/roothash/api/commitment/pool.go
+++ b/go/roothash/api/commitment/pool.go
@@ -138,7 +138,7 @@ func (p *Pool) isScheduler(id signature.PublicKey) bool {
 	if p.Committee == nil {
 		return false
 	}
-	scheduler, err := GetTransactionScheduler(p.Committee, p.Round)
+	scheduler, err := p.Committee.TransactionScheduler(p.Round)
 	if err != nil {
 		return false
 	}
@@ -395,7 +395,7 @@ func (p *Pool) ProcessCommitments(didTimeout bool) (OpenCommitment, error) {
 	}
 
 	// Determine whether the proposer has submitted a commitment.
-	proposer, err := GetTransactionScheduler(p.Committee, p.Round)
+	proposer, err := p.Committee.TransactionScheduler(p.Round)
 	if err != nil {
 		return nil, ErrNoCommittee
 	}

--- a/go/roothash/api/commitment/proposal.go
+++ b/go/roothash/api/commitment/proposal.go
@@ -7,7 +7,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
-	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 )
 
 // ProposalSignatureContext is the context used for signing propose batch dispatch messages.
@@ -98,16 +97,4 @@ func (p *Proposal) Verify(runtimeID common.Namespace) error {
 		return fmt.Errorf("roothash/commitment: signature verification failed")
 	}
 	return nil
-}
-
-// GetTransactionScheduler returns the transaction scheduler of the provided
-// committee based on the provided round.
-func GetTransactionScheduler(committee *scheduler.Committee, round uint64) (*scheduler.CommitteeNode, error) {
-	workers := committee.Workers()
-	numNodes := uint64(len(workers))
-	if numNodes == 0 {
-		return nil, fmt.Errorf("GetTransactionScheduler: no workers in committee")
-	}
-	schedulerIdx := round % numNodes
-	return workers[schedulerIdx], nil
 }

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -329,7 +329,7 @@ func (s *runtimeState) generateExecutorCommitments(t *testing.T, consensus conse
 		ec := commitment.ExecutorCommitment{
 			NodeID: node.Signer.Public(),
 			Header: commitment.ExecutorCommitmentHeader{
-				ComputeResultsHeader: commitment.ComputeResultsHeader{
+				Header: commitment.ComputeResultsHeader{
 					Round:           parent.Header.Round,
 					PreviousHash:    parent.Header.PreviousHash,
 					IORoot:          &parent.Header.IORoot,

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -658,7 +658,7 @@ WaitForProposerTimeoutBlocks:
 
 	// Get scheduler at round.
 	var scheduler *scheduler.CommitteeNode
-	scheduler, err = commitment.GetTransactionScheduler(s.executorCommittee.committee, child.Header.Round)
+	scheduler, err = s.executorCommittee.committee.TransactionScheduler(child.Header.Round)
 	require.NoError(err, "roothash.TransactionScheduler")
 
 	// Select node to trigger timeout.

--- a/go/scheduler/api/api.go
+++ b/go/scheduler/api/api.go
@@ -150,7 +150,7 @@ type Committee struct {
 }
 
 // Workers returns committee nodes with Worker role.
-func (c Committee) Workers() []*CommitteeNode {
+func (c *Committee) Workers() []*CommitteeNode {
 	var workers []*CommitteeNode
 	for _, member := range c.Members {
 		if member.Role != RoleWorker {
@@ -161,8 +161,20 @@ func (c Committee) Workers() []*CommitteeNode {
 	return workers
 }
 
+// TransactionScheduler returns the transaction scheduler of the committee
+// based on the provided round.
+func (c *Committee) TransactionScheduler(round uint64) (*CommitteeNode, error) {
+	workers := c.Workers()
+	numNodes := uint64(len(workers))
+	if numNodes == 0 {
+		return nil, fmt.Errorf("no workers in committee")
+	}
+	schedulerIdx := round % numNodes
+	return workers[schedulerIdx], nil
+}
+
 // String returns a string representation of a Committee.
-func (c Committee) String() string {
+func (c *Committee) String() string {
 	members := make([]string, len(c.Members))
 	for i, m := range c.Members {
 		members[i] = fmt.Sprintf("%+v", m)

--- a/go/worker/common/committee/group.go
+++ b/go/worker/common/committee/group.go
@@ -12,7 +12,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
-	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
 	"github.com/oasisprotocol/oasis-core/go/runtime/nodes"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
@@ -141,7 +140,7 @@ func (e *EpochSnapshot) IsTransactionScheduler(round uint64) bool {
 	if e.executorCommittee == nil || e.executorCommittee.Committee == nil {
 		return false
 	}
-	scheduler, err := commitment.GetTransactionScheduler(e.executorCommittee.Committee, round)
+	scheduler, err := e.executorCommittee.Committee.TransactionScheduler(round)
 	if err != nil {
 		return false
 	}
@@ -170,7 +169,7 @@ func (e *EpochSnapshot) VerifyTxnSchedulerSigner(id signature.PublicKey, round u
 	if e.executorCommittee == nil || e.executorCommittee.Committee == nil {
 		return fmt.Errorf("epoch: no active transaction scheduler")
 	}
-	scheduler, err := commitment.GetTransactionScheduler(e.executorCommittee.Committee, round)
+	scheduler, err := e.executorCommittee.Committee.TransactionScheduler(round)
 	if err != nil {
 		return fmt.Errorf("epoch: error getting transaction scheduler: %w", err)
 	}

--- a/go/worker/compute/executor/committee/discrepancy.go
+++ b/go/worker/compute/executor/committee/discrepancy.go
@@ -80,9 +80,9 @@ func (n *Node) handleObservedExecutorCommitment(ec *commitment.ExecutorCommitmen
 	// Make sure the executor commitment is for the next round.
 	currentRound := n.commonNode.CurrentBlock.Header.Round
 	nextRound := currentRound + 1
-	if ec.Header.Round != nextRound {
+	if ec.Header.Header.Round != nextRound {
 		n.logger.Debug("observed executor commitment is not for the next round",
-			"ec_round", ec.Header.Round,
+			"ec_round", ec.Header.Header.Round,
 			"next_round", nextRound,
 		)
 		return

--- a/go/worker/compute/executor/committee/node.go
+++ b/go/worker/compute/executor/committee/node.go
@@ -1116,8 +1116,8 @@ func (n *Node) proposeBatch(
 	ec := &commitment.ExecutorCommitment{
 		NodeID: n.commonNode.Identity.NodeSigner.Public(),
 		Header: commitment.ExecutorCommitmentHeader{
-			ComputeResultsHeader: batch.Header,
-			RAKSignature:         &rakSig,
+			Header:       batch.Header,
+			RAKSignature: &rakSig,
 		},
 	}
 	// If we are the transaction scheduler also include all the emitted messages.
@@ -1214,7 +1214,7 @@ func (n *Node) proposeBatch(
 	case nil:
 		n.transitionLocked(StateWaitingForFinalize{
 			batchStartTime: state.batchStartTime,
-			proposedIORoot: *ec.Header.IORoot,
+			proposedIORoot: *ec.Header.Header.IORoot,
 			txHashes:       processed.txHashes,
 		})
 	default:
@@ -1439,7 +1439,7 @@ func (n *Node) handleProcessedBatch(batch *processedBatch, processingCh chan *pr
 	commit := &commitment.ExecutorCommitment{
 		NodeID: n.commonNode.Identity.NodeSigner.Public(),
 		Header: commitment.ExecutorCommitmentHeader{
-			ComputeResultsHeader: commitment.ComputeResultsHeader{
+			Header: commitment.ComputeResultsHeader{
 				Round:        lastHeader.Round + 1,
 				PreviousHash: lastHeader.EncodedHash(),
 			},

--- a/runtime/src/consensus/registry.rs
+++ b/runtime/src/consensus/registry.rs
@@ -275,6 +275,23 @@ impl Node {
         }
         false
     }
+
+    /// Searches for an existing supported runtime descriptor
+    /// in runtimes with the specified version and returns it.
+    pub fn get_runtime(&self, runtime_id: &Namespace, version: &Version) -> Option<NodeRuntime> {
+        if let Some(rts) = &self.runtimes {
+            for rt in rts {
+                if runtime_id != &rt.id {
+                    continue;
+                }
+                if version != &rt.version {
+                    continue;
+                }
+                return Some(rt.clone());
+            }
+        }
+        None
+    }
 }
 
 /// Runtime kind.

--- a/runtime/src/consensus/roothash/block.rs
+++ b/runtime/src/consensus/roothash/block.rs
@@ -1,0 +1,104 @@
+//! Roothash block and header.
+//!
+//! # Note
+//!
+//! This **MUST** be kept in sync with go/roothash/api/block.
+//!
+use crate::common::{crypto::hash::Hash, namespace::Namespace};
+
+/// Runtime block.
+///
+/// # Note
+///
+/// This should be kept in sync with go/roothash/api/block/block.go.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, cbor::Encode, cbor::Decode)]
+pub struct Block {
+    /// Header.
+    pub header: Header,
+}
+
+/// Header type.
+///
+/// # Note
+///
+/// This should be kept in sync with go/roothash/api/block/header.go.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, cbor::Encode, cbor::Decode)]
+#[repr(u8)]
+pub enum HeaderType {
+    #[default]
+    Invalid = 0,
+    Normal = 1,
+    RoundFailed = 2,
+    EpochTransition = 3,
+    Suspended = 4,
+}
+
+/// Block header.
+///
+/// # Note
+///
+/// This should be kept in sync with go/roothash/api/block/header.go.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, cbor::Encode, cbor::Decode)]
+pub struct Header {
+    /// Protocol version number.
+    pub version: u16,
+    /// Chain namespace.
+    pub namespace: Namespace,
+    /// Round number.
+    pub round: u64,
+    /// Timestamp (POSIX time).
+    pub timestamp: u64,
+    /// Header type.
+    pub header_type: HeaderType,
+    /// Previous block hash.
+    pub previous_hash: Hash,
+    /// I/O merkle root.
+    pub io_root: Hash,
+    /// State merkle root.
+    pub state_root: Hash,
+    /// Messages hash.
+    pub messages_hash: Hash,
+    /// Hash of processed incoming messages.
+    pub in_msgs_hash: Hash,
+}
+
+impl Header {
+    /// Returns a hash of an encoded header.
+    pub fn encoded_hash(&self) -> Hash {
+        Hash::digest_bytes(&cbor::to_vec(self.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::common::{crypto::hash::Hash, namespace::Namespace};
+
+    use super::*;
+
+    #[test]
+    fn test_consistent_hash_header() {
+        // NOTE: These hashes MUST be synced with go/roothash/api/block/header_test.go.
+        let empty = Header::default();
+        assert_eq!(
+            empty.encoded_hash(),
+            Hash::from("677ad1a6b9f5e99ed94e5d598b6f92a4641a5f952f2d753b2a6122b6dceeb792")
+        );
+
+        let populated = Header {
+            version: 42,
+            namespace: Namespace::from(Hash::empty_hash().as_ref()),
+            round: 1000,
+            timestamp: 1560257841,
+            header_type: HeaderType::RoundFailed,
+            previous_hash: empty.encoded_hash(),
+            io_root: Hash::empty_hash(),
+            state_root: Hash::empty_hash(),
+            messages_hash: Hash::empty_hash(),
+            in_msgs_hash: Hash::empty_hash(),
+        };
+        assert_eq!(
+            populated.encoded_hash(),
+            Hash::from("b17374d9b36796752a787d0726ef44826bfdb3ece52545e126c8e7592663544d")
+        );
+    }
+}

--- a/runtime/src/consensus/roothash/block.rs
+++ b/runtime/src/consensus/roothash/block.rs
@@ -17,6 +17,45 @@ pub struct Block {
     pub header: Header,
 }
 
+impl Block {
+    /// Creates a new empty genesis block given a runtime id and POSIX timestamp.
+    pub fn new_genesis_block(id: Namespace, timestamp: u64) -> Block {
+        Block {
+            header: Header {
+                version: 0,
+                round: 0,
+                timestamp,
+                header_type: HeaderType::Normal,
+                namespace: id,
+                previous_hash: Hash::empty_hash(),
+                io_root: Hash::empty_hash(),
+                state_root: Hash::empty_hash(),
+                messages_hash: Hash::empty_hash(),
+                in_msgs_hash: Hash::empty_hash(),
+            },
+        }
+    }
+
+    /// Creates a new empty block with a specific type.
+    pub fn new_empty_block(child: &Block, timestamp: u64, header_type: HeaderType) -> Block {
+        Block {
+            header: Header {
+                version: child.header.version,
+                namespace: child.header.namespace,
+                round: child.header.round + 1,
+                timestamp,
+                header_type,
+                previous_hash: child.header.encoded_hash(),
+                io_root: Hash::empty_hash(),
+                // State root is unchanged.
+                state_root: child.header.state_root,
+                messages_hash: Hash::empty_hash(),
+                in_msgs_hash: Hash::empty_hash(),
+            },
+        }
+    }
+}
+
 /// Header type.
 ///
 /// # Note

--- a/runtime/src/consensus/roothash/commitment/executor.rs
+++ b/runtime/src/consensus/roothash/commitment/executor.rs
@@ -1,0 +1,75 @@
+use crate::common::crypto::hash::Hash;
+
+/// Compute results header signature context.
+#[cfg_attr(not(target_env = "sgx"), allow(unused))]
+pub const COMPUTE_RESULTS_HEADER_CONTEXT: &[u8] = b"oasis-core/roothash: compute results header";
+
+/// The header of a computed batch output by a runtime. This header is a
+/// compressed representation (e.g., hashes instead of full content) of
+/// the actual results.
+///
+/// # Note
+///
+/// This should be kept in sync with go/roothash/api/commitment/executor.go.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, cbor::Encode, cbor::Decode)]
+pub struct ComputeResultsHeader {
+    /// Round number.
+    pub round: u64,
+    /// Hash of the previous block header this batch was computed against.
+    pub previous_hash: Hash,
+
+    /// The I/O merkle root.
+    #[cbor(optional)]
+    pub io_root: Option<Hash>,
+    /// The root hash of the state after computing this batch.
+    #[cbor(optional)]
+    pub state_root: Option<Hash>,
+    /// Hash of messages sent from this batch.
+    #[cbor(optional)]
+    pub messages_hash: Option<Hash>,
+
+    /// The hash of processed incoming messages.
+    #[cbor(optional)]
+    pub in_msgs_hash: Option<Hash>,
+    /// The number of processed incoming messages.
+    #[cbor(optional)]
+    pub in_msgs_count: u32,
+}
+
+impl ComputeResultsHeader {
+    /// Returns a hash of an encoded header.
+    pub fn encoded_hash(&self) -> Hash {
+        Hash::digest_bytes(&cbor::to_vec(self.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::common::crypto::hash::Hash;
+
+    use super::*;
+
+    #[test]
+    fn test_consistent_hash_compute_results_header() {
+        // NOTE: These hashes MUST be synced with go/roothash/api/commitment/executor_test.go.
+        let empty = ComputeResultsHeader::default();
+        assert_eq!(
+            empty.encoded_hash(),
+            Hash::from("57d73e02609a00fcf4ca43cbf8c9f12867c46942d246fb2b0bce42cbdb8db844")
+        );
+
+        let populated = ComputeResultsHeader {
+            round: 42,
+            previous_hash: empty.encoded_hash(),
+            io_root: Some(Hash::empty_hash()),
+            state_root: Some(Hash::empty_hash()),
+            messages_hash: Some(Hash::empty_hash()),
+            in_msgs_hash: Some(Hash::empty_hash()),
+            in_msgs_count: 0,
+        };
+        assert_eq!(
+            populated.encoded_hash(),
+            Hash::from("8459a9e6e3341cd2df5ada5737469a505baf92397aaa88b7100915324506d843")
+        );
+    }
+}

--- a/runtime/src/consensus/roothash/commitment/executor.rs
+++ b/runtime/src/consensus/roothash/commitment/executor.rs
@@ -1,8 +1,40 @@
-use crate::common::crypto::hash::Hash;
+use std::any::Any;
 
-/// Compute results header signature context.
+use anyhow::{anyhow, Result};
+
+use crate::{
+    common::{
+        crypto::{
+            hash::Hash,
+            signature::{
+                signature_context_with_chain_separation, signature_context_with_runtime_separation,
+                PublicKey, Signature, Signer,
+            },
+        },
+        namespace::Namespace,
+    },
+    consensus::roothash::{Header, Message},
+};
+
+use super::OpenCommitment;
+
+/// The signature context used to sign compute results headers with RAK.
 #[cfg_attr(not(target_env = "sgx"), allow(unused))]
-pub const COMPUTE_RESULTS_HEADER_CONTEXT: &[u8] = b"oasis-core/roothash: compute results header";
+pub const COMPUTE_RESULTS_HEADER_SIGNATURE_CONTEXT: &[u8] =
+    b"oasis-core/roothash: compute results header";
+
+/// The signature context used to sign executor worker commitments.
+pub const EXECUTOR_COMMITMENT_SIGNATURE_CONTEXT: &[u8] =
+    b"oasis-core/roothash: executor commitment";
+
+fn executor_commitment_signature_context(
+    runtime_id: &Namespace,
+    chain_context: &String,
+) -> Vec<u8> {
+    let context = EXECUTOR_COMMITMENT_SIGNATURE_CONTEXT.to_vec();
+    let context = signature_context_with_runtime_separation(context, runtime_id);
+    signature_context_with_chain_separation(context, chain_context)
+}
 
 /// The header of a computed batch output by a runtime. This header is a
 /// compressed representation (e.g., hashes instead of full content) of
@@ -41,6 +73,199 @@ impl ComputeResultsHeader {
     pub fn encoded_hash(&self) -> Hash {
         Hash::digest_bytes(&cbor::to_vec(self.clone()))
     }
+
+    /// Returns true iff the header is the parent of a child header.
+    pub fn is_parent_of(&self, child: &Header) -> bool {
+        if self.round != child.round + 1 {
+            return false;
+        }
+        self.previous_hash == child.encoded_hash()
+    }
+}
+
+/// The executor commitment failure reason.
+#[derive(Clone, Debug, Default, PartialEq, Eq, cbor::Encode, cbor::Decode)]
+#[repr(u8)]
+pub enum ExecutorCommitmentFailure {
+    /// Indicates that no failure has occurred.
+    #[default]
+    FailureNone = 0,
+
+    /// Indicates a generic failure.
+    FailureUnknown = 1,
+
+    /// Indicates that batch processing failed due to the state being
+    /// unavailable.
+    FailureStateUnavailable = 2,
+}
+
+/// The header of an executor commitment.
+#[derive(Clone, Debug, Default, PartialEq, Eq, cbor::Encode, cbor::Decode)]
+pub struct ExecutorCommitmentHeader {
+    /// The compute results header.
+    pub header: ComputeResultsHeader,
+
+    /// The executor commitment failure reason.
+    #[cbor(optional)]
+    pub failure: ExecutorCommitmentFailure,
+
+    // Optional fields (may be absent for failure indication).
+    #[cbor(optional, rename = "rak_sig")]
+    pub rak_signature: Option<Signature>,
+}
+
+impl ExecutorCommitmentHeader {
+    /// Signs the executor commitment header.
+    pub fn sign(
+        &self,
+        signer: &impl Signer,
+        runtime_id: &Namespace,
+        chain_context: &String,
+    ) -> Result<Signature> {
+        let context = executor_commitment_signature_context(runtime_id, chain_context);
+        let message = cbor::to_vec(self.clone());
+
+        signer.sign(&context, &message)
+    }
+
+    /// Verifies the RAK signature.
+    pub fn verify_rak(&self, rak: PublicKey) -> Result<()> {
+        let sig = self.rak_signature.ok_or(anyhow!("missing RAK signature"))?;
+        let message = cbor::to_vec(self.header.clone());
+
+        sig.verify(&rak, COMPUTE_RESULTS_HEADER_SIGNATURE_CONTEXT, &message)
+            .map_err(|_| anyhow!("RAK signature verification failed"))
+    }
+}
+
+/// A commitment to results of processing a proposed runtime block.
+#[derive(Clone, Debug, Default, PartialEq, Eq, cbor::Encode, cbor::Decode)]
+pub struct ExecutorCommitment {
+    // The public key of the node that generated this commitment.
+    pub node_id: PublicKey,
+
+    // The commitment header.
+    pub header: ExecutorCommitmentHeader,
+
+    // The commitment header signature.
+    #[cbor(rename = "sig")]
+    pub signature: Signature,
+
+    // The messages emitted by the runtime.
+    //
+    // This field is only present in case this commitment belongs to the proposer. In case of
+    // the commitment being submitted as equivocation evidence, this field should be omitted.
+    #[cbor(optional)]
+    pub messages: Vec<Message>,
+}
+
+impl ExecutorCommitment {
+    /// Signs the executor commitment header and sets the signature on the commitment.
+    pub fn sign(
+        &mut self,
+        signer: &impl Signer,
+        runtime_id: &Namespace,
+        chain_context: &String,
+    ) -> Result<()> {
+        let pk = signer.public();
+        if self.node_id != pk {
+            return Err(anyhow!(
+                "node ID does not match signer (ID: {} signer: {})",
+                self.node_id,
+                pk,
+            ));
+        }
+
+        self.signature = self.header.sign(signer, runtime_id, chain_context)?;
+
+        Ok(())
+    }
+
+    /// Verifies that the header signature is valid.
+    pub fn verify(&self, runtime_id: &Namespace, chain_context: &String) -> Result<()> {
+        let context = executor_commitment_signature_context(runtime_id, chain_context);
+        let message = cbor::to_vec(self.header.clone());
+
+        self.signature
+            .verify(&self.node_id, &context, &message)
+            .map_err(|_| anyhow!("roothash/commitment: signature verification failed"))
+    }
+
+    pub fn validate_basic(&self) -> Result<()> {
+        match self.header.failure {
+            ExecutorCommitmentFailure::FailureNone => {
+                // Ensure header fields are present.
+                if self.header.header.io_root.is_none() {
+                    return Err(anyhow!("missing IORoot"));
+                }
+                if self.header.header.state_root.is_none() {
+                    return Err(anyhow!("missing StateRoot"));
+                }
+                if self.header.header.messages_hash.is_none() {
+                    return Err(anyhow!("missing messages hash"));
+                }
+                if self.header.header.in_msgs_hash.is_none() {
+                    return Err(anyhow!("missing incoming messages hash"));
+                }
+
+                // Validate any included runtime messages.
+                for msg in self.messages.iter() {
+                    msg.validate_basic()
+                        .map_err(|err| anyhow!("bad runtime message: {:?}", err))?;
+                }
+            }
+            ExecutorCommitmentFailure::FailureUnknown
+            | ExecutorCommitmentFailure::FailureStateUnavailable => {
+                // Ensure header fields are empty.
+                if self.header.header.io_root.is_some() {
+                    return Err(anyhow!("failure indicating body includes IORoot"));
+                }
+                if self.header.header.state_root.is_some() {
+                    return Err(anyhow!("failure indicating commitment includes StateRoot"));
+                }
+                if self.header.header.messages_hash.is_some() {
+                    return Err(anyhow!(
+                        "failure indicating commitment includes MessagesHash"
+                    ));
+                }
+                if self.header.header.in_msgs_hash.is_some()
+                    || self.header.header.in_msgs_count != 0
+                {
+                    return Err(anyhow!(
+                        "failure indicating commitment includes InMessagesHash/Count"
+                    ));
+                }
+                // In case of failure indicating commitment make sure RAK signature is empty.
+                if self.header.rak_signature.is_some() {
+                    return Err(anyhow!("failure indicating body includes RAK signature"));
+                }
+                // In case of failure indicating commitment make sure messages are empty.
+                if !self.messages.is_empty() {
+                    return Err(anyhow!("failure indicating body includes messages"));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl OpenCommitment for ExecutorCommitment {
+    fn mostly_equal(&self, other: &Self) -> bool {
+        self.to_vote() == other.to_vote()
+    }
+
+    fn is_indicating_failure(&self) -> bool {
+        self.header.failure != ExecutorCommitmentFailure::FailureNone
+    }
+
+    fn to_vote(&self) -> Hash {
+        self.header.header.encoded_hash()
+    }
+
+    fn to_dd_result(&self) -> &dyn Any {
+        self
+    }
 }
 
 #[cfg(test)]
@@ -50,7 +275,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_consistent_hash_compute_results_header() {
+    fn test_consistent_hash() {
         // NOTE: These hashes MUST be synced with go/roothash/api/commitment/executor_test.go.
         let empty = ComputeResultsHeader::default();
         assert_eq!(
@@ -71,5 +296,117 @@ mod tests {
             populated.encoded_hash(),
             Hash::from("8459a9e6e3341cd2df5ada5737469a505baf92397aaa88b7100915324506d843")
         );
+    }
+
+    #[test]
+    fn test_validate_basic() {
+        // NOTE: These hashes MUST be synced with go/roothash/api/commitment/executor_test.go.
+        let empty = ComputeResultsHeader::default();
+        assert_eq!(
+            empty.encoded_hash(),
+            Hash::from("57d73e02609a00fcf4ca43cbf8c9f12867c46942d246fb2b0bce42cbdb8db844")
+        );
+
+        let body = ExecutorCommitment {
+            header: ExecutorCommitmentHeader {
+                header: ComputeResultsHeader {
+                    round: 42,
+                    previous_hash: empty.encoded_hash(),
+                    io_root: Some(Hash::empty_hash()),
+                    state_root: Some(Hash::empty_hash()),
+                    messages_hash: Some(Hash::empty_hash()),
+                    in_msgs_hash: Some(Hash::empty_hash()),
+                    in_msgs_count: 0,
+                },
+                failure: ExecutorCommitmentFailure::FailureNone,
+                rak_signature: None,
+            },
+            messages: vec![],
+            node_id: PublicKey::default(),
+            signature: Signature::default(),
+        };
+
+        let tcs: Vec<(&str, fn(&mut ExecutorCommitment), bool)> = vec![
+            (
+                "Ok",
+                |ec: &mut ExecutorCommitment| {
+                    ec.header.header.round -= 1;
+                },
+                false,
+            ),
+            (
+                "Bad io_root",
+                |ec: &mut ExecutorCommitment| ec.header.header.io_root = None,
+                true,
+            ),
+            (
+                "Bad state_root",
+                |ec: &mut ExecutorCommitment| ec.header.header.state_root = None,
+                true,
+            ),
+            (
+                "Bad messages_hash",
+                |ec: &mut ExecutorCommitment| ec.header.header.messages_hash = None,
+                true,
+            ),
+            (
+                "Bad Failure (existing io_root)",
+                |ec: &mut ExecutorCommitment| {
+                    ec.header.failure = ExecutorCommitmentFailure::FailureUnknown;
+                    // ec.header.compute_results_header.io_root is set.
+                    ec.header.header.state_root = None;
+                    ec.header.header.messages_hash = None;
+                    ec.header.header.in_msgs_hash = None;
+                },
+                true,
+            ),
+            (
+                "Bad Failure (existing state_root)",
+                |ec: &mut ExecutorCommitment| {
+                    ec.header.failure = ExecutorCommitmentFailure::FailureUnknown;
+                    ec.header.header.io_root = None;
+                    // ec.header.compute_results_header.state_root is set.
+                    ec.header.header.messages_hash = None;
+                    ec.header.header.in_msgs_hash = None;
+                },
+                true,
+            ),
+            (
+                "Bad Failure (existing messages_hash)",
+                |ec: &mut ExecutorCommitment| {
+                    ec.header.failure = ExecutorCommitmentFailure::FailureUnknown;
+                    ec.header.header.io_root = None;
+                    ec.header.header.state_root = None;
+                    // ec.header.compute_results_header.messages_hash is set.
+                    ec.header.header.in_msgs_hash = None;
+                },
+                true,
+            ),
+            (
+                "Bad Failure (existing in_msgs_hash)",
+                |ec: &mut ExecutorCommitment| {
+                    ec.header.failure = ExecutorCommitmentFailure::FailureUnknown;
+                    ec.header.header.io_root = None;
+                    ec.header.header.state_root = None;
+                    ec.header.header.messages_hash = None;
+                    // ec.header.compute_results_header.in_msgs_hash is set.
+                },
+                true,
+            ),
+            (
+                "Ok Failure",
+                |ec: &mut ExecutorCommitment| {
+                    ec.header.failure = ExecutorCommitmentFailure::FailureUnknown;
+                },
+                true,
+            ),
+        ];
+
+        for (name, f, should_err) in tcs {
+            let mut b = body.clone();
+            f(&mut b);
+            let res = b.validate_basic();
+            assert_eq!(res.is_err(), should_err, "validate_basic({})", name)
+        }
     }
 }

--- a/runtime/src/consensus/roothash/commitment/mod.rs
+++ b/runtime/src/consensus/roothash/commitment/mod.rs
@@ -1,4 +1,40 @@
+//! Roothash commitments.
+//!
+//! # Note
+//!
+//! This **MUST** be kept in sync with go/roothash/api/commitment.
+//!
+use std::any::Any;
+
+use crate::common::crypto::hash::Hash;
+
+// Modules.
 mod executor;
+mod pool;
 
 // Re-exports.
 pub use executor::*;
+pub use pool::*;
+
+/// Verified roothash commitment.
+pub trait OpenCommitment {
+    /// Returns true if the commitment is mostly equal to another
+    /// specified commitment as per discrepancy detection criteria.
+    ///
+    /// The caller MUST guarantee that the passed commitment is of the same
+    /// type.
+    fn mostly_equal(&self, other: &Self) -> bool
+    where
+        Self: Sized;
+
+    /// Returns true if this commitment indicates a failure.
+    fn is_indicating_failure(&self) -> bool;
+
+    /// Returns a hash that represents a vote for this commitment as
+    /// per discrepancy resolution criteria.
+    fn to_vote(&self) -> Hash;
+
+    /// Returns a commitment-specific result after discrepancy
+    /// detection.
+    fn to_dd_result(&self) -> &dyn Any;
+}

--- a/runtime/src/consensus/roothash/commitment/mod.rs
+++ b/runtime/src/consensus/roothash/commitment/mod.rs
@@ -1,0 +1,4 @@
+mod executor;
+
+// Re-exports.
+pub use executor::*;

--- a/runtime/src/consensus/roothash/commitment/pool.rs
+++ b/runtime/src/consensus/roothash/commitment/pool.rs
@@ -1,0 +1,647 @@
+use std::collections::{HashMap, HashSet};
+
+use anyhow::Result;
+
+use crate::{
+    common::crypto::{hash::Hash, signature::PublicKey},
+    consensus::{
+        registry::{Node, Runtime, TEEHardware},
+        roothash::{Block, Error, Message, OpenCommitment},
+        scheduler::{Committee, CommitteeKind, Role},
+    },
+};
+
+use super::ExecutorCommitment;
+
+/// A trait for looking up registry node descriptors.
+pub trait NodeLookup {
+    fn node(&self, id: PublicKey) -> Result<Node, Error>;
+}
+
+/// A trait that validates messages for validity. It can be used for gas accounting.
+pub trait MessageValidator {
+    fn validate(&self, msgs: &[Message]) -> Result<()>;
+}
+
+impl<F> MessageValidator for F
+where
+    F: Fn(&[Message]) -> Result<()>,
+{
+    fn validate(&self, msgs: &[Message]) -> Result<()> {
+        (*self)(msgs)
+    }
+}
+
+/// A pool of commitments that can be used to perform
+/// discrepancy detection.
+///
+/// The pool is not safe for concurrent use.
+pub struct Pool {
+    /// The runtime descriptor this pool is collecting
+    /// the commitments for.
+    runtime: Runtime,
+    /// The committee this pool is collecting the commitments for.
+    committee: Committee,
+    /// The current protocol round.
+    round: u64,
+    // The commitments in the pool iff Committee.Kind
+    // is scheduler.KindComputeExecutor.
+    execute_commitments: HashMap<PublicKey, ExecutorCommitment>,
+    // A flag signalling that a discrepancy has been detected.
+    discrepancy: bool,
+    // The time when the next call to TryFinalize(true) should
+    // be scheduled to be executed. Zero means that no timeout is to be scheduled.
+    _next_timeout: i64,
+
+    // A cached committee member set. It will be automatically
+    // constructed based on the passed Committee.
+    member_set: HashSet<PublicKey>,
+    // A cached committee worker set. It will be automatically
+    // constructed based on the passed Committee.
+    _worker_set: HashSet<PublicKey>,
+}
+
+impl Pool {
+    /// Creates a new pool.
+    pub fn new(runtime: Runtime, committee: Committee, round: u64) -> Self {
+        let mut member_set = HashSet::new();
+        let mut _worker_set = HashSet::new();
+
+        for m in &committee.members {
+            member_set.insert(m.public_key);
+            if m.role == Role::Worker {
+                _worker_set.insert(m.public_key);
+            }
+        }
+
+        Pool {
+            runtime,
+            committee,
+            round,
+            execute_commitments: HashMap::new(),
+            discrepancy: false,
+            _next_timeout: 0,
+            member_set,
+            _worker_set,
+        }
+    }
+
+    fn is_member(&self, id: &PublicKey) -> bool {
+        self.member_set.contains(id)
+    }
+
+    fn _is_worker(&self, id: &PublicKey) -> bool {
+        self._worker_set.contains(id)
+    }
+
+    fn is_scheduler(&self, id: &PublicKey) -> bool {
+        if let Ok(scheduler) = self.committee.transaction_scheduler(self.round) {
+            return &scheduler.public_key == id;
+        }
+        false
+    }
+
+    /// Verifies and adds a new executor commitment to the pool.
+    fn add_verified_executor_commitment(
+        &mut self,
+        blk: &Block,
+        nl: &impl NodeLookup,
+        msg_validator: &impl MessageValidator,
+        commit: ExecutorCommitment,
+    ) -> Result<()> {
+        if self.committee.kind != CommitteeKind::ComputeExecutor {
+            return Err(Error::InvalidCommitteeKind.into());
+        }
+
+        // Ensure that the node is actually a committee member. We do not enforce specific
+        // roles based on current discrepancy state to allow commitments arriving in any
+        // order (e.g., a backup worker can submit a commitment even before there is a
+        // discrepancy).
+        if !self.is_member(&commit.node_id) {
+            return Err(Error::NotInCommittee.into());
+        }
+
+        // Ensure the node did not already submit a commitment.
+        if self.execute_commitments.contains_key(&commit.node_id) {
+            return Err(Error::AlreadyCommitted.into());
+        }
+
+        if self.round != blk.header.round {
+            return Err(Error::InvalidRound.into());
+        }
+
+        // Check if the block is based on the previous block.
+        if !commit.header.header.is_parent_of(&blk.header) {
+            return Err(Error::NotBasedOnCorrectBlock.into());
+        }
+
+        if commit.validate_basic().is_err() {
+            return Err(Error::BadExecutorCommitment.into());
+        }
+
+        // TODO: Check for evidence of equivocation (oasis-core#3685).
+
+        if !commit.is_indicating_failure() {
+            // Verify RAK-attestation.
+            if self.runtime.tee_hardware != TEEHardware::TEEHardwareInvalid {
+                let n = nl.node(commit.node_id).map_err(|_|
+                    // This should never happen as nodes cannot disappear mid-epoch.
+                    Error::NotInCommittee)?;
+
+                let ad = self
+                    .runtime
+                    .active_deployment(self.committee.valid_for)
+                    .ok_or(
+                        // This should never happen as we prevent this elsewhere.
+                        Error::NoRuntime,
+                    )?;
+
+                let rt = n.get_runtime(&self.runtime.id, &ad.version).ok_or(
+                    // We currently prevent this case throughout the rest of the system.
+                    // Still, it's prudent to check.
+                    Error::NotInCommittee,
+                )?;
+
+                let tee = rt.capabilities.tee.ok_or(
+                    // This should never happen as we prevent this elsewhere.
+                    Error::RakSigInvalid,
+                )?;
+
+                commit
+                    .header
+                    .verify_rak(tee.rak)
+                    .map_err(|_| Error::RakSigInvalid)?;
+            }
+
+            // Check emitted runtime messages.
+            match self.is_scheduler(&commit.node_id) {
+                true => {
+                    // The transaction scheduler can include messages.
+                    if commit.messages.len() as u32 > self.runtime.executor.max_messages {
+                        return Err(Error::InvalidMessages.into());
+                    }
+
+                    let messages_hash = commit
+                        .header
+                        .header
+                        .messages_hash
+                        .ok_or(Error::InvalidMessages)?;
+                    let h = Message::messages_hash(&commit.messages);
+                    if h != messages_hash {
+                        return Err(Error::InvalidMessages.into());
+                    }
+
+                    // Perform custom message validation and propagate the error unchanged.
+                    if !commit.messages.is_empty() {
+                        msg_validator.validate(&commit.messages)?;
+                    }
+                }
+                false => {
+                    // Other workers cannot include any messages.
+                    if !commit.messages.is_empty() {
+                        return Err(Error::InvalidMessages.into());
+                    }
+                }
+            }
+        }
+
+        self.execute_commitments.insert(commit.node_id, commit);
+
+        Ok(())
+    }
+
+    /// Verifies and adds a new executor commitment to the pool.
+    pub fn add_executor_commitment(
+        &mut self,
+        blk: &Block,
+        nl: &impl NodeLookup,
+        commit: ExecutorCommitment,
+        msg_validator: &impl MessageValidator,
+        chain_context: &String,
+    ) -> Result<()> {
+        // Check executor commitment signature.
+        commit.verify(&self.runtime.id, chain_context)?;
+
+        self.add_verified_executor_commitment(blk, nl, msg_validator, commit)
+    }
+
+    /// Performs a single round of commitment checks. If there are enough commitments
+    /// in the pool, it performs discrepancy detection or resolution.
+    pub fn process_commitments(&mut self, did_timeout: bool) -> Result<&dyn OpenCommitment> {
+        if self.committee.kind != CommitteeKind::ComputeExecutor {
+            panic!(
+                "roothash/commitment: unknown committee kind: {:?}",
+                self.committee.kind
+            );
+        }
+
+        #[derive(Default)]
+        struct Vote<'a> {
+            commit: Option<&'a ExecutorCommitment>,
+            tally: u16,
+        }
+
+        let mut total = 0;
+        let mut commits = 0;
+        let mut failures = 0;
+
+        // Gather votes.
+        let mut votes: HashMap<Hash, Vote> = HashMap::new();
+        for n in &self.committee.members {
+            if !self.discrepancy && n.role != Role::Worker {
+                continue;
+            }
+            if self.discrepancy && n.role != Role::BackupWorker {
+                continue;
+            }
+
+            total += 1;
+            let commit = match self.execute_commitments.get(&n.public_key) {
+                Some(commit) => commit,
+                None => continue,
+            };
+            commits += 1;
+
+            if commit.is_indicating_failure() {
+                failures += 1;
+                continue;
+            }
+
+            let k = commit.to_vote();
+            match votes.get_mut(&k) {
+                Some(v) => v.tally += 1,
+                None => {
+                    votes.insert(
+                        k,
+                        Vote {
+                            tally: 1,
+                            commit: Some(commit),
+                        },
+                    );
+                }
+            }
+
+            if !self.discrepancy && votes.len() > 1 {
+                self.discrepancy = true;
+                return Err(Error::DiscrepancyDetected.into());
+            }
+        }
+
+        // Determine whether the proposer has submitted a commitment.
+        let proposer = self
+            .committee
+            .transaction_scheduler(self.round)
+            .map_err(|_| Error::NoCommittee)?;
+        let proposer_commit = self.execute_commitments.get(&proposer.public_key);
+        if proposer_commit.is_none() && did_timeout {
+            return Err(Error::NoProposerCommitment.into());
+        }
+
+        match self.discrepancy {
+            false => {
+                // Discrepancy detection.
+                let allowed_stragglers = self.runtime.executor.allowed_stragglers;
+
+                // If it is already known that the number of valid commitments will not exceed the required
+                // threshold, there is no need to wait for the timer to expire. Instead, proceed directly to
+                // the discrepancy resolution mode, regardless of any additional commits.
+                if failures > allowed_stragglers {
+                    self.discrepancy = true;
+                    return Err(Error::DiscrepancyDetected.into());
+                }
+
+                // While a timer is running, all nodes are required to answer.
+                let mut required = total;
+
+                // After the timeout has elapsed, a limited number of stragglers are allowed.
+                if did_timeout {
+                    required -= allowed_stragglers;
+                    commits -= failures // Since failures count as stragglers.
+                }
+
+                // Check if the majority has been reached.
+                if commits < required || proposer_commit.is_none() {
+                    return Err(Error::StillWaiting.into());
+                }
+            }
+            true => {
+                // Discrepancy resolution.
+                let required = total / 2 + 1;
+
+                // Find the commit with the highest number of votes.
+                let mut top_vote = &Vote::default();
+                for v in votes.values() {
+                    if v.tally > top_vote.tally {
+                        top_vote = v;
+                    }
+                }
+
+                // Fail the round if the majority cannot be reached due to insufficient votes remaining
+                // (e.g. too many nodes have failed),
+                let remaining = total - commits;
+                if top_vote.tally + remaining < required {
+                    return Err(Error::InsufficientVotes.into());
+                }
+
+                // Check if the majority has been reached.
+                if top_vote.tally < required || proposer_commit.is_none() {
+                    if did_timeout {
+                        return Err(Error::InsufficientVotes.into());
+                    }
+                    return Err(Error::StillWaiting.into());
+                }
+
+                let proposer_commit = proposer_commit.expect("proposer commit should be set");
+                let top_vote_commit = top_vote.commit.expect("top vote commit should be set");
+
+                // Make sure that the majority commitment is the same as the proposer commitment.
+                if !proposer_commit.mostly_equal(top_vote_commit) {
+                    return Err(Error::BadProposerCommitment.into());
+                }
+            }
+        }
+
+        // We must return the proposer commitment as that one contains additional data.
+        let proposer_commit = proposer_commit.expect("proposer commit should be set");
+        Ok(proposer_commit)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::{anyhow, Result};
+
+    use crate::{
+        common::{
+            crypto::{
+                hash::Hash,
+                signature::{self, PublicKey, Signature},
+            },
+            namespace::Namespace,
+            versioned::Versioned,
+        },
+        consensus::{
+            registry::{
+                ExecutorParameters, Node, NodeRuntime, Runtime, RuntimeGovernanceModel,
+                RuntimeKind, TEEHardware,
+            },
+            roothash::{
+                Block, ComputeResultsHeader, Error, ExecutorCommitment, ExecutorCommitmentFailure,
+                ExecutorCommitmentHeader, HeaderType, Message, Pool, RegistryMessage,
+                StakingMessage,
+            },
+            scheduler::{Committee, CommitteeKind, CommitteeNode, Role},
+            staking::Transfer,
+        },
+    };
+
+    use super::NodeLookup;
+
+    struct StaticNodeLookup {
+        runtime: NodeRuntime,
+    }
+
+    impl NodeLookup for StaticNodeLookup {
+        fn node(&self, id: PublicKey) -> Result<Node, Error> {
+            Ok(Node {
+                id,
+                runtimes: Some(vec![self.runtime.clone()]),
+                ..Default::default()
+            })
+        }
+    }
+
+    #[test]
+    fn test_pool_single_commitment() {
+        let chain_context = "test: oasis-core tests".to_owned();
+
+        // Generate a non-TEE runtime.
+        let id =
+            Namespace::from("0000000000000000000000000000000000000000000000000000000000000000");
+
+        let rt = Runtime {
+            id,
+            kind: RuntimeKind::KindCompute,
+            tee_hardware: TEEHardware::TEEHardwareInvalid,
+            executor: ExecutorParameters {
+                max_messages: 32,
+                ..Default::default()
+            },
+            governance_model: RuntimeGovernanceModel::GovernanceEntity,
+            ..Default::default()
+        };
+
+        // Generate a commitment signing key.
+        let sk = signature::PrivateKey::generate();
+
+        // Generate a committee.
+        let committee = Committee {
+            kind: CommitteeKind::ComputeExecutor,
+            members: vec![CommitteeNode {
+                role: Role::Worker,
+                public_key: sk.public_key(),
+            }],
+            runtime_id: id,
+            valid_for: 0,
+        };
+
+        // Create a pool.
+        let mut pool = Pool::new(rt, committee, 0);
+
+        // Generate a commitment.
+        let (child_blk, _, mut ec) = generate_executor_commitment(id, pool.round);
+
+        let nl = StaticNodeLookup {
+            runtime: NodeRuntime {
+                id,
+                ..Default::default()
+            },
+        };
+
+        // Test invalid commitments.
+        let tcs: Vec<(&str, fn(&mut ExecutorCommitment), Error)> = vec![
+            (
+                "BlockBadRound",
+                |ec: &mut ExecutorCommitment| ec.header.header.round -= 1,
+                Error::NotBasedOnCorrectBlock,
+            ),
+            (
+                "BlockBadPreviousHash",
+                |ec: &mut ExecutorCommitment| {
+                    ec.header.header.previous_hash = Hash::digest_bytes(b"invalid")
+                },
+                Error::NotBasedOnCorrectBlock,
+            ),
+            (
+                "MissingIORootHash",
+                |ec: &mut ExecutorCommitment| ec.header.header.io_root = None,
+                Error::BadExecutorCommitment,
+            ),
+            (
+                "MissingStateRootHash",
+                |ec: &mut ExecutorCommitment| ec.header.header.state_root = None,
+                Error::BadExecutorCommitment,
+            ),
+            (
+                "MissingMessagesHash",
+                |ec: &mut ExecutorCommitment| ec.header.header.messages_hash = None,
+                Error::BadExecutorCommitment,
+            ),
+            (
+                "MissingInMessagesHash",
+                |ec: &mut ExecutorCommitment| ec.header.header.in_msgs_hash = None,
+                Error::BadExecutorCommitment,
+            ),
+            (
+                "BadFailureIndicating",
+                |ec: &mut ExecutorCommitment| {
+                    ec.header.failure = ExecutorCommitmentFailure::FailureUnknown
+                },
+                Error::BadExecutorCommitment,
+            ),
+        ];
+
+        let msg_validator = |_: &_| Ok(());
+        for (name, f, expected_err) in tcs {
+            let (_, _, mut invalid_ec) = generate_executor_commitment(id, pool.round);
+            f(&mut invalid_ec);
+
+            invalid_ec.node_id = sk.public_key();
+            let res = invalid_ec.sign(&sk, &id, &chain_context);
+            assert!(res.is_ok(), "invalid_ec.sign({})", name);
+
+            let res = pool.add_executor_commitment(
+                &child_blk,
+                &nl,
+                invalid_ec,
+                &msg_validator,
+                &chain_context,
+            );
+            assert!(res.is_err(), "add_executor_commitment({})", name);
+            assert_eq!(
+                res.err().unwrap().to_string(),
+                expected_err.to_string(),
+                "add_executor_commitment({})",
+                name
+            );
+        }
+
+        // Generate a valid commitment.
+        ec.node_id = sk.public_key();
+        let res = ec.sign(&sk, &id, &chain_context);
+        assert!(res.is_ok(), "ec.sign");
+
+        // There should not be enough executor commitments.
+        let res = pool.process_commitments(false);
+        assert_eq!(
+            res.err().unwrap().to_string(),
+            Error::StillWaiting.to_string(),
+            "process_commitments",
+        );
+
+        let res = pool.process_commitments(true);
+        assert_eq!(
+            res.err().unwrap().to_string(),
+            Error::NoProposerCommitment.to_string(),
+            "process_commitments",
+        );
+
+        // Test message validator function.
+        let mut ec_with_msgs = ec.clone();
+        ec_with_msgs.messages = vec![
+            Message::Staking(Versioned {
+                version: 0,
+                inner: StakingMessage::Transfer(Transfer::default()),
+            }),
+            Message::Registry(Versioned {
+                version: 0,
+                inner: RegistryMessage::UpdateRuntime(Runtime::default()),
+            }),
+        ];
+        let msg_hash = Message::messages_hash(&ec_with_msgs.messages);
+        ec_with_msgs.header.header.messages_hash = Some(msg_hash);
+
+        let res = ec_with_msgs.sign(&sk, &id, &chain_context);
+        assert!(res.is_ok(), "ec_with_msgs.sign");
+
+        let error_msg = "message validation error";
+        let always_fail_msg_validator = |_: &_| -> Result<()> { Err(anyhow!(error_msg)) };
+        let res = pool.add_executor_commitment(
+            &child_blk,
+            &nl,
+            ec_with_msgs,
+            &always_fail_msg_validator,
+            &chain_context,
+        );
+        assert!(res.is_err(), "add_executor_commitment");
+        assert_eq!(
+            res.err().unwrap().to_string(),
+            error_msg,
+            "add_executor_commitment",
+        );
+
+        // Adding a commitment should succeed.
+        let res = pool.add_executor_commitment(
+            &child_blk,
+            &nl,
+            ec.clone(),
+            &msg_validator,
+            &chain_context,
+        );
+        assert!(res.is_ok(), "add_executor_commitment");
+
+        // Adding a commitment twice for the same node should fail.
+        let res = pool.add_executor_commitment(
+            &child_blk,
+            &nl,
+            ec.clone(),
+            &msg_validator,
+            &chain_context,
+        );
+        assert!(res.is_err(), "add_executor_commitment, duplicate");
+
+        // There should be enough executor commitments and no discrepancy.
+        let res = pool.process_commitments(false);
+        assert!(res.is_ok(), "process_commitments");
+        let dd_ec = res
+            .unwrap()
+            .to_dd_result()
+            .downcast_ref::<ExecutorCommitment>();
+        assert_eq!(dd_ec, Some(&ec), "DD should return the correct commitment");
+        assert_eq!(false, pool.discrepancy);
+    }
+
+    fn generate_executor_commitment(
+        id: Namespace,
+        round: u64,
+    ) -> (Block, Block, ExecutorCommitment) {
+        let child_blk = Block::new_genesis_block(id, round);
+        let parent_blk = Block::new_empty_block(&child_blk, 1, HeaderType::Normal);
+
+        // TODO: Add tests with some emitted messages.
+        let msgs_hash = Message::messages_hash(&vec![]);
+        // TODO: Add tests with some incoming messages.
+        let in_msgs_hash = Message::in_messages_hash(&vec![]);
+
+        let ec = ExecutorCommitment {
+            header: ExecutorCommitmentHeader {
+                header: ComputeResultsHeader {
+                    round: parent_blk.header.round,
+                    previous_hash: parent_blk.header.previous_hash,
+                    io_root: Some(parent_blk.header.io_root),
+                    state_root: Some(parent_blk.header.state_root),
+                    messages_hash: Some(msgs_hash),
+                    in_msgs_hash: Some(in_msgs_hash),
+                    in_msgs_count: 0,
+                },
+                failure: ExecutorCommitmentFailure::FailureNone,
+                rak_signature: None,
+            },
+            node_id: PublicKey::default(),
+            signature: Signature::default(),
+            messages: vec![],
+        };
+
+        (child_blk, parent_blk, ec)
+    }
+}

--- a/runtime/src/consensus/roothash/mod.rs
+++ b/runtime/src/consensus/roothash/mod.rs
@@ -29,6 +29,51 @@ pub enum Error {
 
     #[error(transparent)]
     State(#[from] StateError),
+
+    #[error("roothash/commitment: no runtime configured")]
+    NoRuntime,
+
+    #[error("roothash/commitment: no committee configured")]
+    NoCommittee,
+
+    #[error("roothash/commitment: invalid committee kind")]
+    InvalidCommitteeKind,
+
+    #[error("roothash/commitment: batch RAK signature invalid")]
+    RakSigInvalid,
+
+    #[error("roothash/commitment: node not part of committee")]
+    NotInCommittee,
+
+    #[error("roothash/commitment: node already sent commitment")]
+    AlreadyCommitted,
+
+    #[error("roothash/commitment: submitted commitment is not based on correct block")]
+    NotBasedOnCorrectBlock,
+
+    #[error("roothash/commitment: discrepancy detected")]
+    DiscrepancyDetected,
+
+    #[error("roothash/commitment: still waiting for commits")]
+    StillWaiting,
+
+    #[error("roothash/commitment: insufficient votes to finalize discrepancy resolution round")]
+    InsufficientVotes,
+
+    #[error("roothash/commitment: bad executor commitment")]
+    BadExecutorCommitment,
+
+    #[error("roothash/commitment: invalid messages")]
+    InvalidMessages,
+
+    #[error("roothash/commitment: invalid round")]
+    InvalidRound,
+
+    #[error("roothash/commitment: no proposer commitment")]
+    NoProposerCommitment,
+
+    #[error("roothash/commitment: bad proposer commitment")]
+    BadProposerCommitment,
 }
 
 /// Runtime block annotated with consensus information.

--- a/runtime/src/consensus/roothash/mod.rs
+++ b/runtime/src/consensus/roothash/mod.rs
@@ -1,0 +1,123 @@
+//! Consensus roothash structures.
+//!
+//! # Note
+//!
+//! This **MUST** be kept in sync with go/roothash/api.
+//!
+use thiserror::Error;
+
+use crate::{
+    common::{crypto::signature::PublicKey, namespace::Namespace},
+    consensus::state::StateError,
+};
+
+// Modules.
+mod block;
+mod commitment;
+mod message;
+
+// Re-exports.
+pub use block::*;
+pub use commitment::*;
+pub use message::*;
+
+/// Errors emitted by the roothash module.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("roothash: invalid runtime {0}")]
+    InvalidRuntime(Namespace),
+
+    #[error(transparent)]
+    State(#[from] StateError),
+}
+
+/// Runtime block annotated with consensus information.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, cbor::Encode, cbor::Decode)]
+pub struct AnnotatedBlock {
+    /// Consensus height at which this runtime block was produced.
+    pub consensus_height: i64,
+    /// Runtime block.
+    pub block: Block,
+}
+
+/// Result of a message being processed by the consensus layer.
+#[derive(Clone, Debug, Default, PartialEq, Eq, cbor::Encode, cbor::Decode)]
+pub struct MessageEvent {
+    #[cbor(optional)]
+    pub module: String,
+
+    #[cbor(optional)]
+    pub code: u32,
+
+    #[cbor(optional)]
+    pub index: u32,
+
+    #[cbor(optional)]
+    pub result: Option<cbor::Value>,
+}
+
+impl MessageEvent {
+    /// Returns true if the event indicates that the message was successfully processed.
+    pub fn is_success(&self) -> bool {
+        self.code == 0
+    }
+}
+
+/// Information about how a particular round was executed by the consensus layer.
+#[derive(Clone, Debug, Default, PartialEq, Eq, cbor::Encode, cbor::Decode)]
+pub struct RoundResults {
+    /// Results of executing emitted runtime messages.
+    #[cbor(optional)]
+    pub messages: Vec<MessageEvent>,
+
+    /// Public keys of compute nodes' controlling entities that positively contributed to the round
+    /// by replicating the computation correctly.
+    #[cbor(optional)]
+    pub good_compute_entities: Vec<PublicKey>,
+    /// Public keys of compute nodes' controlling entities that negatively contributed to the round
+    /// by causing discrepancies.
+    #[cbor(optional)]
+    pub bad_compute_entities: Vec<PublicKey>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_consistent_round_results() {
+        let tcs = vec![
+            ("oA==", RoundResults::default()),
+            ("oWhtZXNzYWdlc4GiZGNvZGUBZm1vZHVsZWR0ZXN0", RoundResults {
+                messages: vec![MessageEvent{module: "test".to_owned(), code: 1, index: 0, result: None}],
+                ..Default::default()
+            }),
+            ("omhtZXNzYWdlc4GkZGNvZGUYKmVpbmRleAFmbW9kdWxlZHRlc3RmcmVzdWx0a3Rlc3QtcmVzdWx0dWdvb2RfY29tcHV0ZV9lbnRpdGllc4NYIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAI=",
+                RoundResults {
+                    messages: vec![MessageEvent{module: "test".to_owned(), code: 42, index: 1, result: Some(cbor::Value::TextString("test-result".to_string()))}],
+                    good_compute_entities: vec![
+                        "0000000000000000000000000000000000000000000000000000000000000000".into(),
+                        "0000000000000000000000000000000000000000000000000000000000000001".into(),
+                        "0000000000000000000000000000000000000000000000000000000000000002".into(),
+                    ],
+                    ..Default::default()
+                }),
+            ("o2htZXNzYWdlc4GkZGNvZGUYKmVpbmRleAFmbW9kdWxlZHRlc3RmcmVzdWx0a3Rlc3QtcmVzdWx0dGJhZF9jb21wdXRlX2VudGl0aWVzgVggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF1Z29vZF9jb21wdXRlX2VudGl0aWVzglggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC",
+                RoundResults {
+                    messages: vec![MessageEvent{module: "test".to_owned(), code: 42, index: 1, result: Some(cbor::Value::TextString("test-result".to_string()))}],
+                    good_compute_entities: vec![
+                        "0000000000000000000000000000000000000000000000000000000000000000".into(),
+                        "0000000000000000000000000000000000000000000000000000000000000002".into(),
+                    ],
+                    bad_compute_entities: vec![
+                        "0000000000000000000000000000000000000000000000000000000000000001".into(),
+                    ],
+                }),
+        ];
+        for (encoded_base64, rr) in tcs {
+            let dec: RoundResults = cbor::from_slice(&base64::decode(encoded_base64).unwrap())
+                .expect("round results should deserialize correctly");
+            assert_eq!(dec, rr, "decoded results should match the expected value");
+        }
+    }
+}

--- a/runtime/src/dispatcher.rs
+++ b/runtime/src/dispatcher.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     consensus::{
         beacon::EpochTime,
-        roothash::{self, ComputeResultsHeader, Header, COMPUTE_RESULTS_HEADER_CONTEXT},
+        roothash::{self, ComputeResultsHeader, Header, COMPUTE_RESULTS_HEADER_SIGNATURE_CONTEXT},
         state::keymanager::Status as KeyManagerStatus,
         verifier::Verifier,
         LightBlock,
@@ -701,7 +701,7 @@ impl Dispatcher {
         let rak_sig = self
             .identity
             .sign(
-                COMPUTE_RESULTS_HEADER_CONTEXT,
+                COMPUTE_RESULTS_HEADER_SIGNATURE_CONTEXT,
                 &cbor::to_vec(header.clone()),
             )
             .unwrap();

--- a/runtime/src/identity.rs
+++ b/runtime/src/identity.rs
@@ -373,6 +373,11 @@ impl Identity {
 }
 
 impl Signer for Identity {
+    fn public(&self) -> signature::PublicKey {
+        let inner = self.inner.read().unwrap();
+        inner.rak.public_key()
+    }
+
     fn sign(&self, context: &[u8], message: &[u8]) -> Result<Signature> {
         let inner = self.inner.read().unwrap();
         inner.rak.sign(context, message)


### PR DESCRIPTION
Implement executor commitment related structures in Rust, which should be latter used to verify commitments.

For the time being, we will overlook the cumbersome naming issue that results in `ec.header.header` and do the refactoring of `ComputeResultsHeader` and `ExecutorCommitmentHeader` latter.