### PR TITLE
go/oasis-node/cmd/config/migrate: Add runtime P2P seed address too

### DIFF
--- a/.changelog/5332.trivial.md
+++ b/.changelog/5332.trivial.md
@@ -1,0 +1,1 @@
+go/oasis-node/cmd/config/migrate: Add runtime P2P seed address too

--- a/go/oasis-node/cmd/config/migrate/migrate_test.go
+++ b/go/oasis-node/cmd/config/migrate/migrate_test.go
@@ -448,6 +448,7 @@ func TestConfigMigrationSimple(t *testing.T) {
 	require.Equal(newConfig.Common.Log.Level["cometbft/context"], "error")
 	require.Equal(newConfig.Genesis.File, "/node/etc/genesis.json")
 	require.Equal(newConfig.P2P.Seeds[0], "H6u9MtuoWRKn5DKSgarj/dzr2Z9BsjuRHgRAoXITOcU=@35.199.49.168:26656")
+	require.Equal(newConfig.P2P.Seeds[1], "H6u9MtuoWRKn5DKSgarj/dzr2Z9BsjuRHgRAoXITOcU=@35.199.49.168:9200")
 	require.Equal(newConfig.Runtime.Paths[0], "/node/runtime/cipher-paratime-2.6.2.orc")
 	require.Equal(newConfig.Runtime.Paths[1], "/node/runtime/emerald-paratime-10.0.0.orc")
 	require.Equal(newConfig.Runtime.Paths[2], "/node/runtime/sapphire-paratime-0.4.0.orc")
@@ -469,6 +470,7 @@ func TestConfigMigrationComplex(t *testing.T) {
 	require.Equal(newConfig.Genesis.File, "/storage/node/genesis.json")
 	require.Equal(newConfig.P2P.Port, uint16(9002))
 	require.Equal(newConfig.P2P.Seeds[0], "HcDFrTp/MqRHtju5bCx6TIhIMd6X/0ZQ3lUG73q5898=@34.86.165.6:26656")
+	require.Equal(newConfig.P2P.Seeds[1], "HcDFrTp/MqRHtju5bCx6TIhIMd6X/0ZQ3lUG73q5898=@34.86.165.6:9200")
 	require.Equal(newConfig.Consensus.P2P.PersistentPeer[0], "INSERT_P2P_PUBKEY_HERE@1.2.3.4:5678")
 	require.Equal(newConfig.Consensus.P2P.UnconditionalPeer[0], "HcDFrTp/MqRHtju5bCx6TIhIMd6X/0ZQ3lUG73q5898=@34.86.165.6:26656")
 	require.Equal(newConfig.Consensus.SentryUpstreamAddresses[0], "INSERT_P2P_PUBKEY_HERE@1.2.3.4:5678")
@@ -511,6 +513,7 @@ func TestConfigMigrationKM(t *testing.T) {
 	require.Equal(newConfig.Genesis.File, "/km/etc/genesis.json")
 	require.Equal(newConfig.P2P.Port, uint16(1234))
 	require.Equal(newConfig.P2P.Seeds[0], "INSERT_P2P_PUBKEY_HERE@1.2.3.4:26656")
+	require.Equal(newConfig.P2P.Seeds[1], "INSERT_P2P_PUBKEY_HERE@1.2.3.4:9200")
 	require.Equal(newConfig.P2P.Registration.Addresses[0], "4.3.2.1:26656")
 	require.Equal(newConfig.Registration.Entity, "/km/etc/entity/entity.json")
 	require.Equal(newConfig.IAS.ProxyAddress, []string{"foo@1.2.3.4:5678"})
@@ -536,6 +539,7 @@ func TestConfigMigrationDocsNonValidator(t *testing.T) {
 	require.Equal(newConfig.Common.Log.Level["cometbft/context"], "error")
 	require.Equal(newConfig.Genesis.File, "/node/etc/genesis.json")
 	require.Equal(newConfig.P2P.Seeds[0], "H6u9MtuoWRKn5DKSgarj/dzr2Z9BsjuRHgRAoXITOcU=@35.199.49.168:26656")
+	require.Equal(newConfig.P2P.Seeds[1], "H6u9MtuoWRKn5DKSgarj/dzr2Z9BsjuRHgRAoXITOcU=@35.199.49.168:9200")
 	require.Equal(newConfig.Consensus.Validator, false)
 }
 
@@ -584,6 +588,7 @@ func TestConfigMigrationDocsParaTime(t *testing.T) {
 	require.Equal(newConfig.P2P.Port, uint16(30002))
 	require.Equal(newConfig.P2P.Registration.Addresses[0], "1.2.3.4:30002")
 	require.Equal(newConfig.P2P.Seeds[0], "H6u9MtuoWRKn5DKSgarj/dzr2Z9BsjuRHgRAoXITOcU=@35.199.49.168:26656")
+	require.Equal(newConfig.P2P.Seeds[1], "H6u9MtuoWRKn5DKSgarj/dzr2Z9BsjuRHgRAoXITOcU=@35.199.49.168:9200")
 	require.Equal(newConfig.Registration.Entity, "/node/entity/entity.json")
 	require.Equal(newConfig.IAS.ProxyAddress, []string{"asdf@5.4.3.2:1234"})
 	require.Equal(newConfig.Runtime.SGXLoader, "/node/bin/oasis-core-runtime-loader")
@@ -606,6 +611,7 @@ func TestConfigMigrationDocsParaTimeClient(t *testing.T) {
 	require.Equal(newConfig.Common.Log.Level["cometbft/context"], "error")
 	require.Equal(newConfig.Genesis.File, "/node/etc/genesis.json")
 	require.Equal(newConfig.P2P.Seeds[0], "H6u9MtuoWRKn5DKSgarj/dzr2Z9BsjuRHgRAoXITOcU=@35.199.49.168:26656")
+	require.Equal(newConfig.P2P.Seeds[1], "H6u9MtuoWRKn5DKSgarj/dzr2Z9BsjuRHgRAoXITOcU=@35.199.49.168:9200")
 	require.Equal(newConfig.Runtime.Paths[0], "/node/runtimes/test.orc")
 }
 
@@ -629,5 +635,6 @@ func TestConfigMigrationDocsSentry(t *testing.T) {
 	require.Equal(newConfig.Sentry.Control.Port, uint16(9009))
 	require.Equal(newConfig.Sentry.Control.AuthorizedPubkeys[0], "asdf")
 	require.Equal(newConfig.P2P.Seeds[0], "H6u9MtuoWRKn5DKSgarj/dzr2Z9BsjuRHgRAoXITOcU=@35.199.49.168:26656")
+	require.Equal(newConfig.P2P.Seeds[1], "H6u9MtuoWRKn5DKSgarj/dzr2Z9BsjuRHgRAoXITOcU=@35.199.49.168:9200")
 	require.Equal(newConfig.Consensus.SentryUpstreamAddresses[0], "INSERT_P2P_PUBKEY_HERE@1.2.3.4:26656")
 }


### PR DESCRIPTION
When running the `config migrate` command, an additional P2P runtime seed address is added when migrating seed nodes.