### PR TITLE
[BACKPORT/22.2.x] go/archive: fix runtime queries on archive node

### DIFF
--- a/.changelog/5622.bugfix.md
+++ b/.changelog/5622.bugfix.md
@@ -1,0 +1,4 @@
+go/archive: fix runtime queries on archive nodes
+
+Fixes storage worker initialization on archive nodes which was causing runtime
+queries to fail.

--- a/go/oasis-node/cmd/storage/storage.go
+++ b/go/oasis-node/cmd/storage/storage.go
@@ -164,7 +164,7 @@ func doMigrate(cmd *cobra.Command, args []string) error {
 		err := func() error {
 			runtimeDir := registry.GetRuntimeStateDir(dataDir, rt)
 
-			history, err := history.New(runtimeDir, rt, nil, false)
+			history, err := history.New(runtimeDir, rt, nil, false, false)
 			if err != nil {
 				return fmt.Errorf("error creating history provider: %w", err)
 			}

--- a/go/runtime/history/history_test.go
+++ b/go/runtime/history/history_test.go
@@ -29,7 +29,7 @@ func TestHistory(t *testing.T) {
 	runtimeID := common.NewTestNamespaceFromSeed([]byte("history test ns 1"), 0)
 	runtimeID2 := common.NewTestNamespaceFromSeed([]byte("history test ns 2"), 0)
 
-	history, err := New(dataDir, runtimeID, NewDefaultConfig(), true)
+	history, err := New(dataDir, runtimeID, NewDefaultConfig(), true, false)
 	require.NoError(err, "New")
 
 	require.Equal(runtimeID, history.RuntimeID())
@@ -141,10 +141,10 @@ func TestHistory(t *testing.T) {
 
 	// Try to manually load the block index database with incorrect runtime ID.
 	// Use path from the first runtime.
-	_, err = New(dataDir, runtimeID2, NewDefaultConfig(), true)
+	_, err = New(dataDir, runtimeID2, NewDefaultConfig(), true, false)
 	require.Error(err, "New should return an error on runtime mismatch")
 
-	history, err = New(dataDir, runtimeID, NewDefaultConfig(), true)
+	history, err = New(dataDir, runtimeID, NewDefaultConfig(), true, false)
 	require.NoError(err, "New")
 
 	require.Equal(runtimeID, history.RuntimeID())
@@ -210,7 +210,7 @@ func TestWatchBlocks(t *testing.T) {
 	runtimeID := common.NewTestNamespaceFromSeed([]byte("history test ns 1"), 0)
 
 	// Test history with local storage.
-	history, err := New(dataDir, runtimeID, NewDefaultConfig(), true)
+	history, err := New(dataDir, runtimeID, NewDefaultConfig(), true, false)
 	require.NoError(err, "New")
 	// No blocks should be received.
 	testWatchBlocks(t, history, 0)
@@ -246,7 +246,7 @@ func TestWatchBlocks(t *testing.T) {
 	dataDir2, err := os.MkdirTemp("", "oasis-runtime-history-test_")
 	require.NoError(err, "TempDir")
 	defer os.RemoveAll(dataDir2)
-	history, err = New(dataDir2, runtimeID, NewDefaultConfig(), false)
+	history, err = New(dataDir2, runtimeID, NewDefaultConfig(), false, false)
 	require.NoError(err, "New")
 	// No blocks should be received.
 	testWatchBlocks(t, history, 0)
@@ -308,7 +308,7 @@ func TestHistoryPrune(t *testing.T) {
 	history, err := New(dataDir, runtimeID, &Config{
 		Pruner:        NewKeepLastPruner(10),
 		PruneInterval: 100 * time.Millisecond,
-	}, true)
+	}, true, false)
 	require.NoError(err, "New")
 	defer history.Close()
 
@@ -417,7 +417,7 @@ func TestHistoryPruneError(t *testing.T) {
 	history, err := New(dataDir, runtimeID, &Config{
 		Pruner:        NewKeepLastPruner(10),
 		PruneInterval: 100 * time.Millisecond,
-	}, true)
+	}, true, false)
 	require.NoError(err, "New")
 	defer history.Close()
 

--- a/go/runtime/registry/registry.go
+++ b/go/runtime/registry/registry.go
@@ -518,7 +518,7 @@ func (r *runtimeRegistry) addSupportedRuntime(ctx context.Context, id common.Nam
 	// Create runtime history keeper.
 	// NOTE: Archive node won't commit any new blocks, so disable waiting for storage sync commits.
 	haveLocalStorageWorker := r.cfg.Mode.HasLocalStorage() && r.consensus.Mode() != consensus.ModeArchive
-	history, err := history.New(rt.dataDir, id, &r.cfg.History, haveLocalStorageWorker)
+	history, err := history.New(rt.dataDir, id, &r.cfg.History, haveLocalStorageWorker, r.consensus.Mode() == consensus.ModeArchive)
 	if err != nil {
 		return fmt.Errorf("runtime/registry: cannot create block history for runtime %s: %w", id, err)
 	}


### PR DESCRIPTION
Backports https://github.com/oasisprotocol/oasis-core/pull/5622

@vitrvvivs also confirmed this fixes the issue on the archive node.

Note:
- would probably need some backports for CI to pass, not sure if worth it since 22.2.x version only remains relevant for archive nodes

Local archive test run:
> level=info ts=2024-04-05T11:58:04.55323219Z caller=root.go:464 module=test-runner msg="passed scenario" scenario=e2e/runtime/archive-api run_id=0