### PR TITLE
go/worker/keymanager/status: Show active version of the km runtime

### DIFF
--- a/.changelog/5320.feature.md
+++ b/.changelog/5320.feature.md
@@ -1,0 +1,5 @@
+go/worker/keymanager/status: Show active version of the km runtime
+
+The status of the key manager was updated to include a new attribute called
+`active_version`, which stores the version number of the currently deployed
+key manager runtime. If no deployment is active, the value is set to null.

--- a/go/worker/keymanager/api/api.go
+++ b/go/worker/keymanager/api/api.go
@@ -7,6 +7,7 @@ import (
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/keymanager/api"
 )
 
@@ -95,6 +96,9 @@ type Status struct {
 type WorkerStatus struct {
 	// Status is a concise status of the key manager worker.
 	Status StatusState `json:"status"`
+
+	// ActiveVersion is the currently active version.
+	ActiveVersion *version.Version `json:"active_version"`
 
 	// MayGenerate returns whether the enclave can generate a master secret.
 	MayGenerate bool `json:"may_generate"`

--- a/go/worker/keymanager/status.go
+++ b/go/worker/keymanager/status.go
@@ -6,6 +6,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/worker/keymanager/api"
 )
 
@@ -62,10 +63,17 @@ func (w *Worker) GetStatus(ctx context.Context) (*api.Status, error) {
 		pc = w.enclaveStatus.InitResponse.PolicyChecksum
 	}
 
+	var aw *version.Version
+	if w.rtStatus != nil {
+		aw = &w.rtStatus.version
+	}
+
 	gs := w.globalStatus
 	ws := api.WorkerStatus{
 		Status:           ss,
+		ActiveVersion:    aw,
 		MayGenerate:      w.mayGenerate,
+		RuntimeID:        &w.runtimeID,
 		ClientRuntimes:   rts,
 		AccessList:       al,
 		PrivatePeers:     ps,


### PR DESCRIPTION
The status of the key manager was updated to include a new attribute called `active_version`, which stores the version number of the currently deployed key manager runtime. If no deployment is active, the value is set to null.

Result:
```
➜  oasis-post-upgrade oasis-node control status -a keymanager-1-internal-205141582.sock
{
  "keymanager": {
    "worker": {
      "active_version": {
        "minor": 1
      },
      "runtime_id": "c000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff",
    }
  },
}
```