### PR TITLE
Support detached ROFL components

### DIFF
--- a/.changelog/5707.feature.md
+++ b/.changelog/5707.feature.md
@@ -1,0 +1,11 @@
+Support detached ROFL components
+
+Previously each bundle that contained one or more ROFL components also
+needed to contain the exact version of the RONL component it was
+attaching to.
+
+This is somewhat awkward to use when we assume a more decentralized
+development and deployment of ROFL applications. This commit adds support
+for detached ROFL components where the bundle only contains the ROFL and
+oasis-node then automatically gets the appropriate RONL component from
+another bundle.

--- a/go/runtime/bundle/bundle.go
+++ b/go/runtime/bundle/bundle.go
@@ -296,9 +296,9 @@ func (bnd *Bundle) ExplodedPath(dataDir, fn string) string {
 	var subDir string
 	switch bnd.Manifest.IsDetached() {
 	case false:
-		// DATADIR/runtimes/bundles/runtimeID-version
+		// DATADIR/runtimes/bundles/manifestHash
 		subDir = filepath.Join(ExplodedPath(dataDir),
-			fmt.Sprintf("%s-%s", bnd.Manifest.ID, bnd.Manifest.Version),
+			bnd.Manifest.Hash().String(),
 		)
 	case true:
 		// DATADIR/runtimes/bundles/detached/manifestHash

--- a/go/runtime/bundle/bundle.go
+++ b/go/runtime/bundle/bundle.go
@@ -280,19 +280,32 @@ func (bnd *Bundle) Write(fn string) error {
 	return nil
 }
 
-// ExplodedPath returns the path under the data directory that contains
-// all of the exploded bundles.
+// ExplodedPath returns the path under the data directory that contains all of the exploded bundles.
 func ExplodedPath(dataDir string) string {
 	return filepath.Join(dataDir, "runtimes", "bundles")
 }
 
-// ExplodedPath returns the path that the corresponding asset will be
-// written to via WriteExploded.
+// DetachedExplodedPath returns the path under the data directory that contains all of the detached
+// exploded bundles.
+func DetachedExplodedPath(dataDir string) string {
+	return filepath.Join(ExplodedPath(dataDir), "detached")
+}
+
+// ExplodedPath returns the path that the corresponding asset will be written to via WriteExploded.
 func (bnd *Bundle) ExplodedPath(dataDir, fn string) string {
-	// DATADIR/runtimes/bundles/runtimeID-version
-	subDir := filepath.Join(ExplodedPath(dataDir),
-		fmt.Sprintf("%s-%s", bnd.Manifest.ID, bnd.Manifest.Version),
-	)
+	var subDir string
+	switch bnd.Manifest.IsDetached() {
+	case false:
+		// DATADIR/runtimes/bundles/runtimeID-version
+		subDir = filepath.Join(ExplodedPath(dataDir),
+			fmt.Sprintf("%s-%s", bnd.Manifest.ID, bnd.Manifest.Version),
+		)
+	case true:
+		// DATADIR/runtimes/bundles/detached/manifestHash
+		subDir = filepath.Join(DetachedExplodedPath(dataDir),
+			bnd.Manifest.Hash().String(),
+		)
+	}
 
 	if fn == "" {
 		return subDir

--- a/go/runtime/bundle/component/component.go
+++ b/go/runtime/bundle/component/component.go
@@ -74,5 +74,10 @@ func (c *ID) UnmarshalText(text []byte) error {
 	return nil
 }
 
+// IsRONL returns true iff the component identifier is the special RONL component identifier.
+func (c ID) IsRONL() bool {
+	return c == ID_RONL
+}
+
 // ID_RONL is the identifier of the RONL component.
 var ID_RONL = ID{Kind: RONL, Name: ""} //nolint: revive

--- a/go/runtime/host/composite/composite.go
+++ b/go/runtime/host/composite/composite.go
@@ -72,7 +72,7 @@ func (c *composite) Call(ctx context.Context, body *protocol.Body) (*protocol.Bo
 	}
 
 	for id, comp := range c.comps {
-		if id == component.ID_RONL {
+		if id.IsRONL() {
 			continue // Already handled above.
 		}
 		if !shouldPropagateToComponent(body) {

--- a/go/runtime/host/host.go
+++ b/go/runtime/host/host.go
@@ -3,6 +3,7 @@ package host
 
 import (
 	"context"
+	"path/filepath"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
@@ -38,6 +39,18 @@ type RuntimeBundle struct {
 
 	// ExplodedDataDir is the path to the data directory under which the bundle has been exploded.
 	ExplodedDataDir string
+
+	// ExplodedDetachedDirs are the paths to the data directories of detached components.
+	ExplodedDetachedDirs map[component.ID]string
+}
+
+// ExplodedPath returns the path where the given asset for the given component can be found.
+func (bnd *RuntimeBundle) ExplodedPath(comp component.ID, fn string) string {
+	if detachedDir, ok := bnd.ExplodedDetachedDirs[comp]; ok {
+		return filepath.Join(detachedDir, fn)
+	}
+	// Default to the exploded bundle.
+	return bnd.Bundle.ExplodedPath(bnd.ExplodedDataDir, fn)
 }
 
 // Provisioner is the runtime provisioner interface.

--- a/go/runtime/host/multi/multi.go
+++ b/go/runtime/host/multi/multi.go
@@ -290,7 +290,7 @@ func (agg *Aggregate) Component(id component.ID) (host.Runtime, bool) {
 	if cr, ok := active.host.(host.CompositeRuntime); ok {
 		return cr.Component(id)
 	}
-	if id == component.ID_RONL {
+	if id.IsRONL() {
 		return active.host, true
 	}
 	return nil, false

--- a/go/runtime/host/sandbox/sandbox.go
+++ b/go/runtime/host/sandbox/sandbox.go
@@ -422,9 +422,12 @@ func (r *sandboxedRuntime) startProcess() (err error) {
 		return fmt.Errorf("failed to initialize connection: %w", err)
 	}
 
-	// Make sure the version matches what is configured in the bundle.
-	if bndVersion := r.rtCfg.Bundle.Manifest.Version; *rtVersion != bndVersion {
-		return fmt.Errorf("version mismatch (runtime reported: %s bundle: %s)", *rtVersion, bndVersion)
+	if r.rtCfg.Components[0].IsRONL() {
+		// Make sure the version matches what is configured in the bundle. This check is skipped for
+		// non-RONL components to support detached bundles.
+		if bndVersion := r.rtCfg.Bundle.Manifest.Version; *rtVersion != bndVersion {
+			return fmt.Errorf("version mismatch (runtime reported: %s bundle: %s)", *rtVersion, bndVersion)
+		}
 	}
 
 	hp := &HostInitializerParams{
@@ -661,7 +664,7 @@ func DefaultGetSandboxConfig(logger *logging.Logger, sandboxBinaryPath string) G
 			"component", comp.Kind,
 		)
 		return process.Config{
-			Path: hostCfg.Bundle.ExplodedPath(hostCfg.Bundle.ExplodedDataDir, comp.Executable),
+			Path: hostCfg.Bundle.ExplodedPath(comp.ID(), comp.Executable),
 			Env: map[string]string{
 				"OASIS_WORKER_HOST": socketPath,
 			},

--- a/go/runtime/host/sgx/sgx.go
+++ b/go/runtime/host/sgx/sgx.go
@@ -182,7 +182,7 @@ func (s *sgxProvisioner) loadEnclaveBinaries(rtCfg host.Config, comp *bundle.Com
 	if comp.SGX == nil || comp.SGX.Executable == "" {
 		return nil, nil, fmt.Errorf("SGX executable not available in bundle")
 	}
-	sgxExecutablePath := rtCfg.Bundle.ExplodedPath(rtCfg.Bundle.ExplodedDataDir, comp.SGX.Executable)
+	sgxExecutablePath := rtCfg.Bundle.ExplodedPath(comp.ID(), comp.SGX.Executable)
 
 	var (
 		sig, sgxs   []byte
@@ -198,7 +198,7 @@ func (s *sgxProvisioner) loadEnclaveBinaries(rtCfg host.Config, comp *bundle.Com
 	}
 
 	if comp.SGX.Signature != "" {
-		sgxSignaturePath := rtCfg.Bundle.ExplodedPath(rtCfg.Bundle.ExplodedDataDir, comp.SGX.Signature)
+		sgxSignaturePath := rtCfg.Bundle.ExplodedPath(comp.ID(), comp.SGX.Signature)
 		sig, err = os.ReadFile(sgxSignaturePath)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to load SIGSTRUCT: %w", err)

--- a/go/runtime/registry/host.go
+++ b/go/runtime/registry/host.go
@@ -492,7 +492,7 @@ func (h *runtimeHostHandler) handleHostIdentity() (*protocol.HostIdentityRespons
 func (h *runtimeHostHandler) NewSubHandler(cr host.CompositeRuntime, comp *bundle.Component) (host.RuntimeHandler, error) {
 	switch comp.Kind {
 	case component.ROFL:
-		return newSubHandlerROFL(h, cr)
+		return newSubHandlerROFL(h, cr, comp)
 	default:
 		return nil, fmt.Errorf("cannot create sub-handler for component '%s'", comp.Kind)
 	}

--- a/runtime/src/attestation.rs
+++ b/runtime/src/attestation.rs
@@ -26,7 +26,7 @@ pub struct Handler {
     host: Arc<dyn Host>,
     consensus_verifier: Arc<dyn Verifier>,
     runtime_id: Namespace,
-    version: Version,
+    version: Option<Version>,
     logger: Logger,
 }
 
@@ -37,7 +37,7 @@ impl Handler {
         host: Arc<dyn Host>,
         consensus_verifier: Arc<dyn Verifier>,
         runtime_id: Namespace,
-        version: Version,
+        version: Option<Version>,
     ) -> Self {
         Self {
             identity,
@@ -98,7 +98,7 @@ impl Handler {
 
             // TODO: Make async.
             let consensus_verifier = self.consensus_verifier.clone();
-            let version = Some(self.version);
+            let version = self.version;
             let runtime_id = self.runtime_id;
             let policy = tokio::task::block_in_place(move || {
                 // Obtain current quote policy from (verified) consensus state.

--- a/runtime/src/dispatcher.rs
+++ b/runtime/src/dispatcher.rs
@@ -265,6 +265,14 @@ impl Dispatcher {
             error!(self.logger, "ROFL application initialization failed"; "err" => ?err);
         }
 
+        // Determine what runtime version to support during remote attestation. For runtimes that
+        // define a ROFL application, we use `None` to signal that the active version is used.
+        let version = if app.is_supported() {
+            None
+        } else {
+            Some(protocol.get_config().version)
+        };
+
         let state = State {
             protocol: protocol.clone(),
             consensus_verifier: consensus_verifier.clone(),
@@ -278,7 +286,7 @@ impl Dispatcher {
                 protocol.clone(),
                 consensus_verifier.clone(),
                 protocol.get_runtime_id(),
-                protocol.get_config().version,
+                version,
             ),
             policy_verifier: Arc::new(PolicyVerifier::new(consensus_verifier)),
             cache_set: cache::CacheSet::new(protocol.clone()),


### PR DESCRIPTION
Previously each bundle that contained one or more ROFL components also needed to contain the exact version of the RONL component it was attaching to.

This is somewhat awkward to use so this adds support for detached ROFL components where the bundle only contains the ROFL and oasis-node then automatically gets the appropriate RONL component from another bundle.