### PR TITLE
go/runtime/txpool: Remove rechecked transactions from seen cache

### DIFF
--- a/.changelog/5542.bugfix.md
+++ b/.changelog/5542.bugfix.md
@@ -1,0 +1,5 @@
+go/runtime/txpool: Remove rechecked transactions from seen cache
+
+In case a transaction is rejected because it fails a re-check pass, it
+should also be removed from the seen cache as it may be resubmitted
+later when it could become valid.

--- a/go/worker/compute/executor/committee/node.go
+++ b/go/worker/compute/executor/committee/node.go
@@ -507,7 +507,7 @@ func (n *Node) startSchedulingBatch(ctx context.Context, batch []*txpool.TxQueue
 	}
 
 	// Remove any rejected transactions.
-	n.commonNode.TxPool.HandleTxsUsed(rsp.TxRejectHashes)
+	n.commonNode.TxPool.RejectTxs(rsp.TxRejectHashes)
 	// Mark any proposed transactions.
 	_, _ = n.commonNode.TxPool.PromoteProposedBatch(rsp.TxHashes)
 


### PR DESCRIPTION
In case a transaction is rejected because it fails a re-check pass, it should also be removed from the seen cache as it may be resubmitted later when it could become valid.