### PR TITLE
[BACKPORT/23.0.x] go/p2p/peermgmt/backup: Prevent overwriting TTL when restoring peers 

### DIFF
--- a/.changelog/5469.bugfix.md
+++ b/.changelog/5469.bugfix.md
@@ -1,0 +1,5 @@
+go/p2p/peermgmt/backup: Prevent overwriting TTL when restoring peers
+
+If the peer address of a seed node was added to the libp2p address book
+before peer manager restored backup peer addresses, its permanent TTL
+was replaced with the TTL for recently connected peers.

--- a/go/p2p/peermgmt/backup.go
+++ b/go/p2p/peermgmt/backup.go
@@ -90,7 +90,8 @@ func (b *peerstoreBackup) restore(ctx context.Context) error {
 	}
 
 	for _, info := range peers[peerstoreNamespace] {
-		b.store.SetAddrs(info.ID, info.Addrs, peerstore.RecentlyConnectedAddrTTL)
+		// Make sure to add, not set, the address to avoid overwriting the TTL.
+		b.store.AddAddrs(info.ID, info.Addrs, peerstore.RecentlyConnectedAddrTTL)
 	}
 
 	return nil


### PR DESCRIPTION
Backports:
- #5469 