### PR TITLE
go/p2p/peermgmt/backup: Prevent overwriting TTL when restoring peers

### DIFF
--- a/.changelog/5469.bugfix.md
+++ b/.changelog/5469.bugfix.md
@@ -1,0 +1,5 @@
+go/p2p/peermgmt/backup: Prevent overwriting TTL when restoring peers
+
+If the peer address of a seed node was added to the libp2p address book
+before peer manager restored backup peer addresses, its permanent TTL
+was replaced with the TTL for recently connected peers.

--- a/go/p2p/peermgmt/backup.go
+++ b/go/p2p/peermgmt/backup.go
@@ -90,7 +90,8 @@ func (b *peerstoreBackup) restore(ctx context.Context) error {
 	}
 
 	for _, info := range peers[peerstoreNamespace] {
-		b.store.SetAddrs(info.ID, info.Addrs, peerstore.RecentlyConnectedAddrTTL)
+		// Make sure to add, not set, the address to avoid overwriting the TTL.
+		b.store.AddAddrs(info.ID, info.Addrs, peerstore.RecentlyConnectedAddrTTL)
 	}
 
 	return nil


### PR DESCRIPTION
If the peer address of a seed node was added to the libp2p address book before peer manager restored backup peer addresses, its permanent TTL was replaced with the TTL for recently connected peers.

When running tests locally, the bootstrap client is created before peers are restored. So this bug was probably the reason why we observed the following error in our logs:
```
{"caller":"client.go:463","err":"failed to open stream: failed to dial: no addresses","level":"debug","method":"advertise","module":"p2p/rpc/client","msg":"failed to call method","peer_id":"12D3KooWBpWUqSb8u8AQewueVMmfK2E81pA76xd8srHyK5cLo18A","protocol":"/oasis/bootstrap/1.0.0","ts":"2023-11-23T11:17:33.064203232Z"}
```