### PR TITLE
go/consensus: Do not crash on nil result from Commit

### DIFF
--- a/.changelog/5423.bugfix.md
+++ b/.changelog/5423.bugfix.md
@@ -1,0 +1,4 @@
+go/consensus: Do not crash on nil result from Commit
+
+The Commit function can return both a nil error and a nil result in case
+the given block is not available yet.

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -586,7 +586,7 @@ func (n *commonNode) getLightBlock(ctx context.Context, height int64, allowPendi
 	}
 
 	commit, err := cmtcore.Commit(n.rpcCtx, &tmHeight)
-	if err == nil && commit.Header != nil {
+	if err == nil && commit != nil && commit.Header != nil {
 		lb.SignedHeader = &commit.SignedHeader
 		tmHeight = commit.Header.Height
 	} else if allowPending {


### PR DESCRIPTION
The `Commit` function can return both a nil error and a nil result in case the given block is not available yet.