### PR TITLE
go/registry: Deprecate enable key manager CHURP flag

### DIFF
--- a/.changelog/5790.trivial.md
+++ b/.changelog/5790.trivial.md
@@ -1,0 +1,4 @@
+go/registry: Deprecate enable key manager CHURP flag
+
+Removes the code previously necessary to enable the key manager CHURP
+extension.

--- a/go/consensus/cometbft/apps/keymanager/churp/genesis.go
+++ b/go/consensus/cometbft/apps/keymanager/churp/genesis.go
@@ -13,10 +13,6 @@ import (
 
 // InitChain implements api.Extension.
 func (ext *churpExt) InitChain(ctx *tmapi.Context, _ types.RequestInitChain, _ *genesis.Document) error {
-	if enabled, err := ext.enabled(ctx); err != nil || !enabled {
-		return nil
-	}
-
 	state := churpState.NewMutableState(ctx.State())
 
 	if err := state.SetConsensusParameters(ctx, &churp.DefaultConsensusParameters); err != nil {

--- a/go/consensus/cometbft/apps/keymanager/churp/genesis.go
+++ b/go/consensus/cometbft/apps/keymanager/churp/genesis.go
@@ -1,23 +1,89 @@
 package churp
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cometbft/cometbft/abci/types"
 
 	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	churpState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/keymanager/churp/state"
+	"github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/keymanager/common"
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
 	"github.com/oasisprotocol/oasis-core/go/keymanager/churp"
 )
 
 // InitChain implements api.Extension.
-func (ext *churpExt) InitChain(ctx *tmapi.Context, _ types.RequestInitChain, _ *genesis.Document) error {
-	state := churpState.NewMutableState(ctx.State())
+func (ext *churpExt) InitChain(ctx *tmapi.Context, _ types.RequestInitChain, doc *genesis.Document) error {
+	// Ensure compatibility with Eden genesis file.
+	st := doc.KeyManager.Churp
+	if st == nil {
+		return nil
+	}
 
+	// Insert consensus parameters.
+	state := churpState.NewMutableState(ctx.State())
 	if err := state.SetConsensusParameters(ctx, &churp.DefaultConsensusParameters); err != nil {
 		return fmt.Errorf("cometbft/keymanager/churp: failed to set consensus parameters: %w", err)
 	}
 
+	// Fetch runtimes.
+	epoch, err := ext.state.GetCurrentEpoch(ctx)
+	if err != nil {
+		return fmt.Errorf("cometbft/keymanager/churp: failed to get current epoch: %w", err)
+	}
+	runtimes := common.RegistryRuntimes(ctx, doc, epoch)
+
+	// Insert statuses.
+	for _, status := range st.Statuses {
+		if _, ok := runtimes[status.RuntimeID]; !ok {
+			return fmt.Errorf("cometbft/keymanager/churp: unknown key manager runtime: %s", status.RuntimeID)
+		}
+
+		// Disable handoffs for all instances.
+		status.NextHandoff = churp.HandoffsDisabled
+		status.NextChecksum = nil
+		status.Applications = nil
+
+		// Schedule the next handoff at the beginning of the next epoch.
+		if status.HandoffInterval != 0 {
+			status.NextHandoff = epoch + 1
+		}
+
+		if err := state.SetStatus(ctx, status); err != nil {
+			return fmt.Errorf("cometbft/keymanager/churp: failed to set status: %w", err)
+		}
+
+		ctx.EmitEvent(tmapi.NewEventBuilder(ext.appName).TypedAttribute(&churp.UpdateEvent{
+			Status: status,
+		}))
+	}
+
 	return nil
+}
+
+// Genesis implements Query.
+func (q *querier) Genesis(ctx context.Context) (*churp.Genesis, error) {
+	parameters, err := q.state.ConsensusParameters(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	statuses, err := q.state.AllStatuses(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Disable handoffs for all instances.
+	for _, status := range statuses {
+		status.NextHandoff = churp.HandoffsDisabled
+		status.NextChecksum = nil
+		status.Applications = nil
+	}
+
+	gen := churp.Genesis{
+		Parameters: *parameters,
+		Statuses:   statuses,
+	}
+	return &gen, nil
 }

--- a/go/consensus/cometbft/apps/keymanager/churp/genesis_test.go
+++ b/go/consensus/cometbft/apps/keymanager/churp/genesis_test.go
@@ -1,0 +1,193 @@
+package churp
+
+import (
+	"testing"
+
+	"github.com/cometbft/cometbft/abci/types"
+	"github.com/stretchr/testify/require"
+
+	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/sgx"
+	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
+	churpState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/keymanager/churp/state"
+	"github.com/oasisprotocol/oasis-core/go/genesis/api"
+	keymanager "github.com/oasisprotocol/oasis-core/go/keymanager/api"
+	"github.com/oasisprotocol/oasis-core/go/keymanager/churp"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+)
+
+var (
+	kmRuntimeID common.Namespace
+	_           = kmRuntimeID.UnmarshalHex("c000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff")
+)
+
+func createTestRegistryGenesis() registry.Genesis {
+	return registry.Genesis{
+		Parameters: registry.ConsensusParameters{
+			DebugAllowTestRuntimes: true,
+			EnableRuntimeGovernanceModels: map[registry.RuntimeGovernanceModel]bool{
+				registry.GovernanceEntity: true,
+			},
+		},
+		Runtimes: []*registry.Runtime{
+			{
+				Versioned:   cbor.NewVersioned(registry.LatestRuntimeDescriptorVersion),
+				ID:          kmRuntimeID,
+				EntityID:    signature.PublicKey{},
+				Kind:        registry.KindKeyManager,
+				TEEHardware: node.TEEHardwareIntelSGX,
+				Deployments: []*registry.VersionInfo{
+					{
+						TEE: cbor.Marshal(node.SGXConstraints{
+							Enclaves: []sgx.EnclaveIdentity{{}},
+						}),
+					},
+				},
+				AdmissionPolicy: registry.RuntimeAdmissionPolicy{
+					EntityWhitelist: &registry.EntityWhitelistRuntimeAdmissionPolicy{
+						Entities: map[signature.PublicKey]registry.EntityWhitelistConfig{},
+					},
+				},
+				GovernanceModel: registry.GovernanceEntity,
+			},
+		},
+	}
+}
+
+func createTestChurpGenesis() *churp.Genesis {
+	return &churp.Genesis{
+		Parameters: churp.ConsensusParameters{
+			GasCosts: churp.DefaultGasCosts,
+		},
+		Statuses: []*churp.Status{
+			{
+				Identity: churp.Identity{
+					ID:        1,
+					RuntimeID: kmRuntimeID,
+				},
+				Threshold:       5,
+				HandoffInterval: 0,
+				NextHandoff:     churp.HandoffsDisabled,
+			},
+			{
+				Identity: churp.Identity{
+					ID:        2,
+					RuntimeID: kmRuntimeID,
+				},
+				Threshold:       10,
+				HandoffInterval: 1,
+				NextHandoff:     100,
+				NextChecksum:    &hash.Hash{1, 2, 3},
+				Applications: map[signature.PublicKey]churp.Application{
+					keymanager.InsecureRAK: {
+						Checksum:      hash.Hash{1, 2, 3},
+						Reconstructed: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestInitChain(t *testing.T) {
+	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
+	ctx := appState.NewContext(abciAPI.ContextInitChain)
+	defer ctx.Close()
+
+	state := churpState.NewMutableState(ctx.State())
+	app := &churpExt{
+		state: appState,
+	}
+
+	// Empty state.
+	doc := api.Document{}
+	err := app.InitChain(ctx, types.RequestInitChain{}, &doc)
+	require.NoError(t, err, "failed to initialize empty state")
+
+	params, err := state.ConsensusParameters(ctx)
+	require.NoError(t, err)
+	require.Equal(t, churp.ConsensusParameters{}, *params)
+
+	statuses, err := state.AllStatuses(ctx)
+	require.NoError(t, err)
+	require.Empty(t, statuses)
+
+	// Non-empty state.
+	doc = api.Document{
+		KeyManager: keymanager.Genesis{
+			Churp: createTestChurpGenesis(),
+		},
+		Registry: createTestRegistryGenesis(),
+	}
+
+	err = app.InitChain(ctx, types.RequestInitChain{}, &doc)
+	require.NoError(t, err, "failed to initialize non-empty state")
+
+	params, err = state.ConsensusParameters(ctx)
+	require.NoError(t, err)
+	require.Equal(t, churp.DefaultConsensusParameters, *params)
+
+	statuses, err = state.AllStatuses(ctx)
+	require.NoError(t, err)
+	require.Len(t, statuses, 2)
+
+	require.Equal(t, uint8(1), statuses[0].ID)
+	require.Equal(t, uint8(5), statuses[0].Threshold)
+	require.Equal(t, beacon.EpochTime(0), statuses[0].HandoffInterval)
+	require.Equal(t, churp.HandoffsDisabled, statuses[0].NextHandoff) // Should be disabled.
+	require.Nil(t, statuses[0].NextChecksum)
+	require.Nil(t, statuses[0].Applications)
+
+	require.Equal(t, uint8(2), statuses[1].ID)
+	require.Equal(t, uint8(10), statuses[1].Threshold)
+	require.Equal(t, beacon.EpochTime(1), statuses[1].HandoffInterval)
+	require.Equal(t, beacon.EpochTime(1), statuses[1].NextHandoff) // Should be set.
+	require.Nil(t, statuses[1].NextChecksum)
+	require.Nil(t, statuses[1].Applications)
+}
+
+func TestGenesis(t *testing.T) {
+	appState := abciAPI.NewMockApplicationState(&abciAPI.MockApplicationStateConfig{})
+	ctx := appState.NewContext(abciAPI.ContextEndBlock)
+	defer ctx.Close()
+
+	state := churpState.NewMutableState(ctx.State())
+	q := NewQuery(state.ImmutableState)
+
+	// Empty state.
+	g, err := q.Genesis(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, churp.ConsensusParameters{}, g.Parameters)
+	require.Len(t, g.Statuses, 0)
+
+	// Prepare state that should be exported into the expected genesis.
+	genesis := createTestChurpGenesis()
+
+	err = state.SetConsensusParameters(ctx, &genesis.Parameters)
+	require.NoError(t, err)
+
+	for _, status := range genesis.Statuses {
+		err = state.SetStatus(ctx, status)
+		require.NoError(t, err)
+	}
+
+	// Exported genesis disables handoffs for all instances
+	for i := range genesis.Statuses {
+		genesis.Statuses[i].NextHandoff = churp.HandoffsDisabled
+		genesis.Statuses[i].NextChecksum = nil
+		genesis.Statuses[i].Applications = nil
+	}
+
+	// Non-empty state.
+	g, err = q.Genesis(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, genesis.Parameters, g.Parameters)
+	require.EqualValues(t, genesis.Statuses, g.Statuses)
+}

--- a/go/consensus/cometbft/apps/keymanager/churp/query.go
+++ b/go/consensus/cometbft/apps/keymanager/churp/query.go
@@ -14,6 +14,7 @@ type Query interface {
 	Status(context.Context, common.Namespace, uint8) (*churp.Status, error)
 	Statuses(context.Context, common.Namespace) ([]*churp.Status, error)
 	AllStatuses(context.Context) ([]*churp.Status, error)
+	Genesis(context.Context) (*churp.Genesis, error)
 }
 
 type querier struct {

--- a/go/consensus/cometbft/apps/keymanager/churp/state/state.go
+++ b/go/consensus/cometbft/apps/keymanager/churp/state/state.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
@@ -38,7 +37,7 @@ func (st *ImmutableState) ConsensusParameters(ctx context.Context) (*churp.Conse
 		return nil, abciAPI.UnavailableStateError(err)
 	}
 	if raw == nil {
-		return nil, fmt.Errorf("cometbft/keymanager/churp: expected consensus parameters to be present in app state")
+		return &churp.ConsensusParameters{}, nil
 	}
 
 	var params churp.ConsensusParameters

--- a/go/consensus/cometbft/apps/keymanager/churp/state/state_test.go
+++ b/go/consensus/cometbft/apps/keymanager/churp/state/state_test.go
@@ -26,15 +26,16 @@ func TestConsensusParameters(t *testing.T) {
 	}
 
 	// Empty state.
-	_, err := st.ConsensusParameters(ctx)
-	require.Error(t, err)
+	fetched, err := st.ConsensusParameters(ctx)
+	require.NoError(t, err)
+	require.Equal(t, &churp.ConsensusParameters{}, fetched)
 
 	// Set state.
 	err = st.SetConsensusParameters(ctx, &params)
 	require.NoError(t, err)
 
 	// New state.
-	fetched, err := st.ConsensusParameters(ctx)
+	fetched, err = st.ConsensusParameters(ctx)
 	require.NoError(t, err)
 	require.Len(t, fetched.GasCosts, 1)
 	require.Equal(t, params.GasCosts[churp.GasOpCreate], fetched.GasCosts[churp.GasOpCreate])

--- a/go/consensus/cometbft/apps/keymanager/common/genesis.go
+++ b/go/consensus/cometbft/apps/keymanager/common/genesis.go
@@ -1,0 +1,33 @@
+package common
+
+import (
+	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
+	"github.com/oasisprotocol/oasis-core/go/common"
+	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
+	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+)
+
+// RegistryRuntimes returns verified genesis runtimes.
+func RegistryRuntimes(ctx *tmapi.Context, doc *genesis.Document, epoch beacon.EpochTime) map[common.Namespace]*registry.Runtime {
+	// TODO: The better thing to do would be to move the registry init
+	// before the keymanager, and just query the registry for the runtime
+	// list.
+	regSt := doc.Registry
+	rtMap := make(map[common.Namespace]*registry.Runtime)
+	for _, rt := range regSt.Runtimes {
+		err := registry.VerifyRuntime(&regSt.Parameters, ctx.Logger(), rt, true, false, epoch)
+		if err != nil {
+			ctx.Logger().Error("InitChain: Invalid runtime",
+				"err", err,
+			)
+			continue
+		}
+
+		if rt.Kind == registry.KindKeyManager {
+			rtMap[rt.ID] = rt
+		}
+	}
+
+	return rtMap
+}

--- a/go/consensus/cometbft/keymanager/churp/client.go
+++ b/go/consensus/cometbft/keymanager/churp/client.go
@@ -62,6 +62,16 @@ func (sc *ServiceClient) AllStatuses(ctx context.Context, height int64) ([]*chur
 	return q.Churp().AllStatuses(ctx)
 }
 
+// StateToGenesis implements churp.Backend.
+func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*churp.Genesis, error) {
+	q, err := sc.querier.QueryAt(ctx, height)
+	if err != nil {
+		return nil, err
+	}
+
+	return q.Churp().Genesis(ctx)
+}
+
 // WatchStatuses implements churp.Backend.
 func (sc *ServiceClient) WatchStatuses() (<-chan *churp.Status, *pubsub.Subscription) {
 	sub := sc.statusNotifier.Subscribe()

--- a/go/consensus/cometbft/keymanager/keymanager.go
+++ b/go/consensus/cometbft/keymanager/keymanager.go
@@ -39,7 +39,15 @@ func (sc *serviceClient) StateToGenesis(ctx context.Context, height int64) (*api
 		return nil, err
 	}
 
-	return secretsGenesis, nil
+	churpGenesis, err := sc.churpClient.StateToGenesis(ctx, height)
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.Genesis{
+		Genesis: *secretsGenesis,
+		Churp:   churpGenesis,
+	}, nil
 }
 
 // Implements api.Backend.

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -314,9 +314,11 @@ func TestGenesisSanityCheck(t *testing.T) {
 	// Test keymanager genesis checks.
 	d = testDoc()
 	d.KeyManager = keymanager.Genesis{
-		Statuses: []*secrets.Status{
-			{
-				ID: testRuntimeID,
+		Genesis: secrets.Genesis{
+			Statuses: []*secrets.Status{
+				{
+					ID: testRuntimeID,
+				},
 			},
 		},
 	}
@@ -324,10 +326,12 @@ func TestGenesisSanityCheck(t *testing.T) {
 
 	d = testDoc()
 	d.KeyManager = keymanager.Genesis{
-		Statuses: []*secrets.Status{
-			{
-				ID:    validNS,
-				Nodes: []signature.PublicKey{invalidPK},
+		Genesis: secrets.Genesis{
+			Statuses: []*secrets.Status{
+				{
+					ID:    validNS,
+					Nodes: []signature.PublicKey{invalidPK},
+				},
 			},
 		},
 	}

--- a/go/keymanager/api/api.go
+++ b/go/keymanager/api/api.go
@@ -48,7 +48,15 @@ type Backend interface {
 }
 
 // Genesis is the key manager management genesis state.
-type Genesis = secrets.Genesis
+type Genesis struct {
+	// Genesis is the secret genesis state.
+	//
+	// Embedded to ensure backward compatibility.
+	secrets.Genesis
+
+	// Churp is the optional CHURP genesis state.
+	Churp *churp.Genesis `json:"churp,omitempty"`
+}
 
 func init() {
 	// Old `INSECURE_SIGNING_KEY_PKCS8`.

--- a/go/keymanager/churp/backend.go
+++ b/go/keymanager/churp/backend.go
@@ -27,4 +27,16 @@ type Backend interface {
 	//
 	// Upon subscription the current statuses are sent immediately.
 	WatchStatuses() (<-chan *Status, *pubsub.Subscription)
+
+	// StateToGenesis returns the genesis state at specified block height.
+	StateToGenesis(context.Context, int64) (*Genesis, error)
+}
+
+// Genesis is the key manager management genesis state for CHURP.
+type Genesis struct {
+	// Parameters are the consensus parameters for CHURP.
+	Parameters ConsensusParameters `json:"params"`
+
+	// Statuses are the statuses of CHURP instances.
+	Statuses []*Status `json:"statuses,omitempty"`
 }

--- a/go/keymanager/secrets/api.go
+++ b/go/keymanager/secrets/api.go
@@ -338,11 +338,12 @@ type LoadEphemeralSecretRequest struct {
 	SignedSecret SignedEncryptedEphemeralSecret `json:"signed_secret"`
 }
 
-// Genesis is the key manager management genesis state.
+// Genesis is the key manager management genesis state for secrets.
 type Genesis struct {
-	// Parameters are the key manager consensus parameters.
+	// Parameters are the consensus parameters for secrets.
 	Parameters ConsensusParameters `json:"params"`
 
+	// Statuses are the statuses of secrets.
 	Statuses []*Status `json:"statuses,omitempty"`
 }
 

--- a/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
+++ b/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
@@ -326,11 +326,18 @@ func dumpKeyManager(ctx context.Context, qs *dumpQueryState) (*keymanager.Genesi
 	if err != nil {
 		return nil, fmt.Errorf("dumpdb: failed to create key manager query: %w", err)
 	}
-	st, err := q.Secrets().Genesis(ctx)
+	secrets, err := q.Secrets().Genesis(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("dumpdb: failed to dump key manager state: %w", err)
 	}
-	return st, nil
+	churp, err := q.Churp().Genesis(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("dumpdb: failed to dump key manager state: %w", err)
+	}
+	return &keymanager.Genesis{
+		Genesis: *secrets,
+		Churp:   churp,
+	}, nil
 }
 
 func dumpScheduler(ctx context.Context, qs *dumpQueryState) (*scheduler.Genesis, error) {

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -570,7 +570,7 @@ func AppendRootHashState(doc *genesis.Document, exports []string, l *logging.Log
 // AppendKeyManagerState appends the key manager genesis state given a vector of
 // key manager statuses.
 func AppendKeyManagerState(doc *genesis.Document, statuses []string, l *logging.Logger) error {
-	kmSt := secrets.Genesis{
+	secretsGenesis := secrets.Genesis{
 		Parameters: secrets.ConsensusParameters{
 			GasCosts: secrets.DefaultGasCosts, // TODO: Make these configurable.
 		},
@@ -595,10 +595,10 @@ func AppendKeyManagerState(doc *genesis.Document, statuses []string, l *logging.
 			return err
 		}
 
-		kmSt.Statuses = append(kmSt.Statuses, &status)
+		secretsGenesis.Statuses = append(secretsGenesis.Statuses, &status)
 	}
 
-	doc.KeyManager = kmSt
+	doc.KeyManager.Genesis = secretsGenesis
 
 	return nil
 }

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -61,7 +61,6 @@ const (
 	CfgRegistryDebugAllowUnroutableAddresses          = "registry.debug.allow_unroutable_addresses"
 	CfgRegistryDebugAllowTestRuntimes                 = "registry.debug.allow_test_runtimes"
 	CfgRegistryEnableRuntimeGovernanceModels          = "registry.enable_runtime_governance_models"
-	CfgRegistryEnableKeyManagerCHURP                  = "registry.enable_key_manager_churp"
 	CfgRegistryTEEFeaturesSGXPCS                      = "registry.tee_features.sgx.pcs"
 	CfgRegistryTEEFeaturesSGXSignedAttestations       = "registry.tee_features.sgx.signed_attestations"
 	CfgRegistryTEEFeaturesSGXDefaultMaxAttestationAge = "registry.tee_features.sgx.default_max_attestation_age"
@@ -389,10 +388,6 @@ func AppendRegistryState(doc *genesis.Document, entities, runtimes, nodes []stri
 			return fmt.Errorf("%w: '%s'", err, gmStr)
 		}
 		regSt.Parameters.EnableRuntimeGovernanceModels[gm] = true
-	}
-
-	if viper.GetBool(CfgRegistryEnableKeyManagerCHURP) {
-		regSt.Parameters.EnableKeyManagerCHURP = true
 	}
 
 	entMap := make(map[signature.PublicKey]bool)
@@ -814,7 +809,6 @@ func init() {
 	initGenesisFlags.Bool(CfgRegistryDebugAllowUnroutableAddresses, false, "allow unroutable addreses (UNSAFE)")
 	initGenesisFlags.Bool(CfgRegistryDebugAllowTestRuntimes, false, "enable test runtime registration")
 	initGenesisFlags.StringSlice(CfgRegistryEnableRuntimeGovernanceModels, []string{"entity"}, "set of enabled runtime governance models")
-	initGenesisFlags.Bool(CfgRegistryEnableKeyManagerCHURP, false, "enable key manager CHURP extension")
 	initGenesisFlags.Bool(CfgRegistryTEEFeaturesSGXPCS, true, "enable PCS support for SGX TEEs")
 	initGenesisFlags.Bool(CfgRegistryTEEFeaturesSGXSignedAttestations, true, "enable SGX RAK-signed attestations")
 	initGenesisFlags.Uint64(CfgRegistryTEEFeaturesSGXDefaultMaxAttestationAge, 1200, "default max attestation age (SGX RAK-signed attestations must be enabled") // ~2 hours at 6 sec per block.

--- a/go/oasis-test-runner/oasis/network.go
+++ b/go/oasis-test-runner/oasis/network.go
@@ -175,9 +175,6 @@ type NetworkCfg struct { // nolint: maligned
 	// left empty. Nodes are started in the order in which they appear here (automatically created
 	// nodes are appended).
 	Nodes []string
-
-	// EnableKeyManagerCHURP is the enable key manager CHURP extension flag.
-	EnableKeyManagerCHURP bool `json:"enable_km_churp,omitempty"`
 }
 
 // SetMockEpoch force-enables the mock epoch time keeping.
@@ -803,11 +800,6 @@ func (net *Network) MakeGenesis() error {
 		"--" + genesis.CfgStakingTokenSymbol, genesisTestHelpers.TestStakingTokenSymbol,
 		"--" + genesis.CfgStakingTokenValueExponent, strconv.FormatUint(uint64(genesisTestHelpers.TestStakingTokenValueExponent), 10),
 		"--" + genesis.CfgBeaconBackend, net.cfg.Beacon.Backend,
-	}
-	if net.cfg.EnableKeyManagerCHURP {
-		args = append(args, []string{
-			"--" + genesis.CfgRegistryEnableKeyManagerCHURP, "true",
-		}...)
 	}
 	switch net.cfg.Beacon.Backend {
 	case beacon.BackendInsecure:

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_churp.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_churp.go
@@ -52,9 +52,6 @@ func (sc *kmChurpImpl) Fixture() (*oasis.NetworkFixture, error) {
 		f.Keymanagers[i].NoAutoStart = true
 	}
 
-	// Enable CHURP extension.
-	f.Network.EnableKeyManagerCHURP = true
-
 	// Speed up the test.
 	f.Network.Beacon.VRFParameters = &beacon.VRFParameters{
 		Interval:             10,

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_churp_many.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_churp_many.go
@@ -54,9 +54,6 @@ func (sc *kmChurpManyImpl) Fixture() (*oasis.NetworkFixture, error) {
 	f.Keymanagers[5].ChurpIDs = []uint8{0, 1, 2}
 	f.Keymanagers[5].NoAutoStart = true
 
-	// Enable CHURP extension.
-	f.Network.EnableKeyManagerCHURP = true
-
 	// Speed up the test.
 	f.Network.Beacon.VRFParameters = &beacon.VRFParameters{
 		Interval:             10,

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_churp_txs.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_churp_txs.go
@@ -60,9 +60,6 @@ func (sc *kmChurpTxsImpl) Fixture() (*oasis.NetworkFixture, error) {
 		f.Keymanagers = append(f.Keymanagers, f.Keymanagers[0])
 	}
 
-	// Enable CHURP extension.
-	f.Network.EnableKeyManagerCHURP = true
-
 	// Speed up the test.
 	f.Network.Beacon.VRFParameters = &beacon.VRFParameters{
 		Interval:             10,

--- a/go/oasis-test-runner/scenario/e2e/upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/upgrade.go
@@ -93,14 +93,14 @@ func (c *upgrade240Checker) PreUpgradeFn(ctx context.Context, ctrl *oasis.Contro
 	if err != nil {
 		return fmt.Errorf("can't get registry consensus parameters: %w", err)
 	}
-	if registryParams.EnableKeyManagerCHURP {
+	if registryParams.DeprecatedEnableKeyManagerCHURP { // nolint: staticcheck
 		return fmt.Errorf("key manager CHURP extension is enabled")
 	}
 
 	// Check CHURP parameters.
 	_, err = ctrl.Keymanager.Churp().ConsensusParameters(ctx, consensus.HeightLatest)
-	if err == nil {
-		return fmt.Errorf("key manager CHURP consensus parameters shouldn't be set: %w", err)
+	if err != nil {
+		return fmt.Errorf("key manager CHURP consensus parameters should be set: %w", err)
 	}
 
 	// Check staking parameters.
@@ -176,7 +176,7 @@ func (c *upgrade240Checker) PostUpgradeFn(ctx context.Context, ctrl *oasis.Contr
 	if err != nil {
 		return fmt.Errorf("can't get registry consensus parameters: %w", err)
 	}
-	if !registryParams.EnableKeyManagerCHURP {
+	if !registryParams.DeprecatedEnableKeyManagerCHURP { // nolint: staticcheck
 		return fmt.Errorf("key manager CHURP extension is disabled")
 	}
 

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -1399,8 +1399,10 @@ type ConsensusParameters struct {
 	// disabled outside of the genesis block.
 	DisableKeyManagerRuntimeRegistration bool `json:"disable_km_runtime_registration,omitempty"`
 
-	// EnableKeyManagerCHURP is true iff the CHURP extension for the key manager is enabled.
-	EnableKeyManagerCHURP bool `json:"enable_km_churp,omitempty"`
+	// DeprecatedEnableKeyManagerCHURP is true iff the CHURP extension for the key manager is enabled.
+	//
+	// Deprecated: CHURP extension is enabled by default since version 24.0.
+	DeprecatedEnableKeyManagerCHURP bool `json:"enable_km_churp,omitempty"`
 
 	// GasCosts are the registry transaction gas costs.
 	GasCosts transaction.Costs `json:"gas_costs,omitempty"`

--- a/go/upgrade/migrations/consensus_240.go
+++ b/go/upgrade/migrations/consensus_240.go
@@ -69,7 +69,7 @@ func (h *Handler240) ConsensusUpgrade(privateCtx interface{}) error {
 		if err != nil {
 			return fmt.Errorf("failed to load registry consensus parameters: %w", err)
 		}
-		regParams.EnableKeyManagerCHURP = true
+		regParams.DeprecatedEnableKeyManagerCHURP = true // nolint: staticcheck
 
 		if err = regState.SetConsensusParameters(abciCtx, regParams); err != nil {
 			return fmt.Errorf("failed to update registry consensus parameters: %w", err)


### PR DESCRIPTION
Apply changes from:
- #5573