### PR TITLE
go/oasis-net-runner: Add ability to set node log level and format

### DIFF
--- a/.changelog/5534.feature.md
+++ b/.changelog/5534.feature.md
@@ -1,0 +1,5 @@
+go/oasis-net-runner: Add ability to set node log level and format
+
+Previously, every node started by the net runner had the default
+log level of debug, while now it's possible to set it to other
+levels.  The log format can also be changed.

--- a/go/oasis-net-runner/cmd/root.go
+++ b/go/oasis-net-runner/cmd/root.go
@@ -139,6 +139,10 @@ func runRoot(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("root: failed to instantiate fixture: %w", err)
 	}
 
+	// Set logging level and format for all spawned nodes.
+	net.Config().NodeLogLevel = viper.GetString(cfgLogLevel)
+	net.Config().NodeLogFormat = viper.GetString(cfgLogFmt)
+
 	// Start the network and keep it running.
 	if err = net.Start(); err != nil {
 		logger.Error("failed to start network",

--- a/go/oasis-test-runner/oasis/network.go
+++ b/go/oasis-test-runner/oasis/network.go
@@ -162,6 +162,12 @@ type NetworkCfg struct { // nolint: maligned
 	// externally-provided.
 	UseShortGrpcSocketPaths bool `json:"-"`
 
+	// NodeLogLevel is the log level to use for created nodes.
+	NodeLogLevel string `json:"node_log_level,omitempty"`
+
+	// NodeLogFormat is the log format to use for created nodes.
+	NodeLogFormat string `json:"node_log_format,omitempty"`
+
 	// Nodes lists the names of nodes to be created, enabling an N:M mapping between physical node
 	// processes and the features they host. If a feature is specified as attached to a node that
 	// isn't listed here, a new node will be created automatically, so this list can normally be
@@ -638,8 +644,16 @@ func (net *Network) startOasisNode(
 
 	cfg.Common.DataDir = node.DataDir()
 	cfg.Common.Log.Level = make(map[string]string)
-	cfg.Common.Log.Level["default"] = "debug"
-	cfg.Common.Log.Format = "json"
+	if net.Config().NodeLogLevel != "" {
+		cfg.Common.Log.Level["default"] = net.Config().NodeLogLevel
+	} else {
+		cfg.Common.Log.Level["default"] = "debug"
+	}
+	if net.Config().NodeLogFormat != "" {
+		cfg.Common.Log.Format = net.Config().NodeLogFormat
+	} else {
+		cfg.Common.Log.Format = "json"
+	}
 	cfg.Common.Log.File = nodeLogPath(node.dir)
 	cfg.Genesis.File = net.GenesisPath()
 
@@ -710,6 +724,8 @@ func (net *Network) startOasisNode(
 
 	net.logger.Info("launching Oasis node",
 		"args", strings.Join(args, " "),
+		"log_level", cfg.Common.Log.Level["default"],
+		"log_format", cfg.Common.Log.Format,
 	)
 
 	if err = cmd.Start(); err != nil {


### PR DESCRIPTION
Previously, every node started by the net runner had the default
log level of debug, while now it's possible to set it to other
levels.  The log format can also be changed.