### PR TITLE
go/oasis-test-runner: Run the test runner and scenarios for limited time

### DIFF
--- a/.changelog/5304.feature.md
+++ b/.changelog/5304.feature.md
@@ -1,0 +1,9 @@
+go/oasis-test-runner: Run the test runner and scenarios for limited time
+
+The test runner and scenarios can now be configured to run for a limited
+duration using the following flags:
+
+- `timeout`: the maximum allowable total duration for all scenarios,
+
+- `scenario_timeout`: the maximum allowable duration for an individual
+  scenario.

--- a/go/oasis-test-runner/cmd/root.go
+++ b/go/oasis-test-runner/cmd/root.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -40,6 +41,8 @@ const (
 	cfgMetricsAddr      = "metrics.address"
 	cfgMetricsLabels    = "metrics.labels"
 	cfgMetricsInterval  = "metrics.interval"
+	cfgTimeout          = "timeout"
+	cfgScenarioTimeout  = "scenario_timeout"
 )
 
 var (
@@ -371,6 +374,10 @@ func runRoot(cmd *cobra.Command, args []string) error { // nolint: gocyclo
 		return fmt.Errorf("root: failed to parse scenario parameters: %w", err)
 	}
 
+	// Allow scenarios to run for a limited amount of time.
+	ctx, cancel := context.WithTimeout(context.Background(), viper.GetDuration(cfgTimeout))
+	defer cancel()
+
 	// Run all requested scenarios.
 	index := 0
 	for run := 0; run < numRuns; run++ {
@@ -437,7 +444,7 @@ func runRoot(cmd *cobra.Command, args []string) error { // nolint: gocyclo
 					pusher = pusher.Gatherer(prometheus.DefaultGatherer)
 				}
 
-				if err = doScenario(childEnv, v); err != nil {
+				if err = doScenario(ctx, childEnv, v); err != nil {
 					logger.Error("failed to run scenario",
 						"err", err,
 						"scenario", name,
@@ -473,7 +480,7 @@ func runRoot(cmd *cobra.Command, args []string) error { // nolint: gocyclo
 	return nil
 }
 
-func doScenario(childEnv *env.Env, sc scenario.Scenario) (err error) {
+func doScenario(ctx context.Context, childEnv *env.Env, sc scenario.Scenario) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("root: panic caught running scenario: %v: %s", r, debug.Stack())
@@ -526,7 +533,11 @@ func doScenario(childEnv *env.Env, sc scenario.Scenario) (err error) {
 		}
 	}
 
-	if err = sc.Run(childEnv); err != nil {
+	// Allow scenario to run for a limited amount of time.
+	ctx, cancel := context.WithTimeout(ctx, viper.GetDuration(cfgScenarioTimeout))
+	defer cancel()
+
+	if err = sc.Run(ctx, childEnv); err != nil {
 		err = fmt.Errorf("root: failed to run scenario: %w", err)
 		return
 	}
@@ -622,6 +633,8 @@ func init() {
 	rootFlags.IntVarP(&numRuns, cfgNumRuns, "n", 1, "number of runs for given scenario(s)")
 	rootFlags.Int(cfgParallelJobCount, 1, "(for CI) number of overall parallel jobs")
 	rootFlags.Int(cfgParallelJobIndex, 0, "(for CI) index of this parallel job")
+	rootFlags.Duration(cfgTimeout, 24*time.Hour, "the maximum allowable total duration for all scenarios")
+	rootFlags.Duration(cfgScenarioTimeout, 20*time.Minute, "the maximum allowable duration for an individual scenario")
 	_ = viper.BindPFlags(rootFlags)
 	rootCmd.Flags().AddFlagSet(rootFlags)
 	rootCmd.Flags().AddFlagSet(env.Flags)

--- a/go/oasis-test-runner/scenario/e2e/byzantine_beacon_vrf.go
+++ b/go/oasis-test-runner/scenario/e2e/byzantine_beacon_vrf.go
@@ -93,12 +93,10 @@ func (sc *byzantineVRFBeaconImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *byzantineVRFBeaconImpl) Run(childEnv *env.Env) error {
+func (sc *byzantineVRFBeaconImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
-
-	ctx := context.Background()
 
 	// Wait for the validators to come up.
 	sc.Logger.Info("waiting for validators to initialize",

--- a/go/oasis-test-runner/scenario/e2e/consensus_state_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/consensus_state_sync.go
@@ -59,13 +59,12 @@ func (sc *consensusStateSyncImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *consensusStateSyncImpl) Run(childEnv *env.Env) error {
+func (sc *consensusStateSyncImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
 
 	sc.Logger.Info("waiting for network to come up")
-	ctx := context.Background()
 	if err := sc.Net.Controller().WaitNodesRegistered(ctx, len(sc.Net.Validators())-1); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/debond.go
+++ b/go/oasis-test-runner/scenario/e2e/debond.go
@@ -77,12 +77,10 @@ func (s *debondImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (s *debondImpl) Run(*env.Env) error {
+func (s *debondImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := s.Net.Start(); err != nil {
 		return fmt.Errorf("net Start: %w", err)
 	}
-
-	ctx := context.Background()
 
 	s.Logger.Info("waiting for network to come up")
 	if err := s.Net.Controller().WaitNodesRegistered(ctx, 3); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/early_query.go
+++ b/go/oasis-test-runner/scenario/e2e/early_query.go
@@ -57,7 +57,7 @@ func (sc *earlyQueryImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *earlyQueryImpl) Run(childEnv *env.Env) error {
+func (sc *earlyQueryImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	// Start the network.
 	var err error
 	if err = sc.Net.Start(); err != nil {
@@ -66,7 +66,7 @@ func (sc *earlyQueryImpl) Run(childEnv *env.Env) error {
 
 	// Perform some queries.
 	cs := sc.Net.Controller().Consensus
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 
 	// StateToGenesis.

--- a/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
+++ b/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
@@ -119,9 +119,7 @@ func (sc *gasFeesImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return ff, nil
 }
 
-func (sc *gasFeesImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
-
+func (sc *gasFeesImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.runTests(ctx); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/genesis_file.go
+++ b/go/oasis-test-runner/scenario/e2e/genesis_file.go
@@ -65,7 +65,7 @@ func (s *genesisFileImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (s *genesisFileImpl) Run(childEnv *env.Env) error {
+func (s *genesisFileImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	// Manually provision genesis file.
 	s.Logger.Info("manually provisioning genesis file before starting the network")
 	if err := s.Net.MakeGenesis(); err != nil {
@@ -85,7 +85,7 @@ func (s *genesisFileImpl) Run(childEnv *env.Env) error {
 	}
 
 	s.Logger.Info("waiting for network to come up")
-	if err := s.Net.Controller().WaitNodesRegistered(context.Background(), 1); err != nil {
+	if err := s.Net.Controller().WaitNodesRegistered(ctx, 1); err != nil {
 		return fmt.Errorf("e2e/genesis-file: failed to wait for registered nodes: %w", err)
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/identity_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/identity_cli.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 
 	fileSigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/file"
@@ -48,7 +49,7 @@ func (sc *identityCLIImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return nil, nil
 }
 
-func (sc *identityCLIImpl) Run(childEnv *env.Env) error {
+func (sc *identityCLIImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	// Provision node's identity.
 	args := []string{
 		"identity", "init",

--- a/go/oasis-test-runner/scenario/e2e/min_transact_balance.go
+++ b/go/oasis-test-runner/scenario/e2e/min_transact_balance.go
@@ -116,13 +116,11 @@ func (mtb *minTransactBalanceImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (mtb *minTransactBalanceImpl) Run(childEnv *env.Env) error {
+func (mtb *minTransactBalanceImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	// Start the network
 	if err := mtb.Net.Start(); err != nil {
 		return err
 	}
-
-	ctx := context.Background()
 
 	mtb.Logger.Info("waiting for network to come up")
 	if err := mtb.Net.Controller().WaitNodesRegistered(ctx, 3); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/multiple_seeds.go
+++ b/go/oasis-test-runner/scenario/e2e/multiple_seeds.go
@@ -43,12 +43,10 @@ func (sc *multipleSeeds) Clone() scenario.Scenario {
 	}
 }
 
-func (sc *multipleSeeds) Run(childEnv *env.Env) error { // nolint: gocyclo
+func (sc *multipleSeeds) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	if err := sc.Net.Start(); err != nil {
 		return fmt.Errorf("net Start: %w", err)
 	}
-
-	ctx := context.Background()
 
 	sc.Logger.Info("waiting for network to come up")
 	if err := sc.Net.Controller().WaitNodesRegistered(ctx, 3); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/registry_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/registry_cli.go
@@ -70,12 +70,11 @@ func (sc *registryCLIImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *registryCLIImpl) Run(childEnv *env.Env) error {
+func (sc *registryCLIImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
 
-	ctx := context.Background()
 	sc.Logger.Info("waiting for nodes to register")
 	if err := sc.Net.Controller().WaitNodesRegistered(ctx, 3); err != nil {
 		return fmt.Errorf("waiting for nodes to register: %w", err)

--- a/go/oasis-test-runner/scenario/e2e/runtime/archive_api.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/archive_api.go
@@ -281,8 +281,7 @@ func (sc *archiveAPI) testArchiveAPI(ctx context.Context, archiveCtrl *oasis.Con
 	return nil
 }
 
-func (sc *archiveAPI) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *archiveAPI) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}
@@ -292,7 +291,7 @@ func (sc *archiveAPI) Run(childEnv *env.Env) error {
 		return err
 	}
 	var nextEpoch beacon.EpochTime
-	if nextEpoch, err = sc.initialEpochTransitions(fixture); err != nil {
+	if nextEpoch, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
 	nextEpoch++ // Next, after initial transitions.

--- a/go/oasis-test-runner/scenario/e2e/runtime/byzantine.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/byzantine.go
@@ -453,9 +453,7 @@ func (sc *byzantineImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *byzantineImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
-
+func (sc *byzantineImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
@@ -472,7 +470,7 @@ func (sc *byzantineImpl) Run(childEnv *env.Env) error {
 	}
 	defer blkSub.Close()
 
-	epoch, err := sc.initialEpochTransitions(fixture)
+	epoch, err := sc.initialEpochTransitions(ctx, fixture)
 	if err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/dump_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/dump_restore.go
@@ -118,8 +118,7 @@ func (sc *dumpRestoreImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *dumpRestoreImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *dumpRestoreImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}
@@ -190,5 +189,5 @@ func (sc *dumpRestoreImpl) Run(childEnv *env.Env) error {
 
 	// Check that everything works with restored state.
 	sc.Scenario.testClient = NewKVTestClient().WithSeed("seed2").WithScenario(RemoveKeyValueScenario)
-	return sc.Scenario.Run(childEnv)
+	return sc.Scenario.Run(ctx, childEnv)
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/gas_fees.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/gas_fees.go
@@ -112,15 +112,13 @@ func (sc *gasFeesRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *gasFeesRuntimesImpl) Run(childEnv *env.Env) error {
+func (sc *gasFeesRuntimesImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
 
-	ctx := context.Background()
-
 	// Wait for all nodes to be synced before we proceed.
-	if err := sc.waitNodesSynced(); err != nil {
+	if err := sc.waitNodesSynced(ctx); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/governance_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/governance_upgrade.go
@@ -44,8 +44,6 @@ type governanceConsensusUpgradeImpl struct {
 	shouldCancelUpgrade   bool
 
 	entity *oasis.Entity
-
-	ctx context.Context
 }
 
 func newGovernanceConsensusUpgradeImpl(correctUpgradeVersion, cancelUpgrade bool) scenario.Scenario {
@@ -67,7 +65,6 @@ func newGovernanceConsensusUpgradeImpl(correctUpgradeVersion, cancelUpgrade bool
 		),
 		correctUpgradeVersion: correctUpgradeVersion,
 		shouldCancelUpgrade:   cancelUpgrade,
-		ctx:                   context.Background(),
 	}
 	return sc
 }
@@ -79,7 +76,6 @@ func (sc *governanceConsensusUpgradeImpl) Clone() scenario.Scenario {
 		entityNonce:           sc.entityNonce,
 		correctUpgradeVersion: sc.correctUpgradeVersion,
 		shouldCancelUpgrade:   sc.shouldCancelUpgrade,
-		ctx:                   context.Background(),
 	}
 }
 
@@ -186,7 +182,7 @@ func (sc *governanceConsensusUpgradeImpl) nextEpoch(ctx context.Context) error {
 }
 
 // Submits a proposal, votes for it and ensures the proposal is finalized.
-func (sc *governanceConsensusUpgradeImpl) ensureProposalFinalized(content *api.ProposalContent) (*api.Proposal, error) {
+func (sc *governanceConsensusUpgradeImpl) ensureProposalFinalized(ctx context.Context, content *api.ProposalContent) (*api.Proposal, error) {
 	// Submit proposal.
 	tx := api.NewSubmitProposalTx(sc.entityNonce, &transaction.Fee{Gas: 2000}, content)
 	sc.entityNonce++
@@ -195,13 +191,13 @@ func (sc *governanceConsensusUpgradeImpl) ensureProposalFinalized(content *api.P
 		return nil, fmt.Errorf("failed signing submit proposal transaction: %w", err)
 	}
 	sc.Logger.Info("submitting proposal", "content", content)
-	err = sc.Net.Controller().Consensus.SubmitTx(sc.ctx, sigTx)
+	err = sc.Net.Controller().Consensus.SubmitTx(ctx, sigTx)
 	if err != nil {
 		return nil, fmt.Errorf("failed submitting proposal transaction: %w", err)
 	}
 
 	// Ensure proposal created.
-	aps, err := sc.Net.Controller().Governance.ActiveProposals(sc.ctx, consensus.HeightLatest)
+	aps, err := sc.Net.Controller().Governance.ActiveProposals(ctx, consensus.HeightLatest)
 	if err != nil {
 		return nil, fmt.Errorf("failed querying active proposals: %w", err)
 	}
@@ -228,13 +224,13 @@ func (sc *governanceConsensusUpgradeImpl) ensureProposalFinalized(content *api.P
 		return nil, fmt.Errorf("failed signing cast vote transaction: %w", err)
 	}
 	sc.Logger.Info("submitting vote for proposal", "proposal", proposal, "vote", vote)
-	err = sc.Net.Controller().Consensus.SubmitTx(sc.ctx, sigTx)
+	err = sc.Net.Controller().Consensus.SubmitTx(ctx, sigTx)
 	if err != nil {
 		return nil, fmt.Errorf("failed submitting cast vote transaction: %w", err)
 	}
 
 	// Ensure vote was cast.
-	votes, err := sc.Net.Controller().Governance.Votes(sc.ctx,
+	votes, err := sc.Net.Controller().Governance.Votes(ctx,
 		&api.ProposalQuery{
 			Height:     consensus.HeightLatest,
 			ProposalID: aps[0].ID,
@@ -253,12 +249,12 @@ func (sc *governanceConsensusUpgradeImpl) ensureProposalFinalized(content *api.P
 	// Transition to the epoch when proposal finalizes.
 	for ep := sc.currentEpoch + 1; ep < aps[0].ClosesAt+1; ep++ {
 		sc.Logger.Info("transitioning to epoch", "epoch", ep)
-		if err = sc.nextEpoch(sc.ctx); err != nil {
+		if err = sc.nextEpoch(ctx); err != nil {
 			return nil, err
 		}
 	}
 
-	p, err := sc.Net.Controller().Governance.Proposal(sc.ctx,
+	p, err := sc.Net.Controller().Governance.Proposal(ctx,
 		&api.ProposalQuery{
 			Height:     consensus.HeightLatest,
 			ProposalID: proposal.ID,
@@ -281,8 +277,8 @@ func (sc *governanceConsensusUpgradeImpl) ensureProposalFinalized(content *api.P
 	return p, nil
 }
 
-func (sc *governanceConsensusUpgradeImpl) cancelUpgrade(proposalID uint64) error {
-	_, err := sc.ensureProposalFinalized(
+func (sc *governanceConsensusUpgradeImpl) cancelUpgrade(ctx context.Context, proposalID uint64) error {
+	_, err := sc.ensureProposalFinalized(ctx,
 		&api.ProposalContent{CancelUpgrade: &api.CancelUpgradeProposal{
 			ProposalID: proposalID,
 		}})
@@ -291,7 +287,7 @@ func (sc *governanceConsensusUpgradeImpl) cancelUpgrade(proposalID uint64) error
 	}
 
 	// Ensure pending upgrade was canceled.
-	pendingUpgrades, err := sc.Net.Controller().Governance.PendingUpgrades(sc.ctx, consensus.HeightLatest)
+	pendingUpgrades, err := sc.Net.Controller().Governance.PendingUpgrades(ctx, consensus.HeightLatest)
 	if err != nil {
 		return fmt.Errorf("failed to query pending upgrades: %w", err)
 	}
@@ -302,8 +298,8 @@ func (sc *governanceConsensusUpgradeImpl) cancelUpgrade(proposalID uint64) error
 	return nil
 }
 
-func (sc *governanceConsensusUpgradeImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
-	if err := sc.StartNetworkAndTestClient(sc.ctx, childEnv); err != nil {
+func (sc *governanceConsensusUpgradeImpl) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
+	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}
 
@@ -315,7 +311,7 @@ func (sc *governanceConsensusUpgradeImpl) Run(childEnv *env.Env) error { // noli
 	}
 
 	// Wait for the nodes.
-	if sc.currentEpoch, err = sc.initialEpochTransitions(fixture); err != nil {
+	if sc.currentEpoch, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
 
@@ -324,7 +320,7 @@ func (sc *governanceConsensusUpgradeImpl) Run(childEnv *env.Env) error { // noli
 		return err
 	}
 
-	entityAcc, err := sc.Net.Controller().Staking.Account(sc.ctx,
+	entityAcc, err := sc.Net.Controller().Staking.Account(ctx,
 		&staking.OwnerQuery{
 			Height: consensus.HeightLatest,
 			Owner:  e2e.DeterministicEntity1,
@@ -368,13 +364,13 @@ func (sc *governanceConsensusUpgradeImpl) Run(childEnv *env.Env) error { // noli
 		},
 	}
 	// Submit upgrade proposal.
-	proposal, err := sc.ensureProposalFinalized(content)
+	proposal, err := sc.ensureProposalFinalized(ctx, content)
 	if err != nil {
 		return fmt.Errorf("upgrade proposal error: %w", err)
 	}
 
 	// Ensure pending upgrade exists.
-	pendingUpgrades, err := sc.Net.Controller().Governance.PendingUpgrades(sc.ctx, consensus.HeightLatest)
+	pendingUpgrades, err := sc.Net.Controller().Governance.PendingUpgrades(ctx, consensus.HeightLatest)
 	if err != nil {
 		return fmt.Errorf("failed to query pending upgrades: %w", err)
 	}
@@ -384,7 +380,7 @@ func (sc *governanceConsensusUpgradeImpl) Run(childEnv *env.Env) error { // noli
 
 	// Cancel upgrade if configured so.
 	if sc.shouldCancelUpgrade {
-		if err = sc.cancelUpgrade(proposal.ID); err != nil {
+		if err = sc.cancelUpgrade(ctx, proposal.ID); err != nil {
 			return fmt.Errorf("cancel upgrade failure: %w", err)
 		}
 	}
@@ -400,7 +396,7 @@ func (sc *governanceConsensusUpgradeImpl) Run(childEnv *env.Env) error { // noli
 				sc.Logger.Info("waiting for node to exit", "node", nd.Name)
 				<-nd.Exit()
 				sc.Logger.Info("restarting node", "node", nd.Name)
-				if err = nd.Restart(sc.ctx); err != nil {
+				if err = nd.Restart(ctx); err != nil {
 					errCh <- err
 				}
 			}(i, nd)
@@ -411,7 +407,7 @@ func (sc *governanceConsensusUpgradeImpl) Run(childEnv *env.Env) error { // noli
 	for ep := sc.currentEpoch + 1; ep <= upgradeEpoch; ep++ {
 		sc.Logger.Info("transitioning to epoch", "epoch", ep)
 
-		if err = sc.nextEpoch(sc.ctx); err != nil {
+		if err = sc.nextEpoch(ctx); err != nil {
 			return err
 		}
 	}
@@ -447,7 +443,7 @@ func (sc *governanceConsensusUpgradeImpl) Run(childEnv *env.Env) error { // noli
 		// Upgrade binary matches node binary, upgrade should work.
 		sc.Logger.Info("waiting for nodes to sync")
 		for _, n := range sc.Net.Nodes() {
-			if err = n.WaitReady(sc.ctx); err != nil {
+			if err = n.WaitReady(ctx); err != nil {
 				return fmt.Errorf("failed to wait for a validator: %w", err)
 			}
 		}
@@ -457,18 +453,18 @@ func (sc *governanceConsensusUpgradeImpl) Run(childEnv *env.Env) error { // noli
 			Height: consensus.HeightLatest,
 			ID:     migrations.TestEntity.ID,
 		}
-		_, err = sc.Net.Controller().Registry.GetEntity(sc.ctx, idQuery)
+		_, err = sc.Net.Controller().Registry.GetEntity(ctx, idQuery)
 		if err != nil {
 			return fmt.Errorf("can't get registered test entity: %w", err)
 		}
 	}
 
 	sc.Logger.Info("final epoch transition")
-	if err = sc.nextEpoch(sc.ctx); err != nil {
+	if err = sc.nextEpoch(ctx); err != nil {
 		return err
 	}
 
 	// Check that runtime still works after the upgrade.
 	sc.Scenario.testClient = NewKVTestClient().WithSeed("seed2").WithScenario(RemoveKeyValueScenario)
-	return sc.Scenario.Run(childEnv)
+	return sc.Scenario.Run(ctx, childEnv)
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/halt_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/halt_restore.go
@@ -69,8 +69,7 @@ func (sc *haltRestoreImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *haltRestoreImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
-	ctx := context.Background()
+func (sc *haltRestoreImpl) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}
@@ -80,7 +79,7 @@ func (sc *haltRestoreImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 		return err
 	}
 	var nextEpoch beacon.EpochTime
-	if nextEpoch, err = sc.initialEpochTransitions(fixture); err != nil {
+	if nextEpoch, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
 	nextEpoch++ // Next, after initial transitions.
@@ -227,7 +226,7 @@ func (sc *haltRestoreImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 	if err = sc.StartNetworkAndWaitForClientSync(ctx); err != nil {
 		return err
 	}
-	if _, err = sc.initialEpochTransitionsWith(fixture, genesisDoc.Beacon.Base); err != nil {
+	if _, err = sc.initialEpochTransitionsWith(ctx, fixture, genesisDoc.Beacon.Base); err != nil {
 		return err
 	}
 	if err = sc.startTestClientOnly(ctx, childEnv); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/runtime/halt_restore_nonmock.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/halt_restore_nonmock.go
@@ -50,8 +50,7 @@ func (sc *haltRestoreNonMockImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *haltRestoreNonMockImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
-	ctx := context.Background()
+func (sc *haltRestoreNonMockImpl) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/history_reindex.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/history_reindex.go
@@ -82,8 +82,7 @@ func (sc *historyReindexImpl) Clone() scenario.Scenario {
 	}
 }
 
-func (sc *historyReindexImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *historyReindexImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	cli := cli.New(childEnv, sc.Net, sc.Logger)
 
 	// Start the network.
@@ -158,7 +157,7 @@ func (sc *historyReindexImpl) Run(childEnv *env.Env) error {
 	if err != nil {
 		return err
 	}
-	if err = computeCtrl.WaitReady(context.Background()); err != nil {
+	if err = computeCtrl.WaitReady(ctx); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_ephemeral_keys.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_ephemeral_keys.go
@@ -85,10 +85,9 @@ func (sc *kmEphemeralKeysImpl) Clone() scenario.Scenario {
 	}
 }
 
-func (sc *kmEphemeralKeysImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
+func (sc *kmEphemeralKeysImpl) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	// Start the network, but no need to start the client. Just ensure it
 	// is synced.
-	ctx := context.Background()
 	if err := sc.Scenario.StartNetworkAndWaitForClientSync(ctx); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_replicate.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_replicate.go
@@ -51,8 +51,7 @@ func (sc *kmReplicateImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *kmReplicateImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *kmReplicateImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_restart.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_restart.go
@@ -42,8 +42,7 @@ func (sc *kmRestartImpl) Clone() scenario.Scenario {
 	}
 }
 
-func (sc *kmRestartImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *kmRestartImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_upgrade.go
@@ -200,7 +200,7 @@ func (sc *KmUpgradeImpl) ensureReplicationWorked(ctx context.Context, km *oasis.
 
 	// Grab a state dump and ensure all keymanager nodes have a matching
 	// checksum.
-	doc, err := ctrl.Consensus.StateToGenesis(context.Background(), 0)
+	doc, err := ctrl.Consensus.StateToGenesis(ctx, 0)
 	if err != nil {
 		return fmt.Errorf("failed to obtain consensus state: %w", err)
 	}
@@ -225,8 +225,7 @@ func (sc *KmUpgradeImpl) ensureReplicationWorked(ctx context.Context, km *oasis.
 	return nil
 }
 
-func (sc *KmUpgradeImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *KmUpgradeImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	cli := cli.New(childEnv, sc.Net, sc.Logger)
 
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/runtime/late_start.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/late_start.go
@@ -49,9 +49,7 @@ func (sc *lateStartImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *lateStartImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
-
+func (sc *lateStartImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	// Start the network.
 	var err error
 	if err = sc.Net.Start(); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
@@ -142,7 +142,7 @@ func (sc *multipleRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *multipleRuntimesImpl) Run(childEnv *env.Env) error {
+func (sc *multipleRuntimesImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
@@ -153,11 +153,9 @@ func (sc *multipleRuntimesImpl) Run(childEnv *env.Env) error {
 	}
 
 	// Wait for the nodes.
-	if _, err = sc.initialEpochTransitions(fixture); err != nil {
+	if _, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
-
-	ctx := context.Background()
 
 	// Submit transactions.
 	numComputeRuntimeTxns, _ := sc.Flags.GetInt(cfgNumComputeRuntimeTxns)

--- a/go/oasis-test-runner/scenario/e2e/runtime/node_shutdown.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/node_shutdown.go
@@ -56,8 +56,7 @@ func (sc *nodeShutdownImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *nodeShutdownImpl) Run(childEnv *env.Env) error { //nolint: gocyclo
-	ctx := context.Background()
+func (sc *nodeShutdownImpl) Run(ctx context.Context, childEnv *env.Env) error { //nolint: gocyclo
 	var err error
 
 	if err = sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/runtime/offset_restart.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/offset_restart.go
@@ -47,8 +47,7 @@ func (sc *offsetRestartImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *offsetRestartImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *offsetRestartImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}
@@ -58,7 +57,7 @@ func (sc *offsetRestartImpl) Run(childEnv *env.Env) error {
 		return err
 	}
 
-	if _, err = sc.initialEpochTransitions(fixture); err != nil {
+	if _, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
 
@@ -91,5 +90,5 @@ func (sc *offsetRestartImpl) Run(childEnv *env.Env) error {
 	// hanging the network (no transactions could be submitted).
 	sc.Logger.Info("network back up, trying to run client again")
 	sc.Scenario.testClient = NewKVTestClient().WithSeed("seed2").WithScenario(RemoveKeyValueScenario)
-	return sc.Scenario.Run(childEnv)
+	return sc.Scenario.Run(ctx, childEnv)
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -391,8 +391,7 @@ func (sc *Scenario) waitTestClient() error {
 	return sc.checkTestClientLogs()
 }
 
-func (sc *Scenario) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *Scenario) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}
@@ -583,9 +582,7 @@ func (sc *Scenario) StartNetworkAndWaitForClientSync(ctx context.Context) error 
 	return sc.waitForClientSync(ctx)
 }
 
-func (sc *Scenario) waitNodesSynced() error {
-	ctx := context.Background()
-
+func (sc *Scenario) waitNodesSynced(ctx context.Context) error {
 	checkSynced := func(n *oasis.Node) error {
 		c, err := oasis.NewController(n.SocketPath())
 		if err != nil {
@@ -621,13 +618,11 @@ func (sc *Scenario) waitNodesSynced() error {
 	return nil
 }
 
-func (sc *Scenario) initialEpochTransitions(fixture *oasis.NetworkFixture) (beacon.EpochTime, error) {
-	return sc.initialEpochTransitionsWith(fixture, 0)
+func (sc *Scenario) initialEpochTransitions(ctx context.Context, fixture *oasis.NetworkFixture) (beacon.EpochTime, error) {
+	return sc.initialEpochTransitionsWith(ctx, fixture, 0)
 }
 
-func (sc *Scenario) initialEpochTransitionsWith(fixture *oasis.NetworkFixture, baseEpoch beacon.EpochTime) (beacon.EpochTime, error) {
-	ctx := context.Background()
-
+func (sc *Scenario) initialEpochTransitionsWith(ctx context.Context, fixture *oasis.NetworkFixture, baseEpoch beacon.EpochTime) (beacon.EpochTime, error) {
 	epoch := baseEpoch + 1
 	advanceEpoch := func() error {
 		sc.Logger.Info("triggering epoch transition",

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_dynamic.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_dynamic.go
@@ -88,17 +88,16 @@ func (sc *runtimeDynamicImpl) epochTransition(ctx context.Context) error {
 	return nil
 }
 
-func (sc *runtimeDynamicImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
+func (sc *runtimeDynamicImpl) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	var rtNonce uint64
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
 
-	ctx := context.Background()
 	cli := cli.New(childEnv, sc.Net, sc.Logger)
 
 	// Wait for all nodes to be synced before we proceed.
-	if err := sc.waitNodesSynced(); err != nil {
+	if err := sc.waitNodesSynced(ctx); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_governance.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_governance.go
@@ -227,7 +227,7 @@ func (sc *runtimeGovernanceImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *runtimeGovernanceImpl) Run(childEnv *env.Env) error {
+func (sc *runtimeGovernanceImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
@@ -238,11 +238,10 @@ func (sc *runtimeGovernanceImpl) Run(childEnv *env.Env) error {
 	}
 
 	// Wait for all nodes to start.
-	if _, err = sc.initialEpochTransitions(fixture); err != nil {
+	if _, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
 
-	ctx := context.Background()
 	var rtNonce uint64
 
 	// Filter compute runtimes.

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_message.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_message.go
@@ -48,7 +48,7 @@ func (sc *runtimeMessageImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *runtimeMessageImpl) Run(childEnv *env.Env) error {
+func (sc *runtimeMessageImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
@@ -59,11 +59,10 @@ func (sc *runtimeMessageImpl) Run(childEnv *env.Env) error {
 	}
 
 	var epoch beacon.EpochTime
-	if epoch, err = sc.initialEpochTransitions(fixture); err != nil {
+	if epoch, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
 
-	ctx := context.Background()
 	c := sc.Net.ClientController().RuntimeClient
 
 	blkCh, sub, err := c.WatchBlocks(ctx, runtimeID)

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_prune.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_prune.go
@@ -59,7 +59,7 @@ func (sc *runtimePruneImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *runtimePruneImpl) Run(childEnv *env.Env) error {
+func (sc *runtimePruneImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
@@ -69,11 +69,10 @@ func (sc *runtimePruneImpl) Run(childEnv *env.Env) error {
 		return err
 	}
 
-	if _, err = sc.initialEpochTransitions(fixture); err != nil {
+	if _, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
 
-	ctx := context.Background()
 	c := sc.Net.ClientController().RuntimeClient
 
 	// Submit transactions.

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_upgrade.go
@@ -232,8 +232,7 @@ func (sc *runtimeUpgradeImpl) ensureActiveVersion(ctx context.Context, v version
 	return nil
 }
 
-func (sc *runtimeUpgradeImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *runtimeUpgradeImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	cli := cli.New(childEnv, sc.Net, sc.Logger)
 
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/runtime/sentry.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/sentry.go
@@ -154,13 +154,13 @@ func (s *sentryImpl) dial(address string, clientOpts *cmnGrpc.ClientOptions) (*g
 	return conn, nil
 }
 
-func (s *sentryImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
+func (s *sentryImpl) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	// Run the basic runtime test.
-	if err := s.Scenario.Run(childEnv); err != nil {
+	if err := s.Scenario.Run(ctx, childEnv); err != nil {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), sentryChecksContextTimeout)
+	ctx, cancel := context.WithTimeout(ctx, sentryChecksContextTimeout)
 	defer cancel()
 
 	// Load identities and addresses used in the sanity checks.

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_early_state_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_early_state_sync.go
@@ -106,12 +106,11 @@ func (sc *storageEarlyStateSyncImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *storageEarlyStateSyncImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
+func (sc *storageEarlyStateSyncImpl) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
 
-	ctx := context.Background()
 	cli := cli.New(childEnv, sc.Net, sc.Logger)
 
 	// Wait for validator nodes to register.

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_sync.go
@@ -86,10 +86,8 @@ func (sc *storageSyncImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *storageSyncImpl) Run(childEnv *env.Env) error { //nolint: gocyclo
+func (sc *storageSyncImpl) Run(ctx context.Context, childEnv *env.Env) error { //nolint: gocyclo
 	var err error
-	ctx := context.Background()
-
 	if err = sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_from_registered.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_from_registered.go
@@ -75,8 +75,7 @@ func (sc *storageSyncFromRegisteredImpl) Fixture() (*oasis.NetworkFixture, error
 	return f, nil
 }
 
-func (sc *storageSyncFromRegisteredImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *storageSyncFromRegisteredImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	var nextEpoch beacon.EpochTime
 
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
@@ -88,7 +87,7 @@ func (sc *storageSyncFromRegisteredImpl) Run(childEnv *env.Env) error {
 		return err
 	}
 
-	if nextEpoch, err = sc.initialEpochTransitions(fixture); err != nil {
+	if nextEpoch, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
 	nextEpoch++

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_inconsistent.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_inconsistent.go
@@ -114,11 +114,10 @@ func (sc *storageSyncInconsistentImpl) wipe(ctx context.Context, worker *oasis.N
 	return os.RemoveAll(persistent.GetPersistentStoreDBDir(worker.DataDir()))
 }
 
-func (sc *storageSyncInconsistentImpl) Run(childEnv *env.Env) error {
+func (sc *storageSyncInconsistentImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	compute0 := sc.Net.ComputeWorkers()[0]
 	messyWorker := sc.Net.ComputeWorkers()[sc.messyStorage]
 	sc.runtimeID = sc.Net.Runtimes()[1].ID()
-	ctx := context.Background()
 
 	if err := sc.Scenario.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
@@ -129,7 +128,7 @@ func (sc *storageSyncInconsistentImpl) Run(childEnv *env.Env) error {
 		return err
 	}
 
-	if _, err = sc.initialEpochTransitions(fixture); err != nil {
+	if _, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
@@ -246,9 +246,7 @@ func (sc *TrustRootImpl) chainContext(ctx context.Context) (string, error) {
 	return cc, nil
 }
 
-func (sc *TrustRootImpl) Run(childEnv *env.Env) (err error) {
-	ctx := context.Background()
-
+func (sc *TrustRootImpl) Run(ctx context.Context, childEnv *env.Env) (err error) {
 	// Determine the required directories for building the runtime with an embedded trust root.
 	buildDir, _ := sc.Flags.GetString(cfgRuntimeSourceDir)
 	targetDir, _ := sc.Flags.GetString(cfgRuntimeTargetDir)

--- a/go/oasis-test-runner/scenario/e2e/runtime/trust_root_change.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/trust_root_change.go
@@ -81,11 +81,11 @@ func (sc *trustRootChangeImpl) Clone() scenario.Scenario {
 	}
 }
 
-func (sc *trustRootChangeImpl) Run(childEnv *env.Env) error {
+func (sc *trustRootChangeImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if !sc.happy {
-		return sc.unhappyRun(childEnv)
+		return sc.unhappyRun(ctx, childEnv)
 	}
-	return sc.happyRun(childEnv)
+	return sc.happyRun(ctx, childEnv)
 }
 
 // happyRun tests that trust is transferred to a new light block when consensus
@@ -104,9 +104,7 @@ func (sc *trustRootChangeImpl) Run(childEnv *env.Env) error {
 //   - Start the network and test if everything works.
 //   - Repeat last two points. Chain context transition can be done repeatedly,
 //     as long as new light blocks are trusted and valid.
-func (sc *trustRootChangeImpl) happyRun(childEnv *env.Env) (err error) {
-	ctx := context.Background()
-
+func (sc *trustRootChangeImpl) happyRun(ctx context.Context, childEnv *env.Env) (err error) {
 	// Step 1: Build a simple key/value runtime and start the network.
 	rebuild, err := sc.BuildRuntimeBinary(ctx, childEnv)
 	if err != nil {
@@ -183,9 +181,7 @@ func (sc *trustRootChangeImpl) happyRun(childEnv *env.Env) (err error) {
 //   - Repeat last two points. This time set genesis height to something big
 //     and remove one validator from the set so that we can simulate what
 //     happens when the new validator set has only 2/3 of the voting power.
-func (sc *trustRootChangeImpl) unhappyRun(childEnv *env.Env) (err error) {
-	ctx := context.Background()
-
+func (sc *trustRootChangeImpl) unhappyRun(ctx context.Context, childEnv *env.Env) (err error) {
 	// Step 1: Build a simple key/value runtime and start the network.
 	rebuild, err := sc.BuildRuntimeBinary(ctx, childEnv)
 	if err != nil {
@@ -272,7 +268,7 @@ func (sc *trustRootChangeImpl) unhappyRun(childEnv *env.Env) (err error) {
 		if err = sc.Net.Start(); err != nil {
 			return err
 		}
-		if err = sc.waitNodesSynced(); err != nil {
+		if err = sc.waitNodesSynced(ctx); err != nil {
 			return err
 		}
 
@@ -418,7 +414,7 @@ func (sc *trustRootChangeImpl) startRestoredStateTestClient(ctx context.Context,
 	// Check that everything works with restored state.
 	seed := fmt.Sprintf("seed %d", round)
 	sc.Scenario.testClient = NewKVTestClient().WithSeed(seed).WithScenario(RemoveKeyValueScenario)
-	if err := sc.Scenario.Run(childEnv); err != nil {
+	if err := sc.Scenario.Run(ctx, childEnv); err != nil {
 		return err
 	}
 	return nil

--- a/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/txsource.go
@@ -538,8 +538,8 @@ func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *txSourceImpl) manager(env *env.Env, errCh chan error) {
-	ctx, cancel := context.WithCancel(context.Background())
+func (sc *txSourceImpl) manager(ctx context.Context, env *env.Env, errCh chan error) {
+	ctx, cancel := context.WithCancel(ctx)
 	// Make sure we exit when the environment gets torn down.
 	stopCh := make(chan struct{})
 	env.AddOnCleanup(func() {
@@ -869,17 +869,15 @@ func (sc *txSourceImpl) Clone() scenario.Scenario {
 	}
 }
 
-func (sc *txSourceImpl) Run(childEnv *env.Env) error {
+func (sc *txSourceImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return fmt.Errorf("scenario net Start: %w", err)
 	}
 
 	// Wait for all nodes to be synced before we proceed.
-	if err := sc.waitNodesSynced(); err != nil {
+	if err := sc.waitNodesSynced(ctx); err != nil {
 		return err
 	}
-
-	ctx := context.Background()
 
 	sc.Logger.Info("waiting for network to come up")
 	if err := sc.Net.Controller().WaitNodesRegistered(ctx, sc.Net.NumRegisterNodes()); err != nil {
@@ -902,7 +900,7 @@ func (sc *txSourceImpl) Run(childEnv *env.Env) error {
 		}
 	}
 	// Start background scenario manager.
-	go sc.manager(childEnv, errCh)
+	go sc.manager(ctx, childEnv, errCh)
 
 	// Wait for any workload to terminate.
 	var err error

--- a/go/oasis-test-runner/scenario/e2e/seed_api.go
+++ b/go/oasis-test-runner/scenario/e2e/seed_api.go
@@ -41,12 +41,10 @@ func (sc *seedAPI) Clone() scenario.Scenario {
 	}
 }
 
-func (sc *seedAPI) Run(childEnv *env.Env) error { // nolint: gocyclo
+func (sc *seedAPI) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	if err := sc.Net.Start(); err != nil {
 		return fmt.Errorf("net Start: %w", err)
 	}
-
-	ctx := context.Background()
 
 	sc.Logger.Info("waiting for network to come up")
 	if err := sc.Net.Controller().WaitNodesRegistered(ctx, 3); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/upgrade_cancel.go
+++ b/go/oasis-test-runner/scenario/e2e/upgrade_cancel.go
@@ -22,13 +22,12 @@ var NodeUpgradeCancel scenario.Scenario = newNodeUpgradeCancelImpl()
 type nodeUpgradeCancelImpl struct {
 	Scenario
 
-	ctx          context.Context
 	currentEpoch beacon.EpochTime
 }
 
-func (sc *nodeUpgradeCancelImpl) nextEpoch() error {
+func (sc *nodeUpgradeCancelImpl) nextEpoch(ctx context.Context) error {
 	sc.currentEpoch++
-	if err := sc.Net.Controller().SetEpoch(sc.ctx, sc.currentEpoch); err != nil {
+	if err := sc.Net.Controller().SetEpoch(ctx, sc.currentEpoch); err != nil {
 		return fmt.Errorf("failed to set epoch to %d: %w", sc.currentEpoch, err)
 	}
 	return nil
@@ -37,7 +36,6 @@ func (sc *nodeUpgradeCancelImpl) nextEpoch() error {
 func newNodeUpgradeCancelImpl() scenario.Scenario {
 	sc := &nodeUpgradeCancelImpl{
 		Scenario: *NewScenario("node-upgrade-cancel"),
-		ctx:      context.Background(),
 	}
 	return sc
 }
@@ -45,7 +43,6 @@ func newNodeUpgradeCancelImpl() scenario.Scenario {
 func (sc *nodeUpgradeCancelImpl) Clone() scenario.Scenario {
 	return &nodeUpgradeCancelImpl{
 		Scenario: sc.Scenario.Clone(),
-		ctx:      context.Background(),
 	}
 }
 
@@ -78,7 +75,7 @@ func (sc *nodeUpgradeCancelImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return ff, nil
 }
 
-func (sc *nodeUpgradeCancelImpl) Run(childEnv *env.Env) error {
+func (sc *nodeUpgradeCancelImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	var err error
 
 	if err = sc.Net.Start(); err != nil {
@@ -86,10 +83,10 @@ func (sc *nodeUpgradeCancelImpl) Run(childEnv *env.Env) error {
 	}
 
 	sc.Logger.Info("waiting for network to come up")
-	if err = sc.Net.Controller().WaitNodesRegistered(sc.ctx, len(sc.Net.Validators())); err != nil {
+	if err = sc.Net.Controller().WaitNodesRegistered(ctx, len(sc.Net.Validators())); err != nil {
 		return err
 	}
-	if err = sc.nextEpoch(); err != nil {
+	if err = sc.nextEpoch(ctx); err != nil {
 		return err
 	}
 
@@ -122,7 +119,7 @@ func (sc *nodeUpgradeCancelImpl) Run(childEnv *env.Env) error {
 		return fmt.Errorf("error submitting upgrade descriptor to node: %w", err)
 	}
 
-	if err = sc.nextEpoch(); err != nil {
+	if err = sc.nextEpoch(ctx); err != nil {
 		return err
 	}
 
@@ -137,10 +134,10 @@ func (sc *nodeUpgradeCancelImpl) Run(childEnv *env.Env) error {
 		return fmt.Errorf("error canceling upgrade: %w", err)
 	}
 
-	if err = sc.nextEpoch(); err != nil {
+	if err = sc.nextEpoch(ctx); err != nil {
 		return err
 	}
-	if err = sc.nextEpoch(); err != nil {
+	if err = sc.nextEpoch(ctx); err != nil {
 		return err
 	}
 	// This brings us to epoch 4. If the node failed to cancel the upgrade, it'll be dead by now.

--- a/go/oasis-test-runner/scenario/e2e/validator_equivocation.go
+++ b/go/oasis-test-runner/scenario/e2e/validator_equivocation.go
@@ -85,7 +85,7 @@ func (sc *validatorEquivocationImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *validatorEquivocationImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
+func (sc *validatorEquivocationImpl) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
@@ -93,7 +93,6 @@ func (sc *validatorEquivocationImpl) Run(childEnv *env.Env) error { // nolint: g
 	ctrl := sc.Net.Controller()
 
 	sc.Logger.Info("waiting for network to come up")
-	ctx := context.Background()
 	if err := ctrl.WaitNodesRegistered(ctx, len(sc.Net.Validators())); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/pluginsigner/basic.go
+++ b/go/oasis-test-runner/scenario/pluginsigner/basic.go
@@ -1,6 +1,7 @@
 package pluginsigner
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 
@@ -30,7 +31,7 @@ func (sc *basicImpl) Clone() scenario.Scenario {
 	}
 }
 
-func (sc *basicImpl) Run(childEnv *env.Env) error {
+func (sc *basicImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	roles := []signature.SignerRole{
 		signature.SignerEntity,
 		signature.SignerNode,

--- a/go/oasis-test-runner/scenario/remotesigner/basic.go
+++ b/go/oasis-test-runner/scenario/remotesigner/basic.go
@@ -1,6 +1,7 @@
 package remotesigner
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -34,7 +35,7 @@ func (sc *basicImpl) Clone() scenario.Scenario {
 	}
 }
 
-func (sc *basicImpl) Run(childEnv *env.Env) error {
+func (sc *basicImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	// Provision the server keys.
 	sc.logger.Info("provisioning the server keys")
 	serverBinary, _ := sc.flags.GetString(cfgServerBinary)

--- a/go/oasis-test-runner/scenario/scenario.go
+++ b/go/oasis-test-runner/scenario/scenario.go
@@ -2,6 +2,8 @@
 package scenario
 
 import (
+	"context"
+
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
 )
@@ -37,5 +39,5 @@ type Scenario interface {
 	Init(childEnv *env.Env, net *oasis.Network) error
 
 	// Run runs the scenario.
-	Run(childEnv *env.Env) error
+	Run(ctx context.Context, childEnv *env.Env) error
 }


### PR DESCRIPTION
The test runner and scenarios can now be configured to run for a limited duration, and test scenarios are now simplified as the job of creating the context is now the responsibility of the caller.