### PR TITLE
go/storage/mkvs: Add PathBadger storage backend 

### DIFF
--- a/.changelog/5559.feature.md
+++ b/.changelog/5559.feature.md
@@ -1,0 +1,13 @@
+go/storage/mkvs: Add PathBadger storage backend
+
+Instead of using trie node hashes as keys in the underlying Badger
+store, this new backend instead uses a combination of version and index
+within the batch of trie nodes as keys which leads to improved locality
+when iterating over the trie while at the same time making the database
+smaller and compactions faster.
+
+The new backend makes some (reasonable) assumptions, specifically that
+only one root per type may be finalized in any version and that there
+may be no child roots within the same version.
+
+The new backend is experimental.

--- a/go/.golangci.yml
+++ b/go/.golangci.yml
@@ -27,7 +27,7 @@ linters-settings:
           - github.com/cenkalti/backoff/v4
           - github.com/cometbft/cometbft
           - github.com/cosmos/gogoproto/proto
-          - github.com/dgraph-io/badger/v3
+          - github.com/dgraph-io/badger/v4
           - github.com/eapache/channels
           - github.com/fxamacker/cbor/v2
           - github.com/gammazero/deque

--- a/go/common/badger/helpers.go
+++ b/go/common/badger/helpers.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v4"
 
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 )

--- a/go/common/keyformat/key_format.go
+++ b/go/common/keyformat/key_format.go
@@ -157,9 +157,15 @@ func (k *KeyFormat) Encode(values ...interface{}) []byte {
 		case *uint8:
 			meta.checkSize(i, 1)
 			buf[0] = *t
-		case uint32:
+		case uint16:
 			// Use big endian encoding so the keys sort correctly when doing
 			// range queries.
+			meta.checkSize(i, 2)
+			binary.BigEndian.PutUint16(buf, t)
+		case *uint16:
+			meta.checkSize(i, 2)
+			binary.BigEndian.PutUint16(buf, *t)
+		case uint32:
 			meta.checkSize(i, 4)
 			binary.BigEndian.PutUint32(buf, t)
 		case *uint32:
@@ -246,9 +252,12 @@ func (k *KeyFormat) Decode(data []byte, values ...interface{}) bool {
 		case *uint8:
 			meta.checkSize(i, 1)
 			*t = buf[0]
-		case *uint32:
+		case *uint16:
 			// Use big endian encoding so the keys sort correctly when doing
 			// range queries.
+			meta.checkSize(i, 2)
+			*t = binary.BigEndian.Uint16(buf)
+		case *uint32:
 			meta.checkSize(i, 4)
 			*t = binary.BigEndian.Uint32(buf)
 		case *uint64:
@@ -291,6 +300,10 @@ func (k *KeyFormat) getElementMeta(l interface{}) *elementMeta {
 		return &elementMeta{size: 1}
 	case *uint8:
 		return &elementMeta{size: 1}
+	case uint16:
+		return &elementMeta{size: 2}
+	case *uint16:
+		return &elementMeta{size: 2}
 	case uint32:
 		return &elementMeta{size: 4}
 	case *uint32:

--- a/go/common/persistent/persistent.go
+++ b/go/common/persistent/persistent.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/badger/v3/options"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/options"
 
 	cmnBadger "github.com/oasisprotocol/oasis-core/go/common/badger"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"

--- a/go/consensus/cometbft/abci/prune_test.go
+++ b/go/consensus/cometbft/abci/prune_test.go
@@ -66,7 +66,7 @@ func TestPruneKeepN(t *testing.T) {
 	lastRetainedVersion := pruner.GetLastRetainedVersion()
 	require.EqualValues(1, lastRetainedVersion, "last retained version should be correct")
 
-	err = pruner.Prune(ctx, 11)
+	err = pruner.Prune(11)
 	require.NoError(err, "Prune")
 
 	earliestVersion = ndb.GetEarliestVersion()

--- a/go/consensus/cometbft/abci/state.go
+++ b/go/consensus/cometbft/abci/state.go
@@ -605,7 +605,7 @@ func (s *applicationState) pruneWorker() {
 
 			version := v.(uint64)
 
-			if err := s.statePruner.Prune(s.ctx, version); err != nil {
+			if err := s.statePruner.Prune(version); err != nil {
 				s.logger.Warn("failed to prune state",
 					"err", err,
 					"block_height", version,
@@ -634,12 +634,6 @@ func InitStateStorage(cfg *ApplicationConfig) (storage.LocalBackend, storage.Nod
 		if err := common.Mkdir(baseDir); err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to create application state directory: %w", err)
 		}
-	}
-
-	switch cfg.StorageBackend {
-	case storageDB.BackendNameBadgerDB:
-	default:
-		return nil, nil, nil, fmt.Errorf("unsupported storage backend: %s", cfg.StorageBackend)
 	}
 
 	db, err := storageDB.New(&storage.Config{

--- a/go/consensus/cometbft/api/api.go
+++ b/go/consensus/cometbft/api/api.go
@@ -240,7 +240,7 @@ type StatePruneHandler interface {
 	// Note that this can be called for the same version multiple
 	// times (e.g., if one of the handlers fails but others succeed
 	// and pruning is later retried).
-	Prune(ctx context.Context, version uint64) error
+	Prune(version uint64) error
 }
 
 // StatePruner is a concrete ABCI mux state pruner implementation.

--- a/go/consensus/cometbft/db/badger/badger.go
+++ b/go/consensus/cometbft/db/badger/badger.go
@@ -11,8 +11,8 @@ import (
 
 	dbm "github.com/cometbft/cometbft-db"
 	"github.com/cometbft/cometbft/node"
-	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/badger/v3/options"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/options"
 
 	cmnBadger "github.com/oasisprotocol/oasis-core/go/common/badger"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"

--- a/go/consensus/cometbft/full/archive.go
+++ b/go/consensus/cometbft/full/archive.go
@@ -160,7 +160,7 @@ func NewArchive(
 
 	appConfig := &abci.ApplicationConfig{
 		DataDir:        filepath.Join(srv.dataDir, tmcommon.StateDir),
-		StorageBackend: db.GetBackendName(),
+		StorageBackend: config.GlobalConfig.Storage.Backend,
 		Pruning: abci.PruneConfig{
 			Strategy:      abci.PruneNone,
 			PruneInterval: time.Hour * 100, // Irrelevant as pruning is disabled.

--- a/go/consensus/cometbft/full/full.go
+++ b/go/consensus/cometbft/full/full.go
@@ -533,7 +533,7 @@ func (t *fullService) lazyInit() error { // nolint: gocyclo
 
 	appConfig := &abci.ApplicationConfig{
 		DataDir:                   filepath.Join(t.dataDir, tmcommon.StateDir),
-		StorageBackend:            db.GetBackendName(),
+		StorageBackend:            config.GlobalConfig.Storage.Backend,
 		Pruning:                   pruneCfg,
 		HaltEpoch:                 beaconAPI.EpochTime(config.GlobalConfig.Consensus.HaltEpoch),
 		HaltHeight:                config.GlobalConfig.Consensus.HaltHeight,

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -860,7 +860,7 @@ func (ph *pruneHandler) trackRuntime(bh api.BlockHistory) {
 }
 
 // Implements api.StatePruneHandler.
-func (ph *pruneHandler) Prune(_ context.Context, version uint64) error {
+func (ph *pruneHandler) Prune(version uint64) error {
 	ph.Lock()
 	defer ph.Unlock()
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/cometbft/cometbft v0.0.0-00010101000000-000000000000
 	github.com/cometbft/cometbft-db v0.7.0
 	github.com/cosmos/gogoproto v1.4.1
-	github.com/dgraph-io/badger/v3 v3.2103.4
+	github.com/dgraph-io/badger/v4 v4.2.0
 	github.com/eapache/channels v1.1.0
 	github.com/fxamacker/cbor/v2 v2.4.0
 	github.com/gammazero/deque v0.2.1

--- a/go/go.sum
+++ b/go/go.sum
@@ -145,8 +145,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etly
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/dgraph-io/badger/v2 v2.2007.4 h1:TRWBQg8UrlUhaFdco01nO2uXwzKS7zd+HVdwV/GHc4o=
 github.com/dgraph-io/badger/v2 v2.2007.4/go.mod h1:vSw/ax2qojzbN6eXHIx6KPKtCSHJN/Uz0X0VPruTIhk=
-github.com/dgraph-io/badger/v3 v3.2103.4 h1:WE1B07YNTTJTtG9xjBcSW2wn0RJLyiV99h959RKZqM4=
-github.com/dgraph-io/badger/v3 v3.2103.4/go.mod h1:4MPiseMeDQ3FNCYwRbbcBOGJLf5jsE0PPFzRiKjtcdw=
+github.com/dgraph-io/badger/v4 v4.2.0 h1:kJrlajbXXL9DFTNuhhu9yCx7JJa4qpYWxtE8BzuWsEs=
+github.com/dgraph-io/badger/v4 v4.2.0/go.mod h1:qfCqhPoWDFJRx1gp5QwwyGo8xk1lbHUxvK9nK0OGAak=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgraph-io/ristretto v0.1.1 h1:6CWw5tJNgpegArSHpNHJKldNeq03FQCwYvfMVWajOK8=
 github.com/dgraph-io/ristretto v0.1.1/go.mod h1:S1GPSBCYCIhmVNfcth17y2zZtQT6wzkzgwUve0VDWWA=

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -264,7 +264,7 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 				fixture.ComputeWorkers[j].RuntimeStatePaths[i] = runtimeStatePath
 			}
 
-			dbPath := filepath.Join(runtimeStatePath, database.DBFileBadgerDB)
+			dbPath := filepath.Join(runtimeStatePath, database.DefaultFileName(database.BackendNameBadgerDB))
 			_, err := os.Stat(dbPath)
 			if err != nil {
 				return nil, fmt.Errorf("runtime state path: %w", err)

--- a/go/oasis-node/cmd/common/config/config.go
+++ b/go/oasis-node/cmd/common/config/config.go
@@ -43,7 +43,12 @@ func DefaultConfig() Config {
 		Log: LogConfig{
 			File:   "",
 			Format: "logfmt",
-			Level:  make(map[string]string),
+			Level: map[string]string{
+				"cometbft/context":  "error", // Too verbose by default.
+				"cometbft/db":       "info",  // Debug logs are too verbose and not very useful.
+				"common/persistent": "info",  // Debug logs are too verbose and not very useful.
+				"mkvs/db":           "info",  // Debug logs are too verbose and not very useful.
+			},
 		},
 		Debug: DebugConfig{
 			AllowRoot: false,

--- a/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
+++ b/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
@@ -14,6 +14,7 @@ import (
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/config"
 	"github.com/oasisprotocol/oasis-core/go/consensus/cometbft/abci"
 	abciState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/abci/state"
 	cmtAPI "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
@@ -37,7 +38,6 @@ import (
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
-	storageDB "github.com/oasisprotocol/oasis-core/go/storage/database"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
 )
 
@@ -105,7 +105,7 @@ func doDumpDB(cmd *cobra.Command, _ []string) {
 	ldb, _, stateRoot, err := abci.InitStateStorage(
 		&abci.ApplicationConfig{
 			DataDir:             filepath.Join(dataDir, cmtCommon.StateDir),
-			StorageBackend:      storageDB.BackendNameBadgerDB, // No other backend for now.
+			StorageBackend:      config.GlobalConfig.Storage.Backend,
 			MemoryOnlyStorage:   false,
 			ReadOnlyStorage:     viper.GetBool(cfgDumpReadOnlyDB),
 			DisableCheckpointer: true,

--- a/go/oasis-node/cmd/debug/storage/export.go
+++ b/go/oasis-node/cmd/debug/storage/export.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
@@ -156,23 +155,15 @@ func exportIterator(fn string, root *storageAPI.Root, it mkvs.Iterator) error {
 }
 
 func newDirectStorageBackend(dataDir string, namespace common.Namespace) (storageAPI.Backend, error) {
-	b := strings.ToLower(config.GlobalConfig.Storage.Backend)
 	// The right thing to do will be to use storage.New, but the backend config
 	// assumes that identity is valid, and we don't have one.
 	cfg := &storageAPI.Config{
-		Backend:      b,
-		DB:           dataDir,
+		Backend:      config.GlobalConfig.Storage.Backend,
 		Namespace:    namespace,
 		MaxCacheSize: int64(config.ParseSizeInBytes(config.GlobalConfig.Storage.MaxCacheSize)),
 	}
-
-	switch b {
-	case storageDatabase.BackendNameBadgerDB:
-		cfg.DB = filepath.Join(cfg.DB, storageDatabase.DefaultFileName(cfg.Backend))
-		return storageDatabase.New(cfg)
-	default:
-		return nil, fmt.Errorf("storage: unsupported backend: '%v'", cfg.Backend)
-	}
+	cfg.DB = filepath.Join(dataDir, storageDatabase.DefaultFileName(cfg.Backend))
+	return storageDatabase.New(cfg)
 }
 
 func init() {

--- a/go/oasis-test-runner/oasis/client.go
+++ b/go/oasis-test-runner/oasis/client.go
@@ -59,7 +59,7 @@ func (client *Client) ModifyConfig() error {
 	client.Config.P2P.Port = client.p2pPort
 
 	if len(client.runtimes) > 0 {
-		client.Config.Mode = config.ModeStatelessClient
+		client.Config.Mode = config.ModeClient
 		client.Config.Runtime.Provisioner = client.runtimeProvisioner
 	}
 

--- a/go/oasis-test-runner/oasis/compute.go
+++ b/go/oasis-test-runner/oasis/compute.go
@@ -218,7 +218,7 @@ func (net *Network) NewCompute(cfg *ComputeCfg) (*Compute, error) {
 		cfg.RuntimeProvisioner = runtimeConfig.RuntimeProvisionerSandboxed
 	}
 	if cfg.StorageBackend == "" {
-		cfg.StorageBackend = database.BackendNameBadgerDB
+		cfg.StorageBackend = defaultStorageBackend
 	}
 	// Initialize runtime state paths.
 	for i, path := range cfg.RuntimeStatePaths {

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -23,6 +23,7 @@ import (
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/log"
+	"github.com/oasisprotocol/oasis-core/go/storage/database"
 )
 
 const (
@@ -39,6 +40,8 @@ const (
 	defaultVRFAlphaThreshold  = 3
 	defaultVRFInterval        = 20
 	defaultVRFSubmissionDelay = 5
+
+	defaultStorageBackend = database.BackendNamePathBadger
 
 	logNodeFile        = "node.log"
 	logConsoleFile     = "console.log"
@@ -257,6 +260,8 @@ func (n *Node) Start() error {
 	n.Config.Consensus.Submission.GasPrice = n.consensus.SubmissionGasPrice
 	n.Config.Consensus.MinGasPrice = n.consensus.MinGasPrice
 	n.Config.Consensus.HaltEpoch = n.net.cfg.HaltEpoch
+
+	n.Config.Storage.Backend = defaultStorageBackend
 
 	// Initialize node command-line arguments.
 	args := newArgBuilder().debugDontBlameOasis().debugAllowTestKeys()

--- a/go/runtime/history/db.go
+++ b/go/runtime/history/db.go
@@ -3,8 +3,8 @@ package history
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/badger/v3/options"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/options"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	cmnBadger "github.com/oasisprotocol/oasis-core/go/common/badger"

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -354,7 +354,7 @@ func (h *runtimeHistory) pruneWorker() {
 			select {
 			case round = <-h.pruneCh.Out():
 			case <-h.stopCh:
-				h.logger.Info("prune worker is terminating")
+				h.logger.Debug("prune worker is terminating")
 				return
 			}
 
@@ -362,14 +362,14 @@ func (h *runtimeHistory) pruneWorker() {
 				"round", round.(uint64),
 			)
 
-			if err := h.pruner.Prune(h.ctx, round.(uint64)); err != nil {
+			if err := h.pruner.Prune(round.(uint64)); err != nil {
 				h.logger.Error("failed to prune",
 					"err", err,
 				)
 				continue
 			}
 		case <-h.stopCh:
-			h.logger.Info("prune worker is terminating")
+			h.logger.Debug("prune worker is terminating")
 			return
 		}
 	}

--- a/go/runtime/history/history_test.go
+++ b/go/runtime/history/history_test.go
@@ -277,7 +277,7 @@ type testPruneHandler struct {
 	batches      []int
 }
 
-func (h *testPruneHandler) Prune(_ context.Context, rounds []uint64) error {
+func (h *testPruneHandler) Prune(rounds []uint64) error {
 	// NOTE: Users must ensure that accessing prunedRounds is safe (e.g., that
 	//       no more pruning happens using this handler before prunedRounds is
 	//       accessed from a different goroutine).
@@ -399,7 +399,7 @@ func TestHistoryPrune(t *testing.T) {
 
 type testPruneFailingHandler struct{}
 
-func (h *testPruneFailingHandler) Prune(context.Context, []uint64) error {
+func (h *testPruneFailingHandler) Prune([]uint64) error {
 	return fmt.Errorf("thou shall not pass")
 }
 

--- a/go/runtime/history/prune.go
+++ b/go/runtime/history/prune.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v4"
 
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 )

--- a/go/runtime/localstorage/localstorage.go
+++ b/go/runtime/localstorage/localstorage.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/badger/v3/options"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/options"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	cmnBadger "github.com/oasisprotocol/oasis-core/go/common/badger"

--- a/go/storage/database/database_test.go
+++ b/go/storage/database/database_test.go
@@ -16,6 +16,7 @@ import (
 func TestStorageDatabase(t *testing.T) {
 	for _, v := range []string{
 		BackendNameBadgerDB,
+		BackendNamePathBadger,
 	} {
 		t.Run(v, func(t *testing.T) {
 			doTestImpl(t, v)

--- a/go/storage/mkvs/db/api/hash.go
+++ b/go/storage/mkvs/db/api/hash.go
@@ -1,7 +1,7 @@
-package badger
+package api
 
 import (
-	"crypto/subtle"
+	"bytes"
 	"encoding"
 	"encoding/base64"
 	"encoding/hex"
@@ -12,25 +12,26 @@ import (
 )
 
 var (
-	_ encoding.BinaryMarshaler   = (*typedHash)(nil)
-	_ encoding.BinaryUnmarshaler = (*typedHash)(nil)
+	_ encoding.BinaryMarshaler   = (*TypedHash)(nil)
+	_ encoding.BinaryUnmarshaler = (*TypedHash)(nil)
 )
 
-const typedHashSize = hash.Size + 1
+// TypedHashSize is the size of the TypedHash.
+const TypedHashSize = hash.Size + 1
 
-// typedHash is a node hash prefixed with its root type.
-type typedHash [typedHashSize]byte
+// TypedHash is a node hash prefixed with its root type.
+type TypedHash [TypedHashSize]byte
 
 // MarshalBinary encodes a typed hash into binary form.
-func (h *typedHash) MarshalBinary() (data []byte, err error) {
+func (h *TypedHash) MarshalBinary() (data []byte, err error) {
 	data = append([]byte{}, h[:]...)
 	return
 }
 
 // UnmarshalBinary decodes a binary marshaled hash.
-func (h *typedHash) UnmarshalBinary(data []byte) error {
-	if len(data) != typedHashSize {
-		fmt.Printf("\nunexpected typedhash size: got %v, expected %v\n", len(data), typedHashSize)
+func (h *TypedHash) UnmarshalBinary(data []byte) error {
+	if len(data) != TypedHashSize {
+		fmt.Printf("\nunexpected typedhash size: got %v, expected %v\n", len(data), TypedHashSize)
 		return hash.ErrMalformed
 	}
 
@@ -40,12 +41,12 @@ func (h *typedHash) UnmarshalBinary(data []byte) error {
 }
 
 // MarshalText encodes a Hash into text form.
-func (h typedHash) MarshalText() (data []byte, err error) {
+func (h TypedHash) MarshalText() (data []byte, err error) {
 	return []byte(base64.StdEncoding.EncodeToString(h[:])), nil
 }
 
 // UnmarshalText decodes a text marshaled Hash.
-func (h *typedHash) UnmarshalText(text []byte) error {
+func (h *TypedHash) UnmarshalText(text []byte) error {
 	b, err := base64.StdEncoding.DecodeString(string(text))
 	if err != nil {
 		return err
@@ -55,7 +56,7 @@ func (h *typedHash) UnmarshalText(text []byte) error {
 }
 
 // UnmarshalHex deserializes a hexadecimal text string into the given type.
-func (h *typedHash) UnmarshalHex(text string) error {
+func (h *TypedHash) UnmarshalHex(text string) error {
 	b, err := hex.DecodeString(text)
 	if err != nil {
 		return err
@@ -65,44 +66,44 @@ func (h *typedHash) UnmarshalHex(text string) error {
 }
 
 // Equal compares vs another hash for equality.
-func (h *typedHash) Equal(cmp *typedHash) bool {
+func (h *TypedHash) Equal(cmp *TypedHash) bool {
 	if cmp == nil {
 		return false
 	}
-	return subtle.ConstantTimeCompare(h[:], cmp[:]) == 1
+	return bytes.Equal(h[:], cmp[:])
 }
 
 // String returns the string representation of a typed hash.
-func (h typedHash) String() string {
+func (h TypedHash) String() string {
 	return fmt.Sprintf("%v:%s", node.RootType(h[0]), hex.EncodeToString(h[1:]))
 }
 
 // FromParts returns the typed hash composed of the given type and hash.
-func (h *typedHash) FromParts(typ node.RootType, hash hash.Hash) {
+func (h *TypedHash) FromParts(typ node.RootType, hash hash.Hash) {
 	h[0] = byte(typ)
 	copy(h[1:], hash[:])
 }
 
 // Type returns the storage type of the root corresponding to this typed hash.
-func (h *typedHash) Type() node.RootType {
+func (h *TypedHash) Type() node.RootType {
 	return node.RootType(h[0])
 }
 
 // Hash returns the hash portion of the typed hash.
-func (h *typedHash) Hash() (rh hash.Hash) {
+func (h *TypedHash) Hash() (rh hash.Hash) {
 	copy(rh[:], h[1:])
 	return
 }
 
-// typedHashFromParts creates a new typed hash with the parts given.
-func typedHashFromParts(typ node.RootType, hash hash.Hash) (h typedHash) {
+// TypedHashFromParts creates a new typed hash with the parts given.
+func TypedHashFromParts(typ node.RootType, hash hash.Hash) (h TypedHash) {
 	h[0] = byte(typ)
 	copy(h[1:], hash[:])
 	return
 }
 
-// typedHashFromRoot creates a new typed hash corresponding to the given storage root.
-func typedHashFromRoot(root node.Root) (h typedHash) {
+// TypedHashFromRoot creates a new typed hash corresponding to the given storage root.
+func TypedHashFromRoot(root node.Root) (h TypedHash) {
 	h[0] = byte(root.Type)
 	copy(h[1:], root.Hash[:])
 	return

--- a/go/storage/mkvs/db/badger/badger.go
+++ b/go/storage/mkvs/db/badger/badger.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v4"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	cmnBadger "github.com/oasisprotocol/oasis-core/go/common/badger"

--- a/go/storage/mkvs/db/badger/badger.go
+++ b/go/storage/mkvs/db/badger/badger.go
@@ -40,7 +40,7 @@ var (
 	// old root).
 	//
 	// Value is CBOR-serialized write log.
-	writeLogKeyFmt = keyFormat.New(0x01, uint64(0), &typedHash{}, &typedHash{})
+	writeLogKeyFmt = keyFormat.New(0x01, uint64(0), &api.TypedHash{}, &api.TypedHash{})
 	// rootsMetadataKeyFmt is the key format for roots metadata. The key format is (version).
 	//
 	// Value is CBOR-serialized rootsMetadata.
@@ -50,7 +50,7 @@ var (
 	// the finalized roots. They key format is (version, root).
 	//
 	// Value is CBOR-serialized []updatedNode.
-	rootUpdatedNodesKeyFmt = keyFormat.New(0x03, uint64(0), &typedHash{})
+	rootUpdatedNodesKeyFmt = keyFormat.New(0x03, uint64(0), &api.TypedHash{})
 	// metadataKeyFmt is the key format for metadata.
 	//
 	// Value is CBOR-serialized metadata.
@@ -61,11 +61,11 @@ var (
 	// with these entries.
 	//
 	// Value is empty.
-	multipartRestoreNodeLogKeyFmt = keyFormat.New(0x05, &typedHash{})
+	multipartRestoreNodeLogKeyFmt = keyFormat.New(0x05, &api.TypedHash{})
 	// rootNodeKeyFmt is the key format for root nodes (typed node hash).
 	//
 	// Value is empty.
-	rootNodeKeyFmt = keyFormat.New(0x06, &typedHash{})
+	rootNodeKeyFmt = keyFormat.New(0x06, &api.TypedHash{})
 )
 
 // New creates a new BadgerDB-backed node database.
@@ -184,7 +184,7 @@ func (d *badgerNodeDB) sanityCheckNamespace(ns common.Namespace) error {
 }
 
 func (d *badgerNodeDB) checkRoot(txn *badger.Txn, root node.Root) error {
-	rootHash := typedHashFromRoot(root)
+	rootHash := api.TypedHashFromRoot(root)
 	if _, err := txn.Get(rootNodeKeyFmt.Encode(&rootHash)); err != nil {
 		switch err {
 		case badger.ErrKeyNotFound:
@@ -232,7 +232,7 @@ func (d *badgerNodeDB) cleanMultipartLocked(removeNodes bool) error {
 				d.logger.Info("removing some nodes from a multipart restore")
 				logged = true
 			}
-			var hash typedHash
+			var hash api.TypedHash
 			if !multipartRestoreNodeLogKeyFmt.Decode(key, &hash) {
 				panic("mkvs/badger: bad iterator")
 			}
@@ -361,14 +361,14 @@ func (d *badgerNodeDB) GetWriteLog(ctx context.Context, startRoot, endRoot node.
 
 	type wlItem struct {
 		depth       uint8
-		endRootHash typedHash
+		endRootHash api.TypedHash
 		logKeys     [][]byte
-		logRoots    []typedHash
+		logRoots    []api.TypedHash
 	}
 	// NOTE: We could use a proper deque, but as long as we keep the number of hops and
 	//       forks low, this should not be a problem.
-	queue := []*wlItem{{depth: 0, endRootHash: typedHashFromRoot(endRoot)}}
-	startRootHash := typedHashFromRoot(startRoot)
+	queue := []*wlItem{{depth: 0, endRootHash: api.TypedHashFromRoot(endRoot)}}
+	startRootHash := api.TypedHashFromRoot(startRoot)
 	for len(queue) > 0 {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
@@ -391,8 +391,8 @@ func (d *badgerNodeDB) GetWriteLog(ctx context.Context, startRoot, endRoot node.
 				item := it.Item()
 
 				var decVersion uint64
-				var decEndRootHash typedHash
-				var decStartRootHash typedHash
+				var decEndRootHash api.TypedHash
+				var decStartRootHash api.TypedHash
 
 				if !writeLogKeyFmt.Decode(item.Key(), &decVersion, &decEndRootHash, &decStartRootHash) {
 					// This should not happen as the Badger iterator should take care of it.
@@ -527,7 +527,7 @@ func (d *badgerNodeDB) HasRoot(root node.Root) bool {
 		panic(err)
 	}
 
-	_, exists := rootsMeta.Roots[typedHashFromRoot(root)]
+	_, exists := rootsMeta.Roots[api.TypedHashFromRoot(root)]
 	return exists
 }
 
@@ -567,12 +567,12 @@ func (d *badgerNodeDB) Finalize(roots []node.Root) error { // nolint: gocyclo
 
 	// Determine the set of finalized roots. Finalization is transitive, so if
 	// a parent root is finalized the child should be considered finalized too.
-	finalizedRoots := make(map[typedHash]bool)
+	finalizedRoots := make(map[api.TypedHash]bool)
 	for _, root := range roots {
 		if root.Version != version {
 			return fmt.Errorf("mkvs/badger: roots to finalize don't have matching versions")
 		}
-		finalizedRoots[typedHashFromRoot(root)] = true
+		finalizedRoots[api.TypedHashFromRoot(root)] = true
 	}
 
 	var rootsChanged bool
@@ -1016,7 +1016,7 @@ func (ba *badgerBatch) Commit(root node.Root) error {
 		return err
 	}
 
-	rootHash := typedHashFromRoot(root)
+	rootHash := api.TypedHashFromRoot(root)
 	if err = ba.bat.Set(rootNodeKeyFmt.Encode(&rootHash), []byte{}); err != nil {
 		return err
 	}
@@ -1037,7 +1037,7 @@ func (ba *badgerBatch) Commit(root node.Root) error {
 		}
 	} else {
 		// Create root with no derived roots.
-		rootsMeta.Roots[rootHash] = []typedHash{}
+		rootsMeta.Roots[rootHash] = []api.TypedHash{}
 
 		if err = rootsMeta.save(tx); err != nil {
 			return fmt.Errorf("mkvs/badger: failed to save roots metadata: %w", err)
@@ -1052,7 +1052,7 @@ func (ba *badgerBatch) Commit(root node.Root) error {
 		}
 	} else {
 		// Update the root link for the old root.
-		oldRootHash := typedHashFromRoot(ba.oldRoot)
+		oldRootHash := api.TypedHashFromRoot(ba.oldRoot)
 		if !ba.oldRoot.Hash.IsEmpty() {
 			if ba.oldRoot.Version < ba.db.meta.getEarliestVersion() && ba.oldRoot.Version != root.Version {
 				return api.ErrPreviousVersionMismatch
@@ -1139,7 +1139,7 @@ func (s *badgerSubtree) PutNode(_ node.Depth, ptr *node.Pointer) error {
 	nodeKey := nodeKeyFmt.Encode(&h)
 	if s.batch.multipartNodes != nil {
 		if _, err = s.batch.readTxn.Get(nodeKey); err != nil && errors.Is(err, badger.ErrKeyNotFound) {
-			th := typedHashFromParts(node.RootTypeInvalid, h)
+			th := api.TypedHashFromParts(node.RootTypeInvalid, h)
 			if err = s.batch.multipartNodes.Set(multipartRestoreNodeLogKeyFmt.Encode(&th), []byte{}); err != nil {
 				return err
 			}

--- a/go/storage/mkvs/db/badger/badger_test.go
+++ b/go/storage/mkvs/db/badger/badger_test.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v4"
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/oasis-core/go/common"

--- a/go/storage/mkvs/db/badger/check.go
+++ b/go/storage/mkvs/db/badger/check.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v4"
 
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"

--- a/go/storage/mkvs/db/badger/check.go
+++ b/go/storage/mkvs/db/badger/check.go
@@ -123,7 +123,7 @@ func checkSanityInternal(ctx context.Context, db *badgerNodeDB, display DisplayH
 		hashes: map[hash.Hash]*list.Element{},
 	}
 
-	lastRoots := make(map[typedHash]uint64)
+	lastRoots := make(map[api.TypedHash]uint64)
 	for it.Seek(lastRootsMetadataKey); it.Valid(); it.Next() {
 		rootsMeta := &rootsMetadata{}
 		if !rootsMetadataKeyFmt.Decode(it.Item().Key(), &version) {
@@ -187,7 +187,7 @@ func checkSanityInternal(ctx context.Context, db *badgerNodeDB, display DisplayH
 	defer it.Close()
 
 	for it.Rewind(); it.Valid(); it.Next() {
-		var srcRoot, dstRoot typedHash
+		var srcRoot, dstRoot api.TypedHash
 		if !writeLogKeyFmt.Decode(it.Item().Key(), &version, &dstRoot, &srcRoot) {
 			return fmt.Errorf("mkvs/badger/check: undecodable write log key (%v) at item version %d", it.Item().Key(), it.Item().Version())
 		}

--- a/go/storage/mkvs/db/badger/factory.go
+++ b/go/storage/mkvs/db/badger/factory.go
@@ -1,0 +1,18 @@
+package badger
+
+import "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
+
+// Factory is the node database factory for the Badger backend.
+var Factory = &factory{}
+
+type factory struct{}
+
+// New implements api.Factory.
+func (f *factory) New(cfg *api.Config) (api.NodeDB, error) {
+	return New(cfg)
+}
+
+// Name implements api.Factory.
+func (f *factory) Name() string {
+	return "badger"
+}

--- a/go/storage/mkvs/db/badger/helpers.go
+++ b/go/storage/mkvs/db/badger/helpers.go
@@ -1,8 +1,8 @@
 package badger
 
 import (
-	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/badger/v3/options"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/options"
 
 	cmnBadger "github.com/oasisprotocol/oasis-core/go/common/badger"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"

--- a/go/storage/mkvs/db/badger/helpers.go
+++ b/go/storage/mkvs/db/badger/helpers.go
@@ -33,7 +33,6 @@ func commonConfigToBadgerOptions(cfg *api.Config, db *badgerNodeDB) badger.Optio
 	opts = opts.WithSyncWrites(!cfg.NoFsync)
 	opts = opts.WithCompression(options.Snappy)
 	if cfg.MaxCacheSize == 0 {
-		// Default to 64mb block cache size if not configured to avoid a panic.
 		opts = opts.WithBlockCacheSize(64 * 1024 * 1024)
 	} else {
 		opts = opts.WithBlockCacheSize(cfg.MaxCacheSize)

--- a/go/storage/mkvs/db/badger/metadata.go
+++ b/go/storage/mkvs/db/badger/metadata.go
@@ -9,6 +9,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
 )
 
 // serializedMetadata is the on-disk serialized metadata.
@@ -115,7 +116,7 @@ type rootsMetadata struct {
 	_ struct{} `cbor:",toarray"`
 
 	// Roots is the map of a root created in a version to any derived roots (in this or later versions).
-	Roots map[typedHash][]typedHash
+	Roots map[api.TypedHash][]api.TypedHash
 
 	// version is the version this metadata is for.
 	version uint64
@@ -131,7 +132,7 @@ func loadRootsMetadata(tx *badger.Txn, version uint64) (*rootsMetadata, error) {
 			return nil, fmt.Errorf("mkvs/badger: error reading roots metadata: %w", err)
 		}
 	case badger.ErrKeyNotFound:
-		rootsMeta.Roots = make(map[typedHash][]typedHash)
+		rootsMeta.Roots = make(map[api.TypedHash][]api.TypedHash)
 	default:
 		return nil, fmt.Errorf("mkvs/badger: error reading roots metadata: %w", err)
 	}

--- a/go/storage/mkvs/db/badger/metadata.go
+++ b/go/storage/mkvs/db/badger/metadata.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v4"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"

--- a/go/storage/mkvs/db/badger/migrate.go
+++ b/go/storage/mkvs/db/badger/migrate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v4"
 
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"

--- a/go/storage/mkvs/db/badger/migrate.go
+++ b/go/storage/mkvs/db/badger/migrate.go
@@ -339,7 +339,7 @@ func (v4 *v4Migrator) keyRootsMetadata(item *badger.Item) error { // nolint: goc
 	// Create root typing keys.
 	for h, types := range plainRoots {
 		for t := range types {
-			th := typedHashFromParts(t, h)
+			th := api.TypedHashFromParts(t, h)
 			entry := badger.NewEntry(
 				v4RootNodeKeyFmt.Encode(&th),
 				[]byte{},
@@ -352,15 +352,15 @@ func (v4 *v4Migrator) keyRootsMetadata(item *badger.Item) error { // nolint: goc
 
 	// Build new roots structure.
 	var newRoots v4RootsMetadata
-	newRoots.Roots = map[typedHash][]typedHash{}
+	newRoots.Roots = map[api.TypedHash][]api.TypedHash{}
 	for root, chain := range rootsMeta.Roots {
 		for typ := range plainRoots[root] {
-			arr := make([]typedHash, 0, len(chain))
+			arr := make([]api.TypedHash, 0, len(chain))
 			for _, droot := range chain {
-				th := typedHashFromParts(typ, droot)
+				th := api.TypedHashFromParts(typ, droot)
 				arr = append(arr, th)
 			}
-			th := typedHashFromParts(typ, root)
+			th := api.TypedHashFromParts(typ, root)
 			newRoots.Roots[th] = arr
 		}
 	}
@@ -380,7 +380,7 @@ func (v4 *v4Migrator) keyRootsMetadata(item *badger.Item) error { // nolint: goc
 func (v4 *v4Migrator) keyWriteLog(item *badger.Item) error {
 	var version uint64
 	var h1, h2 hash.Hash
-	var th1, th2 typedHash
+	var th1, th2 api.TypedHash
 	if !v3WriteLogKeyFmt.Decode(item.Key(), &version, &h1, &h2) {
 		return fmt.Errorf("error decoding writelog key")
 	}
@@ -449,7 +449,7 @@ func (v4 *v4Migrator) keyRootUpdatedNodes(item *badger.Item) error {
 	}
 	if item.IsDeletedOrExpired() {
 		for _, typ := range types {
-			th := typedHashFromParts(typ, h1)
+			th := api.TypedHashFromParts(typ, h1)
 			key := v4RootUpdatedNodesKeyFmt.Encode(version, &th)
 			if err = v4.changeBatch.DeleteAt(key, item.Version()); err != nil {
 				return fmt.Errorf("error transforming removed updated nodes list for root %v: %w", th, err)
@@ -475,7 +475,7 @@ func (v4 *v4Migrator) keyRootUpdatedNodes(item *badger.Item) error {
 	}
 
 	for _, typ := range types {
-		th := typedHashFromParts(typ, h1)
+		th := api.TypedHashFromParts(typ, h1)
 
 		if v4.meta.MultipartActive {
 			entry := badger.NewEntry(
@@ -521,7 +521,7 @@ func (v4 *v4Migrator) keyMultipartRestoreNodeLog(item *badger.Item) error {
 	if err := v4.changeBatch.DeleteAt(item.KeyCopy(nil), item.Version()); err != nil {
 		return fmt.Errorf("can't delete old multipart restore log key for %v: %w", h, err)
 	}
-	th := typedHashFromParts(node.RootTypeInvalid, h)
+	th := api.TypedHashFromParts(node.RootTypeInvalid, h)
 	entry := badger.NewEntry(
 		v4MultipartRestoreNodeLogKeyFmt.Encode(&th),
 		[]byte{},
@@ -701,16 +701,16 @@ func (v4 *v4Migrator) Migrate() (rversion uint64, rerr error) {
 }
 
 type v5MigratedRoot struct {
-	Hash    typedHash `json:"hash"`
-	Version uint64    `json:"version"`
+	Hash    api.TypedHash `json:"hash"`
+	Version uint64        `json:"version"`
 }
 
 type v5MigratorMetadata struct {
 	migrationCommonMeta
 
-	LastMigratedVersion *uint64                      `json:"last_migrated_version"`
-	LastMigratedRoots   map[typedHash]v5MigratedRoot `json:"last_migrated_roots"`
-	LastPrunedVersion   *uint64                      `json:"last_pruned_version"`
+	LastMigratedVersion *uint64                          `json:"last_migrated_version"`
+	LastMigratedRoots   map[api.TypedHash]v5MigratedRoot `json:"last_migrated_roots"`
+	LastPrunedVersion   *uint64                          `json:"last_pruned_version"`
 }
 
 func (m *v5MigratorMetadata) load(db *badger.DB) error {
@@ -952,7 +952,7 @@ func (v5 *v5Migrator) migrateNode(h hash.Hash, version uint64) (*hash.Hash, erro
 	return &newHash, nil
 }
 
-func (v5 *v5Migrator) migrateWriteLog(oldSrcRoot, oldDstRoot, newSrcRoot typedHash, newDstRoot v5MigratedRoot) error {
+func (v5 *v5Migrator) migrateWriteLog(oldSrcRoot, oldDstRoot, newSrcRoot api.TypedHash, newDstRoot v5MigratedRoot) error {
 	item, err := v5.readTxn.Get(v4WriteLogKeyFmt.Encode(newDstRoot.Version, &oldDstRoot, &oldSrcRoot))
 	switch err {
 	case nil:
@@ -983,7 +983,7 @@ func (v5 *v5Migrator) migrateWriteLog(oldSrcRoot, oldDstRoot, newSrcRoot typedHa
 	return nil
 }
 
-func (v5 *v5Migrator) migrateVersion(version uint64, migratedRoots map[typedHash]v5MigratedRoot) (bool, error) {
+func (v5 *v5Migrator) migrateVersion(version uint64, migratedRoots map[api.TypedHash]v5MigratedRoot) (bool, error) {
 	defer func() {
 		v5.readTxn.Discard()
 		v5.readTxn = v5.db.db.NewTransactionAt(maxTimestamp, false)
@@ -1008,7 +1008,7 @@ func (v5 *v5Migrator) migrateVersion(version uint64, migratedRoots map[typedHash
 		return false, fmt.Errorf("error decoding roots metadata for version %d: %w", version, err)
 	}
 
-	newRoots := make(map[typedHash][]typedHash)
+	newRoots := make(map[api.TypedHash][]api.TypedHash)
 	for root := range roots.Roots {
 		// Migrate the tree (if not empty).
 		var newRootHash hash.Hash
@@ -1023,14 +1023,14 @@ func (v5 *v5Migrator) migrateVersion(version uint64, migratedRoots map[typedHash
 			newRootHash.Empty()
 		}
 
-		newRoot := typedHashFromParts(root.Type(), newRootHash)
-		newRoots[newRoot] = []typedHash{}
+		newRoot := api.TypedHashFromParts(root.Type(), newRootHash)
+		newRoots[newRoot] = []api.TypedHash{}
 		migratedRoots[root] = v5MigratedRoot{Hash: newRoot, Version: version}
 
 		// Check for a write log from empty root.
 		var emptyHash hash.Hash
 		emptyHash.Empty()
-		emptyRoot := typedHashFromParts(root.Type(), emptyHash)
+		emptyRoot := api.TypedHashFromParts(root.Type(), emptyHash)
 
 		if err = v5.migrateWriteLog(emptyRoot, root, emptyRoot, migratedRoots[root]); err != nil {
 			return false, err
@@ -1227,7 +1227,7 @@ func (v5 *v5Migrator) pruneVersion(version uint64) error {
 	return v5.flush(false)
 }
 
-func (v5 *v5Migrator) pruneWriteLog(version uint64, oldRoot typedHash) error {
+func (v5 *v5Migrator) pruneWriteLog(version uint64, oldRoot api.TypedHash) error {
 	prefix := v4WriteLogKeyFmt.Encode(version, &oldRoot)
 	it := v5.readTxn.NewIterator(badger.IteratorOptions{Prefix: prefix})
 	defer it.Close()
@@ -1307,7 +1307,7 @@ func (v5 *v5Migrator) Migrate() (rversion uint64, rerr error) {
 	v4RootsMetadataKeyFmt.Decode(it.Item().Key(), &lastVersion)
 	it.Close()
 
-	migratedRoots := make(map[typedHash]v5MigratedRoot)
+	migratedRoots := make(map[api.TypedHash]v5MigratedRoot)
 	if lv := v5.meta.LastMigratedVersion; lv != nil {
 		// Resume at the following version.
 		lastVersion = *lv - 1

--- a/go/storage/mkvs/db/badger/migrate_test.go
+++ b/go/storage/mkvs/db/badger/migrate_test.go
@@ -307,7 +307,7 @@ func TestBadgerV5SharedRoots(t *testing.T) {
 		node.RootTypeState,
 		node.RootTypeIO,
 	}
-	for round := uint64(1); round < rounds; round++ {
+	for round := uint64(1); round < rounds-1; round++ {
 		// Check key accessibility for this round.
 		for _, typ := range allTypes {
 			root := node.Root{
@@ -333,7 +333,7 @@ func TestBadgerV5SharedRoots(t *testing.T) {
 		require.NoError(t, err, fmt.Sprintf("checkSanityInternal/%d", round))
 
 		// Try pruning, then move on. The following rounds should all still work.
-		err = ndb.Prune(ctx, round)
+		err = ndb.Prune(round)
 		require.NoError(t, err, fmt.Sprintf("Prune/%d", round))
 	}
 	// prettyPrintDBV5(ndb)
@@ -383,7 +383,7 @@ func TestBadgerV5ToEmpty(t *testing.T) {
 		node.RootTypeState,
 		node.RootTypeIO,
 	}
-	for round := uint64(1); round < rounds; round++ {
+	for round := uint64(1); round < rounds-1; round++ {
 		// Check key accessibility for this round.
 		for _, typ := range allTypes {
 			root := node.Root{
@@ -409,7 +409,7 @@ func TestBadgerV5ToEmpty(t *testing.T) {
 		require.NoError(t, err, fmt.Sprintf("checkSanityInternal/%d", round))
 
 		// Try pruning, then move on. The following rounds should all still work.
-		err = ndb.Prune(ctx, round)
+		err = ndb.Prune(round)
 		require.NoError(t, err, fmt.Sprintf("Prune/%d", round))
 	}
 	// prettyPrintDBV5(ndb)

--- a/go/storage/mkvs/db/badger/migrate_test.go
+++ b/go/storage/mkvs/db/badger/migrate_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v4"
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"

--- a/go/storage/mkvs/db/badger/migrate_test.go
+++ b/go/storage/mkvs/db/badger/migrate_test.go
@@ -452,7 +452,7 @@ func TestBadgerV5KeyVersioning(t *testing.T) {
 	}
 
 	var h hash.Hash
-	var th1, th2 typedHash
+	var th1, th2 api.TypedHash
 	var v uint64
 
 	for it.Rewind(); it.Valid(); it.Next() {
@@ -497,7 +497,7 @@ func prettyPrintDBV5(ndb api.NodeDB) { // nolint: deadcode, unused
 	defer it.Close()
 
 	var h hash.Hash
-	var th1, th2 typedHash
+	var th1, th2 api.TypedHash
 	var v uint64
 
 	for it.Rewind(); it.Valid(); it.Next() {

--- a/go/storage/mkvs/db/badger/rename.go
+++ b/go/storage/mkvs/db/badger/rename.go
@@ -3,7 +3,7 @@ package badger
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v4"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"

--- a/go/storage/mkvs/db/db.go
+++ b/go/storage/mkvs/db/db.go
@@ -1,1 +1,34 @@
 package db
+
+import (
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
+	backendBadger "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/badger"
+	backendPathBadger "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/pathbadger"
+)
+
+// Backends contains the factories for all the backend implementations.
+var Backends = []api.Factory{
+	backendBadger.Factory,
+	backendPathBadger.Factory,
+}
+
+// GetBackendByName returns the backend implementation factory with the given name.
+func GetBackendByName(name string) (api.Factory, error) {
+	for _, factory := range Backends {
+		if name == factory.Name() {
+			return factory, nil
+		}
+	}
+	return nil, fmt.Errorf("unsupported node database backend: %s", name)
+}
+
+// New creates a given named database backend.
+func New(name string, cfg *api.Config) (api.NodeDB, error) {
+	factory, err := GetBackendByName(name)
+	if err != nil {
+		return nil, err
+	}
+	return factory.New(cfg)
+}

--- a/go/storage/mkvs/db/pathbadger/config.go
+++ b/go/storage/mkvs/db/pathbadger/config.go
@@ -1,0 +1,32 @@
+package pathbadger
+
+import (
+	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/options"
+
+	cmnBadger "github.com/oasisprotocol/oasis-core/go/common/badger"
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
+)
+
+// commonConfigToBadgerOptions prepares a badger option struct with common options.
+func commonConfigToBadgerOptions(cfg *api.Config, logger *logging.Logger) badger.Options {
+	opts := badger.DefaultOptions(cfg.DB)
+	opts = opts.WithLogger(cmnBadger.NewLogAdapter(logger))
+	opts = opts.WithSyncWrites(!cfg.NoFsync)
+	opts = opts.WithCompression(options.Snappy)
+	if cfg.MaxCacheSize == 0 {
+		opts = opts.WithBlockCacheSize(64 * 1024 * 1024)
+	} else {
+		opts = opts.WithBlockCacheSize(cfg.MaxCacheSize)
+	}
+	opts = opts.WithReadOnly(cfg.ReadOnly)
+	opts = opts.WithDetectConflicts(false)
+
+	if cfg.MemoryOnly {
+		logger.Warn("using memory-only mode, data will not be persisted")
+		opts = opts.WithInMemory(true).WithDir("").WithValueDir("")
+	}
+
+	return opts
+}

--- a/go/storage/mkvs/db/pathbadger/factory.go
+++ b/go/storage/mkvs/db/pathbadger/factory.go
@@ -1,0 +1,18 @@
+package pathbadger
+
+import "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
+
+// Factory is the node database factory for the PathBadger backend.
+var Factory = &factory{}
+
+type factory struct{}
+
+// New implements api.Factory.
+func (f *factory) New(cfg *api.Config) (api.NodeDB, error) {
+	return New(cfg)
+}
+
+// Name implements api.Factory.
+func (f *factory) Name() string {
+	return "pathbadger"
+}

--- a/go/storage/mkvs/db/pathbadger/keyformat.go
+++ b/go/storage/mkvs/db/pathbadger/keyformat.go
@@ -1,0 +1,56 @@
+package pathbadger
+
+import (
+	"github.com/oasisprotocol/oasis-core/go/common/keyformat"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
+)
+
+var (
+	// keyFormat is the namespace for the pathbadger database key formats.
+	keyFormat = keyformat.NewNamespace("pathbadger")
+
+	// metadataKeyFmt is the key format for metadata.
+	//
+	// Value is CBOR-serialized metadata.
+	metadataKeyFmt = keyFormat.New(0x00)
+
+	// writeLogKeyFmt is the key format for write logs: (version, dst root, src root).
+	//
+	// Value is CBOR-serialized internalWriteLog.
+	writeLogKeyFmt = keyFormat.New(0x01, uint64(0), &api.TypedHash{}, &api.TypedHash{})
+
+	// rootUpdatedNodesKeyFmt is the key format for the pending updated nodes for the given root
+	// that need to be removed only in case the given root is not among the finalized roots. The
+	// key format is (version, root).
+	//
+	// Value is CBOR-serialized []updatedNode.
+	rootUpdatedNodesKeyFmt = keyFormat.New(0x02, uint64(0), &api.TypedHash{})
+
+	// rootNodeKeyFmt is the key format for root nodes: (version, typed node hash).
+	//
+	// Value is the serialized root node.
+	rootNodeKeyFmt = keyFormat.New(0x03, uint64(0), &api.TypedHash{})
+
+	// finalizedNodeKeyFmt is the key format for finalized nodes and pending nodes at zero seqNo.
+	// The latter is done optimistically so in the common case where there are no forks, no copying
+	// of nodes from pending to finalized is needed. The key format is (type, path).
+	//
+	// Value is the serialized node.
+	finalizedNodeKeyFmt = keyFormat.New(0x04, byte(0), []byte{})
+
+	// pendingNodeKeyFmt is the key format for pending nodes at seqNo > 0 which will be discarded
+	// after the version is finalized. In case a non-zero seqNo is finalized, these nodes will need
+	// to first be copied over to the finalizedNode set during finalization. The key format is
+	// (version, type, seqNo, path).
+	//
+	// Value is the serialized node.
+	pendingNodeKeyFmt = keyFormat.New(0x05, uint64(0), byte(0), uint16(0), []byte{})
+
+	// multipartRestoreNodeLogKeyFmt is the key format for the nodes inserted during a chunk
+	// restore. Once a set of chunks is fully restored, these entries should be removed. If chunk
+	// restoration is interrupted for any reason, the nodes associated with these keys should be
+	// removed, along with these entries.
+	//
+	// Value is empty.
+	multipartRestoreNodeLogKeyFmt = keyFormat.New(0x06, byte(0), []byte{})
+)

--- a/go/storage/mkvs/db/pathbadger/metadata.go
+++ b/go/storage/mkvs/db/pathbadger/metadata.go
@@ -1,0 +1,193 @@
+package pathbadger
+
+import (
+	"fmt"
+	"math"
+	"sync"
+
+	"github.com/dgraph-io/badger/v4"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
+)
+
+// maxPendingVersions is the maximum number of allowed non-finalized versions. Increasing this too
+// much can result in the metadata growing too much.
+const maxPendingVersions = 5000
+
+// serializedMetadata is the on-disk serialized metadata.
+type serializedMetadata struct {
+	// Version is the database schema version.
+	Version uint64 `json:"version"`
+	// Namespace is the namespace this database is for.
+	Namespace common.Namespace `json:"namespace"`
+
+	// EarliestVersion is the earliest version.
+	EarliestVersion uint64 `json:"earliest_version"`
+	// LastFinalizedVersion is the last finalized version.
+	LastFinalizedVersion *uint64 `json:"last_finalized_version"`
+	// MultipartVersion is the version for the in-progress multipart restore, or 0 if none was in
+	// progress.
+	MultipartVersion uint64 `json:"multipart_version,omitempty"`
+	// MultipartSeqs are the sequence numbers used for the multipart restore.
+	MultipartSeqs map[uint8]uint16 `json:"multipart_seqs,omitempty"`
+
+	// NextPendingRootSeq contains the next pending root sequence number for a given type in the
+	// given version.
+	NextPendingRootSeq map[uint64]map[uint8]uint16 `json:"next_pending_root_seq,omitempty"`
+	// PendingRootSeqs contains the set of all non-finalized roots in the next version.
+	PendingRootSeqs map[uint64]map[api.TypedHash]uint16 `json:"pending_root_seqs,omitempty"`
+}
+
+// metadata is the database metadata.
+type metadata struct {
+	sync.RWMutex
+
+	value serializedMetadata
+}
+
+func (m *metadata) getEarliestVersion() uint64 {
+	m.RLock()
+	defer m.RUnlock()
+
+	return m.value.EarliestVersion
+}
+
+func (m *metadata) setEarliestVersion(version uint64) {
+	m.Lock()
+	defer m.Unlock()
+
+	// The earliest version can only increase, not decrease.
+	if version < m.value.EarliestVersion {
+		panic(fmt.Errorf("mkvs/pathbadger: earliest version must only increase"))
+	}
+
+	m.value.EarliestVersion = version
+}
+
+func (m *metadata) getLastFinalizedVersion() (uint64, bool) {
+	m.RLock()
+	defer m.RUnlock()
+
+	if m.value.LastFinalizedVersion == nil {
+		return 0, false
+	}
+	return *m.value.LastFinalizedVersion, true
+}
+
+func (m *metadata) setLastFinalizedVersion(version uint64) {
+	m.Lock()
+	defer m.Unlock()
+
+	if m.value.LastFinalizedVersion != nil && version <= *m.value.LastFinalizedVersion {
+		// Note that we cannot use a more strict check here because forward jumps are allowed in
+		// case of multipart restore.
+		return
+	}
+
+	if m.value.LastFinalizedVersion == nil {
+		m.value.EarliestVersion = version
+	}
+
+	m.value.LastFinalizedVersion = &version
+	delete(m.value.NextPendingRootSeq, version)
+	delete(m.value.PendingRootSeqs, version)
+}
+
+func (m *metadata) getMultipart() (uint64, map[uint8]uint16) {
+	m.RLock()
+	defer m.RUnlock()
+
+	return m.value.MultipartVersion, m.value.MultipartSeqs
+}
+
+func (m *metadata) setMultipart(version uint64, meta map[uint8]*multipartMeta) {
+	m.Lock()
+	defer m.Unlock()
+
+	m.value.MultipartVersion = version
+
+	switch meta {
+	case nil:
+		m.value.MultipartSeqs = nil
+	default:
+		m.value.MultipartSeqs = make(map[uint8]uint16)
+		for t, md := range meta {
+			m.value.MultipartSeqs[t] = md.seqNo
+		}
+	}
+}
+
+func (m *metadata) reserveRootSeqNo(version uint64, rootType uint8) (uint16, error) {
+	m.Lock()
+	defer m.Unlock()
+
+	if len(m.value.NextPendingRootSeq) >= maxPendingVersions {
+		return math.MaxUint16, fmt.Errorf("mkvs/pathbadger: too many non-finalized versions")
+	}
+
+	if m.value.NextPendingRootSeq == nil {
+		m.value.NextPendingRootSeq = make(map[uint64]map[uint8]uint16)
+	}
+	if m.value.NextPendingRootSeq[version] == nil {
+		m.value.NextPendingRootSeq[version] = make(map[uint8]uint16)
+	}
+	seqNo := m.value.NextPendingRootSeq[version][rootType]
+	if seqNo == math.MaxUint16 {
+		return math.MaxUint16, fmt.Errorf("mkvs/pathbadger: too many non-finalized roots in version %d", version)
+	}
+	m.value.NextPendingRootSeq[version][rootType]++
+
+	return seqNo, nil
+}
+
+func (m *metadata) setPendingRootSeqNo(version uint64, rootHash api.TypedHash, seqNo uint16) error {
+	m.Lock()
+	defer m.Unlock()
+
+	if len(m.value.PendingRootSeqs) >= maxPendingVersions {
+		return fmt.Errorf("mkvs/pathbadger: too many non-finalized versions")
+	}
+
+	if m.value.PendingRootSeqs == nil {
+		m.value.PendingRootSeqs = make(map[uint64]map[api.TypedHash]uint16)
+	}
+	if m.value.PendingRootSeqs[version] == nil {
+		m.value.PendingRootSeqs[version] = make(map[api.TypedHash]uint16)
+	}
+	m.value.PendingRootSeqs[version][rootHash] = seqNo
+
+	return nil
+}
+
+func (m *metadata) getPendingRootSeqNo(version uint64, rootHash api.TypedHash) (uint16, bool) {
+	m.Lock()
+	defer m.Unlock()
+
+	seqNo, ok := m.value.PendingRootSeqs[version][rootHash]
+	return seqNo, ok
+}
+
+func (m *metadata) commit(tx *badger.Txn) {
+	// The only safe thing to do in case we cannot save metadata is to panic.
+	err := tx.Set(metadataKeyFmt.Encode(), cbor.Marshal(m.value))
+	if err != nil {
+		panic(fmt.Errorf("mkvs/pathbadger: failed to save metadata: %w", err))
+	}
+
+	err = tx.CommitAt(tsMetadata, nil)
+	if err != nil {
+		panic(fmt.Errorf("mkvs/pathbadger: failed to commit metadata: %w", err))
+	}
+}
+
+// updatedNode is an element of the root updated nodes key.
+//
+// NOTE: Public fields of this structure are part of the on-disk format.
+type updatedNode struct {
+	_ struct{} `cbor:",toarray"` // nolint
+
+	Removed bool
+	Key     []byte
+}

--- a/go/storage/mkvs/db/pathbadger/multipart.go
+++ b/go/storage/mkvs/db/pathbadger/multipart.go
@@ -1,0 +1,220 @@
+package pathbadger
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/dgraph-io/badger/v4"
+
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/node"
+)
+
+const (
+	// multipartVersionNone is the value used for the multipart version in metadata when no
+	// multipart restore is in progress.
+	multipartVersionNone uint64 = 0
+)
+
+// multipartMeta contains per-root-type metadata of an ongoing multipart insert operation.
+type multipartMeta struct {
+	seqNo     uint16
+	root      *api.TypedHash
+	lastIndex *atomic.Uint32
+
+	// mpLock is the lock that prevents multiple batches from being inserted concurrently. This is
+	// currently needed because otherwise it would result in corruptions due to merge conflicts.
+	mpLock sync.Mutex
+}
+
+// Implements api.NodeDB.
+func (d *badgerNodeDB) StartMultipartInsert(version uint64) error {
+	d.metaUpdateLock.Lock()
+	defer d.metaUpdateLock.Unlock()
+
+	if version == multipartVersionNone {
+		return api.ErrInvalidMultipartVersion
+	}
+
+	if d.multipartVersion != multipartVersionNone {
+		if d.multipartVersion != version {
+			return api.ErrMultipartInProgress
+		}
+		// Multipart already initialized at the same version, so this was probably called e.g. as
+		// part of a further checkpoint restore.
+		return nil
+	}
+
+	tx := d.db.NewTransactionAt(tsMetadata, true)
+	defer tx.Discard()
+
+	// Reserve sequence numbers for all root types.
+	multiMeta := make(map[uint8]*multipartMeta)
+	for _, rootType := range api.RootTypes() {
+		seqNo, err := d.meta.reserveRootSeqNo(version, uint8(rootType))
+		if err != nil {
+			return err
+		}
+
+		lastIndex := new(atomic.Uint32)
+		lastIndex.Store(indexRootNode)
+
+		multiMeta[uint8(rootType)] = &multipartMeta{
+			seqNo:     seqNo,
+			lastIndex: lastIndex,
+		}
+	}
+
+	d.meta.setMultipart(version, multiMeta)
+	d.meta.commit(tx)
+
+	d.multipartVersion = version
+	d.multipartMeta = multiMeta
+
+	return nil
+}
+
+// Implements api.NodeDB.
+func (d *badgerNodeDB) AbortMultipartInsert() error {
+	d.metaUpdateLock.Lock()
+	defer d.metaUpdateLock.Unlock()
+
+	return d.cleanMultipartLocked(true)
+}
+
+// Assumes metaUpdateLock is held when called.
+func (d *badgerNodeDB) cleanMultipartLocked(removeNodes bool) error {
+	var (
+		version uint64
+		seqs    map[uint8]uint16
+	)
+	if d.multipartVersion != multipartVersionNone {
+		version = d.multipartVersion
+		seqs = make(map[uint8]uint16)
+		for t, m := range d.multipartMeta {
+			seqs[t] = m.seqNo
+		}
+	} else {
+		version, seqs = d.meta.getMultipart()
+	}
+	if version == multipartVersionNone {
+		// No multipart in progress, but it's not an error to call in a situation like this.
+		return nil
+	}
+
+	txn := d.db.NewTransactionAt(tsMetadata, false)
+	defer txn.Discard()
+
+	opts := badger.DefaultIteratorOptions
+	opts.Prefix = multipartRestoreNodeLogKeyFmt.Encode()
+	it := txn.NewIterator(opts)
+	defer it.Close()
+
+	batch := d.db.NewWriteBatchAt(versionToTs(version))
+	defer batch.Cancel()
+
+	var logged bool
+	for it.Rewind(); it.Valid(); it.Next() {
+		key := it.Item().Key()
+		if removeNodes {
+			if !logged {
+				d.logger.Info("removing some nodes from a multipart restore")
+				logged = true
+			}
+			var (
+				rootType uint8
+				dbKey    []byte
+			)
+			if !multipartRestoreNodeLogKeyFmt.Decode(key, &rootType, &dbKey) {
+				panic("mkvs/pathbadger: corrupted key")
+			}
+
+			if seqNo := seqs[rootType]; seqNo == 0 {
+				if err := batch.Delete(finalizedNodeKeyFmt.Encode(rootType, dbKey)); err != nil {
+					return err
+				}
+			} else {
+				if err := batch.DeleteAt(pendingNodeKeyFmt.Encode(d.multipartVersion, rootType, seqNo, dbKey), tsMetadata); err != nil {
+					return err
+				}
+			}
+		}
+		if err := batch.DeleteAt(key, tsMetadata); err != nil {
+			return err
+		}
+	}
+
+	// Flush batch first. If anything fails, having corrupt multipart info in d.meta shouldn't hurt
+	// us next run.
+	if err := batch.Flush(); err != nil {
+		return err
+	}
+
+	metaTx := d.db.NewTransactionAt(tsMetadata, true)
+	defer metaTx.Discard()
+	d.meta.setMultipart(0, nil)
+	d.meta.commit(metaTx)
+
+	d.multipartVersion = multipartVersionNone
+	d.multipartMeta = nil
+	return nil
+}
+
+func (s *badgerSubtree) multipartMergeWithExisting(dbKey []byte, ptr *node.Pointer) error {
+	if dbKey == nil {
+		return nil
+	}
+
+	item, err := s.batch.readTxn.Get(dbKey)
+	switch {
+	case err == nil:
+	case err == badger.ErrKeyNotFound:
+		return nil
+	default:
+		return err
+	}
+
+	// If item already exists, we may need to merge both nodes.
+	intNode, ok := ptr.Node.(*node.InternalNode)
+	if !ok {
+		return nil
+	}
+
+	var n node.Node
+	if err = item.Value(func(val []byte) error {
+		var vErr error
+		n, vErr = nodeFromDb(val)
+		return vErr
+	}); err != nil {
+		return err
+	}
+
+	// Merge both nodes in case they are internal.
+	existingNode, ok := n.(*node.InternalNode)
+	if !ok {
+		return nil
+	}
+
+	// Merge any partial pointers.
+	for _, p := range []struct {
+		existing *node.Pointer
+		new      *node.Pointer
+	}{
+		{existingNode.Left, intNode.Left},
+		{existingNode.Right, intNode.Right},
+		{existingNode.LeafNode, intNode.LeafNode},
+	} {
+		if p.new == nil || p.existing == nil {
+			continue
+		}
+		if !p.existing.Hash.Equal(&p.new.Hash) { //nolint: gosec
+			continue
+		}
+		if p.existing.DBInternal == nil || p.new.DBInternal != nil {
+			continue
+		}
+		p.new.DBInternal = p.existing.DBInternal
+	}
+
+	return nil
+}

--- a/go/storage/mkvs/db/pathbadger/node.go
+++ b/go/storage/mkvs/db/pathbadger/node.go
@@ -1,0 +1,548 @@
+package pathbadger
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/dgraph-io/badger/v4"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/node"
+)
+
+// Database node serialization kind constants.
+const (
+	kindLeaf              = 1
+	kindInternalWithLeft  = 2
+	kindInternalWithRight = 3
+	kindInternalWithBoth  = 4
+)
+
+const (
+	// versionInvalid is an invalid node version.
+	versionInvalid = 0xffffffffffffffff
+
+	// indexRootNode is the index of the root node.
+	indexRootNode = 0
+	// indexInvalid is an invalid node index.
+	indexInvalid = 0xffffffff
+)
+
+// Implements api.NodeDB.
+func (d *badgerNodeDB) GetNode(root node.Root, ptr *node.Pointer) (node.Node, error) {
+	if ptr == nil || !ptr.IsClean() {
+		return nil, fmt.Errorf("mkvs/pathbadger: invalid node pointer")
+	}
+	if err := d.sanityCheckNamespace(&root.Namespace); err != nil {
+		return nil, err
+	}
+	// If the version is earlier than the earliest version, we don't have the node (it was pruned).
+	// Note that the key can still be present in the database until it gets compacted.
+	if root.Version < d.meta.getEarliestVersion() {
+		return nil, api.ErrNodeNotFound
+	}
+
+	tx := d.db.NewTransactionAt(versionToTs(root.Version), false)
+	defer tx.Discard()
+
+	// Check if the root actually exists.
+	if err := d.checkRootExists(tx, root); err != nil {
+		return nil, err
+	}
+	rootHash := api.TypedHashFromRoot(root)
+
+	var (
+		item  *badger.Item
+		dbKey []byte
+		err   error
+	)
+	switch {
+	case ptr.Hash.Equal(&root.Hash):
+		// Requesting the root node which is special.
+		item, err = tx.Get(rootNodeKeyFmt.Encode(root.Version, &rootHash))
+
+		ptr.DBInternal = &dbPtr{
+			version: root.Version,
+			index:   indexRootNode,
+		}
+	default:
+		// Requesting a different node, it must have come from us.
+		iptr, ok := ptr.DBInternal.(*dbPtr)
+		if !ok {
+			return nil, fmt.Errorf("mkvs/pathbadger: invalid node pointer not from this db")
+		}
+
+		// Determine sequence number for the root. All finalized roots use a seqNo of zero.
+		seqNo, _ := d.meta.getPendingRootSeqNo(root.Version, rootHash)
+
+		dbKey = iptr.dbKey()
+		if seqNo == 0 {
+			item, err = tx.Get(finalizedNodeKeyFmt.Encode(byte(root.Type), dbKey))
+		} else {
+			item, err = tx.Get(pendingNodeKeyFmt.Encode(root.Version, byte(root.Type), seqNo, dbKey))
+			if err == badger.ErrKeyNotFound {
+				// The node may be finalized, need to check the finalized version too.
+				item, err = tx.Get(finalizedNodeKeyFmt.Encode(byte(root.Type), dbKey))
+			}
+		}
+	}
+
+	switch err {
+	case nil:
+	case badger.ErrKeyNotFound:
+		return nil, api.ErrNodeNotFound
+	default:
+		d.logger.Error("failed to Get node from backing store",
+			"err", err,
+		)
+		return nil, fmt.Errorf("mkvs/pathbadger: failed to Get node from backing store: %w", err)
+	}
+
+	var n node.Node
+	if err = item.Value(func(val []byte) error {
+		var vErr error
+		n, vErr = nodeFromDb(val)
+		return vErr
+	}); err != nil {
+		d.logger.Error("failed to unmarshal node",
+			"err", err,
+		)
+		return nil, fmt.Errorf("mkvs/pathbadger: failed to unmarshal node: %w", err)
+	}
+
+	return n, nil
+}
+
+type badgerSubtree struct {
+	batch *badgerBatch
+}
+
+// Implements api.Subtree.
+func (s *badgerSubtree) Commit() error {
+	return nil
+}
+
+// Implements api.Subtree.
+func (s *badgerSubtree) VisitCleanNode(depth node.Depth, ptr *node.Pointer, parent *node.Pointer) error {
+	var needsPutNode bool
+	if parent == nil && ptr.DBInternal == nil {
+		// If this is a clean root node, don't do anything as it seems the root has not changed.
+		// This is a special case because roots are only resolved if any modification or lookup is
+		// performed on them, but if nothing has changed, the root pointer may be unresolved.
+		return nil
+	}
+	iptr := ptr.DBInternal.(*dbPtr) // Node is clean so it must be from the database.
+
+	// Check if the node's "root node status" has changed. In this case, we need to reset the index.
+	wasRootNode := iptr.isRoot()
+	isRootNode := parent == nil
+	if wasRootNode != isRootNode {
+		ptr.DBInternal = nil
+		needsPutNode = true
+
+		// Node was not a root node before, but now it has become one. It needs to be removed as it
+		// will otherwise remain in storage for no good reason.
+		if isRootNode {
+			s.batch.updatedNodes = append(s.batch.updatedNodes, updatedNode{
+				Removed: true,
+				Key:     iptr.dbKey(),
+			})
+		}
+	}
+
+	// Check if the node was invalid before but should now be a standalone node.
+	var isInvalid bool
+	wasInvalid := iptr.isInvalid()
+	if parent != nil {
+		if intNode, ok := parent.Node.(*node.InternalNode); ok {
+			isInvalid = intNode.LeafNode == ptr // If we are an internal leaf node.
+		}
+	}
+	if wasInvalid && !isInvalid {
+		ptr.DBInternal = nil
+		needsPutNode = true
+
+	}
+
+	if err := s.refreshDbPtr(ptr, parent); err != nil {
+		return err
+	}
+
+	if needsPutNode {
+		return s.PutNode(depth, ptr)
+	}
+	return nil
+}
+
+// Implements api.Subtree.
+func (s *badgerSubtree) VisitDirtyNode(_ node.Depth, ptr *node.Pointer, parent *node.Pointer) error {
+	return s.refreshDbPtr(ptr, parent)
+}
+
+// refreshDbPtr recomputes the data for the internal database pointer.
+func (s *badgerSubtree) refreshDbPtr(ptr *node.Pointer, parent *node.Pointer) error {
+	if ptr.DBInternal == nil {
+		// Assign new index if none exists.
+		var index uint32
+		switch parent {
+		case nil:
+			// Root node.
+			index = indexRootNode
+		default:
+			// Non-root node, assign new index.
+			index = s.batch.lastIndex.Add(1)
+		}
+
+		ptr.DBInternal = &dbPtr{
+			version: s.batch.version,
+			index:   index,
+		}
+	}
+
+	// If this is a multipart insert, the node may already exist. In this case, we need to fetch it
+	// from the database and update our pointers.
+	s.batch.db.metaUpdateLock.Lock()
+	defer s.batch.db.metaUpdateLock.Unlock()
+
+	multipartVersion := s.batch.db.multipartVersion
+	if multipartVersion == multipartVersionNone {
+		return nil
+	}
+
+	dbKey := ptr.DBInternal.(*dbPtr).dbKey()
+	if parent == nil {
+		multiMeta := s.batch.db.multipartMeta[uint8(s.batch.oldRoot.Type)]
+		if multiMeta.root != nil {
+			dbKey = rootNodeKeyFmt.Encode(multipartVersion, multiMeta.root)
+		}
+	} else {
+		dbKey = s.deriveNodeDbKey(dbKey)
+	}
+
+	return s.multipartMergeWithExisting(dbKey, ptr)
+}
+
+// Implements api.Subtree.
+func (s *badgerSubtree) PutNode(_ node.Depth, ptr *node.Pointer) error {
+	iptr, ok := ptr.DBInternal.(*dbPtr)
+	if !ok {
+		return fmt.Errorf("mkvs/pathbadger: bad internal pointer")
+	}
+
+	// Skip nodes that should not be stored separately.
+	if iptr.isInvalid() {
+		return nil
+	}
+
+	// Determine the correct database key based on the batch sequence number.
+	key, value, err := nodeToDb(ptr)
+	if err != nil {
+		return err
+	}
+
+	// Root node is special.
+	if iptr.isRoot() {
+		s.batch.newRootValue = value
+		return nil
+	}
+
+	s.batch.updatedNodes = append(s.batch.updatedNodes, updatedNode{
+		Key: key,
+	})
+
+	dbKey := s.deriveNodeDbKey(key)
+	if s.batch.seqNo != 0 {
+		// Need to commit at tsMetadata so this can be garbage-collected upon finalization.
+		return s.batch.batMeta.Set(dbKey, value)
+	}
+	return s.batch.bat.Set(dbKey, value)
+}
+
+func (s *badgerSubtree) deriveNodeDbKey(key []byte) []byte {
+	var dbKey []byte
+	rootType := byte(s.batch.oldRoot.Type)
+	seqNo := s.batch.seqNo
+	if seqNo == 0 {
+		dbKey = finalizedNodeKeyFmt.Encode(rootType, key)
+	} else {
+		dbKey = pendingNodeKeyFmt.Encode(s.batch.version, rootType, seqNo, key)
+	}
+	return dbKey
+}
+
+// nodeToDb serializes a node to an internal format for the database.
+func nodeToDb(ptr *node.Pointer) ([]byte, []byte, error) {
+	iptr := ptr.DBInternal.(*dbPtr)
+	key := iptr.dbKey()
+
+	switch n := ptr.Node.(type) {
+	case *node.LeafNode:
+		leafKey, _ := n.Key.MarshalBinary()
+		value := append([]byte{kindLeaf}, leafKey...)
+		value = append(value, n.Value...) // Copy value.
+		return key, value, nil
+	case *node.InternalNode:
+		var kind uint8
+		switch {
+		case n.Left != nil && n.Right != nil:
+			kind = kindInternalWithBoth
+		case n.Left != nil:
+			kind = kindInternalWithLeft
+		case n.Right != nil:
+			kind = kindInternalWithRight
+		}
+
+		value := []byte{kind}
+		label, _ := n.Label.MarshalBinary()
+		value = append(value, label...)
+		value = append(value, n.LabelBitLength.MarshalBinary()...)
+
+		if n.Left != nil {
+			value = append(value, ptrToDb(n.Left)...)
+		}
+		if n.Right != nil {
+			value = append(value, ptrToDb(n.Right)...)
+		}
+		if n.LeafNode != nil {
+			ln := n.LeafNode.Node.(*node.LeafNode)
+			leafKey, _ := ln.Key.MarshalBinary()
+			value = append(value, leafKey...)
+			value = append(value, ln.Value...)
+		}
+		return key, value, nil
+	default:
+		return nil, nil, fmt.Errorf("mkvs: unsupported node kind '%T' (db corruption?)", ptr.Node)
+	}
+}
+
+func leafFromDb(value []byte) ([]byte, []byte, error) {
+	rawNode, err := nodeFromDb(value)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	switch n := rawNode.(type) {
+	case *node.LeafNode:
+		return n.Key, n.Value, nil
+	case *node.InternalNode:
+		if n.LeafNode != nil {
+			ln := n.LeafNode.Node.(*node.LeafNode)
+			return ln.Key, ln.Value, nil
+		}
+	default:
+	}
+	return nil, nil, nil
+}
+
+// nodeFromDb deserializes a node from its internal database format.
+func nodeFromDb(value []byte) (node.Node, error) {
+	if len(value) < 2 {
+		return nil, fmt.Errorf("malformed node (db corruption?)")
+	}
+
+	pos := 1
+
+	// Format: [kind] <data...>
+	switch kind := value[0]; kind {
+	case kindLeaf:
+		// Format: [key] [value]
+		var key node.Key
+		size, err := key.SizedUnmarshalBinary(value[pos:])
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal key: %w", err)
+		}
+		pos += size
+
+		n := node.LeafNode{
+			Clean: true,
+			Key:   key,
+			Value: append([]byte{}, value[pos:]...), // Copy value.
+		}
+		n.UpdateHash()
+
+		return &n, nil
+	case kindInternalWithLeft, kindInternalWithRight, kindInternalWithBoth:
+		// Format: [label] [labelBitLength] [leftPtr] [rightPtr] [key] [value]
+		n := node.InternalNode{
+			Clean: true,
+		}
+
+		// Label of the node's incoming edge is the suffix.
+		size, err := n.Label.SizedUnmarshalBinary(value[pos:])
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal label size: %w", err)
+		}
+		pos += size
+		size, err = n.LabelBitLength.UnmarshalBinary(value[pos:])
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal label bit length: %w", err)
+		}
+		pos += size
+
+		// Left pointer.
+		if kind == kindInternalWithLeft || kind == kindInternalWithBoth {
+			size, ptr, err := ptrFromDb(value[pos:])
+			if err != nil {
+				return nil, err
+			}
+			pos += size
+			n.Left = ptr
+		}
+
+		// Right pointer.
+		if kind == kindInternalWithRight || kind == kindInternalWithBoth {
+			size, ptr, err := ptrFromDb(value[pos:])
+			if err != nil {
+				return nil, err
+			}
+			pos += size
+			n.Right = ptr
+		}
+
+		// Optional value of leaf node if there is anything left.
+		if len(value) > pos {
+			leaf := node.LeafNode{
+				Clean: true,
+			}
+			size, err := leaf.Key.SizedUnmarshalBinary(value[pos:])
+			if err != nil {
+				return nil, fmt.Errorf("failed to unmarshal leaf node size: %w", err)
+			}
+			pos += size
+
+			leaf.Value = append([]byte{}, value[pos:]...) // Copy value.
+			leaf.UpdateHash()
+
+			n.LeafNode = &node.Pointer{
+				Clean:      true,
+				Hash:       leaf.Hash,
+				Node:       &leaf,
+				DBInternal: newInvalidDbPtr(), // Not standalone.
+			}
+		}
+
+		n.UpdateHash()
+
+		return &n, nil
+	default:
+		return nil, fmt.Errorf("mkvs: unsupported node kind '%X' (db corruption?)", kind)
+	}
+}
+
+// ptrToDb serializes a MKVS pointer into an internal database representation.
+func ptrToDb(ptr *node.Pointer) []byte {
+	iptr := ptr.DBInternal.(*dbPtr)
+	if iptr.isInvalid() {
+		panic("mkvs/pathbadger: attempted to serialize invalid internal pointer")
+	}
+	if ptr.Hash.IsEmpty() {
+		panic("mkvs/pathbadger: attempted to serialize an empty pointer")
+	}
+
+	h, _ := ptr.Hash.MarshalBinary()
+	data := append(h, encodeNodeKey(iptr.version, iptr.index)...)
+
+	return data
+}
+
+// ptrFromDb deserializes a pointer from internal database representation.
+func ptrFromDb(data []byte) (int, *node.Pointer, error) {
+	// Format: [hash] [version] [index]
+
+	// Validate data size.
+	if len(data) < hash.Size+8+4 {
+		return 0, nil, fmt.Errorf("malformed pointer (not enough bytes)")
+	}
+
+	var (
+		h   hash.Hash
+		err error
+	)
+	if err = h.UnmarshalBinary(data[:hash.Size]); err != nil {
+		return 0, nil, fmt.Errorf("failed to unmarshal hash: %w", err)
+	}
+	if h.IsEmpty() {
+		// Empty hashes are not allowed in serialized form.
+		return 0, nil, fmt.Errorf("serialized empty hash encountered in pointer (db corruption?)")
+	}
+	pos := hash.Size
+
+	version := binary.BigEndian.Uint64(data[pos:])
+	pos += 8
+	index := binary.BigEndian.Uint32(data[pos:])
+	pos += 4
+
+	ptr := &node.Pointer{
+		Clean: true,
+		Hash:  h,
+		DBInternal: &dbPtr{
+			version: version,
+			index:   index,
+		},
+	}
+	return pos, ptr, nil
+}
+
+func encodeVersionKey(version uint64) []byte {
+	var rawVersion [8]byte
+	binary.BigEndian.PutUint64(rawVersion[:], version)
+	return rawVersion[:]
+}
+
+func encodeIndexKey(index uint32) []byte {
+	var rawIndex [4]byte
+	binary.BigEndian.PutUint32(rawIndex[:], index)
+	return rawIndex[:]
+}
+
+func encodeNodeKey(version uint64, index uint32) []byte {
+	data := append([]byte{}, encodeVersionKey(version)...)
+	data = append(data, encodeIndexKey(index)...)
+	return data
+}
+
+// dbPtr contains internal metadata needed for pointer resolution.
+type dbPtr struct {
+	version uint64
+	index   uint32
+}
+
+// newInvalidDbPtr constructs an invalid dbPtr.
+func newInvalidDbPtr() *dbPtr {
+	return &dbPtr{
+		version: versionInvalid,
+		index:   indexInvalid,
+	}
+}
+
+// isRoot returns true iff this dbPtr represents the root node based on its index.
+func (p *dbPtr) isRoot() bool {
+	return p.index == indexRootNode
+}
+
+// isInvalid returns true iff this dbPtr represents an invalid node. Note that this is different
+// from a dirty node (which just means a node that was locally modified) as an invalid pointer is
+// used for nodes which should never be stored as stand-alone nodes.
+func (p *dbPtr) isInvalid() bool {
+	return p.version == versionInvalid && p.index == indexInvalid
+}
+
+// dbKey returns the database key to use to resolve this pointer.
+func (p *dbPtr) dbKey() []byte {
+	return encodeNodeKey(p.version, p.index)
+}
+
+// Implements node.DBPointer.
+func (p *dbPtr) SetDirty() {
+	p.version = versionInvalid
+	p.index = indexInvalid
+}
+
+// Implements node.DBPointer.
+func (p *dbPtr) Clone() node.DBPointer {
+	return &dbPtr{
+		version: p.version,
+		index:   p.index,
+	}
+}

--- a/go/storage/mkvs/db/pathbadger/node_test.go
+++ b/go/storage/mkvs/db/pathbadger/node_test.go
@@ -1,0 +1,79 @@
+package pathbadger
+
+import (
+	"testing"
+
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/node"
+)
+
+func FuzzPtr(f *testing.F) {
+	// Seed corpus.
+	ptr := &node.Pointer{
+		DBInternal: &dbPtr{},
+	}
+	f.Add(ptrToDb(ptr))
+
+	// Fuzzing.
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		_, ptr, err := ptrFromDb(data)
+		if err != nil {
+			return
+		}
+
+		_ = ptrToDb(ptr)
+	})
+}
+
+func FuzzNode(f *testing.F) {
+	// Seed corpus.
+	ptr := &node.Pointer{
+		Node: &node.LeafNode{
+			Key:   []byte("foo"),
+			Value: []byte("bar"),
+		},
+		DBInternal: &dbPtr{},
+	}
+	_, value, err := nodeToDb(ptr)
+	if err != nil {
+		panic(err)
+	}
+	f.Add(value)
+
+	ptr = &node.Pointer{
+		Node: &node.InternalNode{
+			LeafNode: &node.Pointer{
+				Node: &node.LeafNode{
+					Key:   []byte("moo"),
+					Value: []byte("goo"),
+				},
+				DBInternal: &dbPtr{},
+			},
+			Left: &node.Pointer{
+				DBInternal: &dbPtr{
+					version: 42,
+					index:   7,
+				},
+			},
+		},
+		DBInternal: &dbPtr{},
+	}
+	_, value, err = nodeToDb(ptr)
+	if err != nil {
+		panic(err)
+	}
+	f.Add(value)
+
+	// Fuzzing.
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		n, err := nodeFromDb(data)
+		if err != nil {
+			return
+		}
+
+		ptr := &node.Pointer{Node: n, DBInternal: &dbPtr{}}
+		_, _, err = nodeToDb(ptr)
+		if err != nil {
+			panic(err)
+		}
+	})
+}

--- a/go/storage/mkvs/db/pathbadger/pathbadger.go
+++ b/go/storage/mkvs/db/pathbadger/pathbadger.go
@@ -1,0 +1,950 @@
+// Package pathbadger provides a Badger-backed node database that uses trie paths as keys.
+package pathbadger
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/dgraph-io/badger/v4"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	cmnBadger "github.com/oasisprotocol/oasis-core/go/common/badger"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/node"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/writelog"
+)
+
+// dbVersion is the internal database version. We start with 6 to make sure this is distinct from
+// the older badger backend which uses a database version of 5.
+const dbVersion = 6
+
+// New creates a new BadgerDB-backed node database that uses trie paths as keys.
+func New(cfg *api.Config) (api.NodeDB, error) {
+	db := &badgerNodeDB{
+		logger:           logging.GetLogger("mkvs/db/pathbadger"),
+		namespace:        cfg.Namespace,
+		readOnly:         cfg.ReadOnly,
+		discardWriteLogs: cfg.DiscardWriteLogs,
+	}
+	opts := commonConfigToBadgerOptions(cfg, db.logger)
+
+	var err error
+	if db.db, err = badger.OpenManaged(opts); err != nil {
+		return nil, fmt.Errorf("mkvs/pathbadger: failed to open database: %w", err)
+	}
+
+	// Make sure that we can discard any deleted/invalid metadata.
+	db.db.SetDiscardTs(tsMetadata)
+
+	// Initialize database metadata.
+	if err = db.initMetadata(); err != nil {
+		_ = db.db.Close()
+		return nil, fmt.Errorf("mkvs/pathbadger: failed to initialize metadata: %w", err)
+	}
+
+	// Update discard timestamp based on earliest version.
+	earliestVersion := db.meta.getEarliestVersion()
+	db.db.SetDiscardTs(versionToTs(earliestVersion))
+
+	// Cleanup any multipart restore remnants, since they can't be used anymore.
+	if err = db.cleanMultipartLocked(true); err != nil {
+		_ = db.db.Close()
+		return nil, fmt.Errorf("mkvs/pathbadger: failed to clean leftovers from multipart restore: %w", err)
+	}
+
+	db.gc = cmnBadger.NewGCWorker(db.logger, db.db)
+
+	return db, nil
+}
+
+type badgerNodeDB struct { // nolint: maligned
+	logger *logging.Logger
+
+	namespace common.Namespace
+
+	readOnly         bool
+	discardWriteLogs bool
+
+	multipartVersion uint64
+	multipartMeta    map[uint8]*multipartMeta
+
+	db *badger.DB
+	gc *cmnBadger.GCWorker
+
+	// metaUpdateLock must be held at any point where data at tsMetadata is read and updated. This
+	// is required because all metadata updates happen at the same timestamp and as such conflicts
+	// cannot be detected.
+	metaUpdateLock sync.Mutex
+	meta           metadata
+
+	closeOnce sync.Once
+}
+
+func (d *badgerNodeDB) initMetadata() error {
+	tx := d.db.NewTransactionAt(tsMetadata, true)
+	defer tx.Discard()
+
+	// Ensure that no legacy metadata exists to prevent corrupting a database created using the old
+	// badger backend.
+	if _, err := tx.Get([]byte{0x04}); err != badger.ErrKeyNotFound {
+		return fmt.Errorf("incompatible database version")
+	}
+
+	// Load metadata.
+	item, err := tx.Get(metadataKeyFmt.Encode())
+	switch err {
+	case nil:
+		// Metadata already exists, just load it and verify that it is
+		// compatible with what we have here.
+		err = item.Value(func(data []byte) error {
+			return cbor.UnmarshalTrusted(data, &d.meta.value)
+		})
+		if err != nil {
+			return err
+		}
+
+		if d.meta.value.Version != dbVersion {
+			return fmt.Errorf("incompatible database version (expected: %d got: %d)",
+				dbVersion,
+				d.meta.value.Version,
+			)
+		}
+		if !d.meta.value.Namespace.Equal(&d.namespace) {
+			return fmt.Errorf("incompatible namespace (expected: %s got: %s)",
+				d.namespace,
+				d.meta.value.Namespace,
+			)
+		}
+		return nil
+	case badger.ErrKeyNotFound:
+	default:
+		return err
+	}
+
+	// No metadata exists, create some.
+	d.meta.value.Version = dbVersion
+	d.meta.value.Namespace = d.namespace
+	d.meta.commit(tx)
+
+	return nil
+}
+
+func (d *badgerNodeDB) sanityCheckNamespace(ns *common.Namespace) error {
+	if !ns.Equal(&d.namespace) {
+		return api.ErrBadNamespace
+	}
+	return nil
+}
+
+func (d *badgerNodeDB) checkRootExists(tx *badger.Txn, root node.Root) error {
+	rootHash := api.TypedHashFromRoot(root)
+	if _, err := tx.Get(rootNodeKeyFmt.Encode(root.Version, &rootHash)); err != nil {
+		switch err {
+		case badger.ErrKeyNotFound:
+			return api.ErrRootNotFound
+		default:
+			d.logger.Error("failed to check root existence",
+				"err", err,
+			)
+			return fmt.Errorf("mkvs/pathbadger: failed to check root existence while getting node from backing store: %w", err)
+		}
+	}
+	return nil
+}
+
+// Implements api.NodeDB.
+func (d *badgerNodeDB) GetLatestVersion() (uint64, bool) {
+	return d.meta.getLastFinalizedVersion()
+}
+
+// Implements api.NodeDB.
+func (d *badgerNodeDB) GetEarliestVersion() uint64 {
+	return d.meta.getEarliestVersion()
+}
+
+// Implements api.NodeDB.
+func (d *badgerNodeDB) GetRootsForVersion(version uint64) (roots []node.Root, err error) {
+	// If the version is earlier than the earliest version, we don't have the roots.
+	if version < d.meta.getEarliestVersion() {
+		return nil, nil
+	}
+
+	tx := d.db.NewTransactionAt(versionToTs(version), false)
+	defer tx.Discard()
+
+	prefix := rootNodeKeyFmt.Encode(version)
+	it := tx.NewIterator(badger.IteratorOptions{Prefix: prefix})
+	defer it.Close()
+
+	for it.Rewind(); it.Valid(); it.Next() {
+		var (
+			v        uint64
+			rootHash api.TypedHash
+		)
+		if !rootNodeKeyFmt.Decode(it.Item().Key(), &v, &rootHash) {
+			panic("mkvs/pathbadger: corrupted key")
+		}
+
+		roots = append(roots, node.Root{
+			Namespace: d.namespace,
+			Version:   version,
+			Type:      rootHash.Type(),
+			Hash:      rootHash.Hash(),
+		})
+	}
+	return
+}
+
+// Implements api.NodeDB.
+func (d *badgerNodeDB) HasRoot(root node.Root) bool {
+	if err := d.sanityCheckNamespace(&root.Namespace); err != nil {
+		return false
+	}
+
+	// An empty root is always implicitly present.
+	if root.Hash.IsEmpty() {
+		return true
+	}
+
+	// If the version is earlier than the earliest version, we don't have the root.
+	if root.Version < d.meta.getEarliestVersion() {
+		return false
+	}
+
+	tx := d.db.NewTransactionAt(versionToTs(root.Version), false)
+	defer tx.Discard()
+
+	if err := d.checkRootExists(tx, root); err != nil {
+		return false
+	}
+
+	return true
+}
+
+// Implements api.NodeDB.
+func (d *badgerNodeDB) Finalize(roots []node.Root) error { // nolint: gocyclo
+	if d.readOnly {
+		return api.ErrReadOnly
+	}
+
+	if len(roots) == 0 {
+		return fmt.Errorf("mkvs/pathbadger: need at least one root to finalize")
+	}
+	version := roots[0].Version
+
+	d.metaUpdateLock.Lock()
+	defer d.metaUpdateLock.Unlock()
+
+	// Validate multipart version.
+	if d.multipartVersion != multipartVersionNone && d.multipartVersion != version {
+		return api.ErrInvalidMultipartVersion
+	}
+	// Validate version.
+	if lastFinalizedVersion, exists := d.meta.getLastFinalizedVersion(); exists {
+		// Make sure that this version has not yet been finalized.
+		if version <= lastFinalizedVersion {
+			return api.ErrAlreadyFinalized
+		}
+		// Make sure that the previous version has been finalized (if we are not restoring).
+		if d.multipartVersion == multipartVersionNone && lastFinalizedVersion+1 != version {
+			return api.ErrNotFinalized
+		}
+	}
+
+	// Ensure that all roots are valid and only one root per type is finalized.
+	typeCheck := make(map[node.RootType]struct{})
+	finalizedRoots := make(map[api.TypedHash]struct{})
+	for _, root := range roots {
+		if root.Version != version {
+			return fmt.Errorf("mkvs/pathbadger: roots to finalize don't have matching versions")
+		}
+		h := api.TypedHashFromRoot(root)
+		finalizedRoots[h] = struct{}{}
+
+		if _, ok := typeCheck[root.Type]; ok {
+			return fmt.Errorf("mkvs/pathbadger: only one root of type '%s' may be finalized", root.Type)
+		}
+		typeCheck[root.Type] = struct{}{}
+	}
+
+	// Batch collects removals and copies at the version timestamp.
+	batch := d.db.NewWriteBatchAt(versionToTs(version))
+	defer batch.Cancel()
+	// Batch meta collects removals at the tsMeta timestamp.
+	batchMeta := d.db.NewWriteBatchAt(tsMetadata)
+	defer batchMeta.Cancel()
+	// Transaction is used to read at the version timestamp.
+	tx := d.db.NewTransactionAt(versionToTs(version), true)
+	defer tx.Discard()
+
+	// Ensure that all roots are valid and only one root per type is finalized.
+	var nonEmptyFinalizedRoots, nonEmptyVisitedRoots int
+	for _, root := range roots {
+		if root.Hash.IsEmpty() {
+			continue
+		}
+		if err := d.checkRootExists(tx, root); err != nil {
+			return err
+		}
+		nonEmptyFinalizedRoots++
+	}
+
+	// Traverse all known roots for the version.
+	rootsPrefix := rootNodeKeyFmt.Encode(version)
+	rootIt := tx.NewIterator(badger.IteratorOptions{Prefix: rootsPrefix})
+	defer rootIt.Close()
+
+	var removeMetaKeys [][]byte
+	finalizedSeqNos := make(map[byte]uint16)
+	maybeLoneNodes := make(map[byte]map[string]struct{})
+	notLoneNodes := make(map[byte]map[string]struct{})
+
+	for rootIt.Rewind(); rootIt.Valid(); rootIt.Next() {
+		var (
+			v        uint64
+			rootHash api.TypedHash
+		)
+		if !rootNodeKeyFmt.Decode(rootIt.Item().Key(), &v, &rootHash) {
+			panic("mkvs/pathbadger: corrupted key")
+		}
+
+		// Check sequence number for the root.
+		seqNo, exists := d.meta.getPendingRootSeqNo(version, rootHash)
+		if !exists {
+			return fmt.Errorf("mkvs/pathbadger: pending root sequence number not found for root '%s'", rootHash)
+		}
+
+		// Load set of updated nodes.
+		var updatedNodes []updatedNode
+		rootUpdatedNodesKey := rootUpdatedNodesKeyFmt.Encode(version, &rootHash)
+		item, err := tx.Get(rootUpdatedNodesKey)
+		switch err {
+		case nil:
+			// We have some updated nodes.
+			err = item.Value(func(data []byte) error {
+				return cbor.UnmarshalTrusted(data, &updatedNodes)
+			})
+			if err != nil {
+				return fmt.Errorf("mkvs/pathbadger: corrupted updated nodes index: %w", err)
+			}
+
+			removeMetaKeys = append(removeMetaKeys, rootUpdatedNodesKey)
+		case badger.ErrKeyNotFound:
+			// No updated nodes.
+		default:
+			return fmt.Errorf("mkvs/pathbadger: failed to fetch updated nodes index: %w", err)
+		}
+
+		rht := byte(rootHash.Type())
+		if maybeLoneNodes[rht] == nil {
+			maybeLoneNodes[rht] = make(map[string]struct{})
+		}
+		if notLoneNodes[rht] == nil {
+			notLoneNodes[rht] = make(map[string]struct{})
+		}
+
+		// Determine whether the root has been finalized.
+		switch _, isFinalized := finalizedRoots[rootHash]; isFinalized {
+		case true:
+			// Root has been finalized.
+			for _, un := range updatedNodes {
+				if un.Removed {
+					maybeLoneNodes[rht][string(un.Key)] = struct{}{}
+				} else {
+					notLoneNodes[rht][string(un.Key)] = struct{}{}
+				}
+			}
+
+			finalizedSeqNos[rht] = seqNo
+			if h := rootHash.Hash(); !h.IsEmpty() {
+				nonEmptyVisitedRoots++
+			}
+		case false:
+			// Remove any non-finalized roots. It is safe to remove these nodes as Badger's version
+			// control will make sure they are not removed if they are resurrected in any later
+			// version as long as we make sure that these nodes are not shared with any finalized
+			// roots added in the same version.
+			for _, un := range updatedNodes {
+				if un.Removed {
+					continue // Ignore removed nodes for non-finalized roots.
+				}
+				if seqNo > 0 {
+					continue // All nodes with higher seqNo will be cleared anyway.
+				}
+
+				maybeLoneNodes[rht][string(un.Key)] = struct{}{}
+			}
+
+			// Remove write logs for the non-finalized root.
+			if !d.discardWriteLogs {
+				if err = func() error {
+					rootWriteLogsPrefix := writeLogKeyFmt.Encode(version, &rootHash)
+					wit := tx.NewIterator(badger.IteratorOptions{Prefix: rootWriteLogsPrefix})
+					defer wit.Close()
+
+					for wit.Rewind(); wit.Valid(); wit.Next() {
+						if err = batchMeta.Delete(wit.Item().KeyCopy(nil)); err != nil {
+							return err
+						}
+					}
+					return nil
+				}(); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	rootIt.Close()
+
+	// Sanity check that all finalized roots were visited.
+	if nonEmptyFinalizedRoots != nonEmptyVisitedRoots {
+		return fmt.Errorf("mkvs/pathbadger: not all finalized roots were visited (db corruption?)")
+	}
+
+	// Copy over any updated nodes for finalized roots with non-zero sequence numbers.
+	for rht, nodes := range notLoneNodes {
+		seqNo := finalizedSeqNos[rht]
+		if seqNo == 0 {
+			continue // Already in the right place.
+		}
+
+		for k := range nodes {
+			// Fetch pending node value. We will remove it later.
+			item, err := tx.Get(pendingNodeKeyFmt.Encode(version, rht, seqNo, []byte(k)))
+			if err != nil {
+				return fmt.Errorf("mkvs/pathbadger: failed to copy node: %w", err)
+			}
+			var value []byte
+			err = item.Value(func(data []byte) error {
+				value = append([]byte{}, data...) // Must copy to queue in batch.
+				return nil
+			})
+			if err != nil {
+				return fmt.Errorf("mkvs/pathbadger: failed to copy node: %w", err)
+			}
+
+			// Copy over to new location.
+			if err := batch.Set(finalizedNodeKeyFmt.Encode(rht, []byte(k)), value); err != nil {
+				return fmt.Errorf("mkvs/pathbadger: failed to copy node: %w", err)
+			}
+		}
+	}
+
+	// All removals should be done at the end so in case finalization is interrupted, we can recover
+	// by simply redoing finalization. Flush batches here to ensure all node copying has been
+	// committed.
+	if err := batch.Flush(); err != nil {
+		return err
+	}
+	if err := batchMeta.Flush(); err != nil {
+		return err
+	}
+	batch = d.db.NewWriteBatchAt(versionToTs(version))
+	defer batch.Cancel()
+	batchMeta = d.db.NewWriteBatchAt(tsMetadata)
+	defer batchMeta.Cancel()
+
+	// Remove any lone nodes. This can be retried.
+	for rht, nodes := range maybeLoneNodes {
+		for k := range nodes {
+			if _, isNotLone := notLoneNodes[rht][k]; isNotLone {
+				continue
+			}
+
+			if err := batch.Delete(finalizedNodeKeyFmt.Encode(rht, []byte(k))); err != nil {
+				return fmt.Errorf("mkvs/pathbadger: failed to delete lone node: %w", err)
+			}
+		}
+	}
+
+	// Remove any queued keys. This should happen before removing pending nodes so in case we fail
+	// the worst that can happen is that some pending nodes are left over and will be removed during
+	// next finalization.
+	for _, key := range removeMetaKeys {
+		if err := batchMeta.Delete(key); err != nil {
+			return fmt.Errorf("mkvs/pathbadger: failed to delete key: %w", err)
+		}
+	}
+
+	// Remove all temporary nodes for non-zero sequence numbers. Relevant ones have been copied.
+	pendingPrefix := pendingNodeKeyFmt.Encode(version)
+	pendingIt := tx.NewIterator(badger.IteratorOptions{Prefix: pendingPrefix})
+	defer pendingIt.Close()
+
+	for pendingIt.Rewind(); pendingIt.Valid(); pendingIt.Next() {
+		if err := batchMeta.Delete(pendingIt.Item().KeyCopy(nil)); err != nil {
+			return fmt.Errorf("mkvs/pathbadger: failed to delete pending node: %w", err)
+		}
+	}
+
+	pendingIt.Close()
+
+	// Commit batches. If this fails, deletion will be redone.
+	if err := batch.Flush(); err != nil {
+		return err
+	}
+	if err := batchMeta.Flush(); err != nil {
+		return err
+	}
+
+	// Update last finalized version.
+	d.meta.setLastFinalizedVersion(version)
+	d.meta.commit(tx)
+
+	// Clean multipart metadata if there is any.
+	if d.multipartVersion != multipartVersionNone {
+		if err := d.cleanMultipartLocked(false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Implements api.NodeDB.
+func (d *badgerNodeDB) Prune(version uint64) error {
+	if d.readOnly {
+		return api.ErrReadOnly
+	}
+
+	d.metaUpdateLock.Lock()
+	defer d.metaUpdateLock.Unlock()
+
+	if d.multipartVersion != multipartVersionNone {
+		return api.ErrMultipartInProgress
+	}
+
+	// Make sure that the version that we try to prune has been finalized.
+	lastFinalizedVersion, exists := d.meta.getLastFinalizedVersion()
+	if !exists || lastFinalizedVersion < version {
+		return api.ErrNotFinalized
+	}
+	// Make sure that the version that we are trying to prune is the earliest version.
+	if version != d.meta.getEarliestVersion() {
+		return api.ErrNotEarliest
+	}
+	// Make sure that the version that we are trying to prune is not the only finalized version.
+	if version == lastFinalizedVersion {
+		return api.ErrCannotPruneLatestVersion
+	}
+
+	// Remove all roots in version.
+	batch := d.db.NewWriteBatchAt(versionToTs(version))
+	defer batch.Cancel()
+	batchMeta := d.db.NewWriteBatchAt(tsMetadata)
+	defer batchMeta.Cancel()
+	tx := d.db.NewTransactionAt(versionToTs(version), true)
+	defer tx.Discard()
+
+	// Delete data for all root types that cannot have children.
+	for _, rootType := range api.RootTypesWithPolicy(func(p *api.RootPolicy) bool { return p.NoChildRoots }) {
+		// Delete all finalized nodes.
+		wtx := d.db.NewTransactionAt(versionToTs(version), false)
+		defer wtx.Discard()
+
+		prefix := finalizedNodeKeyFmt.Encode(byte(rootType))
+		it := wtx.NewIterator(badger.IteratorOptions{Prefix: prefix})
+		defer it.Close()
+
+		for it.Rewind(); it.Valid(); it.Next() {
+			if err := batch.Delete(it.Item().KeyCopy(nil)); err != nil {
+				return err
+			}
+		}
+
+		it.Close()
+
+		// Delete all root nodes of this type (there should be only one per type).
+		prefix = rootNodeKeyFmt.Encode(version)
+		it = wtx.NewIterator(badger.IteratorOptions{Prefix: prefix})
+		defer it.Close()
+
+		for it.Rewind(); it.Valid(); it.Next() {
+			var (
+				v        uint64
+				rootHash api.TypedHash
+			)
+			if !rootNodeKeyFmt.Decode(it.Item().Key(), &v, &rootHash) {
+				panic("mkvs/pathbadger: corrupted key")
+			}
+			if rootHash.Type() != rootType {
+				continue
+			}
+
+			if err := batch.Delete(it.Item().KeyCopy(nil)); err != nil {
+				return err
+			}
+		}
+
+		it.Close()
+		wtx.Discard()
+	}
+
+	// Prune all write logs in version.
+	if !d.discardWriteLogs {
+		wtx := d.db.NewTransactionAt(tsMetadata, false)
+		defer wtx.Discard()
+
+		prefix := writeLogKeyFmt.Encode(version)
+		it := wtx.NewIterator(badger.IteratorOptions{Prefix: prefix})
+		defer it.Close()
+
+		for it.Rewind(); it.Valid(); it.Next() {
+			if err := batchMeta.Delete(it.Item().KeyCopy(nil)); err != nil {
+				return err
+			}
+		}
+
+		it.Close()
+		wtx.Discard()
+	}
+
+	// Commit batch.
+	if err := batch.Flush(); err != nil {
+		return fmt.Errorf("mkvs/pathbadger: failed to flush batch: %w", err)
+	}
+	if err := batchMeta.Flush(); err != nil {
+		return fmt.Errorf("mkvs/pathbadger: failed to flush batch: %w", err)
+	}
+
+	// Update metadata.
+	d.meta.setEarliestVersion(version + 1)
+	d.meta.commit(tx)
+
+	// Discard everything invalidated at or below the _new_ earliest version. E.g. there is no need
+	// to keep around any keys that were removed at `version + 1`.
+	d.db.SetDiscardTs(versionToTs(version + 1))
+
+	return nil
+}
+
+// Implements api.NodeDB.
+func (d *badgerNodeDB) NewBatch(oldRoot node.Root, version uint64, chunk bool) (api.Batch, error) {
+	// WARNING: There is a maximum batch size and maximum batch entry count.
+	// Both of these things are derived from the MaxTableSize option.
+	//
+	// The size limit also applies to normal transactions, so the "right"
+	// thing to do would be to either crank up MaxTableSize or maybe split
+	// the transaction out.
+
+	if d.readOnly {
+		return nil, api.ErrReadOnly
+	}
+
+	if version != oldRoot.Version && version != oldRoot.Version+1 {
+		return nil, api.ErrRootMustFollowOld
+	}
+
+	// Ensure old root exists and the batch is compliant with the policy.
+	tx := d.db.NewTransactionAt(versionToTs(oldRoot.Version), true)
+	defer tx.Discard()
+
+	if err := d.sanityCheckNamespace(&oldRoot.Namespace); err != nil {
+		return nil, err
+	}
+
+	if !oldRoot.Hash.IsEmpty() {
+		policy := api.PolicyForRoot(oldRoot)
+		if policy == nil {
+			return nil, fmt.Errorf("mkvs/pathbadger: unsupported root type '%s'", oldRoot.Type)
+		}
+		if policy.NoChildRoots {
+			return nil, fmt.Errorf("mkvs/pathbadger: roots of type '%s' cannot have child roots", oldRoot.Type)
+		}
+		if oldRoot.Version == version {
+			return nil, fmt.Errorf("mkvs/pathbadger: child roots in the same version not supported")
+		}
+		if err := d.checkRootExists(tx, oldRoot); err != nil {
+			return nil, err
+		}
+	}
+
+	d.metaUpdateLock.Lock()
+	var ok bool
+	defer func() {
+		if !ok {
+			d.metaUpdateLock.Unlock()
+		}
+	}()
+
+	if d.multipartVersion != multipartVersionNone && d.multipartVersion != version {
+		return nil, api.ErrInvalidMultipartVersion
+	}
+	if chunk != (d.multipartVersion != multipartVersionNone) {
+		return nil, api.ErrMultipartInProgress
+	}
+
+	var (
+		readTxn   *badger.Txn
+		seqNo     uint16
+		lastIndex *atomic.Uint32
+		mpLock    *sync.Mutex
+	)
+	if d.multipartVersion != multipartVersionNone {
+		readTxn = d.db.NewTransactionAt(versionToTs(version), false)
+		multiMeta := d.multipartMeta[uint8(oldRoot.Type)]
+		// Reuse the same seqNo for all multipart batches that was already reserved.
+		seqNo = multiMeta.seqNo
+		// Reuse the same index for all multipart batches.
+		lastIndex = multiMeta.lastIndex
+		// We currently only allow a single multipart batch concurrently.
+		mpLock = &multiMeta.mpLock
+	} else {
+		// Reserve a sequence number for the batch.
+		var err error
+		seqNo, err = d.meta.reserveRootSeqNo(version, uint8(oldRoot.Type))
+		if err != nil {
+			return nil, err
+		}
+		d.meta.commit(tx)
+		// Start a fresh index.
+		lastIndex = new(atomic.Uint32)
+		lastIndex.Store(indexRootNode)
+	}
+
+	ok = true
+	d.metaUpdateLock.Unlock()
+	if mpLock != nil {
+		mpLock.Lock()
+	}
+
+	return &badgerBatch{
+		db:        d,
+		bat:       d.db.NewWriteBatchAt(versionToTs(version)),
+		batMeta:   d.db.NewWriteBatchAt(tsMetadata),
+		readTxn:   readTxn,
+		oldRoot:   oldRoot,
+		chunk:     chunk,
+		version:   version,
+		seqNo:     seqNo,
+		lastIndex: lastIndex,
+		mpLock:    mpLock,
+	}, nil
+}
+
+// Implements api.NodeDB.
+func (d *badgerNodeDB) Size() (int64, error) {
+	lsm, vlog := d.db.Size()
+	return lsm + vlog, nil
+}
+
+// Implements api.NodeDB.
+func (d *badgerNodeDB) Sync() error {
+	return d.db.Sync()
+}
+
+// Implements api.NodeDB.
+func (d *badgerNodeDB) Close() {
+	d.closeOnce.Do(func() {
+		if d.gc != nil {
+			d.gc.Close()
+		}
+
+		if err := d.db.Close(); err != nil {
+			d.logger.Error("close returned error",
+				"err", err,
+			)
+		}
+	})
+}
+
+type badgerBatch struct {
+	api.BaseBatch
+
+	db      *badgerNodeDB
+	bat     *badger.WriteBatch
+	batMeta *badger.WriteBatch
+
+	// readTx is the read transaction used to check for node existence during
+	// a multipart restore.
+	readTxn *badger.Txn
+
+	oldRoot   node.Root
+	chunk     bool
+	version   uint64
+	seqNo     uint16
+	lastIndex *atomic.Uint32
+
+	writeLog     writelog.WriteLog
+	annotations  writelog.Annotations
+	updatedNodes []updatedNode
+	newRootValue []byte
+
+	mpLock *sync.Mutex
+}
+
+// Implements api.Batch.
+func (ba *badgerBatch) MaybeStartSubtree(subtree api.Subtree, _ node.Depth, _ *node.Pointer) api.Subtree {
+	if subtree == nil {
+		return &badgerSubtree{batch: ba}
+	}
+	return subtree
+}
+
+// Implements api.Batch.
+func (ba *badgerBatch) PutWriteLog(writeLog writelog.WriteLog, annotations writelog.Annotations) error {
+	if ba.chunk {
+		return fmt.Errorf("mkvs/pathbadger: cannot put write log in chunk mode")
+	}
+	if ba.db.discardWriteLogs {
+		return nil
+	}
+	if ba.writeLog != nil || ba.annotations != nil {
+		return fmt.Errorf("mkvs/pathbadger: write log already set")
+	}
+
+	ba.writeLog = writeLog
+	ba.annotations = annotations
+	return nil
+}
+
+// Implements api.Batch.
+func (ba *badgerBatch) RemoveNodes(nodes []*node.Pointer) error {
+	if ba.chunk {
+		return fmt.Errorf("mkvs/pathbadger: cannot remove nodes in chunk mode")
+	}
+
+	for _, ptr := range nodes {
+		iptr, ok := ptr.DBInternal.(*dbPtr)
+		if !ok {
+			continue // Skip nodes that were never persisted in the database.
+		}
+		if iptr.isRoot() {
+			continue // Skip root nodes as those are tracked separately.
+		}
+
+		ba.updatedNodes = append(ba.updatedNodes, updatedNode{
+			Removed: true,
+			Key:     iptr.dbKey(),
+		})
+	}
+	return nil
+}
+
+// Implements api.Batch.
+func (ba *badgerBatch) Commit(root node.Root) error {
+	ba.db.metaUpdateLock.Lock()
+	defer ba.db.metaUpdateLock.Unlock()
+
+	if err := ba.db.sanityCheckNamespace(&root.Namespace); err != nil {
+		return err
+	}
+	if !root.Follows(&ba.oldRoot) {
+		return api.ErrRootMustFollowOld
+	}
+
+	// Make sure that the version that we try to commit into has not yet been finalized.
+	lastFinalizedVersion, exists := ba.db.meta.getLastFinalizedVersion()
+	if exists && lastFinalizedVersion >= root.Version {
+		return api.ErrAlreadyFinalized
+	}
+
+	rootHash := api.TypedHashFromRoot(root)
+	oldRootHash := api.TypedHashFromRoot(ba.oldRoot)
+
+	if ba.db.multipartVersion != multipartVersionNone {
+		if ba.db.multipartVersion != root.Version {
+			return api.ErrInvalidMultipartVersion
+		}
+
+		multiMeta := ba.db.multipartMeta[uint8(rootHash.Type())]
+		if multiMeta.root != nil && !multiMeta.root.Equal(&rootHash) {
+			return fmt.Errorf("mkvs/pathbadger: cannot change multipart root for type '%s'", root.Type)
+		}
+		multiMeta.root = &rootHash
+	}
+
+	// Check if the root already exists.
+	tx := ba.db.db.NewTransactionAt(versionToTs(root.Version), true)
+	defer tx.Discard()
+
+	// If we are not importing a chunk, check if the root already exists.
+	if !ba.chunk {
+		if err := ba.db.checkRootExists(tx, root); err == nil {
+			// No need to do anything since if the hash matches, everything will be identical and we
+			// would just be duplicating work.
+			ba.Reset()
+			return ba.BaseBatch.Commit(root)
+		}
+	}
+
+	// Check if the root node was committed. In cases where the root has not actually changed, there
+	// may be no root node and so we need to actually get it from the old version.
+	if len(ba.newRootValue) == 0 && !root.Hash.IsEmpty() {
+		if !rootHash.Equal(&oldRootHash) {
+			// Should never happen unless something is seriously wrong.
+			return fmt.Errorf("mkvs/pathbadger: no new root node, but new root hash not equal to old")
+		}
+
+		item, err := tx.Get(rootNodeKeyFmt.Encode(ba.oldRoot.Version, &oldRootHash))
+		if err != nil {
+			return fmt.Errorf("mkvs/pathbadger: failed to fetch old root node: %w", err)
+		}
+
+		err = item.Value(func(data []byte) error {
+			ba.newRootValue = append([]byte{}, data...)
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("mkvs/pathbadger: failed to copy old root node: %w", err)
+		}
+	}
+
+	// Record sequence number for the pending (non-finalized) root.
+	if err := ba.db.meta.setPendingRootSeqNo(root.Version, rootHash, ba.seqNo); err != nil {
+		return fmt.Errorf("mkvs/pathbadger: failed to set pending root seqno: %w", err)
+	}
+
+	if !ba.chunk {
+		// Store updated nodes (only needed until the version is finalized).
+		key := rootUpdatedNodesKeyFmt.Encode(root.Version, &rootHash)
+		if err := ba.batMeta.Set(key, cbor.Marshal(ba.updatedNodes)); err != nil {
+			return fmt.Errorf("mkvs/pathbadger: set returned error: %w", err)
+		}
+
+		// Store write log.
+		if err := storeInternalWriteLog(ba.batMeta, oldRootHash, rootHash, root.Version, ba.writeLog, ba.annotations); err != nil {
+			return err
+		}
+	}
+
+	// Make sure root node update happens last so in case anything fails, we can retry.
+	if err := ba.bat.Set(rootNodeKeyFmt.Encode(root.Version, &rootHash), ba.newRootValue); err != nil {
+		return err
+	}
+
+	// Flush node updates.
+	if err := ba.batMeta.Flush(); err != nil {
+		return fmt.Errorf("mkvs/pathbadger: failed to flush batch: %w", err)
+	}
+	if err := ba.bat.Flush(); err != nil {
+		return fmt.Errorf("mkvs/pathbadger: failed to flush batch: %w", err)
+	}
+	ba.db.meta.commit(tx)
+
+	ba.Reset()
+	return ba.BaseBatch.Commit(root)
+}
+
+// Implements api.Batch.
+func (ba *badgerBatch) Reset() {
+	ba.bat.Cancel()
+	ba.batMeta.Cancel()
+
+	if ba.readTxn != nil {
+		ba.readTxn.Discard()
+	}
+
+	ba.writeLog = nil
+	ba.annotations = nil
+	ba.updatedNodes = nil
+	ba.newRootValue = nil
+
+	if ba.mpLock != nil {
+		ba.mpLock.Unlock()
+		ba.mpLock = nil
+	}
+}

--- a/go/storage/mkvs/db/pathbadger/testdata/case-chunkrestore.json
+++ b/go/storage/mkvs/db/pathbadger/testdata/case-chunkrestore.json
@@ -1,0 +1,109 @@
+{
+	"pending_root": "13f1251fc6162fb7128de896792ba2208bc636273ffddbb81772713948a175cd",
+	"long_roots": null,
+	"pending_version": 2,
+	"entries": [
+		{
+			"key": "AATT6kBQDsNtj2MGmoaYqBnaocWf16kCNf7FZBmDnT2b",
+			"value": "AAIAAAAAAAAAGAB0aGlzIGtleSBzaGFyZXMgYSBwcmVmaXgRAAAAYnV0IG5vdCB0aGUgdmFsdWU=",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "ACoMPoe50MBSxLa/wmIDdaGb8GfZWMIxHPbtG7rY0Vul",
+			"value": "AQIAAAAAAAAASACjQ0uZA1sryQMC838caFlR0g5JjBWC+vQGfIRFwifG1zTJwUCPShe6bsAE0+pAUA7DbY9jBpqGmKgZ2qHFn9epAjX+xWQZg509mw==",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AHrBxDharSOeGPkXg4tlekkD5JwN13phXg0e9arbv+1s",
+			"value": "AAEAAAAAAAAAMgBhbmQgdGhpcyBrZXkgbWFrZXMgc3VyZSB3ZSBoYXZlIG1vcmUgdGhhbiBvbmUgbm9kZSQAAABkb3VibGUgdGhlIHZhbHVlcyEgZG91YmxlIHRoZSBtYWdpYyE=",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AHrBxDharSOeGPkXg4tlekkD5JwN13phXg0e9arbv+1s",
+			"value": "AAEAAAAAAAAAMgBhbmQgdGhpcyBrZXkgbWFrZXMgc3VyZSB3ZSBoYXZlIG1vcmUgdGhhbiBvbmUgbm9kZSQAAABkb3VibGUgdGhlIHZhbHVlcyEgZG91YmxlIHRoZSBtYWdpYyE=",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AIyMil+mRhdKClTmrfPQrBkZlC/CwLWYlWRdWqpGYnHA",
+			"value": "AQEAAAAAAAAAAwBgAnrBxDharSOeGPkXg4tlekkD5JwN13phXg0e9arbv+1s838caFlR0g5JjBWC+vQGfIRFwifG1zTJwUCPShe6bsA=",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "ANYDwd1G+OAu6kU0YUvsEwNgVTWp6Zwfrp03z/9/LCVp",
+			"value": "AQIAAAAAAAAAAwBgAnrBxDharSOeGPkXg4tlekkD5JwN13phXg0e9arbv+1sKgw+h7nQwFLEtr/CYgN1oZvwZ9lYwjEc9u0butjRW6U=",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "APN/HGhZUdIOSYwVgvr0BnyERcInxtc0ycFAj0oXum7A",
+			"value": "AAEAAAAAAAAAFgB0aGlzIGtleSBpcyBtYXJ2ZWxsb3VzFAAAAHdpdGggYSB2YWx1ZSB0byBib290",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "APN/HGhZUdIOSYwVgvr0BnyERcInxtc0ycFAj0oXum7A",
+			"value": "AAEAAAAAAAAAFgB0aGlzIGtleSBpcyBtYXJ2ZWxsb3VzFAAAAHdpdGggYSB2YWx1ZSB0byBib290",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AQAAAAAAAAABjIyKX6ZGF0oKVOat89CsGRmUL8LAtZiVZF1aqkZiccDGcrjR71btKKuHw2IsURQGm90617j5c3SY0MAezvCWeg==",
+			"value": "gqJjS2V5VnRoaXMga2V5IGlzIG1hcnZlbGxvdXNsSW5zZXJ0ZWRIYXNoWCDzfxxoWVHSDkmMFYL69AZ8hEXCJ8bXNMnBQI9KF7puwKJjS2V5WDJhbmQgdGhpcyBrZXkgbWFrZXMgc3VyZSB3ZSBoYXZlIG1vcmUgdGhhbiBvbmUgbm9kZWxJbnNlcnRlZEhhc2hYIHrBxDharSOeGPkXg4tlekkD5JwN13phXg0e9arbv+1s",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAB",
+			"value": "gaFYIIyMil+mRhdKClTmrfPQrBkZlC/CwLWYlWRdWqpGYnHAgA==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAC",
+			"value": "gaFYINYDwd1G+OAu6kU0YUvsEwNgVTWp6Zwfrp03z/9/LCVpgA==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AwAAAAAAAAABjIyKX6ZGF0oKVOat89CsGRmUL8LAtZiVZF1aqkZiccA=",
+			"value": null,
+			"version": 1,
+			"delete": true
+		},
+		{
+			"key": "AwAAAAAAAAAC1gPB3Ub44C7qRTRhS+wTA2BVNanpnB+unTfP/38sJWk=",
+			"value": "gA==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "BA==",
+			"value": "pWd2ZXJzaW9uA2luYW1lc3BhY2VYIIAAAAAAAAAA8399aUcoc2zrx7b1uhzJqpwQSzTgzSiIcGVhcmxpZXN0X3ZlcnNpb24BcW11bHRpcGFydF92ZXJzaW9uAnZsYXN0X2ZpbmFsaXplZF92ZXJzaW9uAQ==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "BQTT6kBQDsNtj2MGmoaYqBnaocWf16kCNf7FZBmDnT2b",
+			"value": null,
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "BSoMPoe50MBSxLa/wmIDdaGb8GfZWMIxHPbtG7rY0Vul",
+			"value": null,
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "BdYDwd1G+OAu6kU0YUvsEwNgVTWp6Zwfrp03z/9/LCVp",
+			"value": null,
+			"version": 1,
+			"delete": false
+		}
+	]
+}

--- a/go/storage/mkvs/db/pathbadger/testdata/case-long-toempty.json
+++ b/go/storage/mkvs/db/pathbadger/testdata/case-long-toempty.json
@@ -1,0 +1,318 @@
+{
+	"pending_root": "0000000000000000000000000000000000000000000000000000000000000000",
+	"long_roots": [
+		"bb615ccac38ddb3f165f31e9cab16cbe10cb3840d6b6df1c87ef4364e54426ea",
+		"432a7d2123763d916af266599faafdc28730cd340c875c3c8c23f33175b68f22",
+		"df5900acbffc266972a0d5a89c67f5e4cb4da2b6d7c63927704b4d2a48c5a8a5",
+		"4701b55a067d1a03d2e1f51d103f2e176cd6a5da92e7340586d1a46405402168"
+	],
+	"pending_version": 0,
+	"entries": [
+		{
+			"key": "AAcFUAxJ9/ywLN0PFT+5gaijcefdwpSs7hyZXNC2mzW1",
+			"value": "AQQAAAAAAAAAAQCAAptnweQ1HhKf+tyypQti0s9HVdvNvSu7XyZGuypENftdhY+4+Ds62HbS/acwqC7oat9fFOZxvIFmXmetHqnpC1k=",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "ABBCP/JeHrQxPVEqCOwuDHaskA+mqO5ftgqZ0hAX81my",
+			"value": "AQMAAAAAAAAAAQAAAqwR3PmTlHYVheHDtkfIqkYTHlunfzGB+Oo9F300uKw9uPRxIFkgnhkb2DTwHF5VArpQpyvA4DAwp0FGb67guwA=",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "ABKpOYTlfxeQ8z4dNw586PI1VyEmxZ0ibOfX7uo/9PKL",
+			"value": "AAMAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMyB3aXRoIDIgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMy4y",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "ABtcLHopxGLWMS8pw8BHwY7xZKhFZ7MjovcOOZjseKSa",
+			"value": "AQEAAAAAAAAAAQAAAnhpy1ShZMvwP1vt454UCewu2Bxx/VptubXRiSSR3mk6y5KIEY3qbSg6RBKZ784N4t+fmUqWAfcnjUBV0C7ndKI=",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "ACU8ouENJR+1oll81kBeQ3X72vFX4rohHW9n3JOr2A9b",
+			"value": "AQMAAAAAAAAAAQCAAsFwiU2NaZ0eS9F1byJaU3HRvs+XiUSGLmpXCN+07pdmSwgZXm4W4kvVwp3u/DR0LNkaFDshHoRdYEwsHEGgvXk=",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "ACWYfNwbYmYIORKBPWgo9yLKtAeCkXsR4KNaIs1StvtV",
+			"value": "AAIAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMiB3aXRoIDEgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMi4x",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "ACfKtdxGkeFbJEthSVt3u6CWp5YFxHrJNu+tBn3yt5M3",
+			"value": "AQIAAAAAAAAANwCIHdpdGggMAohXpXg+vJCB5ClfhDBs7agtN96aIhVda/7FeJu+n7gOT7awyrl3tHeU5LlEooaMyUUqwtaJ7uAyvDZYgBJ/Hn8=",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AEWpq9vMkmrrPjm6XkwAwnJRazyvZS/IL/6uI+tPRdVy",
+			"value": "AQQAAAAAAAAAOACEDu0ujQQGAskr/kRQBae22fr1C5xw1MZSDgYNmbNZLmx06UEiO30oqf2z1o10b8WKhrDStbiHYT2U1QPsNIfs2wqb2AUz39w=",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AEsIGV5uFuJL1cKd7vw0dCzZGhQ7IR6EXWBMLBxBoL15",
+			"value": "AQMAAAAAAAAANgCQO7S6NBAYAhBCP/JeHrQxPVEqCOwuDHaskA+mqO5ftgqZ0hAX81myqEVEyfr5BZ7ocRf7MWaEd2PaMFRe/Wig8TzZvQ0Pkzs=",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "AE9xIEQg7G0uOta+MwJ1BIgqa4XQOP2qKdCmgRiZQ+1y",
+			"value": "AAIAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMiB3aXRoIDMgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMi4z",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AE+2sMq5d7R3lOS5RKKGjMlFKsLWie7gMrw2WIASfx5/",
+			"value": "AAIAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMiB3aXRoIDQgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMi40",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AGLtgtP6vtshK6Oroes/swLlt0dxiCXRrmRuiEFwnNBO",
+			"value": "AAQAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNCB3aXRoIDEgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNC4x",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AHAJAlNMiH43aRICmsyGj8bAd6ujtuFlAHoF2rU2PkbD",
+			"value": "AQQAAAAAAAAAhQB0ZXN0IGtleTsgcm91bmQgMAJ9jc3jztJHk4MCwi48i2wJQD/u5fMbvvgqxMcszxmfFUWpq9vMkmrrPjm6XkwAwnJRazyvZS/IL/6uI+tPRdVy",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AHaGIco15RfM6BNMNrK7AHWbMltkTRAL9d1AjeOp7swC",
+			"value": "AAEAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMSB3aXRoIDQgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMS40",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AHhpy1ShZMvwP1vt454UCewu2Bxx/VptubXRiSSR3mk6",
+			"value": "AAEAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMSB3aXRoIDEgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMS4x",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AH2NzePO0keTgwLCLjyLbAlAP+7l8xu++CrExyzPGZ8V",
+			"value": "AQQAAAAAAAAAAQAAAn+e0Rr7v/n3vAjA4M5VP0b0Nyl3NfP6uwZC+JtFbL8uJTyi4Q0lH7WiWXzWQF5Ddfva8VfiuiEdb2fck6vYD1s=",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AH+e0Rr7v/n3vAjA4M5VP0b0Nyl3NfP6uwZC+JtFbL8u",
+			"value": "AQIAAAAAAAAANwBIHdpdGggMAhtcLHopxGLWMS8pw8BHwY7xZKhFZ7MjovcOOZjseKSadoYhyjXlF8zoE0w2srsAdZsyW2RNEAv13UCN46nuzAI=",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AIWPuPg7Oth20v2nMKgu6GrfXxTmcbyBZl5nrR6p6QtZ",
+			"value": "AAQAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNCB3aXRoIDMgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNC4z",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AIeFll1wQ/DE3/D+s63SUrCp7l8/cmx6oeB5Y6OHu32n",
+			"value": "AAEAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMSB3aXRoIDIgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMS4y",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AIhXpXg+vJCB5ClfhDBs7agtN96aIhVda/7FeJu+n7gO",
+			"value": "AQIAAAAAAAAAAQAAAiWYfNwbYmYIORKBPWgo9yLKtAeCkXsR4KNaIs1StvtVlZrpl1OFH8NFNCyl6NfUwJFov6ZxdIaf/YiWeYqDcDA=",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AJGk8cGe3aw7cNkmsynj70kqyFmEtIZpsrYBzOf/eLoR",
+			"value": "AQEAAAAAAAAAvQB0ZXN0IGtleTsgcm91bmQgMSB3aXRoIDACG1wseinEYtYxLynDwEfBjvFkqEVnsyOi9w45mOx4pJp2hiHKNeUXzOgTTDayuwB1mzJbZE0QC/XdQI3jqe7MAg==",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AJWa6ZdThR/DRTQspejX1MCRaL+mcXSGn/2IlnmKg3Aw",
+			"value": "AQIAAAAAAAAAAQCAAt/GaY6ea6xhZy1FOrX+CoxxPuj+ZLWICO/Z33R/2NKLT3EgRCDsbS461r4zAnUEiCprhdA4/aop0KaBGJlD7XI=",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AJtnweQ1HhKf+tyypQti0s9HVdvNvSu7XyZGuypENftd",
+			"value": "AAQAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNCB3aXRoIDIgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNC4y",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AKhFRMn6+QWe6HEX+zFmhHdj2jBUXv1ooPE82b0ND5M7",
+			"value": "AAMAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMyB3aXRoIDQgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMy40",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "AKn9s9aNdG/Fioaw0rW4h2E9lNUD7DSH7NsKm9gFM9/c",
+			"value": "AAQAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNCB3aXRoIDQgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNC40",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AKwR3PmTlHYVheHDtkfIqkYTHlunfzGB+Oo9F300uKw9",
+			"value": "AAMAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMyB3aXRoIDEgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMy4x",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "ALj0cSBZIJ4ZG9g08BxeVQK6UKcrwOAwMKdBRm+u4LsA",
+			"value": "AQMAAAAAAAAAAQCAAhKpOYTlfxeQ8z4dNw586PI1VyEmxZ0ibOfX7uo/9PKL5FZZHt3hcv6w+sbgL5Pxwu5SZNNRKQnghax3ugp4PtA=",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "AMFwiU2NaZ0eS9F1byJaU3HRvs+XiUSGLmpXCN+07pdm",
+			"value": "AQMAAAAAAAAANgAQO7S6NBAYAohXpXg+vJCB5ClfhDBs7agtN96aIhVda/7FeJu+n7gOT7awyrl3tHeU5LlEooaMyUUqwtaJ7uAyvDZYgBJ/Hn8=",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "AMkr/kRQBae22fr1C5xw1MZSDgYNmbNZLmx06UEiO30o",
+			"value": "AQQAAAAAAAAAAQAAAmLtgtP6vtshK6Oroes/swLlt0dxiCXRrmRuiEFwnNBOBwVQDEn3/LAs3Q8VP7mBqKNx593ClKzuHJlc0LabNbU=",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AMoP7biWQrP+8OqgSdoPOUp1M7NTc6gPURk5epY6kkbR",
+			"value": "AQIAAAAAAAAAhgB0ZXN0IGtleTsgcm91bmQgMAJ/ntEa+7/597wIwODOVT9G9DcpdzXz+rsGQvibRWy/LifKtdxGkeFbJEthSVt3u6CWp5YFxHrJNu+tBn3yt5M3",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AMuSiBGN6m0oOkQSme/ODeLfn5lKlgH3J41AVdAu53Si",
+			"value": "AQEAAAAAAAAAAQCAAoeFll1wQ/DE3/D+s63SUrCp7l8/cmx6oeB5Y6OHu32n2LsowWAbAo6V1qjMk5lM8+9eh/LINO0hF+fztbNa5bU=",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AM7cj4WGxSkq9SXSp3+2RmXKxC3YDpu96odJToCZAURV",
+			"value": "AQMAAAAAAAAAhgB0ZXN0IGtleTsgcm91bmQgMAJ/ntEa+7/597wIwODOVT9G9DcpdzXz+rsGQvibRWy/LiU8ouENJR+1oll81kBeQ3X72vFX4rohHW9n3JOr2A9b",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "ANi7KMFgGwKOldaozJOZTPPvXofyyDTtIRfn87WzWuW1",
+			"value": "AAEAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMSB3aXRoIDMgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMS4z",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AN/GaY6ea6xhZy1FOrX+CoxxPuj+ZLWICO/Z33R/2NKL",
+			"value": "AAIAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMiB3aXRoIDIgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMi4y",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AORWWR7d4XL+sPrG4C+T8cLuUmTTUSkJ4IWsd7oKeD7Q",
+			"value": "AAMAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMyB3aXRoIDMgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMy4z",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "AQAAAAAAAAABkaTxwZ7drDtw2SazKePvSSrIWYS0hmmytgHM5/94uhHGcrjR71btKKuHw2IsURQGm90617j5c3SY0MAezvCWeg==",
+			"value": "hKJjS2V5WB50ZXN0IGtleTsgcm91bmQgMSB3aXRoIDEgaW5kZXhsSW5zZXJ0ZWRIYXNoWCB4actUoWTL8D9b7eOeFAnsLtgccf1abbm10Ykkkd5pOqJjS2V5WB50ZXN0IGtleTsgcm91bmQgMSB3aXRoIDIgaW5kZXhsSW5zZXJ0ZWRIYXNoWCCHhZZdcEPwxN/w/rOt0lKwqe5fP3JseqHgeWOjh7t9p6JjS2V5WB50ZXN0IGtleTsgcm91bmQgMSB3aXRoIDMgaW5kZXhsSW5zZXJ0ZWRIYXNoWCDYuyjBYBsCjpXWqMyTmUzz716H8sg07SEX5/O1s1rltaJjS2V5WB50ZXN0IGtleTsgcm91bmQgMSB3aXRoIDQgaW5kZXhsSW5zZXJ0ZWRIYXNoWCB2hiHKNeUXzOgTTDayuwB1mzJbZE0QC/XdQI3jqe7MAg==",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AQAAAAAAAAACyg/tuJZCs/7w6qBJ2g85SnUzs1NzqA9RGTl6ljqSRtGRpPHBnt2sO3DZJrMp4+9JKshZhLSGabK2Aczn/3i6EQ==",
+			"value": "hKJjS2V5WB50ZXN0IGtleTsgcm91bmQgMiB3aXRoIDEgaW5kZXhsSW5zZXJ0ZWRIYXNoWCAlmHzcG2JmCDkSgT1oKPciyrQHgpF7EeCjWiLNUrb7VaJjS2V5WB50ZXN0IGtleTsgcm91bmQgMiB3aXRoIDIgaW5kZXhsSW5zZXJ0ZWRIYXNoWCDfxmmOnmusYWctRTq1/gqMcT7o/mS1iAjv2d90f9jSi6JjS2V5WB50ZXN0IGtleTsgcm91bmQgMiB3aXRoIDMgaW5kZXhsSW5zZXJ0ZWRIYXNoWCBPcSBEIOxtLjrWvjMCdQSIKmuF0Dj9qinQpoEYmUPtcqJjS2V5WB50ZXN0IGtleTsgcm91bmQgMiB3aXRoIDQgaW5kZXhsSW5zZXJ0ZWRIYXNoWCBPtrDKuXe0d5TkuUSihozJRSrC1onu4DK8NliAEn8efw==",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AQAAAAAAAAADztyPhYbFKSr1JdKnf7ZGZcrELdgOm73qh0lOgJkBRFXKD+24lkKz/vDqoEnaDzlKdTOzU3OoD1EZOXqWOpJG0Q==",
+			"value": "hKJjS2V5WB50ZXN0IGtleTsgcm91bmQgMyB3aXRoIDMgaW5kZXhsSW5zZXJ0ZWRIYXNoWCDkVlke3eFy/rD6xuAvk/HC7lJk01EpCeCFrHe6Cng+0KJjS2V5WB50ZXN0IGtleTsgcm91bmQgMyB3aXRoIDQgaW5kZXhsSW5zZXJ0ZWRIYXNoWCCoRUTJ+vkFnuhxF/sxZoR3Y9owVF79aKDxPNm9DQ+TO6JjS2V5WB50ZXN0IGtleTsgcm91bmQgMyB3aXRoIDEgaW5kZXhsSW5zZXJ0ZWRIYXNoWCCsEdz5k5R2FYXhw7ZHyKpGEx5bp38xgfjqPRd9NLisPaJjS2V5WB50ZXN0IGtleTsgcm91bmQgMyB3aXRoIDIgaW5kZXhsSW5zZXJ0ZWRIYXNoWCASqTmE5X8XkPM+HTcOfOjyNVchJsWdImzn1+7qP/Tyiw==",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "AQAAAAAAAAAEcAkCU0yIfjdpEgKazIaPxsB3q6O24WUAegXatTY+RsPO3I+FhsUpKvUl0qd/tkZlysQt2A6bveqHSU6AmQFEVQ==",
+			"value": "hKJjS2V5WB50ZXN0IGtleTsgcm91bmQgNCB3aXRoIDEgaW5kZXhsSW5zZXJ0ZWRIYXNoWCBi7YLT+r7bISujq6HrP7MC5bdHcYgl0a5kbohBcJzQTqJjS2V5WB50ZXN0IGtleTsgcm91bmQgNCB3aXRoIDIgaW5kZXhsSW5zZXJ0ZWRIYXNoWCCbZ8HkNR4Sn/rcsqULYtLPR1Xbzb0ru18mRrsqRDX7XaJjS2V5WB50ZXN0IGtleTsgcm91bmQgNCB3aXRoIDMgaW5kZXhsSW5zZXJ0ZWRIYXNoWCCFj7j4OzrYdtL9pzCoLuhq318U5nG8gWZeZ60eqekLWaJjS2V5WB50ZXN0IGtleTsgcm91bmQgNCB3aXRoIDQgaW5kZXhsSW5zZXJ0ZWRIYXNoWCCp/bPWjXRvxYqGsNK1uIdhPZTVA+w0h+zbCpvYBTPf3A==",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AQAAAAAAAAAFxnK40e9W7Sirh8NiLFEUBpvdOte4+XN0mNDAHs7wlnpwCQJTTIh+N2kSAprMho/GwHero7bhZQB6Bdq1Nj5Gww==",
+			"value": "kKJjS2V5WB50ZXN0IGtleTsgcm91bmQgMSB3aXRoIDMgaW5kZXhsSW5zZXJ0ZWRIYXNo9qJjS2V5WB50ZXN0IGtleTsgcm91bmQgMiB3aXRoIDMgaW5kZXhsSW5zZXJ0ZWRIYXNo9qJjS2V5WB50ZXN0IGtleTsgcm91bmQgMyB3aXRoIDEgaW5kZXhsSW5zZXJ0ZWRIYXNo9qJjS2V5WB50ZXN0IGtleTsgcm91bmQgNCB3aXRoIDMgaW5kZXhsSW5zZXJ0ZWRIYXNo9qJjS2V5WB50ZXN0IGtleTsgcm91bmQgMyB3aXRoIDQgaW5kZXhsSW5zZXJ0ZWRIYXNo9qJjS2V5WB50ZXN0IGtleTsgcm91bmQgMSB3aXRoIDIgaW5kZXhsSW5zZXJ0ZWRIYXNo9qJjS2V5WB50ZXN0IGtleTsgcm91bmQgMSB3aXRoIDQgaW5kZXhsSW5zZXJ0ZWRIYXNo9qJjS2V5WB50ZXN0IGtleTsgcm91bmQgMiB3aXRoIDQgaW5kZXhsSW5zZXJ0ZWRIYXNo9qJjS2V5WB50ZXN0IGtleTsgcm91bmQgMyB3aXRoIDIgaW5kZXhsSW5zZXJ0ZWRIYXNo9qJjS2V5WB50ZXN0IGtleTsgcm91bmQgNCB3aXRoIDEgaW5kZXhsSW5zZXJ0ZWRIYXNo9qJjS2V5WB50ZXN0IGtleTsgcm91bmQgNCB3aXRoIDIgaW5kZXhsSW5zZXJ0ZWRIYXNo9qJjS2V5WB50ZXN0IGtleTsgcm91bmQgNCB3aXRoIDQgaW5kZXhsSW5zZXJ0ZWRIYXNo9qJjS2V5WB50ZXN0IGtleTsgcm91bmQgMSB3aXRoIDEgaW5kZXhsSW5zZXJ0ZWRIYXNo9qJjS2V5WB50ZXN0IGtleTsgcm91bmQgMiB3aXRoIDEgaW5kZXhsSW5zZXJ0ZWRIYXNo9qJjS2V5WB50ZXN0IGtleTsgcm91bmQgMiB3aXRoIDIgaW5kZXhsSW5zZXJ0ZWRIYXNo9qJjS2V5WB50ZXN0IGtleTsgcm91bmQgMyB3aXRoIDMgaW5kZXhsSW5zZXJ0ZWRIYXNo9g==",
+			"version": 7,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAB",
+			"value": "gaFYIJGk8cGe3aw7cNkmsynj70kqyFmEtIZpsrYBzOf/eLoRgVggyg/tuJZCs/7w6qBJ2g85SnUzs1NzqA9RGTl6ljqSRtE=",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAC",
+			"value": "gaFYIMoP7biWQrP+8OqgSdoPOUp1M7NTc6gPURk5epY6kkbRgVggztyPhYbFKSr1JdKnf7ZGZcrELdgOm73qh0lOgJkBRFU=",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAD",
+			"value": "gaFYIM7cj4WGxSkq9SXSp3+2RmXKxC3YDpu96odJToCZAURVgVggcAkCU0yIfjdpEgKazIaPxsB3q6O24WUAegXatTY+RsM=",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAE",
+			"value": "gaFYIHAJAlNMiH43aRICmsyGj8bAd6ujtuFlAHoF2rU2PkbDgVggxnK40e9W7Sirh8NiLFEUBpvdOte4+XN0mNDAHs7wlno=",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAF",
+			"value": "gaFYIMZyuNHvVu0oq4fDYixRFAab3TrXuPlzdJjQwB7O8JZ6gA==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AwAAAAAAAAABkaTxwZ7drDtw2SazKePvSSrIWYS0hmmytgHM5/94uhE=",
+			"value": null,
+			"version": 1,
+			"delete": true
+		},
+		{
+			"key": "AwAAAAAAAAACyg/tuJZCs/7w6qBJ2g85SnUzs1NzqA9RGTl6ljqSRtE=",
+			"value": "ioL0WCB/ntEa+7/597wIwODOVT9G9DcpdzXz+rsGQvibRWy/LoL0WCAlmHzcG2JmCDkSgT1oKPciyrQHgpF7EeCjWiLNUrb7VYL0WCDfxmmOnmusYWctRTq1/gqMcT7o/mS1iAjv2d90f9jSi4L0WCBPcSBEIOxtLjrWvjMCdQSIKmuF0Dj9qinQpoEYmUPtcoL0WCCVmumXU4Ufw0U0LKXo19TAkWi/pnF0hp/9iJZ5ioNwMIL0WCCIV6V4PryQgeQpX4QwbO2oLTfemiIVXWv+xXibvp+4DoL0WCBPtrDKuXe0d5TkuUSihozJRSrC1onu4DK8NliAEn8ef4L0WCAnyrXcRpHhWyRLYUlbd7uglqeWBcR6yTbvrQZ98reTN4L0WCDKD+24lkKz/vDqoEnaDzlKdTOzU3OoD1EZOXqWOpJG0YL1WCCRpPHBnt2sO3DZJrMp4+9JKshZhLSGabK2Aczn/3i6EQ==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AwAAAAAAAAADztyPhYbFKSr1JdKnf7ZGZcrELdgOm73qh0lOgJkBRFU=",
+			"value": "jIL0WCDBcIlNjWmdHkvRdW8iWlNx0b7Pl4lEhi5qVwjftO6XZoL0WCCsEdz5k5R2FYXhw7ZHyKpGEx5bp38xgfjqPRd9NLisPYL0WCASqTmE5X8XkPM+HTcOfOjyNVchJsWdImzn1+7qP/Tyi4L0WCDkVlke3eFy/rD6xuAvk/HC7lJk01EpCeCFrHe6Cng+0IL0WCC49HEgWSCeGRvYNPAcXlUCulCnK8DgMDCnQUZvruC7AIL0WCAQQj/yXh60MT1RKgjsLgx2rJAPpqjuX7YKmdIQF/NZsoL0WCCoRUTJ+vkFnuhxF/sxZoR3Y9owVF79aKDxPNm9DQ+TO4L0WCBLCBlebhbiS9XCne78NHQs2RoUOyEehF1gTCwcQaC9eYL0WCAlPKLhDSUftaJZfNZAXkN1+9rxV+K6IR1vZ9yTq9gPW4L0WCDO3I+FhsUpKvUl0qd/tkZlysQt2A6bveqHSU6AmQFEVYL1WCAnyrXcRpHhWyRLYUlbd7uglqeWBcR6yTbvrQZ98reTN4L1WCDKD+24lkKz/vDqoEnaDzlKdTOzU3OoD1EZOXqWOpJG0Q==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AwAAAAAAAAAEcAkCU0yIfjdpEgKazIaPxsB3q6O24WUAegXatTY+RsM=",
+			"value": "ioL0WCB9jc3jztJHk4MCwi48i2wJQD/u5fMbvvgqxMcszxmfFYL0WCBi7YLT+r7bISujq6HrP7MC5bdHcYgl0a5kbohBcJzQToL0WCCbZ8HkNR4Sn/rcsqULYtLPR1Xbzb0ru18mRrsqRDX7XYL0WCCFj7j4OzrYdtL9pzCoLuhq318U5nG8gWZeZ60eqekLWYL0WCAHBVAMSff8sCzdDxU/uYGoo3Hn3cKUrO4cmVzQtps1tYL0WCDJK/5EUAWnttn69QuccNTGUg4GDZmzWS5sdOlBIjt9KIL0WCCp/bPWjXRvxYqGsNK1uIdhPZTVA+w0h+zbCpvYBTPf3IL0WCBFqavbzJJq6z45ul5MAMJyUWs8r2UvyC/+riPrT0XVcoL0WCBwCQJTTIh+N2kSAprMho/GwHero7bhZQB6Bdq1Nj5Gw4L1WCDO3I+FhsUpKvUl0qd/tkZlysQt2A6bveqHSU6AmQFEVQ==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AwAAAAAAAAAFxnK40e9W7Sirh8NiLFEUBpvdOte4+XN0mNDAHs7wlno=",
+			"value": "mCqC9VggeGnLVKFky/A/W+3jnhQJ7C7YHHH9Wm25tdGJJJHeaTqC9Vggy5KIEY3qbSg6RBKZ784N4t+fmUqWAfcnjUBV0C7ndKKC9VggG1wseinEYtYxLynDwEfBjvFkqEVnsyOi9w45mOx4pJqC9Vggf57RGvu/+fe8CMDgzlU/RvQ3KXc18/q7BkL4m0Vsvy6C9VggfY3N487SR5ODAsIuPItsCUA/7uXzG774KsTHLM8ZnxWC9VggcAkCU0yIfjdpEgKazIaPxsB3q6O24WUAegXatTY+RsOC9Vggh4WWXXBD8MTf8P6zrdJSsKnuXz9ybHqh4Hljo4e7faeC9Vggy5KIEY3qbSg6RBKZ784N4t+fmUqWAfcnjUBV0C7ndKKC9Vgg2LsowWAbAo6V1qjMk5lM8+9eh/LINO0hF+fztbNa5bWC9Vggf57RGvu/+fe8CMDgzlU/RvQ3KXc18/q7BkL4m0Vsvy6C9VggdoYhyjXlF8zoE0w2srsAdZsyW2RNEAv13UCN46nuzAKC9VggJTyi4Q0lH7WiWXzWQF5Ddfva8VfiuiEdb2fck6vYD1uC9VggfY3N487SR5ODAsIuPItsCUA/7uXzG774KsTHLM8ZnxWC9VggJZh83BtiZgg5EoE9aCj3Isq0B4KRexHgo1oizVK2+1WC9VgglZrpl1OFH8NFNCyl6NfUwJFov6ZxdIaf/YiWeYqDcDCC9VggiFeleD68kIHkKV+EMGztqC033poiFV1r/sV4m76fuA6C9VggwXCJTY1pnR5L0XVvIlpTcdG+z5eJRIYualcI37Tul2aC9Vgg38Zpjp5rrGFnLUU6tf4KjHE+6P5ktYgI79nfdH/Y0ouC9VgglZrpl1OFH8NFNCyl6NfUwJFov6ZxdIaf/YiWeYqDcDCC9VggT3EgRCDsbS461r4zAnUEiCprhdA4/aop0KaBGJlD7XKC9VggwXCJTY1pnR5L0XVvIlpTcdG+z5eJRIYualcI37Tul2aC9VggT7awyrl3tHeU5LlEooaMyUUqwtaJ7uAyvDZYgBJ/Hn+C9VggSwgZXm4W4kvVwp3u/DR0LNkaFDshHoRdYEwsHEGgvXmC9VggJTyi4Q0lH7WiWXzWQF5Ddfva8VfiuiEdb2fck6vYD1uC9VggrBHc+ZOUdhWF4cO2R8iqRhMeW6d/MYH46j0XfTS4rD2C9VgguPRxIFkgnhkb2DTwHF5VArpQpyvA4DAwp0FGb67guwCC9VggEEI/8l4etDE9USoI7C4MdqyQD6ao7l+2CpnSEBfzWbKC9VggEqk5hOV/F5DzPh03Dnzo8jVXISbFnSJs59fu6j/08ouC9VgguPRxIFkgnhkb2DTwHF5VArpQpyvA4DAwp0FGb67guwCC9Vgg5FZZHt3hcv6w+sbgL5Pxwu5SZNNRKQnghax3ugp4PtCC9VggSwgZXm4W4kvVwp3u/DR0LNkaFDshHoRdYEwsHEGgvXmC9VggqEVEyfr5BZ7ocRf7MWaEd2PaMFRe/Wig8TzZvQ0PkzuC9VggRamr28ySaus+ObpeTADCclFrPK9lL8gv/q4j609F1XKC9VggcAkCU0yIfjdpEgKazIaPxsB3q6O24WUAegXatTY+RsOC9VggYu2C0/q+2yEro6uh6z+zAuW3R3GIJdGuZG6IQXCc0E6C9VggBwVQDEn3/LAs3Q8VP7mBqKNx593ClKzuHJlc0LabNbWC9VggySv+RFAFp7bZ+vULnHDUxlIOBg2Zs1kubHTpQSI7fSiC9Vggm2fB5DUeEp/63LKlC2LSz0dV2829K7tfJka7KkQ1+12C9VggBwVQDEn3/LAs3Q8VP7mBqKNx593ClKzuHJlc0LabNbWC9VgghY+4+Ds62HbS/acwqC7oat9fFOZxvIFmXmetHqnpC1mC9VggRamr28ySaus+ObpeTADCclFrPK9lL8gv/q4j609F1XKC9Vggqf2z1o10b8WKhrDStbiHYT2U1QPsNIfs2wqb2AUz39w=",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "BA==",
+			"value": "pWd2ZXJzaW9uA2luYW1lc3BhY2VYIIAAAAAAAAAA8399aUcoc2zrx7b1uhzJqpwQSzTgzSiIcGVhcmxpZXN0X3ZlcnNpb24BcW11bHRpcGFydF92ZXJzaW9uAHZsYXN0X2ZpbmFsaXplZF92ZXJzaW9uAQ==",
+			"version": 1,
+			"delete": false
+		}
+	]
+}

--- a/go/storage/mkvs/db/pathbadger/testdata/case-long.json
+++ b/go/storage/mkvs/db/pathbadger/testdata/case-long.json
@@ -1,0 +1,695 @@
+{
+	"pending_root": "0000000000000000000000000000000000000000000000000000000000000000",
+	"long_roots": [
+		"bb615ccac38ddb3f165f31e9cab16cbe10cb3840d6b6df1c87ef4364e54426ea",
+		"432a7d2123763d916af266599faafdc28730cd340c875c3c8c23f33175b68f22",
+		"df5900acbffc266972a0d5a89c67f5e4cb4da2b6d7c63927704b4d2a48c5a8a5",
+		"4701b55a067d1a03d2e1f51d103f2e176cd6a5da92e7340586d1a46405402168",
+		"d5c64ea3cf2a3512ad7155c446bd5f85b9f6931a7f1178caca14e4cc14f871b7",
+		"61ee1e39ad0bf9d0362dbc785bbbc97aad2e74df035946113672ba6fec957fd5",
+		"88cafbd867db4728073431c25bcf3854b1010c60297d0036c8e0bb97c741da8d",
+		"e7d1c7acac39aff7f8681d5508f626581afb237f95394a130d4b2372fec8ec3b",
+		"f5210865c2705be18ce564a67e937aa088ae22604fd0cab09ffe526a58eaa1cb"
+	],
+	"pending_version": 0,
+	"entries": [
+		{
+			"key": "AAcFUAxJ9/ywLN0PFT+5gaijcefdwpSs7hyZXNC2mzW1",
+			"value": "AQQAAAAAAAAAAQCAAptnweQ1HhKf+tyypQti0s9HVdvNvSu7XyZGuypENftdhY+4+Ds62HbS/acwqC7oat9fFOZxvIFmXmetHqnpC1k=",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AAho0FLpZZKS5RyAAlPiZJmoTxoIuBDKsWo/Sn/zbgkL",
+			"value": "AQUAAAAAAAAANgAQO7S6NBAYAskr/kRQBae22fr1C5xw1MZSDgYNmbNZLmx06UEiO30oqf2z1o10b8WKhrDStbiHYT2U1QPsNIfs2wqb2AUz39w=",
+			"version": 7,
+			"delete": false
+		},
+		{
+			"key": "AAlFOcIyUjcD+dqyQ7xtK5bLQlZXJX8H4QKkASiU5Zyw",
+			"value": "AQYAAAAAAAAAAQAAAgho0FLpZZKS5RyAAlPiZJmoTxoIuBDKsWo/Sn/zbgkLkI1K2bzEybgS/q3hRkpQzmlrBBGdUdI8EHCB4Jz52zQ=",
+			"version": 8,
+			"delete": false
+		},
+		{
+			"key": "AA1XpCIKZ1PInN6isTxlRbywZvyI+lTT2X6uKV6K1bin",
+			"value": "AQkAAAAAAAAANgAQO7S6NBAYArlfnbgZtABmTI8KCevS8GKWkL4x6h4iEE7di5Kn7dY0YrmA33gRTGujL+nWRmvZoC2WUtXM/Bt2E2bs7wf9XIA=",
+			"version": 11,
+			"delete": false
+		},
+		{
+			"key": "ABBCP/JeHrQxPVEqCOwuDHaskA+mqO5ftgqZ0hAX81my",
+			"value": "AQMAAAAAAAAAAQAAAqwR3PmTlHYVheHDtkfIqkYTHlunfzGB+Oo9F300uKw9uPRxIFkgnhkb2DTwHF5VArpQpyvA4DAwp0FGb67guwA=",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "ABHQOdxX0k7kmkTx6cJWF18UlUF4Ij24tNlS/Ie5J7Mu",
+			"value": "AQcAAAAAAAAAAQCAAp1tP7BZ9hmhTcygPk/DX46uMSQsPaCLlSBJbzAHU7skoF8YE/SDdoYToWOTEtUEvW0O2L56uxarU7lQ6beXFXU=",
+			"version": 9,
+			"delete": false
+		},
+		{
+			"key": "ABKpOYTlfxeQ8z4dNw586PI1VyEmxZ0ibOfX7uo/9PKL",
+			"value": "AAMAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMyB3aXRoIDIgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMy4y",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "ABjXbVpRsfPAAS5BSwGGp35sHxcUNq40Tozy2hJ8zt4w",
+			"value": "AQcAAAAAAAAAAQCAAjnk8q1RrrFeKeUAdQXhDhz9PkYnaHPc5fntyNHsmWZ5q5nw197W6bsnutmGxbirggWmmatT8DK+eUQq3hPn8Q8=",
+			"version": 9,
+			"delete": false
+		},
+		{
+			"key": "ABtcLHopxGLWMS8pw8BHwY7xZKhFZ7MjovcOOZjseKSa",
+			"value": "AQEAAAAAAAAAAQAAAnhpy1ShZMvwP1vt454UCewu2Bxx/VptubXRiSSR3mk6y5KIEY3qbSg6RBKZ784N4t+fmUqWAfcnjUBV0C7ndKI=",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "ACU8ouENJR+1oll81kBeQ3X72vFX4rohHW9n3JOr2A9b",
+			"value": "AQMAAAAAAAAAAQCAAsFwiU2NaZ0eS9F1byJaU3HRvs+XiUSGLmpXCN+07pdmSwgZXm4W4kvVwp3u/DR0LNkaFDshHoRdYEwsHEGgvXk=",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "ACWYfNwbYmYIORKBPWgo9yLKtAeCkXsR4KNaIs1StvtV",
+			"value": "AAIAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMiB3aXRoIDEgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMi4x",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "ACfKtdxGkeFbJEthSVt3u6CWp5YFxHrJNu+tBn3yt5M3",
+			"value": "AQIAAAAAAAAANwCIHdpdGggMAohXpXg+vJCB5ClfhDBs7agtN96aIhVda/7FeJu+n7gOT7awyrl3tHeU5LlEooaMyUUqwtaJ7uAyvDZYgBJ/Hn8=",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "ACqJnMhT7aNwOV4mzkPjHJeLk16HMYB6NvF9cdVL7IxM",
+			"value": "AAcAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNyB3aXRoIDEgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNy4x",
+			"version": 9,
+			"delete": false
+		},
+		{
+			"key": "AC44b4FEi0B94ZIv4HDYyfTyM6L8+jj7z0fp3xyjPFSB",
+			"value": "AAUAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNSB3aXRoIDEgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNS4x",
+			"version": 7,
+			"delete": false
+		},
+		{
+			"key": "AC/LtKsx3nWO7c03OO1W+P7wUnvOv4/lq1tWOJm6YOu8",
+			"value": "AQgAAAAAAAAAAQCAAnKiAqonP4Xrwjx3HksXrRPKukEaQn+pTsumYP7uu0enjk9e49GEf0RNRe0ykXeox+7i335hvaGpgDYL0R3Z4pI=",
+			"version": 10,
+			"delete": false
+		},
+		{
+			"key": "ADNCzQVXgB5ygM323/RC8LZm1H0iOMsXNHz3GggD3Ia/",
+			"value": "AAYAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNiB3aXRoIDEgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNi4x",
+			"version": 8,
+			"delete": false
+		},
+		{
+			"key": "ADU5QwBimEY61ZMbty6IAH2tVb+3EhdEkfZEn30ptseM",
+			"value": "AQcAAAAAAAAAhQB0ZXN0IGtleTsgcm91bmQgMAJ9jc3jztJHk4MCwi48i2wJQD/u5fMbvvgqxMcszxmfFZoiyHq373j9H0NjxTQCfWUUyoCNelabYSynhmLoqT17",
+			"version": 9,
+			"delete": false
+		},
+		{
+			"key": "ADnk8q1RrrFeKeUAdQXhDhz9PkYnaHPc5fntyNHsmWZ5",
+			"value": "AQcAAAAAAAAANgAQO7S6NBAYAs1rBt+5HXe0Vhf7ZlUsYvG+eKOlDuD0esYfdVovPvljnEi+PBR2AyCi/b2rNFkUh0Qbq+RaqoIi7ujHl4VwCiQ=",
+			"version": 9,
+			"delete": false
+		},
+		{
+			"key": "ADzYnS8YqLjeJZE9czqcAqA5/UvlB4g6bHOFE+ckf861",
+			"value": "AQkAAAAAAAAAhAB0ZXN0IGtleTsgcm91bmQgMAKCg4D1trs4Br3LBu3hItjK4MVxAQtA4FV1iPBCVZGD+EKXdLqgOpH4XgKQi74LjH54b+1c9bdd1oZBGLtk0bbU",
+			"version": 11,
+			"delete": false
+		},
+		{
+			"key": "AEBr1aM/EVfyMZElX1FbU6juHc1nNMZ023WP1ZZkYMb6",
+			"value": "AQYAAAAAAAAAhQB0ZXN0IGtleTsgcm91bmQgMAJ9jc3jztJHk4MCwi48i2wJQD/u5fMbvvgqxMcszxmfFYcILZz6sKL6dIhH4YUw3bwhZW/kZk/gZYfb8GR7Kj2d",
+			"version": 8,
+			"delete": false
+		},
+		{
+			"key": "AEKXdLqgOpH4XgKQi74LjH54b+1c9bdd1oZBGLtk0bbU",
+			"value": "AQkAAAAAAAAAAwCAAg1XpCIKZ1PInN6isTxlRbywZvyI+lTT2X6uKV6K1bin5Eevi9m+kt3yk73cKEBZ4zzVV0T5L1QiIlKyHqWckKI=",
+			"version": 11,
+			"delete": false
+		},
+		{
+			"key": "AEWpq9vMkmrrPjm6XkwAwnJRazyvZS/IL/6uI+tPRdVy",
+			"value": "AQQAAAAAAAAAOACEDu0ujQQGAskr/kRQBae22fr1C5xw1MZSDgYNmbNZLmx06UEiO30oqf2z1o10b8WKhrDStbiHYT2U1QPsNIfs2wqb2AUz39w=",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AEsIGV5uFuJL1cKd7vw0dCzZGhQ7IR6EXWBMLBxBoL15",
+			"value": "AQMAAAAAAAAANgCQO7S6NBAYAhBCP/JeHrQxPVEqCOwuDHaskA+mqO5ftgqZ0hAX81myqEVEyfr5BZ7ocRf7MWaEd2PaMFRe/Wig8TzZvQ0Pkzs=",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "AE9xIEQg7G0uOta+MwJ1BIgqa4XQOP2qKdCmgRiZQ+1y",
+			"value": "AAIAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMiB3aXRoIDMgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMi4z",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AE+2sMq5d7R3lOS5RKKGjMlFKsLWie7gMrw2WIASfx5/",
+			"value": "AAIAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMiB3aXRoIDQgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMi40",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AFQbdzlRnlF2B6s7IHAKCx3wtojpK6m8ezUFr/EXZJIb",
+			"value": "AAYAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNiB3aXRoIDMgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNi4z",
+			"version": 8,
+			"delete": false
+		},
+		{
+			"key": "AFRv1yIYeOqF5Y5XFfxmYKBJN4bJ8kiuzqBIgWY50G+o",
+			"value": "AAcAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNyB3aXRoIDQgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNy40",
+			"version": 9,
+			"delete": false
+		},
+		{
+			"key": "AFb+ncH+cavHq7eH+bW4Oz3QL0DftnEafXeuzwXdJTQy",
+			"value": "AQUAAAAAAAAAAQCAAn73OMSYYUSXtMFqwGxkEoTJcelJMsnPy41u1opjNJ7FcH0hwrZD8CaRIGxzEBPLVtCzJxQdcxMKGTbktXhahB4=",
+			"version": 7,
+			"delete": false
+		},
+		{
+			"key": "AGACM2wPzyatpwAEkiematatNLnGNlEY/UVLVkjO6lyq",
+			"value": "AQUAAAAAAAAAAQAAAi44b4FEi0B94ZIv4HDYyfTyM6L8+jj7z0fp3xyjPFSBVv6dwf5xq8ert4f5tbg7PdAvQN+2cRp9d67PBd0lNDI=",
+			"version": 7,
+			"delete": false
+		},
+		{
+			"key": "AGKd6JhJSqH1Mx9VFXXP+zsim9WpptHNraJhrRXvzffQ",
+			"value": "AAgAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgOCB3aXRoIDEgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgOC4x",
+			"version": 10,
+			"delete": false
+		},
+		{
+			"key": "AGK5gN94EUxroy/p1kZr2aAtllLVzPwbdhNm7O8H/VyA",
+			"value": "AAgAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgOCB3aXRoIDQgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgOC40",
+			"version": 10,
+			"delete": false
+		},
+		{
+			"key": "AGLtgtP6vtshK6Oroes/swLlt0dxiCXRrmRuiEFwnNBO",
+			"value": "AAQAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNCB3aXRoIDEgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNC4x",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AGPSbFNlnFmw618nSNR5zZTcdcpz44UDzJIbvy8/IO5R",
+			"value": "AAkAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgOSB3aXRoIDQgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgOS40",
+			"version": 11,
+			"delete": false
+		},
+		{
+			"key": "AGhBOVJHfuRZq8wD02Xr/T7PkAQLMh8sOXQMwa/S9500",
+			"value": "AAYAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNiB3aXRoIDIgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNi4y",
+			"version": 8,
+			"delete": false
+		},
+		{
+			"key": "AHAJAlNMiH43aRICmsyGj8bAd6ujtuFlAHoF2rU2PkbD",
+			"value": "AQQAAAAAAAAAhQB0ZXN0IGtleTsgcm91bmQgMAJ9jc3jztJHk4MCwi48i2wJQD/u5fMbvvgqxMcszxmfFUWpq9vMkmrrPjm6XkwAwnJRazyvZS/IL/6uI+tPRdVy",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AHB9IcK2Q/AmkSBscxATy1bQsycUHXMTChk25LV4WoQe",
+			"value": "AAUAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNSB3aXRoIDMgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNS4z",
+			"version": 7,
+			"delete": false
+		},
+		{
+			"key": "AHKiAqonP4Xrwjx3HksXrRPKukEaQn+pTsumYP7uu0en",
+			"value": "AAgAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgOCB3aXRoIDIgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgOC4y",
+			"version": 10,
+			"delete": false
+		},
+		{
+			"key": "AHaGIco15RfM6BNMNrK7AHWbMltkTRAL9d1AjeOp7swC",
+			"value": "AAEAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMSB3aXRoIDQgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMS40",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AHcDevdBtaIrmANODIkpvrftS5El6HmROvfp8d9sFVgy",
+			"value": "AQkAAAAAAAAAAQAAAs2XtY+lsrZFGkM+QkZDLjeUGnoqKoLpL4+3nhW5dx2pw5FbjkOvNtFoTxQbQG/TRqbkYvqrhsRbnZaFuxKoj+0=",
+			"version": 11,
+			"delete": false
+		},
+		{
+			"key": "AHhpy1ShZMvwP1vt454UCewu2Bxx/VptubXRiSSR3mk6",
+			"value": "AAEAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMSB3aXRoIDEgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMS4x",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AH2NzePO0keTgwLCLjyLbAlAP+7l8xu++CrExyzPGZ8V",
+			"value": "AQQAAAAAAAAAAQAAAn+e0Rr7v/n3vAjA4M5VP0b0Nyl3NfP6uwZC+JtFbL8uJTyi4Q0lH7WiWXzWQF5Ddfva8VfiuiEdb2fck6vYD1s=",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AH73OMSYYUSXtMFqwGxkEoTJcelJMsnPy41u1opjNJ7F",
+			"value": "AAUAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNSB3aXRoIDIgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNS4y",
+			"version": 7,
+			"delete": false
+		},
+		{
+			"key": "AH+e0Rr7v/n3vAjA4M5VP0b0Nyl3NfP6uwZC+JtFbL8u",
+			"value": "AQIAAAAAAAAANwBIHdpdGggMAhtcLHopxGLWMS8pw8BHwY7xZKhFZ7MjovcOOZjseKSadoYhyjXlF8zoE0w2srsAdZsyW2RNEAv13UCN46nuzAI=",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AIKDgPW2uzgGvcsG7eEi2MrgxXEBC0DgVXWI8EJVkYP4",
+			"value": "AQgAAAAAAAAAAQAAAn2NzePO0keTgwLCLjyLbAlAP+7l8xu++CrExyzPGZ8VmiLIerfveP0fQ2PFNAJ9ZRTKgI16VpthLKeGYuipPXs=",
+			"version": 10,
+			"delete": false
+		},
+		{
+			"key": "AIWPuPg7Oth20v2nMKgu6GrfXxTmcbyBZl5nrR6p6QtZ",
+			"value": "AAQAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNCB3aXRoIDMgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNC4z",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AIcILZz6sKL6dIhH4YUw3bwhZW/kZk/gZYfb8GR7Kj2d",
+			"value": "AQYAAAAAAAAAAQCAAglFOcIyUjcD+dqyQ7xtK5bLQlZXJX8H4QKkASiU5ZywkvSRCMjP1nmiC64lw1cc+1YSRpqZoKyYf64zTtuwzU0=",
+			"version": 8,
+			"delete": false
+		},
+		{
+			"key": "AIeFll1wQ/DE3/D+s63SUrCp7l8/cmx6oeB5Y6OHu32n",
+			"value": "AAEAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMSB3aXRoIDIgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMS4y",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AIhXpXg+vJCB5ClfhDBs7agtN96aIhVda/7FeJu+n7gO",
+			"value": "AQIAAAAAAAAAAQAAAiWYfNwbYmYIORKBPWgo9yLKtAeCkXsR4KNaIs1StvtVlZrpl1OFH8NFNCyl6NfUwJFov6ZxdIaf/YiWeYqDcDA=",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AI5PXuPRhH9ETUXtMpF3qMfu4t9+Yb2hqYA2C9Ed2eKS",
+			"value": "AAgAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgOCB3aXRoIDMgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgOC4z",
+			"version": 10,
+			"delete": false
+		},
+		{
+			"key": "AJCNStm8xMm4Ev6t4UZKUM5pawQRnVHSPBBwgeCc+ds0",
+			"value": "AQUAAAAAAAAANgCQO7S6NBAYAmACM2wPzyatpwAEkiematatNLnGNlEY/UVLVkjO6lyq2FoI8BY3Dbz3YsDTbSoV6jXs8BrHAyLJH8pAi//nJSE=",
+			"version": 7,
+			"delete": false
+		},
+		{
+			"key": "AJGk8cGe3aw7cNkmsynj70kqyFmEtIZpsrYBzOf/eLoR",
+			"value": "AQEAAAAAAAAAvQB0ZXN0IGtleTsgcm91bmQgMSB3aXRoIDACG1wseinEYtYxLynDwEfBjvFkqEVnsyOi9w45mOx4pJp2hiHKNeUXzOgTTDayuwB1mzJbZE0QC/XdQI3jqe7MAg==",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AJL0kQjIz9Z5oguuJcNXHPtWEkaamaCsmH+uM07bsM1N",
+			"value": "AQYAAAAAAAAANwCIHdpdGggMAs1rBt+5HXe0Vhf7ZlUsYvG+eKOlDuD0esYfdVovPvljnEi+PBR2AyCi/b2rNFkUh0Qbq+RaqoIi7ujHl4VwCiQ=",
+			"version": 8,
+			"delete": false
+		},
+		{
+			"key": "AJWa6ZdThR/DRTQspejX1MCRaL+mcXSGn/2IlnmKg3Aw",
+			"value": "AQIAAAAAAAAAAQCAAt/GaY6ea6xhZy1FOrX+CoxxPuj+ZLWICO/Z33R/2NKLT3EgRCDsbS461r4zAnUEiCprhdA4/aop0KaBGJlD7XI=",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AJiq6G5keUlu8mpdOdtL6a4fXQ9kZR6o4v3HyYWpUXnV",
+			"value": "AQUAAAAAAAAAAgCAAgho0FLpZZKS5RyAAlPiZJmoTxoIuBDKsWo/Sn/zbgkLkI1K2bzEybgS/q3hRkpQzmlrBBGdUdI8EHCB4Jz52zQ=",
+			"version": 7,
+			"delete": false
+		},
+		{
+			"key": "AJoiyHq373j9H0NjxTQCfWUUyoCNelabYSynhmLoqT17",
+			"value": "AQcAAAAAAAAAAQCAAglFOcIyUjcD+dqyQ7xtK5bLQlZXJX8H4QKkASiU5ZywGNdtWlGx88ABLkFLAYanfmwfFxQ2rjROjPLaEnzO3jA=",
+			"version": 9,
+			"delete": false
+		},
+		{
+			"key": "AJtnweQ1HhKf+tyypQti0s9HVdvNvSu7XyZGuypENftd",
+			"value": "AAQAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNCB3aXRoIDIgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNC4y",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AJxIvjwUdgMgov29qzRZFIdEG6vkWqqCIu7ox5eFcAok",
+			"value": "AAYAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNiB3aXRoIDQgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNi40",
+			"version": 8,
+			"delete": false
+		},
+		{
+			"key": "AJ1tP7BZ9hmhTcygPk/DX46uMSQsPaCLlSBJbzAHU7sk",
+			"value": "AAcAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNyB3aXRoIDIgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNy4y",
+			"version": 9,
+			"delete": false
+		},
+		{
+			"key": "AKBfGBP0g3aGE6FjkxLVBL1tDti+ersWq1O5UOm3lxV1",
+			"value": "AAcAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNyB3aXRoIDMgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNy4z",
+			"version": 9,
+			"delete": false
+		},
+		{
+			"key": "AKhFRMn6+QWe6HEX+zFmhHdj2jBUXv1ooPE82b0ND5M7",
+			"value": "AAMAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMyB3aXRoIDQgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMy40",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "AKn9s9aNdG/Fioaw0rW4h2E9lNUD7DSH7NsKm9gFM9/c",
+			"value": "AAQAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNCB3aXRoIDQgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNC40",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AKuZ8Nfe1um7J7rZhsW4q4IFppmrU/AyvnlEKt4T5/EP",
+			"value": "AQcAAAAAAAAANgCQO7S6NBAYAtrYYMGrQOjr5pFH3J1Cf+tdSSZlrl/CmOusT9lKHekeVG/XIhh46oXljlcV/GZgoEk3hsnySK7OoEiBZjnQb6g=",
+			"version": 9,
+			"delete": false
+		},
+		{
+			"key": "AKwR3PmTlHYVheHDtkfIqkYTHlunfzGB+Oo9F300uKw9",
+			"value": "AAMAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMyB3aXRoIDEgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMy4x",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "ALj0cSBZIJ4ZG9g08BxeVQK6UKcrwOAwMKdBRm+u4LsA",
+			"value": "AQMAAAAAAAAAAQCAAhKpOYTlfxeQ8z4dNw586PI1VyEmxZ0ibOfX7uo/9PKL5FZZHt3hcv6w+sbgL5Pxwu5SZNNRKQnghax3ugp4PtA=",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "ALlfnbgZtABmTI8KCevS8GKWkL4x6h4iEE7di5Kn7dY0",
+			"value": "AQgAAAAAAAAAAQAAAmKd6JhJSqH1Mx9VFXXP+zsim9WpptHNraJhrRXvzffQL8u0qzHedY7tzTc47Vb4/vBSe86/j+WrW1Y4mbpg67w=",
+			"version": 10,
+			"delete": false
+		},
+		{
+			"key": "AL0vQ42BKTqlPVv6KL2n3l4Hi0FRk/ZUZ53MZcCZOklS",
+			"value": "AQYAAAAAAAAAAQCAAmhBOVJHfuRZq8wD02Xr/T7PkAQLMh8sOXQMwa/S9500VBt3OVGeUXYHqzsgcAoLHfC2iOkrqbx7NQWv8Rdkkhs=",
+			"version": 8,
+			"delete": false
+		},
+		{
+			"key": "AL3z2AOB/0zX/44c/wsLFW+3fC9qNw2K7VExq8fbLrc1",
+			"value": "AQUAAAAAAAAAhQB0ZXN0IGtleTsgcm91bmQgMAJ9jc3jztJHk4MCwi48i2wJQD/u5fMbvvgqxMcszxmfFZiq6G5keUlu8mpdOdtL6a4fXQ9kZR6o4v3HyYWpUXnV",
+			"version": 7,
+			"delete": false
+		},
+		{
+			"key": "AMFjnJ1zMUq39eaqe0C6y+aIhorvvDvVpKHHEQwpBh4s",
+			"value": "AAkAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgOSB3aXRoIDMgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgOS4z",
+			"version": 11,
+			"delete": false
+		},
+		{
+			"key": "AMFwiU2NaZ0eS9F1byJaU3HRvs+XiUSGLmpXCN+07pdm",
+			"value": "AQMAAAAAAAAANgAQO7S6NBAYAohXpXg+vJCB5ClfhDBs7agtN96aIhVda/7FeJu+n7gOT7awyrl3tHeU5LlEooaMyUUqwtaJ7uAyvDZYgBJ/Hn8=",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "AMJUmAAPLSvLVO9TWSbAQb7zp/iBe7uO+q+dz2FAhSsZ",
+			"value": "AAkAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgOSB3aXRoIDIgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgOS4y",
+			"version": 11,
+			"delete": false
+		},
+		{
+			"key": "AMORW45DrzbRaE8UG0Bv00am5GL6q4bEW52WhbsSqI/t",
+			"value": "AQkAAAAAAAAAAQCAAsJUmAAPLSvLVO9TWSbAQb7zp/iBe7uO+q+dz2FAhSsZwWOcnXMxSrf15qp7QLrL5oiGiu+8O9WkoccRDCkGHiw=",
+			"version": 11,
+			"delete": false
+		},
+		{
+			"key": "AMjqe4HCNKwyMsEfO8PjRIQaCV6HNIS9WiPQpi2baWxR",
+			"value": "AQgAAAAAAAAAhAB0ZXN0IGtleTsgcm91bmQgMAKCg4D1trs4Br3LBu3hItjK4MVxAQtA4FV1iPBCVZGD+N6gSGhoVV72GJelKU/z6cKf5UOgmp8Arr2eaiBXSBaE",
+			"version": 10,
+			"delete": false
+		},
+		{
+			"key": "AMkr/kRQBae22fr1C5xw1MZSDgYNmbNZLmx06UEiO30o",
+			"value": "AQQAAAAAAAAAAQAAAmLtgtP6vtshK6Oroes/swLlt0dxiCXRrmRuiEFwnNBOBwVQDEn3/LAs3Q8VP7mBqKNx593ClKzuHJlc0LabNbU=",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AMoP7biWQrP+8OqgSdoPOUp1M7NTc6gPURk5epY6kkbR",
+			"value": "AQIAAAAAAAAAhgB0ZXN0IGtleTsgcm91bmQgMAJ/ntEa+7/597wIwODOVT9G9DcpdzXz+rsGQvibRWy/LifKtdxGkeFbJEthSVt3u6CWp5YFxHrJNu+tBn3yt5M3",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AMuSiBGN6m0oOkQSme/ODeLfn5lKlgH3J41AVdAu53Si",
+			"value": "AQEAAAAAAAAAAQCAAoeFll1wQ/DE3/D+s63SUrCp7l8/cmx6oeB5Y6OHu32n2LsowWAbAo6V1qjMk5lM8+9eh/LINO0hF+fztbNa5bU=",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AM1rBt+5HXe0Vhf7ZlUsYvG+eKOlDuD0esYfdVovPvlj",
+			"value": "AQYAAAAAAAAAAQAAAjNCzQVXgB5ygM323/RC8LZm1H0iOMsXNHz3GggD3Ia/vS9DjYEpOqU9W/oovafeXgeLQVGT9lRnncxlwJk6SVI=",
+			"version": 8,
+			"delete": false
+		},
+		{
+			"key": "AM2XtY+lsrZFGkM+QkZDLjeUGnoqKoLpL4+3nhW5dx2p",
+			"value": "AAkAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgOSB3aXRoIDEgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgOS4x",
+			"version": 11,
+			"delete": false
+		},
+		{
+			"key": "AM7cj4WGxSkq9SXSp3+2RmXKxC3YDpu96odJToCZAURV",
+			"value": "AQMAAAAAAAAAhgB0ZXN0IGtleTsgcm91bmQgMAJ/ntEa+7/597wIwODOVT9G9DcpdzXz+rsGQvibRWy/LiU8ouENJR+1oll81kBeQ3X72vFX4rohHW9n3JOr2A9b",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "ANhaCPAWNw2892LA020qFeo17PAaxwMiyR/KQIv/5yUh",
+			"value": "AAUAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgNSB3aXRoIDQgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgNS40",
+			"version": 7,
+			"delete": false
+		},
+		{
+			"key": "ANi7KMFgGwKOldaozJOZTPPvXofyyDTtIRfn87WzWuW1",
+			"value": "AAEAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMSB3aXRoIDMgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMS4z",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "ANrYYMGrQOjr5pFH3J1Cf+tdSSZlrl/CmOusT9lKHeke",
+			"value": "AQcAAAAAAAAAAQAAAiqJnMhT7aNwOV4mzkPjHJeLk16HMYB6NvF9cdVL7IxMEdA53FfSTuSaRPHpwlYXXxSVQXgiPbi02VL8h7knsy4=",
+			"version": 9,
+			"delete": false
+		},
+		{
+			"key": "AN6gSGhoVV72GJelKU/z6cKf5UOgmp8Arr2eaiBXSBaE",
+			"value": "AQgAAAAAAAAAOQCCB3aXRoIDAAK5X524GbQAZkyPCgnr0vBilpC+MeoeIhBO3YuSp+3WNGK5gN94EUxroy/p1kZr2aAtllLVzPwbdhNm7O8H/VyA",
+			"version": 10,
+			"delete": false
+		},
+		{
+			"key": "AN/GaY6ea6xhZy1FOrX+CoxxPuj+ZLWICO/Z33R/2NKL",
+			"value": "AAIAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMiB3aXRoIDIgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMi4y",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AORHr4vZvpLd8pO93ChAWeM81VdE+S9UIiJSsh6lnJCi",
+			"value": "AQkAAAAAAAAANgCQO7S6NBAYAncDevdBtaIrmANODIkpvrftS5El6HmROvfp8d9sFVgyY9JsU2WcWbDrXydI1HnNlNx1ynPjhQPMkhu/Lz8g7lE=",
+			"version": 11,
+			"delete": false
+		},
+		{
+			"key": "AORWWR7d4XL+sPrG4C+T8cLuUmTTUSkJ4IWsd7oKeD7Q",
+			"value": "AAMAAAAAAAAAHgB0ZXN0IGtleTsgcm91bmQgMyB3aXRoIDMgaW5kZXgVAAAAaW50ZXJlc3RpbmcgdmFsdWUgMy4z",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "AQAAAAAAAAABkaTxwZ7drDtw2SazKePvSSrIWYS0hmmytgHM5/94uhHGcrjR71btKKuHw2IsURQGm90617j5c3SY0MAezvCWeg==",
+			"value": "hKJjS2V5WB50ZXN0IGtleTsgcm91bmQgMSB3aXRoIDEgaW5kZXhsSW5zZXJ0ZWRIYXNoWCB4actUoWTL8D9b7eOeFAnsLtgccf1abbm10Ykkkd5pOqJjS2V5WB50ZXN0IGtleTsgcm91bmQgMSB3aXRoIDIgaW5kZXhsSW5zZXJ0ZWRIYXNoWCCHhZZdcEPwxN/w/rOt0lKwqe5fP3JseqHgeWOjh7t9p6JjS2V5WB50ZXN0IGtleTsgcm91bmQgMSB3aXRoIDMgaW5kZXhsSW5zZXJ0ZWRIYXNoWCDYuyjBYBsCjpXWqMyTmUzz716H8sg07SEX5/O1s1rltaJjS2V5WB50ZXN0IGtleTsgcm91bmQgMSB3aXRoIDQgaW5kZXhsSW5zZXJ0ZWRIYXNoWCB2hiHKNeUXzOgTTDayuwB1mzJbZE0QC/XdQI3jqe7MAg==",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AQAAAAAAAAACyg/tuJZCs/7w6qBJ2g85SnUzs1NzqA9RGTl6ljqSRtGRpPHBnt2sO3DZJrMp4+9JKshZhLSGabK2Aczn/3i6EQ==",
+			"value": "hKJjS2V5WB50ZXN0IGtleTsgcm91bmQgMiB3aXRoIDEgaW5kZXhsSW5zZXJ0ZWRIYXNoWCAlmHzcG2JmCDkSgT1oKPciyrQHgpF7EeCjWiLNUrb7VaJjS2V5WB50ZXN0IGtleTsgcm91bmQgMiB3aXRoIDIgaW5kZXhsSW5zZXJ0ZWRIYXNoWCDfxmmOnmusYWctRTq1/gqMcT7o/mS1iAjv2d90f9jSi6JjS2V5WB50ZXN0IGtleTsgcm91bmQgMiB3aXRoIDMgaW5kZXhsSW5zZXJ0ZWRIYXNoWCBPcSBEIOxtLjrWvjMCdQSIKmuF0Dj9qinQpoEYmUPtcqJjS2V5WB50ZXN0IGtleTsgcm91bmQgMiB3aXRoIDQgaW5kZXhsSW5zZXJ0ZWRIYXNoWCBPtrDKuXe0d5TkuUSihozJRSrC1onu4DK8NliAEn8efw==",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AQAAAAAAAAADztyPhYbFKSr1JdKnf7ZGZcrELdgOm73qh0lOgJkBRFXKD+24lkKz/vDqoEnaDzlKdTOzU3OoD1EZOXqWOpJG0Q==",
+			"value": "hKJjS2V5WB50ZXN0IGtleTsgcm91bmQgMyB3aXRoIDEgaW5kZXhsSW5zZXJ0ZWRIYXNoWCCsEdz5k5R2FYXhw7ZHyKpGEx5bp38xgfjqPRd9NLisPaJjS2V5WB50ZXN0IGtleTsgcm91bmQgMyB3aXRoIDIgaW5kZXhsSW5zZXJ0ZWRIYXNoWCASqTmE5X8XkPM+HTcOfOjyNVchJsWdImzn1+7qP/Tyi6JjS2V5WB50ZXN0IGtleTsgcm91bmQgMyB3aXRoIDMgaW5kZXhsSW5zZXJ0ZWRIYXNoWCDkVlke3eFy/rD6xuAvk/HC7lJk01EpCeCFrHe6Cng+0KJjS2V5WB50ZXN0IGtleTsgcm91bmQgMyB3aXRoIDQgaW5kZXhsSW5zZXJ0ZWRIYXNoWCCoRUTJ+vkFnuhxF/sxZoR3Y9owVF79aKDxPNm9DQ+TOw==",
+			"version": 5,
+			"delete": false
+		},
+		{
+			"key": "AQAAAAAAAAAEcAkCU0yIfjdpEgKazIaPxsB3q6O24WUAegXatTY+RsPO3I+FhsUpKvUl0qd/tkZlysQt2A6bveqHSU6AmQFEVQ==",
+			"value": "hKJjS2V5WB50ZXN0IGtleTsgcm91bmQgNCB3aXRoIDEgaW5kZXhsSW5zZXJ0ZWRIYXNoWCBi7YLT+r7bISujq6HrP7MC5bdHcYgl0a5kbohBcJzQTqJjS2V5WB50ZXN0IGtleTsgcm91bmQgNCB3aXRoIDIgaW5kZXhsSW5zZXJ0ZWRIYXNoWCCbZ8HkNR4Sn/rcsqULYtLPR1Xbzb0ru18mRrsqRDX7XaJjS2V5WB50ZXN0IGtleTsgcm91bmQgNCB3aXRoIDMgaW5kZXhsSW5zZXJ0ZWRIYXNoWCCFj7j4OzrYdtL9pzCoLuhq318U5nG8gWZeZ60eqekLWaJjS2V5WB50ZXN0IGtleTsgcm91bmQgNCB3aXRoIDQgaW5kZXhsSW5zZXJ0ZWRIYXNoWCCp/bPWjXRvxYqGsNK1uIdhPZTVA+w0h+zbCpvYBTPf3A==",
+			"version": 6,
+			"delete": false
+		},
+		{
+			"key": "AQAAAAAAAAAFvfPYA4H/TNf/jhz/CwsVb7d8L2o3DYrtUTGrx9sutzVwCQJTTIh+N2kSAprMho/GwHero7bhZQB6Bdq1Nj5Gww==",
+			"value": "hKJjS2V5WB50ZXN0IGtleTsgcm91bmQgNSB3aXRoIDEgaW5kZXhsSW5zZXJ0ZWRIYXNoWCAuOG+BRItAfeGSL+Bw2Mn08jOi/Po4+89H6d8cozxUgaJjS2V5WB50ZXN0IGtleTsgcm91bmQgNSB3aXRoIDIgaW5kZXhsSW5zZXJ0ZWRIYXNoWCB+9zjEmGFEl7TBasBsZBKEyXHpSTLJz8uNbtaKYzSexaJjS2V5WB50ZXN0IGtleTsgcm91bmQgNSB3aXRoIDMgaW5kZXhsSW5zZXJ0ZWRIYXNoWCBwfSHCtkPwJpEgbHMQE8tW0LMnFB1zEwoZNuS1eFqEHqJjS2V5WB50ZXN0IGtleTsgcm91bmQgNSB3aXRoIDQgaW5kZXhsSW5zZXJ0ZWRIYXNoWCDYWgjwFjcNvPdiwNNtKhXqNezwGscDIskfykCL/+clIQ==",
+			"version": 7,
+			"delete": false
+		},
+		{
+			"key": "AQAAAAAAAAAGQGvVoz8RV/IxkSVfUVtTqO4dzWc0xnTbdY/VlmRgxvq989gDgf9M1/+OHP8LCxVvt3wvajcNiu1RMavH2y63NQ==",
+			"value": "hKJjS2V5WB50ZXN0IGtleTsgcm91bmQgNiB3aXRoIDEgaW5kZXhsSW5zZXJ0ZWRIYXNoWCAzQs0FV4AecoDN9t/0QvC2ZtR9IjjLFzR89xoIA9yGv6JjS2V5WB50ZXN0IGtleTsgcm91bmQgNiB3aXRoIDIgaW5kZXhsSW5zZXJ0ZWRIYXNoWCBoQTlSR37kWavMA9Nl6/0+z5AECzIfLDl0DMGv0vedNKJjS2V5WB50ZXN0IGtleTsgcm91bmQgNiB3aXRoIDMgaW5kZXhsSW5zZXJ0ZWRIYXNoWCBUG3c5UZ5RdgerOyBwCgsd8LaI6SupvHs1Ba/xF2SSG6JjS2V5WB50ZXN0IGtleTsgcm91bmQgNiB3aXRoIDQgaW5kZXhsSW5zZXJ0ZWRIYXNoWCCcSL48FHYDIKL9vas0WRSHRBur5FqqgiLu6MeXhXAKJA==",
+			"version": 8,
+			"delete": false
+		},
+		{
+			"key": "AQAAAAAAAAAHNTlDAGKYRjrVkxu3LogAfa1Vv7cSF0SR9kSffSm2x4xAa9WjPxFX8jGRJV9RW1Oo7h3NZzTGdNt1j9WWZGDG+g==",
+			"value": "hKJjS2V5WB50ZXN0IGtleTsgcm91bmQgNyB3aXRoIDQgaW5kZXhsSW5zZXJ0ZWRIYXNoWCBUb9ciGHjqheWOVxX8ZmCgSTeGyfJIrs6gSIFmOdBvqKJjS2V5WB50ZXN0IGtleTsgcm91bmQgNyB3aXRoIDEgaW5kZXhsSW5zZXJ0ZWRIYXNoWCAqiZzIU+2jcDleJs5D4xyXi5NehzGAejbxfXHVS+yMTKJjS2V5WB50ZXN0IGtleTsgcm91bmQgNyB3aXRoIDIgaW5kZXhsSW5zZXJ0ZWRIYXNoWCCdbT+wWfYZoU3MoD5Pw1+OrjEkLD2gi5UgSW8wB1O7JKJjS2V5WB50ZXN0IGtleTsgcm91bmQgNyB3aXRoIDMgaW5kZXhsSW5zZXJ0ZWRIYXNoWCCgXxgT9IN2hhOhY5MS1QS9bQ7Yvnq7FqtTuVDpt5cVdQ==",
+			"version": 9,
+			"delete": false
+		},
+		{
+			"key": "AQAAAAAAAAAIyOp7gcI0rDIywR87w+NEhBoJXoc0hL1aI9CmLZtpbFE1OUMAYphGOtWTG7cuiAB9rVW/txIXRJH2RJ99KbbHjA==",
+			"value": "hKJjS2V5WB50ZXN0IGtleTsgcm91bmQgOCB3aXRoIDMgaW5kZXhsSW5zZXJ0ZWRIYXNoWCCOT17j0YR/RE1F7TKRd6jH7uLffmG9oamANgvRHdnikqJjS2V5WB50ZXN0IGtleTsgcm91bmQgOCB3aXRoIDQgaW5kZXhsSW5zZXJ0ZWRIYXNoWCBiuYDfeBFMa6Mv6dZGa9mgLZZS1cz8G3YTZuzvB/1cgKJjS2V5WB50ZXN0IGtleTsgcm91bmQgOCB3aXRoIDEgaW5kZXhsSW5zZXJ0ZWRIYXNoWCBineiYSUqh9TMfVRV1z/s7IpvVqabRza2iYa0V78330KJjS2V5WB50ZXN0IGtleTsgcm91bmQgOCB3aXRoIDIgaW5kZXhsSW5zZXJ0ZWRIYXNoWCByogKqJz+F68I8dx5LF60TyrpBGkJ/qU7LpmD+7rtHpw==",
+			"version": 10,
+			"delete": false
+		},
+		{
+			"key": "AQAAAAAAAAAJPNidLxiouN4lkT1zOpwCoDn9S+UHiDpsc4UT5yR/zrXI6nuBwjSsMjLBHzvD40SEGglehzSEvVoj0KYtm2lsUQ==",
+			"value": "hKJjS2V5WB50ZXN0IGtleTsgcm91bmQgOSB3aXRoIDEgaW5kZXhsSW5zZXJ0ZWRIYXNoWCDNl7WPpbK2RRpDPkJGQy43lBp6KiqC6S+Pt54VuXcdqaJjS2V5WB50ZXN0IGtleTsgcm91bmQgOSB3aXRoIDIgaW5kZXhsSW5zZXJ0ZWRIYXNoWCDCVJgADy0ry1TvU1kmwEG+86f4gXu7jvqvnc9hQIUrGaJjS2V5WB50ZXN0IGtleTsgcm91bmQgOSB3aXRoIDMgaW5kZXhsSW5zZXJ0ZWRIYXNoWCDBY5ydczFKt/XmqntAusvmiIaK77w71aShxxEMKQYeLKJjS2V5WB50ZXN0IGtleTsgcm91bmQgOSB3aXRoIDQgaW5kZXhsSW5zZXJ0ZWRIYXNoWCBj0mxTZZxZsOtfJ0jUec2U3HXKc+OFA8ySG78vPyDuUQ==",
+			"version": 11,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAB",
+			"value": "gaFYIJGk8cGe3aw7cNkmsynj70kqyFmEtIZpsrYBzOf/eLoRgVggyg/tuJZCs/7w6qBJ2g85SnUzs1NzqA9RGTl6ljqSRtE=",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAC",
+			"value": "gaFYIMoP7biWQrP+8OqgSdoPOUp1M7NTc6gPURk5epY6kkbRgVggztyPhYbFKSr1JdKnf7ZGZcrELdgOm73qh0lOgJkBRFU=",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAD",
+			"value": "gaFYIM7cj4WGxSkq9SXSp3+2RmXKxC3YDpu96odJToCZAURVgVggcAkCU0yIfjdpEgKazIaPxsB3q6O24WUAegXatTY+RsM=",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAE",
+			"value": "gaFYIHAJAlNMiH43aRICmsyGj8bAd6ujtuFlAHoF2rU2PkbDgVggvfPYA4H/TNf/jhz/CwsVb7d8L2o3DYrtUTGrx9sutzU=",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAF",
+			"value": "gaFYIL3z2AOB/0zX/44c/wsLFW+3fC9qNw2K7VExq8fbLrc1gVggQGvVoz8RV/IxkSVfUVtTqO4dzWc0xnTbdY/VlmRgxvo=",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAG",
+			"value": "gaFYIEBr1aM/EVfyMZElX1FbU6juHc1nNMZ023WP1ZZkYMb6gVggNTlDAGKYRjrVkxu3LogAfa1Vv7cSF0SR9kSffSm2x4w=",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAH",
+			"value": "gaFYIDU5QwBimEY61ZMbty6IAH2tVb+3EhdEkfZEn30ptseMgVggyOp7gcI0rDIywR87w+NEhBoJXoc0hL1aI9CmLZtpbFE=",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAI",
+			"value": "gaFYIMjqe4HCNKwyMsEfO8PjRIQaCV6HNIS9WiPQpi2baWxRgVggPNidLxiouN4lkT1zOpwCoDn9S+UHiDpsc4UT5yR/zrU=",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAJ",
+			"value": "gaFYIDzYnS8YqLjeJZE9czqcAqA5/UvlB4g6bHOFE+ckf861gA==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AwAAAAAAAAABkaTxwZ7drDtw2SazKePvSSrIWYS0hmmytgHM5/94uhE=",
+			"value": null,
+			"version": 1,
+			"delete": true
+		},
+		{
+			"key": "AwAAAAAAAAACyg/tuJZCs/7w6qBJ2g85SnUzs1NzqA9RGTl6ljqSRtE=",
+			"value": "ioL0WCB/ntEa+7/597wIwODOVT9G9DcpdzXz+rsGQvibRWy/LoL0WCAlmHzcG2JmCDkSgT1oKPciyrQHgpF7EeCjWiLNUrb7VYL0WCDfxmmOnmusYWctRTq1/gqMcT7o/mS1iAjv2d90f9jSi4L0WCBPcSBEIOxtLjrWvjMCdQSIKmuF0Dj9qinQpoEYmUPtcoL0WCCVmumXU4Ufw0U0LKXo19TAkWi/pnF0hp/9iJZ5ioNwMIL0WCCIV6V4PryQgeQpX4QwbO2oLTfemiIVXWv+xXibvp+4DoL0WCBPtrDKuXe0d5TkuUSihozJRSrC1onu4DK8NliAEn8ef4L0WCAnyrXcRpHhWyRLYUlbd7uglqeWBcR6yTbvrQZ98reTN4L0WCDKD+24lkKz/vDqoEnaDzlKdTOzU3OoD1EZOXqWOpJG0YL1WCCRpPHBnt2sO3DZJrMp4+9JKshZhLSGabK2Aczn/3i6EQ==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AwAAAAAAAAADztyPhYbFKSr1JdKnf7ZGZcrELdgOm73qh0lOgJkBRFU=",
+			"value": "jIL0WCDBcIlNjWmdHkvRdW8iWlNx0b7Pl4lEhi5qVwjftO6XZoL0WCCsEdz5k5R2FYXhw7ZHyKpGEx5bp38xgfjqPRd9NLisPYL0WCASqTmE5X8XkPM+HTcOfOjyNVchJsWdImzn1+7qP/Tyi4L0WCDkVlke3eFy/rD6xuAvk/HC7lJk01EpCeCFrHe6Cng+0IL0WCC49HEgWSCeGRvYNPAcXlUCulCnK8DgMDCnQUZvruC7AIL0WCAQQj/yXh60MT1RKgjsLgx2rJAPpqjuX7YKmdIQF/NZsoL0WCCoRUTJ+vkFnuhxF/sxZoR3Y9owVF79aKDxPNm9DQ+TO4L0WCBLCBlebhbiS9XCne78NHQs2RoUOyEehF1gTCwcQaC9eYL0WCAlPKLhDSUftaJZfNZAXkN1+9rxV+K6IR1vZ9yTq9gPW4L0WCDO3I+FhsUpKvUl0qd/tkZlysQt2A6bveqHSU6AmQFEVYL1WCAnyrXcRpHhWyRLYUlbd7uglqeWBcR6yTbvrQZ98reTN4L1WCDKD+24lkKz/vDqoEnaDzlKdTOzU3OoD1EZOXqWOpJG0Q==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AwAAAAAAAAAEcAkCU0yIfjdpEgKazIaPxsB3q6O24WUAegXatTY+RsM=",
+			"value": "ioL0WCB9jc3jztJHk4MCwi48i2wJQD/u5fMbvvgqxMcszxmfFYL0WCBi7YLT+r7bISujq6HrP7MC5bdHcYgl0a5kbohBcJzQToL0WCCbZ8HkNR4Sn/rcsqULYtLPR1Xbzb0ru18mRrsqRDX7XYL0WCCFj7j4OzrYdtL9pzCoLuhq318U5nG8gWZeZ60eqekLWYL0WCAHBVAMSff8sCzdDxU/uYGoo3Hn3cKUrO4cmVzQtps1tYL0WCDJK/5EUAWnttn69QuccNTGUg4GDZmzWS5sdOlBIjt9KIL0WCCp/bPWjXRvxYqGsNK1uIdhPZTVA+w0h+zbCpvYBTPf3IL0WCBFqavbzJJq6z45ul5MAMJyUWs8r2UvyC/+riPrT0XVcoL0WCBwCQJTTIh+N2kSAprMho/GwHero7bhZQB6Bdq1Nj5Gw4L1WCDO3I+FhsUpKvUl0qd/tkZlysQt2A6bveqHSU6AmQFEVQ==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AwAAAAAAAAAFvfPYA4H/TNf/jhz/CwsVb7d8L2o3DYrtUTGrx9sutzU=",
+			"value": "jIL0WCAIaNBS6WWSkuUcgAJT4mSZqE8aCLgQyrFqP0p/824JC4L0WCAuOG+BRItAfeGSL+Bw2Mn08jOi/Po4+89H6d8cozxUgYL0WCB+9zjEmGFEl7TBasBsZBKEyXHpSTLJz8uNbtaKYzSexYL0WCBwfSHCtkPwJpEgbHMQE8tW0LMnFB1zEwoZNuS1eFqEHoL0WCBW/p3B/nGrx6u3h/m1uDs90C9A37ZxGn13rs8F3SU0MoL0WCBgAjNsD88mracABJInpmrWrTS5xjZRGP1FS1ZIzupcqoL0WCDYWgjwFjcNvPdiwNNtKhXqNezwGscDIskfykCL/+clIYL0WCCQjUrZvMTJuBL+reFGSlDOaWsEEZ1R0jwQcIHgnPnbNIL0WCCYquhuZHlJbvJqXTnbS+muH10PZGUeqOL9x8mFqVF51YL0WCC989gDgf9M1/+OHP8LCxVvt3wvajcNiu1RMavH2y63NYL1WCBFqavbzJJq6z45ul5MAMJyUWs8r2UvyC/+riPrT0XVcoL1WCBwCQJTTIh+N2kSAprMho/GwHero7bhZQB6Bdq1Nj5Gww==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AwAAAAAAAAAGQGvVoz8RV/IxkSVfUVtTqO4dzWc0xnTbdY/VlmRgxvo=",
+			"value": "jIL0WCAJRTnCMlI3A/naskO8bSuWy0JWVyV/B+ECpAEolOWcsIL0WCAzQs0FV4AecoDN9t/0QvC2ZtR9IjjLFzR89xoIA9yGv4L0WCBoQTlSR37kWavMA9Nl6/0+z5AECzIfLDl0DMGv0vedNIL0WCBUG3c5UZ5RdgerOyBwCgsd8LaI6SupvHs1Ba/xF2SSG4L0WCC9L0ONgSk6pT1b+ii9p95eB4tBUZP2VGedzGXAmTpJUoL0WCDNawbfuR13tFYX+2ZVLGLxvnijpQ7g9HrGH3VaLz75Y4L0WCCcSL48FHYDIKL9vas0WRSHRBur5FqqgiLu6MeXhXAKJIL0WCCS9JEIyM/WeaILriXDVxz7VhJGmpmgrJh/rjNO27DNTYL0WCCHCC2c+rCi+nSIR+GFMN28IWVv5GZP4GWH2/Bkeyo9nYL0WCBAa9WjPxFX8jGRJV9RW1Oo7h3NZzTGdNt1j9WWZGDG+oL1WCCYquhuZHlJbvJqXTnbS+muH10PZGUeqOL9x8mFqVF51YL1WCC989gDgf9M1/+OHP8LCxVvt3wvajcNiu1RMavH2y63NQ==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AwAAAAAAAAAHNTlDAGKYRjrVkxu3LogAfa1Vv7cSF0SR9kSffSm2x4w=",
+			"value": "joL0WCA55PKtUa6xXinlAHUF4Q4c/T5GJ2hz3OX57cjR7JlmeYL0WCAqiZzIU+2jcDleJs5D4xyXi5NehzGAejbxfXHVS+yMTIL0WCCdbT+wWfYZoU3MoD5Pw1+OrjEkLD2gi5UgSW8wB1O7JIL0WCCgXxgT9IN2hhOhY5MS1QS9bQ7Yvnq7FqtTuVDpt5cVdYL0WCAR0DncV9JO5JpE8enCVhdfFJVBeCI9uLTZUvyHuSezLoL0WCDa2GDBq0Do6+aRR9ydQn/rXUkmZa5fwpjrrE/ZSh3pHoL0WCBUb9ciGHjqheWOVxX8ZmCgSTeGyfJIrs6gSIFmOdBvqIL0WCCrmfDX3tbpuye62YbFuKuCBaaZq1PwMr55RCreE+fxD4L0WCAY121aUbHzwAEuQUsBhqd+bB8XFDauNE6M8toSfM7eMIL0WCCaIsh6t+94/R9DY8U0An1lFMqAjXpWm2Esp4Zi6Kk9e4L0WCA1OUMAYphGOtWTG7cuiAB9rVW/txIXRJH2RJ99KbbHjIL1WCCS9JEIyM/WeaILriXDVxz7VhJGmpmgrJh/rjNO27DNTYL1WCCHCC2c+rCi+nSIR+GFMN28IWVv5GZP4GWH2/Bkeyo9nYL1WCBAa9WjPxFX8jGRJV9RW1Oo7h3NZzTGdNt1j9WWZGDG+g==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AwAAAAAAAAAIyOp7gcI0rDIywR87w+NEhBoJXoc0hL1aI9CmLZtpbFE=",
+			"value": "ioL0WCCCg4D1trs4Br3LBu3hItjK4MVxAQtA4FV1iPBCVZGD+IL0WCBineiYSUqh9TMfVRV1z/s7IpvVqabRza2iYa0V78330IL0WCByogKqJz+F68I8dx5LF60TyrpBGkJ/qU7LpmD+7rtHp4L0WCCOT17j0YR/RE1F7TKRd6jH7uLffmG9oamANgvRHdnikoL0WCAvy7SrMd51ju3NNzjtVvj+8FJ7zr+P5atbVjiZumDrvIL0WCC5X524GbQAZkyPCgnr0vBilpC+MeoeIhBO3YuSp+3WNIL0WCBiuYDfeBFMa6Mv6dZGa9mgLZZS1cz8G3YTZuzvB/1cgIL0WCDeoEhoaFVe9hiXpSlP8+nCn+VDoJqfAK69nmogV0gWhIL0WCDI6nuBwjSsMjLBHzvD40SEGglehzSEvVoj0KYtm2lsUYL1WCA1OUMAYphGOtWTG7cuiAB9rVW/txIXRJH2RJ99KbbHjA==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AwAAAAAAAAAJPNidLxiouN4lkT1zOpwCoDn9S+UHiDpsc4UT5yR/zrU=",
+			"value": "jIL0WCANV6QiCmdTyJzeorE8ZUW8sGb8iPpU09l+rileitW4p4L0WCDNl7WPpbK2RRpDPkJGQy43lBp6KiqC6S+Pt54VuXcdqYL0WCDCVJgADy0ry1TvU1kmwEG+86f4gXu7jvqvnc9hQIUrGYL0WCDBY5ydczFKt/XmqntAusvmiIaK77w71aShxxEMKQYeLIL0WCDDkVuOQ6820WhPFBtAb9NGpuRi+quGxFudloW7EqiP7YL0WCB3A3r3QbWiK5gDTgyJKb637UuRJeh5kTr36fHfbBVYMoL0WCBj0mxTZZxZsOtfJ0jUec2U3HXKc+OFA8ySG78vPyDuUYL0WCDkR6+L2b6S3fKTvdwoQFnjPNVXRPkvVCIiUrIepZyQooL0WCBCl3S6oDqR+F4CkIu+C4x+eG/tXPW3XdaGQRi7ZNG21IL0WCA82J0vGKi43iWRPXM6nAKgOf1L5QeIOmxzhRPnJH/OtYL1WCDeoEhoaFVe9hiXpSlP8+nCn+VDoJqfAK69nmogV0gWhIL1WCDI6nuBwjSsMjLBHzvD40SEGglehzSEvVoj0KYtm2lsUQ==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "BA==",
+			"value": "pWd2ZXJzaW9uA2luYW1lc3BhY2VYIIAAAAAAAAAA8399aUcoc2zrx7b1uhzJqpwQSzTgzSiIcGVhcmxpZXN0X3ZlcnNpb24BcW11bHRpcGFydF92ZXJzaW9uAHZsYXN0X2ZpbmFsaXplZF92ZXJzaW9uAQ==",
+			"version": 1,
+			"delete": false
+		}
+	]
+}

--- a/go/storage/mkvs/db/pathbadger/testdata/case-nonfinalized.json
+++ b/go/storage/mkvs/db/pathbadger/testdata/case-nonfinalized.json
@@ -1,0 +1,85 @@
+{
+	"pending_root": "13f1251fc6162fb7128de896792ba2208bc636273ffddbb81772713948a175cd",
+	"long_roots": null,
+	"pending_version": 2,
+	"entries": [
+		{
+			"key": "AATT6kBQDsNtj2MGmoaYqBnaocWf16kCNf7FZBmDnT2b",
+			"value": "AAIAAAAAAAAAGAB0aGlzIGtleSBzaGFyZXMgYSBwcmVmaXgRAAAAYnV0IG5vdCB0aGUgdmFsdWU=",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "ACoMPoe50MBSxLa/wmIDdaGb8GfZWMIxHPbtG7rY0Vul",
+			"value": "AQIAAAAAAAAASACjQ0uZA1sryQMC838caFlR0g5JjBWC+vQGfIRFwifG1zTJwUCPShe6bsAE0+pAUA7DbY9jBpqGmKgZ2qHFn9epAjX+xWQZg509mw==",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AHrBxDharSOeGPkXg4tlekkD5JwN13phXg0e9arbv+1s",
+			"value": "AAEAAAAAAAAAMgBhbmQgdGhpcyBrZXkgbWFrZXMgc3VyZSB3ZSBoYXZlIG1vcmUgdGhhbiBvbmUgbm9kZSQAAABkb3VibGUgdGhlIHZhbHVlcyEgZG91YmxlIHRoZSBtYWdpYyE=",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AIyMil+mRhdKClTmrfPQrBkZlC/CwLWYlWRdWqpGYnHA",
+			"value": "AQEAAAAAAAAAAwBgAnrBxDharSOeGPkXg4tlekkD5JwN13phXg0e9arbv+1s838caFlR0g5JjBWC+vQGfIRFwifG1zTJwUCPShe6bsA=",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "ANYDwd1G+OAu6kU0YUvsEwNgVTWp6Zwfrp03z/9/LCVp",
+			"value": "AQIAAAAAAAAAAwBgAnrBxDharSOeGPkXg4tlekkD5JwN13phXg0e9arbv+1sKgw+h7nQwFLEtr/CYgN1oZvwZ9lYwjEc9u0butjRW6U=",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "APN/HGhZUdIOSYwVgvr0BnyERcInxtc0ycFAj0oXum7A",
+			"value": "AAEAAAAAAAAAFgB0aGlzIGtleSBpcyBtYXJ2ZWxsb3VzFAAAAHdpdGggYSB2YWx1ZSB0byBib290",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AQAAAAAAAAABjIyKX6ZGF0oKVOat89CsGRmUL8LAtZiVZF1aqkZiccDGcrjR71btKKuHw2IsURQGm90617j5c3SY0MAezvCWeg==",
+			"value": "gqJjS2V5VnRoaXMga2V5IGlzIG1hcnZlbGxvdXNsSW5zZXJ0ZWRIYXNoWCDzfxxoWVHSDkmMFYL69AZ8hEXCJ8bXNMnBQI9KF7puwKJjS2V5WDJhbmQgdGhpcyBrZXkgbWFrZXMgc3VyZSB3ZSBoYXZlIG1vcmUgdGhhbiBvbmUgbm9kZWxJbnNlcnRlZEhhc2hYIHrBxDharSOeGPkXg4tlekkD5JwN13phXg0e9arbv+1s",
+			"version": 3,
+			"delete": false
+		},
+		{
+			"key": "AQAAAAAAAAAC1gPB3Ub44C7qRTRhS+wTA2BVNanpnB+unTfP/38sJWmMjIpfpkYXSgpU5q3z0KwZGZQvwsC1mJVkXVqqRmJxwA==",
+			"value": "gaJjS2V5WBh0aGlzIGtleSBzaGFyZXMgYSBwcmVmaXhsSW5zZXJ0ZWRIYXNoWCAE0+pAUA7DbY9jBpqGmKgZ2qHFn9epAjX+xWQZg509mw==",
+			"version": 4,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAB",
+			"value": "gaFYIIyMil+mRhdKClTmrfPQrBkZlC/CwLWYlWRdWqpGYnHAgVgg1gPB3Ub44C7qRTRhS+wTA2BVNanpnB+unTfP/38sJWk=",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AgAAAAAAAAAC",
+			"value": "gaFYINYDwd1G+OAu6kU0YUvsEwNgVTWp6Zwfrp03z/9/LCVpgA==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "AwAAAAAAAAABjIyKX6ZGF0oKVOat89CsGRmUL8LAtZiVZF1aqkZiccA=",
+			"value": null,
+			"version": 1,
+			"delete": true
+		},
+		{
+			"key": "AwAAAAAAAAAC1gPB3Ub44C7qRTRhS+wTA2BVNanpnB+unTfP/38sJWk=",
+			"value": "hIL0WCAE0+pAUA7DbY9jBpqGmKgZ2qHFn9epAjX+xWQZg509m4L0WCAqDD6HudDAUsS2v8JiA3Whm/Bn2VjCMRz27Ru62NFbpYL0WCDWA8HdRvjgLupFNGFL7BMDYFU1qemcH66dN8//fywlaYL1WCCMjIpfpkYXSgpU5q3z0KwZGZQvwsC1mJVkXVqqRmJxwA==",
+			"version": 1,
+			"delete": false
+		},
+		{
+			"key": "BA==",
+			"value": "pWd2ZXJzaW9uA2luYW1lc3BhY2VYIIAAAAAAAAAA8399aUcoc2zrx7b1uhzJqpwQSzTgzSiIcGVhcmxpZXN0X3ZlcnNpb24BcW11bHRpcGFydF92ZXJzaW9uAHZsYXN0X2ZpbmFsaXplZF92ZXJzaW9uAQ==",
+			"version": 1,
+			"delete": false
+		}
+	]
+}

--- a/go/storage/mkvs/db/pathbadger/timestamp.go
+++ b/go/storage/mkvs/db/pathbadger/timestamp.go
@@ -1,0 +1,11 @@
+package pathbadger
+
+// Timestamp at which database metadata is stored. This needs to be 1 so that we can discard any
+// invalid/removed cruft while still keeping everything else even if pruning is not enabled.
+const tsMetadata = 1
+
+// versionToTs converts a MKVS version to a Badger timestamp.
+func versionToTs(version uint64) uint64 {
+	// Version 0 starts at timestamp after metadata.
+	return tsMetadata + 1 + version
+}

--- a/go/storage/mkvs/db/pathbadger/writelog.go
+++ b/go/storage/mkvs/db/pathbadger/writelog.go
@@ -1,0 +1,166 @@
+package pathbadger
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/dgraph-io/badger/v4"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/node"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/writelog"
+)
+
+// internalWriteLog is an internal database representation of a write log. The first byte denotes
+// whether a given key has been inserted or removed. In case the key has been removed, the rest of
+// the entry contains the removed key. In case the key has been inserted, the rest of the entry
+// contains the index and version of the corresponding leaf node.
+type internalWriteLog [][]byte
+
+const (
+	internalWriteLogKindInsert = 0x01
+	internalWriteLogKindDelete = 0x02
+)
+
+// makeInternalWriteLog converts the given write log into an internal database representation.
+func makeInternalWriteLog(writeLog writelog.WriteLog, annotations writelog.Annotations) internalWriteLog {
+	log := make(internalWriteLog, 0, len(writeLog))
+	for i, entry := range writeLog {
+		if annotations[i].InsertedNode == nil {
+			log = append(log, append([]byte{internalWriteLogKindDelete}, entry.Key...))
+		} else {
+			iptr := annotations[i].InsertedNode.DBInternal.(*dbPtr)
+			log = append(log, append([]byte{internalWriteLogKindInsert}, iptr.dbKey()...))
+		}
+	}
+	return log
+}
+
+// storeInternalWriteLog stores the given write log using an internal database representation.
+func storeInternalWriteLog(
+	batch *badger.WriteBatch,
+	startRootHash api.TypedHash,
+	endRootHash api.TypedHash,
+	endRootVersion uint64,
+	writeLog writelog.WriteLog,
+	annotations writelog.Annotations,
+) error {
+	if writeLog == nil || annotations == nil {
+		return nil
+	}
+	intLog := makeInternalWriteLog(writeLog, annotations)
+
+	key := writeLogKeyFmt.Encode(endRootVersion, &endRootHash, &startRootHash)
+	if err := batch.Set(key, cbor.Marshal(intLog)); err != nil {
+		return fmt.Errorf("mkvs/pathbadger: set new write log returned error: %w", err)
+	}
+	return nil
+}
+
+// Implements api.NodeDB.
+func (d *badgerNodeDB) GetWriteLog(_ context.Context, startRoot, endRoot node.Root) (writelog.Iterator, error) {
+	if d.discardWriteLogs {
+		return nil, api.ErrWriteLogNotFound
+	}
+	if !endRoot.Follows(&startRoot) {
+		return nil, api.ErrRootMustFollowOld
+	}
+	if err := d.sanityCheckNamespace(&startRoot.Namespace); err != nil {
+		return nil, err
+	}
+	// If the version is earlier than the earliest version, we don't have the roots.
+	if endRoot.Version < d.meta.getEarliestVersion() {
+		return nil, api.ErrWriteLogNotFound
+	}
+	// If difference between versions is more than 1 we can reject early.
+	if endRoot.Version-startRoot.Version > 1 {
+		return nil, api.ErrWriteLogNotFound
+	}
+
+	tx := d.db.NewTransactionAt(versionToTs(endRoot.Version), false)
+	defer tx.Discard()
+
+	// Check if the root actually exists.
+	if err := d.checkRootExists(tx, endRoot); err != nil {
+		return nil, err
+	}
+
+	startRootHash := api.TypedHashFromRoot(startRoot)
+	endRootHash := api.TypedHashFromRoot(endRoot)
+
+	item, err := tx.Get(writeLogKeyFmt.Encode(endRoot.Version, &endRootHash, &startRootHash))
+	switch err {
+	case nil:
+	case badger.ErrKeyNotFound:
+		return nil, api.ErrWriteLogNotFound
+	default:
+		return nil, fmt.Errorf("mkvs/pathbadger: failed to fetch write log: %w", err)
+	}
+
+	var log internalWriteLog
+	if err = item.Value(func(data []byte) error {
+		return cbor.UnmarshalTrusted(data, &log)
+	}); err != nil {
+		return nil, fmt.Errorf("mkvs/pathbadger: failed to unmarshal write log: %w", err)
+	}
+
+	// Determine sequence number for the root. All finalized roots use a seqNo of zero.
+	seqNo, _ := d.meta.getPendingRootSeqNo(endRoot.Version, endRootHash)
+	if seqNo != 0 {
+		return nil, api.ErrWriteLogNotFound
+	}
+
+	// Note the root node dbKey as an entry could also end there.
+	rootNodeDbKey := encodeNodeKey(endRoot.Version, 0)
+
+	// Resolve the write log.
+	wl := make(writelog.WriteLog, 0, len(log))
+	for _, key := range log {
+		switch key[0] {
+		case internalWriteLogKindDelete:
+			// Deletion.
+			wl = append(wl, writelog.LogEntry{Key: key[1:]})
+		case internalWriteLogKindInsert:
+			// Insertion.
+			if bytes.Equal(key[1:], rootNodeDbKey) {
+				// Fetch the root node as a key ends there.
+				var rootNodeKey, rootNodeValue []byte
+				item, err = tx.Get(rootNodeKeyFmt.Encode(endRoot.Version, &endRootHash))
+				if err != nil {
+					return nil, fmt.Errorf("mkvs/pathbadger: failed to fetch root node: %w", err)
+				}
+				if err = item.Value(func(rawValue []byte) error {
+					rootNodeKey, rootNodeValue, err = leafFromDb(rawValue)
+					return err
+				}); err != nil {
+					return nil, fmt.Errorf("mkvs/pathbadger: failed to unmarshal root node: %w", err)
+				}
+
+				wl = append(wl, writelog.LogEntry{Key: rootNodeKey, Value: rootNodeValue})
+				continue
+			}
+
+			item, err = tx.Get(finalizedNodeKeyFmt.Encode(byte(endRoot.Type), key[1:]))
+			switch err {
+			case nil:
+				// Key has been inserted, resolve value from node.
+				var key, value []byte
+				if err = item.Value(func(rawValue []byte) error {
+					key, value, err = leafFromDb(rawValue)
+					return err
+				}); err != nil {
+					return nil, fmt.Errorf("mkvs/pathbadger: failed to unmarshal node: %w", err)
+				}
+				wl = append(wl, writelog.LogEntry{Key: key, Value: value})
+			default:
+				return nil, fmt.Errorf("mkvs/pathbadger: failed to fetch node: %w", err)
+			}
+		default:
+			return nil, fmt.Errorf("mkvs/pathbadger: internal write log is corrupted")
+		}
+	}
+
+	return writelog.NewStaticIterator(wl), nil
+}

--- a/go/storage/mkvs/db/testing/testing.go
+++ b/go/storage/mkvs/db/testing/testing.go
@@ -1,0 +1,17 @@
+// Package testing provides helpers for running node database tests.
+package testing
+
+import (
+	"testing"
+
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
+)
+
+// TestMultipleBackends runs a given test function on the specified node database backends.
+func TestMultipleBackends(t *testing.T, backends []api.Factory, fn func(*testing.T, api.Factory)) {
+	for _, factory := range backends {
+		t.Run(factory.Name(), func(t *testing.T) {
+			fn(t, factory)
+		})
+	}
+}

--- a/go/storage/mkvs/insert.go
+++ b/go/storage/mkvs/insert.go
@@ -42,6 +42,7 @@ func (t *tree) Insert(ctx context.Context, key, value []byte) error {
 			}
 		} else {
 			entry.value = value
+			entry.insertedLeaf = result.insertedLeaf
 		}
 	}
 
@@ -118,11 +119,11 @@ func (t *tree) doInsert(
 			if !n.LeafNode.IsClean() || !n.Left.IsClean() || !n.Right.IsClean() {
 				if n.Clean {
 					// Node was clean so old node is eligible for removal.
-					t.pendingRemovedNodes = append(t.pendingRemovedNodes, n.ExtractUnchecked())
+					t.pendingRemovedNodes = append(t.pendingRemovedNodes, ptr.ExtractUnchecked())
 				}
 
 				n.Clean = false
-				ptr.Clean = false
+				ptr.SetDirty()
 				// No longer eligible for eviction as it is dirty.
 				t.cache.rollbackNode(ptr)
 			}
@@ -139,11 +140,11 @@ func (t *tree) doInsert(
 
 		if n.Clean {
 			// Node was clean so old node is eligible for removal.
-			t.pendingRemovedNodes = append(t.pendingRemovedNodes, n.ExtractUnchecked())
+			t.pendingRemovedNodes = append(t.pendingRemovedNodes, ptr.ExtractUnchecked())
 		}
 
 		n.Clean = false
-		ptr.Clean = false
+		ptr.SetDirty()
 		// No longer eligible for eviction as it is dirty.
 		t.cache.rollbackNode(ptr)
 
@@ -185,12 +186,12 @@ func (t *tree) doInsert(
 
 			if n.Clean {
 				// Node is dirty so old node is eligible for removal.
-				t.pendingRemovedNodes = append(t.pendingRemovedNodes, n.ExtractUnchecked())
+				t.pendingRemovedNodes = append(t.pendingRemovedNodes, ptr.ExtractUnchecked())
 			}
 
 			n.Value = val
 			n.Clean = false
-			ptr.Clean = false
+			ptr.SetDirty()
 			// No longer eligible for eviction as it is dirty.
 			t.cache.rollbackNode(ptr)
 			return insertResult{

--- a/go/storage/mkvs/syncer/proof_test.go
+++ b/go/storage/mkvs/syncer/proof_test.go
@@ -28,6 +28,9 @@ func TestProofExtraNodes(t *testing.T) {
 	var verifier ProofVerifier
 	_, err = verifier.VerifyProof(context.Background(), rootHash, &proof)
 	require.NoError(err)
+	wl, err := verifier.VerifyProofToWriteLog(context.Background(), rootHash, &proof)
+	require.NoError(err)
+	require.Empty(wl)
 
 	// Duplicate some nodes and add them to the end.
 	proof.Entries = append(proof.Entries, proof.Entries[0])
@@ -43,6 +46,9 @@ func TestProofExtraNodes(t *testing.T) {
 	// Verify the proof as a sanity check.
 	_, err = verifier.VerifyProof(context.Background(), rootHash, &proof)
 	require.NoError(err)
+	wl, err = verifier.VerifyProofToWriteLog(context.Background(), rootHash, &proof)
+	require.NoError(err)
+	require.Empty(wl)
 
 	// Duplicate some nodes and add them to the end.
 	proof.Entries = append(proof.Entries, proof.Entries[0])

--- a/go/storage/mkvs/testdata/case-6.json
+++ b/go/storage/mkvs/testdata/case-6.json
@@ -1,0 +1,21 @@
+[
+    {
+        "op": "Insert",
+        "key": "AgA=",
+        "value": "AQ=="
+    },
+    {
+        "op": "Insert",
+        "key": "Ag==",
+        "value": "AQ=="
+    },
+    {
+        "op": "Insert",
+        "key": "AQ==",
+        "value": "AQ=="
+    },
+    {
+        "op": "Remove",
+        "key": "AgA="
+    }
+]

--- a/go/storage/mkvs/tree.go
+++ b/go/storage/mkvs/tree.go
@@ -22,7 +22,7 @@ type tree struct { // nolint: maligned
 	// pendingRemovedNodes are the nodes that have been removed from the
 	// in-memory tree and should be marked for garbage collection if this
 	// tree is committed to the node database.
-	pendingRemovedNodes []node.Node
+	pendingRemovedNodes []*node.Pointer
 }
 
 type pendingEntry struct {

--- a/go/worker/compute/executor/committee/node.go
+++ b/go/worker/compute/executor/committee/node.go
@@ -743,7 +743,8 @@ func (n *Node) proposeBatch(
 			return err
 		}
 
-		return nil
+		// Ensure storage is written to disk before signing a commitment.
+		return n.storage.NodeDB().Sync()
 	}()
 	if storageErr != nil {
 		n.logger.Error("storage failure, submitting failure indicating commitment",

--- a/go/worker/compute/executor/committee/prune.go
+++ b/go/worker/compute/executor/committee/prune.go
@@ -13,14 +13,14 @@ type pruneHandler struct {
 	commonNode *committee.Node
 }
 
-func (p *pruneHandler) Prune(ctx context.Context, rounds []uint64) error {
+func (p *pruneHandler) Prune(rounds []uint64) error {
 	p.commonNode.CrossNode.Lock()
 	height := p.commonNode.CurrentBlockHeight
 	p.commonNode.CrossNode.Unlock()
 
 	// Make sure we never prune past the last successful round as we need that round in history so
 	// we can fetch any needed round results.
-	state, err := p.commonNode.Consensus.RootHash().GetRuntimeState(ctx, &roothash.RuntimeRequest{
+	state, err := p.commonNode.Consensus.RootHash().GetRuntimeState(context.Background(), &roothash.RuntimeRequest{
 		RuntimeID: p.commonNode.Runtime.ID(),
 		Height:    height,
 	})

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -1284,7 +1284,7 @@ type pruneHandler struct {
 	node   *Node
 }
 
-func (p *pruneHandler) Prune(ctx context.Context, rounds []uint64) error {
+func (p *pruneHandler) Prune(rounds []uint64) error {
 	// Make sure we never prune past what was synced.
 	lastSycnedRound, _, _ := p.node.GetLastSynced()
 
@@ -1300,7 +1300,7 @@ func (p *pruneHandler) Prune(ctx context.Context, rounds []uint64) error {
 		p.logger.Debug("pruning storage for round", "round", round)
 
 		// Prune given block.
-		err := p.node.localStorage.NodeDB().Prune(ctx, round)
+		err := p.node.localStorage.NodeDB().Prune(round)
 		switch err {
 		case nil:
 		case mkvsDB.ErrNotEarliest:

--- a/go/worker/storage/config/config.go
+++ b/go/worker/storage/config/config.go
@@ -2,8 +2,9 @@
 package config
 
 import (
-	"fmt"
 	"time"
+
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/db"
 )
 
 // Config is the storage worker configuration structure.
@@ -34,11 +35,8 @@ type CheckpointerConfig struct {
 
 // Validate validates the configuration settings.
 func (c *Config) Validate() error {
-	if c.Backend != "badger" {
-		return fmt.Errorf("unknown storage backend: %s", c.Backend)
-	}
-
-	return nil
+	_, err := db.GetBackendByName(c.Backend)
+	return err
 }
 
 // DefaultConfig returns the default configuration settings.

--- a/go/worker/storage/init.go
+++ b/go/worker/storage/init.go
@@ -36,6 +36,7 @@ func NewLocalBackend(
 		DB:           dataDir,
 		Namespace:    namespace,
 		MaxCacheSize: int64(config.ParseSizeInBytes(config.GlobalConfig.Storage.MaxCacheSize)),
+		NoFsync:      true, // Should be safe, storage will be re-applied on crashes.
 	}
 
 	cfg.DB = GetLocalBackendDBDir(dataDir, cfg.Backend)

--- a/go/worker/storage/init.go
+++ b/go/worker/storage/init.go
@@ -2,7 +2,6 @@
 package storage
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -39,17 +38,8 @@ func NewLocalBackend(
 		MaxCacheSize: int64(config.ParseSizeInBytes(config.GlobalConfig.Storage.MaxCacheSize)),
 	}
 
-	var (
-		err  error
-		impl api.LocalBackend
-	)
-	switch cfg.Backend {
-	case database.BackendNameBadgerDB:
-		cfg.DB = GetLocalBackendDBDir(dataDir, cfg.Backend)
-		impl, err = database.New(cfg)
-	default:
-		err = fmt.Errorf("storage: unsupported backend: '%v'", cfg.Backend)
-	}
+	cfg.DB = GetLocalBackendDBDir(dataDir, cfg.Backend)
+	impl, err := database.New(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/go/worker/storage/worker.go
+++ b/go/worker/storage/worker.go
@@ -174,12 +174,10 @@ func (w *Worker) Start() error {
 			_ = r.Start()
 		}
 
-		// Wait for runtimes to be initialized and the node to be registered.
+		// Wait for runtimes to be initialized.
 		for _, r := range w.runtimes {
 			<-r.Initialized()
 		}
-
-		<-w.registration.InitialRegistrationCh()
 
 		w.logger.Info("storage worker started")
 


### PR DESCRIPTION
Instead of using trie node hashes as keys in the underlying Badger store, this new backend instead use a combination of version and index within the batch of trie nodes as keys which leads to improved locality when iterating over the trie while at the same time making the database smaller.

The new backend makes some (reasonable) assumptions, specifically that only one root per type may be finalized in any version and that there may be no child roots within the same version.

The new backend is experimental.

Further improvements could be made via node aggregation.

**TODO**
* [x] Add back support for multipart restore.
* [x] Test on existing networks.