### PR TITLE
runtime: add storage proof builder

### DIFF
--- a/.changelog/5514.feature.md
+++ b/.changelog/5514.feature.md
@@ -1,0 +1,4 @@
+runtime: Implement MKVS storage proof builder
+
+Introduces `get_proof` method to retrieve MKVS proofs for specific tree
+entries.

--- a/runtime/src/consensus/state/mod.rs
+++ b/runtime/src/consensus/state/mod.rs
@@ -69,6 +69,10 @@ impl ImmutableMKVS for ConsensusState {
         self.mkvs.get(key)
     }
 
+    fn get_proof(&self, key: &[u8]) -> Result<Option<crate::storage::mkvs::sync::Proof>> {
+        self.mkvs.get_proof(key)
+    }
+
     fn prefetch_prefixes(
         &self,
         prefixes: &[crate::storage::mkvs::Prefix],
@@ -85,6 +89,10 @@ impl ImmutableMKVS for ConsensusState {
 impl ImmutableMKVS for &ConsensusState {
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         self.mkvs.get(key)
+    }
+
+    fn get_proof(&self, key: &[u8]) -> Result<Option<crate::storage::mkvs::sync::Proof>> {
+        self.mkvs.get_proof(key)
     }
 
     fn prefetch_prefixes(

--- a/runtime/src/storage/mkvs/tree/mod.rs
+++ b/runtime/src/storage/mkvs/tree/mod.rs
@@ -169,6 +169,10 @@ impl mkvs::FallibleMKVS for Tree {
         Tree::get(self, key)
     }
 
+    fn get_proof(&self, key: &[u8]) -> Result<Option<Proof>> {
+        Tree::get_proof(self, key)
+    }
+
     fn cache_contains_key(&self, key: &[u8]) -> bool {
         Tree::cache_contains_key(self, key)
     }

--- a/runtime/src/storage/mkvs/tree/overlay.rs
+++ b/runtime/src/storage/mkvs/tree/overlay.rs
@@ -42,6 +42,16 @@ impl<T: mkvs::FallibleMKVS> OverlayTree<T> {
         self.inner.get(key)
     }
 
+    pub fn get_proof(&self, key: &[u8]) -> Result<Option<Proof>> {
+        if !self.dirty.is_empty() {
+            Err(Error::msg(
+                "overlay tree proofs are not supported when there are dirty values",
+            ))?;
+        }
+
+        self.inner.get_proof(key)
+    }
+
     /// Insert a key/value pair into the tree.
     pub fn insert(&mut self, key: &[u8], value: &[u8]) -> Result<Option<Vec<u8>>> {
         let previous = self.get(key)?;
@@ -257,6 +267,10 @@ impl<'tree, T: mkvs::FallibleMKVS> mkvs::Iterator for OverlayTreeIterator<'tree,
 impl<T: mkvs::FallibleMKVS> mkvs::MKVS for OverlayTree<T> {
     fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
         self.get(key).unwrap()
+    }
+
+    fn get_proof(&self, key: &[u8]) -> Option<Proof> {
+        self.get_proof(key).unwrap()
     }
 
     fn cache_contains_key(&self, key: &[u8]) -> bool {


### PR DESCRIPTION
A bit simplified from the go version, for the use case in oasis-sdk (proofs for values in state/io mkvs). 