### PR TITLE
docker: Bump cargo-tarpaulin to 0.27.3

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -341,8 +341,6 @@ steps:
       - make build-helpers
       - export OASIS_STORAGE_PROTOCOL_SERVER_BINARY=$(realpath go/storage/mkvs/interop/mkvs-test-helpers)
       - .buildkite/rust/coverage.sh
-    # Don't cause the build to fail, as tarpaulin is pretty unstable at the moment.
-    soft_fail: true
     retry:
       <<: *retry_agent_failure
     plugins:

--- a/.changelog/5558.internal.md
+++ b/.changelog/5558.internal.md
@@ -1,0 +1,1 @@
+docker: Bump cargo-tarpaulin to 0.27.3

--- a/docker/oasis-core-ci/Dockerfile
+++ b/docker/oasis-core-ci/Dockerfile
@@ -12,4 +12,4 @@ RUN wget -O codecov https://codecov.io/bash && \
     mv codecov /usr/local/bin
 
 # Install tarpaulin.
-RUN cargo install --version 0.25.0 cargo-tarpaulin
+RUN cargo install --version 0.27.3 cargo-tarpaulin


### PR DESCRIPTION
Also remove the `soft_fail` in CI, since this seems to be stable now. I briefly checked CI history and didn't notice any failed coverage runs. At the time `soft_fail` was enabled (version 0.8) the job failed almost always.