### PR TITLE
[BACKPORT/22.2.x] 5403

### DIFF
--- a/.changelog/5403.bugfix.md
+++ b/.changelog/5403.bugfix.md
@@ -1,0 +1,1 @@
+go/worker/client: Fix nil dereference on early Query

--- a/go/worker/client/committee/node.go
+++ b/go/worker/client/committee/node.go
@@ -143,13 +143,14 @@ func (n *Node) Query(ctx context.Context, round uint64, method string, args []by
 	// Fetch the active descriptor so we can get the current message limits.
 	n.commonNode.CrossNode.Lock()
 	dsc := n.commonNode.CurrentDescriptor
-	latestRound := n.commonNode.CurrentBlock.Header.Round
+	blk := n.commonNode.CurrentBlock
 	n.commonNode.CrossNode.Unlock()
 
-	if dsc == nil {
+	if dsc == nil || blk == nil {
 		return nil, api.ErrNoHostedRuntime
 	}
 	maxMessages := dsc.Executor.MaxMessages
+	latestRound := n.commonNode.CurrentBlock.Header.Round
 
 	var resolvedRound uint64
 	queryFn := func(round uint64) ([]byte, error) {


### PR DESCRIPTION
Backport of #5403.

Useful mini fix for archive nodes. 