### PR TITLE
go/runtime/txpool: Don't abort runtime if node is not synced yet

### DIFF
--- a/.changelog/5630.bugfix.md
+++ b/.changelog/5630.bugfix.md
@@ -1,0 +1,6 @@
+go/runtime/txpool: Don't abort runtime if node is not synced yet
+
+If the node hasn't finished syncing, `checkTxBatch` previously
+caused the runtime to be aborted, even though it wasn't the
+runtime's fault.
+Now the checks are retried after the node is finished syncing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2736,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.2"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "rustls-pki-types",

--- a/tests/runtimes/simple-rofl/Cargo.toml
+++ b/tests/runtimes/simple-rofl/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = "1.0"
 async-trait = "0.1.77"
 mbedtls = { version = "0.12.3", features = ["x509"] }
 rand = "0.8.5"
-rustls = { version = "0.22.2", default-features = false }
+rustls = { version = "0.22.4", default-features = false }
 rustls-mbedcrypto-provider = { version = "0.0.2" }
 rustls-mbedpki-provider = { version = "0.0.2" }
 tokio = { version = "1.36.0", features = ["rt", "rt-multi-thread", "sync"] }


### PR DESCRIPTION
If the node hasn't finished syncing, `checkTxBatch` previously caused the runtime to be aborted, even though it wasn't the runtime's fault.
Now the checks are retried after the node is finished syncing.