### PR TITLE
go/runtime/host: Wait for readiness instead of failing immediately

### DIFF
--- a/.changelog/5577.bugfix.md
+++ b/.changelog/5577.bugfix.md
@@ -1,0 +1,1 @@
+go/runtime/host: Wait for readiness instead of failing immediately


### PR DESCRIPTION
This is especially noticable after #5569 which added an early node identity query.