### PR TITLE
go/oasis-node/cmd/ias: Regenerate TLS certificate on startup

### DIFF
--- a/.changelog/5289.bugfix.md
+++ b/.changelog/5289.bugfix.md
@@ -1,0 +1,1 @@
+go/oasis-node/cmd/ias: Regenerate TLS certificate on startup

--- a/go/oasis-node/cmd/ias/proxy.go
+++ b/go/oasis-node/cmd/ias/proxy.go
@@ -99,8 +99,8 @@ func doProxy(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	tlsCertPath, tlsKeyPath := TLSCertPaths(dataDir)
-	cert, err := tlsCert.LoadOrGenerate(tlsCertPath, tlsKeyPath, iasProxy.CommonName)
+	_, tlsKeyPath := TLSCertPaths(dataDir)
+	cert, err := tlsCert.LoadFromKey(tlsKeyPath, iasProxy.CommonName)
 	if err != nil {
 		logger.Error("failed to load or generate TLS cert",
 			"err", err,


### PR DESCRIPTION
Forward-port of #5289 