### PR TITLE
go/runtime/transaction: Use node database directly when possible

### DIFF
--- a/.changelog/5520.bugfix.md
+++ b/.changelog/5520.bugfix.md
@@ -1,0 +1,5 @@
+go/runtime/transaction: Use node database directly when possible
+
+Previously accessing the transaction artifacts tree would always use the
+slower read syncer interface meant for communicating with untrusted db
+instances. This is now short-circuited in case a local db is available.


### PR DESCRIPTION
Based on #5521 

Previously accessing the transaction artifacts tree would always use the slower read syncer interface meant for communicating with untrusted db instances. This is now short-circuited in case a local db is available.