### PR TITLE
go/oasis-node/cmd/ias: Fix TLS certificate generation

### DIFF
--- a/.changelog/5375.bugfix.md
+++ b/.changelog/5375.bugfix.md
@@ -1,0 +1,1 @@
+go/oasis-node/cmd/ias: Regenerate TLS certificate on startup


### PR DESCRIPTION
The fix in 720b88e437b8c49c6680d8cb6e681f3524358a2e (#5290) broke generation of new certificates when none existed.