### PR TITLE
go/worker/compute: Simplify I/O root commit

### DIFF
--- a/.changelog/5553.internal.md
+++ b/.changelog/5553.internal.md
@@ -1,0 +1,4 @@
+go/worker/compute: Simplify I/O root commit
+
+This also avoids an intermediate committed IO root which complicates the
+required database layout.

--- a/go/worker/compute/executor/committee/state.go
+++ b/go/worker/compute/executor/committee/state.go
@@ -167,7 +167,6 @@ type processedBatch struct {
 	rank     uint64
 
 	computed *protocol.ComputedBatch
-	raw      transaction.RawBatch
 
 	txInputWriteLog storage.WriteLog
 }


### PR DESCRIPTION
This also avoids an intermediate committed IO root which complicates the required database layout.