### PR TITLE
runtime/src/storage: Move untrusted in-memory key/value storage

### DIFF
--- a/.changelog/5561.internal.md
+++ b/.changelog/5561.internal.md
@@ -1,0 +1,3 @@
+runtime/src/storage: Move untrusted in-memory key/value storage
+
+The untrusted in-memory key/value storage is now accessible to all tests.

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -1,5 +1,8 @@
 //! Runtime storage interfaces and implementations.
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use crate::types::Error;
 
@@ -8,7 +11,7 @@ pub mod mkvs;
 // Re-exports.
 pub use self::mkvs::MKVS;
 
-/// Trivial Key/Value storage.
+/// Trivial key/value storage.
 pub trait KeyValue: Send + Sync {
     /// Fetch the value for a specific key.
     fn get(&self, key: Vec<u8>) -> Result<Vec<u8>, Error>;
@@ -24,5 +27,40 @@ impl<T: ?Sized + KeyValue> KeyValue for Arc<T> {
 
     fn insert(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error> {
         KeyValue::insert(&**self, key, value)
+    }
+}
+
+/// Untrusted key/value storage which stores arbitrary binary key/value pairs
+/// in memory.
+pub struct UntrustedInMemoryStorage {
+    store: Mutex<HashMap<Vec<u8>, Vec<u8>>>,
+}
+
+impl UntrustedInMemoryStorage {
+    pub fn new() -> Self {
+        Self {
+            store: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl KeyValue for UntrustedInMemoryStorage {
+    fn get(&self, key: Vec<u8>) -> Result<Vec<u8>, Error> {
+        // Return an empty vector if the key is not found.
+        let cache = self.store.lock().unwrap();
+        let value = cache.get(&key).cloned().unwrap_or_default();
+        Ok(value)
+    }
+
+    fn insert(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error> {
+        let mut cache = self.store.lock().unwrap();
+        cache.insert(key, value);
+        Ok(())
+    }
+}
+
+impl Default for UntrustedInMemoryStorage {
+    fn default() -> Self {
+        Self::new()
     }
 }


### PR DESCRIPTION
The untrusted in-memory key/value storage is now accessible to all tests.