### PR TITLE
go/control: Add runtime provisioner type to host status output

### DIFF
--- a/.changelog/5301.feature.md
+++ b/.changelog/5301.feature.md
@@ -1,0 +1,1 @@
+go/control: Add runtime provisioner type to host status output

--- a/go/control/api/api.go
+++ b/go/control/api/api.go
@@ -179,6 +179,9 @@ type RuntimeStatus struct {
 	Executor *executorWorker.Status `json:"executor,omitempty"`
 	// Storage contains the storage worker status in case this node is a storage node.
 	Storage *storageWorker.Status `json:"storage,omitempty"`
+
+	// Provisioner is the name of the runtime provisioner.
+	Provisioner string `json:"provisioner,omitempty"`
 }
 
 // SeedStatus is the status of the seed node.

--- a/go/oasis-node/cmd/node/node_control.go
+++ b/go/oasis-node/cmd/node/node_control.go
@@ -331,6 +331,19 @@ func (n *Node) getRuntimeStatus(ctx context.Context) (map[common.Namespace]contr
 			}
 		}
 
+		// Fetch provisioner type.
+		_, provisioner, err := rt.Host(ctx)
+		switch {
+		case err != nil:
+			n.logger.Error("failed to fetch host configuration",
+				"err", err,
+			)
+		case provisioner != nil:
+			status.Provisioner = provisioner.Name()
+		default:
+			status.Provisioner = "none"
+		}
+
 		runtimes[rt.ID()] = status
 	}
 	return runtimes, nil

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_upgrade.go
@@ -202,6 +202,10 @@ func (sc *runtimeUpgradeImpl) ensureActiveVersion(ctx context.Context, v version
 				return fmt.Errorf("%s: failed to query status: %w", node.Name, err)
 			}
 
+			if status.Runtimes[rt.ID()].Provisioner != "sandbox" {
+				return fmt.Errorf("%s: unexpected runtime provisioner for runtime '%s': %s", node.Name, rt.ID(), status.Runtimes[rt.ID()].Provisioner)
+			}
+
 			cs := status.Runtimes[rt.ID()].Committee
 			if cs == nil {
 				return fmt.Errorf("%s: missing status for runtime '%s'", node.Name, rt.ID())

--- a/go/runtime/host/host.go
+++ b/go/runtime/host/host.go
@@ -42,6 +42,9 @@ type Provisioner interface {
 	// This method may return before the runtime is fully provisioned. The returned runtime will not
 	// be started automatically, you must call Start explicitly.
 	NewRuntime(ctx context.Context, cfg Config) (Runtime, error)
+
+	// Name returns the name of the provisioner.
+	Name() string
 }
 
 // Runtime is a provisioned runtime interface.

--- a/go/runtime/host/mock/mock.go
+++ b/go/runtime/host/mock/mock.go
@@ -34,6 +34,11 @@ func (p *provisioner) NewRuntime(ctx context.Context, cfg host.Config) (host.Run
 	return r, nil
 }
 
+// Implements host.Provisioner.
+func (p *provisioner) Name() string {
+	return "mock"
+}
+
 type runtime struct {
 	runtimeID common.Namespace
 

--- a/go/runtime/host/sandbox/sandbox.go
+++ b/go/runtime/host/sandbox/sandbox.go
@@ -96,6 +96,11 @@ func (p *provisioner) NewRuntime(ctx context.Context, cfg host.Config) (host.Run
 	return r, nil
 }
 
+// Implements host.Provisioner.
+func (p *provisioner) Name() string {
+	return "sandbox"
+}
+
 // abortRequest is a request to the runtime manager goroutine to abort the runtime.
 // In case of failures or if force flag is set, the runtime is restarted.
 type abortRequest struct {

--- a/go/runtime/host/sgx/sgx.go
+++ b/go/runtime/host/sgx/sgx.go
@@ -427,6 +427,11 @@ func (s *sgxProvisioner) NewRuntime(ctx context.Context, cfg host.Config) (host.
 	return s.sandbox.NewRuntime(ctx, cfg)
 }
 
+// Implements host.Provisioner.
+func (s *sgxProvisioner) Name() string {
+	return "sgx"
+}
+
 // New creates a new Intel SGX runtime provisioner.
 func New(cfg Config) (host.Provisioner, error) {
 	// Use a default RuntimeAttestInterval if none was provided.


### PR DESCRIPTION
This PR adds the runtime provisioner type to the status output.