### PR TITLE
[BACKPORT/23.0.x] go/p2p/discovery: Close only idle connections to seed node

### DIFF
--- a/.changelog/5476.bugfix.md
+++ b/.changelog/5476.bugfix.md
@@ -1,0 +1,1 @@
+go/p2p/discovery: Close only idle connections to seed node

--- a/go/p2p/discovery/bootstrap/client.go
+++ b/go/p2p/discovery/bootstrap/client.go
@@ -133,9 +133,9 @@ func (c *client) Advertise(ctx context.Context, ns string, _ ...discovery.Option
 
 	pf.RecordSuccess()
 
-	// Close connections after every call because requests to the seed node are infrequent.
-	if err = c.rc.Close(c.seed.ID); err != nil {
-		c.logger.Warn("failed to close connections to seed node",
+	// Try to close connections after every call because requests to the seed node are infrequent.
+	if err = c.rc.CloseIdle(c.seed.ID); err != nil {
+		c.logger.Warn("failed to close idle connections to seed node",
 			"err", err,
 		)
 	}
@@ -246,9 +246,9 @@ func (c *client) fetchPeers(ctx context.Context, ns string, limit int) []peer.Ad
 		pf.RecordFailure()
 	}
 
-	// Close connections after every call because requests to the seed node are infrequent.
-	if err := c.rc.Close(c.seed.ID); err != nil {
-		c.logger.Warn("failed to close connections to seed node",
+	// Try to close connections after every call because requests to the seed node are infrequent.
+	if err = c.rc.CloseIdle(c.seed.ID); err != nil {
+		c.logger.Warn("failed to close idle connections to seed node",
 			"err", err,
 		)
 	}

--- a/go/p2p/rpc/nop.go
+++ b/go/p2p/rpc/nop.go
@@ -90,6 +90,13 @@ func (c *nopClient) Close(
 }
 
 // Implements Client.
+func (c *nopClient) CloseIdle(
+	peer.ID,
+) error {
+	return nil
+}
+
+// Implements Client.
 func (c *nopClient) RegisterListener(ClientListener) {}
 
 // Implements Client.


### PR DESCRIPTION
Backports:
- #5476 