### PR TITLE
keymanager: Increase MAX_FRESH_HEIGHT_AGE

### DIFF
--- a/.changelog/5703.bugfix.md
+++ b/.changelog/5703.bugfix.md
@@ -1,0 +1,5 @@
+keymanager: Increase MAX_FRESH_HEIGHT_AGE
+
+This avoids issues where key managers get out of sync during operation
+and start rejecting otherwise valid requests. It should still be safe
+especially since all new runtimes now perform freshness checks.

--- a/keymanager/src/runtime/secrets.rs
+++ b/keymanager/src/runtime/secrets.rs
@@ -73,8 +73,8 @@ const MAX_EPHEMERAL_KEY_AGE: EpochTime = 10;
 /// Maximum age of a fresh height in the number of blocks.
 ///
 /// A height is considered fresh if it is not more than specified amount
-/// of blocks lower than the height of the latest trust root.
-const MAX_FRESH_HEIGHT_AGE: u64 = 50;
+/// of blocks lower than the height of the latest verified height.
+const MAX_FRESH_HEIGHT_AGE: u64 = 600; // ~1 hr @ 6s/block
 
 /// Master and ephemeral secrets RPC handler.
 pub struct Secrets {


### PR DESCRIPTION
This avoids issues where key managers get out of sync during operation and start rejecting otherwise valid requests. It should still be safe as especially since all new runtimes now perform freshness checks.