### PR TITLE
go/oasis-test-runner: Verify enclave initialization after km upgrade 

### DIFF
--- a/.changelog/5449.feature.2.md
+++ b/.changelog/5449.feature.2.md
@@ -1,0 +1,4 @@
+go/oasis-test-runner: Verify enclave initialization after km upgrade
+
+Verify whether enclave initialization still functions after the key
+manager upgrade.

--- a/.changelog/5449.feature.md
+++ b/.changelog/5449.feature.md
@@ -1,0 +1,7 @@
+go/oasis-node/cmd/genesis: Make attestation age/interval configurable
+
+A new flag `registry.tee_features.sgx.default_max_attestation_age` was added
+to the genesis command to specify the default maximum attestation age when
+SGX RAK-signed attestations are enabled. Additionally, within the runtime
+registry configuration, one can now set the attestation interval for periodic
+runtime re-attestation.

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -55,15 +55,16 @@ const (
 	CfgInitialHeight = "initial_height"
 
 	// Registry config flags.
-	CfgRegistryMaxNodeExpiration                = "registry.max_node_expiration"
-	CfgRegistryDisableRuntimeRegistration       = "registry.disable_runtime_registration"
-	CfgRegistryDebugAllowUnroutableAddresses    = "registry.debug.allow_unroutable_addresses"
-	CfgRegistryDebugAllowTestRuntimes           = "registry.debug.allow_test_runtimes"
-	cfgRegistryDebugBypassStake                 = "registry.debug.bypass_stake" // nolint: gosec
-	CfgRegistryEnableRuntimeGovernanceModels    = "registry.enable_runtime_governance_models"
-	CfgRegistryTEEFeaturesSGXPCS                = "registry.tee_features.sgx.pcs"
-	CfgRegistryTEEFeaturesSGXSignedAttestations = "registry.tee_features.sgx.signed_attestations"
-	CfgRegistryTEEFeaturesFreshnessProofs       = "registry.tee_features.freshness_proofs"
+	CfgRegistryMaxNodeExpiration                      = "registry.max_node_expiration"
+	CfgRegistryDisableRuntimeRegistration             = "registry.disable_runtime_registration"
+	CfgRegistryDebugAllowUnroutableAddresses          = "registry.debug.allow_unroutable_addresses"
+	CfgRegistryDebugAllowTestRuntimes                 = "registry.debug.allow_test_runtimes"
+	cfgRegistryDebugBypassStake                       = "registry.debug.bypass_stake" // nolint: gosec
+	CfgRegistryEnableRuntimeGovernanceModels          = "registry.enable_runtime_governance_models"
+	CfgRegistryTEEFeaturesSGXPCS                      = "registry.tee_features.sgx.pcs"
+	CfgRegistryTEEFeaturesSGXSignedAttestations       = "registry.tee_features.sgx.signed_attestations"
+	CfgRegistryTEEFeaturesSGXDefaultMaxAttestationAge = "registry.tee_features.sgx.default_max_attestation_age"
+	CfgRegistryTEEFeaturesFreshnessProofs             = "registry.tee_features.freshness_proofs"
 
 	// Scheduler config flags.
 	cfgSchedulerMinValidators          = "scheduler.min_validators"
@@ -349,7 +350,7 @@ func AppendRegistryState(doc *genesis.Document, entities, runtimes, nodes []stri
 		if regSt.Parameters.TEEFeatures == nil {
 			regSt.Parameters.TEEFeatures = &node.TEEFeatures{}
 		}
-		regSt.Parameters.TEEFeatures.SGX = node.TEEFeaturesSGX{PCS: true}
+		regSt.Parameters.TEEFeatures.SGX.PCS = true
 	}
 
 	if viper.GetBool(CfgRegistryTEEFeaturesFreshnessProofs) {
@@ -364,7 +365,7 @@ func AppendRegistryState(doc *genesis.Document, entities, runtimes, nodes []stri
 			regSt.Parameters.TEEFeatures = &node.TEEFeatures{}
 		}
 		regSt.Parameters.TEEFeatures.SGX.SignedAttestations = true
-		regSt.Parameters.TEEFeatures.SGX.DefaultMaxAttestationAge = 1200 // ~2 hours at 6 sec per block.
+		regSt.Parameters.TEEFeatures.SGX.DefaultMaxAttestationAge = viper.GetUint64(CfgRegistryTEEFeaturesSGXDefaultMaxAttestationAge)
 	}
 
 	for _, gmStr := range viper.GetStringSlice(CfgRegistryEnableRuntimeGovernanceModels) {
@@ -795,6 +796,7 @@ func init() {
 	initGenesisFlags.StringSlice(CfgRegistryEnableRuntimeGovernanceModels, []string{"entity"}, "set of enabled runtime governance models")
 	initGenesisFlags.Bool(CfgRegistryTEEFeaturesSGXPCS, true, "enable PCS support for SGX TEEs")
 	initGenesisFlags.Bool(CfgRegistryTEEFeaturesSGXSignedAttestations, true, "enable SGX RAK-signed attestations")
+	initGenesisFlags.Uint64(CfgRegistryTEEFeaturesSGXDefaultMaxAttestationAge, 1200, "default max attestation age (SGX RAK-signed attestations must be enabled") // ~2 hours at 6 sec per block.
 	initGenesisFlags.Bool(CfgRegistryTEEFeaturesFreshnessProofs, true, "enable freshness proofs")
 	_ = initGenesisFlags.MarkHidden(CfgRegistryDebugAllowUnroutableAddresses)
 	_ = initGenesisFlags.MarkHidden(CfgRegistryDebugAllowTestRuntimes)

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -51,16 +51,16 @@ const (
 	cfgKeyManager    = "keymanager"
 	cfgStaking       = "staking"
 	cfgBlockHeight   = "height"
-	cfgChainID       = "chain.id"
-	cfgInitialHeight = "initial_height"
+	CfgChainID       = "chain.id"
+	CfgInitialHeight = "initial_height"
 
 	// Registry config flags.
 	CfgRegistryMaxNodeExpiration                = "registry.max_node_expiration"
 	CfgRegistryDisableRuntimeRegistration       = "registry.disable_runtime_registration"
-	cfgRegistryDebugAllowUnroutableAddresses    = "registry.debug.allow_unroutable_addresses"
+	CfgRegistryDebugAllowUnroutableAddresses    = "registry.debug.allow_unroutable_addresses"
 	CfgRegistryDebugAllowTestRuntimes           = "registry.debug.allow_test_runtimes"
 	cfgRegistryDebugBypassStake                 = "registry.debug.bypass_stake" // nolint: gosec
-	cfgRegistryEnableRuntimeGovernanceModels    = "registry.enable_runtime_governance_models"
+	CfgRegistryEnableRuntimeGovernanceModels    = "registry.enable_runtime_governance_models"
 	CfgRegistryTEEFeaturesSGXPCS                = "registry.tee_features.sgx.pcs"
 	CfgRegistryTEEFeaturesSGXSignedAttestations = "registry.tee_features.sgx.signed_attestations"
 	CfgRegistryTEEFeaturesFreshnessProofs       = "registry.tee_features.freshness_proofs"
@@ -68,7 +68,7 @@ const (
 	// Scheduler config flags.
 	cfgSchedulerMinValidators          = "scheduler.min_validators"
 	cfgSchedulerMaxValidators          = "scheduler.max_validators"
-	cfgSchedulerMaxValidatorsPerEntity = "scheduler.max_validators_per_entity"
+	CfgSchedulerMaxValidatorsPerEntity = "scheduler.max_validators_per_entity"
 	cfgSchedulerDebugBypassStake       = "scheduler.debug.bypass_stake" // nolint: gosec
 	CfgSchedulerDebugForceElect        = "scheduler.debug.force_elect"
 	CfgSchedulerDebugAllowWeakAlpha    = "scheduler.debug.allow_weak_alpha"
@@ -101,7 +101,7 @@ const (
 	CfgStakingTokenValueExponent = "staking.token_value_exponent"
 
 	// CometBFT config flags.
-	cfgConsensusTimeoutCommit            = "consensus.cometbft.timeout_commit"
+	CfgConsensusTimeoutCommit            = "consensus.cometbft.timeout_commit"
 	cfgConsensusSkipTimeoutCommit        = "consensus.cometbft.skip_timeout_commit"
 	cfgConsensusEmptyBlockInterval       = "consensus.cometbft.empty_block_interval"
 	cfgConsensusMaxTxSizeBytes           = "consensus.cometbft.max_tx_size"
@@ -115,7 +115,7 @@ const (
 	cfgConsensusBlacklistPublicKey       = "consensus.blacklist_public_key"
 
 	// Consensus backend config flag.
-	cfgConsensusBackend = "consensus.backend"
+	CfgConsensusBackend = "consensus.backend"
 
 	// Our 'entity' flag overlaps with the common flag 'entity'.
 	// We bind it to a separate Viper key to disambiguate at runtime.
@@ -171,7 +171,7 @@ func doInitGenesis(*cobra.Command, []string) {
 		return
 	}
 
-	chainID := viper.GetString(cfgChainID)
+	chainID := viper.GetString(CfgChainID)
 	if chainID == "" {
 		logger.Error("genesis chain id missing")
 		return
@@ -179,7 +179,7 @@ func doInitGenesis(*cobra.Command, []string) {
 
 	// Build the genesis state, if any.
 	doc := &genesis.Document{
-		Height:  viper.GetInt64(cfgInitialHeight),
+		Height:  viper.GetInt64(CfgInitialHeight),
 		ChainID: chainID,
 		Time:    time.Now(),
 	}
@@ -221,7 +221,7 @@ func doInitGenesis(*cobra.Command, []string) {
 		Parameters: scheduler.ConsensusParameters{
 			MinValidators:          viper.GetInt(cfgSchedulerMinValidators),
 			MaxValidators:          viper.GetInt(cfgSchedulerMaxValidators),
-			MaxValidatorsPerEntity: viper.GetInt(cfgSchedulerMaxValidatorsPerEntity),
+			MaxValidatorsPerEntity: viper.GetInt(CfgSchedulerMaxValidatorsPerEntity),
 			DebugBypassStake:       viper.GetBool(cfgSchedulerDebugBypassStake),
 			DebugAllowWeakAlpha:    viper.GetBool(CfgSchedulerDebugAllowWeakAlpha),
 		},
@@ -283,9 +283,9 @@ func doInitGenesis(*cobra.Command, []string) {
 	}
 
 	doc.Consensus = consensusGenesis.Genesis{
-		Backend: viper.GetString(cfgConsensusBackend),
+		Backend: viper.GetString(CfgConsensusBackend),
 		Parameters: consensusGenesis.Parameters{
-			TimeoutCommit:            viper.GetDuration(cfgConsensusTimeoutCommit),
+			TimeoutCommit:            viper.GetDuration(CfgConsensusTimeoutCommit),
 			SkipTimeoutCommit:        viper.GetBool(cfgConsensusSkipTimeoutCommit),
 			EmptyBlockInterval:       viper.GetDuration(cfgConsensusEmptyBlockInterval),
 			MaxTxSize:                uint64(viper.GetSizeInBytes(cfgConsensusMaxTxSizeBytes)),
@@ -332,7 +332,7 @@ func doInitGenesis(*cobra.Command, []string) {
 func AppendRegistryState(doc *genesis.Document, entities, runtimes, nodes []string, l *logging.Logger) error {
 	regSt := registry.Genesis{
 		Parameters: registry.ConsensusParameters{
-			DebugAllowUnroutableAddresses: viper.GetBool(cfgRegistryDebugAllowUnroutableAddresses),
+			DebugAllowUnroutableAddresses: viper.GetBool(CfgRegistryDebugAllowUnroutableAddresses),
 			DebugAllowTestRuntimes:        viper.GetBool(CfgRegistryDebugAllowTestRuntimes),
 			DebugBypassStake:              viper.GetBool(cfgRegistryDebugBypassStake),
 			GasCosts:                      registry.DefaultGasCosts, // TODO: Make these configurable.
@@ -367,7 +367,7 @@ func AppendRegistryState(doc *genesis.Document, entities, runtimes, nodes []stri
 		regSt.Parameters.TEEFeatures.SGX.DefaultMaxAttestationAge = 1200 // ~2 hours at 6 sec per block.
 	}
 
-	for _, gmStr := range viper.GetStringSlice(cfgRegistryEnableRuntimeGovernanceModels) {
+	for _, gmStr := range viper.GetStringSlice(CfgRegistryEnableRuntimeGovernanceModels) {
 		var gm registry.RuntimeGovernanceModel
 		if err := gm.UnmarshalText([]byte(strings.ToLower(gmStr))); err != nil {
 			return fmt.Errorf("%w: '%s'", err, gmStr)
@@ -783,27 +783,27 @@ func init() {
 	initGenesisFlags.StringSlice(cfgRootHash, nil, "path to roothash genesis runtime states file")
 	initGenesisFlags.String(cfgStaking, "", "path to staking genesis file")
 	initGenesisFlags.StringSlice(cfgKeyManager, nil, "path to key manager genesis status file")
-	initGenesisFlags.String(cfgChainID, "", "genesis chain id")
-	initGenesisFlags.Int64(cfgInitialHeight, 1, "initial block height")
+	initGenesisFlags.String(CfgChainID, "", "genesis chain id")
+	initGenesisFlags.Int64(CfgInitialHeight, 1, "initial block height")
 
 	// Registry config flags.
 	initGenesisFlags.Uint64(CfgRegistryMaxNodeExpiration, 5, "maximum node registration lifespan in epochs")
 	initGenesisFlags.Bool(CfgRegistryDisableRuntimeRegistration, false, "disable non-genesis runtime registration")
-	initGenesisFlags.Bool(cfgRegistryDebugAllowUnroutableAddresses, false, "allow unroutable addreses (UNSAFE)")
+	initGenesisFlags.Bool(CfgRegistryDebugAllowUnroutableAddresses, false, "allow unroutable addreses (UNSAFE)")
 	initGenesisFlags.Bool(CfgRegistryDebugAllowTestRuntimes, false, "enable test runtime registration")
 	initGenesisFlags.Bool(cfgRegistryDebugBypassStake, false, "bypass all stake checks and operations (UNSAFE)")
-	initGenesisFlags.StringSlice(cfgRegistryEnableRuntimeGovernanceModels, []string{"entity"}, "set of enabled runtime governance models")
+	initGenesisFlags.StringSlice(CfgRegistryEnableRuntimeGovernanceModels, []string{"entity"}, "set of enabled runtime governance models")
 	initGenesisFlags.Bool(CfgRegistryTEEFeaturesSGXPCS, true, "enable PCS support for SGX TEEs")
 	initGenesisFlags.Bool(CfgRegistryTEEFeaturesSGXSignedAttestations, true, "enable SGX RAK-signed attestations")
 	initGenesisFlags.Bool(CfgRegistryTEEFeaturesFreshnessProofs, true, "enable freshness proofs")
-	_ = initGenesisFlags.MarkHidden(cfgRegistryDebugAllowUnroutableAddresses)
+	_ = initGenesisFlags.MarkHidden(CfgRegistryDebugAllowUnroutableAddresses)
 	_ = initGenesisFlags.MarkHidden(CfgRegistryDebugAllowTestRuntimes)
 	_ = initGenesisFlags.MarkHidden(cfgRegistryDebugBypassStake)
 
 	// Scheduler config flags.
 	initGenesisFlags.Int(cfgSchedulerMinValidators, 1, "minimum number of validators")
 	initGenesisFlags.Int(cfgSchedulerMaxValidators, 100, "maximum number of validators")
-	initGenesisFlags.Int(cfgSchedulerMaxValidatorsPerEntity, 1, "maximum number of validators per entity")
+	initGenesisFlags.Int(CfgSchedulerMaxValidatorsPerEntity, 1, "maximum number of validators per entity")
 	initGenesisFlags.Bool(cfgSchedulerDebugBypassStake, false, "bypass all stake checks and operations (UNSAFE)")
 	initGenesisFlags.String(CfgSchedulerDebugForceElect, "", "force elect the (runtime, node, role) tuple(s) (UNSAFE)")
 	initGenesisFlags.Bool(CfgSchedulerDebugAllowWeakAlpha, false, "bypass alpha strength check for VRF elections (UNSAFE)")
@@ -842,7 +842,7 @@ func init() {
 	initGenesisFlags.Uint8(CfgStakingTokenValueExponent, 0, "token value's base-10 exponent")
 
 	// CometBFT config flags.
-	initGenesisFlags.Duration(cfgConsensusTimeoutCommit, 1*time.Second, "cometbft commit timeout")
+	initGenesisFlags.Duration(CfgConsensusTimeoutCommit, 1*time.Second, "cometbft commit timeout")
 	initGenesisFlags.Bool(cfgConsensusSkipTimeoutCommit, false, "skip cometbft commit timeout")
 	initGenesisFlags.Duration(cfgConsensusEmptyBlockInterval, 0*time.Second, "cometbft empty block interval")
 	initGenesisFlags.String(cfgConsensusMaxTxSizeBytes, "32kb", "cometbft maximum transaction size (in bytes)")
@@ -856,7 +856,7 @@ func init() {
 	initGenesisFlags.StringSlice(cfgConsensusBlacklistPublicKey, nil, "blacklist public key")
 
 	// Consensus backend flag.
-	initGenesisFlags.String(cfgConsensusBackend, cmt.BackendName, "consensus backend")
+	initGenesisFlags.String(CfgConsensusBackend, cmt.BackendName, "consensus backend")
 
 	_ = viper.BindPFlags(initGenesisFlags)
 	initGenesisFlags.StringSlice(cfgEntity, nil, "path to entity registration file")

--- a/go/oasis-test-runner/oasis/compute.go
+++ b/go/oasis-test-runner/oasis/compute.go
@@ -166,6 +166,7 @@ func (worker *Compute) ModifyConfig() error {
 	worker.Config.Mode = config.ModeCompute
 	worker.Config.Runtime.Provisioner = worker.runtimeProvisioner
 	worker.Config.Runtime.SGXLoader = worker.net.cfg.RuntimeSGXLoaderBinary
+	worker.Config.Runtime.AttestInterval = worker.net.cfg.RuntimeAttestInterval
 
 	worker.Config.Storage.Backend = worker.storageBackend
 	worker.Config.Storage.PublicRPCEnabled = !worker.disablePublicRPC

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -292,6 +292,7 @@ func (km *Keymanager) ModifyConfig() error {
 	km.Config.Mode = config.ModeKeyManager
 	km.Config.Runtime.Provisioner = km.runtimeProvisioner
 	km.Config.Runtime.SGXLoader = km.net.cfg.RuntimeSGXLoaderBinary
+	km.Config.Runtime.AttestInterval = km.net.cfg.RuntimeAttestInterval
 	km.Config.Runtime.Paths = append(km.Config.Runtime.Paths, km.runtime.BundlePaths()...)
 
 	km.Config.Keymanager.RuntimeID = km.runtime.ID().String()

--- a/go/oasis-test-runner/oasis/network.go
+++ b/go/oasis-test-runner/oasis/network.go
@@ -34,6 +34,7 @@ import (
 	genesisTestHelpers "github.com/oasisprotocol/oasis-core/go/genesis/tests"
 	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
+	cmdFlags "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/metrics"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/genesis"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
@@ -652,7 +653,7 @@ func (net *Network) startOasisNode(
 
 		extraArgs = extraArgs.debugAllowDebugEnclaves()
 	} else {
-		baseArgs = append(baseArgs, "--genesis.file", net.GenesisPath())
+		baseArgs = append(baseArgs, "--"+cmdFlags.CfgGenesisFile, net.GenesisPath())
 	}
 	if net.cfg.UseShortGrpcSocketPaths {
 		// Keep the socket, if it was already generated!
@@ -748,21 +749,20 @@ func (net *Network) startOasisNode(
 func (net *Network) MakeGenesis() error {
 	args := []string{
 		"genesis", "init",
-		"--genesis.file", net.GenesisPath(),
-		"--chain.id", genesisTestHelpers.TestChainID,
-		"--initial_height", strconv.FormatInt(net.cfg.InitialHeight, 10),
-		"--consensus.backend", net.cfg.Consensus.Backend,
-		"--consensus.cometbft.timeout_commit", net.cfg.Consensus.Parameters.TimeoutCommit.String(),
-		"--registry.enable_runtime_governance_models", "entity,runtime",
-		"--registry.debug.allow_unroutable_addresses", "true",
+		"--" + cmdFlags.CfgGenesisFile, net.GenesisPath(),
+		"--" + genesis.CfgChainID, genesisTestHelpers.TestChainID,
+		"--" + genesis.CfgInitialHeight, strconv.FormatInt(net.cfg.InitialHeight, 10),
+		"--" + genesis.CfgConsensusBackend, net.cfg.Consensus.Backend,
+		"--" + genesis.CfgConsensusTimeoutCommit, net.cfg.Consensus.Parameters.TimeoutCommit.String(),
+		"--" + genesis.CfgRegistryEnableRuntimeGovernanceModels, "entity,runtime",
+		"--" + genesis.CfgRegistryDebugAllowUnroutableAddresses, "true",
 		"--" + genesis.CfgRegistryDebugAllowTestRuntimes, "true",
-		"--scheduler.max_validators_per_entity", strconv.Itoa(len(net.Validators())),
+		"--" + genesis.CfgSchedulerMaxValidatorsPerEntity, strconv.Itoa(len(net.Validators())),
 		"--" + genesis.CfgConsensusGasCostsTxByte, strconv.FormatUint(uint64(net.cfg.Consensus.Parameters.GasCosts[consensusGenesis.GasOpTxByte]), 10),
 		"--" + genesis.CfgConsensusStateCheckpointInterval, strconv.FormatUint(net.cfg.Consensus.Parameters.StateCheckpointInterval, 10),
 		"--" + genesis.CfgConsensusStateCheckpointNumKept, strconv.FormatUint(net.cfg.Consensus.Parameters.StateCheckpointNumKept, 10),
 		"--" + genesis.CfgStakingTokenSymbol, genesisTestHelpers.TestStakingTokenSymbol,
-		"--" + genesis.CfgStakingTokenValueExponent, strconv.FormatUint(
-			uint64(genesisTestHelpers.TestStakingTokenValueExponent), 10),
+		"--" + genesis.CfgStakingTokenValueExponent, strconv.FormatUint(uint64(genesisTestHelpers.TestStakingTokenValueExponent), 10),
 		"--" + genesis.CfgBeaconBackend, net.cfg.Beacon.Backend,
 	}
 	switch net.cfg.Beacon.Backend {

--- a/go/oasis-test-runner/oasis/network.go
+++ b/go/oasis-test-runner/oasis/network.go
@@ -104,6 +104,13 @@ type NetworkCfg struct { // nolint: maligned
 	// RuntimeSGXLoaderBinary is the path to the Oasis SGX runtime loader.
 	RuntimeSGXLoaderBinary string `json:"runtime_loader_binary"`
 
+	// RuntimeAttestInterval is the interval for periodic runtime re-attestation. If not specified
+	// a default will be used.
+	RuntimeAttestInterval time.Duration `json:"runtime_attest_interval,omitempty"`
+
+	// RuntimeDefaultMaxAttestationAge is the default maximum attestation age (in blocks).
+	RuntimeDefaultMaxAttestationAge uint64 `json:"runtime_max_attestation_age,omitempty"`
+
 	// Consensus are the network-wide consensus parameters.
 	Consensus consensusGenesis.Genesis `json:"consensus"`
 
@@ -786,6 +793,9 @@ func (net *Network) MakeGenesis() error {
 	}
 	if net.cfg.Beacon.DebugMockBackend {
 		args = append(args, "--"+genesis.CfgBeaconDebugMockBackend)
+	}
+	if net.cfg.RuntimeDefaultMaxAttestationAge != 0 {
+		args = append(args, "--"+genesis.CfgRegistryTEEFeaturesSGXDefaultMaxAttestationAge, strconv.FormatUint(net.cfg.RuntimeDefaultMaxAttestationAge, 10))
 	}
 	if cfg := net.cfg.GovernanceParameters; cfg != nil {
 		args = append(args, []string{

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_upgrade.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"time"
 
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
@@ -38,6 +39,9 @@ func (sc *KmUpgradeImpl) Fixture() (*oasis.NetworkFixture, error) {
 	if sc.upgradedKeyManagerIndex, err = sc.UpgradeKeyManagerFixture(f); err != nil {
 		return nil, err
 	}
+
+	f.Network.RuntimeAttestInterval = 2 * time.Minute
+	f.Network.RuntimeDefaultMaxAttestationAge = 200 // 4 min at 1.2 sec per block.
 
 	return f, nil
 }

--- a/go/runtime/config/config.go
+++ b/go/runtime/config/config.go
@@ -90,6 +90,10 @@ type Config struct {
 	// Number of epochs before runtime activation epoch when to start the runtime to warm it up and
 	// prepare any required attestations. Zero disables pre-warming.
 	PreWarmEpochs uint64 `yaml:"pre_warm_epochs,omitempty"`
+
+	// AttestInterval is the interval for periodic runtime re-attestation. If not specified
+	// a default will be used.
+	AttestInterval time.Duration `yaml:"attest_interval,omitempty"`
 }
 
 // PruneConfig is the history pruner configuration structure.

--- a/go/runtime/registry/config.go
+++ b/go/runtime/registry/config.go
@@ -117,6 +117,7 @@ func newConfig(dataDir string, commonStore *persistent.CommonStore, consensus co
 		// Register provisioners based on the configured provisioner.
 		var insecureNoSandbox bool
 		sandboxBinary := config.GlobalConfig.Runtime.SandboxBinary
+		attestInterval := config.GlobalConfig.Runtime.AttestInterval
 		rh.Provisioners = make(map[node.TEEHardware]runtimeHost.Provisioner)
 		switch p := config.GlobalConfig.Runtime.Provisioner; p {
 		case rtConfig.RuntimeProvisionerMock:
@@ -182,14 +183,15 @@ func newConfig(dataDir string, commonStore *persistent.CommonStore, consensus co
 				}
 
 				rh.Provisioners[node.TEEHardwareIntelSGX], err = hostSgx.New(hostSgx.Config{
-					HostInfo:          hostInfo,
-					CommonStore:       commonStore,
-					LoaderPath:        sgxLoader,
-					IAS:               ias,
-					PCS:               pc,
-					Consensus:         consensus,
-					SandboxBinaryPath: sandboxBinary,
-					InsecureNoSandbox: insecureNoSandbox,
+					HostInfo:              hostInfo,
+					CommonStore:           commonStore,
+					LoaderPath:            sgxLoader,
+					IAS:                   ias,
+					PCS:                   pc,
+					Consensus:             consensus,
+					SandboxBinaryPath:     sandboxBinary,
+					InsecureNoSandbox:     insecureNoSandbox,
+					RuntimeAttestInterval: attestInterval,
 				})
 				if err != nil {
 					return nil, fmt.Errorf("failed to create SGX runtime provisioner: %w", err)


### PR DESCRIPTION
Updating the key manager upgrade test to cover scenario observed on the testnet:
- A new key manager registered with RSK.
- The old key manager couldn't re-register due to its inability to decode the key manager status (new unknown field).
- The old key manager was removed from the committee after its attestation expired (enclave initialization failed).

Next steps (upgrade test):
- Post-upgrade branch will be bumped to the latest master. This will cause the upgrade test to fail (testnet scenario).
- Pre-upgrade branch will be bumped to #5432. This will solve the problem and the upgrade test will not fail anymore (mainnet scenario).