### PR TITLE
go/worker/client/committee/node: Cleanup method Query

### DIFF
--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -132,13 +132,6 @@ type ClientBackend interface {
 	// client verification.
 	GetLightBlock(ctx context.Context, height int64) (*LightBlock, error)
 
-	// GetLightBlockForState returns a light block for the state as of executing the consensus layer
-	// block at the specified height. Note that the height of the returned block may differ
-	// depending on consensus layer implementation details.
-	//
-	// In case light block for the given height is not yet available, it returns ErrVersionNotFound.
-	GetLightBlockForState(ctx context.Context, height int64) (*LightBlock, error)
-
 	// State returns a MKVS read syncer that can be used to read consensus state from a remote node
 	// and verify it against the trusted local root.
 	State() syncer.ReadSyncer

--- a/go/consensus/api/grpc.go
+++ b/go/consensus/api/grpc.go
@@ -38,8 +38,6 @@ var (
 	methodGetBlock = serviceName.NewMethod("GetBlock", int64(0))
 	// methodGetLightBlock is the GetLightBlock method.
 	methodGetLightBlock = serviceName.NewMethod("GetLightBlock", int64(0))
-	// methodGetLightBlockForState is the GetLightBlockForState method.
-	methodGetLightBlockForState = serviceName.NewMethod("GetLightBlockForState", int64(0))
 	// methodGetTransactions is the GetTransactions method.
 	methodGetTransactions = serviceName.NewMethod("GetTransactions", int64(0))
 	// methodGetTransactionsWithResults is the GetTransactionsWithResults method.
@@ -106,10 +104,6 @@ var (
 			{
 				MethodName: methodGetLightBlock.ShortName(),
 				Handler:    handlerGetLightBlock,
-			},
-			{
-				MethodName: methodGetLightBlockForState.ShortName(),
-				Handler:    handlerGetLightBlockForState,
 			},
 			{
 				MethodName: methodGetTransactions.ShortName(),
@@ -354,29 +348,6 @@ func handlerGetLightBlock(
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ClientBackend).GetLightBlock(ctx, req.(int64))
-	}
-	return interceptor(ctx, height, info, handler)
-}
-
-func handlerGetLightBlockForState(
-	srv interface{},
-	ctx context.Context,
-	dec func(interface{}) error,
-	interceptor grpc.UnaryServerInterceptor,
-) (interface{}, error) {
-	var height int64
-	if err := dec(&height); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(ClientBackend).GetLightBlockForState(ctx, height)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: methodGetLightBlockForState.FullName(),
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ClientBackend).GetLightBlockForState(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -748,14 +719,6 @@ func (c *consensusClient) GetBlock(ctx context.Context, height int64) (*Block, e
 func (c *consensusClient) GetLightBlock(ctx context.Context, height int64) (*LightBlock, error) {
 	var rsp LightBlock
 	if err := c.conn.Invoke(ctx, methodGetLightBlock.FullName(), height, &rsp); err != nil {
-		return nil, err
-	}
-	return &rsp, nil
-}
-
-func (c *consensusClient) GetLightBlockForState(ctx context.Context, height int64) (*LightBlock, error) {
-	var rsp LightBlock
-	if err := c.conn.Invoke(ctx, methodGetLightBlockForState.FullName(), height, &rsp); err != nil {
 		return nil, err
 	}
 	return &rsp, nil

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -348,9 +348,6 @@ pub struct Features {
     /// A feature specifying that the runtime supports rotating key manager's master secret.
     #[cbor(optional)]
     pub key_manager_master_secret_rotation: bool,
-    /// A feature specifying that the runtime supports same-block consensus validation.
-    #[cbor(optional)]
-    pub same_block_consensus_validation: bool,
 }
 
 impl Default for Features {
@@ -360,7 +357,6 @@ impl Default for Features {
             key_manager_quote_policy_updates: true,
             key_manager_status_updates: true,
             key_manager_master_secret_rotation: false,
-            same_block_consensus_validation: true,
         }
     }
 }


### PR DESCRIPTION
Should be merged after Oasis Core 23.0.x with same-block consensus validation is released.
See also https://github.com/oasisprotocol/oasis-core/pull/5300.