### PR TITLE
storage/sync: Backoff when storage sync starts failing

### DIFF
--- a/.changelog/5326.bugfix.md
+++ b/.changelog/5326.bugfix.md
@@ -1,0 +1,5 @@
+Backoff when storage sync starts failing
+
+Fixes the case where if storage requests start failing (e.g. due to network
+errors) the storage worker would crazily retry requests - using lots of CPU
+and filling up the logs.


### PR DESCRIPTION
Alternative fix to https://github.com/oasisprotocol/oasis-core/pull/5326

See **https://github.com/oasisprotocol/oasis-core/pull/5326#discussion_r1269716139** for reasoning

TODO:
- [x] tested with an artificial instant storage-synch fetch failure in storage-sync tests