### PR TITLE
rhp: don't prepend 'failed to read response' to module errors

### DIFF
--- a/.changelog/5488.bugfix.md
+++ b/.changelog/5488.bugfix.md
@@ -1,0 +1,1 @@
+rhp: don't prepend 'failed to read response' to runtime module errors

--- a/go/runtime/host/protocol/connection.go
+++ b/go/runtime/host/protocol/connection.go
@@ -322,7 +322,7 @@ func (c *connection) call(ctx context.Context, body *Body) (result *Body, err er
 	// Await a response.
 	resp, err := c.readResponse(ctx, respCh)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
+		return nil, err
 	}
 
 	return resp, nil
@@ -349,9 +349,9 @@ func (c *connection) readResponse(ctx context.Context, respCh <-chan *Body) (*Bo
 
 		return resp, nil
 	case <-c.closeCh:
-		return nil, fmt.Errorf("connection closed")
+		return nil, fmt.Errorf("failed to read response: %w", fmt.Errorf("connection closed"))
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, fmt.Errorf("failed to read response: %w", ctx.Err())
 	}
 }
 


### PR DESCRIPTION
Runtime errors that are successfully decoded shouldn't have the "failed to read response" errors (these were successfully read but failed):

e.g. evm runtime error
```
failed to read response: reverted: EQs2VRAjRWeJq83vECNFZ4mrze8QI0VniavN7xAjRWeJq83v
```