### PR TITLE
staking: Fix reward distribution when common pool is exhausted

### DIFF
--- a/.changelog/5319.bugfix.md
+++ b/.changelog/5319.bugfix.md
@@ -1,0 +1,1 @@
+staking: Fix reward distribution when common pool is exhausted


### PR DESCRIPTION
This PR fixes the scenario when the reward schedule hasn't completed yet, but the common pool has been exhausted.