### PR TITLE
go/workerpool: support backoff on failures

### DIFF
--- a/.changelog/5326.bugfix.md
+++ b/.changelog/5326.bugfix.md
@@ -1,0 +1,5 @@
+Backoff when storage sync starts failing
+
+Fixes the case where if storage requests start failing (e.g. due to network
+errors) the storage worker would crazily retry requests - using lots of CPU
+and filling up the logs.

--- a/go/common/workerpool/workerpool_test.go
+++ b/go/common/workerpool/workerpool_test.go
@@ -1,0 +1,50 @@
+package workerpool
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoolBackoff(t *testing.T) {
+	require := require.New(t)
+
+	// Test that the backoff is reset on success.
+	pool := New("test", &PoolConfig{Backoff: &BackoffConfig{MinTimeout: 500 * time.Millisecond, MaxTimeout: 3 * time.Second}})
+	pool.Resize(4)
+
+	fnSuccess := func() error { return nil }
+	fnFail := func() error { return fmt.Errorf("job failure") }
+
+	// Ensure no backoff on successes.
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-pool.Submit(fnSuccess)
+		}()
+	}
+	wg.Wait()
+	require.EqualValues(0, pool.backoff.Timeout(), "there should be no backoff on success")
+
+	// Ensure max backoff on multilple failures.
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-pool.Submit(fnFail)
+		}()
+	}
+	wg.Wait()
+	// Note: The exact backoff is not known as the backoff is randomized, and can even increase
+	// beyond MaxBackoff by a bit due to the upstream backoff implementation.
+	require.GreaterOrEqual(pool.backoff.Timeout(), 1*time.Second, "repeated failures should increase backoff")
+
+	// Ensure backoff is reset on success.
+	<-pool.Submit(fnSuccess)
+	require.EqualValues(0, pool.backoff.Timeout(), "backoff should be reset on success")
+}

--- a/go/p2p/rpc/client.go
+++ b/go/p2p/rpc/client.go
@@ -363,7 +363,7 @@ func (c *client) CallMulti(
 	}
 
 	// Create a worker pool.
-	pool := workerpool.New("p2p/rpc")
+	pool := workerpool.New("p2p/rpc", nil)
 	pool.Resize(co.maxParallelRequests)
 	defer pool.Stop()
 
@@ -384,11 +384,11 @@ func (c *client) CallMulti(
 	for _, peer := range peers {
 		peer := peer // Make sure goroutine below operates on the right instance.
 
-		pool.Submit(func() {
+		pool.Submit(func() error {
 			// Abort early in case we are done.
 			select {
 			case <-peerCtx.Done():
-				return
+				return nil
 			default:
 			}
 
@@ -396,6 +396,7 @@ func (c *client) CallMulti(
 			pf, err := c.timeCall(peerCtx, peer, &request, rsp, co.maxPeerResponseTime)
 
 			resultCh <- result{rsp, pf, err}
+			return nil
 		})
 	}
 

--- a/go/worker/storage/worker.go
+++ b/go/worker/storage/worker.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/grpc"
@@ -59,7 +60,15 @@ func New(
 		return s, nil
 	}
 
-	s.fetchPool = workerpool.New("storage_fetch")
+	s.fetchPool = workerpool.New(
+		"storage_fetch",
+		&workerpool.PoolConfig{
+			Backoff: &workerpool.BackoffConfig{
+				MinTimeout: 10 * time.Millisecond,
+				MaxTimeout: 2 * time.Second,
+			},
+		},
+	)
 	s.fetchPool.Resize(config.GlobalConfig.Storage.FetcherCount)
 
 	var checkpointerCfg *checkpoint.CheckpointerConfig


### PR DESCRIPTION
Adds support for backoff on failures to the workerpool module. 

Use the backoff in the storage sync protocol to fix the case where currently if storage sync requests start failing (e.g. due to a network error), the storage worker will crazily retry and fill up logs / cpu.

TODO: 
- [x] minor todo's in code
- [x] add some unit tests to the workerpool module
- [x] test that this fixes the mentioned storage sync issue

Before fix (with an artificial instant failure):
```
cat node.log | grep "error calling getdiff" | grep "11:22:03" | wc -l
18202
```

after:
```
cat node.log | grep "error calling getdiff" | grep "11:50:5" | wc -l
23
```

From ~18k calls per second, to ~2 per second.