### PR TITLE
go/staking: Read token information from state when available

### DIFF
--- a/.changelog/5648.feature.md
+++ b/.changelog/5648.feature.md
@@ -1,0 +1,1 @@
+go/staking: Read token information from state when available

--- a/go/oasis-node/cmd/stake/stake.go
+++ b/go/oasis-node/cmd/stake/stake.go
@@ -75,7 +75,7 @@ func doConnect(cmd *cobra.Command) (*grpc.ClientConn, api.Backend) {
 }
 
 func getTokenSymbol(ctx context.Context, client api.Backend) string {
-	symbol, err := client.TokenSymbol(ctx)
+	symbol, err := client.TokenSymbol(ctx, consensus.HeightLatest)
 	if err != nil {
 		logger.Error("failed to query token's symbol",
 			"err", err,
@@ -86,7 +86,7 @@ func getTokenSymbol(ctx context.Context, client api.Backend) string {
 }
 
 func getTokenValueExponent(ctx context.Context, client api.Backend) uint8 {
-	exp, err := client.TokenValueExponent(ctx)
+	exp, err := client.TokenValueExponent(ctx, consensus.HeightLatest)
 	if err != nil {
 		logger.Error("failed to query token's value exponent",
 			"err", err,

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -114,11 +114,11 @@ var (
 // Backend is a staking implementation.
 type Backend interface {
 	// TokenSymbol returns the token's ticker symbol.
-	TokenSymbol(ctx context.Context) (string, error)
+	TokenSymbol(ctx context.Context, height int64) (string, error)
 
 	// TokenValueExponent is the token's value base-10 exponent, i.e.
 	// 1 token = 10**TokenValueExponent base units.
-	TokenValueExponent(ctx context.Context) (uint8, error)
+	TokenValueExponent(ctx context.Context, height int64) (uint8, error)
 
 	// TotalSupply returns the total number of base units.
 	TotalSupply(ctx context.Context, height int64) (*quantity.Quantity, error)
@@ -1183,6 +1183,13 @@ type Genesis struct {
 
 // ConsensusParameters are the staking consensus parameters.
 type ConsensusParameters struct { // nolint: maligned
+	// TokenSymbol is the token's ticker symbol.
+	// Only upper case A-Z characters are allowed.
+	TokenSymbol string `json:"token_symbol,omitempty"`
+	// TokenValueExponent is the token's value base-10 exponent, i.e.
+	// 1 token = 10**TokenValueExponent base units.
+	TokenValueExponent uint8 `json:"token_value_exponent,omitempty"`
+
 	Thresholds                        map[ThresholdKind]quantity.Quantity `json:"thresholds,omitempty"`
 	DebondingInterval                 beacon.EpochTime                    `json:"debonding_interval,omitempty"`
 	RewardSchedule                    []RewardStep                        `json:"reward_schedule,omitempty"`


### PR DESCRIPTION
This unifies handling of the two remaining attributes so everything is consistently read from state, in a backwards compatible manner.