### PR TITLE
runtime: Add EndorsedCapabilityTEE::verify_endorsement

### DIFF
--- a/runtime/src/consensus/registry.rs
+++ b/runtime/src/consensus/registry.rs
@@ -191,18 +191,26 @@ pub struct EndorsedCapabilityTEE {
 }
 
 impl EndorsedCapabilityTEE {
-    /// Verify endorsed TEE capability is valid.
-    pub fn verify(
-        &self,
-        policy: &sgx::QuotePolicy,
-    ) -> anyhow::Result<VerifiedEndorsedCapabilityTEE> {
-        // Verify node endorsement.
+    /// Verify the endorsement signature is valid.
+    ///
+    /// **This does not verify the TEE capability itself, use `verify` for that.**
+    pub fn verify_endorsement(&self) -> anyhow::Result<()> {
         if !self.node_endorsement.verify(
             ENDORSE_CAPABILITY_TEE_SIGNATURE_CONTEXT,
             &cbor::to_vec(self.capability_tee.clone()),
         ) {
             bail!("invalid node endorsement signature");
         }
+        Ok(())
+    }
+
+    /// Verify endorsed TEE capability is valid.
+    pub fn verify(
+        &self,
+        policy: &sgx::QuotePolicy,
+    ) -> anyhow::Result<VerifiedEndorsedCapabilityTEE> {
+        // Verify node endorsement.
+        self.verify_endorsement()?;
 
         // Verify TEE capability.
         let verified_quote = self


### PR DESCRIPTION
This can be useful when only checking the endorsement itself is important as the content will be verified separately.