### PR TITLE
dependabot: rename tendermint->cometbft, try groups feature

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,9 +27,9 @@ updates:
       - c:deps
       - golang
     ignore:
-      # Tendermint is manualy kept up to date.
-      - dependency-name: github.com/tendermint/tendermint
-      - dependency-name: github.com/tendermint/tm-db
+      # CometBFT is manualy kept up to date.
+      - dependency-name: github.com/cometbft/cometbft
+      - dependency-name: github.com/cometbft/cometbft-db
 
   # Manage Rust pacakge versions.
   - package-ecosystem: cargo

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,11 @@ updates:
       # CometBFT is manualy kept up to date.
       - dependency-name: github.com/cometbft/cometbft
       - dependency-name: github.com/cometbft/cometbft-db
+    groups:
+      # Group all libp2p dependency updates together.
+      libp2p:
+        patterns:
+          - "github.com/libp2p*"
 
   # Manage Rust pacakge versions.
   - package-ecosystem: cargo


### PR DESCRIPTION
Fix the ignore clause to prevents PR's like: https://github.com/oasisprotocol/oasis-core/pull/5310

Try out the new [groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) feature. For now, only group libp2p packages as a test. We could probably create a group that matches all packages other than select few (e.g. badger, cbor, libp2p) to reduce the number of PR's (and CI runs) opened by dependabot.