### PR TITLE
.github/dependabot: fix empty excludes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,9 +52,11 @@ updates:
         patterns:
           - "*"
         # Excluded dependencies are updated in separate PRs.
-        exclude-patterns: []
+        # Commented out because it requires at least one entry to be valid.
+        # exclude-patterns: []
     # Ignored depenednecies are ignored by dependabot.
-    ignore: []
+    # Commented out because it requires at least one entry to be valid.
+    # ignore: []
     labels:
       - c:deps
       - rust


### PR DESCRIPTION
Wanted to keep empty `exclude-patterns` and `ignore` in the config, so that one can clearly see where these should be added if needed (e.g. for dependencies that will be harder to update/will require more changes and should be updated in separate PRs).

But:

> The property '#/updates/2/groups/rust/exclude-patterns' did not contain a minimum number of items 1
