### PR TITLE
go/upgrade: Adjust MaxTxSize and MaxBlockSize in consensus240 handler

### DIFF
--- a/.changelog/5588.feature.md
+++ b/.changelog/5588.feature.md
@@ -1,0 +1,4 @@
+go/upgrade: Adjust MaxTxSize and MaxBlockSize in consensus240 handler
+
+This is needed as DCAP quotes are larger and nodes running multiple
+confidential runtimes may otherwise exceed the max transaction size.

--- a/go/go.mod
+++ b/go/go.mod
@@ -57,7 +57,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d
 	google.golang.org/grpc v1.59.0
 	google.golang.org/grpc/security/advancedtls v0.0.0-20221004221323-12db695f1648
-	google.golang.org/protobuf v1.31.0
+	google.golang.org/protobuf v1.33.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go/go.sum
+++ b/go/go.sum
@@ -1093,8 +1093,8 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
-google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go/oasis-test-runner/scenario/e2e/upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/upgrade.go
@@ -104,6 +104,24 @@ func (c *upgrade240Checker) PreUpgradeFn(ctx context.Context, ctrl *oasis.Contro
 }
 
 func (c *upgrade240Checker) PostUpgradeFn(ctx context.Context, ctrl *oasis.Controller) error {
+	// Check updated consensus parameters.
+	consParams, err := ctrl.Consensus.GetParameters(ctx, consensus.HeightLatest)
+	if err != nil {
+		return fmt.Errorf("can't get consensus parameters: %w", err)
+	}
+	if expectedMaxTxSize := 128 * 1024; consParams.Parameters.MaxTxSize != uint64(expectedMaxTxSize) {
+		return fmt.Errorf("consensus parameter MaxTxSize not updated correctly (expected: %d actual: %d)",
+			expectedMaxTxSize,
+			consParams.Parameters.MaxTxSize,
+		)
+	}
+	if expectedMaxBlockSize := 4 * 1024 * 1024; consParams.Parameters.MaxBlockSize != uint64(expectedMaxBlockSize) {
+		return fmt.Errorf("consensus parameter MaxBlockSize not updated correctly (expected: %d actual: %d)",
+			expectedMaxBlockSize,
+			consParams.Parameters.MaxBlockSize,
+		)
+	}
+
 	// Check updated registry parameters.
 	registryParams, err := ctrl.Registry.ConsensusParameters(ctx, consensus.HeightLatest)
 	if err != nil {


### PR DESCRIPTION
This is needed as DCAP quotes are larger and nodes running multiple confidential runtimes may otherwise exceed the max transaction size.