### PR TITLE
go/runtime/host/sandbox: Release lock before calling into runtime

### DIFF
--- a/.changelog/5438.bugfix.2.md
+++ b/.changelog/5438.bugfix.2.md
@@ -1,0 +1,1 @@
+go/worker/compute: Bound batch execution time

--- a/.changelog/5438.bugfix.md
+++ b/.changelog/5438.bugfix.md
@@ -1,0 +1,5 @@
+go/runtime/host/sandbox: Release lock before calling into runtime
+
+Similar to how this is handled in the multi runtime host, we need to
+release the lock before calling into the runtime as otherwise this could
+lead to a deadlock in certain situations.

--- a/go/worker/compute/executor/committee/node.go
+++ b/go/worker/compute/executor/committee/node.go
@@ -45,6 +45,10 @@ var (
 	getInfoTimeout = 5 * time.Second
 )
 
+// executeBatchTimeoutFactor is the factor F in calculation of the batch execution timeout using
+// the formula F * ProposerTimeout to ensure that a broken runtime doesn't block forever.
+const executeBatchTimeoutFactor = 3
+
 // Node is a committee node.
 type Node struct { // nolint: maligned
 	runtimeReady         bool
@@ -186,7 +190,7 @@ func (n *Node) transitionState(state NodeState) {
 }
 
 func (n *Node) transitionStateToProcessing(ctx context.Context, proposal *commitment.Proposal, rank uint64, batch transaction.RawBatch) {
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
 	done := make(chan struct{})
 
 	n.transitionState(StateProcessingBatch{
@@ -220,7 +224,7 @@ func (n *Node) transitionStateToProcessingFailure(
 		"max_batch_size", maxBatchSize,
 	)
 
-	cancel := func() {}
+	cancel := func(_ error) {}
 	done := make(chan struct{})
 	close(done)
 
@@ -415,7 +419,7 @@ func (n *Node) scheduleBatch(ctx context.Context, round uint64, force bool) {
 		return
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
 	done := make(chan struct{})
 
 	n.transitionState(StateProcessingBatch{
@@ -686,15 +690,26 @@ func (n *Node) runtimeExecuteTxBatch(
 		batchRuntimeProcessingTime.With(n.getMetricLabels()).Observe(time.Since(rtStartTime).Seconds())
 	}()
 
-	rsp, err := rt.Call(ctx, rq)
+	// Ensure batch execution is bounded.
+	proposerTimeout := state.Runtime.TxnScheduler.ProposerTimeout
+	callCtx, cancelCallFn := context.WithTimeoutCause(
+		ctx,
+		executeBatchTimeoutFactor*proposerTimeout,
+		errors.New("proposer timeout expired"),
+	)
+	defer cancelCallFn()
+
+	rsp, err := rt.Call(callCtx, rq)
 	switch {
 	case err == nil:
 	case errors.Is(err, context.Canceled):
 		// Context was canceled while the runtime was processing a request.
-		n.logger.Error("batch processing aborted by context, restarting runtime")
+		n.logger.Error("batch processing aborted by context, restarting runtime",
+			"cause", context.Cause(callCtx),
+		)
 
 		// Abort the runtime, so we can start processing the next batch.
-		abortCtx, cancel := context.WithTimeout(n.ctx, abortTimeout)
+		abortCtx, cancel := context.WithTimeout(ctx, abortTimeout)
 		defer cancel()
 
 		if err = rt.Abort(abortCtx, false); err != nil {
@@ -778,7 +793,7 @@ func (n *Node) abortBatch(state *StateProcessingBatch) {
 	n.logger.Warn("aborting processing batch")
 
 	// Stop processing.
-	state.Cancel()
+	state.Cancel(errors.New("batch aborted"))
 
 	// Discard the result if there was any.
 	select {
@@ -1500,8 +1515,8 @@ func (n *Node) worker() {
 			var wg sync.WaitGroup
 			defer wg.Wait()
 
-			ctx, cancel := context.WithCancel(n.ctx)
-			defer cancel()
+			ctx, cancel := context.WithCancelCause(n.ctx)
+			defer cancel(errors.New("round finished"))
 
 			wg.Add(1)
 			go func() {

--- a/go/worker/compute/executor/committee/state.go
+++ b/go/worker/compute/executor/committee/state.go
@@ -141,7 +141,7 @@ type StateProcessingBatch struct {
 	// Timing for this batch.
 	batchStartTime time.Time
 	// Function for cancelling batch processing.
-	cancelFn context.CancelFunc
+	cancelFn context.CancelCauseFunc
 	// Channel which will provide the result.
 	done chan struct{}
 }
@@ -157,8 +157,8 @@ func (s StateProcessingBatch) String() string {
 }
 
 // Cancel invokes the cancellation function and waits for the processing to actually stop.
-func (s *StateProcessingBatch) Cancel() {
-	s.cancelFn()
+func (s *StateProcessingBatch) Cancel(cause error) {
+	s.cancelFn(cause)
 	<-s.done
 }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -70,6 +70,11 @@ jsonrpc = { version = "0.13.0", features = ["simple_uds"] }
 tempfile = "3.4.0"
 tendermint-testgen = "0.30.0"
 
+[features]
+default = []
+# Enables debug-level logging in release builds.
+debug-logging = ["slog/max_level_debug", "slog/release_max_level_debug"]
+
 [[bin]]
 name = "fuzz-mkvs-proof"
 path = "fuzz/mkvs_proof.rs"

--- a/runtime/src/protocol.rs
+++ b/runtime/src/protocol.rs
@@ -367,10 +367,7 @@ impl Protocol {
             }
             Body::RuntimeAbortRequest {} => {
                 info!(self.logger, "Received worker abort request");
-                self.ensure_initialized()?;
-                self.dispatcher.abort_and_wait()?;
-                info!(self.logger, "Handled worker abort request");
-                Ok(Some(Body::RuntimeAbortResponse {}))
+                Err(ProtocolError::MethodNotSupported.into())
             }
 
             // Attestation-related requests.


### PR DESCRIPTION
Similar to how this is handled in the multi runtime host, we need to release the lock before calling into the runtime as otherwise this could lead to a deadlock in certain situations.