### PR TITLE
mkvs/proofs: Remove implicit internal leaf nodes from proofs

### DIFF
--- a/.changelog/5531.feature.md
+++ b/.changelog/5531.feature.md
@@ -1,0 +1,10 @@
+Support for Proofs Without Implicit Internal Leaf Nodes
+
+Previously, internal MKVS nodes in proofs included full leaf nodes implicitly.
+With this update, leaf nodes are explicitly added as regular child nodes
+within the proof structure. This modification optimizes proof sizes by
+avoiding inclusion of potentially large values associated with leaf nodes that
+are not directly relevant to the proof's target node.
+
+This change maintains backward compatibility. Existing proofs are unmarshaled
+as version 0, while version 1 proofs adopt the new scheme.

--- a/go/storage/mkvs/checkpoint/chunk.go
+++ b/go/storage/mkvs/checkpoint/chunk.go
@@ -28,7 +28,11 @@ func createChunk(
 	nextOffset node.Key,
 	err error,
 ) {
-	it := tree.NewIterator(ctx, mkvs.WithProof(root.Hash))
+	it := tree.NewIterator(
+		ctx,
+		// V1 checkpoints use V0 proofs.
+		mkvs.WithProofBuilder(syncer.NewProofBuilderV0(root.Hash, root.Hash)),
+	)
 	defer it.Close()
 
 	// We build the chunk until the proof becomes too large or we have reached the end.
@@ -82,6 +86,7 @@ func restoreChunk(ctx context.Context, ndb db.NodeDB, chunk *ChunkMetadata, r io
 	// Reconstruct the proof.
 	var decodeErr error
 	var p syncer.Proof
+	p.V = checkpointProofsVersion
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()

--- a/go/storage/mkvs/checkpoint/file.go
+++ b/go/storage/mkvs/checkpoint/file.go
@@ -20,6 +20,10 @@ const (
 	chunksDir              = "chunks"
 	checkpointMetadataFile = "meta"
 	checkpointVersion      = 1
+
+	// Versions 1 of checkpoint chunks use proofs version 0. Consider bumping
+	// this to latest version when introducing new checkpoint versions.
+	checkpointProofsVersion = 0
 )
 
 type fileCreator struct {

--- a/go/storage/mkvs/iterator.go
+++ b/go/storage/mkvs/iterator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/node"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/syncer"
 )
@@ -25,12 +24,16 @@ func (t *tree) SyncIterate(ctx context.Context, request *syncer.IterateRequest) 
 	if !t.cache.pendingRoot.IsClean() {
 		return nil, syncer.ErrDirtyRoot
 	}
+	pb, err := syncer.NewProofBuilderForVersion(request.Tree.Root.Hash, request.Tree.Root.Hash, request.ProofVersion)
+	if err != nil {
+		return nil, err
+	}
 
 	// Create an iterator which generates proofs. Always anchor the proof at the
 	// root as an iterator may encompass many subtrees. Make sure to propagate
 	// prefetching to any upstream remote syncers.
 	it := t.NewIterator(ctx,
-		WithProof(request.Tree.Root.Hash),
+		WithProofBuilder(pb),
 		IteratorPrefetch(request.Prefetch),
 	)
 	defer it.Close()
@@ -64,8 +67,9 @@ func (t *tree) newFetcherSyncIterate(key node.Key, prefetch uint16) readSyncFetc
 				Root:     t.cache.syncRoot,
 				Position: ptr.Hash,
 			},
-			Key:      key,
-			Prefetch: prefetch,
+			Key:          key,
+			Prefetch:     prefetch,
+			ProofVersion: syncProofsVersion,
 		})
 		if err != nil {
 			return nil, err
@@ -146,11 +150,11 @@ func IteratorPrefetch(prefetch uint16) IteratorOption {
 	}
 }
 
-// WithProof configures the iterator for generating proofs of all
-// visited nodes.
-func WithProof(root hash.Hash) IteratorOption {
+// WithProofBuilder configures the iterator for generating proofs of all
+// visited nodes with the given proof builder.
+func WithProofBuilder(pb *syncer.ProofBuilder) IteratorOption {
 	return func(it Iterator) {
-		it.(*treeIterator).proofBuilder = syncer.NewProofBuilder(root, root)
+		it.(*treeIterator).proofBuilder = pb
 	}
 }
 

--- a/go/storage/mkvs/lookup.go
+++ b/go/storage/mkvs/lookup.go
@@ -140,9 +140,6 @@ func (t *tree) doGet(
 				}
 			}
 
-			// Omit the proof builder as the leaf node is always included with
-			// the internal node itself.
-			opts.proofBuilder = nil
 			return t.doGet(ctx, n.LeafNode, bitLength, key, opts, false)
 		}
 

--- a/go/storage/mkvs/prefetch.go
+++ b/go/storage/mkvs/prefetch.go
@@ -36,8 +36,9 @@ func (t *tree) doPrefetchPrefixes(ctx context.Context, prefixes [][]byte, limit 
 					Root:     t.cache.syncRoot,
 					Position: t.cache.syncRoot.Hash,
 				},
-				Prefixes: prefixes,
-				Limit:    limit,
+				Prefixes:     prefixes,
+				Limit:        limit,
+				ProofVersion: syncProofsVersion,
 			})
 			if err != nil {
 				return nil, err
@@ -72,7 +73,11 @@ func (t *tree) SyncGetPrefixes(ctx context.Context, request *syncer.GetPrefixesR
 		}
 	}
 
-	it := t.NewIterator(ctx, WithProof(request.Tree.Root.Hash))
+	pb, err := syncer.NewProofBuilderForVersion(request.Tree.Root.Hash, request.Tree.Root.Hash, request.ProofVersion)
+	if err != nil {
+		return nil, err
+	}
+	it := t.NewIterator(ctx, WithProofBuilder(pb))
 	defer it.Close()
 
 	var total int

--- a/go/storage/mkvs/syncer/proof.go
+++ b/go/storage/mkvs/syncer/proof.go
@@ -5,9 +5,15 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/node"
+)
+
+const (
+	// MinimumProofVersion is the minimum supported proof version.
+	MinimumProofVersion = 0
+	// LatestProofVersion is the latest supported proof version.
+	LatestProofVersion = 1
 )
 
 const (
@@ -19,7 +25,21 @@ const (
 
 // Proof is a Merkle proof for a subtree.
 type Proof struct {
-	cbor.Versioned
+	// V is the proof version.
+	//
+	// Similar to `cbor.Versioned` but the version is omitted if it is 0.
+	// We don't use `cbor.Versioned` since we want version 0 proofs to be
+	// backwards compatible with the old structure which was not versioned.
+	//
+	// Version 0:
+	// Initial format.
+	//
+	// Version 1 change:
+	// Leaf nodes are included separately, as children. In version 0 the leaf node was
+	// serialized within the internal node.  The rationale behind this change is to eliminate
+	// the need to serialize all leaf nodes on the path when proving the existence of a
+	// specific value.
+	V uint16 `json:"v,omitempty"`
 
 	// UntrustedRoot is the root hash this proof is for. This should only be
 	// used as a quick sanity check and proof verification MUST use an
@@ -36,19 +56,48 @@ type proofNode struct {
 
 // ProofBuilder is a Merkle proof builder.
 type ProofBuilder struct {
-	root     hash.Hash
-	subtree  hash.Hash
-	included map[hash.Hash]*proofNode
-	size     uint64
+	proofVersion uint16
+	root         hash.Hash
+	subtree      hash.Hash
+	included     map[hash.Hash]*proofNode
+	size         uint64
 }
 
 // NewProofBuilder creates a new Merkle proof builder for the given root.
 func NewProofBuilder(root, subtree hash.Hash) *ProofBuilder {
-	return &ProofBuilder{
-		root:     root,
-		subtree:  subtree,
-		included: make(map[hash.Hash]*proofNode),
+	pb, err := NewProofBuilderForVersion(root, subtree, LatestProofVersion)
+	if err != nil {
+		panic(err)
 	}
+	return pb
+}
+
+// NewProofBuilderV0 creates a new version 0 proof builder for the given root.
+func NewProofBuilderV0(root, subtree hash.Hash) *ProofBuilder {
+	pb, err := NewProofBuilderForVersion(root, subtree, 0)
+	if err != nil {
+		panic(err)
+	}
+	return pb
+}
+
+// NewProofBuilderForVersion creates a new Merkle proof builder for the given root
+// in a given proof version format.
+func NewProofBuilderForVersion(root, subtree hash.Hash, proofVersion uint16) (*ProofBuilder, error) {
+	if proofVersion < MinimumProofVersion || proofVersion > LatestProofVersion {
+		return nil, fmt.Errorf("%v: %d", ErrUnsupportedProofVersion, proofVersion)
+	}
+	return &ProofBuilder{
+		proofVersion: proofVersion,
+		root:         root,
+		subtree:      subtree,
+		included:     make(map[hash.Hash]*proofNode),
+	}, nil
+}
+
+// Version returns the proof version.
+func (b *ProofBuilder) Version() uint16 {
+	return b.proofVersion
 }
 
 // Include adds a node to the set of included nodes.
@@ -71,19 +120,43 @@ func (b *ProofBuilder) Include(n node.Node) {
 	// Node is available, serialize it.
 	var err error
 	var pn proofNode
-	pn.serialized, err = n.CompactMarshalBinary()
+	switch b.proofVersion {
+	case 0:
+		// In version 0, the leaf is included in the internal node.
+		pn.serialized, err = n.CompactMarshalBinaryV0()
+	case 1:
+		// In version 1, the leaf node is added separately, as a child.
+		pn.serialized, err = n.CompactMarshalBinaryV1()
+	default:
+		panic("proof: unexpected proof version")
+	}
 	if err != nil {
 		panic(err)
 	}
 
 	// For internal nodes, also add any children.
 	if nd, ok := n.(*node.InternalNode); ok {
-		// Add leaf, left and right.
-		for _, child := range []*node.Pointer{
-			nd.LeafNode,
-			nd.Left,
-			nd.Right,
-		} {
+
+		var children []*node.Pointer
+		switch b.proofVersion {
+		case 0:
+			// In version 0, the leaf node is included in the internal node.
+			children = []*node.Pointer{
+				nd.Left,
+				nd.Right,
+			}
+		case 1:
+			// In version 1, the leaf node is added separately, as a child.
+			children = []*node.Pointer{
+				nd.LeafNode,
+				nd.Left,
+				nd.Right,
+			}
+		default:
+			panic("proof: unexpected proof version")
+		}
+
+		for _, child := range children {
 			var childHash hash.Hash
 			if child == nil {
 				childHash.Empty()
@@ -117,7 +190,7 @@ func (b *ProofBuilder) Size() uint64 {
 // Build tries to build the proof.
 func (b *ProofBuilder) Build(ctx context.Context) (*Proof, error) {
 	proof := Proof{
-		Versioned: cbor.NewVersioned(1),
+		V: b.proofVersion,
 	}
 
 	switch b.HasSubtreeRoot() {
@@ -175,6 +248,10 @@ type ProofVerifier struct{}
 // VerifyProof verifies a proof and generates an in-memory subtree representing
 // the nodes which are included in the proof.
 func (pv *ProofVerifier) VerifyProof(ctx context.Context, root hash.Hash, proof *Proof) (*node.Pointer, error) {
+	if proof.V < MinimumProofVersion || proof.V > LatestProofVersion {
+		return nil, fmt.Errorf("verifier: unsupported proof version: %d", proof.V)
+	}
+
 	// Sanity check that the proof is for the correct root (as otherwise it
 	// makes no sense to verify the proof).
 	if !proof.UntrustedRoot.Equal(&root) {
@@ -239,13 +316,19 @@ func (pv *ProofVerifier) verifyProof(ctx context.Context, proof *Proof, idx int)
 		// For internal nodes, also decode children.
 		pos := idx + 1
 		if nd, ok := n.(*node.InternalNode); ok {
-			// In version 0, the leaf node is included in the internal node.
-			if proof.V == 1 {
+			switch proof.V {
+			case 0:
+				// In version 0, the leaf node is included in the internal node.
+			case 1:
+				// In version 1, the leaf node is added separately, as a child.
 				// Leaf.
 				pos, nd.LeafNode, err = pv.verifyProof(ctx, proof, pos)
 				if err != nil {
 					return -1, nil, err
 				}
+			default:
+				// Checked in VerifyProof.
+				panic("unexpected proof version")
 			}
 
 			// Left.

--- a/go/storage/mkvs/syncer/proof_test.go
+++ b/go/storage/mkvs/syncer/proof_test.go
@@ -17,16 +17,30 @@ func TestProofExtraNodes(t *testing.T) {
 	var rootHash hash.Hash
 	err := rootHash.UnmarshalHex("59e67c2fdc08b8e10dd08bb6b8efe614fcc965ecb89625f97f17f87f07104613")
 	require.NoError(err)
-	rawProof, _ := base64.StdEncoding.DecodeString("omdlbnRyaWVzhUoBASQAa2V5IDACRgEBAQAAAlghAsFltYRhD4dAwHOdOmEigY1r02pJH6InhiibKlh9neYlWCECpsJnkjOnIgc4+yfvpsqCcIYHh5eld1hNMWTT7arAfHFYIQLhNTLWRbks1RBf52ulnlOTO+7D5EZNMYFzTx8U46sCnm51bnRydXN0ZWRfcm9vdFggWeZ8L9wIuOEN0Iu2uO/mFPzJZey4liX5fxf4fwcQRhM=")
 
+	// V0 Proof.
+	rawProofV0, _ := base64.StdEncoding.DecodeString("omdlbnRyaWVzhUoBASQAa2V5IDACRgEBAQAAAlghAsFltYRhD4dAwHOdOmEigY1r02pJH6InhiibKlh9neYlWCECpsJnkjOnIgc4+yfvpsqCcIYHh5eld1hNMWTT7arAfHFYIQLhNTLWRbks1RBf52ulnlOTO+7D5EZNMYFzTx8U46sCnm51bnRydXN0ZWRfcm9vdFggWeZ8L9wIuOEN0Iu2uO/mFPzJZey4liX5fxf4fwcQRhM=")
 	var proof Proof
-	err = cbor.Unmarshal(rawProof, &proof)
-	if err != nil {
-		panic(err)
-	}
-
+	err = cbor.Unmarshal(rawProofV0, &proof)
+	require.NoError(err, "failed to unmarshal V0 proof")
+	require.EqualValues(0, proof.V)
 	// Verify the proof as a sanity check.
 	var verifier ProofVerifier
+	_, err = verifier.VerifyProof(context.Background(), rootHash, &proof)
+	require.NoError(err)
+
+	// Duplicate some nodes and add them to the end.
+	proof.Entries = append(proof.Entries, proof.Entries[0])
+
+	_, err = verifier.VerifyProof(context.Background(), rootHash, &proof)
+	require.Error(err, "proof with extra data should fail to validate")
+
+	// V1 Proof.
+	rawProofV1, _ := base64.StdEncoding.DecodeString("o2F2AWdlbnRyaWVzh0oBASQAa2V5IDAC9kYBAQEAAAL2WCECwWW1hGEPh0DAc506YSKBjWvTakkfoieGKJsqWH2d5iVYIQKmwmeSM6ciBzj7J++myoJwhgeHl6V3WE0xZNPtqsB8cVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCBZ5nwv3Ai44Q3Qi7a47+YU/Mll7LiWJfl/F/h/BxBGEw==")
+	err = cbor.Unmarshal(rawProofV1, &proof)
+	require.NoError(err, "failed to unmarshal V1 proof")
+	require.EqualValues(1, proof.V)
+	// Verify the proof as a sanity check.
 	_, err = verifier.VerifyProof(context.Background(), rootHash, &proof)
 	require.NoError(err)
 
@@ -39,8 +53,10 @@ func TestProofExtraNodes(t *testing.T) {
 
 func FuzzProof(f *testing.F) {
 	// Seed corpus.
-	rawProof, _ := base64.StdEncoding.DecodeString("omdlbnRyaWVzhUoBASQAa2V5IDACRgEBAQAAAlghAsFltYRhD4dAwHOdOmEigY1r02pJH6InhiibKlh9neYlWCECpsJnkjOnIgc4+yfvpsqCcIYHh5eld1hNMWTT7arAfHFYIQLhNTLWRbks1RBf52ulnlOTO+7D5EZNMYFzTx8U46sCnm51bnRydXN0ZWRfcm9vdFggWeZ8L9wIuOEN0Iu2uO/mFPzJZey4liX5fxf4fwcQRhM=")
-	f.Add(rawProof)
+	rawProofV0, _ := base64.StdEncoding.DecodeString("omdlbnRyaWVzhUoBASQAa2V5IDACRgEBAQAAAlghAsFltYRhD4dAwHOdOmEigY1r02pJH6InhiibKlh9neYlWCECpsJnkjOnIgc4+yfvpsqCcIYHh5eld1hNMWTT7arAfHFYIQLhNTLWRbks1RBf52ulnlOTO+7D5EZNMYFzTx8U46sCnm51bnRydXN0ZWRfcm9vdFggWeZ8L9wIuOEN0Iu2uO/mFPzJZey4liX5fxf4fwcQRhM=")
+	f.Add(rawProofV0)
+	rawProofV1, _ := base64.StdEncoding.DecodeString("o2F2AWdlbnRyaWVzh0oBASQAa2V5IDAC9lghAibniky28BTAIiYrb3z9/rTq7r91woTo2EqR91Pf16P9RgEBAwCAAvZYIQIwwW7eyXCi2yXyFCzFD9U+Ssy1gwSwiskBQfk+9KCUA1QBAAUAa2V5IDkHAAAAdmFsdWUgOW51bnRydXN0ZWRfcm9vdFggWeZ8L9wIuOEN0Iu2uO/mFPzJZey4liX5fxf4fwcQRhM=")
+	f.Add(rawProofV1)
 
 	// Fuzzing.
 	f.Fuzz(func(_ *testing.T, data []byte) {

--- a/go/storage/mkvs/syncer/syncer.go
+++ b/go/storage/mkvs/syncer/syncer.go
@@ -18,6 +18,8 @@ var (
 	ErrInvalidRoot = errors.New("mkvs: invalid root")
 	// ErrUnsupported is the error returned when a ReadSyncer method is not supported.
 	ErrUnsupported = errors.New("mkvs: method not supported")
+	// ErrUnsupportedProofVersion is the error returned when a ReadSyncer requests an unsuported proof version.
+	ErrUnsupportedProofVersion = errors.New("mkvs: unsupported proof version")
 )
 
 // TreeID identifies a specific tree and a position within that tree.
@@ -34,6 +36,10 @@ type GetRequest struct {
 	Tree            TreeID `json:"tree"`
 	Key             []byte `json:"key"`
 	IncludeSiblings bool   `json:"include_siblings,omitempty"`
+
+	// ProofVersion specifies the proof version to use. If not specified,
+	// the default (0) version is used for backwards compatibility.
+	ProofVersion uint16 `json:"proof_version,omitempty"`
 }
 
 // GetPrefixesRequest is a request for the SyncGetPrefixes operation.
@@ -41,6 +47,10 @@ type GetPrefixesRequest struct {
 	Tree     TreeID   `json:"tree"`
 	Prefixes [][]byte `json:"prefixes"`
 	Limit    uint16   `json:"limit"`
+
+	// ProofVersion specifies the proof version to use. If not specified,
+	// the default (0) version is used for backwards compatibility.
+	ProofVersion uint16 `json:"proof_version,omitempty"`
 }
 
 // IterateRequest is a request for the SyncIterate operation.
@@ -48,6 +58,10 @@ type IterateRequest struct {
 	Tree     TreeID `json:"tree"`
 	Key      []byte `json:"key"`
 	Prefetch uint16 `json:"prefetch"`
+
+	// ProofVersion specifies the proof version to use. If not specified,
+	// the default (0) version is used for backwards compatibility.
+	ProofVersion uint16 `json:"proof_version,omitempty"`
 }
 
 // ProofResponse is a response for requests that produce proofs.

--- a/go/storage/mkvs/syncer_test.go
+++ b/go/storage/mkvs/syncer_test.go
@@ -3,7 +3,6 @@ package mkvs
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,12 +14,162 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/syncer"
 )
 
-func TestProof(t *testing.T) {
+func TestProofV0(t *testing.T) {
 	require := require.New(t)
 
 	// Build a simple in-memory Merkle tree.
 	ctx := context.Background()
 	keys, values := generateKeyValuePairsEx("", 10)
+	var ns common.Namespace
+
+	tree := New(nil, nil, node.RootTypeState).(*tree)
+	for i, key := range keys {
+		err := tree.Insert(ctx, key, values[i])
+		require.NoError(err, "Insert")
+	}
+	_, rootHash, err := tree.Commit(ctx, ns, 0)
+	require.NoError(err, "Commit")
+
+	// Create a Merkle proof, starting at the root node.
+	builder := syncer.NewProofBuilderV0(rootHash, rootHash)
+	require.False(builder.HasSubtreeRoot(), "HasSubtreeRoot should return false")
+	require.EqualValues(rootHash, builder.GetSubtreeRoot(), "GetSubtreeRoot should return correct root")
+
+	rootOnlyProof, err := builder.Build(ctx)
+	require.NoError(err, "Build should not fail without a root present")
+
+	// Including a nil node should not panic.
+	builder.Include(nil)
+
+	// Include root node.
+	rootNode := tree.cache.pendingRoot.Node
+	builder.Include(rootNode)
+	require.True(builder.HasSubtreeRoot(), "HasRoot should return true after root included")
+
+	proof, err := builder.Build(ctx)
+	require.NoError(err, "Build should not fail")
+	require.EqualValues(proof.UntrustedRoot, rootHash, "UntrustedRoot should be correct")
+	require.Len(proof.Entries, 3, "proof should only contain the root and two child hashes")
+
+	// Include root.left node.
+	rootIntNode := rootNode.(*node.InternalNode)
+	leftNode1 := rootIntNode.Left.Node
+	builder.Include(leftNode1)
+
+	proof, err = builder.Build(ctx)
+	require.NoError(err, "Build should not fail")
+	// Pre-order: root(full), root.left(full), root.left.left(hash), root.left.right(hash), root.right(hash)
+	require.Len(proof.Entries, 5, "proof should only contain the correct amount of nodes")
+	require.EqualValues(proof.Entries[0][0], 0x01, "first entry should be a full node")
+	require.EqualValues(proof.Entries[1][0], 0x01, "second entry should be a full node")
+	require.EqualValues(proof.Entries[2][0], 0x02, "third entry should be a hash")
+	require.EqualValues(proof.Entries[3][0], 0x02, "fourth entry should be a hash")
+	require.EqualValues(proof.Entries[4][0], 0x02, "fifth entry should be a hash")
+
+	decNode, err := node.UnmarshalBinary(proof.Entries[0][1:])
+	require.NoError(err, "first entry should unmarshal as a node")
+	decIntNode, ok := decNode.(*node.InternalNode)
+	require.True(ok, "first entry must be an internal node (root)")
+	require.Nil(decIntNode.Left, "first entry must use compact encoding")
+	require.Nil(decIntNode.Right, "first entry must use compact encoding")
+
+	decNode, err = node.UnmarshalBinary(proof.Entries[1][1:])
+	require.NoError(err, "second entry should unmarshal as a node")
+	decIntNode, ok = decNode.(*node.InternalNode)
+	require.True(ok, "second entry must be an internal node (root.left)")
+	require.Nil(decIntNode.Left, "second entry must use compact encoding")
+	require.Nil(decIntNode.Right, "second entry must use compact encoding")
+
+	leftIntNode1 := leftNode1.(*node.InternalNode)
+	require.EqualValues(leftIntNode1.Left.Hash[:], proof.Entries[2][1:], "third entry hash should be correct (root.left.left)")
+	require.EqualValues(leftIntNode1.Right.Hash[:], proof.Entries[3][1:], "fourth entry hash should be correct (root.left.left)")
+	require.EqualValues(rootIntNode.Right.Hash[:], proof.Entries[4][1:], "fifth entry hash should be correct (root.right)")
+
+	// Proofs should be stable.
+	// NOTE: Ensure these match the test in runtime/src/storage/mkvs/sync/proof.rs.
+	// TODO: Provide multiple test vectors.
+	// Root only proof.
+	require.EqualValues(
+		"omdlbnRyaWVzgVghAlnmfC/cCLjhDdCLtrjv5hT8yWXsuJYl+X8X+H8HEEYTbnVudHJ1c3RlZF9yb290WCBZ5nwv3Ai44Q3Qi7a47+YU/Mll7LiWJfl/F/h/BxBGEw==",
+		base64.StdEncoding.EncodeToString(cbor.Marshal(rootOnlyProof)),
+	)
+	// Root and root.left proof.
+	require.EqualValues(
+		"omdlbnRyaWVzhUoBASQAa2V5IDACRgEBAQAAAlghAsFltYRhD4dAwHOdOmEigY1r02pJH6InhiibKlh9neYlWCECpsJnkjOnIgc4+yfvpsqCcIYHh5eld1hNMWTT7arAfHFYIQLhNTLWRbks1RBf52ulnlOTO+7D5EZNMYFzTx8U46sCnm51bnRydXN0ZWRfcm9vdFggWeZ8L9wIuOEN0Iu2uO/mFPzJZey4liX5fxf4fwcQRhM=",
+		base64.StdEncoding.EncodeToString(cbor.Marshal(proof)),
+	)
+	testVectorRootHash := rootHash.String()
+	require.EqualValues("59e67c2fdc08b8e10dd08bb6b8efe614fcc965ecb89625f97f17f87f07104613", testVectorRootHash)
+
+	// Proof should verify.
+	var pv syncer.ProofVerifier
+	_, err = pv.VerifyProof(ctx, rootHash, proof)
+	require.NoError(err, "VerifyProof should not fail with a valid proof")
+
+	// Proof with only the root node should verify.
+	_, err = pv.VerifyProof(ctx, rootHash, rootOnlyProof)
+	require.NoError(err, "VerifyProof should not fail on a proof with only the root node")
+
+	// Empty root proof should verify.
+	var emptyHash hash.Hash
+	emptyHash.Empty()
+	builder = syncer.NewProofBuilder(emptyHash, emptyHash)
+	emptyRootProof, err := builder.Build(ctx)
+	require.NoError(err, "Build should not fail for an empty root")
+	emptyRootPtr, err := pv.VerifyProof(ctx, emptyHash, emptyRootProof)
+	require.NoError(err, "VerifyProof should not fail with a valid proof for an empty root")
+	require.Nil(emptyRootPtr, "VerifyProof should return nil pointer for an empty root")
+
+	// Invalid proofs should not verify.
+
+	// Empty proof.
+	var emptyProof syncer.Proof
+	_, err = pv.VerifyProof(ctx, rootHash, &emptyProof)
+	require.Error(err, "VerifyProof should fail with empty proof")
+
+	// Different root.
+	bogusHash := hash.NewFromBytes([]byte("i am a bogus hash"))
+	_, err = pv.VerifyProof(ctx, bogusHash, proof)
+	require.Error(err, "VerifyProof should fail with proof for a different root")
+
+	// Different hash element.
+	corrupted := copyProof(proof)
+	corrupted.Entries[4][10] = 0x00
+	_, err = pv.VerifyProof(ctx, rootHash, corrupted)
+	require.Error(err, "VerifyProof should fail with invalid proof")
+
+	// Corrupted full node.
+	corrupted = copyProof(proof)
+	corrupted.Entries[0] = corrupted.Entries[0][:3]
+	_, err = pv.VerifyProof(ctx, rootHash, corrupted)
+	require.Error(err, "VerifyProof should fail with invalid proof")
+
+	// Corrupted hash.
+	corrupted = copyProof(proof)
+	corrupted.Entries[2] = corrupted.Entries[2][:3]
+	_, err = pv.VerifyProof(ctx, rootHash, corrupted)
+	require.Error(err, "VerifyProof should fail with invalid proof")
+
+	// Corrupted proof element type.
+	corrupted = copyProof(proof)
+	corrupted.Entries[3][0] = 0xaa
+	_, err = pv.VerifyProof(ctx, rootHash, corrupted)
+	require.Error(err, "VerifyProof should fail with invalid proof")
+
+	// Missing elements.
+	corrupted = copyProof(proof)
+	corrupted.Entries = corrupted.Entries[:3]
+	_, err = pv.VerifyProof(ctx, rootHash, corrupted)
+	require.Error(err, "VerifyProof should fail with invalid proof")
+}
+
+func TestProofV1(t *testing.T) {
+	require := require.New(t)
+
+	// Build a simple in-memory Merkle tree.
+	ctx := context.Background()
+	// Use 11 keys so that "key 1" is prefix of "key 10".
+	keys, values := generateKeyValuePairsEx("", 11)
 	var ns common.Namespace
 
 	tree := New(nil, nil, node.RootTypeState).(*tree)
@@ -47,18 +196,17 @@ func TestProof(t *testing.T) {
 	builder.Include(rootNode)
 	require.True(builder.HasSubtreeRoot(), "HasRoot should return true after root included")
 
-	proof, err := builder.Build(ctx)
+	rootIncludedProof, err := builder.Build(ctx)
 	require.NoError(err, "Build should not fail")
-	require.EqualValues(proof.UntrustedRoot, rootHash, "UntrustedRoot should be correct")
-	require.Len(proof.Entries, 4, "proof should only contain the root and three child hashes")
+	require.EqualValues(rootIncludedProof.UntrustedRoot, rootHash, "UntrustedRoot should be correct")
+	require.Len(rootIncludedProof.Entries, 4, "proof should only contain the root and three child hashes")
 
 	// Include root.left node.
 	rootIntNode := rootNode.(*node.InternalNode)
-	fmt.Println("Root int node leaf:", rootIntNode.LeafNode)
 	leftNode1 := rootIntNode.Left.Node
 	builder.Include(leftNode1)
 
-	proof, err = builder.Build(ctx)
+	proof, err := builder.Build(ctx)
 	require.NoError(err, "Build should not fail")
 	// Pre-order: root(full), root.leaf(nil), root.left(full), root.left.leaf(full), root.left.left(hash), root.left.right(hash), root.right(hash)
 	require.Len(proof.Entries, 7, "proof should only contain the correct amount of nodes")
@@ -99,18 +247,21 @@ func TestProof(t *testing.T) {
 	// TODO: Provide multiple test vectors.
 	// Root only proof.
 	require.EqualValues(
-		//"omdlbnRyaWVzgVghAlnmfC/cCLjhDdCLtrjv5hT8yWXsuJYl+X8X+H8HEEYTbnVudHJ1c3RlZF9yb290WCBZ5nwv3Ai44Q3Qi7a47+YU/Mll7LiWJfl/F/h/BxBGEw==",
-		"o2F2AWdlbnRyaWVzgVghAlnmfC/cCLjhDdCLtrjv5hT8yWXsuJYl+X8X+H8HEEYTbnVudHJ1c3RlZF9yb290WCBZ5nwv3Ai44Q3Qi7a47+YU/Mll7LiWJfl/F/h/BxBGEw==",
+		"o2F2AWdlbnRyaWVzgVghAqlAud7XYhorEEl8hG9G3Hd4OXl5VR1xvuLAepMZ5qpFbnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
 		base64.StdEncoding.EncodeToString(cbor.Marshal(rootOnlyProof)),
 	)
-	// Root and root.left proof.
+	// Root included proof.
 	require.EqualValues(
-		// "+yfvpsqCcIYHh5eld1hNMWTT7arAfHFYIQLhNTLWRbks1RBf52ulnlOTO+7D5EZNMYFzTx8U46sCnm51bnRydXN0ZWRfcm9vdFggWeZ8L9wIuOEN0Iu2uO/mFPzJZey4liX5fxf4fwcQRhM=",
-		"o2F2AWdlbnRyaWVzh0oBASQAa2V5IDAC9kYBAQEAAAL2WCECwWW1hGEPh0DAc506YSKBjWvTakkfoieGKJsqWH2d5iVYIQKmwmeSM6ciBzj7J++myoJwhgeHl6V3WE0xZNPtqsB8cVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCBZ5nwv3Ai44Q3Qi7a47+YU/Mll7LiWJfl/F/h/BxBGEw==",
+		"o2F2AWdlbnRyaWVzhEoBASQAa2V5IDAC9lghAhQ6RgqFtADx+B6VKE0CVRrfDHmwgZwU3ewsj4gswWv+WCEC4TUy1kW5LNUQX+drpZ5Tkzvuw+RGTTGBc08fFOOrAp5udW50cnVzdGVkX3Jvb3RYIKlAud7XYhorEEl8hG9G3Hd4OXl5VR1xvuLAepMZ5qpF",
+		base64.StdEncoding.EncodeToString(cbor.Marshal(rootIncludedProof)),
+	)
+	// Root and root.left included proof.
+	require.EqualValues(
+		"o2F2AWdlbnRyaWVzh0oBASQAa2V5IDAC9kYBAQEAAAL2WCEC+OrSSPCCo9/QXQt7IsunAp+eUqMndKBCu0NcGHx4HrhYIQKmwmeSM6ciBzj7J++myoJwhgeHl6V3WE0xZNPtqsB8cVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
 		base64.StdEncoding.EncodeToString(cbor.Marshal(proof)),
 	)
 	testVectorRootHash := rootHash.String()
-	require.EqualValues("59e67c2fdc08b8e10dd08bb6b8efe614fcc965ecb89625f97f17f87f07104613", testVectorRootHash)
+	require.EqualValues("a940b9ded7621a2b10497c846f46dc7778397979551d71bee2c07a9319e6aa45", testVectorRootHash)
 
 	// Proof should verify.
 	var pv syncer.ProofVerifier
@@ -178,6 +329,70 @@ func TestProof(t *testing.T) {
 	corrupted.Entries = corrupted.Entries[:3]
 	_, err = pv.VerifyProof(ctx, rootHash, corrupted)
 	require.Error(err, "VerifyProof should fail with invalid proof")
+
+	// Test with non-nil leaf node on the path.
+	builder = syncer.NewProofBuilder(rootHash, rootHash)
+
+	// Include root node.
+	builder.Include(rootNode)
+
+	// Include root.left node.
+	rootIntNode = rootNode.(*node.InternalNode)
+	leftNode1 = rootIntNode.Left.Node
+	builder.Include(leftNode1)
+
+	// Include root.left.left node.
+	left2Node := leftNode1.(*node.InternalNode).Left.Node
+	builder.Include(left2Node)
+
+	// Include root.left.left.left node.
+	left3Node := left2Node.(*node.InternalNode).Left.Node
+	builder.Include(left3Node)
+
+	// Include root.left.left.left.right node.
+	left3RightNode := left3Node.(*node.InternalNode).Right.Node
+	builder.Include(left3RightNode)
+
+	// Ensure this is the expected node (it should have non-nil leaf and left, right is nil).
+	require.NotNil(left3RightNode.(*node.InternalNode).LeafNode)
+	require.NotNil(left3RightNode.(*node.InternalNode).Left)
+	require.Nil(left3RightNode.(*node.InternalNode).Right)
+
+	// Include root.left.left.left.right.left leaf node.
+	bottomNode := left3RightNode.(*node.InternalNode).Left.Node
+	builder.Include(bottomNode)
+
+	proof, err = builder.Build(ctx)
+	require.NoError(err, "Build should not fail")
+
+	// Pre-order: root(full), root.leaf(nil),
+	//            root.left(full), root.left.leaf(nil),
+	//            root.left.left(full), root.left.left.leaf(nil),
+	//            root.left.left.left(full), root.left.left.left.leaf(nil),
+	//            root.left.left.left.left(hash), root.left.left.left.right(full), (10th entry->) root.left.left.left.right.leaf(hash),
+	//            root.left.left.left.right.left(full)  <- target leaf node,
+	//            root.left.left.left.right.right(hash=nil),
+	//            root.left.left.left.right(hash),
+	//            root.left.left.right(hash),
+	//            root.left.right(hash),
+	//            root.right(hash)
+	require.Len(proof.Entries, 16, "proof should only contain the correct amount of nodes")
+	// Ensure 9th entry is the left3RightNode.Leaf, which should be the hash.
+	require.EqualValues(left3RightNode.(*node.InternalNode).LeafNode.Hash[:], proof.Entries[10][1:], "10th entry hash should be correct")
+
+	// Ensure 9th entry is the left3RightNode, which is a full node, without leaf.
+	decNode, err = node.UnmarshalBinary(proof.Entries[9][1:])
+	require.NoError(err, "9th entry should unmarshal as a node")
+	decIntNode, ok = decNode.(*node.InternalNode)
+	require.True(ok, "9th entry must be an internal node (root.left.left.left.right)")
+	require.Nil(decIntNode.Left, "9th entry must use compact encoding")
+	require.Nil(decIntNode.Right, "9th entry must use compact encoding")
+	require.Nil(decIntNode.LeafNode, "9th entry must use compact encoding")
+
+	require.EqualValues(
+		"o2F2AWdlbnRyaWVzkEoBASQAa2V5IDAC9kYBAQEAAAL2RgEBAQAAAvZGAQEBAAAC9lghAlF8/rp9QOAd1qSchhUxDtVkpmnze6sjz5IfFhdOuaypRgEBAQCAAlghAldMzQwgHh/Ecm+rF+i31AnOgFYBipBAlcx5Tf5l4yW+VgEABgBrZXkgMTAIAAAAdmFsdWUgMTD2WCECDnYjQhsAp5fD+gf0W5YYFY6CnGURrEETtJvJp+ijH4xYIQKmwmeSM6ciBzj7J++myoJwhgeHl6V3WE0xZNPtqsB8cVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+		base64.StdEncoding.EncodeToString(cbor.Marshal(proof)),
+	)
 }
 
 func copyProof(p *syncer.Proof) *syncer.Proof {
@@ -199,7 +414,7 @@ func TestTreeProofs(t *testing.T) {
 
 	// Build a simple in-memory Merkle tree.
 	ctx := context.Background()
-	keys, values := generateKeyValuePairsEx("", 10)
+	keys, values := generateKeyValuePairsEx("", 11)
 	var ns common.Namespace
 
 	tree := New(nil, nil, node.RootTypeState).(*tree)
@@ -210,62 +425,91 @@ func TestTreeProofs(t *testing.T) {
 	_, roothash, err := tree.Commit(ctx, ns, 0)
 	require.NoError(err, "Commit")
 
-	// Ensure SyncGet returns expected proofs.
-	// Keys[0].
-	resp, err := tree.SyncGet(ctx, &syncer.GetRequest{
-		Tree: syncer.TreeID{
-			Root:     node.Root{Namespace: ns, Version: 0, Hash: roothash, Type: node.RootTypeState},
-			Position: roothash,
+	for _, tc := range []struct {
+		proofVersion    uint16
+		includeSiblings bool
+		proofs          []string
+	}{
+		{
+			proofVersion:    0,
+			includeSiblings: false,
+			proofs: []string{
+				// 0.
+				"omdlbnRyaWVziUoBASQAa2V5IDACRgEBAQAAAkYBAQEAAAJGAQEBAAACVAEABQBrZXkgMAcAAAB2YWx1ZSAwWCECU7w+1iQZMSDfThv/P9y/igfr4FFonzyVrJ/tWAiXfFNYIQIOdiNCGwCnl8P6B/RblhgVjoKcZRGsQRO0m8mn6KMfjFghAqbCZ5IzpyIHOPsn76bKgnCGB4eXpXdYTTFk0+2qwHxxWCEC4TUy1kW5LNUQX+drpZ5Tkzvuw+RGTTGBc08fFOOrAp5udW50cnVzdGVkX3Jvb3RYIKlAud7XYhorEEl8hG9G3Hd4OXl5VR1xvuLAepMZ5qpF",
+				// 1.
+				"omdlbnRyaWVzi0oBASQAa2V5IDACRgEBAQAAAkYBAQEAAAJGAQEBAAACWCECUXz+un1A4B3WpJyGFTEO1WSmafN7qyPPkh8WF065rKlYGAEBAQCAAAUAa2V5IDEHAAAAdmFsdWUgMVghAm2EG0dH85+yEl5rdT67+D59/gbjHB9qDtnCcv0kkuje9lghAg52I0IbAKeXw/oH9FuWGBWOgpxlEaxBE7Sbyafoox+MWCECpsJnkjOnIgc4+yfvpsqCcIYHh5eld1hNMWTT7arAfHFYIQLhNTLWRbks1RBf52ulnlOTO+7D5EZNMYFzTx8U46sCnm51bnRydXN0ZWRfcm9vdFggqUC53tdiGisQSXyEb0bcd3g5eXlVHXG+4sB6kxnmqkU=",
+				// 2.
+				"omdlbnRyaWVziUoBASQAa2V5IDACRgEBAQAAAkYBAQEAAAJYIQLnu/nMm00WQo9ZxRbRFM/hVtoTov4Phs3vIQ/6jS/29kYBAQEAgAJUAQAFAGtleSAyBwAAAHZhbHVlIDJYIQIm0h28G9KzZWHhnWCFjfO8e8rwmygGa3f50GlEI10D/FghAqbCZ5IzpyIHOPsn76bKgnCGB4eXpXdYTTFk0+2qwHxxWCEC4TUy1kW5LNUQX+drpZ5Tkzvuw+RGTTGBc08fFOOrAp5udW50cnVzdGVkX3Jvb3RYIKlAud7XYhorEEl8hG9G3Hd4OXl5VR1xvuLAepMZ5qpF",
+				// 3.
+				"omdlbnRyaWVziUoBASQAa2V5IDACRgEBAQAAAkYBAQEAAAJYIQLnu/nMm00WQo9ZxRbRFM/hVtoTov4Phs3vIQ/6jS/29kYBAQEAgAJYIQKhiPVO61Qd4HUrRqdPWFG2zwAo7DwB8S2f3rdcxXFXXFQBAAUAa2V5IDMHAAAAdmFsdWUgM1ghAqbCZ5IzpyIHOPsn76bKgnCGB4eXpXdYTTFk0+2qwHxxWCEC4TUy1kW5LNUQX+drpZ5Tkzvuw+RGTTGBc08fFOOrAp5udW50cnVzdGVkX3Jvb3RYIKlAud7XYhorEEl8hG9G3Hd4OXl5VR1xvuLAepMZ5qpF",
+				// 4.
+				"omdlbnRyaWVziUoBASQAa2V5IDACRgEBAQAAAlghAvjq0kjwgqPf0F0LeyLLpwKfnlKjJ3SgQrtDXBh8eB64RgEBAQCAAkYBAQEAAAJUAQAFAGtleSA0BwAAAHZhbHVlIDRYIQLu4RLQdOG/CJESxLo4oYM6h00aftYYLcFMElIsEiwl/VghArfWCo9vCnfczvIpvZVKjt4HyniNlmZgacnueN4UEYe1WCEC4TUy1kW5LNUQX+drpZ5Tkzvuw+RGTTGBc08fFOOrAp5udW50cnVzdGVkX3Jvb3RYIKlAud7XYhorEEl8hG9G3Hd4OXl5VR1xvuLAepMZ5qpF",
+				// 5.
+				"omdlbnRyaWVziUoBASQAa2V5IDACRgEBAQAAAlghAvjq0kjwgqPf0F0LeyLLpwKfnlKjJ3SgQrtDXBh8eB64RgEBAQCAAkYBAQEAAAJYIQLGCmUSnaMGinOcyqgElnV7MITsg7YFvkKovKkL4iISGlQBAAUAa2V5IDUHAAAAdmFsdWUgNVghArfWCo9vCnfczvIpvZVKjt4HyniNlmZgacnueN4UEYe1WCEC4TUy1kW5LNUQX+drpZ5Tkzvuw+RGTTGBc08fFOOrAp5udW50cnVzdGVkX3Jvb3RYIKlAud7XYhorEEl8hG9G3Hd4OXl5VR1xvuLAepMZ5qpF",
+				// 6.
+				"omdlbnRyaWVziUoBASQAa2V5IDACRgEBAQAAAlghAvjq0kjwgqPf0F0LeyLLpwKfnlKjJ3SgQrtDXBh8eB64RgEBAQCAAlghAivLwJbWkwZ8nROaPHGxpfthiG8vqyPbvzhkEEX793dIRgEBAQCAAlQBAAUAa2V5IDYHAAAAdmFsdWUgNlghAr3oK8Bozi85F6ot74Cg7opqNgVmJSwDK9KLysSAKVTsWCEC4TUy1kW5LNUQX+drpZ5Tkzvuw+RGTTGBc08fFOOrAp5udW50cnVzdGVkX3Jvb3RYIKlAud7XYhorEEl8hG9G3Hd4OXl5VR1xvuLAepMZ5qpF",
+				// 7.
+				"omdlbnRyaWVziUoBASQAa2V5IDACRgEBAQAAAlghAvjq0kjwgqPf0F0LeyLLpwKfnlKjJ3SgQrtDXBh8eB64RgEBAQCAAlghAivLwJbWkwZ8nROaPHGxpfthiG8vqyPbvzhkEEX793dIRgEBAQCAAlghAgI8X2yVJ8szMIqkgZQoValdarl3F9V197rB8ZbrGN6vVAEABQBrZXkgNwcAAAB2YWx1ZSA3WCEC4TUy1kW5LNUQX+drpZ5Tkzvuw+RGTTGBc08fFOOrAp5udW50cnVzdGVkX3Jvb3RYIKlAud7XYhorEEl8hG9G3Hd4OXl5VR1xvuLAepMZ5qpF",
+				// 8.
+				"omdlbnRyaWVzhUoBASQAa2V5IDACWCECFDpGCoW0APH4HpUoTQJVGt8MebCBnBTd7CyPiCzBa/5GAQEDAIACVAEABQBrZXkgOAcAAAB2YWx1ZSA4WCECDXMyfNOnjK/k/4hrCZqPPyUBV2bY8tf5PmrNFfRXX1RudW50cnVzdGVkX3Jvb3RYIKlAud7XYhorEEl8hG9G3Hd4OXl5VR1xvuLAepMZ5qpF",
+				// 9.
+				"omdlbnRyaWVzhUoBASQAa2V5IDACWCECFDpGCoW0APH4HpUoTQJVGt8MebCBnBTd7CyPiCzBa/5GAQEDAIACWCECMMFu3slwotsl8hQsxQ/VPkrMtYMEsIrJAUH5PvSglANUAQAFAGtleSA5BwAAAHZhbHVlIDludW50cnVzdGVkX3Jvb3RYIKlAud7XYhorEEl8hG9G3Hd4OXl5VR1xvuLAepMZ5qpF",
+				// 10.
+				"omdlbnRyaWVzi0oBASQAa2V5IDACRgEBAQAAAkYBAQEAAAJGAQEBAAACWCECUXz+un1A4B3WpJyGFTEO1WSmafN7qyPPkh8WF065rKlYGAEBAQCAAAUAa2V5IDEHAAAAdmFsdWUgMVYBAAYAa2V5IDEwCAAAAHZhbHVlIDEw9lghAg52I0IbAKeXw/oH9FuWGBWOgpxlEaxBE7Sbyafoox+MWCECpsJnkjOnIgc4+yfvpsqCcIYHh5eld1hNMWTT7arAfHFYIQLhNTLWRbks1RBf52ulnlOTO+7D5EZNMYFzTx8U46sCnm51bnRydXN0ZWRfcm9vdFggqUC53tdiGisQSXyEb0bcd3g5eXlVHXG+4sB6kxnmqkU=",
+			},
 		},
-		Key:             keys[0],
-		IncludeSiblings: false,
-	})
-	require.NoError(err, "SyncGet keys[0]")
-	require.EqualValues(
-		// "omdlbnRyaWVziUoBASQAa2V5IDACRgEBAQAAAkYBAQEAAAJGAQEBAAACVAEABQBrZXkgMAcAAAB2YWx1ZSAwWCECV0zNDCAeH8Ryb6sX6LfUCc6AVgGKkECVzHlN/mXjJb5YIQIOdiNCGwCnl8P6B/RblhgVjoKcZRGsQRO0m8mn6KMfjFghAqbCZ5IzpyIHOPsn76bKgnCGB4eXpXdYTTFk0+2qwHxxWCEC4TUy1kW5LNUQX+drpZ5Tkzvuw+RGTTGBc08fFOOrAp5udW50cnVzdGVkX3Jvb3RYIFnmfC/cCLjhDdCLtrjv5hT8yWXsuJYl+X8X+H8HEEYT",
-		"o2F2AWdlbnRyaWVzjUoBASQAa2V5IDAC9kYBAQEAAAL2RgEBAQAAAvZGAQEBAAAC9lQBAAUAa2V5IDAHAAAAdmFsdWUgMFghAldMzQwgHh/Ecm+rF+i31AnOgFYBipBAlcx5Tf5l4yW+WCECDnYjQhsAp5fD+gf0W5YYFY6CnGURrEETtJvJp+ijH4xYIQKmwmeSM6ciBzj7J++myoJwhgeHl6V3WE0xZNPtqsB8cVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCBZ5nwv3Ai44Q3Qi7a47+YU/Mll7LiWJfl/F/h/BxBGEw==",
-		base64.StdEncoding.EncodeToString(cbor.Marshal(resp.Proof)),
-	)
-	// Proof should verify.
-	var pv syncer.ProofVerifier
-	_, err = pv.VerifyProof(ctx, roothash, &resp.Proof)
-	require.NoError(err, "VerifyProof should not fail with a valid proof")
+		{
+			proofVersion:    1,
+			includeSiblings: false,
+			proofs: []string{
+				// 0.
+				"o2F2AWdlbnRyaWVzjUoBASQAa2V5IDAC9kYBAQEAAAL2RgEBAQAAAvZGAQEBAAAC9lQBAAUAa2V5IDAHAAAAdmFsdWUgMFghAlO8PtYkGTEg304b/z/cv4oH6+BRaJ88layf7VgIl3xTWCECDnYjQhsAp5fD+gf0W5YYFY6CnGURrEETtJvJp+ijH4xYIQKmwmeSM6ciBzj7J++myoJwhgeHl6V3WE0xZNPtqsB8cVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+				// 1.
+				"o2F2AWdlbnRyaWVzkEoBASQAa2V5IDAC9kYBAQEAAAL2RgEBAQAAAvZGAQEBAAAC9lghAlF8/rp9QOAd1qSchhUxDtVkpmnze6sjz5IfFhdOuaypRgEBAQCAAlQBAAUAa2V5IDEHAAAAdmFsdWUgMVghAm2EG0dH85+yEl5rdT67+D59/gbjHB9qDtnCcv0kkuje9lghAg52I0IbAKeXw/oH9FuWGBWOgpxlEaxBE7Sbyafoox+MWCECpsJnkjOnIgc4+yfvpsqCcIYHh5eld1hNMWTT7arAfHFYIQLhNTLWRbks1RBf52ulnlOTO+7D5EZNMYFzTx8U46sCnm51bnRydXN0ZWRfcm9vdFggqUC53tdiGisQSXyEb0bcd3g5eXlVHXG+4sB6kxnmqkU=",
+				// 2.
+				"o2F2AWdlbnRyaWVzjUoBASQAa2V5IDAC9kYBAQEAAAL2RgEBAQAAAvZYIQLnu/nMm00WQo9ZxRbRFM/hVtoTov4Phs3vIQ/6jS/29kYBAQEAgAL2VAEABQBrZXkgMgcAAAB2YWx1ZSAyWCECJtIdvBvSs2Vh4Z1ghY3zvHvK8JsoBmt3+dBpRCNdA/xYIQKmwmeSM6ciBzj7J++myoJwhgeHl6V3WE0xZNPtqsB8cVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+				// 3.
+				"o2F2AWdlbnRyaWVzjUoBASQAa2V5IDAC9kYBAQEAAAL2RgEBAQAAAvZYIQLnu/nMm00WQo9ZxRbRFM/hVtoTov4Phs3vIQ/6jS/29kYBAQEAgAL2WCECoYj1TutUHeB1K0anT1hRts8AKOw8AfEtn963XMVxV1xUAQAFAGtleSAzBwAAAHZhbHVlIDNYIQKmwmeSM6ciBzj7J++myoJwhgeHl6V3WE0xZNPtqsB8cVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+				// 4.
+				"o2F2AWdlbnRyaWVzjUoBASQAa2V5IDAC9kYBAQEAAAL2WCEC+OrSSPCCo9/QXQt7IsunAp+eUqMndKBCu0NcGHx4HrhGAQEBAIAC9kYBAQEAAAL2VAEABQBrZXkgNAcAAAB2YWx1ZSA0WCEC7uES0HThvwiREsS6OKGDOodNGn7WGC3BTBJSLBIsJf1YIQK31gqPbwp33M7yKb2VSo7eB8p4jZZmYGnJ7njeFBGHtVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+				// 5.
+				"o2F2AWdlbnRyaWVzjUoBASQAa2V5IDAC9kYBAQEAAAL2WCEC+OrSSPCCo9/QXQt7IsunAp+eUqMndKBCu0NcGHx4HrhGAQEBAIAC9kYBAQEAAAL2WCECxgplEp2jBopznMqoBJZ1ezCE7IO2Bb5CqLypC+IiEhpUAQAFAGtleSA1BwAAAHZhbHVlIDVYIQK31gqPbwp33M7yKb2VSo7eB8p4jZZmYGnJ7njeFBGHtVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+				// 6.
+				"o2F2AWdlbnRyaWVzjUoBASQAa2V5IDAC9kYBAQEAAAL2WCEC+OrSSPCCo9/QXQt7IsunAp+eUqMndKBCu0NcGHx4HrhGAQEBAIAC9lghAivLwJbWkwZ8nROaPHGxpfthiG8vqyPbvzhkEEX793dIRgEBAQCAAvZUAQAFAGtleSA2BwAAAHZhbHVlIDZYIQK96CvAaM4vOReqLe+AoO6KajYFZiUsAyvSi8rEgClU7FghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+				// 7.
+				"o2F2AWdlbnRyaWVzjUoBASQAa2V5IDAC9kYBAQEAAAL2WCEC+OrSSPCCo9/QXQt7IsunAp+eUqMndKBCu0NcGHx4HrhGAQEBAIAC9lghAivLwJbWkwZ8nROaPHGxpfthiG8vqyPbvzhkEEX793dIRgEBAQCAAvZYIQICPF9slSfLMzCKpIGUKFWpXWq5dxfVdfe6wfGW6xjer1QBAAUAa2V5IDcHAAAAdmFsdWUgN1ghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+				// 8.
+				"o2F2AWdlbnRyaWVzh0oBASQAa2V5IDAC9lghAhQ6RgqFtADx+B6VKE0CVRrfDHmwgZwU3ewsj4gswWv+RgEBAwCAAvZUAQAFAGtleSA4BwAAAHZhbHVlIDhYIQINczJ806eMr+T/iGsJmo8/JQFXZtjy1/k+as0V9FdfVG51bnRydXN0ZWRfcm9vdFggqUC53tdiGisQSXyEb0bcd3g5eXlVHXG+4sB6kxnmqkU=",
+				// 9.
+				"o2F2AWdlbnRyaWVzh0oBASQAa2V5IDAC9lghAhQ6RgqFtADx+B6VKE0CVRrfDHmwgZwU3ewsj4gswWv+RgEBAwCAAvZYIQIwwW7eyXCi2yXyFCzFD9U+Ssy1gwSwiskBQfk+9KCUA1QBAAUAa2V5IDkHAAAAdmFsdWUgOW51bnRydXN0ZWRfcm9vdFggqUC53tdiGisQSXyEb0bcd3g5eXlVHXG+4sB6kxnmqkU=",
+				// 10.
+				"o2F2AWdlbnRyaWVzkEoBASQAa2V5IDAC9kYBAQEAAAL2RgEBAQAAAvZGAQEBAAAC9lghAlF8/rp9QOAd1qSchhUxDtVkpmnze6sjz5IfFhdOuaypRgEBAQCAAlghAldMzQwgHh/Ecm+rF+i31AnOgFYBipBAlcx5Tf5l4yW+VgEABgBrZXkgMTAIAAAAdmFsdWUgMTD2WCECDnYjQhsAp5fD+gf0W5YYFY6CnGURrEETtJvJp+ijH4xYIQKmwmeSM6ciBzj7J++myoJwhgeHl6V3WE0xZNPtqsB8cVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+			},
+		},
+	} {
+		// Ensure SyncGet returns expected proofs for all keys.
 
-	// Keys[5].
-	resp, err = tree.SyncGet(ctx, &syncer.GetRequest{
-		Tree: syncer.TreeID{
-			Root:     node.Root{Namespace: ns, Version: 0, Hash: roothash, Type: node.RootTypeState},
-			Position: roothash,
-		},
-		Key:             keys[5],
-		IncludeSiblings: false,
-	})
-	require.NoError(err, "SyncGet keys[5]")
-	require.EqualValues(
-		// "omdlbnRyaWVziUoBASQAa2V5IDACRgEBAQAAAlghAsFltYRhD4dAwHOdOmEigY1r02pJH6InhiibKlh9neYlRgEBAQCAAkYBAQEAAAJYIQLGCmUSnaMGinOcyqgElnV7MITsg7YFvkKovKkL4iISGlQBAAUAa2V5IDUHAAAAdmFsdWUgNVghArfWCo9vCnfczvIpvZVKjt4HyniNlmZgacnueN4UEYe1WCEC4TUy1kW5LNUQX+drpZ5Tkzvuw+RGTTGBc08fFOOrAp5udW50cnVzdGVkX3Jvb3RYIFnmfC/cCLjhDdCLtrjv5hT8yWXsuJYl+X8X+H8HEEYT",
-		"o2F2AWdlbnRyaWVzjUoBASQAa2V5IDAC9kYBAQEAAAL2WCECwWW1hGEPh0DAc506YSKBjWvTakkfoieGKJsqWH2d5iVGAQEBAIAC9kYBAQEAAAL2WCECxgplEp2jBopznMqoBJZ1ezCE7IO2Bb5CqLypC+IiEhpUAQAFAGtleSA1BwAAAHZhbHVlIDVYIQK31gqPbwp33M7yKb2VSo7eB8p4jZZmYGnJ7njeFBGHtVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCBZ5nwv3Ai44Q3Qi7a47+YU/Mll7LiWJfl/F/h/BxBGEw==",
-		base64.StdEncoding.EncodeToString(cbor.Marshal(resp.Proof)),
-	)
-	// Proof should verify.
-	_, err = pv.VerifyProof(ctx, roothash, &resp.Proof)
-	require.NoError(err, "VerifyProof should not fail with a valid proof")
+		for i, key := range keys {
+			resp, err := tree.SyncGet(ctx, &syncer.GetRequest{
+				Tree: syncer.TreeID{
+					Root:     node.Root{Namespace: ns, Version: 0, Hash: roothash, Type: node.RootTypeState},
+					Position: roothash,
+				},
+				Key:             key,
+				IncludeSiblings: tc.includeSiblings,
+				ProofVersion:    tc.proofVersion,
+			})
+			require.NoError(err, "SyncGet keys[%d], version: %d", i, tc.proofVersion)
+			require.EqualValues(
 
-	// Key[9].
-	resp, err = tree.SyncGet(ctx, &syncer.GetRequest{
-		Tree: syncer.TreeID{
-			Root:     node.Root{Namespace: ns, Version: 0, Hash: roothash, Type: node.RootTypeState},
-			Position: roothash,
-		},
-		Key:             keys[9],
-		IncludeSiblings: false,
-	})
-	require.NoError(err, "SyncGet keys[9]")
-	require.EqualValues(
-		// "omdlbnRyaWVzhUoBASQAa2V5IDACWCECJueKTLbwFMAiJitvfP3+tOruv3XChOjYSpH3U9/Xo/1GAQEDAIACWCECMMFu3slwotsl8hQsxQ/VPkrMtYMEsIrJAUH5PvSglANUAQAFAGtleSA5BwAAAHZhbHVlIDludW50cnVzdGVkX3Jvb3RYIFnmfC/cCLjhDdCLtrjv5hT8yWXsuJYl+X8X+H8HEEYT",
-		"o2F2AWdlbnRyaWVzh0oBASQAa2V5IDAC9lghAibniky28BTAIiYrb3z9/rTq7r91woTo2EqR91Pf16P9RgEBAwCAAvZYIQIwwW7eyXCi2yXyFCzFD9U+Ssy1gwSwiskBQfk+9KCUA1QBAAUAa2V5IDkHAAAAdmFsdWUgOW51bnRydXN0ZWRfcm9vdFggWeZ8L9wIuOEN0Iu2uO/mFPzJZey4liX5fxf4fwcQRhM=",
-		base64.StdEncoding.EncodeToString(cbor.Marshal(resp.Proof)),
-	)
-	// Proof should verify.
-	_, err = pv.VerifyProof(ctx, roothash, &resp.Proof)
-	require.NoError(err, "VerifyProof should not fail with a valid proof")
+				tc.proofs[i],
+				base64.StdEncoding.EncodeToString(cbor.Marshal(resp.Proof)),
+				"keys[%d], version: %d", i, tc.proofVersion,
+			)
+			// Proof should verify.
+			var pv syncer.ProofVerifier
+			_, err = pv.VerifyProof(ctx, roothash, &resp.Proof)
+			require.NoError(err, "VerifyProof should not fail with a valid proof: keys[%d], version: %d", i, tc.proofVersion)
+		}
+	}
 }

--- a/runtime/src/storage/mkvs/sync/proof.rs
+++ b/runtime/src/storage/mkvs/sync/proof.rs
@@ -1,6 +1,8 @@
 use std::{
+    cell::RefCell,
     collections::BTreeMap,
     ops::{Deref, DerefMut},
+    rc::Rc,
 };
 
 use anyhow::{anyhow, Result};
@@ -15,6 +17,10 @@ use crate::{
 const PROOF_ENTRY_FULL: u8 = 0x01;
 /// Proof entry type for subtree hashes.
 const PROOF_ENTRY_HASH: u8 = 0x02;
+
+// Min and max supported proof versions.
+const MIN_PROOF_VERSION: u16 = 0;
+const MAX_PROOF_VERSION: u16 = 1;
 
 /// A raw proof entry.
 #[derive(Clone, Debug, Default, PartialEq, Eq, cbor::Encode, cbor::Decode, Arbitrary)]
@@ -56,6 +62,21 @@ impl From<Vec<u8>> for RawProofEntry {
 /// A Merkle proof for a subtree.
 #[derive(Clone, Debug, Default, PartialEq, Eq, cbor::Encode, cbor::Decode)]
 pub struct Proof {
+    // The proof version.
+    //
+    // We don't use `Versioned` since we want version 0 proofs to be
+    // backwards compatible with the old structure which was not versioned.
+    //
+    // Version 0:
+    // Initial format.
+    //
+    // Version 1 change:
+    // Leaf nodes are included separately, as children. In version 0 the leaf node was
+    // serialized within the internal node.  The rationale behind this change is to eliminate
+    // the need to serialize all leaf nodes on the path when proving the existence of a
+    // specific value.
+    #[cbor(optional)]
+    pub v: u16,
     /// The root hash this proof is for. This should only be used as a quick
     /// sanity check and proof verification MUST use an independently obtained
     /// root hash as the prover can provide any root.
@@ -71,6 +92,7 @@ struct ProofNode {
 
 /// A Merkle proof builder.
 pub struct ProofBuilder {
+    proof_version: u16,
     root: Hash,
     included: BTreeMap<Hash, ProofNode>,
 }
@@ -78,10 +100,23 @@ pub struct ProofBuilder {
 impl ProofBuilder {
     /// Create a new proof builder for the given root hash.
     pub fn new(root: Hash) -> Self {
-        Self {
+        Self::new_with_version(root, MAX_PROOF_VERSION).unwrap()
+    }
+
+    /// Create a new proof builder for the given root hash and proof version.
+    pub fn new_with_version(root: Hash, proof_version: u16) -> Result<Self> {
+        if !(MIN_PROOF_VERSION..=MAX_PROOF_VERSION).contains(&proof_version) {
+            return Err(anyhow!(
+                "proof builder: unsupported proof version: {}",
+                proof_version
+            ));
+        }
+
+        Ok(Self {
+            proof_version,
             root,
             included: BTreeMap::new(),
-        }
+        })
     }
 
     /// Add a node to the set of included nodes.
@@ -101,30 +136,27 @@ impl ProofBuilder {
         }
         let mut pn = ProofNode {
             serialized: node
-                .compact_marshal_binary()
+                .compact_marshal_binary(self.proof_version)
                 .expect("marshaling node in proof"),
             children: vec![],
         };
 
         // For internal nodes, also include children.
         if let NodeBox::Internal(nd) = node {
-            let ch = nd
-                .left
-                .borrow()
-                .node
-                .as_ref()
-                .map(|n| n.borrow().get_hash())
-                .unwrap_or(Hash::empty_hash());
-            pn.children.push(ch);
+            fn get_child_hash(nd: &Rc<RefCell<NodePointer>>) -> Hash {
+                nd.borrow()
+                    .node
+                    .as_ref()
+                    .map(|n| n.borrow().get_hash())
+                    .unwrap_or_else(Hash::empty_hash)
+            }
 
-            let ch = nd
-                .right
-                .borrow()
-                .node
-                .as_ref()
-                .map(|n| n.borrow().get_hash())
-                .unwrap_or(Hash::empty_hash());
-            pn.children.push(ch);
+            if self.proof_version == 1 {
+                // In proof version 1, leaf nodes are included separately as children.
+                pn.children.push(get_child_hash(&nd.leaf_node));
+            }
+            pn.children.push(get_child_hash(&nd.left));
+            pn.children.push(get_child_hash(&nd.right));
         }
 
         self.included.insert(nh, pn);
@@ -133,6 +165,7 @@ impl ProofBuilder {
     /// Build the (unverified) proof.
     pub fn build(&self) -> Proof {
         let mut proof = Proof {
+            v: self.proof_version,
             untrusted_root: self.root,
             entries: vec![],
         };
@@ -181,6 +214,11 @@ impl ProofVerifier {
     /// Verify a proof and generate an in-memory subtree representing the
     /// nodes which are included in the proof.
     pub fn verify_proof(&self, root: Hash, proof: &Proof) -> Result<NodePtrRef> {
+        // Check proof version.
+        if !(MIN_PROOF_VERSION..=MAX_PROOF_VERSION).contains(&proof.v) {
+            return Err(anyhow!("verifier: unsupported proof version: {}", proof.v));
+        }
+
         // Sanity check that the proof is for the correct root (as otherwise it
         // makes no sense to verify the proof).
         if proof.untrusted_root != root {
@@ -233,14 +271,24 @@ impl ProofVerifier {
                 // For internal nodes, also decode children.
                 let mut pos = idx + 1;
                 if let NodeBox::Internal(ref mut nd) = node {
+                    match proof.v {
+                        0 => {
+                            // In proof version 0, leaf nodes are included within the internal node.
+                        }
+                        1 => {
+                            // In proof version 1, leaf nodes are included separately as children.
+                            (pos, nd.leaf_node) = Self::_verify_proof(proof, pos)?;
+                        }
+                        _ => {
+                            // Should not happen, checked in verify_proof.
+                            panic!("unsupported proof version: {:?}", proof.v)
+                        }
+                    }
+
                     // Left.
-                    let result = Self::_verify_proof(proof, pos)?;
-                    pos = result.0;
-                    nd.left = result.1;
+                    (pos, nd.left) = Self::_verify_proof(proof, pos)?;
                     // Right.
-                    let result = Self::_verify_proof(proof, pos)?;
-                    pos = result.0;
-                    nd.right = result.1;
+                    (pos, nd.right) = Self::_verify_proof(proof, pos)?;
 
                     // Recompute hash as hashes were not recomputed for compact encoding.
                     nd.update_hash();
@@ -276,19 +324,30 @@ mod test {
 
     #[test]
     fn test_proof() {
-        // Test vector generated by Go.
-        // TODO: Provide multiple test vectors.
+        // Test vectors generated by Go.
+
+        // V0 proof.
         let test_vector_proof = base64::decode(
             "omdlbnRyaWVzhUoBASQAa2V5IDACRgEBAQAAAlghAsFltYRhD4dAwHOdOmEigY1r02pJH6InhiibKlh9neYlWCECpsJnkjOnIgc4+\
 yfvpsqCcIYHh5eld1hNMWTT7arAfHFYIQLhNTLWRbks1RBf52ulnlOTO+7D5EZNMYFzTx8U46sCnm51bnRydXN0ZWRfcm9vdFggWeZ8L9wIuOEN0Iu2\
 uO/mFPzJZey4liX5fxf4fwcQRhM=",
         ).unwrap();
+
         let test_vector_root_hash =
             "59e67c2fdc08b8e10dd08bb6b8efe614fcc965ecb89625f97f17f87f07104613";
 
         // Proof should decode.
-        let proof: Proof = cbor::from_slice(&test_vector_proof).expect("proof should deserialize");
+        let proof: Proof =
+            cbor::from_slice(&test_vector_proof).expect("V0 proof should deserialize");
+        assert_eq!(proof.v, 0, "proof version should be 0");
         let root_hash = Hash::from(test_vector_root_hash);
+
+        // Proof should round-trip.
+        assert_eq!(
+            test_vector_proof,
+            cbor::to_vec(proof.clone()),
+            "proof should round-trip"
+        );
 
         // Proof should verify.
         let pv = ProofVerifier;
@@ -357,15 +416,116 @@ uO/mFPzJZey4liX5fxf4fwcQRhM=",
             result.is_err(),
             "verify proof should fail with invalid proof"
         );
+
+        // V1 proof.
+        let test_vector_proof = base64::decode(
+            "o2F2AWdlbnRyaWVzh0oBASQAa2V5IDAC9kYBAQEAAAL2WCECwWW1hGEPh0DAc506YSKBjWvTakkfoieGKJsqWH2d5iVYIQKmwmeSM6ciBzj7J+\
+            +myoJwhgeHl6V3WE0xZNPtqsB8cVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCBZ5nwv3Ai44Q3Qi7a47+\
+            YU/Mll7LiWJfl/F/h/BxBGEw=="
+        ).unwrap();
+
+        // Proof should decode.
+        let proof: Proof =
+            cbor::from_slice(&test_vector_proof).expect("V1 proof should deserialize");
+        assert_eq!(proof.v, 1, "proof version should be 1");
+        let root_hash = Hash::from(test_vector_root_hash);
+
+        // Proof should round-trip.
+        assert_eq!(
+            test_vector_proof,
+            cbor::to_vec(proof.clone()),
+            "proof should round-trip"
+        );
+
+        // Proof should verify.
+        let pv = ProofVerifier;
+        pv.verify_proof(root_hash, &proof)
+            .expect("verify proof should not fail with a valid proof");
+    }
+
+    #[test]
+    fn test_proof_builder_v1() {
+        // NOTE: Ensure this test matches TestProofV1 in go/storage/mkvs/syncer_test.go.
+
+        // Prepare test tree.
+        let mut tree = Tree::builder()
+            .with_root(Root {
+                hash: Hash::empty_hash(),
+                ..Default::default()
+            })
+            .build(Box::new(NoopReadSyncer));
+        for i in 0..11 {
+            let k = format!("key {}", i).into_bytes();
+            let v = format!("value {}", i).into_bytes();
+            tree.insert(&k, &v).expect("insert");
+        }
+        let roothash = tree.commit(Default::default(), 1).expect("commit");
+
+        let mut pb = ProofBuilder::new(roothash);
+
+        // Ensure proof matches Go side.
+        let proof = pb.build();
+        assert_eq!(
+            base64::encode(cbor::to_vec(proof)),
+            "o2F2AWdlbnRyaWVzgVghAqlAud7XYhorEEl8hG9G3Hd4OXl5VR1xvuLAepMZ5qpFbnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ=="
+        );
+
+        // Include root node.
+        let root_ptr = tree.cache.borrow().get_pending_root();
+        let root_node = root_ptr.borrow().get_node();
+        pb.include(&*root_node.borrow());
+        // Ensure proof matches Go side.
+        let proof = pb.build();
+        assert_eq!(
+            base64::encode(cbor::to_vec(proof)),
+		    "o2F2AWdlbnRyaWVzhEoBASQAa2V5IDAC9lghAhQ6RgqFtADx+B6VKE0CVRrfDHmwgZwU3ewsj4gswWv+WCEC4TUy1kW5LNUQX+drpZ5Tkzvuw+RGTTGBc08fFOOrAp5udW50cnVzdGVkX3Jvb3RYIKlAud7XYhorEEl8hG9G3Hd4OXl5VR1xvuLAepMZ5qpF",
+        );
+
+        // Include root.left node.
+        let root_left = noderef_as!(root_node, Internal).left.borrow().get_node();
+        pb.include(&*root_left.borrow());
+        // Ensure proof matches Go side.
+        let proof = pb.build();
+        assert_eq!(
+            base64::encode(cbor::to_vec(proof)),
+            "o2F2AWdlbnRyaWVzh0oBASQAa2V5IDAC9kYBAQEAAAL2WCEC+OrSSPCCo9/QXQt7IsunAp+eUqMndKBCu0NcGHx4HrhYIQKmwmeSM6ciBzj7J++myoJwhgeHl6V3WE0xZNPtqsB8cVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+        );
+
+        // Include root.left.left node.
+        let root_left2 = noderef_as!(root_left, Internal).left.borrow().get_node();
+        pb.include(&*root_left2.borrow());
+
+        // Include root.left.left.left node.
+        let root_left3: Rc<RefCell<NodeBox>> =
+            noderef_as!(root_left2, Internal).left.borrow().get_node();
+        pb.include(&*root_left3.borrow());
+
+        // Include root.left.left.left.right node.
+        let root_left3_right = noderef_as!(root_left3, Internal).right.borrow().get_node();
+        pb.include(&*root_left3_right.borrow());
+
+        // Include root.left.left.left.right.left leaf node.
+        let bottom = noderef_as!(root_left3_right, Internal)
+            .left
+            .borrow()
+            .get_node();
+        pb.include(&*bottom.borrow());
+        // Ensure proof matches Go side.
+        let proof = pb.build();
+        assert_eq!(
+            base64::encode(cbor::to_vec(proof)),
+		    "o2F2AWdlbnRyaWVzkEoBASQAa2V5IDAC9kYBAQEAAAL2RgEBAQAAAvZGAQEBAAAC9lghAlF8/rp9QOAd1qSchhUxDtVkpmnze6sjz5IfFhdOuaypRgEBAQCAAlghAldMzQwgHh/Ecm+rF+i31AnOgFYBipBAlcx5Tf5l4yW+VgEABgBrZXkgMTAIAAAAdmFsdWUgMTD2WCECDnYjQhsAp5fD+gf0W5YYFY6CnGURrEETtJvJp+ijH4xYIQKmwmeSM6ciBzj7J++myoJwhgeHl6V3WE0xZNPtqsB8cVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+        );
     }
 
     #[test]
     fn test_proof_extra_nodes() {
+        // V0 proof.
         let test_vector_proof = base64::decode(
-            "omdlbnRyaWVzhUoBASQAa2V5IDACRgEBAQAAAlghAsFltYRhD4dAwHOdOmEigY1r02pJH6InhiibKlh9neYlWCECpsJnkjOnIgc4+\
-yfvpsqCcIYHh5eld1hNMWTT7arAfHFYIQLhNTLWRbks1RBf52ulnlOTO+7D5EZNMYFzTx8U46sCnm51bnRydXN0ZWRfcm9vdFggWeZ8L9wIuOEN0Iu2\
-uO/mFPzJZey4liX5fxf4fwcQRhM=",
-        ).unwrap();
+                "omdlbnRyaWVzhUoBASQAa2V5IDACRgEBAQAAAlghAsFltYRhD4dAwHOdOmEigY1r02pJH6InhiibKlh9neYlWCECpsJnkjOnIgc4+\
+    yfvpsqCcIYHh5eld1hNMWTT7arAfHFYIQLhNTLWRbks1RBf52ulnlOTO+7D5EZNMYFzTx8U46sCnm51bnRydXN0ZWRfcm9vdFggWeZ8L9wIuOEN0Iu2\
+    uO/mFPzJZey4liX5fxf4fwcQRhM=",
+            ).unwrap();
         let test_vector_root_hash =
             "59e67c2fdc08b8e10dd08bb6b8efe614fcc965ecb89625f97f17f87f07104613";
 
@@ -384,11 +544,34 @@ uO/mFPzJZey4liX5fxf4fwcQRhM=",
 
         pv.verify_proof(root_hash, &proof)
             .expect_err("proof with extra data should fail to validate");
+
+        // V1 proof.
+        let test_vector_proof = base64::decode(
+                "o2F2AWdlbnRyaWVzh0oBASQAa2V5IDAC9kYBAQEAAAL2WCECwWW1hGEPh0DAc506YSKBjWvTakkfoieGKJsqWH2d5iVYIQKmwmeSM6ciBzj7J+\
+                +myoJwhgeHl6V3WE0xZNPtqsB8cVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCBZ5nwv3Ai44Q3Qi7a47+\
+                YU/Mll7LiWJfl/F/h/BxBGEw=="
+            ).unwrap();
+
+        // Proof should decode.
+        let mut proof: Proof =
+            cbor::from_slice(&test_vector_proof).expect("V1 proof should deserialize");
+        assert_eq!(proof.v, 1, "proof version should be 1");
+        let root_hash = Hash::from(test_vector_root_hash);
+
+        // Proof should verify.
+        let pv = ProofVerifier;
+        pv.verify_proof(root_hash, &proof)
+            .expect("verify proof should not fail with a valid proof");
+
+        // Duplicate some nodes and add them to the end.
+        proof.entries.push(proof.entries[0].clone());
+        pv.verify_proof(root_hash, &proof)
+            .expect_err("verify proof should fail with an invalid proof");
     }
 
     #[test]
-    fn test_proof_builder() {
-        // NOTE: Ensure this test matches TestProof in go/storage/mkvs/syncer_test.go.
+    fn test_proof_builder_v0() {
+        // NOTE: Ensure this test matches TestProofV0 in go/storage/mkvs/syncer_test.go.
 
         // Prepare test tree.
         let mut tree = Tree::builder()
@@ -411,7 +594,7 @@ uO/mFPzJZey4liX5fxf4fwcQRhM=",
         );
 
         // Ensure proof matches Go side.
-        let mut pb = ProofBuilder::new(roothash);
+        let mut pb = ProofBuilder::new_with_version(roothash, 0).expect("new proof builder v0");
         let root_only_proof = pb.build();
         assert_eq!(
             base64::encode(cbor::to_vec(root_only_proof)),
@@ -434,7 +617,7 @@ uO/mFPzJZey4liX5fxf4fwcQRhM=",
         let test_proof = pb.build();
         assert_eq!(
             base64::encode(cbor::to_vec(test_proof)),
-		    "omdlbnRyaWVzhUoBASQAa2V5IDACRgEBAQAAAlghAsFltYRhD4dAwHOdOmEigY1r02pJH6InhiibKlh9neYlWCECpsJnkjOnIgc4+yfvpsqCcIYHh5eld1hNMWTT7arAfHFYIQLhNTLWRbks1RBf52ulnlOTO+7D5EZNMYFzTx8U46sCnm51bnRydXN0ZWRfcm9vdFggWeZ8L9wIuOEN0Iu2uO/mFPzJZey4liX5fxf4fwcQRhM=",
+            "omdlbnRyaWVzhUoBASQAa2V5IDACRgEBAQAAAlghAsFltYRhD4dAwHOdOmEigY1r02pJH6InhiibKlh9neYlWCECpsJnkjOnIgc4+yfvpsqCcIYHh5eld1hNMWTT7arAfHFYIQLhNTLWRbks1RBf52ulnlOTO+7D5EZNMYFzTx8U46sCnm51bnRydXN0ZWRfcm9vdFggWeZ8L9wIuOEN0Iu2uO/mFPzJZey4liX5fxf4fwcQRhM=",
         );
     }
 
@@ -450,49 +633,65 @@ uO/mFPzJZey4liX5fxf4fwcQRhM=",
             })
             .build(Box::new(NoopReadSyncer));
         let mut keys = vec![];
-        for i in 0..10 {
+        for i in 0..11 {
             let k = format!("key {}", i).into_bytes();
             let v = format!("value {}", i).into_bytes();
             tree.insert(&k, &v).expect("insert");
             keys.push(k);
         }
         let roothash = tree.commit(Default::default(), 1).expect("commit");
-
         // Ensure tree matches Go side.
         assert_eq!(
             roothash.0.to_hex::<String>(),
-            "59e67c2fdc08b8e10dd08bb6b8efe614fcc965ecb89625f97f17f87f07104613",
+            "a940b9ded7621a2b10497c846f46dc7778397979551d71bee2c07a9319e6aa45",
         );
 
-        // Ensure tree proofs match Go side.
-        // Keys[0].
-        let proof = tree
-            .get_proof(&keys[0])
-            .expect("get proof keys[0] works")
-            .expect("proof keys[0] exists");
-        assert_eq!(
-            base64::encode(cbor::to_vec(proof)),
-		    "omdlbnRyaWVziUoBASQAa2V5IDACRgEBAQAAAkYBAQEAAAJGAQEBAAACVAEABQBrZXkgMAcAAAB2YWx1ZSAwWCECV0zNDCAeH8Ryb6sX6LfUCc6AVgGKkECVzHlN/mXjJb5YIQIOdiNCGwCnl8P6B/RblhgVjoKcZRGsQRO0m8mn6KMfjFghAqbCZ5IzpyIHOPsn76bKgnCGB4eXpXdYTTFk0+2qwHxxWCEC4TUy1kW5LNUQX+drpZ5Tkzvuw+RGTTGBc08fFOOrAp5udW50cnVzdGVkX3Jvb3RYIFnmfC/cCLjhDdCLtrjv5hT8yWXsuJYl+X8X+H8HEEYT",
-        );
-
-        // Keys[5].
-        let proof = tree
-            .get_proof(&keys[5])
-            .expect("get proof keys[5] works")
-            .expect("proof keys[5] exists");
-        assert_eq!(
-            base64::encode(cbor::to_vec(proof)),
-		    "omdlbnRyaWVziUoBASQAa2V5IDACRgEBAQAAAlghAsFltYRhD4dAwHOdOmEigY1r02pJH6InhiibKlh9neYlRgEBAQCAAkYBAQEAAAJYIQLGCmUSnaMGinOcyqgElnV7MITsg7YFvkKovKkL4iISGlQBAAUAa2V5IDUHAAAAdmFsdWUgNVghArfWCo9vCnfczvIpvZVKjt4HyniNlmZgacnueN4UEYe1WCEC4TUy1kW5LNUQX+drpZ5Tkzvuw+RGTTGBc08fFOOrAp5udW50cnVzdGVkX3Jvb3RYIFnmfC/cCLjhDdCLtrjv5hT8yWXsuJYl+X8X+H8HEEYT",
-        );
-
-        // Keys[9].
-        let proof = tree
-            .get_proof(&keys[9])
-            .expect("get proof keys[9] works")
-            .expect("proof keys[9] exists");
-        assert_eq!(
-            base64::encode(cbor::to_vec(proof)),
-		    "omdlbnRyaWVzhUoBASQAa2V5IDACWCECJueKTLbwFMAiJitvfP3+tOruv3XChOjYSpH3U9/Xo/1GAQEDAIACWCECMMFu3slwotsl8hQsxQ/VPkrMtYMEsIrJAUH5PvSglANUAQAFAGtleSA5BwAAAHZhbHVlIDludW50cnVzdGVkX3Jvb3RYIFnmfC/cCLjhDdCLtrjv5hT8yWXsuJYl+X8X+H8HEEYT",
-        );
+        for tc in vec![
+            // Note: Tree::get_proof doesn't support version 0 proofs.
+            // We test only version 1 proofs here.
+            (
+                // Proof v.
+                1,
+                vec![
+                    // 0.
+                    "o2F2AWdlbnRyaWVzjUoBASQAa2V5IDAC9kYBAQEAAAL2RgEBAQAAAvZGAQEBAAAC9lQBAAUAa2V5IDAHAAAAdmFsdWUgMFghAlO8PtYkGTEg304b/z/cv4oH6+BRaJ88layf7VgIl3xTWCECDnYjQhsAp5fD+gf0W5YYFY6CnGURrEETtJvJp+ijH4xYIQKmwmeSM6ciBzj7J++myoJwhgeHl6V3WE0xZNPtqsB8cVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+                    // 1.
+                    "o2F2AWdlbnRyaWVzkEoBASQAa2V5IDAC9kYBAQEAAAL2RgEBAQAAAvZGAQEBAAAC9lghAlF8/rp9QOAd1qSchhUxDtVkpmnze6sjz5IfFhdOuaypRgEBAQCAAlQBAAUAa2V5IDEHAAAAdmFsdWUgMVghAm2EG0dH85+yEl5rdT67+D59/gbjHB9qDtnCcv0kkuje9lghAg52I0IbAKeXw/oH9FuWGBWOgpxlEaxBE7Sbyafoox+MWCECpsJnkjOnIgc4+yfvpsqCcIYHh5eld1hNMWTT7arAfHFYIQLhNTLWRbks1RBf52ulnlOTO+7D5EZNMYFzTx8U46sCnm51bnRydXN0ZWRfcm9vdFggqUC53tdiGisQSXyEb0bcd3g5eXlVHXG+4sB6kxnmqkU=",
+                    // 2.
+                    "o2F2AWdlbnRyaWVzjUoBASQAa2V5IDAC9kYBAQEAAAL2RgEBAQAAAvZYIQLnu/nMm00WQo9ZxRbRFM/hVtoTov4Phs3vIQ/6jS/29kYBAQEAgAL2VAEABQBrZXkgMgcAAAB2YWx1ZSAyWCECJtIdvBvSs2Vh4Z1ghY3zvHvK8JsoBmt3+dBpRCNdA/xYIQKmwmeSM6ciBzj7J++myoJwhgeHl6V3WE0xZNPtqsB8cVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+                    // 3.
+                    "o2F2AWdlbnRyaWVzjUoBASQAa2V5IDAC9kYBAQEAAAL2RgEBAQAAAvZYIQLnu/nMm00WQo9ZxRbRFM/hVtoTov4Phs3vIQ/6jS/29kYBAQEAgAL2WCECoYj1TutUHeB1K0anT1hRts8AKOw8AfEtn963XMVxV1xUAQAFAGtleSAzBwAAAHZhbHVlIDNYIQKmwmeSM6ciBzj7J++myoJwhgeHl6V3WE0xZNPtqsB8cVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+                    // 4.
+                    "o2F2AWdlbnRyaWVzjUoBASQAa2V5IDAC9kYBAQEAAAL2WCEC+OrSSPCCo9/QXQt7IsunAp+eUqMndKBCu0NcGHx4HrhGAQEBAIAC9kYBAQEAAAL2VAEABQBrZXkgNAcAAAB2YWx1ZSA0WCEC7uES0HThvwiREsS6OKGDOodNGn7WGC3BTBJSLBIsJf1YIQK31gqPbwp33M7yKb2VSo7eB8p4jZZmYGnJ7njeFBGHtVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+                    // 5.
+                    "o2F2AWdlbnRyaWVzjUoBASQAa2V5IDAC9kYBAQEAAAL2WCEC+OrSSPCCo9/QXQt7IsunAp+eUqMndKBCu0NcGHx4HrhGAQEBAIAC9kYBAQEAAAL2WCECxgplEp2jBopznMqoBJZ1ezCE7IO2Bb5CqLypC+IiEhpUAQAFAGtleSA1BwAAAHZhbHVlIDVYIQK31gqPbwp33M7yKb2VSo7eB8p4jZZmYGnJ7njeFBGHtVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+                    // 6.
+                    "o2F2AWdlbnRyaWVzjUoBASQAa2V5IDAC9kYBAQEAAAL2WCEC+OrSSPCCo9/QXQt7IsunAp+eUqMndKBCu0NcGHx4HrhGAQEBAIAC9lghAivLwJbWkwZ8nROaPHGxpfthiG8vqyPbvzhkEEX793dIRgEBAQCAAvZUAQAFAGtleSA2BwAAAHZhbHVlIDZYIQK96CvAaM4vOReqLe+AoO6KajYFZiUsAyvSi8rEgClU7FghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+                    // 7.
+                    "o2F2AWdlbnRyaWVzjUoBASQAa2V5IDAC9kYBAQEAAAL2WCEC+OrSSPCCo9/QXQt7IsunAp+eUqMndKBCu0NcGHx4HrhGAQEBAIAC9lghAivLwJbWkwZ8nROaPHGxpfthiG8vqyPbvzhkEEX793dIRgEBAQCAAvZYIQICPF9slSfLMzCKpIGUKFWpXWq5dxfVdfe6wfGW6xjer1QBAAUAa2V5IDcHAAAAdmFsdWUgN1ghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+                    // 8.
+                    "o2F2AWdlbnRyaWVzh0oBASQAa2V5IDAC9lghAhQ6RgqFtADx+B6VKE0CVRrfDHmwgZwU3ewsj4gswWv+RgEBAwCAAvZUAQAFAGtleSA4BwAAAHZhbHVlIDhYIQINczJ806eMr+T/iGsJmo8/JQFXZtjy1/k+as0V9FdfVG51bnRydXN0ZWRfcm9vdFggqUC53tdiGisQSXyEb0bcd3g5eXlVHXG+4sB6kxnmqkU=",
+                    // 9.
+                    "o2F2AWdlbnRyaWVzh0oBASQAa2V5IDAC9lghAhQ6RgqFtADx+B6VKE0CVRrfDHmwgZwU3ewsj4gswWv+RgEBAwCAAvZYIQIwwW7eyXCi2yXyFCzFD9U+Ssy1gwSwiskBQfk+9KCUA1QBAAUAa2V5IDkHAAAAdmFsdWUgOW51bnRydXN0ZWRfcm9vdFggqUC53tdiGisQSXyEb0bcd3g5eXlVHXG+4sB6kxnmqkU=",
+                    // 10.
+                    "o2F2AWdlbnRyaWVzkEoBASQAa2V5IDAC9kYBAQEAAAL2RgEBAQAAAvZGAQEBAAAC9lghAlF8/rp9QOAd1qSchhUxDtVkpmnze6sjz5IfFhdOuaypRgEBAQCAAlghAldMzQwgHh/Ecm+rF+i31AnOgFYBipBAlcx5Tf5l4yW+VgEABgBrZXkgMTAIAAAAdmFsdWUgMTD2WCECDnYjQhsAp5fD+gf0W5YYFY6CnGURrEETtJvJp+ijH4xYIQKmwmeSM6ciBzj7J++myoJwhgeHl6V3WE0xZNPtqsB8cVghAuE1MtZFuSzVEF/na6WeU5M77sPkRk0xgXNPHxTjqwKebnVudHJ1c3RlZF9yb290WCCpQLne12IaKxBJfIRvRtx3eDl5eVUdcb7iwHqTGeaqRQ==",
+                ],
+            ),
+            ]{
+                // Ensure tree proofs match Go side.
+                for (i, k) in tc.1.iter().enumerate() {
+                    let proof = tree.get_proof(&keys[i]).expect("get proof works").expect("proof exists");
+                    assert_eq!(
+                        base64::encode(cbor::to_vec(proof.clone())),
+                        *k,
+                        "expected proof for keys[{}]",
+                        i
+                    );
+                    // Proof should verify.
+                    let pv = ProofVerifier;
+                    pv.verify_proof(roothash, &proof)
+                        .expect("verify proof should not fail with a valid proof");
+                }
+            };
     }
 }

--- a/runtime/src/storage/mkvs/tree/lookup.rs
+++ b/runtime/src/storage/mkvs/tree/lookup.rs
@@ -109,7 +109,7 @@ impl Tree {
                             bit_depth + n.label_bit_length,
                             key,
                             check_only,
-                            None, // Omit the proof builder as the leaf node is always included with the internal node itself.
+                            proof_builder,
                         );
                     }
 


### PR DESCRIPTION
Internal MKVS nodes always implicitly contained the full leaf node in the proof. Instead it should be added as a regular child node in the proof. That way an unneded large value (e.g. value in a leaf node of an internal node on the path to the actual node we're proving) won't inflate the proofs size.

Change is backwards compatible, existing proofs are unmarshaled as V0.

TODO:
- [x] use the (commented out from existing test cases) V0 base64 proof encodings in a new test as V0 proof test vectors 
- [x] add a test case with non-nil internal leaf-node 
- [x] update rust part