### PR TITLE
Various minor upgrade-related fixes

### DIFF
--- a/go/oasis-node/cmd/genesis/migrate.go
+++ b/go/oasis-node/cmd/genesis/migrate.go
@@ -364,6 +364,9 @@ NodeLoop:
 		}
 	}
 
+	// Reduce maximum consensus layer block size.
+	newDoc.Consensus.Parameters.MaxBlockSize = 1_048_576 // 1 MiB
+
 	return &newDoc, nil
 }
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/helpers_runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/helpers_runtime.go
@@ -178,7 +178,8 @@ func (sc *Scenario) EnsureActiveVersionForComputeWorker(ctx context.Context, nod
 			return fmt.Errorf("%s: unexpected active version (expected: %s got: %s)", node.Name, v, cs.ActiveVersion)
 		}
 		if cs.Status != commonWorker.StatusStateReady {
-			return fmt.Errorf("%s: runtime is not ready (got: %s)", node.Name, cs.Status)
+			time.Sleep(1 * time.Second)
+			continue
 		}
 		break
 	}

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -613,6 +613,8 @@ func (n *Node) handleNewEventLocked(ev *roothash.Event) {
 
 // Guarded by n.CrossNode.
 func (n *Node) handleRuntimeHostEventLocked(ev *host.Event) {
+	n.logger.Debug("got runtime event", "ev", ev)
+
 	switch {
 	case ev.Started != nil:
 		atomic.StoreUint32(&n.hostedRuntimeProvisioned, 1)


### PR DESCRIPTION
* go/oasis-node: Reduce maximum consenus layer block size in migrate
* go/oasis-test-runner: Properly wait for runtime readiness