### PR TITLE
[BACKPORT/23.0.x] go/consensus/cometbft/light: Only fetch from light store for now

### DIFF
--- a/.changelog/5481.bugfix.md
+++ b/.changelog/5481.bugfix.md
@@ -1,0 +1,5 @@
+go/consensus/cometbft/light: Only fetch from light store for now
+
+In practice the previously introduced fetch from light client caused
+the light client to fall back to slow backwards verification due to
+target blocks being in the past, below the pruning window.

--- a/go/consensus/cometbft/light/service.go
+++ b/go/consensus/cometbft/light/service.go
@@ -289,21 +289,17 @@ func (c *client) GetLightBlock(ctx context.Context, height int64) (*consensus.Li
 		return lb, rpc.NewNopPeerFeedback(), nil
 	}
 
-	// Light client.
-	lightClientSource := func() (*consensus.LightBlock, rpc.PeerFeedback, error) {
-		clb, err := c.lc.GetVerifiedLightBlock(ctx, height)
+	// Light client store.
+	lightClientStoreSource := func() (*consensus.LightBlock, rpc.PeerFeedback, error) {
+		lb, err := c.GetStoredLightBlock(height)
 		if err != nil {
-			c.logger.Debug("failed to fetch light block from light client",
+			c.logger.Debug("failed to fetch light block from light client store",
 				"err", err,
 				"height", height,
 			)
 			return nil, nil, err
 		}
 
-		lb, err := api.NewLightBlock(clb)
-		if err != nil {
-			return nil, nil, err
-		}
 		return lb, rpc.NewNopPeerFeedback(), nil
 	}
 
@@ -316,7 +312,7 @@ func (c *client) GetLightBlock(ctx context.Context, height int64) (*consensus.Li
 	var mergedErr error
 	for _, src := range []func() (*consensus.LightBlock, rpc.PeerFeedback, error){
 		localBackendSource,
-		lightClientSource,
+		lightClientStoreSource,
 		directPeerQuerySource,
 	} {
 		lb, pf, err := src()

--- a/go/oasis-test-runner/scenario/e2e/genesis_file.go
+++ b/go/oasis-test-runner/scenario/e2e/genesis_file.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// Mainnet genesis dump at height: 11645601.
-	genesisURL    = "https://oasis-artifacts.s3.us-east-2.amazonaws.com/genesis_mainnet_dump_11645601.json"
+	genesisURL    = "https://oasis-artifacts.s3.eu-central-1.amazonaws.com/genesis_mainnet_dump_11645601.json"
 	genesisSHA256 = "16386902d822227d0ba1e011ab84a754a48c61457e06240986f9c00e84895459" // #nosec G101
 
 	genesisNeedsUpgrade = true


### PR DESCRIPTION
Backport #5481