### PR TITLE
buildkite: Fix uploading artifacts when e2e test fails

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -225,8 +225,7 @@ steps:
       - export CFLAGS_x86_64_fortanix_unknown_sgx="-isystem/usr/include/x86_64-linux-gnu -mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening"
       - export CC_x86_64_fortanix_unknown_sgx=clang-11
       # Only run runtime scenarios as others do not use SGX.
-      - .buildkite/scripts/test_e2e.sh --scenario e2e/runtime/runtime-encryption --scenario e2e/runtime/trust-root/.+ --scenario e2e/runtime/keymanager-.+
-      - buildkite-agent artifact upload "coverage-merged-e2e-*.txt;/tmp/e2e/**/*.log;/tmp/e2e/**/genesis.json;/tmp/e2e/**/runtime_genesis.json"
+      - .buildkite/scripts/run_tests_and_upload_artifacts.sh test_e2e.sh --scenario e2e/runtime/runtime-encryption --scenario e2e/runtime/trust-root/.+ --scenario e2e/runtime/keymanager-.+
     env:
       # Unsafe flags needed as the trust-root test rebuilds the enclave with embedded trust root data.
       OASIS_UNSAFE_SKIP_AVR_VERIFY: "1"
@@ -253,8 +252,7 @@ steps:
       # Needed as the trust-root test rebuilds the enclave with embedded trust root data.
       - cargo install --locked --path tools
       # Only run runtime scenarios as others do not use SGX.
-      - .buildkite/scripts/test_e2e.sh --scenario e2e/runtime/.*
-      - buildkite-agent artifact upload "coverage-merged-e2e-*.txt;/tmp/e2e/**/*.log;/tmp/e2e/**/genesis.json;/tmp/e2e/**/runtime_genesis.json"
+      - .buildkite/scripts/run_tests_and_upload_artifacts.sh test_e2e.sh --scenario e2e/runtime/.*
     env:
       # Unsafe flags needed as the trust-root test rebuilds the enclave with embedded trust root data.
       OASIS_UNSAFE_SKIP_AVR_VERIFY: "1"
@@ -281,8 +279,7 @@ steps:
     timeout_in_minutes: 20
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
-      - .buildkite/scripts/test_e2e.sh
-      - buildkite-agent artifact upload "coverage-merged-e2e-*.txt;/tmp/e2e/**/*.log;/tmp/e2e/**/genesis.json;/tmp/e2e/**/runtime_genesis.json"
+      - .buildkite/scripts/run_tests_and_upload_artifacts.sh test_e2e.sh
     env:
       OASIS_E2E_COVERAGE: enable
       # Since the trust-root scenarios are tested in SGX mode (for which they are actually relevant)
@@ -303,8 +300,7 @@ steps:
     timeout_in_minutes: 20
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
-      - .buildkite/scripts/test_e2e.sh --scenario e2e/runtime/txsource-multi-short
-      - buildkite-agent artifact upload "coverage-merged-e2e-*.txt;/tmp/e2e/**/*.log;/tmp/e2e/**/genesis.json;/tmp/e2e/**/runtime_genesis.json"
+      - .buildkite/scripts/run_tests_and_upload_artifacts.sh test_e2e.sh --scenario e2e/runtime/txsource-multi-short
     env:
       OASIS_E2E_COVERAGE: enable
       TEST_BASE_DIR: /tmp
@@ -320,8 +316,7 @@ steps:
     branches: master stable/*
     timeout_in_minutes: 20
     command:
-      - .buildkite/scripts/sgx_ias_tests.sh
-      - buildkite-agent artifact upload "coverage-merged-e2e-*.txt;/tmp/e2e/**/*.log;/tmp/e2e/**/genesis.json;/tmp/e2e/**/runtime_genesis.json"
+      - .buildkite/scripts/run_tests_and_upload_artifacts.sh sgx_ias_tests.sh
     # A unique string to identify the step. The value is available in the
     # BUILDKITE_STEP_KEY and is used to ensure the generated coverage file
     # names are unique across this pipeline.

--- a/.buildkite/scripts/run_tests_and_upload_artifacts.sh
+++ b/.buildkite/scripts/run_tests_and_upload_artifacts.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Check if the name of the script is provided.
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <script-name> [args...]"
+    exit 1
+fi
+
+# Pop the name to the script.
+script_name="$1"
+shift
+
+# Construct the path to the script.
+script_path="$PWD/.buildkite/scripts/$script_name"
+
+# Check if the specified script exists.
+if [ ! -f "$script_path" ]; then
+    echo "Error: Script '$script_path' not found."
+    exit 1
+fi
+
+# Don't enable the 'e' option, which would cause the script to immediately
+# exit if the script failed.
+set -uo pipefail
+
+# Execute the script with the remaining arguments.
+bash "$script_path" "$@"
+
+# Capture the exit status.
+exit_status=$?
+
+# Upload artifacts always.
+buildkite-agent artifact upload "coverage-merged-e2e-*.txt;/tmp/e2e/**/*.log;/tmp/e2e/**/genesis.json;/tmp/e2e/**/runtime_genesis.json"
+
+# Exit with the status of the script.
+exit $exit_status

--- a/.changelog/5382.trivial.md
+++ b/.changelog/5382.trivial.md
@@ -1,0 +1,1 @@
+go/runtime/host/sgx: Fix SGX device search order


### PR DESCRIPTION
Problem: Failed tests didn't have artifacts.