### PR TITLE
runtime: Create controller in RpcClient constructor

### DIFF
--- a/.changelog/5450.bugfix.md
+++ b/.changelog/5450.bugfix.md
@@ -1,0 +1,10 @@
+runtime: Create controller in RpcClient constructor
+
+Previously if no RPC calls were initiated by the runtime, the client
+controller task was never spawned which caused quote policy update
+requests to pile up in the command queue, eventually blocking the entire
+runtime from processing requests.
+
+Since the async runtime is now available early on during initialization,
+we can spawn the controller in the RpcClient constructor, avoiding these
+problems.

--- a/runtime/src/dispatcher.rs
+++ b/runtime/src/dispatcher.rs
@@ -220,6 +220,9 @@ impl Dispatcher {
             guard.take().unwrap()
         };
 
+        // Ensure Tokio runtime is available during dispatcher initialization.
+        let _guard = self.tokio_runtime.enter();
+
         // Create actual dispatchers for RPCs and transactions.
         info!(self.logger, "Starting the runtime dispatcher");
         let mut rpc_demux = RpcDemux::new(self.identity.clone());


### PR DESCRIPTION
Previously if no RPC calls were initiated by the runtime, the client controller task was never spawned which caused quote policy update requests to pile up in the command queue, eventually blocking the entire runtime from processing requests.

Since the async runtime is now available early on during initialization, we can spawn the controller in the RpcClient constructor, avoiding these problems.