### PR TITLE
go/p2p/peermgmt: Find peers and connect only when needed

### DIFF
--- a/.changelog/5480.bugfix.md
+++ b/.changelog/5480.bugfix.md
@@ -1,0 +1,5 @@
+go/p2p/peermgmt: Find peers and connect only when needed
+
+If we are already connected to a sufficient number of peers
+for a given topic or protocol, there's no need to retrieve
+additional peers from the registry or the seed node.


### PR DESCRIPTION
Should fix the following error that occurs when discovery is started and stopped immediately if there are enough peers.

```
Nov 27 22:04:11 opf-sgx-a oasis-node[461305]: {"caller":"client.go:466","err":"failed to open stream: failed to dial: context canceled","level":"debug","method":"discover","module":"p2p/rpc/client","msg":"failed to call method","peer_id":"12D3KooWBpWUqSb8u8AQewueVMmfK2E81pA76xd8srHyK5cLo18A","protocol":"/oasis/bootstrap/1.0.0","ts":"2023-11-27T22:04:11.485476292Z"}
```