### PR TITLE
go/worker/storage: Make fetch pool per-runtime

### DIFF
--- a/.changelog/5595.feature.md
+++ b/.changelog/5595.feature.md
@@ -1,0 +1,4 @@
+go/worker/storage: Make fetch pool per-runtime
+
+This should speed up storage sync in case of nodes that have multiple
+runtimes configured.


### PR DESCRIPTION
This should speed up storage sync in case of nodes that have multiple runtimes configured.