### PR TITLE
go/worker/common: Display additional information in the liveness status

### DIFF
--- a/go/roothash/api/liveness.go
+++ b/go/roothash/api/liveness.go
@@ -11,14 +11,14 @@ type LivenessStatistics struct {
 	LiveRounds []uint64 `json:"good_rounds"`
 
 	// FinalizedProposals is a list that records the number of finalized rounds when a node
-	// acted as a proposer.
+	// acted as a proposer with the highest rank.
 	//
 	// The list is ordered according to the committee arrangement (i.e., the counter at index i
 	// holds the value for the node at index i in the committee).
 	FinalizedProposals []uint64 `json:"finalized_proposals"`
 
 	// MissedProposals is a list that records the number of failed rounds when a node
-	// acted as a proposer.
+	// acted as a proposer with the highest rank.
 	//
 	// The list is ordered according to the committee arrangement (i.e., the counter at index i
 	// holds the value for the node at index i in the committee).

--- a/go/worker/common/api/api.go
+++ b/go/worker/common/api/api.go
@@ -144,4 +144,12 @@ type LivenessStatus struct {
 
 	// LiveRounds is the number of rounds in which the node positively contributed.
 	LiveRounds uint64 `json:"live_rounds"`
+
+	// FinalizedProposals is the number of finalized rounds when a node acted as a proposer
+	// with the highest rank.
+	FinalizedProposals uint64 `json:"finalized_proposals"`
+
+	// MissedProposals is the number of failed rounds when a node acted as a proposer
+	// with the highest rank.
+	MissedProposals uint64 `json:"missed_proposals"`
 }

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -330,6 +330,8 @@ func (n *Node) GetStatus() (*api.Status, error) {
 
 				for _, index := range cmte.Indices {
 					status.Liveness.LiveRounds += rs.LivenessStatistics.LiveRounds[index]
+					status.Liveness.FinalizedProposals += rs.LivenessStatistics.FinalizedProposals[index]
+					status.Liveness.MissedProposals += rs.LivenessStatistics.MissedProposals[index]
 				}
 			}
 		}


### PR DESCRIPTION
```
oasis-node control status -a compute-2-internal-3562597129.sock
        "liveness": {
          "total_rounds": 15,
          "live_rounds": 15,
          "finalized_proposals": 7,
          "missed_proposals": 0
        },
```