### PR TITLE
roothash: Store past runtime state and I/O roots in consensus state

### DIFF
--- a/.changelog/5359.breaking.md
+++ b/.changelog/5359.breaking.md
@@ -1,0 +1,6 @@
+roothash: Store past runtime state and I/O roots in consensus state
+
+A new roothash consensus parameter was added (`MaxPastRootsStored`),
+which enables storing runtime state and I/O roots for the past
+`MaxPastRootsStored` rounds in the consensus state.
+This enables easier cross-runtime communication.

--- a/go/consensus/cometbft/apps/roothash/liveness_test.go
+++ b/go/consensus/cometbft/apps/roothash/liveness_test.go
@@ -61,6 +61,8 @@ func TestLivenessProcessing(t *testing.T) {
 
 	// Initialize roothash state.
 	roothashState := roothashState.NewMutableState(ctx.State())
+	err = roothashState.SetConsensusParameters(ctx, &roothash.ConsensusParameters{})
+	require.NoError(err, "SetConsensusParameters")
 	blk := block.NewGenesisBlock(runtime.ID, 0)
 	rtState := &roothash.RuntimeState{
 		Runtime:            &runtime,

--- a/go/consensus/cometbft/apps/roothash/messages_test.go
+++ b/go/consensus/cometbft/apps/roothash/messages_test.go
@@ -1,6 +1,7 @@
 package roothash
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,7 +10,9 @@ import (
 	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	roothashState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/roothash/state"
 	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 )
 
 func TestChangeParameters(t *testing.T) {
@@ -87,4 +90,361 @@ func TestChangeParameters(t *testing.T) {
 		_, err := app.changeParameters(ctx, &proposal, true)
 		require.EqualError(err, "roothash: failed to validate consensus parameter changes: consensus parameter changes should not be empty")
 	})
+}
+
+func initRuntimeGenesisBlock(require *require.Assertions, ctx *abciAPI.Context, id int) (*registry.Runtime, *block.Block) {
+	var runtime registry.Runtime
+	err := runtime.ID.UnmarshalHex(fmt.Sprintf("8%0*d", 63, id))
+	require.NoError(err, "UnmarshalHex")
+
+	blk := block.NewGenesisBlock(runtime.ID, 0)
+	err = blk.Header.StateRoot.UnmarshalHex(fmt.Sprintf("%0*d%0*d", 32, id, 32, 1))
+	require.NoError(err, "UnmarshalHex")
+	err = blk.Header.IORoot.UnmarshalHex(fmt.Sprintf("%0*d%0*d", 32, id, 32, 2))
+	require.NoError(err, "UnmarshalHex")
+
+	state := roothashState.NewMutableState(ctx.State())
+	err = state.SetRuntimeState(ctx, &roothash.RuntimeState{
+		Runtime:            &runtime,
+		GenesisBlock:       blk,
+		CurrentBlock:       blk,
+		CurrentBlockHeight: 1,
+		LastNormalRound:    0,
+		LastNormalHeight:   1,
+	})
+	require.NoError(err, "SetRuntimeState")
+
+	return &runtime, blk
+}
+
+func advanceRuntimeState(require *require.Assertions, ctx *abciAPI.Context, genesisBlock *block.Block, parentBlock *block.Block, runtime *registry.Runtime, round uint64) *block.Block {
+	blk := block.NewEmptyBlock(parentBlock, round, block.Normal)
+
+	err := blk.Header.StateRoot.UnmarshalHex(fmt.Sprintf("%s%0*d", runtime.ID.Hex()[:32], 32, round+3))
+	require.NoError(err, "UnmarshalHex")
+	err = blk.Header.IORoot.UnmarshalHex(fmt.Sprintf("%s%0*d", runtime.ID.Hex()[:32], 32, round+4))
+	require.NoError(err, "UnmarshalHex")
+
+	state := roothashState.NewMutableState(ctx.State())
+	err = state.SetRuntimeState(ctx, &roothash.RuntimeState{
+		Runtime:            runtime,
+		GenesisBlock:       genesisBlock,
+		CurrentBlock:       blk,
+		CurrentBlockHeight: int64(round + 1),
+		LastNormalRound:    round,
+		LastNormalHeight:   int64(round + 1),
+	})
+	require.NoError(err, "SetRuntimeState")
+
+	return blk
+}
+
+func changeMaxPastRootsStored(require *require.Assertions, app *rootHashApplication, ctx *abciAPI.Context, state *roothashState.MutableState, newMaxPRS uint64) {
+	// Prepare proposal for changing the number of roots stored.
+	changes := roothash.ConsensusParameterChanges{
+		MaxPastRootsStored: &newMaxPRS,
+	}
+	proposal := governance.ChangeParametersProposal{
+		Module:  roothash.ModuleName,
+		Changes: cbor.Marshal(changes),
+	}
+
+	// Apply proposal.
+	res, err := app.changeParameters(ctx, &proposal, true)
+	require.NoError(err, "changing consensus parameters should succeed")
+	require.Equal(struct{}{}, res)
+
+	cp, err := state.ConsensusParameters(ctx)
+	require.NoError(err, "fetching consensus parameters should succeed")
+	require.Equal(newMaxPRS, cp.MaxPastRootsStored, "consensus parameters should change")
+}
+
+func TestMaxPastRootsStoredMulti(t *testing.T) {
+	require := require.New(t)
+
+	// Prepare context.
+	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
+	ctx := appState.NewContext(abciAPI.ContextEndBlock)
+
+	// Setup state.
+	state := roothashState.NewMutableState(ctx.State())
+	_ = &rootHashApplication{
+		state: appState,
+	}
+	params := &roothash.ConsensusParameters{
+		MaxPastRootsStored: 2,
+	}
+	err := state.SetConsensusParameters(ctx, params)
+	require.NoError(err, "setting consensus parameters should succeed")
+
+	cp, err := state.ConsensusParameters(ctx)
+	require.NoError(err, "fetching consensus parameters should succeed")
+	require.EqualValues(2, cp.MaxPastRootsStored, "consensus parameters should have been set")
+
+	// Switch context.
+	ctx.Close()
+	ctx = appState.NewContext(abciAPI.ContextBeginBlock)
+
+	numRuntimes := 10
+
+	// Round 0 (init runtimes, 1 root pair stored).
+	rt := make([]*registry.Runtime, numRuntimes)
+	genBlk := make([]*block.Block, numRuntimes)
+	blk1 := make([]*block.Block, numRuntimes)
+	blk2 := make([]*block.Block, numRuntimes)
+	for id := 0; id < numRuntimes; id++ {
+		rt[id], genBlk[id] = initRuntimeGenesisBlock(require, ctx, id)
+	}
+
+	// Make sure that stored past roots are unique between runtimes.
+	for a := 0; a < numRuntimes; a++ {
+		rtA := rt[a]
+		for b := 0; b < numRuntimes; b++ {
+			if a == b {
+				continue
+			}
+
+			rtB := rt[b]
+
+			rootsA, err := state.PastRoundRoots(ctx, rtA.ID)
+			require.NoError(err, "PastRoundRoots")
+			require.EqualValues(1, len(rootsA))
+			require.EqualValues(len(rootsA), state.PastRoundRootsCount(ctx, rtA.ID))
+			require.EqualValues(genBlk[a].Header.StateRoot, rootsA[0].StateRoot)
+			require.EqualValues(genBlk[a].Header.IORoot, rootsA[0].IORoot)
+
+			rootsB, err := state.PastRoundRoots(ctx, rtB.ID)
+			require.NoError(err, "PastRoundRoots")
+			require.EqualValues(1, len(rootsB))
+			require.EqualValues(len(rootsB), state.PastRoundRootsCount(ctx, rtB.ID))
+			require.EqualValues(genBlk[b].Header.StateRoot, rootsB[0].StateRoot)
+			require.EqualValues(genBlk[b].Header.IORoot, rootsB[0].IORoot)
+
+			require.NotEqualValues(rootsA[0].StateRoot, rootsB[0].StateRoot)
+			require.NotEqualValues(rootsA[0].IORoot, rootsB[0].IORoot)
+		}
+	}
+
+	// Round 1 (2 root pairs stored).
+	for id := 0; id < numRuntimes; id++ {
+		blk1[id] = advanceRuntimeState(require, ctx, genBlk[id], genBlk[id], rt[id], 1)
+		roots, err := state.PastRoundRoots(ctx, rt[id].ID)
+		require.NoError(err, "PastRoundRoots")
+		require.EqualValues(2, len(roots))
+		require.EqualValues(len(roots), state.PastRoundRootsCount(ctx, rt[id].ID))
+		require.EqualValues(genBlk[id].Header.StateRoot, roots[0].StateRoot)
+		require.EqualValues(genBlk[id].Header.IORoot, roots[0].IORoot)
+		require.EqualValues(blk1[id].Header.StateRoot, roots[1].StateRoot)
+		require.EqualValues(blk1[id].Header.IORoot, roots[1].IORoot)
+
+		rfr1, err := state.RoundRoots(ctx, rt[id].ID, 1)
+		require.NoError(err, "RoundRoots 1")
+		require.EqualValues(blk1[id].Header.StateRoot, rfr1.StateRoot)
+		require.EqualValues(blk1[id].Header.IORoot, rfr1.IORoot)
+	}
+
+	// Round 2 (2 root pairs stored).
+	for id := 0; id < numRuntimes; id++ {
+		blk2[id] = advanceRuntimeState(require, ctx, genBlk[id], blk1[id], rt[id], 2)
+		roots, err := state.PastRoundRoots(ctx, rt[id].ID)
+		require.NoError(err, "PastRoundRoots")
+		require.EqualValues(2, len(roots))
+		require.EqualValues(len(roots), state.PastRoundRootsCount(ctx, rt[id].ID))
+		require.EqualValues(blk1[id].Header.StateRoot, roots[1].StateRoot)
+		require.EqualValues(blk1[id].Header.IORoot, roots[1].IORoot)
+		require.EqualValues(blk2[id].Header.StateRoot, roots[2].StateRoot)
+		require.EqualValues(blk2[id].Header.IORoot, roots[2].IORoot)
+
+		rfr2, err := state.RoundRoots(ctx, rt[id].ID, 2)
+		require.NoError(err, "RoundRoots 2")
+		require.EqualValues(blk2[id].Header.StateRoot, rfr2.StateRoot)
+		require.EqualValues(blk2[id].Header.IORoot, rfr2.IORoot)
+	}
+
+	// Verify it again to make sure state didn't get corrupt when advancing.
+	for id := 0; id < numRuntimes; id++ {
+		roots, err := state.PastRoundRoots(ctx, rt[id].ID)
+		require.NoError(err, "PastRoundRoots")
+		require.EqualValues(2, len(roots))
+		require.EqualValues(len(roots), state.PastRoundRootsCount(ctx, rt[id].ID))
+		require.EqualValues(blk1[id].Header.StateRoot, roots[1].StateRoot)
+		require.EqualValues(blk1[id].Header.IORoot, roots[1].IORoot)
+		require.EqualValues(blk2[id].Header.StateRoot, roots[2].StateRoot)
+		require.EqualValues(blk2[id].Header.IORoot, roots[2].IORoot)
+
+		rfr2, err := state.RoundRoots(ctx, rt[id].ID, 2)
+		require.NoError(err, "RoundRoots 2")
+		require.EqualValues(blk2[id].Header.StateRoot, rfr2.StateRoot)
+		require.EqualValues(blk2[id].Header.IORoot, rfr2.IORoot)
+	}
+}
+
+func TestChangeMaxPastRootsStored(t *testing.T) {
+	require := require.New(t)
+
+	// Prepare context.
+	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
+	ctx := appState.NewContext(abciAPI.ContextEndBlock)
+
+	// Setup state.
+	state := roothashState.NewMutableState(ctx.State())
+	app := &rootHashApplication{
+		state: appState,
+	}
+	params := &roothash.ConsensusParameters{
+		MaxPastRootsStored: 2,
+	}
+	err := state.SetConsensusParameters(ctx, params)
+	require.NoError(err, "setting consensus parameters should succeed")
+
+	cp, err := state.ConsensusParameters(ctx)
+	require.NoError(err, "fetching consensus parameters should succeed")
+	require.EqualValues(2, cp.MaxPastRootsStored, "consensus parameters should have been set")
+
+	// Switch context.
+	ctx.Close()
+	ctx = appState.NewContext(abciAPI.ContextBeginBlock)
+
+	// Round 0 (init, 1 root pair stored).
+	runtime, blk := initRuntimeGenesisBlock(require, ctx, 0)
+
+	roots, err := state.PastRoundRoots(ctx, runtime.ID)
+	require.NoError(err, "PastRoundRoots")
+	require.EqualValues(1, len(roots))
+	require.EqualValues(len(roots), state.PastRoundRootsCount(ctx, runtime.ID))
+	require.EqualValues(blk.Header.StateRoot, roots[0].StateRoot)
+	require.EqualValues(blk.Header.IORoot, roots[0].IORoot)
+
+	rfr0, err := state.RoundRoots(ctx, runtime.ID, 0)
+	require.NoError(err, "RoundRoots 0")
+	require.EqualValues(blk.Header.StateRoot, rfr0.StateRoot)
+	require.EqualValues(blk.Header.IORoot, rfr0.IORoot)
+
+	// Round 1 (2 root pairs stored).
+	blk1 := advanceRuntimeState(require, ctx, blk, blk, runtime, 1)
+	roots, err = state.PastRoundRoots(ctx, runtime.ID)
+	require.NoError(err, "PastRoundRoots")
+	require.EqualValues(2, len(roots))
+	require.EqualValues(len(roots), state.PastRoundRootsCount(ctx, runtime.ID))
+	require.EqualValues(blk.Header.StateRoot, roots[0].StateRoot)
+	require.EqualValues(blk.Header.IORoot, roots[0].IORoot)
+	require.EqualValues(blk1.Header.StateRoot, roots[1].StateRoot)
+	require.EqualValues(blk1.Header.IORoot, roots[1].IORoot)
+
+	rfr1, err := state.RoundRoots(ctx, runtime.ID, 1)
+	require.NoError(err, "RoundRoots 1")
+	require.EqualValues(blk1.Header.StateRoot, rfr1.StateRoot)
+	require.EqualValues(blk1.Header.IORoot, rfr1.IORoot)
+
+	// Switch context.
+	ctx.Close()
+	ctx = appState.NewContext(abciAPI.ContextEndBlock)
+
+	// Prepare & apply proposal for reducing the number of roots stored.
+	changeMaxPastRootsStored(require, app, ctx, state, 1)
+
+	// Switch context.
+	ctx.Close()
+	ctx = appState.NewContext(abciAPI.ContextBeginBlock)
+
+	// Round 2 (1 root pair stored).
+	blk2 := advanceRuntimeState(require, ctx, blk, blk1, runtime, 2)
+	roots, err = state.PastRoundRoots(ctx, runtime.ID)
+	require.NoError(err, "PastRoundRoots")
+	require.EqualValues(1, len(roots))
+	require.EqualValues(blk2.Header.StateRoot, roots[2].StateRoot)
+	require.EqualValues(blk2.Header.IORoot, roots[2].IORoot)
+
+	rfr1, err = state.RoundRoots(ctx, runtime.ID, 1)
+	require.NoError(err, "RoundRoots 1")
+	require.Nil(rfr1, "roots for round 1 should have been deleted after changing the max")
+
+	// Round 3 (1 root pair stored).
+	blk3 := advanceRuntimeState(require, ctx, blk, blk2, runtime, 3)
+	roots, err = state.PastRoundRoots(ctx, runtime.ID)
+	require.NoError(err, "PastRoundRoots")
+	require.EqualValues(1, len(roots))
+	require.EqualValues(len(roots), state.PastRoundRootsCount(ctx, runtime.ID))
+	require.EqualValues(blk3.Header.StateRoot, roots[3].StateRoot)
+	require.EqualValues(blk3.Header.IORoot, roots[3].IORoot)
+
+	rfr2, err := state.RoundRoots(ctx, runtime.ID, 2)
+	require.NoError(err, "RoundRoots 2")
+	require.Nil(rfr2, "roots for round 2 should have been deleted in round 3")
+
+	// Switch context.
+	ctx.Close()
+	ctx = appState.NewContext(abciAPI.ContextEndBlock)
+
+	// Prepare & apply proposal for increasing the number of roots stored.
+	changeMaxPastRootsStored(require, app, ctx, state, 2)
+
+	// Switch context.
+	ctx.Close()
+	ctx = appState.NewContext(abciAPI.ContextBeginBlock)
+
+	// Round 4 (2 root pairs stored).
+	blk4 := advanceRuntimeState(require, ctx, blk, blk3, runtime, 4)
+	roots, err = state.PastRoundRoots(ctx, runtime.ID)
+	require.NoError(err, "PastRoundRoots")
+	require.EqualValues(2, len(roots))
+	require.EqualValues(len(roots), state.PastRoundRootsCount(ctx, runtime.ID))
+	require.EqualValues(blk3.Header.StateRoot, roots[3].StateRoot)
+	require.EqualValues(blk3.Header.IORoot, roots[3].IORoot)
+	require.EqualValues(blk4.Header.StateRoot, roots[4].StateRoot)
+	require.EqualValues(blk4.Header.IORoot, roots[4].IORoot)
+
+	// Round 5 (2 root pairs stored).
+	blk5 := advanceRuntimeState(require, ctx, blk, blk4, runtime, 5)
+	roots, err = state.PastRoundRoots(ctx, runtime.ID)
+	require.NoError(err, "PastRoundRoots")
+	require.EqualValues(2, len(roots))
+	require.EqualValues(len(roots), state.PastRoundRootsCount(ctx, runtime.ID))
+	require.EqualValues(blk4.Header.StateRoot, roots[4].StateRoot)
+	require.EqualValues(blk4.Header.IORoot, roots[4].IORoot)
+	require.EqualValues(blk5.Header.StateRoot, roots[5].StateRoot)
+	require.EqualValues(blk5.Header.IORoot, roots[5].IORoot)
+
+	rfr3, err := state.RoundRoots(ctx, runtime.ID, 3)
+	require.NoError(err, "RoundRoots 3")
+	require.Nil(rfr3, "roots for round 3 should have been deleted in round 5")
+
+	// Round 6 (2 root pairs stored).
+	blk6 := advanceRuntimeState(require, ctx, blk, blk5, runtime, 6)
+	roots, err = state.PastRoundRoots(ctx, runtime.ID)
+	require.NoError(err, "PastRoundRoots")
+	require.EqualValues(2, len(roots))
+	require.EqualValues(len(roots), state.PastRoundRootsCount(ctx, runtime.ID))
+	require.EqualValues(blk5.Header.StateRoot, roots[5].StateRoot)
+	require.EqualValues(blk5.Header.IORoot, roots[5].IORoot)
+	require.EqualValues(blk6.Header.StateRoot, roots[6].StateRoot)
+	require.EqualValues(blk6.Header.IORoot, roots[6].IORoot)
+
+	rfr4, err := state.RoundRoots(ctx, runtime.ID, 4)
+	require.NoError(err, "RoundRoots 4")
+	require.Nil(rfr4, "roots for round 4 should have been deleted in round 6")
+
+	// Switch context.
+	ctx.Close()
+	ctx = appState.NewContext(abciAPI.ContextEndBlock)
+
+	// Prepare & apply proposal for disabling storing the roots.
+	changeMaxPastRootsStored(require, app, ctx, state, 0)
+
+	// Switch context.
+	ctx.Close()
+	ctx = appState.NewContext(abciAPI.ContextBeginBlock)
+
+	// Round 7 (0 root pairs stored).
+	_ = advanceRuntimeState(require, ctx, blk, blk6, runtime, 7)
+	roots, err = state.PastRoundRoots(ctx, runtime.ID)
+	require.NoError(err, "PastRoundRoots")
+	require.EqualValues(0, len(roots))
+	require.EqualValues(len(roots), state.PastRoundRootsCount(ctx, runtime.ID))
+
+	rfr7, err := state.RoundRoots(ctx, runtime.ID, 7)
+	require.NoError(err, "RoundRoots 7")
+	require.Nil(rfr7, "roots for round 7 should not exist")
+
+	ctx.Close()
 }

--- a/go/consensus/cometbft/apps/roothash/state/state_test.go
+++ b/go/consensus/cometbft/apps/roothash/state/state_test.go
@@ -116,11 +116,66 @@ func TestSeparateRuntimeRoots(t *testing.T) {
 	require := require.New(t)
 
 	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
-	ctx := appState.NewContext(abciAPI.ContextBeginBlock)
+
+	ctx := appState.NewContext(abciAPI.ContextInitChain)
+	st := NewMutableState(ctx.State())
+	err := st.SetConsensusParameters(ctx, &api.ConsensusParameters{})
+	require.NoError(err, "SetConsensusParameters")
+	ctx.Close()
+
+	ctx = appState.NewContext(abciAPI.ContextBeginBlock)
 	defer ctx.Close()
 
-	st := NewMutableState(ctx.State())
+	st = NewMutableState(ctx.State())
 
+	var runtime registry.Runtime
+	err = runtime.ID.UnmarshalHex("8000000000000000000000000000000000000000000000000000000000000000")
+	require.NoError(err, "UnmarshalHex")
+
+	blk := block.NewGenesisBlock(runtime.ID, 0)
+	err = blk.Header.StateRoot.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000001")
+	require.NoError(err, "UnmarshalHex")
+	err = blk.Header.IORoot.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000002")
+	require.NoError(err, "UnmarshalHex")
+	err = st.SetRuntimeState(ctx, &api.RuntimeState{
+		Runtime:            &runtime,
+		GenesisBlock:       blk,
+		CurrentBlock:       blk,
+		CurrentBlockHeight: 1,
+		LastNormalRound:    0,
+		LastNormalHeight:   1,
+	})
+	require.NoError(err, "SetRuntimeState")
+
+	stateRoot, err := st.StateRoot(ctx, runtime.ID)
+	require.NoError(err, "StateRoot")
+	require.EqualValues(blk.Header.StateRoot, stateRoot)
+
+	ioRoot, err := st.IORoot(ctx, runtime.ID)
+	require.NoError(err, "IORoot")
+	require.EqualValues(blk.Header.IORoot, ioRoot)
+}
+
+func TestPastRuntimeRoots(t *testing.T) {
+	require := require.New(t)
+
+	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
+
+	// Set the consensus parameters.
+	initCtx := appState.NewContext(abciAPI.ContextInitChain)
+	st := NewMutableState(initCtx.State())
+	params := &api.ConsensusParameters{
+		MaxPastRootsStored: 2,
+	}
+	require.NoError(st.SetConsensusParameters(initCtx, params), "SetConsensusParameters")
+	initCtx.Close()
+
+	// Do the test.
+	ctx := appState.NewContext(abciAPI.ContextBeginBlock)
+	defer ctx.Close()
+	st = NewMutableState(ctx.State())
+
+	// Round 0.
 	var runtime registry.Runtime
 	err := runtime.ID.UnmarshalHex("8000000000000000000000000000000000000000000000000000000000000000")
 	require.NoError(err, "UnmarshalHex")
@@ -147,4 +202,106 @@ func TestSeparateRuntimeRoots(t *testing.T) {
 	ioRoot, err := st.IORoot(ctx, runtime.ID)
 	require.NoError(err, "IORoot")
 	require.EqualValues(blk.Header.IORoot, ioRoot)
+
+	roots, err := st.PastRoundRoots(ctx, runtime.ID)
+	require.NoError(err, "PastRoundRoots")
+	require.EqualValues(1, len(roots))
+	require.EqualValues(len(roots), st.PastRoundRootsCount(ctx, runtime.ID))
+	require.EqualValues(blk.Header.StateRoot, roots[0].StateRoot)
+	require.EqualValues(blk.Header.IORoot, roots[0].IORoot)
+
+	rfr0, err := st.RoundRoots(ctx, runtime.ID, 0)
+	require.NoError(err, "RoundRoots 0")
+	require.EqualValues(blk.Header.StateRoot, rfr0.StateRoot)
+	require.EqualValues(blk.Header.IORoot, rfr0.IORoot)
+
+	rfr1, err := st.RoundRoots(ctx, runtime.ID, 1)
+	require.NoError(err, "RoundRoots 1")
+	require.Nil(rfr1, "round 1 hasn't happened yet, so there should be no roots for it yet")
+
+	// Round 1.
+	blk1 := block.NewEmptyBlock(blk, 1, block.Normal)
+	err = blk1.Header.StateRoot.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000003")
+	require.NoError(err, "UnmarshalHex")
+	err = blk1.Header.IORoot.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000004")
+	require.NoError(err, "UnmarshalHex")
+	err = st.SetRuntimeState(ctx, &api.RuntimeState{
+		Runtime:            &runtime,
+		GenesisBlock:       blk,
+		CurrentBlock:       blk1,
+		CurrentBlockHeight: 2,
+		LastNormalRound:    1,
+		LastNormalHeight:   2,
+	})
+	require.NoError(err, "SetRuntimeState")
+
+	roots, err = st.PastRoundRoots(ctx, runtime.ID)
+	require.NoError(err, "PastRoundRoots")
+	require.EqualValues(2, len(roots))
+	require.EqualValues(len(roots), st.PastRoundRootsCount(ctx, runtime.ID))
+	require.EqualValues(blk.Header.StateRoot, roots[0].StateRoot)
+	require.EqualValues(blk.Header.IORoot, roots[0].IORoot)
+	require.EqualValues(blk1.Header.StateRoot, roots[1].StateRoot)
+	require.EqualValues(blk1.Header.IORoot, roots[1].IORoot)
+
+	rfr1, err = st.RoundRoots(ctx, runtime.ID, 1)
+	require.NoError(err, "RoundRoots 1")
+	require.EqualValues(rfr1.StateRoot, roots[1].StateRoot)
+	require.EqualValues(rfr1.IORoot, roots[1].IORoot)
+
+	// Round 2.
+	blk2 := block.NewEmptyBlock(blk1, 2, block.Normal)
+	err = blk2.Header.StateRoot.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000005")
+	require.NoError(err, "UnmarshalHex")
+	err = blk2.Header.IORoot.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000006")
+	require.NoError(err, "UnmarshalHex")
+	err = st.SetRuntimeState(ctx, &api.RuntimeState{
+		Runtime:            &runtime,
+		GenesisBlock:       blk,
+		CurrentBlock:       blk2,
+		CurrentBlockHeight: 3,
+		LastNormalRound:    2,
+		LastNormalHeight:   3,
+	})
+	require.NoError(err, "SetRuntimeState")
+
+	roots, err = st.PastRoundRoots(ctx, runtime.ID)
+	require.NoError(err, "PastRoundRoots")
+	require.EqualValues(2, len(roots))
+	require.EqualValues(len(roots), st.PastRoundRootsCount(ctx, runtime.ID))
+	require.EqualValues(blk1.Header.StateRoot, roots[1].StateRoot)
+	require.EqualValues(blk1.Header.IORoot, roots[1].IORoot)
+	require.EqualValues(blk2.Header.StateRoot, roots[2].StateRoot)
+	require.EqualValues(blk2.Header.IORoot, roots[2].IORoot)
+
+	// Reduce max space for roots to 1 -- only the older root should be removed.
+	err = st.ShrinkPastRoots(ctx, 1)
+	require.NoError(err, "ShrinkPastRoots 1")
+
+	roots, err = st.PastRoundRoots(ctx, runtime.ID)
+	require.NoError(err, "PastRoundRoots")
+	require.EqualValues(1, len(roots))
+	require.EqualValues(len(roots), st.PastRoundRootsCount(ctx, runtime.ID))
+	require.EqualValues(blk2.Header.StateRoot, roots[2].StateRoot)
+	require.EqualValues(blk2.Header.IORoot, roots[2].IORoot)
+
+	// Increase it back to 2 -- the existing root should remain.
+	err = st.ShrinkPastRoots(ctx, 2)
+	require.NoError(err, "ShrinkPastRoots 2")
+
+	roots, err = st.PastRoundRoots(ctx, runtime.ID)
+	require.NoError(err, "PastRoundRoots")
+	require.EqualValues(1, len(roots))
+	require.EqualValues(len(roots), st.PastRoundRootsCount(ctx, runtime.ID))
+	require.EqualValues(blk2.Header.StateRoot, roots[2].StateRoot)
+	require.EqualValues(blk2.Header.IORoot, roots[2].IORoot)
+
+	// Now reduce it to 0 -- no roots should remain.
+	err = st.ShrinkPastRoots(ctx, 0)
+	require.NoError(err, "ShrinkPastRoots 0")
+
+	roots, err = st.PastRoundRoots(ctx, runtime.ID)
+	require.NoError(err, "PastRoundRoots")
+	require.EqualValues(0, len(roots))
+	require.EqualValues(len(roots), st.PastRoundRootsCount(ctx, runtime.ID))
 }

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -94,6 +94,7 @@ const (
 	cfgRoothashDebugBypassStake          = "roothash.debug.bypass_stake" // nolint: gosec
 	CfgRoothashMaxRuntimeMessages        = "roothash.max_runtime_messages"
 	CfgRoothashMaxInRuntimeMessages      = "roothash.max_in_runtime_messages"
+	CfgRoothashMaxPastRootsStored        = "roothash.max_past_roots_stored"
 
 	// Staking config flags.
 	CfgStakingTokenSymbol        = "staking.token_symbol"
@@ -509,6 +510,7 @@ func AppendRootHashState(doc *genesis.Document, exports []string, l *logging.Log
 			DebugBypassStake:          viper.GetBool(cfgRoothashDebugBypassStake),
 			MaxRuntimeMessages:        viper.GetUint32(CfgRoothashMaxRuntimeMessages),
 			MaxInRuntimeMessages:      viper.GetUint32(CfgRoothashMaxInRuntimeMessages),
+			MaxPastRootsStored:        viper.GetUint64(CfgRoothashMaxPastRootsStored),
 			GasCosts:                  roothash.DefaultGasCosts, // TODO: Make these configurable.
 		},
 	}
@@ -831,6 +833,7 @@ func init() {
 	initGenesisFlags.Bool(cfgRoothashDebugBypassStake, false, "bypass all roothash stake checks and operations (UNSAFE)")
 	initGenesisFlags.Uint32(CfgRoothashMaxRuntimeMessages, 128, "maximum number of runtime messages submitted in a round")
 	initGenesisFlags.Uint32(CfgRoothashMaxInRuntimeMessages, 128, "maximum number of ququed incoming runtime messages")
+	initGenesisFlags.Uint64(CfgRoothashMaxPastRootsStored, 1200, "maximum number of past runtime state and I/O roots stored in consensus state")
 	_ = initGenesisFlags.MarkHidden(cfgRoothashDebugDoNotSuspendRuntimes)
 	_ = initGenesisFlags.MarkHidden(cfgRoothashDebugBypassStake)
 

--- a/go/oasis-node/cmd/genesis/migrate.go
+++ b/go/oasis-node/cmd/genesis/migrate.go
@@ -345,6 +345,9 @@ NodeLoop:
 		}
 	}
 
+	// Add a sensible default for the MaxPastRootsStored parameter.
+	newDoc.RootHash.Parameters.MaxPastRootsStored = 1200
+
 	return &newDoc, nil
 }
 

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -571,6 +571,10 @@ type ConsensusParameters struct {
 
 	// MaxEvidenceAge is the maximum age of submitted evidence in the number of rounds.
 	MaxEvidenceAge uint64 `json:"max_evidence_age"`
+
+	// MaxPastRootsStored is the maximum number of past runtime state and I/O
+	// roots that are stored in the consensus state.
+	MaxPastRootsStored uint64 `json:"max_past_roots_stored,omitempty"`
 }
 
 // ConsensusParameterChanges are allowed roothash consensus parameter changes.
@@ -586,6 +590,10 @@ type ConsensusParameterChanges struct {
 
 	// MaxEvidenceAge is the new maximum evidence age.
 	MaxEvidenceAge *uint64 `json:"max_evidence_age"`
+
+	// MaxPastRootsStored is the new maximum number of past runtime state and I/O
+	// roots that are stored in the consensus state.
+	MaxPastRootsStored *uint64 `json:"max_past_roots_stored,omitempty"`
 }
 
 // Apply applies changes to the given consensus parameters.
@@ -601,6 +609,9 @@ func (c *ConsensusParameterChanges) Apply(params *ConsensusParameters) error {
 	}
 	if c.MaxEvidenceAge != nil {
 		params.MaxEvidenceAge = *c.MaxEvidenceAge
+	}
+	if c.MaxPastRootsStored != nil {
+		params.MaxPastRootsStored = *c.MaxPastRootsStored
 	}
 	return nil
 }
@@ -639,4 +650,15 @@ func VerifyRuntimeParameters(rt *registry.Runtime, params *ConsensusParameters) 
 		return ErrMaxInMessagesTooBig
 	}
 	return nil
+}
+
+// RoundRoots holds the per-round state and I/O roots that are stored in
+// consensus state.
+type RoundRoots struct {
+	// Serialize this struct as an array with two elements to save space in
+	// the consensus state.
+	_ struct{} `cbor:",toarray"` //nolint
+
+	StateRoot hash.Hash
+	IORoot    hash.Hash
 }

--- a/go/roothash/api/sanity_check.go
+++ b/go/roothash/api/sanity_check.go
@@ -50,7 +50,8 @@ func (c *ConsensusParameterChanges) SanityCheck() error {
 	if c.GasCosts == nil &&
 		c.MaxRuntimeMessages == nil &&
 		c.MaxInRuntimeMessages == nil &&
-		c.MaxEvidenceAge == nil {
+		c.MaxEvidenceAge == nil &&
+		c.MaxPastRootsStored == nil {
 		return fmt.Errorf("consensus parameter changes should not be empty")
 	}
 	return nil


### PR DESCRIPTION
This adds the ability to store past N runtime state and I/O roots in consensus state.