### PR TITLE
go/consensus: Add block metadata to allow same-block state validation

### DIFF
--- a/.changelog/5292.breaking.md
+++ b/.changelog/5292.breaking.md
@@ -1,0 +1,1 @@
+go/consensus: Add block metadata to allow same-block state validation

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -32,8 +32,8 @@ import (
 )
 
 const (
-	// moduleName is the module name used for error definitions.
-	moduleName = "consensus"
+	// ModuleName is the module name used for error definitions.
+	ModuleName = "consensus"
 
 	// HeightLatest is the height that represents the most recent block height.
 	HeightLatest int64 = 0
@@ -42,24 +42,29 @@ const (
 var (
 	// ErrNoCommittedBlocks is the error returned when there are no committed
 	// blocks and as such no state can be queried.
-	ErrNoCommittedBlocks = errors.New(moduleName, 1, "consensus: no committed blocks")
+	ErrNoCommittedBlocks = errors.New(ModuleName, 1, "consensus: no committed blocks")
 
 	// ErrOversizedTx is the error returned when the given transaction is too big to be processed.
-	ErrOversizedTx = errors.New(moduleName, 2, "consensus: oversized transaction")
+	ErrOversizedTx = errors.New(ModuleName, 2, "consensus: oversized transaction")
 
 	// ErrVersionNotFound is the error returned when the given version (height) cannot be found,
 	// possibly because it was pruned.
-	ErrVersionNotFound = errors.New(moduleName, 3, "consensus: version not found")
+	ErrVersionNotFound = errors.New(ModuleName, 3, "consensus: version not found")
 
 	// ErrUnsupported is the error returned when the given method is not supported by the consensus
 	// backend.
-	ErrUnsupported = errors.New(moduleName, 4, "consensus: method not supported")
+	ErrUnsupported = errors.New(ModuleName, 4, "consensus: method not supported")
 
 	// ErrDuplicateTx is the error returned when the transaction already exists in the mempool.
-	ErrDuplicateTx = errors.New(moduleName, 5, "consensus: duplicate transaction")
+	ErrDuplicateTx = errors.New(ModuleName, 5, "consensus: duplicate transaction")
 
 	// ErrInvalidArgument is the error returned when the request contains an invalid argument.
-	ErrInvalidArgument = errors.New(moduleName, 6, "consensus: invalid argument")
+	ErrInvalidArgument = errors.New(ModuleName, 6, "consensus: invalid argument")
+
+	// SystemMethods is a map of all system methods.
+	SystemMethods = map[transaction.MethodName]struct{}{
+		MethodMeta: {},
+	}
 )
 
 // FeatureMask is the consensus backend feature bitmask.

--- a/go/consensus/api/meta.go
+++ b/go/consensus/api/meta.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
+)
+
+// MethodMeta is the method name for the special block metadata transaction.
+var MethodMeta = transaction.NewMethodName(ModuleName, "Meta", BlockMetadata{})
+
+// BlockMetadataMaxSize is the maximum size of a fully populated and signed block metadata
+// transaction.
+//
+// This should be less than any reasonably configured MaxTxSize.
+const BlockMetadataMaxSize = 16_384
+
+// BlockMetadata contains additional metadata related to the executing block.
+//
+// The metadata is included in the form of a special transaction where this structure is the
+// transaction body.
+type BlockMetadata struct {
+	// StateRoot is the state root after executing all logic in the block.
+	StateRoot hash.Hash `json:"state_root"`
+}
+
+// ValidateBasic performs basic block metadata structure validation.
+func (bm *BlockMetadata) ValidateBasic() error {
+	return nil
+}
+
+// NewBlockMetadataTx creates a new block metadata transaction.
+func NewBlockMetadataTx(meta *BlockMetadata) *transaction.Transaction {
+	return transaction.NewTransaction(0, nil, MethodMeta, meta)
+}

--- a/go/consensus/tendermint/abci/system.go
+++ b/go/consensus/tendermint/abci/system.go
@@ -1,0 +1,132 @@
+package abci
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cometbft/cometbft/abci/types"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
+	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
+	tmcrypto "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/crypto"
+)
+
+// prepareSystemTxs prepares a list of system transactions to be included in a proposed block in
+// case where the node is currently the block proposer.
+func (mux *abciMux) prepareSystemTxs() ([][]byte, []*types.ResponseDeliverTx, error) {
+	var (
+		systemTxs       [][]byte
+		systemTxResults []*types.ResponseDeliverTx
+	)
+
+	// Append block metadata as a system transaction.
+	stateRoot, err := mux.state.workingStateRoot()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to compute working state root: %w", err)
+	}
+
+	blockMeta := consensus.NewBlockMetadataTx(&consensus.BlockMetadata{
+		StateRoot: stateRoot,
+	})
+	sigBlockMeta, err := transaction.Sign(mux.state.identity.ConsensusSigner, blockMeta)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to sign block metadata transaction: %w", err)
+	}
+	sigBlockMetaRaw := cbor.Marshal(sigBlockMeta)
+	if l := len(sigBlockMetaRaw); l > consensus.BlockMetadataMaxSize {
+		mux.logger.Error("serialized block metadata larger than maximum allowed size",
+			"meta_size", l,
+			"max_meta_size", consensus.BlockMetadataMaxSize,
+		)
+		return nil, nil, fmt.Errorf("serialized block metadata would be oversized")
+	}
+	systemTxs = append(systemTxs, sigBlockMetaRaw)
+	systemTxResults = append(systemTxResults, &types.ResponseDeliverTx{
+		Code: types.CodeTypeOK,
+		Data: cbor.Marshal(nil),
+	})
+
+	return systemTxs, systemTxResults, nil
+}
+
+// processSystemTx processes a system transaction in DeliverTx context.
+func (mux *abciMux) processSystemTx(ctx *api.Context, tx *transaction.Transaction) error {
+	if ctx.Mode() != api.ContextDeliverTx {
+		return fmt.Errorf("system methods are not allowed to be called")
+	}
+
+	// NOTE: The panics below will either trigger a bad proposal being rejected (on nodes in the
+	//       validator set) or a failure in block processing (on other nodes).
+
+	// Since system transactions can only be injected by the proposer, make sure they are not
+	// themselves included in the proposal phase.
+	if len(mux.state.proposal.hash) == 0 {
+		panic(fmt.Errorf("system transaction included during proposal phase"))
+	}
+
+	// Nonce must be zero and fee must be nil.
+	if tx.Nonce != 0 || tx.Fee != nil {
+		panic(fmt.Errorf("malformed system transaction in block"))
+	}
+	// Transaction must be signed by the proposer.
+	txSigner := ctx.TxSigner()
+	txSignerAddress := []byte(tmcrypto.PublicKeyToTendermint(&txSigner).Address())
+	if proposerAddress := ctx.BlockContext().ProposerAddress; !bytes.Equal(txSignerAddress, proposerAddress) {
+		panic(fmt.Errorf("system transaction not signed by block proposer (expected: %x got: %x)", proposerAddress, txSignerAddress))
+	}
+
+	// Accumulate system transactions for later verification.
+	ctx.BlockContext().SystemTransactions = append(ctx.BlockContext().SystemTransactions, tx)
+
+	return nil
+}
+
+// validateSystemTxs performs system transaction validation at the end of a block.
+func (mux *abciMux) validateSystemTxs() error {
+	// Don't perform any validation when we are still building the proposal.
+	if len(mux.state.proposal.hash) == 0 {
+		return nil
+	}
+
+	var hasBlockMetadata bool
+	for _, tx := range mux.state.blockCtx.SystemTransactions {
+		switch tx.Method {
+		case consensus.MethodMeta:
+			// Block metadata, verify state root.
+			if hasBlockMetadata {
+				return fmt.Errorf("duplicate block metadata in block")
+			}
+			hasBlockMetadata = true
+
+			var meta consensus.BlockMetadata
+			if err := cbor.Unmarshal(tx.Body, &meta); err != nil {
+				return fmt.Errorf("malformed block metadata: %w", err)
+			}
+			if err := meta.ValidateBasic(); err != nil {
+				return fmt.Errorf("malformed block metadata: %w", err)
+			}
+
+			// Verify state root.
+			stateRoot, err := mux.state.workingStateRoot()
+			if err != nil {
+				return fmt.Errorf("failed to compute working state root: %w", err)
+			}
+			if !stateRoot.Equal(&meta.StateRoot) {
+				return fmt.Errorf("invalid state root in block metadata (expected: %s got: %s)", stateRoot, meta.StateRoot)
+			}
+
+			mux.logger.Debug("validated block metadata",
+				"state_root", meta.StateRoot,
+			)
+		default:
+			return fmt.Errorf("unknown system method: %s", tx.Method)
+		}
+	}
+
+	if !hasBlockMetadata {
+		return fmt.Errorf("missing required block metadata")
+	}
+	return nil
+}

--- a/go/consensus/tendermint/abci/transaction.go
+++ b/go/consensus/tendermint/abci/transaction.go
@@ -55,6 +55,11 @@ func (mux *abciMux) decodeTx(ctx *api.Context, rawTx []byte) (*transaction.Trans
 }
 
 func (mux *abciMux) processTx(ctx *api.Context, tx *transaction.Transaction, txSize int) error {
+	// Handle special methods.
+	if _, isSystem := consensus.SystemMethods[tx.Method]; isSystem {
+		return mux.processSystemTx(ctx, tx)
+	}
+
 	// Lookup method handler.
 	app := mux.appsByMethod[tx.Method]
 	if app == nil {

--- a/go/consensus/tendermint/api/block.go
+++ b/go/consensus/tendermint/api/block.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/cometbft/cometbft/abci/types"
+
+	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 )
 
 // BlockInfo contains information about a block which is always present in block context.
@@ -13,7 +15,8 @@ type BlockInfo struct {
 	LastCommitInfo       types.CommitInfo
 	ValidatorMisbehavior []types.Misbehavior
 
-	GasAccountant GasAccountant
+	GasAccountant      GasAccountant
+	SystemTransactions []*transaction.Transaction
 }
 
 // BlockContextKey is an interface for a block context key.

--- a/go/consensus/tendermint/apps/beacon/backend_vrf.go
+++ b/go/consensus/tendermint/apps/beacon/backend_vrf.go
@@ -12,7 +12,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/tuplehash"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
-	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint/abci"
+	abciState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/abci/state"
 	"github.com/oasisprotocol/oasis-core/go/consensus/tendermint/api"
 	beaconState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/beacon/state"
 	registryState "github.com/oasisprotocol/oasis-core/go/consensus/tendermint/apps/registry/state"
@@ -485,13 +485,13 @@ func MustGetChainContext(ctx *api.Context) []byte {
 	// Using panic on errors is ok because if this isn't present, something
 	// has went horrifically wrong (the key is inserted by the ABCI mux
 	// during initialization).
-	st := ctx.State()
-	b, err := st.Get(ctx, []byte(abci.StateKeyGenesisDigest))
+	state := abciState.NewMutableState(ctx.State())
+	b, err := state.ChainContext(ctx)
 	if err != nil {
 		panic("BUG: failed to get chain context: " + err.Error())
 	}
 	if len(b) == 0 {
 		panic("BUG: chain context length is 0")
 	}
-	return b
+	return []byte(b)
 }

--- a/go/consensus/tendermint/full/archive.go
+++ b/go/consensus/tendermint/full/archive.go
@@ -165,7 +165,7 @@ func NewArchive(
 			Strategy:      abci.PruneNone,
 			PruneInterval: time.Hour * 100, // Irrelevant as pruning is disabled.
 		},
-		OwnTxSigner:         srv.identity.NodeSigner.Public(),
+		Identity:            srv.identity,
 		DisableCheckpointer: true,
 		InitialHeight:       uint64(srv.genesis.Height),
 		// ReadOnly should actually be preferable for archive but there is a badger issue with read-only:

--- a/go/consensus/tendermint/full/full.go
+++ b/go/consensus/tendermint/full/full.go
@@ -557,7 +557,7 @@ func (t *fullService) lazyInit() error { // nolint: gocyclo
 		HaltEpoch:                 beaconAPI.EpochTime(config.GlobalConfig.Consensus.HaltEpoch),
 		HaltHeight:                config.GlobalConfig.Consensus.HaltHeight,
 		MinGasPrice:               config.GlobalConfig.Consensus.MinGasPrice,
-		OwnTxSigner:               t.identity.NodeSigner.Public(),
+		Identity:                  t.identity,
 		DisableCheckpointer:       config.GlobalConfig.Consensus.Checkpointer.Disabled,
 		CheckpointerCheckInterval: config.GlobalConfig.Consensus.Checkpointer.CheckInterval,
 		InitialHeight:             uint64(t.genesis.Height),

--- a/go/go.mod
+++ b/go/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.1
 	github.com/thepudds/fzgo v0.2.2
+	github.com/tidwall/btree v1.6.0
 	github.com/tyler-smith/go-bip39 v1.1.0
 	go.uber.org/multierr v1.10.0
 	go.uber.org/zap v1.24.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -678,6 +678,8 @@ github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c h1:g+WoO5jjkqGAzH
 github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c/go.mod h1:ahpPrc7HpcfEWDQRZEmnXMzHY03mLDYMCxeDzy46i+8=
 github.com/thepudds/fzgo v0.2.2 h1:bGofmgAGfTLpVgETkL9jvhg6azylvCF/kW6JPy5fkzQ=
 github.com/thepudds/fzgo v0.2.2/go.mod h1:ZgigL1toyKrar3rWdXz7Fuv7bUpKZ4BAYN49TpEFMCI=
+github.com/tidwall/btree v1.6.0 h1:LDZfKfQIBHGHWSwckhXI0RPSXzlo+KYdjK7FWSqOzzg=
+github.com/tidwall/btree v1.6.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
 github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=

--- a/go/storage/mkvs/mkvs.go
+++ b/go/storage/mkvs/mkvs.go
@@ -61,6 +61,14 @@ type OverlayTree interface {
 	KeyValueTree
 	ClosableTree
 
+	// Copy creates an isolated copy of the overlay tree.
+	//
+	// The passed tree is used as the underlying tree of the copy.
+	//
+	// In case the passed tree is nil, the underlying tree is shared by both copies (e.g. both
+	// copies commit to and read from the same tree instance).
+	Copy(inner KeyValueTree) OverlayTree
+
 	// Commit commits any modifications to the underlying tree.
 	//
 	// Returns the underlying tree on success.

--- a/go/storage/mkvs/overlay_test.go
+++ b/go/storage/mkvs/overlay_test.go
@@ -193,6 +193,11 @@ func TestOverlay(t *testing.T) {
 	require.NoError(t, err, "Commit")
 	require.Equal(t, tree, innerTree, "inner tree returned from Commit should be correct")
 
+	// Make sure committing an already committed tree works just as well.
+	innerTree, err = overlay.Commit(ctx)
+	require.NoError(t, err, "Commit")
+	require.Equal(t, tree, innerTree, "inner tree returned from Commit should be correct")
+
 	// Test that all keys can be fetched from an updated tree.
 	t.Run("Committed/Get", func(t *testing.T) {
 		require := require.New(t)


### PR DESCRIPTION
Based on #5285 