### PR TITLE
registry: update proveFreshness tx body

### DIFF
--- a/.changelog/5708.bugfix.md
+++ b/.changelog/5708.bugfix.md
@@ -1,0 +1,1 @@
+go/registry/api: update ProveFreshness tx body type

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -131,7 +131,7 @@ var (
 	// MethodRegisterRuntime is the method name for registering runtimes.
 	MethodRegisterRuntime = transaction.NewMethodName(ModuleName, "RegisterRuntime", Runtime{})
 	// MethodProveFreshness is the method name for freshness proofs.
-	MethodProveFreshness = transaction.NewMethodName(ModuleName, "ProveFreshness", Runtime{})
+	MethodProveFreshness = transaction.NewMethodName(ModuleName, "ProveFreshness", [32]byte{})
 
 	// Methods is the list of all methods supported by the registry backend.
 	Methods = []transaction.MethodName{


### PR DESCRIPTION
The body of the ProveFreshness tx [seems to be outdated](https://github.com/oasisprotocol/oasis-core/blob/master/go/consensus/cometbft/apps/registry/registry.go#L138), this PR switches the type to the [32]byte blob. 

Nexus currently uses a [workaround](https://github.com/oasisprotocol/nexus/blob/main/analyzer/consensus/convert_tx.go#L104) that deserializes the tx body into a custom type.