### PR TITLE
go/upgrade/migrations: Prepare handler for version 24.2.0

### DIFF
--- a/.changelog/5777.feature.md
+++ b/.changelog/5777.feature.md
@@ -1,0 +1,1 @@
+go/upgrade/migrations: Prepare handler for version 24.2.0

--- a/go/consensus/cometbft/apps/keymanager/churp/txs.go
+++ b/go/consensus/cometbft/apps/keymanager/churp/txs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/keymanager/churp"
 	"github.com/oasisprotocol/oasis-core/go/registry/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
+	"github.com/oasisprotocol/oasis-core/go/upgrade/migrations"
 )
 
 func (ext *churpExt) create(ctx *tmapi.Context, req *churp.CreateRequest) error {
@@ -559,7 +560,7 @@ func resetHandoff(status *churp.Status, nextHandoff beacon.EpochTime) {
 
 func verifyPolicy(ctx *tmapi.Context, policy *churp.SignedPolicySGX) error {
 	// Allow non-empty `MayQuery` field with the 24.2 release.
-	enabled, err := features.IsFeatureVersion(ctx, "24.2")
+	enabled, err := features.IsFeatureVersion(ctx, migrations.Version242)
 	if err != nil {
 		return err
 	}

--- a/go/consensus/cometbft/features/features.go
+++ b/go/consensus/cometbft/features/features.go
@@ -3,13 +3,14 @@ package features
 import (
 	"fmt"
 
+	"github.com/oasisprotocol/oasis-core/go/common/version"
 	consensusState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/abci/state"
 	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 )
 
 // IsFeatureVersion returns true iff the consensus feature version is high
 // enough for the feature to be enabled.
-func IsFeatureVersion(ctx *tmapi.Context, minVersion string) (bool, error) {
+func IsFeatureVersion(ctx *tmapi.Context, minVersion version.Version) (bool, error) {
 	// Consensus parameters.
 	consState := consensusState.NewMutableState(ctx.State())
 	consParams, err := consState.ConsensusParameters(ctx)
@@ -17,5 +18,5 @@ func IsFeatureVersion(ctx *tmapi.Context, minVersion string) (bool, error) {
 		return false, fmt.Errorf("failed to load consensus parameters: %w", err)
 	}
 
-	return consParams.IsFeatureVersion(minVersion)
+	return consParams.IsFeatureVersion(minVersion), nil
 }

--- a/go/consensus/genesis/genesis.go
+++ b/go/consensus/genesis/genesis.go
@@ -51,17 +51,12 @@ type Parameters struct { // nolint: maligned
 
 // IsFeatureVersion returns true iff the consensus feature version is high
 // enough for the feature to be enabled.
-func (p *Parameters) IsFeatureVersion(minVersion string) (bool, error) {
-	mimFeatureVersion, err := version.FromString(minVersion)
-	if err != nil {
-		return false, err
-	}
-
+func (p *Parameters) IsFeatureVersion(minVersion version.Version) bool {
 	if p.FeatureVersion == nil {
-		return false, nil
+		return false
 	}
 
-	return p.FeatureVersion.ToU64() >= mimFeatureVersion.ToU64(), nil
+	return p.FeatureVersion.ToU64() >= minVersion.ToU64()
 }
 
 const (

--- a/go/oasis-test-runner/scenario/e2e/scenario.go
+++ b/go/oasis-test-runner/scenario/e2e/scenario.go
@@ -138,6 +138,7 @@ func RegisterScenarios() error {
 		NodeUpgradeEmpty,
 		NodeUpgradeCancel,
 		NodeUpgradeConsensus240,
+		NodeUpgradeConsensus242,
 		// Debonding entries from genesis test.
 		Debond,
 		// Consensus state sync.

--- a/go/upgrade/migrations/consensus_242.go
+++ b/go/upgrade/migrations/consensus_242.go
@@ -1,0 +1,63 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common/version"
+	consensusState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/abci/state"
+	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
+)
+
+// Consensus242 is the name of the upgrade that enables features introduced in Oasis Core 24.2.
+//
+// This upgrade includes:
+//   - The `MayQuery“ field in the CHURP SGX policy, which defines which enclave identities
+//     are allowed to query runtime key shares.
+const Consensus242 = "consensus242"
+
+// Version242 is the Oasis Core 24.2 version.
+var Version242 = version.MustFromString("24.2")
+
+var _ Handler = (*Handler242)(nil)
+
+// Handler242 is the upgrade handler that transitions Oasis Core from version 24.1 to 24.2.
+type Handler242 struct{}
+
+// HasStartupUpgrade implements Handler.
+func (h *Handler242) HasStartupUpgrade() bool {
+	return false
+}
+
+// StartupUpgrade implements Handler.
+func (h *Handler242) StartupUpgrade() error {
+	return nil
+}
+
+// ConsensusUpgrade implements Handler.
+func (h *Handler242) ConsensusUpgrade(privateCtx interface{}) error {
+	abciCtx := privateCtx.(*abciAPI.Context)
+	switch abciCtx.Mode() {
+	case abciAPI.ContextBeginBlock:
+		// Nothing to do.
+	case abciAPI.ContextEndBlock:
+		// Consensus parameters.
+		consState := consensusState.NewMutableState(abciCtx.State())
+		consParams, err := consState.ConsensusParameters(abciCtx)
+		if err != nil {
+			return fmt.Errorf("failed to load consensus parameters: %w", err)
+		}
+
+		consParams.FeatureVersion = &Version242
+
+		if err = consState.SetConsensusParameters(abciCtx, consParams); err != nil {
+			return fmt.Errorf("failed to set consensus parameters: %w", err)
+		}
+	default:
+		return fmt.Errorf("upgrade handler called in unexpected context: %s", abciCtx.Mode())
+	}
+	return nil
+}
+
+func init() {
+	Register(Consensus242, &Handler242{})
+}


### PR DESCRIPTION
The handler can be renamed to 24.x if we need to release some no-breaking changes first.