### PR TITLE
runtime/sgx/pcs: Make useful attestation verification methods public

### DIFF
--- a/.changelog/5503.feature.md
+++ b/.changelog/5503.feature.md
@@ -1,0 +1,1 @@
+runtime/sgx/pcs: Make useful attestation verification methods public


### PR DESCRIPTION
Make some of the PCS attestation helper functions public so that these can be reused (e.g. in the [attestation-tool](https://github.com/oasisprotocol/tools/tree/main/attestation-tool)). Most of the structs are already public.