### PR TITLE
buildkite: Download artifacts after runtimes are built

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -374,6 +374,8 @@ steps:
   - group: "E2E upgrade tests - sgx1"
     depends_on:
       - "build-go"
+      - "build-rust-runtime-loader"
+      - "build-rust-runtimes"
     steps:
       - block: "Confirm E2E upgrade tests run"
         prompt: "Run E2E upgrade tests for this pull request"


### PR DESCRIPTION
The upgrade-test should now pass, as #5432 was merged.