### PR TITLE
go/oasis-test-runner/scenario: Add master secret generation to txs

### DIFF
--- a/go/oasis-test-runner/scenario/e2e/runtime/gas_fees.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/gas_fees.go
@@ -126,7 +126,7 @@ func (sc *gasFeesRuntimesImpl) Run(childEnv *env.Env) error {
 
 	// Submit a runtime transaction to check whether transaction processing works.
 	sc.Logger.Info("submitting transaction to runtime")
-	if _, err := sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, 0, "hello", "non-free world", false); err != nil {
+	if _, err := sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, 0, "hello", "non-free world", false, 0); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
@@ -170,7 +170,7 @@ func (sc *multipleRuntimesImpl) Run(childEnv *env.Env) error {
 					"runtime_id", rt.ID,
 				)
 
-				if _, err := sc.submitKeyValueRuntimeInsertTx(ctx, rt.ID, uint64(i), "hello", fmt.Sprintf("world at iteration %d from %s", i, rt.ID), false); err != nil {
+				if _, err := sc.submitKeyValueRuntimeInsertTx(ctx, rt.ID, uint64(i), "hello", fmt.Sprintf("world at iteration %d from %s", i, rt.ID), false, 0); err != nil {
 					return err
 				}
 			}

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_client_kv.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_client_kv.go
@@ -126,6 +126,7 @@ func (cli *KVTestClient) submit(ctx context.Context, req interface{}, rng rand.S
 			req.Key,
 			req.Value,
 			req.Encrypted,
+			req.Generation,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to insert k/v pair: %w", err)
@@ -141,6 +142,7 @@ func (cli *KVTestClient) submit(ctx context.Context, req interface{}, rng rand.S
 			rng.Uint64(),
 			req.Key,
 			req.Encrypted,
+			req.Generation,
 		)
 		if err != nil {
 			return err
@@ -156,6 +158,7 @@ func (cli *KVTestClient) submit(ctx context.Context, req interface{}, rng rand.S
 			rng.Uint64(),
 			req.Key,
 			req.Encrypted,
+			req.Generation,
 		)
 		if err != nil {
 			return err
@@ -234,19 +237,23 @@ func (sc *Scenario) submitKeyValueRuntimeInsertTx(
 	nonce uint64,
 	key, value string,
 	encrypted bool,
+	generation uint64,
 ) (string, error) {
 	sc.Logger.Info("inserting k/v pair",
 		"key", key,
 		"value", value,
 		"encrypted", encrypted,
+		"generation", generation,
 	)
 
 	args := struct {
-		Key   string `json:"key"`
-		Value string `json:"value"`
+		Key        string `json:"key"`
+		Value      string `json:"value"`
+		Generation uint64 `json:"generation,omitempty"`
 	}{
-		Key:   key,
-		Value: value,
+		Key:        key,
+		Value:      value,
+		Generation: generation,
 	}
 
 	if encrypted {
@@ -261,16 +268,20 @@ func (sc *Scenario) submitKeyValueRuntimeGetTx(
 	nonce uint64,
 	key string,
 	encrypted bool,
+	generation uint64,
 ) (string, error) {
 	sc.Logger.Info("retrieving k/v pair",
 		"key", key,
 		"encrypted", encrypted,
+		"generation", generation,
 	)
 
 	args := struct {
-		Key string `json:"key"`
+		Key        string `json:"key"`
+		Generation uint64 `json:"generation,omitempty"`
 	}{
-		Key: key,
+		Key:        key,
+		Generation: generation,
 	}
 
 	if encrypted {
@@ -285,16 +296,20 @@ func (sc *Scenario) submitKeyValueRuntimeRemoveTx(
 	nonce uint64,
 	key string,
 	encrypted bool,
+	generation uint64,
 ) (string, error) {
 	sc.Logger.Info("removing k/v pair",
 		"key", key,
 		"encrypted", encrypted,
+		"generation", generation,
 	)
 
 	args := struct {
-		Key string `json:"key"`
+		Key        string `json:"key"`
+		Generation uint64 `json:"generation,omitempty"`
 	}{
-		Key: key,
+		Key:        key,
+		Generation: generation,
 	}
 
 	if encrypted {

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_client_kv_scenario.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_client_kv_scenario.go
@@ -6,32 +6,32 @@ import (
 
 var (
 	InsertKeyValueScenario = NewTestClientScenario([]interface{}{
-		InsertKeyValueTx{"my_key", "my_value", "", false},
-		GetKeyValueTx{"my_key", "my_value", false},
+		InsertKeyValueTx{"my_key", "my_value", "", false, 0},
+		GetKeyValueTx{"my_key", "my_value", false, 0},
 	})
 
 	RemoveKeyValueScenario = NewTestClientScenario([]interface{}{
-		GetKeyValueTx{"my_key", "my_value", false},
+		GetKeyValueTx{"my_key", "my_value", false, 0},
 	})
 
 	InsertTransferKeyValueScenario = NewTestClientScenario([]interface{}{
-		InsertKeyValueTx{"my_key", "my_value", "", false},
-		GetKeyValueTx{"my_key", "my_value", false},
+		InsertKeyValueTx{"my_key", "my_value", "", false, 0},
+		GetKeyValueTx{"my_key", "my_value", false, 0},
 		ConsensusTransferTx{},
 	})
 
 	InsertRemoveKeyValueEncScenario = NewTestClientScenario([]interface{}{
-		InsertKeyValueTx{"my_key", "my_value", "", true},
-		GetKeyValueTx{"my_key", "my_value", true},
-		RemoveKeyValueTx{"my_key", "my_value", true},
-		GetKeyValueTx{"my_key", "", true},
+		InsertKeyValueTx{"my_key", "my_value", "", true, 0},
+		GetKeyValueTx{"my_key", "my_value", true, 0},
+		RemoveKeyValueTx{"my_key", "my_value", true, 0},
+		GetKeyValueTx{"my_key", "", true, 0},
 	})
 
 	InsertRemoveKeyValueEncScenarioV2 = NewTestClientScenario([]interface{}{
-		InsertKeyValueTx{"my_key2", "my_value2", "", true},
-		GetKeyValueTx{"my_key2", "my_value2", true},
-		RemoveKeyValueTx{"my_key2", "my_value2", true},
-		GetKeyValueTx{"my_key2", "", true},
+		InsertKeyValueTx{"my_key2", "my_value2", "", true, 0},
+		GetKeyValueTx{"my_key2", "my_value2", true, 0},
+		RemoveKeyValueTx{"my_key2", "my_value2", true, 0},
+		GetKeyValueTx{"my_key2", "", true, 0},
 	})
 
 	SimpleKeyValueScenario = newSimpleKeyValueScenario(false)
@@ -60,10 +60,10 @@ func newSimpleKeyValueScenario(repeat bool) TestClientScenario {
 				response = fmt.Sprintf("hello_value_from_%s:%d", runtimeID, iter-1)
 			}
 
-			if err := submit(InsertKeyValueTx{key, value, response, false}); err != nil {
+			if err := submit(InsertKeyValueTx{key, value, response, false, 0}); err != nil {
 				return err
 			}
-			if err := submit(GetKeyValueTx{key, value, false}); err != nil {
+			if err := submit(GetKeyValueTx{key, value, false, 0}); err != nil {
 				return err
 			}
 
@@ -75,13 +75,13 @@ func newSimpleKeyValueScenario(repeat bool) TestClientScenario {
 				response = value
 			}
 
-			if err := submit(InsertKeyValueTx{key, value, response, false}); err != nil {
+			if err := submit(InsertKeyValueTx{key, value, response, false, 0}); err != nil {
 				return err
 			}
 			if err := submit(ConsensusTransferTx{}); err != nil {
 				return err
 			}
-			if err := submit(GetKeyValueTx{key, value, false}); err != nil {
+			if err := submit(GetKeyValueTx{key, value, false, 0}); err != nil {
 				return err
 			}
 
@@ -98,7 +98,7 @@ func newSimpleKeyValueScenario(repeat bool) TestClientScenario {
 		if err := submit(InsertMsg{inMsgKey, inMsgValue}); err != nil {
 			return err
 		}
-		if err := submit(GetKeyValueTx{inMsgKey, inMsgValue, false}); err != nil {
+		if err := submit(GetKeyValueTx{inMsgKey, inMsgValue, false, 0}); err != nil {
 			return err
 		}
 		if err := submit(ConsensusAccountsTx{}); err != nil {
@@ -112,25 +112,28 @@ func newSimpleKeyValueScenario(repeat bool) TestClientScenario {
 // InsertKeyValueTx inserts a key/value pair to the database, and verifies that the response
 // (previous value) contains the expected data.
 type InsertKeyValueTx struct {
-	Key       string
-	Value     string
-	Response  string
-	Encrypted bool
+	Key        string
+	Value      string
+	Response   string
+	Encrypted  bool
+	Generation uint64
 }
 
 // GetKeyValueTx retrieves the value stored under the given key from the database,
 // and verifies that the response (current value) contains the expected data.
 type GetKeyValueTx struct {
-	Key       string
-	Response  string
-	Encrypted bool
+	Key        string
+	Response   string
+	Encrypted  bool
+	Generation uint64
 }
 
 // RemoveKeyValueTx removes the value stored under the given key from the database.
 type RemoveKeyValueTx struct {
-	Key       string
-	Response  string
-	Encrypted bool
+	Key        string
+	Response   string
+	Encrypted  bool
+	Generation uint64
 }
 
 // InsertMsg inserts an incoming runtime message.

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_dynamic.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_dynamic.go
@@ -260,7 +260,7 @@ func (sc *runtimeDynamicImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 		sc.Logger.Info("submitting transaction to runtime",
 			"seq", i,
 		)
-		if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, rtNonce, "hello", fmt.Sprintf("world %d", i), false); err != nil {
+		if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, rtNonce, "hello", fmt.Sprintf("world %d", i), false, 0); err != nil {
 			return err
 		}
 		rtNonce++
@@ -368,7 +368,7 @@ func (sc *runtimeDynamicImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 
 	// Submit a runtime transaction to check whether the runtimes got resumed.
 	sc.Logger.Info("submitting transaction to runtime")
-	if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, rtNonce, "hello", "final world", false); err != nil {
+	if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, rtNonce, "hello", "final world", false, 0); err != nil {
 		return err
 	}
 	rtNonce++
@@ -549,7 +549,7 @@ func (sc *runtimeDynamicImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 
 	// Submit a runtime transaction to check whether the runtimes got resumed.
 	sc.Logger.Info("submitting transaction to runtime")
-	if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, rtNonce, "hello", "final world for sure", false); err != nil {
+	if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, rtNonce, "hello", "final world for sure", false, 0); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_prune.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_prune.go
@@ -82,7 +82,7 @@ func (sc *runtimePruneImpl) Run(childEnv *env.Env) error {
 			"seq", i,
 		)
 
-		if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, uint64(i), "hello", fmt.Sprintf("world %d", i), false); err != nil {
+		if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, uint64(i), "hello", fmt.Sprintf("world %d", i), false, 0); err != nil {
 			return err
 		}
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_sync.go
@@ -108,7 +108,7 @@ func (sc *storageSyncImpl) Run(childEnv *env.Env) error { //nolint: gocyclo
 		sc.Logger.Info("submitting transaction to runtime",
 			"seq", i,
 		)
-		if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, drbg.Uint64(), "checkpoint", fmt.Sprintf("my cp %d", i), false); err != nil {
+		if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, drbg.Uint64(), "checkpoint", fmt.Sprintf("my cp %d", i), false, 0); err != nil {
 			return err
 		}
 	}
@@ -185,7 +185,7 @@ func (sc *storageSyncImpl) Run(childEnv *env.Env) error { //nolint: gocyclo
 		sc.Logger.Info("submitting large transaction to runtime",
 			"seq", i,
 		)
-		if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, drbg.Uint64(), fmt.Sprintf("%d key %d", i, i), fmt.Sprintf("my cp %d: ", i)+largeVal, false); err != nil {
+		if _, err = sc.submitKeyValueRuntimeInsertTx(ctx, runtimeID, drbg.Uint64(), fmt.Sprintf("%d key %d", i, i), fmt.Sprintf("my cp %d: ", i)+largeVal, false, 0); err != nil {
 			return err
 		}
 	}

--- a/tests/runtimes/simple-keyvalue/src/methods.rs
+++ b/tests/runtimes/simple-keyvalue/src/methods.rs
@@ -254,12 +254,10 @@ impl Methods {
     fn get_encryption_context(
         ctx: &mut TxContext,
         key: &[u8],
+        generation: u64,
     ) -> Result<EncryptionContext, String> {
         // Derive key pair ID based on key.
         let key_pair_id = KeyPairId::from(Hash::digest_bytes(key).as_ref());
-
-        // Always use keys from generation 0.
-        let generation = 0;
 
         // Fetch encryption keys.
         let result = ctx
@@ -282,7 +280,7 @@ impl Methods {
         //       to also generate a (deterministic) nonce.
         let nonce = [0u8; NONCE_SIZE];
 
-        let enc_ctx = Self::get_encryption_context(ctx, args.key.as_bytes())?;
+        let enc_ctx = Self::get_encryption_context(ctx, args.key.as_bytes(), args.generation)?;
         let existing = enc_ctx.insert(
             ctx.parent.core.runtime_state,
             args.key.as_bytes(),
@@ -300,7 +298,7 @@ impl Methods {
         if ctx.is_check_only() {
             return Ok(None);
         }
-        let enc_ctx = Self::get_encryption_context(ctx, args.key.as_bytes())?;
+        let enc_ctx = Self::get_encryption_context(ctx, args.key.as_bytes(), args.generation)?;
         let existing = enc_ctx.get(ctx.parent.core.runtime_state, args.key.as_bytes());
         existing
             .map(String::from_utf8)
@@ -313,7 +311,7 @@ impl Methods {
         if ctx.is_check_only() {
             return Ok(None);
         }
-        let enc_ctx = Self::get_encryption_context(ctx, args.key.as_bytes())?;
+        let enc_ctx = Self::get_encryption_context(ctx, args.key.as_bytes(), args.generation)?;
         let existing = enc_ctx.remove(ctx.parent.core.runtime_state, args.key.as_bytes());
         existing
             .map(String::from_utf8)

--- a/tests/runtimes/simple-keyvalue/src/types.rs
+++ b/tests/runtimes/simple-keyvalue/src/types.rs
@@ -32,12 +32,14 @@ pub enum CallOutput {
 #[derive(Clone, Debug, Default, cbor::Encode, cbor::Decode)]
 pub struct Key {
     pub key: String,
+    pub generation: u64,
 }
 
 #[derive(Clone, Debug, Default, cbor::Encode, cbor::Decode)]
 pub struct KeyValue {
     pub key: String,
     pub value: String,
+    pub generation: u64,
 }
 
 #[derive(Clone, Debug, Default, cbor::Encode, cbor::Decode)]


### PR DESCRIPTION
The runtime test client can now select which generation of the master secret should be used to insert, fetch, or delete a key/value pair from the simple key/value runtime. Until now, all encrypted transactions used master secret generation 0.

Needed for master secret generations cross-version/upgrade tests.