### PR TITLE
go/worker/keymanager/p2p: Remove retries and sticky peers

### DIFF
--- a/.changelog/5546.feature.md
+++ b/.changelog/5546.feature.md
@@ -1,0 +1,5 @@
+go/worker/keymanager/p2p: Remove retries and sticky peers
+
+Since retry and peer selection is now handled in the runtimes having it
+also done outside is detrimental to latency. The runtime knows better
+when to actually retry and which peers to select.

--- a/.changelog/5546.internal.1.md
+++ b/.changelog/5546.internal.1.md
@@ -1,0 +1,1 @@
+go/p2p/rpc: Remove support for sticky peers

--- a/.changelog/5546.internal.2.md
+++ b/.changelog/5546.internal.2.md
@@ -1,0 +1,1 @@
+runtime/enclave_rpc: Support caller to provide peer feedback

--- a/go/p2p/rpc/client.go
+++ b/go/p2p/rpc/client.go
@@ -28,7 +28,7 @@ const (
 	// retries by setting the WithMaxRetries option to a non-zero value. It can be overridden by
 	// using the WithRetryInterval call option.
 	DefaultCallRetryInterval = 1 * time.Second
-	// DefaultParallelRequests is the default number of parallel requests that can be mande
+	// DefaultParallelRequests is the default number of parallel requests that can be made
 	// when calling multiple peers.
 	DefaultParallelRequests = 5
 )

--- a/go/runtime/host/mock/mock.go
+++ b/go/runtime/host/mock/mock.go
@@ -55,7 +55,7 @@ func (r *runtime) GetInfo(context.Context) (*protocol.RuntimeInfoResponse, error
 	return &protocol.RuntimeInfoResponse{
 		ProtocolVersion: version.RuntimeHostProtocol,
 		RuntimeVersion:  version.MustFromString("0.0.0"),
-		Features: &protocol.Features{
+		Features: protocol.Features{
 			ScheduleControl: &protocol.FeatureScheduleControl{
 				InitialBatchSize: 100,
 			},

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -214,7 +214,7 @@ type RuntimeInfoResponse struct {
 	RuntimeVersion version.Version `json:"runtime_version"`
 
 	// Features describe the features supported by the runtime.
-	Features *Features `json:"features,omitempty"`
+	Features Features `json:"features,omitempty"`
 }
 
 // RuntimeCapabilityTEERakInitRequest is a worker RFC 0009 CapabilityTEE

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -190,6 +190,8 @@ type Features struct {
 	// SameBlockConsensusValidation is a feature specifying that the runtime supports same-block
 	// consensus validation.
 	SameBlockConsensusValidation bool `json:"same_block_consensus_validation,omitempty"`
+	// RPCPeerID is a feature specifying that the runtime supports RPC peer IDs.
+	RPCPeerID bool `json:"rpc_peer_id,omitempty"`
 }
 
 // HasScheduleControl returns true when the runtime supports the schedule control feature.
@@ -257,6 +259,8 @@ type RuntimeRPCCallRequest struct {
 	Request []byte `json:"request"`
 	// Kind is the type of RPC call.
 	Kind enclaverpc.Kind `json:"kind,omitempty"`
+	// PeerID is the identifier of the peer making the request.
+	PeerID []byte `json:"peer_id,omitempty"`
 }
 
 // RuntimeRPCCallResponse is a worker RPC call response message body.

--- a/go/worker/keymanager/p2p/client.go
+++ b/go/worker/keymanager/p2p/client.go
@@ -35,9 +35,7 @@ type client struct {
 
 func (c *client) CallEnclave(ctx context.Context, request *CallEnclaveRequest, peers []core.PeerID) (*CallEnclaveResponse, rpc.PeerFeedback, error) {
 	var rsp CallEnclaveResponse
-	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(rpc.WithLimitPeers(peers)), MethodCallEnclave, request, &rsp,
-		rpc.WithMaxRetries(MaxCallEnclaveRetries),
-	)
+	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(rpc.WithLimitPeers(peers)), MethodCallEnclave, request, &rsp)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -47,7 +45,7 @@ func (c *client) CallEnclave(ctx context.Context, request *CallEnclaveRequest, p
 // NewClient creates a new keymanager protocol client.
 func NewClient(p2p p2p.Service, chainContext string, keymanagerID common.Namespace) Client {
 	pid := protocol.NewRuntimeProtocolID(chainContext, keymanagerID, KeyManagerProtocolID, KeyManagerProtocolVersion)
-	mgr := rpc.NewPeerManager(p2p, pid, rpc.WithStickyPeers(true))
+	mgr := rpc.NewPeerManager(p2p, pid)
 	rc := rpc.NewClient(p2p.Host(), pid)
 	rc.RegisterListener(mgr)
 

--- a/go/worker/keymanager/p2p/client.go
+++ b/go/worker/keymanager/p2p/client.go
@@ -35,7 +35,9 @@ type client struct {
 
 func (c *client) CallEnclave(ctx context.Context, request *CallEnclaveRequest, peers []core.PeerID) (*CallEnclaveResponse, rpc.PeerFeedback, error) {
 	var rsp CallEnclaveResponse
-	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(rpc.WithLimitPeers(peers)), MethodCallEnclave, request, &rsp)
+	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(rpc.WithLimitPeers(peers)), MethodCallEnclave, request, &rsp,
+		rpc.WithMaxPeerResponseTime(MethodCallEnclaveTimeout),
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/worker/keymanager/p2p/protocol.go
+++ b/go/worker/keymanager/p2p/protocol.go
@@ -1,6 +1,8 @@
 package p2p
 
 import (
+	"time"
+
 	"github.com/libp2p/go-libp2p/core"
 
 	"github.com/oasisprotocol/oasis-core/go/common/node"
@@ -16,8 +18,11 @@ const KeyManagerProtocolID = "keymanager"
 // KeyManagerProtocolVersion is the supported version of the keymanager protocol.
 var KeyManagerProtocolVersion = version.Version{Major: 2, Minor: 0, Patch: 0}
 
-// MethodCallEnclave is the name of the CallEnclave method.
-const MethodCallEnclave = "CallEnclave"
+// Constants related to the CallEnclave method.
+const (
+	MethodCallEnclave        = "CallEnclave"
+	MethodCallEnclaveTimeout = 3 * time.Second
+)
 
 // CallEnclaveRequest is a CallEnclave request.
 type CallEnclaveRequest struct {

--- a/go/worker/keymanager/p2p/protocol.go
+++ b/go/worker/keymanager/p2p/protocol.go
@@ -16,11 +16,8 @@ const KeyManagerProtocolID = "keymanager"
 // KeyManagerProtocolVersion is the supported version of the keymanager protocol.
 var KeyManagerProtocolVersion = version.Version{Major: 2, Minor: 0, Patch: 0}
 
-// Constants related to the GetDiff method.
-const (
-	MethodCallEnclave     = "CallEnclave"
-	MaxCallEnclaveRetries = 15
-)
+// MethodCallEnclave is the name of the CallEnclave method.
+const MethodCallEnclave = "CallEnclave"
 
 // CallEnclaveRequest is a CallEnclave request.
 type CallEnclaveRequest struct {

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -184,6 +184,19 @@ func (w *Worker) CallEnclave(ctx context.Context, data []byte, kind enclaverpc.K
 	if rt == nil {
 		return nil, fmt.Errorf("not initialized")
 	}
+	rtInfo, err := rt.GetInfo(ctx)
+	if err != nil {
+		w.logger.Error("failed to fetch runtime features",
+			"err", err,
+		)
+		return nil, fmt.Errorf("not initialized")
+	}
+
+	// Only include PeerIDs if the runtime supports it.
+	if rtInfo.Features.RPCPeerID {
+		req.RuntimeRPCCallRequest.PeerID = []byte(peerID)
+	}
+
 	response, err := rt.Call(ctx, req)
 	if err != nil {
 		w.logger.Error("failed to dispatch RPC call to runtime",

--- a/keymanager/src/client/remote.rs
+++ b/keymanager/src/client/remote.rs
@@ -281,6 +281,8 @@ impl KeyManagerClient for RemoteClient {
                 },
             )
             .await
+            .into_result_with_feedback()
+            .await
             .map_err(|err| KeyManagerError::Other(err.into()))?;
 
         // Cache key.
@@ -329,6 +331,8 @@ impl KeyManagerClient for RemoteClient {
                 },
             )
             .await
+            .into_result_with_feedback()
+            .await
             .map_err(|err| KeyManagerError::Other(err.into()))?;
 
         // Verify the signature.
@@ -374,6 +378,8 @@ impl KeyManagerClient for RemoteClient {
                     epoch,
                 },
             )
+            .await
+            .into_result_with_feedback()
             .await
             .map_err(|err| KeyManagerError::Other(err.into()))?;
 
@@ -430,6 +436,8 @@ impl KeyManagerClient for RemoteClient {
                 },
             )
             .await
+            .into_result_with_feedback()
+            .await
             .map_err(|err| KeyManagerError::Other(err.into()))?;
 
         // Verify the signature.
@@ -461,6 +469,8 @@ impl KeyManagerClient for RemoteClient {
                 },
             )
             .await
+            .into_result_with_feedback()
+            .await
             .map_err(|err| KeyManagerError::Other(err.into()))
             .map(|rsp: ReplicateMasterSecretResponse| VerifiableSecret {
                 secret: rsp.master_secret,
@@ -486,6 +496,8 @@ impl KeyManagerClient for RemoteClient {
                     epoch,
                 },
             )
+            .await
+            .into_result_with_feedback()
             .await
             .map_err(|err| KeyManagerError::Other(err.into()))
             .map(|rsp: ReplicateEphemeralSecretResponse| rsp.ephemeral_secret)

--- a/runtime/src/config.rs
+++ b/runtime/src/config.rs
@@ -2,7 +2,7 @@
 use crate::{common::version::Version, consensus::verifier::TrustRoot, types::Features};
 
 /// Global runtime configuration.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct Config {
     /// Semantic runtime version.
     pub version: Version,
@@ -11,12 +11,25 @@ pub struct Config {
     /// Storage configuration.
     pub storage: Storage,
     /// Advertised runtime features.
-    pub features: Option<Features>,
+    pub features: Features,
     /// Whether storage state should be persisted between transaction check invocations. The state
     /// is invalidated on the next round.
     pub persist_check_tx_state: bool,
     /// Whether TEE freshness is verified with freshness proofs.
     pub freshness_proofs: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            version: Default::default(),
+            trust_root: None,
+            storage: Default::default(),
+            features: Default::default(),
+            persist_check_tx_state: false,
+            freshness_proofs: true,
+        }
+    }
 }
 
 /// Storage-related configuration.

--- a/runtime/src/enclave_rpc/client.rs
+++ b/runtime/src/enclave_rpc/client.rs
@@ -551,7 +551,6 @@ mod test {
     use crate::{
         common::crypto::signature,
         enclave_rpc::{demux::Demux, session, types},
-        identity::Identity,
     };
 
     use super::{super::transport::Transport, RpcClient};
@@ -567,7 +566,7 @@ mod test {
     impl MockTransport {
         fn new() -> Self {
             Self {
-                demux: Arc::new(Demux::new(Arc::new(Identity::new()))),
+                demux: Arc::new(Demux::new(session::Builder::default(), 4, 4, 60)),
                 next_error: Arc::new(AtomicBool::new(false)),
                 peer_feedback: Arc::new(Mutex::new((0, None))),
                 peer_feedback_history: Arc::new(Mutex::new(Vec::new())),
@@ -627,8 +626,10 @@ mod test {
                 types::Kind::NoiseSession => {
                     // Deliver directly to the multiplexer.
                     let mut buffer = Vec::new();
-                    let (mut session, message) =
-                        self.demux.process_frame(request, &mut buffer).await?;
+                    let (mut session, message) = self
+                        .demux
+                        .process_frame(vec![], request, &mut buffer)
+                        .await?;
 
                     match message {
                         Some(message) => {

--- a/runtime/src/enclave_rpc/client.rs
+++ b/runtime/src/enclave_rpc/client.rs
@@ -365,6 +365,62 @@ impl Controller {
     }
 }
 
+/// An EnclaveRPC response that can be used to provide peer feedback.
+pub struct Response<T> {
+    inner: Result<T, RpcClientError>,
+    kind: types::Kind,
+    cmdq: mpsc::WeakSender<Command>,
+    pfid: Option<u64>,
+}
+
+impl<T> Response<T> {
+    /// Report success if result was `Ok(_)` and failure if result was `Err(_)`, then return the
+    /// inner result consuming the response instance.
+    pub async fn into_result_with_feedback(mut self) -> Result<T, RpcClientError> {
+        match self.inner {
+            Ok(_) => self.success().await,
+            Err(_) => self.failure().await,
+        }
+
+        self.inner
+    }
+
+    /// Reference to inner result.
+    pub fn result(&self) -> &Result<T, RpcClientError> {
+        &self.inner
+    }
+
+    /// Consume the response instance returning the inner result.
+    pub fn into_result(self) -> Result<T, RpcClientError> {
+        self.inner
+    }
+
+    /// Report success as peer feedback.
+    pub async fn success(&mut self) {
+        self.send_peer_feedback(types::PeerFeedback::Success).await;
+    }
+
+    /// Report failure as peer feedback.
+    pub async fn failure(&mut self) {
+        self.send_peer_feedback(types::PeerFeedback::Failure).await;
+    }
+
+    /// Report bad peer as peer feedback.
+    pub async fn bad_peer(&mut self) {
+        self.send_peer_feedback(types::PeerFeedback::BadPeer).await;
+    }
+
+    /// Send peer feedback.
+    async fn send_peer_feedback(&mut self, pf: types::PeerFeedback) {
+        if let Some(pfid) = self.pfid.take() {
+            // Only count feedback once.
+            if let Some(cmdq) = self.cmdq.upgrade() {
+                let _ = cmdq.send(Command::PeerFeedback(pfid, pf, self.kind)).await;
+            }
+        }
+    }
+}
+
 /// RPC client.
 pub struct RpcClient {
     /// Internal command queue (sender part).
@@ -409,11 +465,7 @@ impl RpcClient {
     }
 
     /// Call a remote method using an encrypted and authenticated Noise session.
-    pub async fn secure_call<C, O>(
-        &self,
-        method: &'static str,
-        args: C,
-    ) -> Result<O, RpcClientError>
+    pub async fn secure_call<C, O>(&self, method: &'static str, args: C) -> Response<O>
     where
         C: cbor::Encode,
         O: cbor::Decode + Send + 'static,
@@ -422,11 +474,7 @@ impl RpcClient {
     }
 
     /// Call a remote method over an insecure channel where messages are sent in plain text.
-    pub async fn insecure_call<C, O>(
-        &self,
-        method: &'static str,
-        args: C,
-    ) -> Result<O, RpcClientError>
+    pub async fn insecure_call<C, O>(&self, method: &'static str, args: C) -> Response<O>
     where
         C: cbor::Encode,
         O: cbor::Decode + Send + 'static,
@@ -434,12 +482,7 @@ impl RpcClient {
         self.call(method, args, types::Kind::InsecureQuery).await
     }
 
-    async fn call<C, O>(
-        &self,
-        method: &'static str,
-        args: C,
-        kind: types::Kind,
-    ) -> Result<O, RpcClientError>
+    async fn call<C, O>(&self, method: &'static str, args: C, kind: types::Kind) -> Response<O>
     where
         C: cbor::Encode,
         O: cbor::Decode + Send + 'static,
@@ -449,20 +492,22 @@ impl RpcClient {
             args: cbor::to_value(args),
         };
 
-        let (pfid, response) = self.execute_call(request, kind).await?;
-        let result = match response.body {
-            types::Body::Success(value) => cbor::from_value(value).map_err(Into::into),
-            types::Body::Error(error) => Err(RpcClientError::CallFailed(error)),
+        let (pfid, inner) = match self.execute_call(request, kind).await {
+            Ok((pfid, response)) => match response.body {
+                types::Body::Success(value) => {
+                    (Some(pfid), cbor::from_value(value).map_err(Into::into))
+                }
+                types::Body::Error(error) => (Some(pfid), Err(RpcClientError::CallFailed(error))),
+            },
+            Err(err) => (None, Err(err)),
         };
 
-        // Report peer feedback based on whether call was successful.
-        let pf = match result {
-            Ok(_) => types::PeerFeedback::Success,
-            Err(_) => types::PeerFeedback::Failure,
-        };
-        let _ = self.cmdq.send(Command::PeerFeedback(pfid, pf, kind)).await;
-
-        result
+        Response {
+            inner,
+            kind,
+            cmdq: self.cmdq.downgrade(),
+            pfid,
+        }
     }
 
     async fn execute_call(
@@ -690,7 +735,15 @@ mod test {
         let client = RpcClient::new(Box::new(transport.clone()), builder, vec![]);
 
         // Basic secure call.
-        let result: u64 = rt.block_on(client.secure_call("test", 42)).unwrap();
+        let result: u64 = rt
+            .block_on(async {
+                client
+                    .secure_call("test", 42)
+                    .await
+                    .into_result_with_feedback()
+                    .await
+            })
+            .unwrap();
         rt.block_on(client.flush_cmd_queue()).unwrap(); // Flush cmd queue to get peer feedback.
         assert_eq!(result, 42, "secure call should work");
         assert_eq!(
@@ -706,7 +759,15 @@ mod test {
         // Reset all sessions on the server and make sure that we can still get a response.
         transport.reset();
 
-        let result: u64 = rt.block_on(client.secure_call("test", 43)).unwrap();
+        let result: u64 = rt
+            .block_on(async {
+                client
+                    .secure_call("test", 43)
+                    .await
+                    .into_result_with_feedback()
+                    .await
+            })
+            .unwrap();
         rt.block_on(client.flush_cmd_queue()).unwrap(); // Flush cmd queue to get peer feedback.
         assert_eq!(result, 43, "secure call should work");
         assert_eq!(
@@ -724,7 +785,15 @@ mod test {
         // can still get a response.
         transport.induce_transport_error();
 
-        let result: u64 = rt.block_on(client.secure_call("test", 44)).unwrap();
+        let result: u64 = rt
+            .block_on(async {
+                client
+                    .secure_call("test", 44)
+                    .await
+                    .into_result_with_feedback()
+                    .await
+            })
+            .unwrap();
         rt.block_on(client.flush_cmd_queue()).unwrap(); // Flush cmd queue to get peer feedback.
         assert_eq!(result, 44, "secure call should work");
         assert_eq!(
@@ -740,7 +809,15 @@ mod test {
         );
 
         // Basic insecure call.
-        let result: u64 = rt.block_on(client.insecure_call("test", 45)).unwrap();
+        let result: u64 = rt
+            .block_on(async {
+                client
+                    .insecure_call("test", 45)
+                    .await
+                    .into_result_with_feedback()
+                    .await
+            })
+            .unwrap();
         rt.block_on(client.flush_cmd_queue()).unwrap(); // Flush cmd queue to get peer feedback.
         assert_eq!(result, 45, "insecure call should work");
         assert_eq!(
@@ -754,7 +831,15 @@ mod test {
         // Induce a single transport error and make sure we can still get a response.
         transport.induce_transport_error();
 
-        let result: u64 = rt.block_on(client.insecure_call("test", 46)).unwrap();
+        let result: u64 = rt
+            .block_on(async {
+                client
+                    .insecure_call("test", 46)
+                    .await
+                    .into_result_with_feedback()
+                    .await
+            })
+            .unwrap();
         rt.block_on(client.flush_cmd_queue()).unwrap(); // Flush cmd queue to get peer feedback.
         assert_eq!(result, 46, "insecure call should work");
         assert_eq!(

--- a/runtime/src/enclave_rpc/demux.rs
+++ b/runtime/src/enclave_rpc/demux.rs
@@ -15,13 +15,13 @@ use super::{
 use crate::{common::time::insecure_posix_system_time, identity::Identity};
 
 /// Maximum concurrent EnclaveRPC sessions.
-const MAX_CONCURRENT_SESSIONS: usize = 100;
+const MAX_CONCURRENT_SESSIONS: usize = 1024;
 /// Sessions without any processed frame for more than STALE_SESSION_TIMEOUT_SECS seconds
 /// can be purged.
-const STALE_SESSION_TIMEOUT_SECS: u64 = 60;
+const STALE_SESSION_TIMEOUT_SECS: u64 = 5;
 /// Stale session check will be performed on any new incoming connection with at minimum
 /// STALE_SESSIONS_CHECK_TIMEOUT_SECS seconds between checks.
-const STALE_SESSIONS_CHECK_TIMEOUT_SECS: u64 = 10;
+const STALE_SESSIONS_CHECK_TIMEOUT_SECS: u64 = 5;
 
 /// Demultiplexer error.
 #[derive(Error, Debug)]

--- a/runtime/src/enclave_rpc/demux.rs
+++ b/runtime/src/enclave_rpc/demux.rs
@@ -1,27 +1,18 @@
 //! Session demultiplexer.
 use std::{
-    collections::HashMap,
+    collections::{BTreeSet, HashMap},
     io::Write,
     sync::{Arc, Mutex},
-    time::SystemTime,
 };
 
 use thiserror::Error;
+use tokio::sync::OwnedMutexGuard;
 
 use super::{
     session::{Builder, Session, SessionInfo},
     types::{Frame, Message, SessionID},
 };
-use crate::{common::time::insecure_posix_system_time, identity::Identity};
-
-/// Maximum concurrent EnclaveRPC sessions.
-const MAX_CONCURRENT_SESSIONS: usize = 1024;
-/// Sessions without any processed frame for more than STALE_SESSION_TIMEOUT_SECS seconds
-/// can be purged.
-const STALE_SESSION_TIMEOUT_SECS: u64 = 5;
-/// Stale session check will be performed on any new incoming connection with at minimum
-/// STALE_SESSIONS_CHECK_TIMEOUT_SECS seconds between checks.
-const STALE_SESSIONS_CHECK_TIMEOUT_SECS: u64 = 5;
+use crate::common::time::insecure_posix_time;
 
 /// Demultiplexer error.
 #[derive(Error, Debug)]
@@ -57,138 +48,283 @@ impl From<Error> for crate::types::Error {
     }
 }
 
-/// A map of session identifiers to session instances.
-type SessionMap = HashMap<SessionID, Arc<tokio::sync::Mutex<MultiplexedSession>>>;
+/// Peer identifier.
+type PeerID = Vec<u8>;
+
+/// Shared pointer to a multiplexed session.
+type SharedSession = Arc<tokio::sync::Mutex<MultiplexedSession>>;
+
+/// Key for use in the by-idle-time index.
+type SessionByTimeKey = (i64, PeerID, SessionID);
+
+/// Structure used for session accounting.
+struct SessionMeta {
+    /// Peer identifier.
+    peer_id: PeerID,
+    /// Session identifier.
+    session_id: SessionID,
+    /// Timestamp when the session was last accessed.
+    last_access_time: i64,
+    /// The shared session pointer that needs to be locked for access.
+    inner: SharedSession,
+}
+
+impl SessionMeta {
+    /// Key for ordering in the by-idle-time index.
+    fn by_time_key(&self) -> SessionByTimeKey {
+        (self.last_access_time, self.peer_id.clone(), self.session_id)
+    }
+}
+
+/// Session indices and management operations.
+struct Sessions {
+    /// Session builder.
+    builder: Builder,
+    /// Maximum number of sessions.
+    max_sessions: usize,
+    /// Maximum number of sessions per peer.
+    max_sessions_per_peer: usize,
+    /// Stale session timeout (in seconds).
+    stale_session_timeout: i64,
+
+    /// A map of sessions for each peer.
+    by_peer: HashMap<PeerID, HashMap<SessionID, SessionMeta>>,
+    /// A set of all sessions, ordered by idle time.
+    by_idle_time: BTreeSet<SessionByTimeKey>,
+}
+
+impl Sessions {
+    /// Create a new session management instance.
+    fn new(
+        builder: Builder,
+        max_sessions: usize,
+        max_sessions_per_peer: usize,
+        stale_session_timeout: i64,
+    ) -> Self {
+        Self {
+            builder,
+            max_sessions,
+            max_sessions_per_peer,
+            stale_session_timeout,
+            by_peer: HashMap::new(),
+            by_idle_time: BTreeSet::new(),
+        }
+    }
+
+    /// Create a new multiplexed session.
+    fn create_session(
+        mut builder: Builder,
+        peer_id: PeerID,
+        session_id: SessionID,
+        now: i64,
+    ) -> SessionMeta {
+        // If no quote policy is set, use the local one.
+        if builder.get_quote_policy().is_none() {
+            let policy = builder
+                .get_local_identity()
+                .as_ref()
+                .and_then(|id| id.quote_policy());
+            builder = builder.quote_policy(policy);
+        }
+
+        SessionMeta {
+            inner: Arc::new(tokio::sync::Mutex::new(MultiplexedSession {
+                peer_id: peer_id.clone(),
+                session_id,
+                inner: builder.build_responder(),
+            })),
+            peer_id,
+            session_id,
+            last_access_time: now,
+        }
+    }
+
+    /// Fetch an existing session given its identifier or create a new one.
+    fn get_or_create(
+        &mut self,
+        peer_id: PeerID,
+        session_id: SessionID,
+    ) -> Result<(SharedSession, bool), Error> {
+        let now = insecure_posix_time();
+
+        // Check if peer exists.
+        if let Some(sessions) = self.by_peer.get_mut(&peer_id) {
+            // Check if the session exists. If so, return it.
+            if let Some(session) = sessions.get_mut(&session_id) {
+                // Remove old idle time.
+                self.by_idle_time.remove(&session.by_time_key());
+                // Update idle time.
+                session.last_access_time = now;
+                self.by_idle_time.insert(session.by_time_key());
+
+                return Ok((session.inner.clone(), false));
+            }
+
+            // Check if the peer has max sessions or if no more sessions are available globally. If
+            // so, remove the oldest or return an error.
+            if sessions.len() >= self.max_sessions_per_peer
+                || self.by_idle_time.len() >= self.max_sessions
+            {
+                // Force close the oldest idle session so we can start a new one.
+                let inner = sessions
+                    .iter()
+                    .min_by_key(|(_, s)| {
+                        if let Ok(_inner) = s.inner.try_lock() {
+                            s.last_access_time
+                        } else {
+                            i64::MAX // Session is currently in use.
+                        }
+                    })
+                    .map(|(_, s)| s.inner.clone())
+                    .ok_or(Error::MaxConcurrentSessions)?;
+
+                if let Ok(inner) = inner.try_lock_owned() {
+                    self.remove(&inner);
+                } else {
+                    // All sessions are in use.
+                    return Err(Error::MaxConcurrentSessions);
+                }
+            }
+        }
+
+        // Check if there are too many sessions. If so, remove one or return an error.
+        if self.by_idle_time.len() >= self.max_sessions {
+            // Attempt to prune stale sessions, starting with the oldest ones.
+            let mut remove_session: Option<OwnedMutexGuard<MultiplexedSession>> = None;
+            for (last_process_frame_time, peer_id, session_id) in self.by_idle_time.iter() {
+                if now.saturating_sub(*last_process_frame_time) < self.stale_session_timeout {
+                    // This is the oldest session, all next ones will be more fresh.
+                    return Err(Error::MaxConcurrentSessions);
+                }
+
+                // Fetch session and attempt to lock it.
+                if let Some(sessions) = self.by_peer.get(peer_id) {
+                    if let Some(session) = sessions.get(session_id) {
+                        if let Ok(session) = session.inner.clone().try_lock_owned() {
+                            remove_session = Some(session);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if let Some(session) = remove_session {
+                // We found a session that can be removed.
+                self.remove(&session);
+            } else {
+                // All stale sessions are in use.
+                return Err(Error::MaxConcurrentSessions);
+            }
+        }
+
+        // Create a new session.
+        let sessions = self.by_peer.entry(peer_id.clone()).or_default();
+        let session = Self::create_session(self.builder.clone(), peer_id.clone(), session_id, now);
+        let inner = session.inner.clone();
+        sessions.insert(session_id, session);
+        self.by_idle_time.insert((now, peer_id, session_id));
+
+        Ok((inner, true))
+    }
+
+    /// Remove a session that must be currently owned by the caller.
+    fn remove(&mut self, session: &OwnedMutexGuard<MultiplexedSession>) {
+        let sessions = self.by_peer.get_mut(&session.peer_id).unwrap();
+        let session_meta = sessions.get(&session.session_id).unwrap();
+        let key = session_meta.by_time_key();
+        sessions.remove(&session.session_id);
+        self.by_idle_time.remove(&key);
+
+        // If peer doesn't have any more sessions, remove the peer.
+        if sessions.is_empty() {
+            self.by_peer.remove(&session.peer_id);
+        }
+    }
+
+    /// Clear all sessions.
+    fn clear(&mut self) {
+        self.by_peer.clear();
+        self.by_idle_time.clear();
+    }
+
+    /// Number of all sessions.
+    #[cfg(test)]
+    fn session_count(&self) -> usize {
+        self.by_idle_time.len()
+    }
+
+    /// Number of all peers.
+    #[cfg(test)]
+    fn peer_count(&self) -> usize {
+        self.by_peer.len()
+    }
+}
 
 /// Session demultiplexer.
 pub struct Demux {
-    identity: Arc<Identity>,
-
-    sessions: Mutex<SessionMap>,
-    last_stale_sessions_purge: Mutex<SystemTime>,
+    sessions: Mutex<Sessions>,
 }
 
 /// A multiplexed session.
 pub struct MultiplexedSession {
-    id: SessionID,
-    session: Session,
-    last_process_frame_time: SystemTime,
+    /// Peer identifier (needed for resolution when only given the shared pointer).
+    peer_id: PeerID,
+    /// Session identifier (needed for resolution when only given the shared pointer).
+    session_id: SessionID,
+    /// The actual session.
+    inner: Session,
 }
 
 impl MultiplexedSession {
     /// Session information.
     pub fn info(&self) -> Option<Arc<SessionInfo>> {
-        self.session.session_info()
+        self.inner.session_info()
     }
 
     /// Process incoming session data.
-    pub async fn process_data<W: Write>(
+    async fn process_data<W: Write>(
         &mut self,
         data: Vec<u8>,
         writer: W,
     ) -> Result<Option<Message>, Error> {
-        let msg = self.session.process_data(data, writer).await?;
-
-        // Update last processed frame time.
-        self.last_process_frame_time = insecure_posix_system_time();
-
-        Ok(msg)
+        Ok(self.inner.process_data(data, writer).await?)
     }
 
     /// Write message to session and generate a response.
     pub fn write_message<W: Write>(&mut self, msg: Message, mut writer: W) -> Result<(), Error> {
-        Ok(self.session.write_message(msg, &mut writer)?)
+        Ok(self.inner.write_message(msg, &mut writer)?)
     }
 }
 
 impl Demux {
     /// Create new session demultiplexer.
-    pub fn new(identity: Arc<Identity>) -> Self {
+    pub fn new(
+        builder: Builder,
+        max_sessions: usize,
+        max_sessions_per_peer: usize,
+        stale_session_timeout: i64,
+    ) -> Self {
         Self {
-            identity,
-            sessions: Default::default(),
-            last_stale_sessions_purge: Mutex::new(insecure_posix_system_time()),
+            sessions: Mutex::new(Sessions::new(
+                builder,
+                max_sessions,
+                max_sessions_per_peer,
+                stale_session_timeout,
+            )),
         }
     }
 
-    fn purge_stale_sessions(&self, sessions: &mut SessionMap) {
-        let now = insecure_posix_system_time();
-        if STALE_SESSION_TIMEOUT_SECS == 0 {
-            // If 0, sessions should never be considered stale.
-            return;
-        }
-
-        let mut last_stale_sessions_purge = self.last_stale_sessions_purge.lock().unwrap();
-
-        if now
-            .duration_since(*last_stale_sessions_purge)
-            .unwrap()
-            .as_secs()
-            < STALE_SESSIONS_CHECK_TIMEOUT_SECS
-        {
-            // Skip pruning if already pruned.
-            return;
-        }
-
-        // Prune sessions.
-        sessions.retain(|_, ms| {
-            match ms.try_lock() {
-                Ok(ms) => {
-                    // No locks held, check if we can prune.
-                    now.duration_since(ms.last_process_frame_time)
-                        .unwrap()
-                        .as_secs()
-                        < STALE_SESSION_TIMEOUT_SECS
-                }
-                Err(_) => {
-                    // Session is currently in use, skip pruning.
-                    true
-                }
-            }
-        });
-        *last_stale_sessions_purge = now;
-    }
-
-    /// Decode a frame.
-    fn decode_frame(&self, data: Vec<u8>) -> Result<Frame, Error> {
-        Ok(cbor::from_slice(&data)?)
-    }
-
-    /// Fetch an existing session given its identifier or create a new session with the given
-    /// identifier, returning the locked session guard.
-    fn get_or_create_session(
+    async fn get_or_create_session(
         &self,
-        id: SessionID,
-    ) -> Result<Arc<tokio::sync::Mutex<MultiplexedSession>>, Error> {
-        let mut sessions = self.sessions.lock().unwrap();
+        peer_id: PeerID,
+        session_id: SessionID,
+    ) -> Result<OwnedMutexGuard<MultiplexedSession>, Error> {
+        let (session, _) = {
+            let mut sessions = self.sessions.lock().unwrap();
+            sessions.get_or_create(peer_id, session_id)?
+        };
 
-        if let Some(session) = sessions.get(&id) {
-            Ok(session.clone())
-        } else {
-            // Session does not yet exist, first check if any stale sessions should be closed.
-            //
-            // Don't check if less than STALE_SESSIONS_CHECK_TIMEOUT_SECS seconds since last check.
-            self.purge_stale_sessions(&mut sessions);
-
-            // Create a new session.
-            if sessions.len() < MAX_CONCURRENT_SESSIONS {
-                let session = Builder::default()
-                    .quote_policy(self.identity.quote_policy())
-                    .local_identity(self.identity.clone())
-                    .build_responder();
-                let session = Arc::new(tokio::sync::Mutex::new(MultiplexedSession {
-                    id,
-                    session,
-                    last_process_frame_time: insecure_posix_system_time(),
-                }));
-
-                sessions.insert(id, session.clone());
-
-                Ok(session)
-            } else {
-                Err(Error::MaxConcurrentSessions)
-            }
-        }
+        Ok(session.lock_owned().await)
     }
 
     /// Process a frame, returning the locked session guard and decoded message.
@@ -196,25 +332,16 @@ impl Demux {
     /// Any data that needs to be transmitted back to the peer is written to the passed writer.
     pub async fn process_frame<W: Write>(
         &self,
+        peer_id: PeerID,
         data: Vec<u8>,
         writer: W,
-    ) -> Result<
-        (
-            tokio::sync::OwnedMutexGuard<MultiplexedSession>,
-            Option<Message>,
-        ),
-        Error,
-    > {
+    ) -> Result<(OwnedMutexGuard<MultiplexedSession>, Option<Message>), Error> {
         // Decode frame.
-        let frame = self.decode_frame(data)?;
+        let frame: Frame = cbor::from_slice(&data)?;
         // Get the existing session or create a new one.
-        let mut session = self
-            .get_or_create_session(frame.session)?
-            .lock_owned()
-            .await;
+        let mut session = self.get_or_create_session(peer_id, frame.session).await?;
         // Process session data.
-        let result = session.process_data(frame.payload, writer).await;
-        match result {
+        match session.process_data(frame.payload, writer).await {
             Ok(msg) => {
                 if let Some(Message::Request(ref req)) = msg {
                     // Make sure that the untrusted_plaintext matches the request's method.
@@ -227,9 +354,9 @@ impl Demux {
             }
             Err(err) => {
                 // In case the session was closed, remove the session.
-                if session.session.is_closed() {
+                if session.inner.is_closed() {
                     let mut sessions = self.sessions.lock().unwrap();
-                    sessions.remove(&frame.session);
+                    sessions.remove(&session);
                 }
                 Err(err)
             }
@@ -241,11 +368,11 @@ impl Demux {
     /// Any data that needs to be transmitted back to the peer is written to the passed writer.
     pub fn close<W: Write>(
         &self,
-        mut session: tokio::sync::OwnedMutexGuard<MultiplexedSession>,
+        mut session: OwnedMutexGuard<MultiplexedSession>,
         writer: W,
     ) -> Result<(), Error> {
         let mut sessions = self.sessions.lock().unwrap();
-        sessions.remove(&session.id);
+        sessions.remove(&session);
 
         session.write_message(Message::Close, writer)?;
         Ok(())
@@ -255,5 +382,250 @@ impl Demux {
     pub fn reset(&self) {
         let mut sessions = self.sessions.lock().unwrap();
         sessions.clear();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::enclave_rpc::{session::Builder, types::SessionID};
+
+    use super::{Error, Sessions};
+
+    fn ids() -> (Vec<Vec<u8>>, Vec<SessionID>) {
+        let peer_ids: Vec<Vec<u8>> = (1..16).map(|x| vec![x]).collect();
+        let session_ids: Vec<SessionID> = (1..16).map(|_| SessionID::random()).collect();
+
+        (peer_ids, session_ids)
+    }
+
+    #[test]
+    fn test_namespacing() {
+        let (peer_ids, session_ids) = ids();
+        let mut sessions = Sessions::new(Builder::default(), 16, 4, 60);
+
+        let (s1, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[0])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        let s1_owned = s1.try_lock().unwrap();
+        assert_eq!(&s1_owned.peer_id, &peer_ids[0]);
+        assert_eq!(&s1_owned.session_id, &session_ids[0]);
+        drop(s1_owned);
+        assert_eq!(sessions.session_count(), 1);
+        assert_eq!(sessions.peer_count(), 1);
+
+        let (_, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[1])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        let (_, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[2])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        let (_, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[3])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        assert_eq!(sessions.session_count(), 4);
+        assert_eq!(sessions.peer_count(), 1);
+
+        // Requesting an existing session for an existing peer should return it.
+        let (s1r, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[0])
+            .expect("get_or_create should succeed");
+        assert!(!created, "session should be reused");
+        let s1r_owned = s1r.try_lock().unwrap();
+        assert_eq!(&s1r_owned.peer_id, &peer_ids[0]);
+        assert_eq!(&s1r_owned.session_id, &session_ids[0]);
+        drop(s1r_owned);
+        assert_eq!(sessions.session_count(), 4);
+        assert_eq!(sessions.peer_count(), 1);
+
+        // Sessions should be properly namespaced by peer.
+        let (s5, created) = sessions
+            .get_or_create(peer_ids[1].clone(), session_ids[0])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created due to namespacing");
+        let s5_owned = s5.try_lock().unwrap();
+        assert_eq!(&s5_owned.peer_id, &peer_ids[1]);
+        assert_eq!(&s5_owned.session_id, &session_ids[0]);
+        drop(s5_owned);
+        assert_eq!(sessions.session_count(), 5);
+        assert_eq!(sessions.peer_count(), 2);
+    }
+
+    #[test]
+    fn test_max_sessions_per_peer() {
+        let (peer_ids, session_ids) = ids();
+        let mut sessions = Sessions::new(Builder::default(), 16, 4, 60); // Stale timeout is ignored.
+
+        let (_, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[0])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+
+        // Sleep to make sure the first session is the oldest.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+
+        let (_, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[1])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        let (_, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[2])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        let (_, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[3])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        assert_eq!(sessions.session_count(), 4);
+        assert_eq!(sessions.peer_count(), 1);
+
+        // Creating more sessions for the same peer should result in the oldest session being
+        // closed.
+        let (_, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[4])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        assert_eq!(sessions.session_count(), 4);
+        assert_eq!(sessions.peer_count(), 1);
+
+        // Only the oldest session should be closed.
+        let (_, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[1])
+            .expect("get_or_create should succeed");
+        assert!(!created, "session should be reused");
+        let (_, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[2])
+            .expect("get_or_create should succeed");
+        assert!(!created, "session should be reused");
+        let (_, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[3])
+            .expect("get_or_create should succeed");
+        assert!(!created, "session should be reused");
+        assert_eq!(sessions.session_count(), 4);
+        assert_eq!(sessions.peer_count(), 1);
+
+        let (_, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[0])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        assert_eq!(sessions.session_count(), 4);
+        assert_eq!(sessions.peer_count(), 1);
+    }
+
+    #[test]
+    fn test_max_sessions() {
+        let (peer_ids, session_ids) = ids();
+        let mut sessions = Sessions::new(Builder::default(), 4, 4, 60);
+
+        let (_, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[0])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        let (_, created) = sessions
+            .get_or_create(peer_ids[1].clone(), session_ids[1])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        let (_, created) = sessions
+            .get_or_create(peer_ids[2].clone(), session_ids[2])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        let (_, created) = sessions
+            .get_or_create(peer_ids[3].clone(), session_ids[3])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        assert_eq!(sessions.session_count(), 4);
+        assert_eq!(sessions.peer_count(), 4);
+
+        // Creating more sessions for a different peer should fail as no sessions are available and
+        // none are stale.
+        let res = sessions.get_or_create(peer_ids[4].clone(), session_ids[4]);
+        assert!(
+            matches!(res, Err(Error::MaxConcurrentSessions)),
+            "get_or_create should fail"
+        );
+        assert_eq!(sessions.session_count(), 4);
+        assert_eq!(sessions.peer_count(), 4);
+
+        // Creating more sessions for one of the existing peers should still work as it should force
+        // evict an old session. Note that each peer has 4 available slots, but globally there are
+        // only 4 slots so if global slots are full this should still trigger peer session eviction.
+        let (_, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[5])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        assert_eq!(sessions.session_count(), 4);
+        assert_eq!(sessions.peer_count(), 4);
+    }
+
+    #[test]
+    fn test_max_sessions_prune_stale() {
+        let (peer_ids, session_ids) = ids();
+        let mut sessions = Sessions::new(Builder::default(), 4, 4, 0); // Stale timeout is zero.
+
+        let (_, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[0])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        let (_, created) = sessions
+            .get_or_create(peer_ids[1].clone(), session_ids[1])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        let (_, created) = sessions
+            .get_or_create(peer_ids[2].clone(), session_ids[2])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        let (_, created) = sessions
+            .get_or_create(peer_ids[3].clone(), session_ids[3])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        assert_eq!(sessions.session_count(), 4);
+        assert_eq!(sessions.peer_count(), 4);
+
+        // Creating more sessions for a different peer should succeed as one of the stale sessions
+        // should be removed to make room for a new session.
+        let (_, created) = sessions
+            .get_or_create(peer_ids[4].clone(), session_ids[4])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        assert_eq!(sessions.session_count(), 4);
+        assert_eq!(sessions.peer_count(), 4);
+    }
+
+    #[test]
+    fn test_remove() {
+        let (peer_ids, session_ids) = ids();
+        let mut sessions = Sessions::new(Builder::default(), 16, 4, 0); // Stale timeout is zero.
+
+        let (s1, created) = sessions
+            .get_or_create(peer_ids[0].clone(), session_ids[0])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        let (s2, created) = sessions
+            .get_or_create(peer_ids[1].clone(), session_ids[1])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        let (_, created) = sessions
+            .get_or_create(peer_ids[1].clone(), session_ids[2])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        let (_, created) = sessions
+            .get_or_create(peer_ids[2].clone(), session_ids[3])
+            .expect("get_or_create should succeed");
+        assert!(created, "new session should be created");
+        assert_eq!(sessions.session_count(), 4);
+        assert_eq!(sessions.peer_count(), 3);
+
+        let s1r = s1.try_lock_owned().unwrap();
+        sessions.remove(&s1r);
+        assert_eq!(sessions.session_count(), 3);
+        assert_eq!(sessions.peer_count(), 2);
+
+        let s2r = s2.try_lock_owned().unwrap();
+        sessions.remove(&s2r);
+        assert_eq!(sessions.session_count(), 2);
+        assert_eq!(sessions.peer_count(), 2);
     }
 }

--- a/runtime/src/enclave_rpc/session.rs
+++ b/runtime/src/enclave_rpc/session.rs
@@ -483,6 +483,11 @@ impl Builder {
         self
     }
 
+    /// Return the local identity if configured in the builder.
+    pub fn get_local_identity(&self) -> &Option<Arc<Identity>> {
+        &self.identity
+    }
+
     /// Enable RAK binding.
     pub fn local_identity(mut self, identity: Arc<Identity>) -> Self {
         self.identity = Some(identity);

--- a/runtime/src/enclave_rpc/types.rs
+++ b/runtime/src/enclave_rpc/types.rs
@@ -11,9 +11,8 @@ impl_bytes!(
 impl SessionID {
     /// Generate a random session identifier.
     pub fn random() -> Self {
-        let mut rng = OsRng {};
         let mut session_id = [0u8; 32];
-        rng.fill(&mut session_id);
+        OsRng.fill(&mut session_id);
 
         SessionID(session_id)
     }

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -145,6 +145,7 @@ pub enum Body {
     RuntimeRPCCallRequest {
         request: Vec<u8>,
         kind: enclave_rpc::types::Kind,
+        peer_id: Vec<u8>,
     },
     RuntimeRPCCallResponse {
         response: Vec<u8>,
@@ -345,6 +346,9 @@ pub struct Features {
     /// A feature specifying that the runtime supports updating key manager's status.
     #[cbor(optional)]
     pub key_manager_status_updates: bool,
+    /// A feature specifying that the runtime supports RPC peer IDs.
+    #[cbor(optional)]
+    pub rpc_peer_id: bool,
 }
 
 impl Default for Features {
@@ -353,6 +357,7 @@ impl Default for Features {
             schedule_control: None,
             key_manager_quote_policy_updates: true,
             key_manager_status_updates: true,
+            rpc_peer_id: true,
         }
     }
 }

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -376,8 +376,7 @@ pub struct RuntimeInfoResponse {
     pub runtime_version: Version,
 
     /// Describes the features supported by the runtime.
-    #[cbor(optional)]
-    pub features: Option<Features>,
+    pub features: Features,
 }
 
 /// Batch execution mode.

--- a/tests/runtimes/simple-keymanager/src/main.rs
+++ b/tests/runtimes/simple-keymanager/src/main.rs
@@ -30,7 +30,6 @@ pub fn main_with_version(version: Version) {
         Config {
             version,
             trust_root,
-            freshness_proofs: true,
             ..Default::default()
         },
     );

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -435,14 +435,13 @@ pub fn main_with_version(version: Version) {
         Config {
             version,
             trust_root,
-            features: Some(Features {
+            features: Features {
                 // Enable the schedule control feature.
                 schedule_control: Some(FeatureScheduleControl {
                     initial_batch_size: MAX_BATCH_SIZE.try_into().unwrap(),
                 }),
                 ..Default::default()
-            }),
-            freshness_proofs: true,
+            },
             ..Default::default()
         },
     );


### PR DESCRIPTION
Since retry and peer selection is now handled in the runtimes having it also done outside is detrimental to latency. The runtime knows better when to actually retry and which peers to select.