### PR TITLE
Enable fixgenesis features

### DIFF
--- a/.changelog/5286.internal.md
+++ b/.changelog/5286.internal.md
@@ -1,0 +1,3 @@
+go: Update fixgenesis command
+
+Make the fixgenesis command update a few more consensus parameters.

--- a/go/oasis-node/cmd/debug/fixgenesis/fixgenesis.go
+++ b/go/oasis-node/cmd/debug/fixgenesis/fixgenesis.go
@@ -315,6 +315,21 @@ NodeLoop:
 	newDoc.KeyManager.Parameters.GasCosts[keymanager.GasOpUpdatePolicy] = newDoc.Registry.Parameters.GasCosts["update_keymanager"]
 	delete(newDoc.Registry.Parameters.GasCosts, "update_keymanager")
 
+	// Update registry parameters.
+	newDoc.Registry.Parameters.TEEFeatures = &node.TEEFeatures{
+		SGX: node.TEEFeaturesSGX{
+			PCS:                      true,
+			SignedAttestations:       true,
+			DefaultMaxAttestationAge: 1200, // ~2 hours at 6 sec per block.
+		},
+		FreshnessProofs: true,
+	}
+	newDoc.Registry.Parameters.GasCosts[registry.GasOpProveFreshness] = registry.DefaultGasCosts[registry.GasOpProveFreshness]
+	newDoc.Registry.Parameters.MaxRuntimeDeployments = 5
+
+	// Update governance parameters.
+	newDoc.Governance.Parameters.EnableChangeParametersProposal = true
+
 	return &newDoc, nil
 }
 


### PR DESCRIPTION
Update the `fixgenesis` command to be in line with the v62 consensus migration.