### PR TITLE
dependabot: remove libp2p group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,11 +30,6 @@ updates:
       # CometBFT is manualy kept up to date.
       - dependency-name: github.com/cometbft/cometbft
       - dependency-name: github.com/cometbft/cometbft-db
-    groups:
-      # Group all libp2p dependency updates together.
-      libp2p:
-        patterns:
-          - "github.com/libp2p*"
 
   # Manage Rust pacakge versions.
   - package-ecosystem: cargo


### PR DESCRIPTION
Otherwise it will keep trying to "update" the libp2p as in:
- https://github.com/oasisprotocol/oasis-core/pull/5312
- https://github.com/oasisprotocol/oasis-core/pull/5315