### PR TITLE
keymanager/src/churp: Serve key shares to lagging clients

### DIFF
--- a/.changelog/5784.trivial.md
+++ b/.changelog/5784.trivial.md
@@ -1,0 +1,1 @@
+keymanager/src/churp: Serve key shares to lagging clients

--- a/go/keymanager/churp/rpc.go
+++ b/go/keymanager/churp/rpc.go
@@ -6,8 +6,8 @@ import (
 )
 
 var (
-	// RPCMethodInit is the name of the `init` method.
-	RPCMethodInit = "churp/init"
+	// RPCMethodApply is the name of the `apply` method.
+	RPCMethodApply = "churp/apply"
 
 	// RPCMethodShareReduction is the name of the `share_reduction` method.
 	RPCMethodShareReduction = "churp/share_reduction"

--- a/go/worker/keymanager/churp.go
+++ b/go/worker/keymanager/churp.go
@@ -491,7 +491,7 @@ func (s *submissionScheduler) trySubmitApplication(ctx context.Context, status *
 		Epoch: status.NextHandoff,
 	}
 	var rsp churp.SignedApplicationRequest
-	if err := timeCallEnclaveLocal(ctx, s.kmWorker, churp.RPCMethodInit, req, &rsp, status); err != nil {
+	if err := timeCallEnclaveLocal(ctx, s.kmWorker, churp.RPCMethodApply, req, &rsp, status); err != nil {
 		return fmt.Errorf("failed to generate verification matrix: %w", err)
 	}
 

--- a/keymanager/src/churp/handler.rs
+++ b/keymanager/src/churp/handler.rs
@@ -310,7 +310,7 @@ impl Churp {
     /// needs to be kept secret and generated only for authorized nodes.
     pub fn share_distribution_switch_point(
         &self,
-        _ctx: &RpcContext,
+        ctx: &RpcContext,
         req: &QueryRequest,
     ) -> Result<Vec<u8>> {
         let status = self.verify_next_handoff(req.id, req.runtime_id, req.epoch)?;
@@ -325,8 +325,8 @@ impl Churp {
             return Err(Error::NotInCommittee.into());
         }
 
-        self.verify_node_id(_ctx, node_id)?;
-        self.verify_km_enclave(_ctx, &status.policy)?;
+        self.verify_node_id(ctx, node_id)?;
+        self.verify_km_enclave(ctx, &status.policy)?;
 
         match status.suite_id {
             SuiteId::NistP384Sha3_384 => {
@@ -377,7 +377,7 @@ impl Churp {
     /// for authorized nodes.
     pub fn bivariate_share(
         &self,
-        _ctx: &RpcContext,
+        ctx: &RpcContext,
         req: &QueryRequest,
     ) -> Result<EncodedVerifiableSecretShare> {
         let status = self.verify_next_handoff(req.id, req.runtime_id, req.epoch)?;
@@ -387,8 +387,8 @@ impl Churp {
             return Err(Error::NotInCommittee.into());
         }
 
-        self.verify_node_id(_ctx, node_id)?;
-        self.verify_km_enclave(_ctx, &status.policy)?;
+        self.verify_node_id(ctx, node_id)?;
+        self.verify_km_enclave(ctx, &status.policy)?;
 
         match status.suite_id {
             SuiteId::NistP384Sha3_384 => {

--- a/keymanager/src/churp/methods.rs
+++ b/keymanager/src/churp/methods.rs
@@ -8,8 +8,8 @@ use oasis_core_runtime::enclave_rpc::{
 
 use crate::churp::{Churp, Handler};
 
-/// Name of the `init` method.
-pub const METHOD_INIT: &str = "churp/init";
+/// Name of the `apply` method.
+pub const METHOD_APPLY: &str = "churp/apply";
 /// Name of the `share_reduction` method.
 pub const METHOD_SHARE_REDUCTION: &str = "churp/share_reduction";
 /// Name of the `share_distribution` method.
@@ -74,10 +74,10 @@ impl RpcHandler for Churp {
             /* Local queries */
             RpcMethod::new(
                 RpcMethodDescriptor {
-                    name: METHOD_INIT.to_string(),
+                    name: METHOD_APPLY.to_string(),
                     kind: RpcKind::LocalQuery,
                 },
-                move |_ctx: &_, req: &_| self.init(req),
+                move |_ctx: &_, req: &_| self.apply(req),
             ),
             RpcMethod::new(
                 RpcMethodDescriptor {

--- a/keymanager/src/churp/methods.rs
+++ b/keymanager/src/churp/methods.rs
@@ -6,7 +6,7 @@ use oasis_core_runtime::enclave_rpc::{
     types::Kind as RpcKind,
 };
 
-use crate::churp::Churp;
+use crate::churp::{Churp, Handler};
 
 /// Name of the `init` method.
 pub const METHOD_INIT: &str = "churp/init";

--- a/keymanager/src/churp/state.rs
+++ b/keymanager/src/churp/state.rs
@@ -35,4 +35,22 @@ impl State {
 
         Ok(status)
     }
+
+    /// Returns CHURP status before the given number of blocks.
+    pub fn status_before(
+        &self,
+        runtime_id: Namespace,
+        churp_id: u8,
+        blocks: u64,
+    ) -> Result<Status> {
+        let height = block_on(self.consensus_verifier.latest_height())?;
+        let height = height.saturating_sub(blocks).max(1);
+        let consensus_state = block_on(self.consensus_verifier.state_at(height))?;
+        let churp_state = ChurpState::new(&consensus_state);
+        let status = churp_state
+            .status(runtime_id, churp_id)?
+            .ok_or(Error::StatusNotPublished)?;
+
+        Ok(status)
+    }
 }

--- a/keymanager/src/churp/storage.rs
+++ b/keymanager/src/churp/storage.rs
@@ -218,14 +218,14 @@ impl Storage {
     /// Creates storage key for the secret share.
     fn create_secret_share_storage_key(churp_id: u8) -> Vec<u8> {
         let mut key = SECRET_SHARE_STORAGE_KEY_PREFIX.to_vec();
-        key.extend(vec![churp_id]);
+        key.extend(&[churp_id]);
         key
     }
 
     /// Creates storage key for the next secret share.
     fn create_next_secret_share_storage_key(churp_id: u8) -> Vec<u8> {
         let mut key = NEXT_SECRET_SHARE_STORAGE_KEY_PREFIX.to_vec();
-        key.extend(vec![churp_id]);
+        key.extend(&[churp_id]);
         key
     }
 


### PR DESCRIPTION
Also refactored code to:
- better handle different churp instances (added new trait `Handler`),
- load shares and polynomials only on startup (and not on every request if the share/polynomial is missing),
- verify loaded dealer before returning a response with bivariate share.