### PR TITLE
Fix handling of detached bundles

### DIFF
--- a/.changelog/5785.bugfix.md
+++ b/.changelog/5785.bugfix.md
@@ -1,0 +1,1 @@
+go/runtime/bundle: Use manifest hash at bundle load time

--- a/.changelog/5785.feature.md
+++ b/.changelog/5785.feature.md
@@ -1,0 +1,5 @@
+go/runtime: Automatically enable all configured detached components
+
+Since they are explicitly configured there should be no need to enable
+them twice. This just defaults detached components to be enabled and one
+needs to explicitly disable them.

--- a/go/runtime/config/config_test.go
+++ b/go/runtime/config/config_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/oasisprotocol/oasis-core/go/runtime/bundle/component"
+)
+
+func TestComponentConfig(t *testing.T) {
+	require := require.New(t)
+
+	cfg := Config{
+		Components: []ComponentConfig{
+			{
+				ID:       component.ID{Kind: component.ROFL, Name: "foo-test"},
+				Disabled: false,
+			},
+		},
+	}
+
+	compCfg, ok := cfg.GetComponent(component.ID{Kind: component.ROFL, Name: "foo-test"})
+	require.True(ok)
+	require.EqualValues(compCfg.ID.Kind, component.ROFL)
+	require.EqualValues(compCfg.ID.Name, "foo-test")
+	require.False(compCfg.Disabled)
+
+	compCfg, ok = cfg.GetComponent(component.ID{Kind: component.ROFL, Name: "does-not-exist"})
+	require.False(ok)
+	require.EqualValues(compCfg, ComponentConfig{})
+
+	// Deserialization.
+	yamlCfg := `
+components:
+    - rofl.foo-test
+    - id: rofl.another
+      disabled: true
+`
+	var decCfg Config
+	err := yaml.Unmarshal([]byte(yamlCfg), &decCfg)
+	require.NoError(err, "yaml.Unmarshal")
+
+	compCfg, ok = decCfg.GetComponent(component.ID{Kind: component.ROFL, Name: "foo-test"})
+	require.True(ok)
+	require.EqualValues(compCfg.ID.Kind, component.ROFL)
+	require.EqualValues(compCfg.ID.Name, "foo-test")
+	require.False(compCfg.Disabled)
+
+	compCfg, ok = decCfg.GetComponent(component.ID{Kind: component.ROFL, Name: "another"})
+	require.True(ok)
+	require.EqualValues(compCfg.ID.Kind, component.ROFL)
+	require.EqualValues(compCfg.ID.Name, "another")
+	require.True(compCfg.Disabled)
+}

--- a/go/runtime/registry/config.go
+++ b/go/runtime/registry/config.go
@@ -289,8 +289,9 @@ func newConfig( //nolint: gocyclo
 			}
 
 			rtBnd := &runtimeHost.RuntimeBundle{
-				Bundle:          bnd,
-				ExplodedDataDir: dataDir,
+				Bundle:               bnd,
+				ExplodedDataDir:      dataDir,
+				ExplodedDetachedDirs: make(map[component.ID]string),
 			}
 
 			// Merge in detached components.
@@ -320,6 +321,10 @@ func newConfig( //nolint: gocyclo
 				// On non-compute nodes, assume all components are disabled by default.
 				if config.GlobalConfig.Mode != config.ModeCompute {
 					enabled = false
+				}
+				// Detached components are explicit and they should be enabled by default.
+				if _, ok := rtBnd.ExplodedDetachedDirs[comp.ID()]; ok {
+					enabled = true
 				}
 
 				// Check for any overrides in the node configuration.


### PR DESCRIPTION
* go/runtime: Automatically enable all configured detached components
* go/runtime/bundle: Use manifest hash at bundle load time