### PR TITLE
go/worker: fix storageCommitLatency timing

### DIFF
--- a/go/worker/compute/executor/committee/node.go
+++ b/go/worker/compute/executor/committee/node.go
@@ -830,7 +830,7 @@ func (n *Node) proposeBatch(
 	// Commit I/O and state write logs to storage.
 	storageErr := func() error {
 		start := time.Now()
-		defer storageCommitLatency.With(n.getMetricLabels()).Observe(time.Since(start).Seconds())
+		defer func() { storageCommitLatency.With(n.getMetricLabels()).Observe(time.Since(start).Seconds()) }()
 
 		ctx, cancel := context.WithCancel(roundCtx)
 		defer cancel()


### PR DESCRIPTION
golangci-lint >=1.55.0 found this. (should also update version used in CI)