### PR TITLE
e2e: Fix test for provisioner type in status output

### DIFF
--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_upgrade.go
@@ -202,8 +202,9 @@ func (sc *runtimeUpgradeImpl) ensureActiveVersion(ctx context.Context, v version
 				return fmt.Errorf("%s: failed to query status: %w", node.Name, err)
 			}
 
-			if status.Runtimes[rt.ID()].Provisioner != "sandbox" {
-				return fmt.Errorf("%s: unexpected runtime provisioner for runtime '%s': %s", node.Name, rt.ID(), status.Runtimes[rt.ID()].Provisioner)
+			provisioner := status.Runtimes[rt.ID()].Provisioner
+			if provisioner != "sandbox" && provisioner != "sgx" {
+				return fmt.Errorf("%s: unexpected runtime provisioner for runtime '%s': %s", node.Name, rt.ID(), provisioner)
 			}
 
 			cs := status.Runtimes[rt.ID()].Committee


### PR DESCRIPTION
This fixes a dumb bug I introduced to the e2e test for checking if the provisioner type works in the status output.