### PR TITLE
ci: Remove daily artifacts on successful test run

### DIFF
--- a/.buildkite/scripts/daily_txsource.sh
+++ b/.buildkite/scripts/daily_txsource.sh
@@ -5,13 +5,15 @@ set -euxo pipefail
 # Script invoked from .buildkite/longtests.pipeline.yml
 
 if [[ $BUILDKITE_RETRY_COUNT == 0 ]]; then
-    rm -rf /var/tmp/longtests/*
     ./.buildkite/scripts/test_e2e.sh \
         --metrics.address $METRICS_PUSH_ADDR \
         --metrics.labels instance=$BUILDKITE_PIPELINE_NAME-$BUILDKITE_BUILD_NUMBER \
         --scenario_timeout 900m \
         --scenario e2e/runtime/txsource-multi \
         "$@"
+
+    # In case of success daily artifacts are not interesting and can be removed.
+    rm -rf /var/tmp/longtests/*
 else
     curl -H "Content-Type: application/json" \
         -X POST \


### PR DESCRIPTION
In case of success daily artifacts are not interesting and can be removed, otherwise the script will error out before reaching the added line.