### PR TITLE
[22.2.x] Pin tendermint links to 22.2.x branch

### DIFF
--- a/.changelog/5347.doc.md
+++ b/.changelog/5347.doc.md
@@ -1,0 +1,5 @@
+docs: Pin tendermint links to 22.2.x branch
+
+Since we moved (and renamed folders) from tendermint to cometbft in the master
+branch, links in the stable branch docs to the source files are now broken.
+Fix the links by pointing to source files in the stable git branch.

--- a/docs/consensus/README.md
+++ b/docs/consensus/README.md
@@ -75,7 +75,7 @@ The Tendermint consensus backend is split into two major parts:
    Oasis Core Consensus interface.
 
 <!-- markdownlint-disable line-length -->
-[`go/consensus/tendermint`]: https://github.com/oasisprotocol/oasis-core/tree/master/go/consensus/tendermint
+[`go/consensus/tendermint`]: https://github.com/oasisprotocol/oasis-core/tree/stable/22.2.x/go/consensus/tendermint
 [the Tendermint Core developer documentation]: https://docs.tendermint.com/
 <!-- markdownlint-enable line-length -->
 
@@ -93,8 +93,8 @@ _consensus layer_ interface living in [`go/consensus/tendermint/apps/<app>`].
 
 <!-- markdownlint-disable line-length -->
 [ABCI protocol]: https://github.com/tendermint/tendermint/blob/master/spec/abci/abci.md
-[`go/consensus/tendermint/abci/mux.go`]: https://github.com/oasisprotocol/oasis-core/tree/master/go/consensus/tendermint/abci/mux.go
-[`go/consensus/tendermint/apps/<app>`]: https://github.com/oasisprotocol/oasis-core/tree/master/go/consensus/tendermint/apps
+[`go/consensus/tendermint/abci/mux.go`]: https://github.com/oasisprotocol/oasis-core/tree/stable/22.2.x/go/consensus/tendermint/abci/mux.go
+[`go/consensus/tendermint/apps/<app>`]: https://github.com/oasisprotocol/oasis-core/tree/stable/22.2.x/go/consensus/tendermint/apps
 <!-- markdownlint-enable line-length -->
 
 ### State Storage
@@ -156,7 +156,7 @@ func (s *staking) TotalSupply(ctx context.Context, height int64) (*quantity.Quan
 ```
 
 <!-- markdownlint-disable line-length -->
-[`go/consensus/tendermint/<service>`]: https://github.com/oasisprotocol/oasis-core/tree/master/go/consensus/tendermint
+[`go/consensus/tendermint/<service>`]: https://github.com/oasisprotocol/oasis-core/tree/stable/22.2.x/go/consensus/tendermint
 [ABCI query functionality]: https://github.com/tendermint/tendermint/blob/master/spec/abci/abci.md#query-1
 <!-- markdownlint-enable line-length -->
 


### PR DESCRIPTION
Since we moved (and renamed folders) from tendermint to cometbft in the master branch, links in the stable branch docs to the source files are now broken. Fix the links by pointing to source files in the stable git branch.

Note: Auto-generated metrics.md doc still contains invalid link.