### PR TITLE
go/oasis-test-runner: Build key manager runtime with trust root 

### DIFF
--- a/.changelog/5307.internal.md
+++ b/.changelog/5307.internal.md
@@ -1,0 +1,4 @@
+go/oasis-test-runner: Build key manager runtime with trust root
+
+The runtime trust-root scenarios now build not only the simple key/value
+but also the key manager runtime with an embedded trust root.

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -603,6 +603,11 @@ func (sc *Scenario) waitNodesSynced(ctx context.Context) error {
 			return err
 		}
 	}
+	for _, n := range sc.Net.Keymanagers() {
+		if err := checkSynced(n.Node); err != nil {
+			return err
+		}
+	}
 	for _, n := range sc.Net.ComputeWorkers() {
 		if err := checkSynced(n.Node); err != nil {
 			return err

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_client_kv.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_client_kv.go
@@ -188,6 +188,8 @@ func (cli *KVTestClient) submit(ctx context.Context, req interface{}, rng rand.S
 			rng.Uint64(),
 			req.Key,
 			req.Value,
+			req.Encrypted,
+			req.Generation,
 		)
 		if err != nil {
 			return err
@@ -352,21 +354,30 @@ func (sc *Scenario) submitKeyValueRuntimeInsertMsg(
 	id common.Namespace,
 	nonce uint64,
 	key, value string,
+	encrypted bool,
+	generation uint64,
 ) error {
-	sc.Logger.Info("submitting incoming runtime message")
+	sc.Logger.Info("submitting incoming runtime message",
+		"key", key,
+		"value", value,
+		"encrypted", encrypted,
+		"generation", generation,
+	)
 
-	err := sc.submitRuntimeInMsg(ctx, id, nonce, "insert", struct {
-		Key   string `json:"key"`
-		Value string `json:"value"`
+	args := struct {
+		Key        string `json:"key"`
+		Value      string `json:"value"`
+		Generation uint64 `json:"generation,omitempty"`
 	}{
-		Key:   key,
-		Value: value,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to submit insert incoming runtime message: %w", err)
+		Key:        key,
+		Value:      value,
+		Generation: generation,
 	}
 
-	return nil
+	if encrypted {
+		return sc.submitRuntimeInMsg(ctx, id, nonce, "enc_insert", args)
+	}
+	return sc.submitRuntimeInMsg(ctx, id, nonce, "insert", args)
 }
 
 func (sc *Scenario) submitAndDecodeRuntimeQuery(

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_client_kv_scenario.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_client_kv_scenario.go
@@ -10,8 +10,17 @@ var (
 		GetKeyValueTx{"my_key", "my_value", false, 0},
 	})
 
+	InsertKeyValueEncScenario = NewTestClientScenario([]interface{}{
+		InsertKeyValueTx{"my_key", "my_value", "", true, 0},
+		GetKeyValueTx{"my_key", "my_value", true, 0},
+	})
+
 	RemoveKeyValueScenario = NewTestClientScenario([]interface{}{
 		GetKeyValueTx{"my_key", "my_value", false, 0},
+	})
+
+	RemoveKeyValueEncScenario = NewTestClientScenario([]interface{}{
+		GetKeyValueTx{"my_key", "my_value", true, 0},
 	})
 
 	InsertTransferKeyValueScenario = NewTestClientScenario([]interface{}{
@@ -34,12 +43,14 @@ var (
 		GetKeyValueTx{"my_key2", "", true, 0},
 	})
 
-	SimpleKeyValueScenario = newSimpleKeyValueScenario(false)
+	SimpleKeyValueScenario = newSimpleKeyValueScenario(false, false)
 
-	SimpleKeyValueScenarioRepeated = newSimpleKeyValueScenario(true)
+	SimpleKeyValueEncScenario = newSimpleKeyValueScenario(false, true)
+
+	SimpleKeyValueScenarioRepeated = newSimpleKeyValueScenario(true, false)
 )
 
-func newSimpleKeyValueScenario(repeat bool) TestClientScenario {
+func newSimpleKeyValueScenario(repeat bool, encrypted bool) TestClientScenario {
 	return func(submit func(req interface{}) error) error {
 		// Check whether Runtime ID is also set remotely.
 		//
@@ -60,10 +71,10 @@ func newSimpleKeyValueScenario(repeat bool) TestClientScenario {
 				response = fmt.Sprintf("hello_value_from_%s:%d", runtimeID, iter-1)
 			}
 
-			if err := submit(InsertKeyValueTx{key, value, response, false, 0}); err != nil {
+			if err := submit(InsertKeyValueTx{key, value, response, encrypted, 0}); err != nil {
 				return err
 			}
-			if err := submit(GetKeyValueTx{key, value, false, 0}); err != nil {
+			if err := submit(GetKeyValueTx{key, value, encrypted, 0}); err != nil {
 				return err
 			}
 
@@ -75,13 +86,13 @@ func newSimpleKeyValueScenario(repeat bool) TestClientScenario {
 				response = value
 			}
 
-			if err := submit(InsertKeyValueTx{key, value, response, false, 0}); err != nil {
+			if err := submit(InsertKeyValueTx{key, value, response, encrypted, 0}); err != nil {
 				return err
 			}
 			if err := submit(ConsensusTransferTx{}); err != nil {
 				return err
 			}
-			if err := submit(GetKeyValueTx{key, value, false, 0}); err != nil {
+			if err := submit(GetKeyValueTx{key, value, encrypted, 0}); err != nil {
 				return err
 			}
 
@@ -95,10 +106,10 @@ func newSimpleKeyValueScenario(repeat bool) TestClientScenario {
 			inMsgKey   = "in_msg"
 			inMsgValue = "hello world from inmsg"
 		)
-		if err := submit(InsertMsg{inMsgKey, inMsgValue}); err != nil {
+		if err := submit(InsertMsg{inMsgKey, inMsgValue, encrypted, 0}); err != nil {
 			return err
 		}
-		if err := submit(GetKeyValueTx{inMsgKey, inMsgValue, false, 0}); err != nil {
+		if err := submit(GetKeyValueTx{inMsgKey, inMsgValue, encrypted, 0}); err != nil {
 			return err
 		}
 		if err := submit(ConsensusAccountsTx{}); err != nil {
@@ -146,8 +157,10 @@ type RemoveKeyValueTx struct {
 
 // InsertMsg inserts an incoming runtime message.
 type InsertMsg struct {
-	Key   string
-	Value string
+	Key        string
+	Value      string
+	Encrypted  bool
+	Generation uint64
 }
 
 // GetRuntimeIDTx retrieves the runtime ID.

--- a/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
@@ -25,7 +25,7 @@ import (
 // TrustRoot is the consensus trust root verification scenario.
 var TrustRoot scenario.Scenario = NewTrustRootImpl(
 	"simple",
-	NewKVTestClient().WithScenario(SimpleKeyValueScenario),
+	NewKVTestClient().WithScenario(SimpleKeyValueEncScenario),
 )
 
 type trustRoot struct {
@@ -385,6 +385,7 @@ func (sc *TrustRootImpl) Run(ctx context.Context, childEnv *env.Env) (err error)
 		key := fmt.Sprintf("my_key_%d", i)
 		value := fmt.Sprintf("my_value_%d", i)
 
+		// Use non-encrypted transactions, as queries don't support decryption.
 		queries = append(queries,
 			InsertKeyValueTx{key, value, "", false, 0},
 			KeyValueQuery{key, value, roothash.RoundLatest},

--- a/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/hashicorp/go-multierror"
+
+	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
@@ -28,7 +31,6 @@ var TrustRoot scenario.Scenario = NewTrustRootImpl(
 type trustRoot struct {
 	height       string
 	hash         string
-	runtimeID    string
 	chainContext string
 }
 
@@ -65,6 +67,9 @@ func (sc *TrustRootImpl) Fixture() (*oasis.NetworkFixture, error) {
 
 	// Make sure no nodes are started initially as we need to determine the trust root and build an
 	// appropriate runtime with the trust root embedded.
+	for i := range f.Keymanagers {
+		f.Keymanagers[i].NoAutoStart = true
+	}
 	for i := range f.ComputeWorkers {
 		f.ComputeWorkers[i].NoAutoStart = true
 	}
@@ -75,85 +80,86 @@ func (sc *TrustRootImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *TrustRootImpl) buildRuntimeBinary(ctx context.Context, childEnv *env.Env, root trustRoot) (func() error, error) {
-	sc.Logger.Info("building runtime with embedded trust root",
-		"height", root.height,
-		"hash", root.hash,
-		"runtime_id", root.runtimeID,
-		"chain_context", root.chainContext,
-	)
-
+func (sc *TrustRootImpl) buildRuntimes(ctx context.Context, childEnv *env.Env, runtimes map[common.Namespace]string, trustRoot *trustRoot) error {
 	// Determine the required directories for building the runtime with an embedded trust root.
 	buildDir, _ := sc.Flags.GetString(cfgRuntimeSourceDir)
 	targetDir, _ := sc.Flags.GetString(cfgRuntimeTargetDir)
-	if len(buildDir) == 0 || len(targetDir) == 0 {
-		return nil, fmt.Errorf("runtime build dir and/or target dir not configured")
+	if buildDir == "" || targetDir == "" {
+		return fmt.Errorf("runtime build dir and/or target dir not configured")
 	}
 
-	// Build a new runtime with the given trust root embedded.
-	teeHardware, _ := sc.getTEEHardware()
-	builder := rust.NewBuilder(childEnv, teeHardware, runtimeBinary, filepath.Join(buildDir, runtimeBinary), targetDir)
-	builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_HEIGHT", root.height)
-	builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_HASH", root.hash)
-	builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_RUNTIME_ID", root.runtimeID)
-	builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_CHAIN_CONTEXT", root.chainContext)
-	if err := builder.Build(); err != nil {
-		return nil, fmt.Errorf("failed to build runtime '%s' with trust root: %w", runtimeBinary, err)
+	// Determine TEE hardware.
+	teeHardware, err := sc.getTEEHardware()
+	if err != nil {
+		return err
 	}
 
-	rebuild := func() error {
-		sc.Logger.Info("rebuilding runtime without the embedded trust root")
-		builder.ResetEnv()
-		if buildErr := builder.Build(); buildErr != nil {
-			return fmt.Errorf("failed to build plain runtime '%s': %w", runtimeBinary, buildErr)
+	// Prepare the builder.
+	builder := rust.NewBuilder(childEnv, buildDir, targetDir, teeHardware)
+
+	// Build runtimes one by one.
+	var errs *multierror.Error
+	for runtimeID, runtimeBinary := range runtimes {
+		switch trustRoot {
+		case nil:
+			sc.Logger.Info("building runtime without embedded trust root",
+				"runtime_id", runtimeID,
+				"runtime_binary", runtimeBinary,
+			)
+		default:
+			sc.Logger.Info("building runtime with embedded trust root",
+				"runtime_id", runtimeID,
+				"runtime_binary", runtimeBinary,
+				"trust_root_height", trustRoot.hash,
+				"trust_root_hash", trustRoot.hash,
+				"trust_root_chainContext", trustRoot.chainContext,
+			)
+
+			// Prepare environment.
+			builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_HEIGHT", trustRoot.height)
+			builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_HASH", trustRoot.hash)
+			builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_CHAIN_CONTEXT", trustRoot.chainContext)
+			builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_RUNTIME_ID", runtimeID.String())
 		}
-		return nil
+
+		// Build a new runtime with the given trust root embedded.
+		if err = builder.Build(runtimeBinary); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+	if err = errs.ErrorOrNil(); err != nil {
+		return fmt.Errorf("failed to build runtimes: %w", err)
 	}
 
-	return rebuild, nil
+	return nil
 }
 
-func (sc *TrustRootImpl) registerRuntimes(ctx context.Context, childEnv *env.Env) error {
-	// Nonce used for transactions (increase this by 1 after each transaction).
-	var nonce uint64
-	cli := cli.New(childEnv, sc.Net, sc.Logger)
-
-	// Fetch current epoch.
-	epoch, err := sc.Net.Controller().Beacon.GetEpoch(ctx, consensus.HeightLatest)
-	if err != nil {
-		return fmt.Errorf("failed to get current epoch: %w", err)
+func (sc *TrustRootImpl) buildAllRuntimes(ctx context.Context, childEnv *env.Env, trustRoot *trustRoot) error {
+	runtimes := map[common.Namespace]string{
+		runtimeID:    runtimeBinary,
+		keymanagerID: keyManagerBinary,
 	}
 
-	// Register a new keymanager runtime.
-	kmRt := sc.Net.Runtimes()[0]
-	rtDsc := kmRt.ToRuntimeDescriptor()
-	rtDsc.Deployments[0].ValidFrom = epoch + 2
-	kmTxPath := filepath.Join(childEnv.Dir(), "register_km_runtime.json")
-	if err = cli.Registry.GenerateRegisterRuntimeTx(childEnv.Dir(), rtDsc, nonce, kmTxPath); err != nil {
-		return fmt.Errorf("failed to generate register KM runtime tx: %w", err)
-	}
-	nonce++
-	if err = cli.Consensus.SubmitTx(kmTxPath); err != nil {
-		return fmt.Errorf("failed to register KM runtime: %w", err)
+	return sc.buildRuntimes(ctx, childEnv, runtimes, trustRoot)
+}
+
+func (sc *TrustRootImpl) registerRuntime(ctx context.Context, childEnv *env.Env, cli *cli.Helpers, rt *oasis.Runtime, validFrom beacon.EpochTime, nonce uint64) error {
+	dsc := rt.ToRuntimeDescriptor()
+	dsc.Deployments[0].ValidFrom = validFrom
+
+	txPath := filepath.Join(childEnv.Dir(), fmt.Sprintf("register_runtime_%s.json", rt.ID()))
+	if err := cli.Registry.GenerateRegisterRuntimeTx(childEnv.Dir(), dsc, nonce, txPath); err != nil {
+		return fmt.Errorf("failed to generate register runtime tx: %w", err)
 	}
 
-	// Register a new compute runtime.
-	// Note that the bundles need to be refreshed before setting the key manager policy.
-	compRt := sc.Net.Runtimes()[1]
-	if err = compRt.RefreshRuntimeBundles(); err != nil {
-		return fmt.Errorf("failed to refresh runtime bundles: %w", err)
-	}
-	compRtDesc := compRt.ToRuntimeDescriptor()
-	compRtDesc.Deployments[0].ValidFrom = epoch + 2
-	txPath := filepath.Join(childEnv.Dir(), "register_compute_runtime.json")
-	if err = cli.Registry.GenerateRegisterRuntimeTx(childEnv.Dir(), compRtDesc, nonce, txPath); err != nil {
-		return fmt.Errorf("failed to generate register compute runtime tx: %w", err)
-	}
-	nonce++
-	if err = cli.Consensus.SubmitTx(txPath); err != nil {
-		return fmt.Errorf("failed to register compute runtime: %w", err)
+	if err := cli.Consensus.SubmitTx(txPath); err != nil {
+		return fmt.Errorf("failed to register runtime: %w", err)
 	}
 
+	return nil
+}
+
+func (sc *TrustRootImpl) updateKeyManagerPolicy(ctx context.Context, childEnv *env.Env, cli *cli.Helpers, nonce uint64) error {
 	// Generate and update the new keymanager runtime's policy.
 	kmPolicyPath := filepath.Join(childEnv.Dir(), "km_policy.cbor")
 	kmPolicySig1Path := filepath.Join(childEnv.Dir(), "km_policy_sig1.pem")
@@ -162,6 +168,7 @@ func (sc *TrustRootImpl) registerRuntimes(ctx context.Context, childEnv *env.Env
 	kmUpdateTxPath := filepath.Join(childEnv.Dir(), "km_gen_update.json")
 	sc.Logger.Info("building KM SGX policy enclave policies map")
 	enclavePolicies := make(map[sgx.EnclaveIdentity]*keymanager.EnclavePolicySGX)
+	kmRt := sc.Net.Runtimes()[0]
 	kmRtEncID := kmRt.GetEnclaveIdentity(0)
 	var havePolicy bool
 	if kmRtEncID != nil {
@@ -180,35 +187,27 @@ func (sc *TrustRootImpl) registerRuntimes(ctx context.Context, childEnv *env.Env
 		}
 	}
 	sc.Logger.Info("initing KM policy")
-	if err = cli.Keymanager.InitPolicy(kmRt.ID(), 1, enclavePolicies, kmPolicyPath); err != nil {
+	if err := cli.Keymanager.InitPolicy(kmRt.ID(), 1, enclavePolicies, kmPolicyPath); err != nil {
 		return err
 	}
 	sc.Logger.Info("signing KM policy")
-	if err = cli.Keymanager.SignPolicy("1", kmPolicyPath, kmPolicySig1Path); err != nil {
+	if err := cli.Keymanager.SignPolicy("1", kmPolicyPath, kmPolicySig1Path); err != nil {
 		return err
 	}
-	if err = cli.Keymanager.SignPolicy("2", kmPolicyPath, kmPolicySig2Path); err != nil {
+	if err := cli.Keymanager.SignPolicy("2", kmPolicyPath, kmPolicySig2Path); err != nil {
 		return err
 	}
-	if err = cli.Keymanager.SignPolicy("3", kmPolicyPath, kmPolicySig3Path); err != nil {
+	if err := cli.Keymanager.SignPolicy("3", kmPolicyPath, kmPolicySig3Path); err != nil {
 		return err
 	}
 	if havePolicy {
 		// In SGX mode, we can update the policy as intended.
 		sc.Logger.Info("updating KM policy")
-		if err = cli.Keymanager.GenUpdate(nonce, kmPolicyPath, []string{kmPolicySig1Path, kmPolicySig2Path, kmPolicySig3Path}, kmUpdateTxPath); err != nil {
+		if err := cli.Keymanager.GenUpdate(nonce, kmPolicyPath, []string{kmPolicySig1Path, kmPolicySig2Path, kmPolicySig3Path}, kmUpdateTxPath); err != nil {
 			return err
 		}
-		if err = cli.Consensus.SubmitTx(kmUpdateTxPath); err != nil {
+		if err := cli.Consensus.SubmitTx(kmUpdateTxPath); err != nil {
 			return fmt.Errorf("failed to update KM policy: %w", err)
-		}
-	}
-
-	// Wait for key manager nodes to register.
-	sc.Logger.Info("waiting for key manager nodes to initialize")
-	for _, n := range sc.Net.Keymanagers() {
-		if err = n.WaitReady(ctx); err != nil {
-			return fmt.Errorf("failed to wait for a key manager node: %w", err)
 		}
 	}
 
@@ -246,76 +245,85 @@ func (sc *TrustRootImpl) chainContext(ctx context.Context) (string, error) {
 	return cc, nil
 }
 
-func (sc *TrustRootImpl) Run(ctx context.Context, childEnv *env.Env) (err error) {
-	// Determine the required directories for building the runtime with an embedded trust root.
-	buildDir, _ := sc.Flags.GetString(cfgRuntimeSourceDir)
-	targetDir, _ := sc.Flags.GetString(cfgRuntimeTargetDir)
-	if len(buildDir) == 0 || len(targetDir) == 0 {
-		return fmt.Errorf("runtime build dir and/or target dir not configured")
+func (sc *TrustRootImpl) trustRoot(ctx context.Context) (*trustRoot, error) {
+	sc.Logger.Info("preparing trust root")
+
+	// Let the network run for few blocks to select a suitable trust root.
+	block, err := sc.waitBlocks(ctx, 5)
+	if err != nil {
+		return nil, err
 	}
 
+	chainContext, err := sc.chainContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &trustRoot{
+		height:       strconv.FormatInt(block.Height, 10),
+		hash:         block.Hash.Hex(),
+		chainContext: chainContext,
+	}, nil
+}
+
+// PreRun starts the network, prepares a trust root, builds simple key/value and key manager
+// runtimes, prepares runtime bundles, and runs the test client.
+func (sc *TrustRootImpl) PreRun(ctx context.Context, childEnv *env.Env) (err error) {
+	cli := cli.New(childEnv, sc.Net, sc.Logger)
+
+	// Nonce used for transactions (increase this by 1 after each transaction).
+	var nonce uint64
+
+	// Start generating blocks.
 	if err = sc.Net.Start(); err != nil {
 		return err
 	}
+	if err = sc.Net.Controller().WaitNodesRegistered(ctx, len(sc.Net.Validators())); err != nil {
+		return err
+	}
 
-	// Let the network run for 10 blocks to select a suitable trust root.
 	// Pick one block and use it as an embedded trust root.
-	block, err := sc.waitBlocks(ctx, 10)
+	trustRoot, err := sc.trustRoot(ctx)
 	if err != nil {
 		return err
 	}
-	chainContext, err := sc.chainContext(ctx)
-	if err != nil {
-		return err
-	}
-	root := trustRoot{
-		height:       strconv.FormatInt(block.Height, 10),
-		hash:         block.Hash.Hex(),
-		runtimeID:    runtimeID.String(),
-		chainContext: chainContext,
-	}
 
-	rebuild, err := sc.buildRuntimeBinary(ctx, childEnv, root)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err2 := rebuild(); err2 != nil {
-			err = fmt.Errorf("%w (original error: %s)", err2, err)
-		}
-	}()
-
-	// Now that the runtime is built, let's register it and start all the required workers.
-	if err = sc.registerRuntimes(ctx, childEnv); err != nil {
+	// Build simple key/value and key manager runtimes.
+	if err = sc.buildAllRuntimes(ctx, childEnv, trustRoot); err != nil {
 		return err
 	}
 
-	// Start the compute workers and client.
-	sc.Logger.Info("starting clients and compute workers")
-	for _, n := range sc.Net.Clients() {
-		if err = n.Start(); err != nil {
-			return fmt.Errorf("failed to start node: %w", err)
-		}
-	}
-	for _, n := range sc.Net.ComputeWorkers() {
-		if err = n.Start(); err != nil {
-			return fmt.Errorf("failed to start node: %w", err)
+	// Refresh the bundles. This needs to be done before setting the key manager policy,
+	// to ensure enclave IDs are correct.
+	for _, rt := range sc.Net.Runtimes() {
+		if err = rt.RefreshRuntimeBundles(); err != nil {
+			return fmt.Errorf("failed to refresh runtime bundles: %w", err)
 		}
 	}
 
-	sc.Logger.Info("waiting for compute workers to become ready")
-	for _, n := range sc.Net.ComputeWorkers() {
-		if err = n.WaitReady(ctx); err != nil {
-			return fmt.Errorf("failed to wait for a compute worker: %w", err)
-		}
-	}
-
-	// Setup a client controller (as there is none due to the client node not being autostarted).
-	ctrl, err := oasis.NewController(sc.Net.Clients()[0].SocketPath())
+	// Fetch current epoch.
+	epoch, err := sc.Net.Controller().Beacon.GetEpoch(ctx, consensus.HeightLatest)
 	if err != nil {
-		return fmt.Errorf("failed to create client controller: %w", err)
+		return fmt.Errorf("failed to get current epoch: %w", err)
 	}
-	sc.Net.SetClientController(ctrl)
+
+	// Register the runtimes.
+	for _, rt := range sc.Net.Runtimes() {
+		if err = sc.registerRuntime(ctx, childEnv, cli, rt, epoch+2, nonce); err != nil {
+			return err
+		}
+		nonce++
+	}
+
+	// Update the key manager policy.
+	if err = sc.updateKeyManagerPolicy(ctx, childEnv, cli, nonce); err != nil {
+		return err
+	}
+
+	// Start all the required workers.
+	if err = sc.startClientComputeAndKeyManagerNodes(ctx, childEnv); err != nil {
+		return err
+	}
 
 	// Run the test client workload to ensure that blocks get processed correctly.
 	if err = sc.startTestClientOnly(ctx, childEnv); err != nil {
@@ -324,6 +332,24 @@ func (sc *TrustRootImpl) Run(ctx context.Context, childEnv *env.Env) (err error)
 	if err = sc.waitTestClient(); err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// PostRun re-builds simple key/value and key manager runtimes.
+func (sc *TrustRootImpl) PostRun(ctx context.Context, childEnv *env.Env) error {
+	// In the end, always rebuild all runtimes as we are changing binaries in one of the steps.
+	return sc.buildAllRuntimes(ctx, childEnv, nil)
+}
+
+func (sc *TrustRootImpl) Run(ctx context.Context, childEnv *env.Env) (err error) {
+	if err = sc.PreRun(ctx, childEnv); err != nil {
+		return err
+	}
+	defer func() {
+		err2 := sc.PostRun(ctx, childEnv)
+		err = multierror.Append(err, err2).ErrorOrNil()
+	}()
 
 	sc.Logger.Info("testing query latest block")
 	_, err = sc.submitKeyValueRuntimeGetQuery(
@@ -336,7 +362,7 @@ func (sc *TrustRootImpl) Run(ctx context.Context, childEnv *env.Env) (err error)
 		return err
 	}
 
-	latestBlk, err := ctrl.Roothash.GetLatestBlock(ctx, &roothash.RuntimeRequest{RuntimeID: runtimeID, Height: consensus.HeightLatest})
+	latestBlk, err := sc.Net.ClientController().Roothash.GetLatestBlock(ctx, &roothash.RuntimeRequest{RuntimeID: runtimeID, Height: consensus.HeightLatest})
 	if err != nil {
 		return err
 	}
@@ -372,4 +398,55 @@ func (sc *TrustRootImpl) Run(ctx context.Context, childEnv *env.Env) (err error)
 	}
 
 	return sc.waitTestClient()
+}
+
+func (sc *TrustRootImpl) startClientComputeAndKeyManagerNodes(ctx context.Context, childEnv *env.Env) error {
+	// Start client, compute workers and key manager nodes as they are not auto-started.
+	sc.Logger.Info("starting clients, compute workers and key managers")
+	for _, n := range sc.Net.Clients() {
+		if err := n.Start(); err != nil {
+			return fmt.Errorf("failed to start node: %w", err)
+		}
+	}
+	for _, n := range sc.Net.ComputeWorkers() {
+		if err := n.Start(); err != nil {
+			return fmt.Errorf("failed to start node: %w", err)
+		}
+	}
+	for _, n := range sc.Net.Keymanagers() {
+		if err := n.Start(); err != nil {
+			return fmt.Errorf("failed to start node: %w", err)
+		}
+	}
+
+	sc.Logger.Info("waiting for key manager nodes to become ready")
+	for _, n := range sc.Net.Keymanagers() {
+		if err := n.WaitReady(ctx); err != nil {
+			return fmt.Errorf("failed to wait for a key manager node: %w", err)
+		}
+	}
+
+	sc.Logger.Info("waiting for compute workers to become ready")
+	for _, n := range sc.Net.ComputeWorkers() {
+		if err := n.WaitReady(ctx); err != nil {
+			return fmt.Errorf("failed to wait for a compute worker: %w", err)
+		}
+	}
+
+	sc.Logger.Info("waiting for client nodes to become ready")
+	for _, n := range sc.Net.Clients() {
+		if err := n.WaitReady(ctx); err != nil {
+			return fmt.Errorf("failed to wait for a client node: %w", err)
+		}
+	}
+
+	// Setup a client controller as there is none due to the client node not
+	// being auto-started.
+	ctrl, err := oasis.NewController(sc.Net.Clients()[0].SocketPath())
+	if err != nil {
+		return fmt.Errorf("failed to create client controller: %w", err)
+	}
+	sc.Net.SetClientController(ctrl)
+
+	return nil
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/trust_root_change.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/trust_root_change.go
@@ -3,8 +3,9 @@ package runtime
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
+
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
@@ -13,19 +14,21 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario/e2e"
+	commonWorker "github.com/oasisprotocol/oasis-core/go/worker/common/api"
 )
 
 // Keep the following two constants synced with the Rust part of the code in:
 // runtime/src/consensus/tendermint/verifier/mod.rs.
 const (
 	// LogEventTrustRootChangeNoTrust is the event emitted when a compute
-	// worker fails to initialize the verifier as there is not enough trust
-	// in the new light block.
+	// worker or a key manager node fails to initialize the verifier as there
+	// is not enough trust in the new light block.
 	LogEventTrustRootChangeNoTrust = "consensus/cometbft/verifier/chain_context/no_trust"
 
 	// LogEventTrustRootChangeFailed is the event emitted when a compute
-	// worker fails to initialize the verifier as the new light block is
-	// invalid, e.g. has lower height than the last known trusted block.
+	// worker or a key manager node fails to initialize the verifier as
+	// the new light block is invalid, e.g. has lower height than the last
+	// known trusted block.
 	LogEventTrustRootChangeFailed = "consensus/cometbft/verifier/chain_context/failed"
 )
 
@@ -92,9 +95,9 @@ func (sc *trustRootChangeImpl) Run(ctx context.Context, childEnv *env.Env) error
 // chain context changes if validator set has enough votes.
 //
 // It consists of 3 steps:
-//   - Build a simple key/value runtime with an embedded trust root, register
-//     it to the network together with key manager runtime and test that
-//     everything works.
+//   - Build a simple key/value and key manager runtime with an embedded trust
+//     root, register them to the network together and test that everything
+//     works.
 //   - Do dump/restore procedure which simulates a real network upgrade.
 //     This step will stop the network, clear everything except runtime's
 //     local storage (we need it as the verifier has last trust root
@@ -106,14 +109,12 @@ func (sc *trustRootChangeImpl) Run(ctx context.Context, childEnv *env.Env) error
 //     as long as new light blocks are trusted and valid.
 func (sc *trustRootChangeImpl) happyRun(ctx context.Context, childEnv *env.Env) (err error) {
 	// Step 1: Build a simple key/value runtime and start the network.
-	rebuild, err := sc.BuildRuntimeBinary(ctx, childEnv)
-	if err != nil {
+	if err = sc.PreRun(ctx, childEnv); err != nil {
 		return err
 	}
 	defer func() {
-		if err2 := rebuild(); err2 != nil {
-			err = fmt.Errorf("%w (original error: %s)", err2, err)
-		}
+		err2 := sc.PostRun(ctx, childEnv)
+		err = multierror.Append(err, err2).ErrorOrNil()
 	}()
 
 	// All chain contexts should be unique.
@@ -148,7 +149,7 @@ func (sc *trustRootChangeImpl) happyRun(ctx context.Context, childEnv *env.Env) 
 
 		// Test runtime to be sure that blocks get processed correctly.
 		// We do this by checking if key/value store was successfully restored.
-		if err := sc.startClientAndComputeWorkers(ctx, childEnv); err != nil {
+		if err := sc.startClientComputeAndKeyManagerNodes(ctx, childEnv); err != nil {
 			return err
 		}
 		if err := sc.startRestoredStateTestClient(ctx, childEnv, round); err != nil {
@@ -168,29 +169,28 @@ func (sc *trustRootChangeImpl) happyRun(ctx context.Context, childEnv *env.Env) 
 // light blocks when consensus chain context changes.
 //
 // It consists of 5 steps:
-//   - Build a simple key/value runtime with an embedded trust root, register
-//     it to the network together with key manager runtime and test that
-//     everything works.
+//   - Build a simple key/value and key manager runtime with an embedded trust
+//     root, register them to the network together and test that everything
+//     works.
 //   - Stop the network, set genesis height to 1 and reset the consensus state.
 //     This will cause a chain context change when the network will be started
 //     again. When doing state wipe be careful not to delete compute workers
-//     local storages as they contain sealed trusted roots.
-//   - Start the network. If everything works as expected, compute workers
-//     should never be ready as the verifier cannot transfer trust to light
-//     blocks on a new chain.
+//     and key manager local storages as they contain sealed trusted roots.
+//   - Start the network. If everything works as expected, key manager nodes
+//     should never be ready as the verifier cannot transfer trust the light
+//     blocks on a new chain. As a consequence, the runtime workers will get
+//     stuck waiting for available key manager.
 //   - Repeat last two points. This time set genesis height to something big
 //     and remove one validator from the set so that we can simulate what
 //     happens when the new validator set has only 2/3 of the voting power.
 func (sc *trustRootChangeImpl) unhappyRun(ctx context.Context, childEnv *env.Env) (err error) {
 	// Step 1: Build a simple key/value runtime and start the network.
-	rebuild, err := sc.BuildRuntimeBinary(ctx, childEnv)
-	if err != nil {
+	if err = sc.PreRun(ctx, childEnv); err != nil {
 		return err
 	}
 	defer func() {
-		if err2 := rebuild(); err2 != nil {
-			err = fmt.Errorf("%w (original error: %s)", err2, err)
-		}
+		err2 := sc.PostRun(ctx, childEnv)
+		err = multierror.Append(err, err2).ErrorOrNil()
 	}()
 
 	chainContext, err := sc.chainContext(ctx)
@@ -204,13 +204,17 @@ func (sc *trustRootChangeImpl) unhappyRun(ctx context.Context, childEnv *env.Env
 	f := []func(fixture *oasis.NetworkFixture){
 		// First dump with too low genesis height.
 		func(fixture *oasis.NetworkFixture) {
-			// We only need one compute worker.
+			// We only need one compute worker and one key manager node.
+			fixture.Keymanagers = fixture.Keymanagers[:1]
 			fixture.ComputeWorkers = fixture.ComputeWorkers[:1]
 			fixture.Clients = fixture.Clients[:0]
 
-			// Observe logs for invalid genesis block error messages.
+			// Start both nodes after dump-restore.
+			fixture.Keymanagers[0].NoAutoStart = false
 			fixture.ComputeWorkers[0].NoAutoStart = false
-			fixture.ComputeWorkers[0].LogWatcherHandlerFactories = []log.WatcherHandlerFactory{
+
+			// Observe logs for invalid genesis block error messages.
+			fixture.Keymanagers[0].LogWatcherHandlerFactories = []log.WatcherHandlerFactory{
 				oasis.LogAssertEvent(LogEventTrustRootChangeFailed, "the verifier should emit invalid genesis block event"),
 			}
 		},
@@ -219,12 +223,18 @@ func (sc *trustRootChangeImpl) unhappyRun(ctx context.Context, childEnv *env.Env
 		func(fixture *oasis.NetworkFixture) {
 			// Remove one validator so that trust validation will fail.
 			fixture.Validators = fixture.Validators[:2]
+
+			// We only need one compute worker and one key manager node.
+			fixture.Keymanagers = fixture.Keymanagers[:1]
 			fixture.ComputeWorkers = fixture.ComputeWorkers[:1]
 			fixture.Clients = fixture.Clients[:0]
 
-			// Observe logs for not enough trust error messages.
+			// Start both nodes after dump-restore.
+			fixture.Keymanagers[0].NoAutoStart = false
 			fixture.ComputeWorkers[0].NoAutoStart = false
-			fixture.ComputeWorkers[0].LogWatcherHandlerFactories = []log.WatcherHandlerFactory{
+
+			// Observe logs for not enough trust error messages.
+			fixture.Keymanagers[0].LogWatcherHandlerFactories = []log.WatcherHandlerFactory{
 				oasis.LogAssertEvent(LogEventTrustRootChangeNoTrust, "the verifier should emit not trusted chain event"),
 			}
 		},
@@ -282,77 +292,40 @@ func (sc *trustRootChangeImpl) unhappyRun(ctx context.Context, childEnv *env.Env
 			return fmt.Errorf("chain context hasn't changed")
 		}
 
-		// Starting the key/value runtime should now be a problem for compute
-		// workers as the verifier will never initialize.
+		// The key manager should now have a problem starting the key manager
+		// runtime as the verifier will never initialize. As a consequence,
+		// the runtime worker will get stuck waiting for available key manager.
 		func() {
 			waitCtx, cancel := context.WithTimeout(ctx, time.Minute)
 			defer cancel()
 
-			_ = sc.Net.ComputeWorkers()[0].WaitReady(waitCtx)
+			_ = sc.Net.Keymanagers()[0].WaitReady(waitCtx)
 		}()
 
+		// Verify that the compute worker is stuck.
+		ctrl, err := oasis.NewController(sc.Net.ComputeWorkers()[0].SocketPath())
+		if err != nil {
+			return err
+		}
+		status, err := ctrl.GetStatus(ctx)
+		if err != nil {
+			return err
+		}
+		rtStatus, ok := status.Runtimes[sc.Net.Runtimes()[1].ID()]
+		if !ok {
+			return fmt.Errorf("runtime not supported by the compute worker")
+		}
+		if rtStatus.Committee.Status != commonWorker.StatusStateWaitingKeymanager {
+			return fmt.Errorf("compute worker should be waiting for available key manager")
+		}
+
+		// Verify that the key manager node failed to trust the new trust root.
 		if err := sc.Net.CheckLogWatchers(); err != nil {
 			return err
 		}
 	}
 
 	return nil
-}
-
-func (sc *TrustRootImpl) BuildRuntimeBinary(ctx context.Context, childEnv *env.Env) (func() error, error) {
-	// Start network with validators only, as configured in the fixture.
-	// We need those to produce blocks from which we pick one and use it
-	// as our embedded trust root.
-	if err := sc.Net.Start(); err != nil {
-		return nil, err
-	}
-	if err := sc.Net.Controller().WaitNodesRegistered(ctx, len(sc.Net.Validators())); err != nil {
-		return nil, err
-	}
-
-	// Pick one block and use it as an embedded trust root.
-	block, err := sc.waitBlocks(ctx, 3)
-	if err != nil {
-		return nil, err
-	}
-	chainContext, err := sc.chainContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	root := trustRoot{
-		height:       strconv.FormatInt(block.Height, 10),
-		hash:         block.Hash.Hex(),
-		runtimeID:    runtimeID.String(),
-		chainContext: chainContext,
-	}
-
-	// Build the runtime using given trust root. Observe that we are changing
-	// the binary here, so we need to rebuild the runtime when we are done.
-	rebuild, err := sc.buildRuntimeBinary(ctx, childEnv, root)
-	if err != nil {
-		return nil, err
-	}
-
-	// Once binary with the embedded root is built, we can register runtimes.
-	if err = sc.registerRuntimes(ctx, childEnv); err != nil {
-		return nil, err
-	}
-
-	// Test runtime to be sure that blocks get processed correctly.
-	// Remember that only validators are currently running.
-	if err = sc.startClientAndComputeWorkers(ctx, childEnv); err != nil {
-		return nil, err
-	}
-
-	// Test transactions.
-	if err := sc.startTestClientOnly(ctx, childEnv); err != nil {
-		return nil, err
-	}
-	if err := sc.waitTestClient(); err != nil {
-		return nil, err
-	}
-
-	return rebuild, nil
 }
 
 func (sc *trustRootChangeImpl) dumpRestoreNetwork(childEnv *env.Env, f func(*oasis.NetworkFixture), g func(*genesis.Document)) error {
@@ -375,37 +348,6 @@ func (sc *trustRootChangeImpl) dumpRestoreNetwork(childEnv *env.Env, f func(*oas
 	if err = sc.DumpRestoreNetwork(childEnv, fixture, false, g, resetFlags); err != nil {
 		return err
 	}
-
-	return nil
-}
-
-func (sc *TrustRootImpl) startClientAndComputeWorkers(ctx context.Context, childEnv *env.Env) error {
-	// Start client and compute workers as they are not auto started.
-	sc.Logger.Info("starting clients and compute workers")
-	for _, n := range sc.Net.Clients() {
-		if err := n.Start(); err != nil {
-			return fmt.Errorf("failed to start node: %w", err)
-		}
-	}
-	for _, n := range sc.Net.ComputeWorkers() {
-		if err := n.Start(); err != nil {
-			return fmt.Errorf("failed to start node: %w", err)
-		}
-	}
-	sc.Logger.Info("waiting for compute workers to become ready")
-	for _, n := range sc.Net.ComputeWorkers() {
-		if err := n.WaitReady(ctx); err != nil {
-			return fmt.Errorf("failed to wait for a compute worker: %w", err)
-		}
-	}
-
-	// Setup a client controller as there is none due to the client node not
-	// being auto started.
-	ctrl, err := oasis.NewController(sc.Net.Clients()[0].SocketPath())
-	if err != nil {
-		return fmt.Errorf("failed to create client controller: %w", err)
-	}
-	sc.Net.SetClientController(ctrl)
 
 	return nil
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/trust_root_change.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/trust_root_change.go
@@ -38,7 +38,7 @@ var (
 	// changes, e.g. on dump-restore network upgrades.
 	TrustRootChangeTest scenario.Scenario = newTrustRootChangeImpl(
 		"change",
-		NewKVTestClient().WithScenario(InsertKeyValueScenario),
+		NewKVTestClient().WithScenario(InsertKeyValueEncScenario),
 		true,
 	)
 
@@ -47,7 +47,7 @@ var (
 	// consensus chain context changes.
 	TrustRootChangeFailsTest scenario.Scenario = newTrustRootChangeImpl(
 		"change-fails",
-		NewKVTestClient().WithScenario(SimpleKeyValueScenario),
+		NewKVTestClient().WithScenario(SimpleKeyValueEncScenario),
 		false,
 	)
 )
@@ -355,7 +355,7 @@ func (sc *trustRootChangeImpl) dumpRestoreNetwork(childEnv *env.Env, f func(*oas
 func (sc *trustRootChangeImpl) startRestoredStateTestClient(ctx context.Context, childEnv *env.Env, round int64) error {
 	// Check that everything works with restored state.
 	seed := fmt.Sprintf("seed %d", round)
-	sc.Scenario.testClient = NewKVTestClient().WithSeed(seed).WithScenario(RemoveKeyValueScenario)
+	sc.Scenario.testClient = NewKVTestClient().WithSeed(seed).WithScenario(RemoveKeyValueEncScenario)
 	if err := sc.Scenario.Run(ctx, childEnv); err != nil {
 		return err
 	}

--- a/runtime/src/consensus/tendermint/verifier/noop.rs
+++ b/runtime/src/consensus/tendermint/verifier/noop.rs
@@ -2,8 +2,10 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
+use slog::info;
 
 use crate::{
+    common::logger::get_logger,
     consensus::{
         beacon::EpochTime,
         roothash::Header,
@@ -25,6 +27,12 @@ impl NopVerifier {
     /// Create a new non-verifying verifier.
     pub fn new(protocol: Arc<Protocol>) -> Self {
         Self { protocol }
+    }
+
+    /// Start the non-verifying verifier.
+    pub fn start(&self) {
+        let logger = get_logger("consensus/cometbft/verifier");
+        info!(logger, "Starting consensus noop verifier");
     }
 
     async fn fetch_light_block(&self, height: u64) -> Result<LightBlock, Error> {

--- a/runtime/src/protocol.rs
+++ b/runtime/src/protocol.rs
@@ -450,7 +450,10 @@ impl Protocol {
                 Box::new(handle)
             } else {
                 // Create a no-op verifier.
-                Box::new(tendermint::verifier::NopVerifier::new(self.clone()))
+                let verifier = tendermint::verifier::NopVerifier::new(self.clone());
+                verifier.start();
+
+                Box::new(verifier)
             };
 
         // Configure the host environment info.

--- a/tests/runtimes/simple-keymanager/src/main.rs
+++ b/tests/runtimes/simple-keymanager/src/main.rs
@@ -1,18 +1,39 @@
 use oasis_core_keymanager::runtime::init::new_keymanager;
-use oasis_core_runtime::{common::version::Version, config::Config, types::Features};
+use oasis_core_runtime::{
+    common::version::Version, config::Config, consensus::verifier::TrustRoot, types::Features,
+};
 
 mod api;
 
 pub fn main_with_version(version: Version) {
+    // Initializer.
     let init = new_keymanager(api::trusted_policy_signers());
+
+    // Determine test trust root based on build settings.
+    let trust_root = option_env!("OASIS_TESTS_CONSENSUS_TRUST_HEIGHT").map(|height| {
+        let hash = option_env!("OASIS_TESTS_CONSENSUS_TRUST_HASH").unwrap();
+        let runtime_id = option_env!("OASIS_TESTS_CONSENSUS_TRUST_RUNTIME_ID").unwrap();
+        let chain_context = option_env!("OASIS_TESTS_CONSENSUS_TRUST_CHAIN_CONTEXT").unwrap();
+
+        TrustRoot {
+            height: height.parse::<u64>().unwrap(),
+            hash: hash.to_string(),
+            runtime_id: runtime_id.into(),
+            chain_context: chain_context.to_string(),
+        }
+    });
+
+    // Start the runtime.
     oasis_core_runtime::start_runtime(
         init,
         Config {
             version,
+            trust_root,
             features: Some(Features {
                 key_manager_master_secret_rotation: true,
                 ..Default::default()
             }),
+            freshness_proofs: true,
             ..Default::default()
         },
     );


### PR DESCRIPTION
Build and test the key manager runtime with an embedded trust root.
Use secure operations when running trust root scenarios.