### PR TITLE
[BACKPORT/23.0.x] go/oasis-node: Remove obsolete db section during config migration

### DIFF
--- a/.changelog/5473.bugfix.md
+++ b/.changelog/5473.bugfix.md
@@ -1,0 +1,1 @@
+go/oasis-node: Remove obsolete db section during config migration

--- a/go/oasis-node/cmd/config/migrate/migrate.go
+++ b/go/oasis-node/cmd/config/migrate/migrate.go
@@ -346,6 +346,9 @@ func doMigrateConfig(cmd *cobra.Command, args []string) {
 							m(newCfg["consensus"])["prune"] = prune
 							delete(m(m(tendermint)["abci"]), "prune")
 						}
+					} else if k == "db" {
+						logger.Info("consensus.db.* is no longer needed")
+						delete(m(tendermint), "db")
 					} else {
 						m(newCfg["consensus"])[k] = v
 						delete(m(tendermint), k)

--- a/go/oasis-node/cmd/config/migrate/migrate_test.go
+++ b/go/oasis-node/cmd/config/migrate/migrate_test.go
@@ -120,6 +120,8 @@ consensus:
       upstream_address:
         - "asdf@1.2.3.4:5678"
     mode: full
+    db:
+      backend: badger
 
     # Validators behind sentry nodes should set sentries as persistent peers.
     p2p:


### PR DESCRIPTION
Backport of #5473 