### PR TITLE
[BACKPORT/23.0.x] go/runtime/host/multi: Propagate consensus sync requests to next version

### DIFF
--- a/.changelog/5433.bugfix.md
+++ b/.changelog/5433.bugfix.md
@@ -1,0 +1,10 @@
+go/runtime/host/multi: Propagate special requests to next version
+
+Previously periodic consensus sync requests were not propagated to the
+next (e.g. upcoming) runtime version. This could result in the runtime's
+consensus view going stale which would make the attestations too old so
+they would be rejected during scheduling.
+
+Additionally, key manager update requests should also be propagated to
+ensure the runtime is ready immediately when activated, avoiding any
+potential race conditions.


### PR DESCRIPTION
Backport of #5433.