### PR TITLE
.github/dependabot: group rust dependency updates

### DIFF
--- a/.changelog/5654.internal.md
+++ b/.changelog/5654.internal.md
@@ -1,0 +1,1 @@
+.github/dependabot: group rust dependency updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,21 @@ updates:
       time: "07:00"
     commit-message:
       prefix: "rust:"
+    groups:
+      # Update Tendermint dependencies together in a single PR.
+      tendermint:
+        patterns:
+          - tendermint
+          - tendermint-*
+      # Update all other dependencies in a single PR.
+      rust:
+        # Update all dependencies, unless explicitly ignored.
+        patterns:
+          - "*"
+        # Excluded dependencies are updated in separate PRs.
+        exclude-patterns: []
+    # Ignored depenednecies are ignored by dependabot.
+    ignore: []
     labels:
       - c:deps
       - rust


### PR DESCRIPTION
Let's see how this works.  It should look something like this: https://github.com/fortanix/rust-sgx/pull/581