### PR TITLE
governance: Remove unchanged proposal parameters

### DIFF
--- a/.changelog/5566.bugfix.md
+++ b/.changelog/5566.bugfix.md
@@ -1,0 +1,4 @@
+governance/ChangeParametersProposal: Display only changed parameters
+
+Omit the unchanged parameter values when pretty-printing the
+`ChangeParameterProposal`.

--- a/go/governance/api/api.go
+++ b/go/governance/api/api.go
@@ -241,6 +241,9 @@ func (p *ChangeParametersProposal) PrettyPrint(_ context.Context, prefix string,
 	fmt.Fprintf(w, "%sModule: %s\n", prefix, p.Module)
 	fmt.Fprintf(w, "%sChanges: \n", prefix)
 	for param, value := range changes {
+		if value == nil {
+			continue
+		}
 		fmt.Fprintf(w, "%s  - Parameter: %s\n", prefix, param)
 		fmt.Fprintf(w, "%s    Value: %v\n", prefix, value)
 	}


### PR DESCRIPTION
Previously, when creating a governance proposal, the writer would output unchanged parameters and show them as nil value. 