### PR TITLE
Install setuptools to make Towncrier fork work with Python 3.12

### DIFF
--- a/.changelog/5421.internal.md
+++ b/.changelog/5421.internal.md
@@ -1,0 +1,1 @@
+Install setuptools to make Towncrier fork work with Python 3.12

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -56,6 +56,10 @@ jobs:
       - name: Install gitlint
         run: |
           python -m pip install gitlint
+        # Needed for Towncrier fork to work with 3.12 and above
+      - name: Install setuptools
+        run: |
+          python -m pip install setuptools
       - name: Install towncrier
         run: |
           python -m pip install https://github.com/oasisprotocol/towncrier/archive/oasis-master.tar.gz


### PR DESCRIPTION
Keep CI alive while we do not have Towncrier fork updated 
sample issue from other repo https://github.com/oasisprotocol/oasis-wallet-web/actions/runs/6692075152/job/18180527014?pr=1747