### PR TITLE
go/worker/client: Fix observer node registration

### DIFF
--- a/.changelog/5545.bugfix.md
+++ b/.changelog/5545.bugfix.md
@@ -1,0 +1,5 @@
+go/worker/client: Fix observer node registration
+
+Previously a node configured as an observer node would forget to
+register for all of its configured runtimes, causing the registration
+to fail.

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -321,7 +321,11 @@ func (n *Node) initRuntimeWorkers() error {
 	n.svcMgr.Register(n.ExecutorWorker)
 
 	// Initialize the client worker.
-	n.ClientWorker, err = workerClient.New(n.grpcInternal, n.CommonWorker)
+	n.ClientWorker, err = workerClient.New(
+		n.grpcInternal,
+		n.CommonWorker,
+		n.RegistrationWorker,
+	)
 	if err != nil {
 		return err
 	}

--- a/go/worker/common/committee/registration.go
+++ b/go/worker/common/committee/registration.go
@@ -1,0 +1,38 @@
+package committee
+
+import (
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+)
+
+// RegisterNodeRuntime adds our runtime registration to an existing node descriptor.
+func (n *Node) RegisterNodeRuntime(nd *node.Node) error {
+	// Obtain the active runtime version.
+	activeVersion, err := n.GetHostedRuntimeActiveVersion()
+	if err != nil {
+		n.logger.Warn("failed to get active runtime version, skipping",
+			"err", err,
+		)
+		return nil
+	}
+
+	for _, version := range n.Runtime.HostVersions() {
+		// Skip sending any old versions that will never be active again.
+		if version.ToU64() < activeVersion.ToU64() {
+			continue
+		}
+
+		// Obtain CapabilityTEE for the given runtime version.
+		capabilityTEE, err := n.GetHostedRuntimeCapabilityTEEForVersion(version)
+		if err != nil {
+			n.logger.Warn("failed to get CapabilityTEE for hosted runtime, skipping",
+				"err", err,
+				"version", version,
+			)
+			continue
+		}
+
+		rt := nd.AddOrUpdateRuntime(n.Runtime.ID(), version)
+		rt.Capabilities.TEE = capabilityTEE
+	}
+	return nil
+}

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -1098,18 +1098,6 @@ func New(
 		rp.SetAvailable(func(*node.Node) error { return nil })
 	}
 
-	// When a node is a client node and it has an entity configured, we register it with the
-	// observer role as this may be needed for confidential runtimes.
-	if config.GlobalConfig.Mode == config.ModeClient {
-		rp, err := w.NewRoleProvider(node.RoleObserver)
-		if err != nil {
-			return nil, err
-		}
-
-		// The observer role is available immediately.
-		rp.SetAvailable(func(*node.Node) error { return nil })
-	}
-
 	return w, nil
 }
 


### PR DESCRIPTION
Previously a node configured as an observer node would forget to register for all of its configured runtimes, causing the registration to fail.