### PR TITLE
Build runtime binaries in release mode

### DIFF
--- a/.buildkite/benchmarks.pipeline.yml
+++ b/.buildkite/benchmarks.pipeline.yml
@@ -17,8 +17,8 @@ docker_plugin_default_config: &docker_plugin_default_config
     # Shared Rust SGX standard library artifacts cache.
     - /storage/buildkite/global_cache/xargo_cache:/root/.xargo
     # Per-branch shared Rust incremental compile caches.
-    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/debug:/var/tmp/artifacts/default/debug/incremental
-    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/debug_sgx:/var/tmp/artifacts/sgx/x86_64-unknown-linux-sgx/debug/incremental
+    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/release:/var/tmp/artifacts/default/release/incremental
+    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/release_sgx:/var/tmp/artifacts/sgx/x86_64-unknown-linux-sgx/release/incremental
     # Per-build shared downloaded Buildkite artifacts.
     - /storage/buildkite/build_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BUILD_NUMBER}/artifacts:/tmp/artifacts
     # Per-build shared benchmark tests.
@@ -77,7 +77,7 @@ steps:
       - .buildkite/rust/build_generic.sh /workdir -p oasis-core-runtime-loader
 
       # Upload the built artifacts.
-      - cd /var/tmp/artifacts/default/debug
+      - cd /var/tmp/artifacts/default/release
       - buildkite-agent artifact upload oasis-core-runtime-loader
     plugins:
       <<: *docker_plugin
@@ -92,13 +92,13 @@ steps:
       - .buildkite/rust/build_runtime.sh tests/runtimes/simple-rofl
 
       # Upload the built artifacts.
-      - cd /var/tmp/artifacts/sgx/x86_64-fortanix-unknown-sgx/debug
+      - cd /var/tmp/artifacts/sgx/x86_64-fortanix-unknown-sgx/release
       - buildkite-agent artifact upload simple-keymanager.sgxs
       - buildkite-agent artifact upload simple-keyvalue.sgxs
       - buildkite-agent artifact upload simple-keyvalue-upgrade.sgxs
       - buildkite-agent artifact upload simple-keymanager-upgrade.sgxs
       - buildkite-agent artifact upload simple-rofl.sgxs
-      - cd /var/tmp/artifacts/default/debug
+      - cd /var/tmp/artifacts/default/release
       - buildkite-agent artifact upload simple-keymanager
       - buildkite-agent artifact upload simple-keyvalue
       - buildkite-agent artifact upload simple-keyvalue-upgrade
@@ -121,12 +121,12 @@ steps:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
       - rm -rf /var/tmp/benchmarks/*
       - >-
-          .buildkite/scripts/test_e2e.sh
-            --metrics.address $METRICS_PUSH_ADDR
-            --metrics.interval 5s
-            --metrics.labels instance=$BUILDKITE_PIPELINE_NAME-$BUILDKITE_BUILD_NUMBER
-            --num_runs $NUM_RUNS
-            --scenario $SCENARIOS
+        .buildkite/scripts/test_e2e.sh
+          --metrics.address $METRICS_PUSH_ADDR
+          --metrics.interval 5s
+          --metrics.labels instance=$BUILDKITE_PIPELINE_NAME-$BUILDKITE_BUILD_NUMBER
+          --num_runs $NUM_RUNS
+          --scenario $SCENARIOS
     env:
       TEST_BASE_DIR: /var/tmp/benchmarks
     agents:

--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -25,8 +25,8 @@ docker_plugin_default_config: &docker_plugin_default_config
     # Shared Rust SGX standard library artifacts cache.
     - /storage/buildkite/global_cache/xargo_cache:/root/.xargo
     # Per-branch shared Rust incremental compile caches.
-    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/debug:/var/tmp/artifacts/default/debug/incremental
-    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/debug_sgx:/var/tmp/artifacts/sgx/x86_64-unknown-linux-sgx/debug/incremental
+    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/release:/var/tmp/artifacts/default/release/incremental
+    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/release_sgx:/var/tmp/artifacts/sgx/x86_64-unknown-linux-sgx/release/incremental
     # Per-build shared downloaded Buildkite artifacts.
     - /storage/buildkite/build_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BUILD_NUMBER}/artifacts:/tmp/artifacts
   tmpfs:
@@ -156,7 +156,7 @@ steps:
       - .buildkite/rust/build_generic.sh /workdir -p oasis-core-runtime-loader
 
       # Upload the built artifacts.
-      - cd /var/tmp/artifacts/default/debug
+      - cd /var/tmp/artifacts/default/release
       - buildkite-agent artifact upload oasis-core-runtime-loader
     retry:
       <<: *retry_agent_failure
@@ -174,13 +174,13 @@ steps:
       - .buildkite/rust/build_runtime.sh tests/runtimes/simple-rofl
 
       # Upload the built artifacts.
-      - cd /var/tmp/artifacts/sgx/x86_64-fortanix-unknown-sgx/debug
+      - cd /var/tmp/artifacts/sgx/x86_64-fortanix-unknown-sgx/release
       - buildkite-agent artifact upload simple-keymanager.sgxs
       - buildkite-agent artifact upload simple-keyvalue.sgxs
       - buildkite-agent artifact upload simple-keyvalue-upgrade.sgxs
       - buildkite-agent artifact upload simple-keymanager-upgrade.sgxs
       - buildkite-agent artifact upload simple-rofl.sgxs
-      - cd /var/tmp/artifacts/default/debug
+      - cd /var/tmp/artifacts/default/release
       - buildkite-agent artifact upload simple-keymanager
       - buildkite-agent artifact upload simple-keyvalue
       - buildkite-agent artifact upload simple-keyvalue-upgrade

--- a/.buildkite/go/test_and_coverage.sh
+++ b/.buildkite/go/test_and_coverage.sh
@@ -16,9 +16,9 @@ source .buildkite/scripts/common.sh
 source .buildkite/rust/common.sh
 
 # Setup worker and test runtime which is needed to test the worker host.
-download_artifact simple-keyvalue target/debug 755
+download_artifact simple-keyvalue target/release 755
 
-export OASIS_TEST_RUNTIME_HOST_RUNTIME_PATH=$(pwd)/target/debug/simple-keyvalue
+export OASIS_TEST_RUNTIME_HOST_RUNTIME_PATH=$(pwd)/target/release/simple-keyvalue
 
 #####################
 # Test the Oasis node

--- a/.buildkite/longtests.pipeline.yml
+++ b/.buildkite/longtests.pipeline.yml
@@ -17,8 +17,8 @@ docker_plugin_default_config: &docker_plugin_default_config
     # Shared Rust SGX standard library artifacts cache.
     - /storage/buildkite/global_cache/xargo_cache:/root/.xargo
     # Per-branch shared Rust incremental compile caches.
-    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/debug:/var/tmp/artifacts/default/debug/incremental
-    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/debug_sgx:/var/tmp/artifacts/sgx/x86_64-unknown-linux-sgx/debug/incremental
+    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/release:/var/tmp/artifacts/default/release/incremental
+    - /storage/buildkite/branch_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BRANCH_SLUG}/cargo_ic/release_sgx:/var/tmp/artifacts/sgx/x86_64-unknown-linux-sgx/release/incremental
     # Per-build shared downloaded Buildkite artifacts.
     - /storage/buildkite/build_cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BUILD_NUMBER}/artifacts:/tmp/artifacts
     # Per-build shared long tests.
@@ -67,7 +67,7 @@ steps:
       - .buildkite/rust/build_generic.sh /workdir -p oasis-core-runtime-loader
 
       # Upload the built artifacts.
-      - cd /var/tmp/artifacts/default/debug
+      - cd /var/tmp/artifacts/default/release
       - buildkite-agent artifact upload oasis-core-runtime-loader
     plugins:
       <<: *docker_plugin
@@ -79,13 +79,13 @@ steps:
       - .buildkite/rust/build_runtime.sh tests/runtimes/simple-rofl
 
       # Upload the built artifacts.
-      - cd /var/tmp/artifacts/sgx/x86_64-fortanix-unknown-sgx/debug
+      - cd /var/tmp/artifacts/sgx/x86_64-fortanix-unknown-sgx/release
       - buildkite-agent artifact upload simple-keymanager.sgxs
       - buildkite-agent artifact upload simple-keyvalue.sgxs
       - buildkite-agent artifact upload simple-keyvalue-upgrade.sgxs
       - buildkite-agent artifact upload simple-keymanager-upgrade.sgxs
       - buildkite-agent artifact upload simple-rofl.sgxs
-      - cd /var/tmp/artifacts/default/debug
+      - cd /var/tmp/artifacts/default/release
       - buildkite-agent artifact upload simple-keymanager
       - buildkite-agent artifact upload simple-keyvalue
       - buildkite-agent artifact upload simple-keyvalue-upgrade

--- a/.buildkite/rust/build_generic.sh
+++ b/.buildkite/rust/build_generic.sh
@@ -35,5 +35,5 @@ source .buildkite/rust/common.sh
 # Run the build
 ###############
 pushd $src_dir
-  CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/default" cargo build --locked $extra_args
+  CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/default" cargo build --release --locked $extra_args
 popd

--- a/.buildkite/rust/build_runtime.sh
+++ b/.buildkite/rust/build_runtime.sh
@@ -42,12 +42,12 @@ fi
 ###############
 pushd $src_dir
     # Build non-SGX runtime. Checking KM policy requires SGX, disable it.
-    CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/default" OASIS_UNSAFE_SKIP_KM_POLICY="1" cargo build --locked
+    CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/default" OASIS_UNSAFE_SKIP_KM_POLICY="1" cargo build --release --locked
 
     # Build SGX runtime.
     export CFLAGS_x86_64_fortanix_unknown_sgx="-isystem/usr/include/x86_64-linux-gnu -mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening"
     export CC_x86_64_fortanix_unknown_sgx=clang-11
     unset OASIS_UNSAFE_SKIP_KM_POLICY
-    CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/sgx" cargo build --locked --target x86_64-fortanix-unknown-sgx
-    CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/sgx" cargo elf2sgxs
+    CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/sgx" cargo build --release --locked --target x86_64-fortanix-unknown-sgx
+    CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/sgx" cargo elf2sgxs --release
 popd

--- a/.buildkite/rust/test_generic.sh
+++ b/.buildkite/rust/test_generic.sh
@@ -30,7 +30,7 @@ unset OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES
 # Run the build and tests
 #########################
 pushd $src_dir
-  CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/default" cargo build --all --locked --exclude simple-keyvalue
+  CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/default" cargo build --release --all --locked --exclude simple-keyvalue
   cargo fmt -- --check
   CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/default" cargo test --all --locked --exclude simple-keyvalue
 popd

--- a/.buildkite/scripts/download_e2e_test_artifacts.sh
+++ b/.buildkite/scripts/download_e2e_test_artifacts.sh
@@ -28,22 +28,22 @@ download_artifact oasis-test-pre-upgrade tests/upgrade/pre 755
 download_artifact oasis-test-post-upgrade tests/upgrade/post 755
 
 # Runtime loader.
-download_artifact oasis-core-runtime-loader target/default/debug 755
+download_artifact oasis-core-runtime-loader target/default/release 755
 
 # Simple Key manager runtime.
-download_artifact simple-keymanager.sgxs target/sgx/x86_64-fortanix-unknown-sgx/debug 755
-download_artifact simple-keymanager target/default/debug 755
+download_artifact simple-keymanager.sgxs target/sgx/x86_64-fortanix-unknown-sgx/release 755
+download_artifact simple-keymanager target/default/release 755
 
 # Simple Key manager runtime used in keymenager upgrade test.
-download_artifact simple-keymanager-upgrade.sgxs target/sgx/x86_64-fortanix-unknown-sgx/debug 755
-download_artifact simple-keymanager-upgrade target/default/debug 755
+download_artifact simple-keymanager-upgrade.sgxs target/sgx/x86_64-fortanix-unknown-sgx/release 755
+download_artifact simple-keymanager-upgrade target/default/release 755
 
 # Test simple-keyvalue runtime.
-download_artifact simple-keyvalue.sgxs target/sgx/x86_64-fortanix-unknown-sgx/debug 755
-download_artifact simple-keyvalue target/default/debug 755
-download_artifact simple-keyvalue-upgrade.sgxs target/sgx/x86_64-fortanix-unknown-sgx/debug 755
-download_artifact simple-keyvalue-upgrade target/default/debug 755
+download_artifact simple-keyvalue.sgxs target/sgx/x86_64-fortanix-unknown-sgx/release 755
+download_artifact simple-keyvalue target/default/release 755
+download_artifact simple-keyvalue-upgrade.sgxs target/sgx/x86_64-fortanix-unknown-sgx/release 755
+download_artifact simple-keyvalue-upgrade target/default/release 755
 
 # Test ROFL runtime.
-download_artifact simple-rofl.sgxs target/sgx/x86_64-fortanix-unknown-sgx/debug 755
-download_artifact simple-rofl target/default/debug 755
+download_artifact simple-rofl.sgxs target/sgx/x86_64-fortanix-unknown-sgx/release 755
+download_artifact simple-rofl target/default/release 755

--- a/.buildkite/scripts/test_e2e.sh
+++ b/.buildkite/scripts/test_e2e.sh
@@ -48,11 +48,11 @@ ${test_runner_binary} \
     ${BUILDKITE:+--basedir ${TEST_BASE_DIR:-$PWD}/e2e} \
     --basedir.no_cleanup \
     --e2e.node.binary ${node_binary} \
-    --e2e/runtime.runtime.binary_dir.default ${WORKDIR}/target/default/debug \
-    --e2e/runtime.runtime.binary_dir.intel-sgx ${WORKDIR}/target/sgx/x86_64-fortanix-unknown-sgx/debug \
+    --e2e/runtime.runtime.binary_dir.default ${WORKDIR}/target/default/release \
+    --e2e/runtime.runtime.binary_dir.intel-sgx ${WORKDIR}/target/sgx/x86_64-fortanix-unknown-sgx/release \
     --e2e/runtime.runtime.source_dir ${WORKDIR}/tests/runtimes \
     --e2e/runtime.runtime.target_dir ${WORKDIR}/target \
-    --e2e/runtime.runtime.loader ${WORKDIR}/target/default/debug/oasis-core-runtime-loader \
+    --e2e/runtime.runtime.loader ${WORKDIR}/target/default/release/oasis-core-runtime-loader \
     --e2e/runtime.tee_hardware ${OASIS_TEE_HARDWARE:-""} \
     --e2e/runtime.ias.mock=${ias_mock} \
     --remote-signer.binary ${WORKDIR}/go/oasis-remote-signer/oasis-remote-signer \

--- a/.buildkite/scripts/test_upgrade.sh
+++ b/.buildkite/scripts/test_upgrade.sh
@@ -104,11 +104,11 @@ ${pre_upgrade_test_runner_binary} \
     --basedir.no_cleanup \
     --basedir.no_temp_dir \
     --e2e.node.binary ${pre_upgrade_node_binary} \
-    --e2e/runtime.runtime.binary_dir.default ${pre_upgrade_datadir}/oasis-core/target/default/debug \
-    --e2e/runtime.runtime.binary_dir.intel-sgx ${pre_upgrade_datadir}/oasis-core/target/sgx/x86_64-fortanix-unknown-sgx/debug \
+    --e2e/runtime.runtime.binary_dir.default ${pre_upgrade_datadir}/oasis-core/target/default/release \
+    --e2e/runtime.runtime.binary_dir.intel-sgx ${pre_upgrade_datadir}/oasis-core/target/sgx/x86_64-fortanix-unknown-sgx/release \
     --e2e/runtime.runtime.source_dir ${pre_upgrade_datadir}/oasis-core/tests/runtimes \
     --e2e/runtime.runtime.target_dir ${pre_upgrade_datadir}/oasis-core/target \
-    --e2e/runtime.runtime.loader ${pre_upgrade_datadir}/oasis-core/target/default/debug/oasis-core-runtime-loader \
+    --e2e/runtime.runtime.loader ${pre_upgrade_datadir}/oasis-core/target/default/release/oasis-core-runtime-loader \
     --e2e/runtime.tee_hardware ${OASIS_TEE_HARDWARE:-""} \
     --e2e/runtime.ias.mock=${ias_mock} \
     --upgrade.protocol_versions=${protocol_versions} \
@@ -128,11 +128,11 @@ ${post_upgrade_test_runner_binary} \
     --basedir.no_cleanup \
     --basedir.no_temp_dir \
     --e2e.node.binary ${post_upgrade_node_binary} \
-    --e2e/runtime.runtime.binary_dir.default ${post_upgrade_datadir}/oasis-core/target/default/debug \
-    --e2e/runtime.runtime.binary_dir.intel-sgx ${post_upgrade_datadir}/oasis-core/target/sgx/x86_64-fortanix-unknown-sgx/debug \
+    --e2e/runtime.runtime.binary_dir.default ${post_upgrade_datadir}/oasis-core/target/default/release \
+    --e2e/runtime.runtime.binary_dir.intel-sgx ${post_upgrade_datadir}/oasis-core/target/sgx/x86_64-fortanix-unknown-sgx/release \
     --e2e/runtime.runtime.source_dir ${post_upgrade_datadir}/oasis-core/tests/runtimes \
     --e2e/runtime.runtime.target_dir ${post_upgrade_datadir}/oasis-core/target \
-    --e2e/runtime.runtime.loader ${post_upgrade_datadir}/oasis-core/target/default/debug/oasis-core-runtime-loader \
+    --e2e/runtime.runtime.loader ${post_upgrade_datadir}/oasis-core/target/default/release/oasis-core-runtime-loader \
     --e2e/runtime.tee_hardware ${OASIS_TEE_HARDWARE:-""} \
     --e2e/runtime.ias.mock=${ias_mock} \
     --scenario_timeout 1h \

--- a/.changelog/5641.internal.md
+++ b/.changelog/5641.internal.md
@@ -1,0 +1,5 @@
+Build runtime binaries in release mode
+
+Running SGX tests with binaries built in debug mode can be extremely
+slow, so build everything in release mode. This should also speed up
+E2E tests.

--- a/Makefile
+++ b/Makefile
@@ -23,15 +23,15 @@ build-runtimes:
 	@CARGO_TARGET_ROOT=$(shell pwd)/target && for e in $(RUNTIMES); do \
 		$(ECHO) "$(MAGENTA)*** Building runtime: $$e...$(OFF)"; \
 		(cd $$e && \
-			CARGO_TARGET_DIR=$${CARGO_TARGET_ROOT}/sgx cargo build --target x86_64-fortanix-unknown-sgx && \
-			CARGO_TARGET_DIR=$${CARGO_TARGET_ROOT}/default cargo build && \
-			CARGO_TARGET_DIR=$${CARGO_TARGET_ROOT}/sgx cargo elf2sgxs \
+			CARGO_TARGET_DIR=$${CARGO_TARGET_ROOT}/sgx cargo build --release --target x86_64-fortanix-unknown-sgx && \
+			CARGO_TARGET_DIR=$${CARGO_TARGET_ROOT}/default cargo build --release && \
+			CARGO_TARGET_DIR=$${CARGO_TARGET_ROOT}/sgx cargo elf2sgxs --release \
 		) || exit 1; \
 	done
 
 build-rust:
 	@$(ECHO) "$(MAGENTA)*** Building Rust libraries and runtime loader...$(OFF)"
-	@CARGO_TARGET_DIR=target/default cargo build
+	@CARGO_TARGET_DIR=target/default cargo build --release
 
 build-go:
 	@$(MAKE) -C go build

--- a/docs/development-setup/deploying-a-runtime.md
+++ b/docs/development-setup/deploying-a-runtime.md
@@ -305,7 +305,7 @@ environment variables to simplify instructions.
 - `RUNTIME_BINARY` - Path to the runtime binary that will be run on the node. We
   will use the [simple-keyvalue] runtime. If you followed the [build
   instructions] the built binary is available at
-  `./target/default/debug/simple-keyvalue`.
+  `./target/default/release/simple-keyvalue`.
 - `SEED_NODE_ADDRESS` - Address of the seed node in the development network.
   Seed node address can be seen in the `oasis-net-runner` logs, when the network
   is initially provisioned.
@@ -313,7 +313,7 @@ environment variables to simplify instructions.
 <!-- markdownlint-disable line-length -->
 
 ```
-export RUNTIME_BINARY=/workdir/target/default/debug/simple-keyvalue
+export RUNTIME_BINARY=/workdir/target/default/release/simple-keyvalue
 export SEED_NODE_ADDRESS=<seed-node-cometbft-addr>@127.0.0.1:20000
 
 # Runtime node data dir.

--- a/docs/development-setup/oasis-net-runner.md
+++ b/docs/development-setup/oasis-net-runner.md
@@ -20,9 +20,9 @@ running the `simple-keyvalue` test runtime, do:
 ```
 ./go/oasis-net-runner/oasis-net-runner \
   --fixture.default.node.binary go/oasis-node/oasis-node \
-  --fixture.default.runtime.binary target/default/debug/simple-keyvalue \
-  --fixture.default.runtime.loader target/default/debug/oasis-core-runtime-loader \
-  --fixture.default.keymanager.binary target/default/debug/simple-keymanager
+  --fixture.default.runtime.binary target/default/release/simple-keyvalue \
+  --fixture.default.runtime.loader target/default/release/oasis-core-runtime-loader \
+  --fixture.default.keymanager.binary target/default/release/simple-keymanager
 ```
 
 Wait for the network to start, there should be messages about nodes being
@@ -47,7 +47,7 @@ client as follows (substituting the socket path from your log output) in a
 different terminal:
 
 ```
-./target/default/debug/simple-keyvalue-client \
+./target/default/release/simple-keyvalue-client \
   --runtime-id 8000000000000000000000000000000000000000000000000000000000000000 \
   --node-address unix:/tmp/oasis-net-runner530668299/net-runner/network/client-0/internal.sock
 ```
@@ -73,9 +73,9 @@ To run an Oasis node under SGX follow the same steps as for non-SGX, except the
 ./go/oasis-net-runner/oasis-net-runner \
   --fixture.default.tee_hardware intel-sgx \
   --fixture.default.node.binary go/oasis-node/oasis-node \
-  --fixture.default.runtime.binary target/sgx/x86_64-fortanix-unknown-sgx/debug/simple-keyvalue.sgxs \
-  --fixture.default.runtime.loader target/default/debug/oasis-core-runtime-loader \
-  --fixture.default.keymanager.binary target/sgx/x86_64-fortanix-unknown-sgx/debug/simple-keymanager.sgxs
+  --fixture.default.runtime.binary target/sgx/x86_64-fortanix-unknown-sgx/release/simple-keyvalue.sgxs \
+  --fixture.default.runtime.loader target/default/release/oasis-core-runtime-loader \
+  --fixture.default.keymanager.binary target/sgx/x86_64-fortanix-unknown-sgx/release/simple-keymanager.sgxs
 ```
 <!-- markdownlint-enable line-length -->
 

--- a/go/oasis-test-runner/rust/builder.go
+++ b/go/oasis-test-runner/rust/builder.go
@@ -82,6 +82,7 @@ func (b *Builder) Build(pkg string) error {
 	}
 
 	cmd.Args = append(cmd.Args, "--package", pkg)
+	cmd.Args = append(cmd.Args, "--release")
 
 	if b.teeHardware == node.TEEHardwareIntelSGX {
 		cmd.Args = append(cmd.Args, "--target", "x86_64-fortanix-unknown-sgx")
@@ -100,6 +101,9 @@ func (b *Builder) Build(pkg string) error {
 		if cmd, err = b.cargoCommand("elf2sgxs", pkg); err != nil {
 			return fmt.Errorf("failed to elf2sgxs runtime: %w", err)
 		}
+
+		cmd.Args = append(cmd.Args, "--release")
+
 		if err = cmd.Run(); err != nil {
 			return fmt.Errorf("failed to elf2sgxs runtime: %w", err)
 		}


### PR DESCRIPTION
Running SGX tests with binaries built in debug mode can be extremely slow, so build everything in release mode. This should also speed up E2E tests.