### PR TITLE
[BACKPORT/22.2.x] go/oasis-test-runner: Build key manager runtime with trust root 

### DIFF
--- a/.changelog/5308.internal.md
+++ b/.changelog/5308.internal.md
@@ -1,0 +1,4 @@
+go/oasis-test-runner: Build key manager runtime with trust root
+
+The runtime trust-root scenarios now build not only the simple key/value
+but also the key manager runtime with an embedded trust root.

--- a/go/oasis-test-runner/scenario/e2e/byzantine_beacon_vrf.go
+++ b/go/oasis-test-runner/scenario/e2e/byzantine_beacon_vrf.go
@@ -93,12 +93,10 @@ func (sc *byzantineVRFBeaconImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *byzantineVRFBeaconImpl) Run(childEnv *env.Env) error {
+func (sc *byzantineVRFBeaconImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
-
-	ctx := context.Background()
 
 	// Wait for the validators to come up.
 	sc.Logger.Info("waiting for validators to initialize",

--- a/go/oasis-test-runner/scenario/e2e/consensus_state_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/consensus_state_sync.go
@@ -61,13 +61,12 @@ func (sc *consensusStateSyncImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *consensusStateSyncImpl) Run(childEnv *env.Env) error {
+func (sc *consensusStateSyncImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
 
 	sc.Logger.Info("waiting for network to come up")
-	ctx := context.Background()
 	if err := sc.Net.Controller().WaitNodesRegistered(ctx, len(sc.Net.Validators())-1); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/debond.go
+++ b/go/oasis-test-runner/scenario/e2e/debond.go
@@ -77,12 +77,10 @@ func (s *debondImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (s *debondImpl) Run(*env.Env) error {
+func (s *debondImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := s.Net.Start(); err != nil {
 		return fmt.Errorf("net Start: %w", err)
 	}
-
-	ctx := context.Background()
 
 	s.Logger.Info("waiting for network to come up")
 	if err := s.Net.Controller().WaitNodesRegistered(ctx, 3); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/early_query.go
+++ b/go/oasis-test-runner/scenario/e2e/early_query.go
@@ -57,7 +57,7 @@ func (sc *earlyQueryImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *earlyQueryImpl) Run(childEnv *env.Env) error {
+func (sc *earlyQueryImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	// Start the network.
 	var err error
 	if err = sc.Net.Start(); err != nil {
@@ -66,7 +66,7 @@ func (sc *earlyQueryImpl) Run(childEnv *env.Env) error {
 
 	// Perform some queries.
 	cs := sc.Net.Controller().Consensus
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 
 	// StateToGenesis.

--- a/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
+++ b/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
@@ -119,9 +119,7 @@ func (sc *gasFeesImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return ff, nil
 }
 
-func (sc *gasFeesImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
-
+func (sc *gasFeesImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.runTests(ctx); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/genesis_file.go
+++ b/go/oasis-test-runner/scenario/e2e/genesis_file.go
@@ -60,7 +60,7 @@ func (s *genesisFileImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (s *genesisFileImpl) Run(childEnv *env.Env) error {
+func (s *genesisFileImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	// Manually provision genesis file.
 	s.Logger.Info("manually provisioning genesis file before starting the network")
 	if err := s.Net.MakeGenesis(); err != nil {
@@ -80,7 +80,7 @@ func (s *genesisFileImpl) Run(childEnv *env.Env) error {
 	}
 
 	s.Logger.Info("waiting for network to come up")
-	if err := s.Net.Controller().WaitNodesRegistered(context.Background(), 1); err != nil {
+	if err := s.Net.Controller().WaitNodesRegistered(ctx, 1); err != nil {
 		return fmt.Errorf("e2e/genesis-file: failed to wait for registered nodes: %w", err)
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/identity_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/identity_cli.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 
 	fileSigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/file"
@@ -48,7 +49,7 @@ func (sc *identityCLIImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return nil, nil
 }
 
-func (sc *identityCLIImpl) Run(childEnv *env.Env) error {
+func (sc *identityCLIImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	// Provision node's identity.
 	args := []string{
 		"identity", "init",

--- a/go/oasis-test-runner/scenario/e2e/min_transact_balance.go
+++ b/go/oasis-test-runner/scenario/e2e/min_transact_balance.go
@@ -116,13 +116,11 @@ func (mtb *minTransactBalanceImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (mtb *minTransactBalanceImpl) Run(childEnv *env.Env) error {
+func (mtb *minTransactBalanceImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	// Start the network
 	if err := mtb.Net.Start(); err != nil {
 		return err
 	}
-
-	ctx := context.Background()
 
 	mtb.Logger.Info("waiting for network to come up")
 	if err := mtb.Net.Controller().WaitNodesRegistered(ctx, 3); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/multiple_seeds.go
+++ b/go/oasis-test-runner/scenario/e2e/multiple_seeds.go
@@ -43,12 +43,10 @@ func (sc *multipleSeeds) Clone() scenario.Scenario {
 	}
 }
 
-func (sc *multipleSeeds) Run(childEnv *env.Env) error { // nolint: gocyclo
+func (sc *multipleSeeds) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	if err := sc.Net.Start(); err != nil {
 		return fmt.Errorf("net Start: %w", err)
 	}
-
-	ctx := context.Background()
 
 	sc.Logger.Info("waiting for network to come up")
 	if err := sc.Net.Controller().WaitNodesRegistered(ctx, 3); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/registry_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/registry_cli.go
@@ -67,12 +67,11 @@ func (sc *registryCLIImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *registryCLIImpl) Run(childEnv *env.Env) error {
+func (sc *registryCLIImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
 
-	ctx := context.Background()
 	sc.Logger.Info("waiting for nodes to register")
 	if err := sc.Net.Controller().WaitNodesRegistered(ctx, 3); err != nil {
 		return fmt.Errorf("waiting for nodes to register: %w", err)

--- a/go/oasis-test-runner/scenario/e2e/runtime/archive_api.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/archive_api.go
@@ -281,8 +281,7 @@ func (sc *archiveAPI) testArchiveAPI(ctx context.Context, archiveCtrl *oasis.Con
 	return nil
 }
 
-func (sc *archiveAPI) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *archiveAPI) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}
@@ -292,7 +291,7 @@ func (sc *archiveAPI) Run(childEnv *env.Env) error {
 		return err
 	}
 	var nextEpoch beacon.EpochTime
-	if nextEpoch, err = sc.initialEpochTransitions(fixture); err != nil {
+	if nextEpoch, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
 	nextEpoch++ // Next, after initial transitions.

--- a/go/oasis-test-runner/scenario/e2e/runtime/byzantine.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/byzantine.go
@@ -453,9 +453,7 @@ func (sc *byzantineImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *byzantineImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
-
+func (sc *byzantineImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
@@ -472,7 +470,7 @@ func (sc *byzantineImpl) Run(childEnv *env.Env) error {
 	}
 	defer blkSub.Close()
 
-	epoch, err := sc.initialEpochTransitions(fixture)
+	epoch, err := sc.initialEpochTransitions(ctx, fixture)
 	if err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/dump_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/dump_restore.go
@@ -118,8 +118,7 @@ func (sc *dumpRestoreImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *dumpRestoreImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *dumpRestoreImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}
@@ -190,5 +189,5 @@ func (sc *dumpRestoreImpl) Run(childEnv *env.Env) error {
 
 	// Check that everything works with restored state.
 	sc.Scenario.testClient = NewKVTestClient().WithSeed("seed2").WithScenario(RemoveKeyValueScenario)
-	return sc.Scenario.Run(childEnv)
+	return sc.Scenario.Run(ctx, childEnv)
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/gas_fees.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/gas_fees.go
@@ -112,15 +112,13 @@ func (sc *gasFeesRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *gasFeesRuntimesImpl) Run(childEnv *env.Env) error {
+func (sc *gasFeesRuntimesImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
 
-	ctx := context.Background()
-
 	// Wait for all nodes to be synced before we proceed.
-	if err := sc.waitNodesSynced(); err != nil {
+	if err := sc.waitNodesSynced(ctx); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/halt_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/halt_restore.go
@@ -69,8 +69,7 @@ func (sc *haltRestoreImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *haltRestoreImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
-	ctx := context.Background()
+func (sc *haltRestoreImpl) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}
@@ -80,7 +79,7 @@ func (sc *haltRestoreImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 		return err
 	}
 	var nextEpoch beacon.EpochTime
-	if nextEpoch, err = sc.initialEpochTransitions(fixture); err != nil {
+	if nextEpoch, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
 	nextEpoch++ // Next, after initial transitions.
@@ -227,7 +226,7 @@ func (sc *haltRestoreImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 	if err = sc.StartNetworkAndWaitForClientSync(ctx); err != nil {
 		return err
 	}
-	if _, err = sc.initialEpochTransitionsWith(fixture, genesisDoc.Beacon.Base); err != nil {
+	if _, err = sc.initialEpochTransitionsWith(ctx, fixture, genesisDoc.Beacon.Base); err != nil {
 		return err
 	}
 	if err = sc.startTestClientOnly(ctx, childEnv); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/runtime/halt_restore_nonmock.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/halt_restore_nonmock.go
@@ -50,8 +50,7 @@ func (sc *haltRestoreNonMockImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *haltRestoreNonMockImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
-	ctx := context.Background()
+func (sc *haltRestoreNonMockImpl) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/history_reindex.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/history_reindex.go
@@ -82,8 +82,7 @@ func (sc *historyReindexImpl) Clone() scenario.Scenario {
 	}
 }
 
-func (sc *historyReindexImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *historyReindexImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	cli := cli.New(childEnv, sc.Net, sc.Logger)
 
 	// Start the network.
@@ -158,7 +157,7 @@ func (sc *historyReindexImpl) Run(childEnv *env.Env) error {
 	if err != nil {
 		return err
 	}
-	if err = computeCtrl.WaitReady(context.Background()); err != nil {
+	if err = computeCtrl.WaitReady(ctx); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_key_generation.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_key_generation.go
@@ -45,10 +45,9 @@ func (sc *kmKeyGenerationImpl) Clone() scenario.Scenario {
 	}
 }
 
-func (sc *kmKeyGenerationImpl) Run(childEnv *env.Env) error {
+func (sc *kmKeyGenerationImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	// Start the network, but no need to start the client. Just ensure it
 	// is synced.
-	ctx := context.Background()
 	if err := sc.Scenario.StartNetworkAndWaitForClientSync(ctx); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_replicate.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_replicate.go
@@ -51,8 +51,7 @@ func (sc *kmReplicateImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *kmReplicateImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *kmReplicateImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_restart.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_restart.go
@@ -42,8 +42,7 @@ func (sc *kmRestartImpl) Clone() scenario.Scenario {
 	}
 }
 
-func (sc *kmRestartImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *kmRestartImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_upgrade.go
@@ -198,7 +198,7 @@ func (sc *kmUpgradeImpl) ensureReplicationWorked(ctx context.Context, km *oasis.
 
 	// Grab a state dump and ensure all keymanager nodes have a matching
 	// checksum.
-	doc, err := ctrl.Consensus.StateToGenesis(context.Background(), 0)
+	doc, err := ctrl.Consensus.StateToGenesis(ctx, 0)
 	if err != nil {
 		return fmt.Errorf("failed to obtain consensus state: %w", err)
 	}
@@ -223,8 +223,7 @@ func (sc *kmUpgradeImpl) ensureReplicationWorked(ctx context.Context, km *oasis.
 	return nil
 }
 
-func (sc *kmUpgradeImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *kmUpgradeImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	cli := cli.New(childEnv, sc.Net, sc.Logger)
 
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/runtime/late_start.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/late_start.go
@@ -49,9 +49,7 @@ func (sc *lateStartImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *lateStartImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
-
+func (sc *lateStartImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	// Start the network.
 	var err error
 	if err = sc.Net.Start(); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/multiple_runtimes.go
@@ -142,7 +142,7 @@ func (sc *multipleRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *multipleRuntimesImpl) Run(childEnv *env.Env) error {
+func (sc *multipleRuntimesImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
@@ -153,11 +153,9 @@ func (sc *multipleRuntimesImpl) Run(childEnv *env.Env) error {
 	}
 
 	// Wait for the nodes.
-	if _, err = sc.initialEpochTransitions(fixture); err != nil {
+	if _, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
-
-	ctx := context.Background()
 
 	// Submit transactions.
 	numComputeRuntimeTxns, _ := sc.Flags.GetInt(cfgNumComputeRuntimeTxns)

--- a/go/oasis-test-runner/scenario/e2e/runtime/node_shutdown.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/node_shutdown.go
@@ -56,8 +56,7 @@ func (sc *nodeShutdownImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *nodeShutdownImpl) Run(childEnv *env.Env) error { //nolint: gocyclo
-	ctx := context.Background()
+func (sc *nodeShutdownImpl) Run(ctx context.Context, childEnv *env.Env) error { //nolint: gocyclo
 	var err error
 
 	if err = sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/runtime/offset_restart.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/offset_restart.go
@@ -47,8 +47,7 @@ func (sc *offsetRestartImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *offsetRestartImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *offsetRestartImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}
@@ -58,7 +57,7 @@ func (sc *offsetRestartImpl) Run(childEnv *env.Env) error {
 		return err
 	}
 
-	if _, err = sc.initialEpochTransitions(fixture); err != nil {
+	if _, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
 
@@ -91,5 +90,5 @@ func (sc *offsetRestartImpl) Run(childEnv *env.Env) error {
 	// hanging the network (no transactions could be submitted).
 	sc.Logger.Info("network back up, trying to run client again")
 	sc.Scenario.testClient = NewKVTestClient().WithSeed("seed2").WithScenario(RemoveKeyValueScenario)
-	return sc.Scenario.Run(childEnv)
+	return sc.Scenario.Run(ctx, childEnv)
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -585,6 +585,11 @@ func (sc *Scenario) waitNodesSynced(ctx context.Context) error {
 			return err
 		}
 	}
+	for _, n := range sc.Net.Keymanagers() {
+		if err := checkSynced(n.Node); err != nil {
+			return err
+		}
+	}
 	for _, n := range sc.Net.ComputeWorkers() {
 		if err := checkSynced(n.Node); err != nil {
 			return err

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime.go
@@ -373,8 +373,7 @@ func (sc *Scenario) waitTestClient() error {
 	return sc.checkTestClientLogs()
 }
 
-func (sc *Scenario) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *Scenario) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
 	}
@@ -565,9 +564,7 @@ func (sc *Scenario) StartNetworkAndWaitForClientSync(ctx context.Context) error 
 	return sc.waitForClientSync(ctx)
 }
 
-func (sc *Scenario) waitNodesSynced() error {
-	ctx := context.Background()
-
+func (sc *Scenario) waitNodesSynced(ctx context.Context) error {
 	checkSynced := func(n *oasis.Node) error {
 		c, err := oasis.NewController(n.SocketPath())
 		if err != nil {
@@ -603,13 +600,11 @@ func (sc *Scenario) waitNodesSynced() error {
 	return nil
 }
 
-func (sc *Scenario) initialEpochTransitions(fixture *oasis.NetworkFixture) (beacon.EpochTime, error) {
-	return sc.initialEpochTransitionsWith(fixture, 0)
+func (sc *Scenario) initialEpochTransitions(ctx context.Context, fixture *oasis.NetworkFixture) (beacon.EpochTime, error) {
+	return sc.initialEpochTransitionsWith(ctx, fixture, 0)
 }
 
-func (sc *Scenario) initialEpochTransitionsWith(fixture *oasis.NetworkFixture, baseEpoch beacon.EpochTime) (beacon.EpochTime, error) {
-	ctx := context.Background()
-
+func (sc *Scenario) initialEpochTransitionsWith(ctx context.Context, fixture *oasis.NetworkFixture, baseEpoch beacon.EpochTime) (beacon.EpochTime, error) {
 	epoch := baseEpoch + 1
 	advanceEpoch := func() error {
 		sc.Logger.Info("triggering epoch transition",

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_client_kv.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_client_kv.go
@@ -118,6 +118,20 @@ func (cli *KVTestClient) workload(ctx context.Context) error {
 
 func (cli *KVTestClient) submit(ctx context.Context, req interface{}, rng rand.Source64) error {
 	switch req := req.(type) {
+	case KeyValueQuery:
+		rsp, err := cli.sc.submitKeyValueRuntimeGetQuery(
+			ctx,
+			runtimeID,
+			req.Key,
+			req.Round,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to query k/v pair: %w", err)
+		}
+		if rsp != req.Response {
+			return fmt.Errorf("response does not have expected value (got: '%v', expected: '%v')", rsp, req.Response)
+		}
+
 	case InsertKeyValueTx:
 		rsp, err := cli.sc.submitKeyValueRuntimeInsertTx(
 			ctx,

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_client_kv_scenario.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_client_kv_scenario.go
@@ -10,8 +10,17 @@ var (
 		GetKeyValueTx{"my_key", "my_value", false},
 	})
 
+	InsertKeyValueEncScenario = NewTestClientScenario([]interface{}{
+		InsertKeyValueTx{"my_key", "my_value", "", true},
+		GetKeyValueTx{"my_key", "my_value", true},
+	})
+
 	RemoveKeyValueScenario = NewTestClientScenario([]interface{}{
 		GetKeyValueTx{"my_key", "my_value", false},
+	})
+
+	RemoveKeyValueEncScenario = NewTestClientScenario([]interface{}{
+		GetKeyValueTx{"my_key", "my_value", true},
 	})
 
 	InsertTransferKeyValueScenario = NewTestClientScenario([]interface{}{
@@ -34,12 +43,14 @@ var (
 		GetKeyValueTx{"my_key2", "", true},
 	})
 
-	SimpleKeyValueScenario = newSimpleKeyValueScenario(false)
+	SimpleKeyValueScenario = newSimpleKeyValueScenario(false, false)
 
-	SimpleKeyValueScenarioRepeated = newSimpleKeyValueScenario(true)
+	SimpleKeyValueEncScenario = newSimpleKeyValueScenario(false, true)
+
+	SimpleKeyValueScenarioRepeated = newSimpleKeyValueScenario(true, false)
 )
 
-func newSimpleKeyValueScenario(repeat bool) TestClientScenario {
+func newSimpleKeyValueScenario(repeat bool, encrypted bool) TestClientScenario {
 	return func(submit func(req interface{}) error) error {
 		// Check whether Runtime ID is also set remotely.
 		//
@@ -60,10 +71,10 @@ func newSimpleKeyValueScenario(repeat bool) TestClientScenario {
 				response = fmt.Sprintf("hello_value_from_%s:%d", runtimeID, iter-1)
 			}
 
-			if err := submit(InsertKeyValueTx{key, value, response, false}); err != nil {
+			if err := submit(InsertKeyValueTx{key, value, response, encrypted}); err != nil {
 				return err
 			}
-			if err := submit(GetKeyValueTx{key, value, false}); err != nil {
+			if err := submit(GetKeyValueTx{key, value, encrypted}); err != nil {
 				return err
 			}
 
@@ -75,13 +86,13 @@ func newSimpleKeyValueScenario(repeat bool) TestClientScenario {
 				response = value
 			}
 
-			if err := submit(InsertKeyValueTx{key, value, response, false}); err != nil {
+			if err := submit(InsertKeyValueTx{key, value, response, encrypted}); err != nil {
 				return err
 			}
 			if err := submit(ConsensusTransferTx{}); err != nil {
 				return err
 			}
-			if err := submit(GetKeyValueTx{key, value, false}); err != nil {
+			if err := submit(GetKeyValueTx{key, value, encrypted}); err != nil {
 				return err
 			}
 
@@ -95,10 +106,10 @@ func newSimpleKeyValueScenario(repeat bool) TestClientScenario {
 			inMsgKey   = "in_msg"
 			inMsgValue = "hello world from inmsg"
 		)
-		if err := submit(InsertMsg{inMsgKey, inMsgValue}); err != nil {
+		if err := submit(InsertMsg{inMsgKey, inMsgValue, encrypted}); err != nil {
 			return err
 		}
-		if err := submit(GetKeyValueTx{inMsgKey, inMsgValue, false}); err != nil {
+		if err := submit(GetKeyValueTx{inMsgKey, inMsgValue, encrypted}); err != nil {
 			return err
 		}
 		if err := submit(ConsensusAccountsTx{}); err != nil {
@@ -143,8 +154,9 @@ type RemoveKeyValueTx struct {
 
 // InsertMsg inserts an incoming runtime message.
 type InsertMsg struct {
-	Key   string
-	Value string
+	Key       string
+	Value     string
+	Encrypted bool
 }
 
 // GetRuntimeIDTx retrieves the runtime ID.

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_client_kv_scenario.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_client_kv_scenario.go
@@ -109,6 +109,14 @@ func newSimpleKeyValueScenario(repeat bool) TestClientScenario {
 	}
 }
 
+// KeyValueQuery queries the value stored under the given key for the specified round from
+// the database, and verifies that the response (current value) contains the expected data.
+type KeyValueQuery struct {
+	Key      string
+	Response string
+	Round    uint64
+}
+
 // InsertKeyValueTx inserts a key/value pair to the database, and verifies that the response
 // (previous value) contains the expected data.
 type InsertKeyValueTx struct {

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_dynamic.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_dynamic.go
@@ -88,17 +88,16 @@ func (sc *runtimeDynamicImpl) epochTransition(ctx context.Context) error {
 	return nil
 }
 
-func (sc *runtimeDynamicImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
+func (sc *runtimeDynamicImpl) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	var rtNonce uint64
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
 
-	ctx := context.Background()
 	cli := cli.New(childEnv, sc.Net, sc.Logger)
 
 	// Wait for all nodes to be synced before we proceed.
-	if err := sc.waitNodesSynced(); err != nil {
+	if err := sc.waitNodesSynced(ctx); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_governance.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_governance.go
@@ -227,7 +227,7 @@ func (sc *runtimeGovernanceImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *runtimeGovernanceImpl) Run(childEnv *env.Env) error {
+func (sc *runtimeGovernanceImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
@@ -238,11 +238,10 @@ func (sc *runtimeGovernanceImpl) Run(childEnv *env.Env) error {
 	}
 
 	// Wait for all nodes to start.
-	if _, err = sc.initialEpochTransitions(fixture); err != nil {
+	if _, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
 
-	ctx := context.Background()
 	var rtNonce uint64
 
 	// Filter compute runtimes.

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_message.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_message.go
@@ -48,7 +48,7 @@ func (sc *runtimeMessageImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *runtimeMessageImpl) Run(childEnv *env.Env) error {
+func (sc *runtimeMessageImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
@@ -59,11 +59,10 @@ func (sc *runtimeMessageImpl) Run(childEnv *env.Env) error {
 	}
 
 	var epoch beacon.EpochTime
-	if epoch, err = sc.initialEpochTransitions(fixture); err != nil {
+	if epoch, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
 
-	ctx := context.Background()
 	c := sc.Net.ClientController().RuntimeClient
 
 	blkCh, sub, err := c.WatchBlocks(ctx, runtimeID)

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_prune.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_prune.go
@@ -59,7 +59,7 @@ func (sc *runtimePruneImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *runtimePruneImpl) Run(childEnv *env.Env) error {
+func (sc *runtimePruneImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
@@ -69,11 +69,10 @@ func (sc *runtimePruneImpl) Run(childEnv *env.Env) error {
 		return err
 	}
 
-	if _, err = sc.initialEpochTransitions(fixture); err != nil {
+	if _, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
 
-	ctx := context.Background()
 	c := sc.Net.ClientController().RuntimeClient
 
 	// Submit transactions.

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_upgrade.go
@@ -178,8 +178,7 @@ func (sc *runtimeUpgradeImpl) applyUpgradePolicy(childEnv *env.Env) error {
 	return nil
 }
 
-func (sc *runtimeUpgradeImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *runtimeUpgradeImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	cli := cli.New(childEnv, sc.Net, sc.Logger)
 
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/runtime/sentry.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/sentry.go
@@ -154,13 +154,13 @@ func (s *sentryImpl) dial(address string, clientOpts *cmnGrpc.ClientOptions) (*g
 	return conn, nil
 }
 
-func (s *sentryImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
+func (s *sentryImpl) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	// Run the basic runtime test.
-	if err := s.Scenario.Run(childEnv); err != nil {
+	if err := s.Scenario.Run(ctx, childEnv); err != nil {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), sentryChecksContextTimeout)
+	ctx, cancel := context.WithTimeout(ctx, sentryChecksContextTimeout)
 	defer cancel()
 
 	// Load identities and addresses used in the sanity checks.

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_early_state_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_early_state_sync.go
@@ -107,12 +107,11 @@ func (sc *storageEarlyStateSyncImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *storageEarlyStateSyncImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
+func (sc *storageEarlyStateSyncImpl) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
 
-	ctx := context.Background()
 	cli := cli.New(childEnv, sc.Net, sc.Logger)
 
 	// Wait for validator nodes to register.

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_sync.go
@@ -86,9 +86,8 @@ func (sc *storageSyncImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *storageSyncImpl) Run(childEnv *env.Env) error { //nolint: gocyclo
+func (sc *storageSyncImpl) Run(ctx context.Context, childEnv *env.Env) error { //nolint: gocyclo
 	var err error
-	ctx := context.Background()
 
 	if err = sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_from_registered.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_from_registered.go
@@ -75,8 +75,7 @@ func (sc *storageSyncFromRegisteredImpl) Fixture() (*oasis.NetworkFixture, error
 	return f, nil
 }
 
-func (sc *storageSyncFromRegisteredImpl) Run(childEnv *env.Env) error {
-	ctx := context.Background()
+func (sc *storageSyncFromRegisteredImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	var nextEpoch beacon.EpochTime
 
 	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
@@ -88,7 +87,7 @@ func (sc *storageSyncFromRegisteredImpl) Run(childEnv *env.Env) error {
 		return err
 	}
 
-	if nextEpoch, err = sc.initialEpochTransitions(fixture); err != nil {
+	if nextEpoch, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
 	nextEpoch++

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_inconsistent.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_sync_inconsistent.go
@@ -114,11 +114,10 @@ func (sc *storageSyncInconsistentImpl) wipe(ctx context.Context, worker *oasis.N
 	return os.RemoveAll(persistent.GetPersistentStoreDBDir(worker.DataDir()))
 }
 
-func (sc *storageSyncInconsistentImpl) Run(childEnv *env.Env) error {
+func (sc *storageSyncInconsistentImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	compute0 := sc.Net.ComputeWorkers()[0]
 	messyWorker := sc.Net.ComputeWorkers()[sc.messyStorage]
 	sc.runtimeID = sc.Net.Runtimes()[1].ID()
-	ctx := context.Background()
 
 	if err := sc.Scenario.StartNetworkAndTestClient(ctx, childEnv); err != nil {
 		return err
@@ -129,7 +128,7 @@ func (sc *storageSyncInconsistentImpl) Run(childEnv *env.Env) error {
 		return err
 	}
 
-	if _, err = sc.initialEpochTransitions(fixture); err != nil {
+	if _, err = sc.initialEpochTransitions(ctx, fixture); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/hashicorp/go-multierror"
+
+	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
@@ -28,7 +31,6 @@ var TrustRoot scenario.Scenario = NewTrustRootImpl(
 type trustRoot struct {
 	height       string
 	hash         string
-	runtimeID    string
 	chainContext string
 }
 
@@ -65,6 +67,9 @@ func (sc *TrustRootImpl) Fixture() (*oasis.NetworkFixture, error) {
 
 	// Make sure no nodes are started initially as we need to determine the trust root and build an
 	// appropriate runtime with the trust root embedded.
+	for i := range f.Keymanagers {
+		f.Keymanagers[i].NoAutoStart = true
+	}
 	for i := range f.ComputeWorkers {
 		f.ComputeWorkers[i].NoAutoStart = true
 	}
@@ -75,85 +80,86 @@ func (sc *TrustRootImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *TrustRootImpl) buildRuntimeBinary(ctx context.Context, childEnv *env.Env, root trustRoot) (func() error, error) {
-	sc.Logger.Info("building runtime with embedded trust root",
-		"height", root.height,
-		"hash", root.hash,
-		"runtime_id", root.runtimeID,
-		"chain_context", root.chainContext,
-	)
-
+func (sc *TrustRootImpl) buildRuntimes(ctx context.Context, childEnv *env.Env, runtimes map[common.Namespace]string, trustRoot *trustRoot) error {
 	// Determine the required directories for building the runtime with an embedded trust root.
 	buildDir, _ := sc.Flags.GetString(cfgRuntimeSourceDir)
 	targetDir, _ := sc.Flags.GetString(cfgRuntimeTargetDir)
-	if len(buildDir) == 0 || len(targetDir) == 0 {
-		return nil, fmt.Errorf("runtime build dir and/or target dir not configured")
+	if buildDir == "" || targetDir == "" {
+		return fmt.Errorf("runtime build dir and/or target dir not configured")
 	}
 
-	// Build a new runtime with the given trust root embedded.
-	teeHardware, _ := sc.getTEEHardware()
-	builder := rust.NewBuilder(childEnv, teeHardware, runtimeBinary, filepath.Join(buildDir, runtimeBinary), targetDir)
-	builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_HEIGHT", root.height)
-	builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_HASH", root.hash)
-	builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_RUNTIME_ID", root.runtimeID)
-	builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_CHAIN_CONTEXT", root.chainContext)
-	if err := builder.Build(); err != nil {
-		return nil, fmt.Errorf("failed to build runtime '%s' with trust root: %w", runtimeBinary, err)
+	// Determine TEE hardware.
+	teeHardware, err := sc.getTEEHardware()
+	if err != nil {
+		return err
 	}
 
-	rebuild := func() error {
-		sc.Logger.Info("rebuilding runtime without the embedded trust root")
-		builder.ResetEnv()
-		if buildErr := builder.Build(); buildErr != nil {
-			return fmt.Errorf("failed to build plain runtime '%s': %w", runtimeBinary, buildErr)
+	// Prepare the builder.
+	builder := rust.NewBuilder(childEnv, buildDir, targetDir, teeHardware)
+
+	// Build runtimes one by one.
+	var errs *multierror.Error
+	for runtimeID, runtimeBinary := range runtimes {
+		switch trustRoot {
+		case nil:
+			sc.Logger.Info("building runtime without embedded trust root",
+				"runtime_id", runtimeID,
+				"runtime_binary", runtimeBinary,
+			)
+		default:
+			sc.Logger.Info("building runtime with embedded trust root",
+				"runtime_id", runtimeID,
+				"runtime_binary", runtimeBinary,
+				"trust_root_height", trustRoot.hash,
+				"trust_root_hash", trustRoot.hash,
+				"trust_root_chainContext", trustRoot.chainContext,
+			)
+
+			// Prepare environment.
+			builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_HEIGHT", trustRoot.height)
+			builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_HASH", trustRoot.hash)
+			builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_CHAIN_CONTEXT", trustRoot.chainContext)
+			builder.SetEnv("OASIS_TESTS_CONSENSUS_TRUST_RUNTIME_ID", runtimeID.String())
 		}
-		return nil
+
+		// Build a new runtime with the given trust root embedded.
+		if err = builder.Build(runtimeBinary); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+	if err = errs.ErrorOrNil(); err != nil {
+		return fmt.Errorf("failed to build runtimes: %w", err)
 	}
 
-	return rebuild, nil
+	return nil
 }
 
-func (sc *TrustRootImpl) registerRuntimes(ctx context.Context, childEnv *env.Env) error {
-	// Nonce used for transactions (increase this by 1 after each transaction).
-	var nonce uint64
-	cli := cli.New(childEnv, sc.Net, sc.Logger)
-
-	// Fetch current epoch.
-	epoch, err := sc.Net.Controller().Beacon.GetEpoch(ctx, consensus.HeightLatest)
-	if err != nil {
-		return fmt.Errorf("failed to get current epoch: %w", err)
+func (sc *TrustRootImpl) buildAllRuntimes(ctx context.Context, childEnv *env.Env, trustRoot *trustRoot) error {
+	runtimes := map[common.Namespace]string{
+		runtimeID:    runtimeBinary,
+		keymanagerID: keyManagerBinary,
 	}
 
-	// Register a new keymanager runtime.
-	kmRt := sc.Net.Runtimes()[0]
-	rtDsc := kmRt.ToRuntimeDescriptor()
-	rtDsc.Deployments[0].ValidFrom = epoch + 2
-	kmTxPath := filepath.Join(childEnv.Dir(), "register_km_runtime.json")
-	if err = cli.Registry.GenerateRegisterRuntimeTx(childEnv.Dir(), rtDsc, nonce, kmTxPath); err != nil {
-		return fmt.Errorf("failed to generate register KM runtime tx: %w", err)
-	}
-	nonce++
-	if err = cli.Consensus.SubmitTx(kmTxPath); err != nil {
-		return fmt.Errorf("failed to register KM runtime: %w", err)
+	return sc.buildRuntimes(ctx, childEnv, runtimes, trustRoot)
+}
+
+func (sc *TrustRootImpl) registerRuntime(ctx context.Context, childEnv *env.Env, cli *cli.Helpers, rt *oasis.Runtime, validFrom beacon.EpochTime, nonce uint64) error {
+	dsc := rt.ToRuntimeDescriptor()
+	dsc.Deployments[0].ValidFrom = validFrom
+
+	txPath := filepath.Join(childEnv.Dir(), fmt.Sprintf("register_runtime_%s.json", rt.ID()))
+	if err := cli.Registry.GenerateRegisterRuntimeTx(childEnv.Dir(), dsc, nonce, txPath); err != nil {
+		return fmt.Errorf("failed to generate register runtime tx: %w", err)
 	}
 
-	// Register a new compute runtime.
-	// Note that the bundles need to be refreshed before setting the key manager policy.
-	compRt := sc.Net.Runtimes()[1]
-	if err = compRt.RefreshRuntimeBundles(); err != nil {
-		return fmt.Errorf("failed to refresh runtime bundles: %w", err)
-	}
-	compRtDesc := compRt.ToRuntimeDescriptor()
-	compRtDesc.Deployments[0].ValidFrom = epoch + 2
-	txPath := filepath.Join(childEnv.Dir(), "register_compute_runtime.json")
-	if err = cli.Registry.GenerateRegisterRuntimeTx(childEnv.Dir(), compRtDesc, nonce, txPath); err != nil {
-		return fmt.Errorf("failed to generate register compute runtime tx: %w", err)
-	}
-	nonce++
-	if err = cli.Consensus.SubmitTx(txPath); err != nil {
-		return fmt.Errorf("failed to register compute runtime: %w", err)
+	if err := cli.Consensus.SubmitTx(txPath); err != nil {
+		return fmt.Errorf("failed to register runtime: %w", err)
 	}
 
+	return nil
+}
+
+func (sc *TrustRootImpl) updateKeyManagerPolicy(ctx context.Context, childEnv *env.Env, cli *cli.Helpers, nonce uint64) error {
 	// Generate and update the new keymanager runtime's policy.
 	kmPolicyPath := filepath.Join(childEnv.Dir(), "km_policy.cbor")
 	kmPolicySig1Path := filepath.Join(childEnv.Dir(), "km_policy_sig1.pem")
@@ -162,6 +168,7 @@ func (sc *TrustRootImpl) registerRuntimes(ctx context.Context, childEnv *env.Env
 	kmUpdateTxPath := filepath.Join(childEnv.Dir(), "km_gen_update.json")
 	sc.Logger.Info("building KM SGX policy enclave policies map")
 	enclavePolicies := make(map[sgx.EnclaveIdentity]*keymanager.EnclavePolicySGX)
+	kmRt := sc.Net.Runtimes()[0]
 	kmRtEncID := kmRt.GetEnclaveIdentity(0)
 	var havePolicy bool
 	if kmRtEncID != nil {
@@ -180,35 +187,27 @@ func (sc *TrustRootImpl) registerRuntimes(ctx context.Context, childEnv *env.Env
 		}
 	}
 	sc.Logger.Info("initing KM policy")
-	if err = cli.Keymanager.InitPolicy(kmRt.ID(), 1, enclavePolicies, kmPolicyPath); err != nil {
+	if err := cli.Keymanager.InitPolicy(kmRt.ID(), 1, enclavePolicies, kmPolicyPath); err != nil {
 		return err
 	}
 	sc.Logger.Info("signing KM policy")
-	if err = cli.Keymanager.SignPolicy("1", kmPolicyPath, kmPolicySig1Path); err != nil {
+	if err := cli.Keymanager.SignPolicy("1", kmPolicyPath, kmPolicySig1Path); err != nil {
 		return err
 	}
-	if err = cli.Keymanager.SignPolicy("2", kmPolicyPath, kmPolicySig2Path); err != nil {
+	if err := cli.Keymanager.SignPolicy("2", kmPolicyPath, kmPolicySig2Path); err != nil {
 		return err
 	}
-	if err = cli.Keymanager.SignPolicy("3", kmPolicyPath, kmPolicySig3Path); err != nil {
+	if err := cli.Keymanager.SignPolicy("3", kmPolicyPath, kmPolicySig3Path); err != nil {
 		return err
 	}
 	if havePolicy {
 		// In SGX mode, we can update the policy as intended.
 		sc.Logger.Info("updating KM policy")
-		if err = cli.Keymanager.GenUpdate(nonce, kmPolicyPath, []string{kmPolicySig1Path, kmPolicySig2Path, kmPolicySig3Path}, kmUpdateTxPath); err != nil {
+		if err := cli.Keymanager.GenUpdate(nonce, kmPolicyPath, []string{kmPolicySig1Path, kmPolicySig2Path, kmPolicySig3Path}, kmUpdateTxPath); err != nil {
 			return err
 		}
-		if err = cli.Consensus.SubmitTx(kmUpdateTxPath); err != nil {
+		if err := cli.Consensus.SubmitTx(kmUpdateTxPath); err != nil {
 			return fmt.Errorf("failed to update KM policy: %w", err)
-		}
-	}
-
-	// Wait for key manager nodes to register.
-	sc.Logger.Info("waiting for key manager nodes to initialize")
-	for _, n := range sc.Net.Keymanagers() {
-		if err = n.WaitReady(ctx); err != nil {
-			return fmt.Errorf("failed to wait for a key manager node: %w", err)
 		}
 	}
 
@@ -246,78 +245,85 @@ func (sc *TrustRootImpl) chainContext(ctx context.Context) (string, error) {
 	return cc, nil
 }
 
-func (sc *TrustRootImpl) Run(childEnv *env.Env) (err error) {
-	ctx := context.Background()
+func (sc *TrustRootImpl) trustRoot(ctx context.Context) (*trustRoot, error) {
+	sc.Logger.Info("preparing trust root")
 
-	// Determine the required directories for building the runtime with an embedded trust root.
-	buildDir, _ := sc.Flags.GetString(cfgRuntimeSourceDir)
-	targetDir, _ := sc.Flags.GetString(cfgRuntimeTargetDir)
-	if len(buildDir) == 0 || len(targetDir) == 0 {
-		return fmt.Errorf("runtime build dir and/or target dir not configured")
+	// Let the network run for few blocks to select a suitable trust root.
+	block, err := sc.waitBlocks(ctx, 5)
+	if err != nil {
+		return nil, err
 	}
 
+	chainContext, err := sc.chainContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &trustRoot{
+		height:       strconv.FormatInt(block.Height, 10),
+		hash:         block.Hash.Hex(),
+		chainContext: chainContext,
+	}, nil
+}
+
+// PreRun starts the network, prepares a trust root, builds simple key/value and key manager
+// runtimes, prepares runtime bundles, and runs the test client.
+func (sc *TrustRootImpl) PreRun(ctx context.Context, childEnv *env.Env) (err error) {
+	cli := cli.New(childEnv, sc.Net, sc.Logger)
+
+	// Nonce used for transactions (increase this by 1 after each transaction).
+	var nonce uint64
+
+	// Start generating blocks.
 	if err = sc.Net.Start(); err != nil {
 		return err
 	}
+	if err = sc.Net.Controller().WaitNodesRegistered(ctx, len(sc.Net.Validators())); err != nil {
+		return err
+	}
 
-	// Let the network run for 10 blocks to select a suitable trust root.
 	// Pick one block and use it as an embedded trust root.
-	block, err := sc.waitBlocks(ctx, 10)
+	trustRoot, err := sc.trustRoot(ctx)
 	if err != nil {
 		return err
 	}
-	chainContext, err := sc.chainContext(ctx)
-	if err != nil {
-		return err
-	}
-	root := trustRoot{
-		height:       strconv.FormatInt(block.Height, 10),
-		hash:         block.Hash.Hex(),
-		runtimeID:    runtimeID.String(),
-		chainContext: chainContext,
-	}
 
-	rebuild, err := sc.buildRuntimeBinary(ctx, childEnv, root)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err2 := rebuild(); err2 != nil {
-			err = fmt.Errorf("%w (original error: %s)", err2, err)
-		}
-	}()
-
-	// Now that the runtime is built, let's register it and start all the required workers.
-	if err = sc.registerRuntimes(ctx, childEnv); err != nil {
+	// Build simple key/value and key manager runtimes.
+	if err = sc.buildAllRuntimes(ctx, childEnv, trustRoot); err != nil {
 		return err
 	}
 
-	// Start the compute workers and client.
-	sc.Logger.Info("starting clients and compute workers")
-	for _, n := range sc.Net.Clients() {
-		if err = n.Start(); err != nil {
-			return fmt.Errorf("failed to start node: %w", err)
-		}
-	}
-	for _, n := range sc.Net.ComputeWorkers() {
-		if err = n.Start(); err != nil {
-			return fmt.Errorf("failed to start node: %w", err)
+	// Refresh the bundles. This needs to be done before setting the key manager policy,
+	// to ensure enclave IDs are correct.
+	for _, rt := range sc.Net.Runtimes() {
+		if err = rt.RefreshRuntimeBundles(); err != nil {
+			return fmt.Errorf("failed to refresh runtime bundles: %w", err)
 		}
 	}
 
-	sc.Logger.Info("waiting for compute workers to become ready")
-	for _, n := range sc.Net.ComputeWorkers() {
-		if err = n.WaitReady(ctx); err != nil {
-			return fmt.Errorf("failed to wait for a compute worker: %w", err)
-		}
-	}
-
-	// Setup a client controller (as there is none due to the client node not being autostarted).
-	ctrl, err := oasis.NewController(sc.Net.Clients()[0].SocketPath())
+	// Fetch current epoch.
+	epoch, err := sc.Net.Controller().Beacon.GetEpoch(ctx, consensus.HeightLatest)
 	if err != nil {
-		return fmt.Errorf("failed to create client controller: %w", err)
+		return fmt.Errorf("failed to get current epoch: %w", err)
 	}
-	sc.Net.SetClientController(ctrl)
+
+	// Register the runtimes.
+	for _, rt := range sc.Net.Runtimes() {
+		if err = sc.registerRuntime(ctx, childEnv, cli, rt, epoch+2, nonce); err != nil {
+			return err
+		}
+		nonce++
+	}
+
+	// Update the key manager policy.
+	if err = sc.updateKeyManagerPolicy(ctx, childEnv, cli, nonce); err != nil {
+		return err
+	}
+
+	// Start all the required workers.
+	if err = sc.startClientComputeAndKeyManagerNodes(ctx, childEnv); err != nil {
+		return err
+	}
 
 	// Run the test client workload to ensure that blocks get processed correctly.
 	if err = sc.startTestClientOnly(ctx, childEnv); err != nil {
@@ -326,6 +332,24 @@ func (sc *TrustRootImpl) Run(childEnv *env.Env) (err error) {
 	if err = sc.waitTestClient(); err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// PostRun re-builds simple key/value and key manager runtimes.
+func (sc *TrustRootImpl) PostRun(ctx context.Context, childEnv *env.Env) error {
+	// In the end, always rebuild all runtimes as we are changing binaries in one of the steps.
+	return sc.buildAllRuntimes(ctx, childEnv, nil)
+}
+
+func (sc *TrustRootImpl) Run(ctx context.Context, childEnv *env.Env) (err error) {
+	if err = sc.PreRun(ctx, childEnv); err != nil {
+		return err
+	}
+	defer func() {
+		err2 := sc.PostRun(ctx, childEnv)
+		err = multierror.Append(err, err2).ErrorOrNil()
+	}()
 
 	sc.Logger.Info("testing query latest block")
 	_, err = sc.submitKeyValueRuntimeGetQuery(
@@ -338,7 +362,7 @@ func (sc *TrustRootImpl) Run(childEnv *env.Env) (err error) {
 		return err
 	}
 
-	latestBlk, err := ctrl.Roothash.GetLatestBlock(ctx, &roothash.RuntimeRequest{RuntimeID: runtimeID, Height: consensus.HeightLatest})
+	latestBlk, err := sc.Net.ClientController().Roothash.GetLatestBlock(ctx, &roothash.RuntimeRequest{RuntimeID: runtimeID, Height: consensus.HeightLatest})
 	if err != nil {
 		return err
 	}
@@ -374,4 +398,55 @@ func (sc *TrustRootImpl) Run(childEnv *env.Env) (err error) {
 	}
 
 	return sc.waitTestClient()
+}
+
+func (sc *TrustRootImpl) startClientComputeAndKeyManagerNodes(ctx context.Context, childEnv *env.Env) error {
+	// Start client, compute workers and key manager nodes as they are not auto-started.
+	sc.Logger.Info("starting clients, compute workers and key managers")
+	for _, n := range sc.Net.Clients() {
+		if err := n.Start(); err != nil {
+			return fmt.Errorf("failed to start node: %w", err)
+		}
+	}
+	for _, n := range sc.Net.ComputeWorkers() {
+		if err := n.Start(); err != nil {
+			return fmt.Errorf("failed to start node: %w", err)
+		}
+	}
+	for _, n := range sc.Net.Keymanagers() {
+		if err := n.Start(); err != nil {
+			return fmt.Errorf("failed to start node: %w", err)
+		}
+	}
+
+	sc.Logger.Info("waiting for key manager nodes to become ready")
+	for _, n := range sc.Net.Keymanagers() {
+		if err := n.WaitReady(ctx); err != nil {
+			return fmt.Errorf("failed to wait for a key manager node: %w", err)
+		}
+	}
+
+	sc.Logger.Info("waiting for compute workers to become ready")
+	for _, n := range sc.Net.ComputeWorkers() {
+		if err := n.WaitReady(ctx); err != nil {
+			return fmt.Errorf("failed to wait for a compute worker: %w", err)
+		}
+	}
+
+	sc.Logger.Info("waiting for client nodes to become ready")
+	for _, n := range sc.Net.Clients() {
+		if err := n.WaitReady(ctx); err != nil {
+			return fmt.Errorf("failed to wait for a client node: %w", err)
+		}
+	}
+
+	// Setup a client controller as there is none due to the client node not
+	// being auto-started.
+	ctrl, err := oasis.NewController(sc.Net.Clients()[0].SocketPath())
+	if err != nil {
+		return fmt.Errorf("failed to create client controller: %w", err)
+	}
+	sc.Net.SetClientController(ctrl)
+
+	return nil
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
@@ -25,7 +25,7 @@ import (
 // TrustRoot is the consensus trust root verification scenario.
 var TrustRoot scenario.Scenario = NewTrustRootImpl(
 	"simple",
-	NewKVTestClient().WithScenario(SimpleKeyValueScenario),
+	NewKVTestClient().WithScenario(SimpleKeyValueEncScenario),
 )
 
 type trustRoot struct {
@@ -385,6 +385,7 @@ func (sc *TrustRootImpl) Run(ctx context.Context, childEnv *env.Env) (err error)
 		key := fmt.Sprintf("my_key_%d", i)
 		value := fmt.Sprintf("my_value_%d", i)
 
+		// Use non-encrypted transactions, as queries don't support decryption.
 		queries = append(queries,
 			InsertKeyValueTx{key, value, "", false},
 			KeyValueQuery{key, value, roothash.RoundLatest},

--- a/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/trust_root.go
@@ -354,5 +354,24 @@ func (sc *TrustRootImpl) Run(childEnv *env.Env) (err error) {
 		return err
 	}
 
-	return nil
+	// Run the test client again to verify that queries work correctly immediately after
+	// the transactions have been published.
+	queries := make([]interface{}, 0)
+	for i := 0; i < 5; i++ {
+		key := fmt.Sprintf("my_key_%d", i)
+		value := fmt.Sprintf("my_value_%d", i)
+
+		queries = append(queries,
+			InsertKeyValueTx{key, value, "", false},
+			KeyValueQuery{key, value, roothash.RoundLatest},
+		)
+	}
+
+	sc.Logger.Info("starting a second test client to check if queries for the last round work")
+	sc.Scenario.testClient = NewKVTestClient().WithSeed("seed2").WithScenario(NewTestClientScenario(queries))
+	if err := sc.startTestClientOnly(ctx, childEnv); err != nil {
+		return err
+	}
+
+	return sc.waitTestClient()
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/trust_root_change.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/trust_root_change.go
@@ -78,11 +78,11 @@ func (sc *trustRootChangeImpl) Clone() scenario.Scenario {
 	}
 }
 
-func (sc *trustRootChangeImpl) Run(childEnv *env.Env) error {
+func (sc *trustRootChangeImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	if !sc.happy {
-		return sc.unhappyRun(childEnv)
+		return sc.unhappyRun(ctx, childEnv)
 	}
-	return sc.happyRun(childEnv)
+	return sc.happyRun(ctx, childEnv)
 }
 
 // happyRun tests that trust is transferred to a new light block when consensus
@@ -101,9 +101,7 @@ func (sc *trustRootChangeImpl) Run(childEnv *env.Env) error {
 //   - Start the network and test if everything works.
 //   - Repeat last two points. Chain context transition can be done repeatedly,
 //     as long as new light blocks are trusted and valid.
-func (sc *trustRootChangeImpl) happyRun(childEnv *env.Env) (err error) {
-	ctx := context.Background()
-
+func (sc *trustRootChangeImpl) happyRun(ctx context.Context, childEnv *env.Env) (err error) {
 	// Step 1: Build a simple key/value runtime and start the network.
 	rebuild, err := sc.BuildRuntimeBinary(ctx, childEnv)
 	if err != nil {
@@ -180,9 +178,7 @@ func (sc *trustRootChangeImpl) happyRun(childEnv *env.Env) (err error) {
 //   - Repeat last two points. This time set genesis height to something big
 //     and remove one validator from the set so that we can simulate what
 //     happens when the new validator set has only 2/3 of the voting power.
-func (sc *trustRootChangeImpl) unhappyRun(childEnv *env.Env) (err error) {
-	ctx := context.Background()
-
+func (sc *trustRootChangeImpl) unhappyRun(ctx context.Context, childEnv *env.Env) (err error) {
 	// Step 1: Build a simple key/value runtime and start the network.
 	rebuild, err := sc.BuildRuntimeBinary(ctx, childEnv)
 	if err != nil {
@@ -417,7 +413,7 @@ func (sc *trustRootChangeImpl) startRestoredStateTestClient(ctx context.Context,
 	// Check that everything works with restored state.
 	seed := fmt.Sprintf("seed %d", round)
 	sc.Scenario.testClient = NewKVTestClient().WithSeed(seed).WithScenario(RemoveKeyValueScenario)
-	if err := sc.Scenario.Run(childEnv); err != nil {
+	if err := sc.Scenario.Run(ctx, childEnv); err != nil {
 		return err
 	}
 	return nil

--- a/go/oasis-test-runner/scenario/e2e/runtime/trust_root_change.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/trust_root_change.go
@@ -3,7 +3,9 @@ package runtime
 import (
 	"context"
 	"fmt"
-	"strconv"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
@@ -12,17 +14,19 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario/e2e"
+	commonWorker "github.com/oasisprotocol/oasis-core/go/worker/common/api"
 )
 
 const (
 	// LogEventTrustRootChangeNoTrust is the event emitted when a compute
-	// worker fails to initialize the verifier as there is not enough trust
-	// in the new light block.
+	// worker or a key manager node fails to initialize the verifier as there
+	// is not enough trust in the new light block.
 	LogEventTrustRootChangeNoTrust = "consensus/tendermint/verifier/chain_context/no_trust"
 
 	// LogEventTrustRootChangeFailed is the event emitted when a compute
-	// worker fails to initialize the verifier as the new light block is
-	// invalid, e.g. has lower height than the last known trusted block.
+	// worker or a key manager node fails to initialize the verifier as
+	// the new light block is invalid, e.g. has lower height than the last
+	// known trusted block.
 	LogEventTrustRootChangeFailed = "consensus/tendermint/verifier/chain_context/failed"
 )
 
@@ -89,9 +93,9 @@ func (sc *trustRootChangeImpl) Run(ctx context.Context, childEnv *env.Env) error
 // chain context changes if validator set has enough votes.
 //
 // It consists of 3 steps:
-//   - Build a simple key/value runtime with an embedded trust root, register
-//     it to the network together with key manager runtime and test that
-//     everything works.
+//   - Build a simple key/value and key manager runtime with an embedded trust
+//     root, register them to the network together and test that everything
+//     works.
 //   - Do dump/restore procedure which simulates a real network upgrade.
 //     This step will stop the network, clear everything except runtime's
 //     local storage (we need it as the verifier has last trust root
@@ -103,14 +107,12 @@ func (sc *trustRootChangeImpl) Run(ctx context.Context, childEnv *env.Env) error
 //     as long as new light blocks are trusted and valid.
 func (sc *trustRootChangeImpl) happyRun(ctx context.Context, childEnv *env.Env) (err error) {
 	// Step 1: Build a simple key/value runtime and start the network.
-	rebuild, err := sc.BuildRuntimeBinary(ctx, childEnv)
-	if err != nil {
+	if err = sc.PreRun(ctx, childEnv); err != nil {
 		return err
 	}
 	defer func() {
-		if err2 := rebuild(); err2 != nil {
-			err = fmt.Errorf("%w (original error: %s)", err2, err)
-		}
+		err2 := sc.PostRun(ctx, childEnv)
+		err = multierror.Append(err, err2).ErrorOrNil()
 	}()
 
 	// All chain contexts should be unique.
@@ -145,7 +147,7 @@ func (sc *trustRootChangeImpl) happyRun(ctx context.Context, childEnv *env.Env) 
 
 		// Test runtime to be sure that blocks get processed correctly.
 		// We do this by checking if key/value store was successfully restored.
-		if err := sc.startClientAndComputeWorkers(ctx, childEnv); err != nil {
+		if err := sc.startClientComputeAndKeyManagerNodes(ctx, childEnv); err != nil {
 			return err
 		}
 		if err := sc.startRestoredStateTestClient(ctx, childEnv, round); err != nil {
@@ -165,29 +167,28 @@ func (sc *trustRootChangeImpl) happyRun(ctx context.Context, childEnv *env.Env) 
 // light blocks when consensus chain context changes.
 //
 // It consists of 5 steps:
-//   - Build a simple key/value runtime with an embedded trust root, register
-//     it to the network together with key manager runtime and test that
-//     everything works.
+//   - Build a simple key/value and key manager runtime with an embedded trust
+//     root, register them to the network together and test that everything
+//     works.
 //   - Stop the network, set genesis height to 1 and reset the consensus state.
 //     This will cause a chain context change when the network will be started
 //     again. When doing state wipe be careful not to delete compute workers
-//     local storages as they contain sealed trusted roots.
-//   - Start the network. If everything works as expected, compute workers
-//     should never be ready as the verifier cannot transfer trust to light
-//     blocks on a new chain.
+//     and key manager local storages as they contain sealed trusted roots.
+//   - Start the network. If everything works as expected, key manager nodes
+//     should never be ready as the verifier cannot transfer trust the light
+//     blocks on a new chain. As a consequence, the runtime workers will get
+//     stuck waiting for available key manager.
 //   - Repeat last two points. This time set genesis height to something big
 //     and remove one validator from the set so that we can simulate what
 //     happens when the new validator set has only 2/3 of the voting power.
 func (sc *trustRootChangeImpl) unhappyRun(ctx context.Context, childEnv *env.Env) (err error) {
 	// Step 1: Build a simple key/value runtime and start the network.
-	rebuild, err := sc.BuildRuntimeBinary(ctx, childEnv)
-	if err != nil {
+	if err = sc.PreRun(ctx, childEnv); err != nil {
 		return err
 	}
 	defer func() {
-		if err2 := rebuild(); err2 != nil {
-			err = fmt.Errorf("%w (original error: %s)", err2, err)
-		}
+		err2 := sc.PostRun(ctx, childEnv)
+		err = multierror.Append(err, err2).ErrorOrNil()
 	}()
 
 	chainContext, err := sc.chainContext(ctx)
@@ -201,18 +202,17 @@ func (sc *trustRootChangeImpl) unhappyRun(ctx context.Context, childEnv *env.Env
 	f := []func(fixture *oasis.NetworkFixture){
 		// First dump with too low genesis height.
 		func(fixture *oasis.NetworkFixture) {
-			// Make sure all nodes are started initially although we only need
-			// one compute worker. We have to start them as otherwise tendermint
-			// reset will fail.
-			for i := range fixture.ComputeWorkers {
-				fixture.ComputeWorkers[i].NoAutoStart = false
-			}
-			for i := range fixture.Clients {
-				fixture.Clients[i].NoAutoStart = false
-			}
+			// We only need one compute worker and one key manager node.
+			fixture.Keymanagers = fixture.Keymanagers[:1]
+			fixture.ComputeWorkers = fixture.ComputeWorkers[:1]
+			fixture.Clients = fixture.Clients[:0]
+
+			// Start both nodes after dump-restore.
+			fixture.Keymanagers[0].NoAutoStart = false
+			fixture.ComputeWorkers[0].NoAutoStart = false
 
 			// Observe logs for invalid genesis block error messages.
-			fixture.ComputeWorkers[0].LogWatcherHandlerFactories = []log.WatcherHandlerFactory{
+			fixture.Keymanagers[0].LogWatcherHandlerFactories = []log.WatcherHandlerFactory{
 				oasis.LogAssertEvent(LogEventTrustRootChangeFailed, "the verifier should emit invalid genesis block event"),
 			}
 		},
@@ -222,8 +222,18 @@ func (sc *trustRootChangeImpl) unhappyRun(ctx context.Context, childEnv *env.Env
 			// Remove one validator in the set so that trust validation will
 			// fail and observe logs for failure.
 			fixture.Validators = fixture.Validators[:2]
+
+			// We only need one compute worker and one key manager node.
+			fixture.Keymanagers = fixture.Keymanagers[:1]
+			fixture.ComputeWorkers = fixture.ComputeWorkers[:1]
+			fixture.Clients = fixture.Clients[:0]
+
+			// Start both nodes after dump-restore.
+			fixture.Keymanagers[0].NoAutoStart = false
 			fixture.ComputeWorkers[0].NoAutoStart = false
-			fixture.ComputeWorkers[0].LogWatcherHandlerFactories = []log.WatcherHandlerFactory{
+
+			// Observe logs for not enough trust error messages.
+			fixture.Keymanagers[0].LogWatcherHandlerFactories = []log.WatcherHandlerFactory{
 				oasis.LogAssertEvent(LogEventTrustRootChangeNoTrust, "the verifier should emit not trusted chain event"),
 			}
 		},
@@ -281,77 +291,40 @@ func (sc *trustRootChangeImpl) unhappyRun(ctx context.Context, childEnv *env.Env
 			return fmt.Errorf("chain context hasn't changed")
 		}
 
-		// Running network for few blocks so that compute workers have enough
-		// time to get ready.
-		_, err = sc.waitBlocks(ctx, 25)
+		// The key manager should now have a problem starting the key manager
+		// runtime as the verifier will never initialize. As a consequence,
+		// the runtime worker will get stuck waiting for available key manager.
+		func() {
+			waitCtx, cancel := context.WithTimeout(ctx, time.Minute)
+			defer cancel()
+
+			_ = sc.Net.Keymanagers()[0].WaitReady(waitCtx)
+		}()
+
+		// Verify that the compute worker is stuck.
+		ctrl, err := oasis.NewController(sc.Net.ComputeWorkers()[0].SocketPath())
 		if err != nil {
 			return err
 		}
+		status, err := ctrl.GetStatus(ctx)
+		if err != nil {
+			return err
+		}
+		rtStatus, ok := status.Runtimes[sc.Net.Runtimes()[1].ID()]
+		if !ok {
+			return fmt.Errorf("runtime not supported by the compute worker")
+		}
+		if rtStatus.Committee.Status != commonWorker.StatusStateWaitingKeymanager {
+			return fmt.Errorf("compute worker should be waiting for available key manager")
+		}
 
-		// Starting the key/value runtime should now be a problem for compute
-		// workers as the verifier will never initialize.
+		// Verify that the key manager node failed to trust the new trust root.
 		if err := sc.Net.CheckLogWatchers(); err != nil {
 			return err
 		}
 	}
 
 	return nil
-}
-
-func (sc *TrustRootImpl) BuildRuntimeBinary(ctx context.Context, childEnv *env.Env) (func() error, error) {
-	// Start network with validators only, as configured in the fixture.
-	// We need those to produce blocks from which we pick one and use it
-	// as our embedded trust root.
-	if err := sc.Net.Start(); err != nil {
-		return nil, err
-	}
-	if err := sc.Net.Controller().WaitNodesRegistered(ctx, len(sc.Net.Validators())); err != nil {
-		return nil, err
-	}
-
-	// Pick one block and use it as an embedded trust root.
-	block, err := sc.waitBlocks(ctx, 3)
-	if err != nil {
-		return nil, err
-	}
-	chainContext, err := sc.chainContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	root := trustRoot{
-		height:       strconv.FormatInt(block.Height, 10),
-		hash:         block.Hash.Hex(),
-		runtimeID:    runtimeID.String(),
-		chainContext: chainContext,
-	}
-
-	// Build the runtime using given trust root. Observe that we are changing
-	// the binary here, so we need to rebuild the runtime when we are done.
-	rebuild, err := sc.buildRuntimeBinary(ctx, childEnv, root)
-	if err != nil {
-		return nil, err
-	}
-
-	// Once binary with the embedded root is built, we can register runtimes.
-	if err = sc.registerRuntimes(ctx, childEnv); err != nil {
-		return nil, err
-	}
-
-	// Test runtime to be sure that blocks get processed correctly.
-	// Remember that only validators are currently running.
-	if err = sc.startClientAndComputeWorkers(ctx, childEnv); err != nil {
-		return nil, err
-	}
-
-	// Test transactions.
-	if err := sc.startTestClientOnly(ctx, childEnv); err != nil {
-		return nil, err
-	}
-	if err := sc.waitTestClient(); err != nil {
-		return nil, err
-	}
-
-	return rebuild, nil
 }
 
 func (sc *trustRootChangeImpl) dumpRestoreNetwork(childEnv *env.Env, f func(*oasis.NetworkFixture), g func(*genesis.Document)) error {
@@ -374,37 +347,6 @@ func (sc *trustRootChangeImpl) dumpRestoreNetwork(childEnv *env.Env, f func(*oas
 	if err = sc.DumpRestoreNetwork(childEnv, fixture, false, g, resetFlags); err != nil {
 		return err
 	}
-
-	return nil
-}
-
-func (sc *TrustRootImpl) startClientAndComputeWorkers(ctx context.Context, childEnv *env.Env) error {
-	// Start client and compute workers as they are not auto started.
-	sc.Logger.Info("starting clients and compute workers")
-	for _, n := range sc.Net.Clients() {
-		if err := n.Start(); err != nil {
-			return fmt.Errorf("failed to start node: %w", err)
-		}
-	}
-	for _, n := range sc.Net.ComputeWorkers() {
-		if err := n.Start(); err != nil {
-			return fmt.Errorf("failed to start node: %w", err)
-		}
-	}
-	sc.Logger.Info("waiting for compute workers to become ready")
-	for _, n := range sc.Net.ComputeWorkers() {
-		if err := n.WaitReady(ctx); err != nil {
-			return fmt.Errorf("failed to wait for a compute worker: %w", err)
-		}
-	}
-
-	// Setup a client controller as there is none due to the client node not
-	// being auto started.
-	ctrl, err := oasis.NewController(sc.Net.Clients()[0].SocketPath())
-	if err != nil {
-		return fmt.Errorf("failed to create client controller: %w", err)
-	}
-	sc.Net.SetClientController(ctrl)
 
 	return nil
 }

--- a/go/oasis-test-runner/scenario/e2e/runtime/trust_root_change.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/trust_root_change.go
@@ -36,7 +36,7 @@ var (
 	// changes, e.g. on dump-restore network upgrades.
 	TrustRootChangeTest scenario.Scenario = newTrustRootChangeImpl(
 		"change",
-		NewKVTestClient().WithScenario(InsertKeyValueScenario),
+		NewKVTestClient().WithScenario(InsertKeyValueEncScenario),
 		true,
 	)
 
@@ -45,7 +45,7 @@ var (
 	// consensus chain context changes.
 	TrustRootChangeFailsTest scenario.Scenario = newTrustRootChangeImpl(
 		"change-fails",
-		NewKVTestClient().WithScenario(SimpleKeyValueScenario),
+		NewKVTestClient().WithScenario(SimpleKeyValueEncScenario),
 		false,
 	)
 )
@@ -354,7 +354,7 @@ func (sc *trustRootChangeImpl) dumpRestoreNetwork(childEnv *env.Env, f func(*oas
 func (sc *trustRootChangeImpl) startRestoredStateTestClient(ctx context.Context, childEnv *env.Env, round int64) error {
 	// Check that everything works with restored state.
 	seed := fmt.Sprintf("seed %d", round)
-	sc.Scenario.testClient = NewKVTestClient().WithSeed(seed).WithScenario(RemoveKeyValueScenario)
+	sc.Scenario.testClient = NewKVTestClient().WithSeed(seed).WithScenario(RemoveKeyValueEncScenario)
 	if err := sc.Scenario.Run(ctx, childEnv); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/seed_api.go
+++ b/go/oasis-test-runner/scenario/e2e/seed_api.go
@@ -42,12 +42,10 @@ func (sc *seedAPI) Clone() scenario.Scenario {
 	}
 }
 
-func (sc *seedAPI) Run(childEnv *env.Env) error { // nolint: gocyclo
+func (sc *seedAPI) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	if err := sc.Net.Start(); err != nil {
 		return fmt.Errorf("net Start: %w", err)
 	}
-
-	ctx := context.Background()
 
 	sc.Logger.Info("waiting for network to come up")
 	if err := sc.Net.Controller().WaitNodesRegistered(ctx, 3); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/upgrade.go
@@ -159,7 +159,6 @@ type nodeUpgradeImpl struct {
 
 	nodeCh <-chan *registry.NodeEvent
 
-	ctx          context.Context
 	currentEpoch beacon.EpochTime
 
 	handlerName    upgrade.HandlerName
@@ -178,9 +177,9 @@ func (sc *nodeUpgradeImpl) writeDescriptor(name string, content []byte) (string,
 	return filePath, nil
 }
 
-func (sc *nodeUpgradeImpl) nextEpoch() error {
+func (sc *nodeUpgradeImpl) nextEpoch(ctx context.Context) error {
 	sc.currentEpoch++
-	if err := sc.Net.Controller().SetEpoch(sc.ctx, sc.currentEpoch); err != nil {
+	if err := sc.Net.Controller().SetEpoch(ctx, sc.currentEpoch); err != nil {
 		// Errors can happen because an upgrade happens exactly during an epoch transition. So
 		// make sure to ignore them.
 		sc.Logger.Warn("failed to set epoch",
@@ -191,9 +190,9 @@ func (sc *nodeUpgradeImpl) nextEpoch() error {
 	return nil
 }
 
-func (sc *nodeUpgradeImpl) restart(wait bool) error {
+func (sc *nodeUpgradeImpl) restart(ctx context.Context, wait bool) error {
 	sc.Logger.Debug("restarting validator")
-	if err := sc.validator.Restart(sc.ctx); err != nil {
+	if err := sc.validator.Restart(ctx); err != nil {
 		return fmt.Errorf("can't restart validator: %w", err)
 	}
 
@@ -206,7 +205,7 @@ func (sc *nodeUpgradeImpl) restart(wait bool) error {
 		case ev := <-sc.nodeCh:
 			if ev.IsRegistration && ev.Node.ID.Equal(sc.validator.NodeID) {
 				// Nothing else is restarted, so no need to check for specifics here.
-				_ = sc.controller.WaitSync(sc.ctx)
+				_ = sc.controller.WaitSync(ctx)
 				return nil
 			}
 		case <-time.After(60 * time.Second):
@@ -218,7 +217,6 @@ func (sc *nodeUpgradeImpl) restart(wait bool) error {
 func newNodeUpgradeImpl(handlerName upgrade.HandlerName, upgradeChecker upgradeChecker) scenario.Scenario {
 	sc := &nodeUpgradeImpl{
 		Scenario:       *NewScenario("node-upgrade-" + string(handlerName)),
-		ctx:            context.Background(),
 		handlerName:    handlerName,
 		upgradeChecker: upgradeChecker,
 	}
@@ -228,7 +226,6 @@ func newNodeUpgradeImpl(handlerName upgrade.HandlerName, upgradeChecker upgradeC
 func (sc *nodeUpgradeImpl) Clone() scenario.Scenario {
 	return &nodeUpgradeImpl{
 		Scenario:       sc.Scenario.Clone(),
-		ctx:            context.Background(),
 		handlerName:    sc.handlerName,
 		upgradeChecker: sc.upgradeChecker,
 	}
@@ -267,7 +264,7 @@ func (sc *nodeUpgradeImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return ff, nil
 }
 
-func (sc *nodeUpgradeImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
+func (sc *nodeUpgradeImpl) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	var err error
 	var descPath string
 
@@ -276,15 +273,15 @@ func (sc *nodeUpgradeImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 	}
 
 	sc.Logger.Info("waiting for network to come up")
-	if err = sc.Net.Controller().WaitNodesRegistered(sc.ctx, len(sc.Net.Validators())); err != nil {
+	if err = sc.Net.Controller().WaitNodesRegistered(ctx, len(sc.Net.Validators())); err != nil {
 		return err
 	}
-	if err = sc.nextEpoch(); err != nil {
+	if err = sc.nextEpoch(ctx); err != nil {
 		return err
 	}
 
 	var nodeSub pubsub.ClosableSubscription
-	sc.nodeCh, nodeSub, err = sc.Net.Controller().Registry.WatchNodes(sc.ctx)
+	sc.nodeCh, nodeSub, err = sc.Net.Controller().Registry.WatchNodes(ctx)
 	if err != nil {
 		return fmt.Errorf("can't subscribe to registry node events: %w", err)
 	}
@@ -303,12 +300,12 @@ func (sc *nodeUpgradeImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 	if err != nil {
 		return err
 	}
-	if err = sc.controller.WaitSync(sc.ctx); err != nil {
+	if err = sc.controller.WaitSync(ctx); err != nil {
 		return err
 	}
 
 	// Run pre-upgrade checker.
-	if err = sc.upgradeChecker.PreUpgradeFn(sc.ctx, sc.Net.Controller()); err != nil {
+	if err = sc.upgradeChecker.PreUpgradeFn(ctx, sc.Net.Controller()); err != nil {
 		return err
 	}
 
@@ -342,7 +339,7 @@ func (sc *nodeUpgradeImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 		return fmt.Errorf("error submitting descriptor with nonexistent handler to node: %w", err)
 	}
 
-	if err = sc.nextEpoch(); err != nil {
+	if err = sc.nextEpoch(ctx); err != nil {
 		return err
 	}
 	<-sc.validator.Exit()
@@ -351,7 +348,7 @@ func (sc *nodeUpgradeImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 
 	// Try restarting the node. It should exit immediately now; on paper it can't handle the upgrade
 	// described in the descriptor.
-	if err = sc.restart(false); err != nil {
+	if err = sc.restart(ctx, false); err != nil {
 		return err
 	}
 	<-sc.validator.Exit()
@@ -398,7 +395,7 @@ func (sc *nodeUpgradeImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 	}
 
 	// Restart the node again, so we have the full set of validators.
-	if err = sc.restart(true); err != nil {
+	if err = sc.restart(ctx, true); err != nil {
 		return err
 	}
 
@@ -410,7 +407,7 @@ func (sc *nodeUpgradeImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 			return fmt.Errorf("failed to submit upgrade descriptor to validator %d: %w", i, err)
 		}
 	}
-	if err = sc.nextEpoch(); err != nil {
+	if err = sc.nextEpoch(ctx); err != nil {
 		return err
 	}
 
@@ -424,7 +421,7 @@ func (sc *nodeUpgradeImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 			sc.Logger.Debug("waiting for validator to exit", "num", i)
 			<-val.Exit()
 			sc.Logger.Debug("restarting validator", "num", i)
-			if restartError := val.Restart(sc.ctx); err != nil {
+			if restartError := val.Restart(ctx); err != nil {
 				errCh <- restartError
 			}
 		}(i, val)
@@ -438,16 +435,16 @@ func (sc *nodeUpgradeImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
 	}
 
 	sc.Logger.Info("waiting for network to come back up")
-	if err = sc.Net.Controller().WaitNodesRegistered(sc.ctx, len(sc.Net.Validators())); err != nil {
+	if err = sc.Net.Controller().WaitNodesRegistered(ctx, len(sc.Net.Validators())); err != nil {
 		return err
 	}
 	sc.Logger.Info("final epoch advance")
-	if err = sc.nextEpoch(); err != nil {
+	if err = sc.nextEpoch(ctx); err != nil {
 		return err
 	}
 
 	// Run post-upgrade checker.
-	if err = sc.upgradeChecker.PostUpgradeFn(sc.ctx, sc.Net.Controller()); err != nil {
+	if err = sc.upgradeChecker.PostUpgradeFn(ctx, sc.Net.Controller()); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/validator_equivocation.go
+++ b/go/oasis-test-runner/scenario/e2e/validator_equivocation.go
@@ -85,7 +85,7 @@ func (sc *validatorEquivocationImpl) Fixture() (*oasis.NetworkFixture, error) {
 	return f, nil
 }
 
-func (sc *validatorEquivocationImpl) Run(childEnv *env.Env) error { // nolint: gocyclo
+func (sc *validatorEquivocationImpl) Run(ctx context.Context, childEnv *env.Env) error { // nolint: gocyclo
 	if err := sc.Net.Start(); err != nil {
 		return err
 	}
@@ -93,7 +93,6 @@ func (sc *validatorEquivocationImpl) Run(childEnv *env.Env) error { // nolint: g
 	ctrl := sc.Net.Controller()
 
 	sc.Logger.Info("waiting for network to come up")
-	ctx := context.Background()
 	if err := ctrl.WaitNodesRegistered(ctx, len(sc.Net.Validators())); err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/pluginsigner/basic.go
+++ b/go/oasis-test-runner/scenario/pluginsigner/basic.go
@@ -1,6 +1,7 @@
 package pluginsigner
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 
@@ -30,7 +31,7 @@ func (sc *basicImpl) Clone() scenario.Scenario {
 	}
 }
 
-func (sc *basicImpl) Run(childEnv *env.Env) error {
+func (sc *basicImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	roles := []signature.SignerRole{
 		signature.SignerEntity,
 		signature.SignerNode,

--- a/go/oasis-test-runner/scenario/remotesigner/basic.go
+++ b/go/oasis-test-runner/scenario/remotesigner/basic.go
@@ -1,6 +1,7 @@
 package remotesigner
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -35,7 +36,7 @@ func (sc *basicImpl) Clone() scenario.Scenario {
 	}
 }
 
-func (sc *basicImpl) Run(childEnv *env.Env) error {
+func (sc *basicImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	// Provision the server keys.
 	sc.logger.Info("provisioning the server keys")
 	serverBinary, _ := sc.flags.GetString(cfgServerBinary)

--- a/go/oasis-test-runner/scenario/scenario.go
+++ b/go/oasis-test-runner/scenario/scenario.go
@@ -2,6 +2,8 @@
 package scenario
 
 import (
+	"context"
+
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
 )
@@ -37,5 +39,5 @@ type Scenario interface {
 	Init(childEnv *env.Env, net *oasis.Network) error
 
 	// Run runs the scenario.
-	Run(childEnv *env.Env) error
+	Run(ctx context.Context, childEnv *env.Env) error
 }

--- a/runtime/src/consensus/tendermint/verifier/noop.rs
+++ b/runtime/src/consensus/tendermint/verifier/noop.rs
@@ -2,8 +2,10 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use io_context::Context;
+use slog::info;
 
 use crate::{
+    common::logger::get_logger,
     consensus::{
         beacon::EpochTime,
         roothash::{ComputeResultsHeader, Header},
@@ -25,6 +27,12 @@ impl NopVerifier {
     /// Create a new non-verifying verifier.
     pub fn new(protocol: Arc<Protocol>) -> Self {
         Self { protocol }
+    }
+
+    /// Start the non-verifying verifier.
+    pub fn start(&self) {
+        let logger = get_logger("consensus/cometbft/verifier");
+        info!(logger, "Starting consensus noop verifier");
     }
 
     fn fetch_light_block(&self, height: u64) -> Result<LightBlock, Error> {

--- a/runtime/src/protocol.rs
+++ b/runtime/src/protocol.rs
@@ -439,7 +439,10 @@ impl Protocol {
                 Box::new(handle)
             } else {
                 // Create a no-op verifier.
-                Box::new(tendermint::verifier::NopVerifier::new(self.clone()))
+                let verifier = tendermint::verifier::NopVerifier::new(self.clone());
+                verifier.start();
+
+                Box::new(verifier)
             };
 
         // Configure the host environment info.

--- a/tests/runtimes/simple-keymanager/src/main.rs
+++ b/tests/runtimes/simple-keymanager/src/main.rs
@@ -1,14 +1,38 @@
 use oasis_core_keymanager::runtime::init::new_keymanager;
-use oasis_core_runtime::{common::version::Version, config::Config};
+use oasis_core_runtime::{
+    common::version::Version, config::Config, consensus::verifier::TrustRoot, types::Features,
+};
 
 mod api;
 
 pub fn main_with_version(version: Version) {
+    // Initializer.
     let init = new_keymanager(api::trusted_policy_signers());
+
+    // Determine test trust root based on build settings.
+    let trust_root = option_env!("OASIS_TESTS_CONSENSUS_TRUST_HEIGHT").map(|height| {
+        let hash = option_env!("OASIS_TESTS_CONSENSUS_TRUST_HASH").unwrap();
+        let runtime_id = option_env!("OASIS_TESTS_CONSENSUS_TRUST_RUNTIME_ID").unwrap();
+        let chain_context = option_env!("OASIS_TESTS_CONSENSUS_TRUST_CHAIN_CONTEXT").unwrap();
+
+        TrustRoot {
+            height: height.parse::<u64>().unwrap(),
+            hash: hash.to_string(),
+            runtime_id: runtime_id.into(),
+            chain_context: chain_context.to_string(),
+        }
+    });
+
+    // Start the runtime.
     oasis_core_runtime::start_runtime(
         init,
         Config {
             version,
+            trust_root,
+            features: Some(Features {
+                ..Default::default()
+            }),
+            freshness_proofs: true,
             ..Default::default()
         },
     );


### PR DESCRIPTION
Backport of #5300 (support key/value queries), #5304 (add `ctx` to `Run`), #5307 (build key manager with trust root and use encrypted txs in trust root scenarios).

Needed so that we can test dump-restore upgrades with key manager runtimes built with trust root. 