### PR TITLE
governance: fix delegator-validator vote match check

### DIFF
--- a/.changelog/5479.bugfix.md
+++ b/.changelog/5479.bugfix.md
@@ -1,0 +1,1 @@
+governance: fix delegator-validator vote match check

--- a/go/consensus/cometbft/apps/governance/governance.go
+++ b/go/consensus/cometbft/apps/governance/governance.go
@@ -416,8 +416,9 @@ func (app *governanceApplication) closeProposal(
 			}
 			delegationToValidator = true
 			validatorVote := validatorVotes[to]
-			if validatorVote == &vote.Vote { //nolint:gosec
-				// Vote matches the delegated validator vote.
+
+			// Skip if vote matches the delegated validator vote.
+			if validatorVote != nil && *validatorVote == vote.Vote {
 				continue
 			}
 

--- a/go/oasis-test-runner/scenario/e2e/genesis_file.go
+++ b/go/oasis-test-runner/scenario/e2e/genesis_file.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// Mainnet genesis dump at height: 11645601.
-	genesisURL    = "https://oasis-artifacts.s3.us-east-2.amazonaws.com/genesis_mainnet_dump_11645601.json"
+	genesisURL    = "https://oasis-artifacts.s3.eu-central-1.amazonaws.com/genesis_mainnet_dump_11645601.json"
 	genesisSHA256 = "16386902d822227d0ba1e011ab84a754a48c61457e06240986f9c00e84895459" // #nosec G101
 
 	genesisNeedsUpgrade = true


### PR DESCRIPTION
Non breaking since this is just an early stop in loop to avoid a no-op - adding and subtracting shares for the same vote.