### PR TITLE
go/consensus: Add the latest consensus-breaking software version

### DIFF
--- a/.changelog/5760.internal.md
+++ b/.changelog/5760.internal.md
@@ -1,0 +1,5 @@
+go/consensus: Add the latest consensus-breaking software feature version
+
+Useful for enabling new consensus-breaking features with upcoming releases.
+A feature is enabled if the latest consensus-breaking software feature
+version is not lower than the version in which the feature is to be enabled.

--- a/go/consensus/cometbft/features/features.go
+++ b/go/consensus/cometbft/features/features.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"fmt"
+
+	consensusState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/abci/state"
+	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
+)
+
+// IsFeatureVersion returns true iff the consensus feature version is high
+// enough for the feature to be enabled.
+func IsFeatureVersion(ctx *tmapi.Context, minVersion string) (bool, error) {
+	// Consensus parameters.
+	consState := consensusState.NewMutableState(ctx.State())
+	consParams, err := consState.ConsensusParameters(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to load consensus parameters: %w", err)
+	}
+
+	return consParams.IsFeatureVersion(minVersion)
+}

--- a/go/consensus/genesis/genesis.go
+++ b/go/consensus/genesis/genesis.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	"github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 )
@@ -42,6 +43,25 @@ type Parameters struct { // nolint: maligned
 
 	// PublicKeyBlacklist is the network-wide public key blacklist.
 	PublicKeyBlacklist []signature.PublicKey `json:"public_key_blacklist,omitempty"`
+
+	// FeatureVersion represents the latest consensus-breaking software version
+	// that follows calendar versioning (yy.minor[.micro]).
+	FeatureVersion *version.Version `json:"feature_version,omitempty"`
+}
+
+// IsFeatureVersion returns true iff the consensus feature version is high
+// enough for the feature to be enabled.
+func (p *Parameters) IsFeatureVersion(minVersion string) (bool, error) {
+	mimFeatureVersion, err := version.FromString(minVersion)
+	if err != nil {
+		return false, err
+	}
+
+	if p.FeatureVersion == nil {
+		return false, nil
+	}
+
+	return p.FeatureVersion.ToU64() >= mimFeatureVersion.ToU64(), nil
 }
 
 const (

--- a/go/oasis-test-runner/oasis/network.go
+++ b/go/oasis-test-runner/oasis/network.go
@@ -799,6 +799,7 @@ func (net *Network) MakeGenesis() error {
 		"--" + genesis.CfgConsensusGasCostsTxByte, strconv.FormatUint(uint64(net.cfg.Consensus.Parameters.GasCosts[consensusGenesis.GasOpTxByte]), 10),
 		"--" + genesis.CfgConsensusStateCheckpointInterval, strconv.FormatUint(net.cfg.Consensus.Parameters.StateCheckpointInterval, 10),
 		"--" + genesis.CfgConsensusStateCheckpointNumKept, strconv.FormatUint(net.cfg.Consensus.Parameters.StateCheckpointNumKept, 10),
+		"--" + genesis.CfgConsensusFeatureVersion, "100.0", // High enough to enable all features.
 		"--" + genesis.CfgStakingTokenSymbol, genesisTestHelpers.TestStakingTokenSymbol,
 		"--" + genesis.CfgStakingTokenValueExponent, strconv.FormatUint(uint64(genesisTestHelpers.TestStakingTokenValueExponent), 10),
 		"--" + genesis.CfgBeaconBackend, net.cfg.Beacon.Backend,


### PR DESCRIPTION
Useful for enabling new consensus-breaking features with upcoming releases. A feature is enabled if the latest consensus-breaking software version is not lower than the version in which the feature is to be enabled.

Example of usage:
```go
if consParams.SoftwareVersion != nil && consParams.SoftwareVersion.ToU64() >= version.MustFromString("24.2").ToU64() {
    // Enable feature.
} else {
    // Disable feature and behave like version 24.1.
}
```