### PR TITLE
go/p2p: Improve seed node performance

### DIFF
--- a/.changelog/5456.bugfix.2.md
+++ b/.changelog/5456.bugfix.2.md
@@ -1,0 +1,1 @@
+go/p2p: Increase incoming connection limit for seed nodes

--- a/.changelog/5456.bugfix.md
+++ b/.changelog/5456.bugfix.md
@@ -1,0 +1,7 @@
+go/p2p: Close connection to seed node after every request
+
+Bootstrap client, which is responsible for peer discovery and advertisement,
+now terminates connection to the seed node after every request. This action
+should free up recourses (e.g. inbound/outbound connections) on both sides
+without affecting performance since discovered peers are cached (see retention
+period) and advertisement is done infrequently (see TTL).

--- a/go/p2p/discovery/bootstrap/client.go
+++ b/go/p2p/discovery/bootstrap/client.go
@@ -133,6 +133,13 @@ func (c *client) Advertise(ctx context.Context, ns string, _ ...discovery.Option
 
 	pf.RecordSuccess()
 
+	// Close connections after every call because requests to the seed node are infrequent.
+	if err = c.rc.Close(c.seed.ID); err != nil {
+		c.logger.Warn("failed to close connections to seed node",
+			"err", err,
+		)
+	}
+
 	return res.TTL, nil
 }
 
@@ -237,6 +244,13 @@ func (c *client) fetchPeers(ctx context.Context, ns string, limit int) []peer.Ad
 		c.nextDiscovery = now.Add(c.backoff.NextBackOff())
 
 		pf.RecordFailure()
+	}
+
+	// Close connections after every call because requests to the seed node are infrequent.
+	if err := c.rc.Close(c.seed.ID); err != nil {
+		c.logger.Warn("failed to close connections to seed node",
+			"err", err,
+		)
 	}
 
 	return cache.peers

--- a/go/p2p/rpc/nop.go
+++ b/go/p2p/rpc/nop.go
@@ -83,6 +83,13 @@ func (c *nopClient) CallMulti(
 }
 
 // Implements Client.
+func (c *nopClient) Close(
+	peer.ID,
+) error {
+	return nil
+}
+
+// Implements Client.
 func (c *nopClient) RegisterListener(ClientListener) {}
 
 // Implements Client.


### PR DESCRIPTION
Some nodes cannot bootstrap because the seed node has too many open connections.
```
{"attempted":1,"caller":"scope.go:584","current":77,"direction":"Inbound","edge":"system","error":"system: cannot reserve inbound connection: resource limit exceeded","level":"debug","limit":77,"module":"libp2p:rcmgr","msg":"blocked connection from constraining edge","scope":"conn-9516","stat":{"NumStreamsInbound":0,"NumStreamsOutbound":0,"NumConnsInbound":77,"NumConnsOutbound":0,"NumFD":77,"Memory":0},"ts":"2023-11-16T21:09:27.902582862Z","usefd":true}
{"caller":"listener.go:99","error":"conn-9516: system: cannot reserve inbound connection: resource limit exceeded","level":"debug","module":"libp2p:upgrader","msg":"resource manager blocked accept of new connection","ts":"2023-11-16T21:09:27.902778381Z"}
```
The problem lies in the default settings of the resource manager, which are set too low. Consequently, the connection manager never trims connections down to the low watermark (set at 100 by default) because the high watermark (set at 130 by default) is never attained. Increasing the number of inbound connections for seed nodes to 128+ (extra connections come from autoscaling), should solve the problem.