### PR TITLE
[BACKPORT/22.2.x] go/storage/mkvs: Fix commit of nil entries

### DIFF
--- a/.changelog/5321.bugfix.md
+++ b/.changelog/5321.bugfix.md
@@ -1,0 +1,1 @@
+go/storage/mkvs: Fix commit of nil entries

--- a/go/storage/mkvs/commit.go
+++ b/go/storage/mkvs/commit.go
@@ -111,7 +111,7 @@ func (t *tree) commitWithHooks(
 		}
 
 		log = append(log, writelog.LogEntry{Key: entry.key, Value: entry.value})
-		if len(entry.value) == 0 {
+		if entry.value == nil {
 			logAnns = append(logAnns, writelog.LogEntryAnnotation{InsertedNode: nil})
 		} else {
 			logAnns = append(logAnns, writelog.LogEntryAnnotation{InsertedNode: entry.insertedLeaf})


### PR DESCRIPTION
Backport of #5321 