### PR TITLE
storage/sync: don't immediately trigger more round fetches on failures

### DIFF
--- a/.changelog/5326.bugfix.md
+++ b/.changelog/5326.bugfix.md
@@ -1,0 +1,1 @@
+storage/sync: don't immediately trigger more round fetches on failures

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -1247,9 +1247,11 @@ mainLoop:
 				syncingRounds[item.round].retry(item.thisRoot.Type)
 			} else {
 				heap.Push(outOfOrderDoneDiffs, item)
+				// Item was successfully processed, trigger more round fetches.
+				// This ensures that new rounds are processed as fast as possible
+				// when we're syncing and are far behind.
+				triggerRoundFetches()
 			}
-
-			triggerRoundFetches()
 
 		case finalized := <-n.finalizeCh:
 			// If finalization failed, things start falling apart.


### PR DESCRIPTION
Before, after every processed result, the `triggerRoundFetches` was triggered. In the pathological case, where storage fetching always failed immediately, this caused the repeated calling of `triggerRoundFetches` completely hog the CPU - since there was no time spent blocking on i/o or anything.

The clickup issue suggested implementing back-off mechanism (implemented in: https://github.com/oasisprotocol/oasis-core/pull/5341), however it seems that simply not triggering `triggerRoundFetches` on failures fixes the pathological case as well, with not many downsides.

One (minor?) downside is that in case the whole batch of fetches within a `triggerRoundFetches` fails (e.g. due to unlucky selection of p2p nodes when fetching diffs), the next `triggerRoundFetches` will be triggered only after the next `heartbeat` tick or a new block is received. 
