### PR TITLE
go/worker/keymanager: Authorize noise session connect calls

### DIFF
--- a/.changelog/5539.feature.md
+++ b/.changelog/5539.feature.md
@@ -1,0 +1,4 @@
+go/worker/keymanager: Authorize noise session connect calls
+
+A peer is granted permission to connect if it is authorized
+to invoke at least one secure enclave RPC method.

--- a/go/keymanager/api/api.go
+++ b/go/keymanager/api/api.go
@@ -76,6 +76,9 @@ var (
 		MethodPublishEphemeralSecret,
 	}
 
+	// RPCMethodConnect is the name of the method used to establish a Noise session.
+	RPCMethodConnect = ""
+
 	// RPCMethodInit is the name of the `init` method.
 	RPCMethodInit = "init"
 

--- a/go/worker/keymanager/api/api.go
+++ b/go/worker/keymanager/api/api.go
@@ -175,6 +175,10 @@ type RPCAccessController interface {
 	// Methods returns a list of allowed methods.
 	Methods() []string
 
+	// Connect verifies whether the peer is allowed to establish a secure Noise connection,
+	// meaning it is authorized to invoke at least one secure RPC method.
+	Connect(peerID core.PeerID) bool
+
 	// Authorize verifies whether the peer is allowed to invoke the specified RPC method.
 	Authorize(method string, kind enclaverpc.Kind, peerID core.PeerID) error
 }

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -63,7 +63,8 @@ type Worker struct { // nolint: maligned
 	kmRuntimeWatcher *kmRuntimeWatcher
 	secretsWorker    *secretsWorker
 
-	accessControllers map[string]workerKeymanager.RPCAccessController
+	accessControllers         []workerKeymanager.RPCAccessController
+	accessControllersByMethod map[string]workerKeymanager.RPCAccessController
 
 	accessList *AccessList
 
@@ -145,20 +146,25 @@ func (w *Worker) CallEnclave(ctx context.Context, data []byte, kind enclaverpc.K
 	}
 
 	// Handle access control.
-	switch {
-	case method == "" && kind == enclaverpc.KindNoiseSession:
-		// Anyone can connect.
-	default:
-		peerID, ok := rpc.PeerIDFromContext(ctx)
-		if !ok {
-			return nil, fmt.Errorf("not authorized: unknown peer")
-		}
+	peerID, ok := rpc.PeerIDFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("not authorized: unknown peer")
+	}
 
-		ctrl, ok := w.accessControllers[method]
+	switch {
+	case method == api.RPCMethodConnect && kind == enclaverpc.KindNoiseSession:
+		// Allow connection if at least one controller grants authorization.
+		fn := func(ctrl workerKeymanager.RPCAccessController) bool {
+			return ctrl.Connect(peerID)
+		}
+		if !slices.ContainsFunc(w.accessControllers, fn) {
+			return nil, fmt.Errorf("not authorized to connect")
+		}
+	default:
+		ctrl, ok := w.accessControllersByMethod[method]
 		if !ok {
 			return nil, fmt.Errorf("unsupported RPC method")
 		}
-
 		if err := ctrl.Authorize(method, kind, peerID); err != nil {
 			return nil, fmt.Errorf("not authorized: %w", err)
 		}

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -174,8 +174,10 @@ func (w *Worker) CallEnclave(ctx context.Context, data []byte, kind enclaverpc.K
 		},
 	}
 
-	// Hosted runtime should not be nil as we are initialized.
 	rt := w.GetHostedRuntime()
+	if rt == nil {
+		return nil, fmt.Errorf("not initialized")
+	}
 	response, err := rt.Call(ctx, req)
 	if err != nil {
 		w.logger.Error("failed to dispatch RPC call to runtime",
@@ -208,6 +210,9 @@ func (w *Worker) callEnclaveLocal(method string, args interface{}, rsp interface
 	}
 
 	rt := w.GetHostedRuntime()
+	if rt == nil {
+		return fmt.Errorf("not initialized")
+	}
 	response, err := rt.Call(w.ctx, body)
 	if err != nil {
 		w.logger.Error("failed to dispatch local RPC call to runtime",


### PR DESCRIPTION
Also fixed two minor bugs:
- method `Methods` should not return local methods,
- method `CallEnclave` should verify if the hosted runtime is available.