### PR TITLE
keymanager/runtime: Use insecure RPC requests for ephemeral public keys

### DIFF
--- a/.changelog/5554.internal.md
+++ b/.changelog/5554.internal.md
@@ -1,0 +1,1 @@
+keymanager/runtime: Use insecure RPC requests for ephemeral public keys

--- a/runtime/src/dispatcher.rs
+++ b/runtime/src/dispatcher.rs
@@ -899,17 +899,11 @@ impl Dispatcher {
         let protocol = state.protocol.clone();
         let consensus_verifier = state.consensus_verifier.clone();
         let rpc_dispatcher = state.rpc_dispatcher.clone();
-        let is_secure = kind == RpcKind::NoiseSession;
 
         let response = tokio::task::spawn_blocking(move || {
             let untrusted_local = Arc::new(ProtocolUntrustedLocalStorage::new(protocol.clone()));
-            let rpc_ctx = RpcContext::new(
-                identity,
-                is_secure,
-                session_info,
-                consensus_verifier,
-                &untrusted_local,
-            );
+            let rpc_ctx =
+                RpcContext::new(identity, session_info, consensus_verifier, &untrusted_local);
 
             rpc_dispatcher.dispatch(rpc_ctx, request, kind)
         })

--- a/runtime/src/enclave_rpc/context.rs
+++ b/runtime/src/enclave_rpc/context.rs
@@ -10,8 +10,6 @@ struct NoRuntimeContext;
 pub struct Context<'a> {
     /// The current runtime identity if any.
     pub identity: Arc<Identity>,
-    /// Whether the RPC call is using a secure channel.
-    pub is_secure: bool,
     /// Information about the session the RPC call was delivered over.
     pub session_info: Option<Arc<SessionInfo>>,
     /// Consensus verifier.
@@ -26,14 +24,12 @@ impl<'a> Context<'a> {
     /// Construct new transaction context.
     pub fn new(
         identity: Arc<Identity>,
-        is_secure: bool,
         session_info: Option<Arc<SessionInfo>>,
         consensus_verifier: Arc<dyn Verifier>,
         untrusted_local_storage: &'a dyn KeyValue,
     ) -> Self {
         Self {
             identity,
-            is_secure,
             session_info,
             consensus_verifier,
             runtime: Box::new(NoRuntimeContext),

--- a/runtime/src/enclave_rpc/dispatcher.rs
+++ b/runtime/src/enclave_rpc/dispatcher.rs
@@ -193,15 +193,11 @@ impl Dispatcher {
             }),
         };
 
-        match (method.get_kind(), kind) {
-            (Kind::NoiseSession, Kind::NoiseSession) => {}
-            (Kind::InsecureQuery, Kind::InsecureQuery) => {}
-            (Kind::InsecureQuery, Kind::NoiseSession) => {}
-            (Kind::LocalQuery, Kind::LocalQuery) => {}
-            _ => bail!(DispatchError::InvalidRpcKind {
+        if method.get_kind() != kind {
+            bail!(DispatchError::InvalidRpcKind {
                 method: request.method,
                 kind,
-            }),
+            });
         };
 
         method.dispatch(ctx, request)


### PR DESCRIPTION
Removing support for outdated key manager clients, which fetched public key via noise sessions.