### PR TITLE
go/roothash: expose PastRoundRoots in roothash client

### DIFF
--- a/.changelog/5467.feature.md
+++ b/.changelog/5467.feature.md
@@ -1,0 +1,1 @@
+go/roothash: expose RoundRoots in the roothash client

--- a/go/consensus/cometbft/apps/roothash/query.go
+++ b/go/consensus/cometbft/apps/roothash/query.go
@@ -17,6 +17,8 @@ type Query interface {
 	GenesisBlock(context.Context, common.Namespace) (*block.Block, error)
 	RuntimeState(context.Context, common.Namespace) (*roothash.RuntimeState, error)
 	LastRoundResults(context.Context, common.Namespace) (*roothash.RoundResults, error)
+	RoundRoots(context.Context, common.Namespace, uint64) (*roothash.RoundRoots, error)
+	PastRoundRoots(context.Context, common.Namespace) (map[uint64]roothash.RoundRoots, error)
 	IncomingMessageQueueMeta(context.Context, common.Namespace) (*message.IncomingMessageQueueMeta, error)
 	IncomingMessageQueue(ctx context.Context, id common.Namespace, offset uint64, limit uint32) ([]*message.IncomingMessage, error)
 	Genesis(context.Context) (*roothash.Genesis, error)
@@ -63,6 +65,14 @@ func (rq *rootHashQuerier) RuntimeState(ctx context.Context, id common.Namespace
 
 func (rq *rootHashQuerier) LastRoundResults(ctx context.Context, id common.Namespace) (*roothash.RoundResults, error) {
 	return rq.state.LastRoundResults(ctx, id)
+}
+
+func (rq *rootHashQuerier) RoundRoots(ctx context.Context, id common.Namespace, round uint64) (*roothash.RoundRoots, error) {
+	return rq.state.RoundRoots(ctx, id, round)
+}
+
+func (rq *rootHashQuerier) PastRoundRoots(ctx context.Context, id common.Namespace) (map[uint64]roothash.RoundRoots, error) {
+	return rq.state.PastRoundRoots(ctx, id)
 }
 
 func (rq *rootHashQuerier) IncomingMessageQueueMeta(ctx context.Context, id common.Namespace) (*message.IncomingMessageQueueMeta, error) {

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -145,6 +145,24 @@ func (sc *serviceClient) GetLastRoundResults(ctx context.Context, request *api.R
 	return q.LastRoundResults(ctx, request.RuntimeID)
 }
 
+func (sc *serviceClient) GetRoundRoots(ctx context.Context, request *api.RoundRootsRequest) (*api.RoundRoots, error) {
+	q, err := sc.querier.QueryAt(ctx, request.Height)
+	if err != nil {
+		return nil, err
+	}
+
+	return q.RoundRoots(ctx, request.RuntimeID, request.Round)
+}
+
+func (sc *serviceClient) GetPastRoundRoots(ctx context.Context, request *api.RuntimeRequest) (map[uint64]api.RoundRoots, error) {
+	q, err := sc.querier.QueryAt(ctx, request.Height)
+	if err != nil {
+		return nil, err
+	}
+
+	return q.PastRoundRoots(ctx, request.RuntimeID)
+}
+
 // Implements api.Backend.
 func (sc *serviceClient) GetIncomingMessageQueueMeta(ctx context.Context, request *api.RuntimeRequest) (*message.IncomingMessageQueueMeta, error) {
 	q, err := sc.querier.QueryAt(ctx, request.Height)

--- a/go/oasis-node/cmd/debug/txsource/workload/governance.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/governance.go
@@ -401,6 +401,9 @@ func (g *governanceWorkload) doChangeParametersProposal() error { // nolint: goc
 		if randBool() {
 			pc.MaxEvidenceAge = &params.MaxEvidenceAge
 		}
+		if randBool() {
+			pc.MaxPastRootsStored = &params.MaxPastRootsStored
+		}
 		shouldFail = pc.SanityCheck() != nil
 		module = roothash.ModuleName
 		changes = cbor.Marshal(pc)

--- a/go/oasis-test-runner/oasis/network.go
+++ b/go/oasis-test-runner/oasis/network.go
@@ -811,6 +811,7 @@ func (net *Network) MakeGenesis() error {
 		args = append(args, []string{
 			"--" + genesis.CfgRoothashMaxRuntimeMessages, strconv.FormatUint(uint64(cfg.MaxRuntimeMessages), 10),
 			"--" + genesis.CfgRoothashMaxInRuntimeMessages, strconv.FormatUint(uint64(cfg.MaxInRuntimeMessages), 10),
+			"--" + genesis.CfgRoothashMaxRuntimeMessages, strconv.FormatUint(uint64(cfg.MaxRuntimeMessages), 10),
 		}...)
 	}
 	if cfg := net.cfg.SchedulerForceElect; cfg != nil {

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -121,6 +121,12 @@ type Backend interface {
 	// GetRuntimeState returns the given runtime's state.
 	GetRuntimeState(ctx context.Context, request *RuntimeRequest) (*RuntimeState, error)
 
+	// GetPastRoundRoots returns the stored state and I/O roots for the given runtime and round.
+	GetRoundRoots(ctx context.Context, request *RoundRootsRequest) (*RoundRoots, error)
+
+	// GetPastRoundRoots returns the stored past state and I/O roots for the given runtime.
+	GetPastRoundRoots(ctx context.Context, request *RuntimeRequest) (map[uint64]RoundRoots, error)
+
 	// GetLastRoundResults returns the given runtime's last normal round results.
 	GetLastRoundResults(ctx context.Context, request *RuntimeRequest) (*RoundResults, error)
 
@@ -168,6 +174,13 @@ type Backend interface {
 type RuntimeRequest struct {
 	RuntimeID common.Namespace `json:"runtime_id"`
 	Height    int64            `json:"height"`
+}
+
+// RoundRootsRequest is a request for a specific runtime and round's state and I/O roots.
+type RoundRootsRequest struct {
+	RuntimeID common.Namespace `json:"runtime_id"`
+	Height    int64            `json:"height"`
+	Round     uint64           `json:"round"`
 }
 
 // InMessageQueueRequest is a request for queued incoming messages.

--- a/go/roothash/api/grpc.go
+++ b/go/roothash/api/grpc.go
@@ -25,6 +25,10 @@ var (
 	methodGetRuntimeState = serviceName.NewMethod("GetRuntimeState", RuntimeRequest{})
 	// methodGetLastRoundResults is the GetLastRoundResults method.
 	methodGetLastRoundResults = serviceName.NewMethod("GetLastRoundResults", RuntimeRequest{})
+	// methodGetRoundRoots is the GetRoundRoots method.
+	methodGetRoundRoots = serviceName.NewMethod("GetRoundRoots", RoundRootsRequest{})
+	// methodGetPastRoundRoots is the GetPastRoundRoots method.
+	methodGetPastRoundRoots = serviceName.NewMethod("GetPastRoundRoots", RuntimeRequest{})
 	// methodGetIncomingMessageQueueMeta is the GetIncomingMessageQueueMeta method.
 	methodGetIncomingMessageQueueMeta = serviceName.NewMethod("GetIncomingMessageQueueMeta", RuntimeRequest{})
 	// methodGetIncomingMessageQueue is the GetIncomingMessageQueue method.
@@ -63,6 +67,14 @@ var (
 			{
 				MethodName: methodGetLastRoundResults.ShortName(),
 				Handler:    handlerGetLastRoundResults,
+			},
+			{
+				MethodName: methodGetRoundRoots.ShortName(),
+				Handler:    handlerGetRoundRoots,
+			},
+			{
+				MethodName: methodGetPastRoundRoots.ShortName(),
+				Handler:    handlerGetPastRoundRoots,
 			},
 			{
 				MethodName: methodGetIncomingMessageQueueMeta.ShortName(),
@@ -193,6 +205,52 @@ func handlerGetLastRoundResults(
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(Backend).GetLastRoundResults(ctx, req.(*RuntimeRequest))
+	}
+	return interceptor(ctx, &rq, info, handler)
+}
+
+func handlerGetRoundRoots(
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var rq RoundRootsRequest
+	if err := dec(&rq); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(Backend).GetRoundRoots(ctx, &rq)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodGetRoundRoots.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).GetRoundRoots(ctx, req.(*RoundRootsRequest))
+	}
+	return interceptor(ctx, &rq, info, handler)
+}
+
+func handlerGetPastRoundRoots(
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var rq RuntimeRequest
+	if err := dec(&rq); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(Backend).GetPastRoundRoots(ctx, &rq)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodGetPastRoundRoots.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).GetPastRoundRoots(ctx, req.(*RuntimeRequest))
 	}
 	return interceptor(ctx, &rq, info, handler)
 }
@@ -438,6 +496,22 @@ func (c *roothashClient) GetLastRoundResults(ctx context.Context, request *Runti
 		return nil, err
 	}
 	return &rsp, nil
+}
+
+func (c *roothashClient) GetRoundRoots(ctx context.Context, request *RoundRootsRequest) (*RoundRoots, error) {
+	var rsp RoundRoots
+	if err := c.conn.Invoke(ctx, methodGetRoundRoots.FullName(), request, &rsp); err != nil {
+		return nil, err
+	}
+	return &rsp, nil
+}
+
+func (c *roothashClient) GetPastRoundRoots(ctx context.Context, request *RuntimeRequest) (map[uint64]RoundRoots, error) {
+	var rsp map[uint64]RoundRoots
+	if err := c.conn.Invoke(ctx, methodGetPastRoundRoots.FullName(), request, &rsp); err != nil {
+		return nil, err
+	}
+	return rsp, nil
 }
 
 func (c *roothashClient) GetIncomingMessageQueueMeta(ctx context.Context, request *RuntimeRequest) (*message.IncomingMessageQueueMeta, error) {


### PR DESCRIPTION
Also adds roothash to the txsource queries workload e2e test.