### PR TITLE
go/oais-node/grpc: remove unneeded datadir check

### DIFF
--- a/go/oasis-node/cmd/common/grpc/grpc.go
+++ b/go/oasis-node/cmd/common/grpc/grpc.go
@@ -3,7 +3,6 @@ package grpc
 
 import (
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -64,11 +63,6 @@ func NewServerTCP(cert *tls.Certificate, installWrapper bool) (*cmnGrpc.Server, 
 // This internally takes a snapshot of the current global tracer, so
 // make sure you initialize the global tracer before calling this.
 func NewServerLocal(installWrapper bool) (*cmnGrpc.Server, error) {
-	dataDir := common.DataDir()
-	if dataDir == "" {
-		return nil, errors.New("data directory must be set")
-	}
-
 	config := &cmnGrpc.ServerConfig{
 		Name:           "internal",
 		Path:           common.InternalSocketPath(),


### PR DESCRIPTION
There's no reason to check for non-empty datadir here specifically. On node init it is already checked in: https://github.com/oasisprotocol/oasis-core/blob/12e86f1a77b9d9359d88297c01db26c659d0efee/go/oasis-node/cmd/node/node.go#L473