### PR TITLE
go/archive: fix runtime queries on archive nodes

### DIFF
--- a/.changelog/5622.bugfix.md
+++ b/.changelog/5622.bugfix.md
@@ -1,0 +1,4 @@
+go/archive: fix runtime queries on archive nodes
+
+Fixes storage worker initialization on archive nodes which was causing runtime
+queries to fail.

--- a/go/consensus/cometbft/full/archive.go
+++ b/go/consensus/cometbft/full/archive.go
@@ -16,6 +16,7 @@ import (
 	cmtcore "github.com/cometbft/cometbft/rpc/core"
 	"github.com/cometbft/cometbft/state"
 	"github.com/cometbft/cometbft/store"
+	cmttypes "github.com/cometbft/cometbft/types"
 	"github.com/spf13/viper"
 
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
@@ -37,6 +38,7 @@ type archiveService struct {
 	*commonNode
 
 	abciClient abcicli.Client
+	eb         *cmttypes.EventBus
 
 	quitCh chan struct{}
 
@@ -47,6 +49,10 @@ type archiveService struct {
 func (srv *archiveService) Start() error {
 	if srv.started() {
 		return fmt.Errorf("cometbft: service already started")
+	}
+
+	if err := srv.eb.Start(); err != nil {
+		return err
 	}
 
 	if err := srv.commonNode.start(); err != nil {
@@ -69,6 +75,15 @@ func (srv *archiveService) Start() error {
 			}
 		}
 	}()
+
+	// Start command dispatchers for all the service clients.
+	srv.serviceClientsWg.Add(len(srv.serviceClients))
+	for _, svc := range srv.serviceClients {
+		go func() {
+			defer srv.serviceClientsWg.Done()
+			srv.serviceClientWorker(srv.ctx, svc)
+		}()
+	}
 
 	srv.commonNode.finishStart()
 
@@ -213,6 +228,7 @@ func NewArchive(
 		return nil, err
 	}
 
+	srv.eb = cmttypes.NewEventBus()
 	// Setup minimal CometBFT environment needed to support consensus queries.
 	cmtcore.SetEnvironment(&cmtcore.Environment{
 		ProxyAppQuery:    cmtproxy.NewAppConnQuery(srv.abciClient, nil),
@@ -224,7 +240,7 @@ func NewArchive(
 		GenDoc:           tmGenDoc,
 		Logger:           logger,
 		Config:           *cmtConfig.RPC,
-		EventBus:         nil,
+		EventBus:         srv.eb,
 		P2PPeers:         nil,
 		P2PTransport:     nil,
 		PubKey:           nil,
@@ -235,4 +251,47 @@ func NewArchive(
 	})
 
 	return srv, srv.initialize()
+}
+
+// serviceClientWorker handles command dispatching.
+func (srv *archiveService) serviceClientWorker(ctx context.Context, svc api.ServiceClient) {
+	sd := svc.ServiceDescriptor()
+	if sd == nil {
+		// Some services don't actually need a worker.
+		return
+	}
+
+	// Archive only handles commands.
+	cmdCh := sd.Commands()
+	if cmdCh == nil {
+		// Services without commands do not need a worker.
+		return
+	}
+
+	logger := srv.Logger.With("service", sd.Name())
+	logger.Info("starting command dispatcher")
+
+	// Fetch and remember the latest block. This won't change on an archive node.
+	latestBlock, err := srv.commonNode.GetBlock(ctx, consensusAPI.HeightLatest)
+	if err != nil {
+		logger.Error("failed to fetch latest block",
+			"err", err,
+		)
+		return
+	}
+
+	// Service client event loop.
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case cmd := <-cmdCh:
+			if err := svc.DeliverCommand(ctx, latestBlock.Height, cmd); err != nil {
+				logger.Error("failed to deliver command to service client",
+					"err", err,
+				)
+				continue
+			}
+		}
+	}
 }

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
+	"github.com/oasisprotocol/oasis-core/go/config"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 )
@@ -176,6 +177,11 @@ func (h *runtimeHistory) ConsensusCheckpoint(height int64) error {
 }
 
 func (h *runtimeHistory) StorageSyncCheckpoint(round uint64) error {
+	if config.GlobalConfig.Mode == config.ModeArchive {
+		// If we are in archive mode, ignore storage sync checkpoints.
+		return nil
+	}
+
 	if !h.haveLocalStorageWorker {
 		panic("received storage sync checkpoint when local storage worker is disabled")
 	}


### PR DESCRIPTION
TODO: Also backport to 22.2.x

Fix runtime queries on archive nodes. Also adds a runtime query to the archive_api E2E test.

Runtime queries are failing on archive due to the `CurrentBlock` not being set in the common node.