### PR TITLE
fix consensus light client status shows empty peer IDs

### DIFF
--- a/.changelog/5408.bugfix.md
+++ b/.changelog/5408.bugfix.md
@@ -1,0 +1,1 @@
+Fix showing empty peer IDs in the Consensus light client status output

--- a/go/consensus/cometbft/light/p2p/p2p.go
+++ b/go/consensus/cometbft/light/p2p/p2p.go
@@ -189,6 +189,8 @@ func (lp *lightClientProvider) Initialized() <-chan struct{} {
 func (lp *lightClientProvider) PeerID() string {
 	peer := lp.getPeer()
 	if peer == nil {
+		// This happens if a provider is not yet initialized, or
+		// (less likely) if a peer was just dropped and no new peer is available.
 		return ""
 	}
 	return peer.String()

--- a/go/consensus/cometbft/light/service.go
+++ b/go/consensus/cometbft/light/service.go
@@ -106,7 +106,9 @@ func (c *client) GetStatus() (*consensus.LightClientStatus, error) {
 	}
 
 	for _, p := range c.providers {
-		status.PeerIDs = append(status.PeerIDs, p.PeerID())
+		if id := p.PeerID(); id != "" {
+			status.PeerIDs = append(status.PeerIDs, id)
+		}
 	}
 
 	return status, nil


### PR DESCRIPTION
Alternatively could also set it to something like `<uninitialized>` in the status instead of skipping.

TODO: backport