### PR TITLE
go/worker/storage: Do not add any particular roles

### DIFF
--- a/.changelog/5725.bugfix.md
+++ b/.changelog/5725.bugfix.md
@@ -1,0 +1,5 @@
+go/worker/storage: Do not add any particular roles
+
+Since the storage node is always coupled with another role, make sure
+to not add any particular role as otherwise this could cause observer
+nodes to also register as compute nodes and then misbehave.

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -177,6 +177,8 @@ func (sw SoftwareVersion) ValidateBasic() error {
 type RolesMask uint32
 
 const (
+	// RoleEmpty is the roles bitmask that specifies no roles.
+	RoleEmpty RolesMask = 0
 	// RoleComputeWorker is the compute worker role.
 	RoleComputeWorker RolesMask = 1 << 0
 	// RoleObserver is the observer role.
@@ -214,6 +216,11 @@ func Roles() (roles []RolesMask) {
 		RoleValidator,
 		RoleStorageRPC,
 	}
+}
+
+// IsEmptyRole returns true if RolesMask encodes no roles (e.g. is equal to RoleEmpty).
+func (m RolesMask) IsEmptyRole() bool {
+	return m == RoleEmpty
 }
 
 // IsSingleRole returns true if RolesMask encodes a single valid role.

--- a/go/worker/storage/worker.go
+++ b/go/worker/storage/worker.go
@@ -70,7 +70,10 @@ func (w *Worker) registerRuntime(commonNode *committeeCommon.Node) error {
 		"runtime_id", id,
 	)
 
-	rp, err := w.registration.NewRuntimeRoleProvider(node.RoleComputeWorker, id)
+	// Since the storage node is always coupled with another role, make sure to not add any
+	// particular role here. Instead this only serves to prevent registration until the storage node
+	// is synced by making the role provider unavailable.
+	rp, err := w.registration.NewRuntimeRoleProvider(node.RoleEmpty, id)
 	if err != nil {
 		return fmt.Errorf("failed to create role provider: %w", err)
 	}


### PR DESCRIPTION
Since the storage node is always coupled with another role, make sure to not add any particular role as otherwise this could cause observer nodes to also register as compute nodes and then misbehave.