### PR TITLE
runtime: Improve error reporting if DeoxysII unsealing fails

### DIFF
--- a/.changelog/5458.bugfix.md
+++ b/.changelog/5458.bugfix.md
@@ -1,0 +1,6 @@
+runtime: Improve error reporting if DeoxysII unsealing fails
+
+Previously, if the CPU changed between runs of the Oasis node, the error
+reported was a cryptic "ciphertext is corrupted" (because the sealed SGX
+secrets were invalidated).
+Now we add a bit more context to make it easier for the end-user.

--- a/keymanager/src/crypto/kdf.rs
+++ b/keymanager/src/crypto/kdf.rs
@@ -780,7 +780,7 @@ impl Kdf {
         let d2 = new_deoxysii(Keypolicy::MRENCLAVE, MASTER_SECRET_SEAL_CONTEXT);
         let plaintext = d2
             .open(&nonce, ciphertext.to_vec(), additional_data)
-            .expect("persisted state is corrupted");
+            .unwrap();
 
         Some(Secret(plaintext.try_into().unwrap()))
     }

--- a/keymanager/src/policy/cached.rs
+++ b/keymanager/src/policy/cached.rs
@@ -172,10 +172,12 @@ impl Policy {
     fn load_policy(storage: &dyn KeyValue) -> Option<CachedPolicy> {
         let ciphertext = storage.get(POLICY_STORAGE_KEY.to_vec()).unwrap();
 
-        unseal(Keypolicy::MRENCLAVE, POLICY_SEAL_CONTEXT, &ciphertext).map(|plaintext| {
-            // Deserialization failures are fatal, because it is state corruption.
-            CachedPolicy::parse_raw(&plaintext).expect("failed to deserialize persisted policy")
-        })
+        unseal(Keypolicy::MRENCLAVE, POLICY_SEAL_CONTEXT, &ciphertext)
+            .unwrap()
+            .map(|plaintext| {
+                // Deserialization failures are fatal, because it is state corruption.
+                CachedPolicy::parse_raw(&plaintext).expect("failed to deserialize persisted policy")
+            })
     }
 
     fn save_raw_policy(storage: &dyn KeyValue, raw_policy: &[u8]) {

--- a/runtime/src/consensus/tendermint/verifier/mod.rs
+++ b/runtime/src/consensus/tendermint/verifier/mod.rs
@@ -646,9 +646,17 @@ impl Verifier {
         // Build a light client using the embedded trust root or trust root
         // stored in the local store.
         info!(self.logger, "Loading trusted state");
-        let trusted_state: TrustedState = self
+        let trusted_state = self
             .trusted_state_store
-            .load(self.runtime_version, &self.trust_root)?;
+            .load(self.runtime_version, &self.trust_root);
+
+        let trusted_state: TrustedState = match trusted_state {
+            Ok(state) => state,
+            Err(err) => {
+                error!(self.logger, "failed to load trusted state (if running in SGX mode, check if the CPU had changed; if yes, wipe 'worker-local-storage.badger.db' and restart the node)");
+                return Err(err);
+            }
+        };
 
         // Verify if we can trust light blocks from a new chain if the consensus
         // chain context changes.

--- a/runtime/src/consensus/tendermint/verifier/store/state.rs
+++ b/runtime/src/consensus/tendermint/verifier/store/state.rs
@@ -147,7 +147,9 @@ impl TrustedStateStore {
             TRUSTED_STATE_CONTEXT,
             &untrusted_value,
         )
+        .map_err(|_| Error::TrustedStateLoadingFailed)?
         .unwrap();
+
         let trusted_state: TrustedState =
             cbor::from_slice(&raw).expect("corrupted sealed trusted state");
 


### PR DESCRIPTION
Previously, if the CPU changed between runs of the Oasis node, the error
reported was a cryptic "ciphertext is corrupted" (because the sealed SGX
secrets were invalidated).
Now we add a bit more context to make it easier for the end-user.