### PR TITLE
secret-sharing: Make sensitive functions constant time

### DIFF
--- a/.changelog/5800.internal.md
+++ b/.changelog/5800.internal.md
@@ -1,0 +1,1 @@
+secret-sharing: Make sensitive functions constant time

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,6 +2693,7 @@ dependencies = [
  "rand",
  "rand_core",
  "sha3",
+ "subtle",
  "thiserror",
 ]
 

--- a/go/common/crypto/signature/signer.go
+++ b/go/common/crypto/signature/signer.go
@@ -278,7 +278,7 @@ type SignerFactory interface {
 	// implementations require an entropy source to be provided.
 	Generate(role SignerRole, rng io.Reader) (Signer, error)
 
-	// Load will load the private key corresonding to the provided role, and
+	// Load will load the private key corresponding to the provided role, and
 	// return a Signer ready for use.
 	Load(role SignerRole) (Signer, error)
 }

--- a/keymanager/src/churp/storage.rs
+++ b/keymanager/src/churp/storage.rs
@@ -166,7 +166,7 @@ impl Storage {
             .open(nonce, ciphertext, additional_data)
             .map_err(|_| Error::InvalidBivariatePolynomial)?;
 
-        BivariatePolynomial::from_bytes(plaintext)
+        BivariatePolynomial::from_bytes(&plaintext)
             .ok_or(Error::BivariatePolynomialDecodingFailed.into())
     }
 

--- a/secret-sharing/Cargo.toml
+++ b/secret-sharing/Cargo.toml
@@ -12,6 +12,7 @@ group = "0.13.0"
 p384 = { version = "0.13.0", features = ["hash2curve"] }
 rand_core = "0.6.4"
 sha3 = "0.10.8"
+subtle = "2.6.1"
 thiserror = "1.0"
 
 # Fuzzing.

--- a/secret-sharing/src/churp/dealer.rs
+++ b/secret-sharing/src/churp/dealer.rs
@@ -193,14 +193,13 @@ mod tests {
         let x = PrimeField::from_u64(2);
 
         let test_cases = vec![
-            (HandoffKind::DealingPhase, 4, 5),
-            (HandoffKind::CommitteeUnchanged, 4, 5),
-            (HandoffKind::CommitteeChanged, 2, 3),
+            (HandoffKind::DealingPhase, 5),
+            (HandoffKind::CommitteeUnchanged, 5),
+            (HandoffKind::CommitteeChanged, 3),
         ];
 
-        for (kind, degree, size) in test_cases {
+        for (kind, size) in test_cases {
             let share = dealer.make_share(x, kind);
-            assert_eq!(share.polynomial().degree(), degree);
             assert_eq!(share.polynomial().size(), size);
         }
     }

--- a/secret-sharing/src/churp/shareholder.rs
+++ b/secret-sharing/src/churp/shareholder.rs
@@ -218,7 +218,7 @@ where
 
     /// Calculates the number of rows and columns in the verification matrix
     /// based on the given threshold.
-    fn calculate_dimensions(threshold: u8) -> (usize, usize) {
+    const fn calculate_dimensions(threshold: u8) -> (usize, usize) {
         let rows: usize = threshold as usize + 1;
         let cols = threshold as usize * 2 + 1;
         (rows, cols)

--- a/secret-sharing/src/churp/shareholder.rs
+++ b/secret-sharing/src/churp/shareholder.rs
@@ -56,7 +56,7 @@ where
         p: &Polynomial<G::Scalar>,
         vm: &VerificationMatrix<G>,
     ) -> Result<Shareholder<G>> {
-        if p.degree() != self.verifiable_share.share.p.degree() {
+        if p.size() != self.verifiable_share.share.p.size() {
             return Err(Error::PolynomialDegreeMismatch.into());
         }
         if !vm.is_zero_hole() {

--- a/secret-sharing/src/churp/switch.rs
+++ b/secret-sharing/src/churp/switch.rs
@@ -435,7 +435,7 @@ where
         let ys = &self.bijs[0..self.n];
         let p = lagrange(xs, ys);
 
-        if p.degree() + 1 != self.n {
+        if p.size() != self.n {
             return Err(Error::PolynomialDegreeMismatch.into());
         }
 

--- a/secret-sharing/src/kdc/mod.rs
+++ b/secret-sharing/src/kdc/mod.rs
@@ -72,7 +72,7 @@ pub trait KeyRecoverer {
         Ok(key)
     }
 
-    /// Returns true if shares are from distinct shareholders.
+    /// Returns true iff shares are from distinct shareholders.
     fn distinct_shares<G: Group>(shares: &[EncryptedPoint<G>]) -> bool {
         // For a small number of shareholders, a brute-force approach should
         // suffice, and it doesn't require the prime field to be hashable.

--- a/secret-sharing/src/poly/lagrange/naive.rs
+++ b/secret-sharing/src/poly/lagrange/naive.rs
@@ -140,7 +140,6 @@ mod tests {
             }
 
             // Verify degree.
-            assert_eq!(p.degree(), size - 1);
             assert_eq!(p.size(), size);
         }
     }
@@ -167,7 +166,6 @@ mod tests {
                 }
 
                 // Verify degree.
-                assert_eq!(p.degree(), xs.len() - 1);
                 assert_eq!(p.size(), xs.len());
             }
         }

--- a/secret-sharing/src/poly/lagrange/optimized.rs
+++ b/secret-sharing/src/poly/lagrange/optimized.rs
@@ -159,7 +159,6 @@ mod tests {
             }
 
             // Verify degree.
-            assert_eq!(p.degree(), size - 1);
             assert_eq!(p.size(), size);
         }
     }
@@ -188,7 +187,6 @@ mod tests {
                 }
 
                 // Verify degree.
-                assert_eq!(p.degree(), xs.len() - 1);
                 assert_eq!(p.size(), xs.len());
             }
         }

--- a/secret-sharing/src/poly/scalar.rs
+++ b/secret-sharing/src/poly/scalar.rs
@@ -6,10 +6,13 @@ pub fn scalar_to_bytes<F: PrimeField>(element: &F) -> Vec<u8> {
 }
 
 /// Converts bytes to an element of a non-binary prime field.
+///
+/// This method is not constant time if the length of the slice is invalid.
 pub fn scalar_from_bytes<F: PrimeField>(bytes: &[u8]) -> Option<F> {
     let mut repr: F::Repr = Default::default();
     let slice = &mut repr.as_mut()[..];
 
+    // Short-circuit on the length of the slice, not its contents.
     if slice.len() != bytes.len() {
         return None;
     }

--- a/secret-sharing/src/poly/univariate.rs
+++ b/secret-sharing/src/poly/univariate.rs
@@ -82,23 +82,6 @@ where
         self.a[0].is_zero().into()
     }
 
-    /// Returns the highest of the degrees of the polynomial's monomials with
-    /// non-zero coefficients.
-    ///
-    /// This method is not constant time.
-    pub fn degree(&self) -> usize {
-        let mut deg = self.a.len().saturating_sub(1);
-        for ai in self.a.iter().rev() {
-            if ai.is_zero().into() {
-                deg = deg.saturating_sub(1);
-            } else {
-                break;
-            }
-        }
-
-        deg
-    }
-
     /// Returns the number of coefficients in the polynomial.
     pub fn size(&self) -> usize {
         self.a.len()
@@ -520,20 +503,19 @@ mod tests {
     }
 
     #[test]
-    fn test_degree_and_size() {
+    fn test_size() {
         let test_cases = vec![
-            (0, 1, vec![]),
-            (0, 1, vec![0]),
-            (0, 1, vec![1]),
-            (0, 2, vec![0, 0]),
-            (2, 3, vec![1, 2, 3]),
-            (2, 5, vec![1, 2, 3, 0, 0]),
-            (4, 5, vec![0, 1, 2, 0, 3]),
+            (1, vec![]),
+            (1, vec![0]),
+            (1, vec![1]),
+            (2, vec![0, 0]),
+            (3, vec![1, 2, 3]),
+            (5, vec![1, 2, 3, 0, 0]),
+            (5, vec![0, 1, 2, 0, 3]),
         ];
 
-        for (degree, size, coefficients) in test_cases {
+        for (size, coefficients) in test_cases {
             let p = Polynomial::with_coefficients(scalars(&coefficients));
-            assert_eq!(p.degree(), degree);
             assert_eq!(p.size(), size);
         }
     }

--- a/secret-sharing/src/poly/univariate.rs
+++ b/secret-sharing/src/poly/univariate.rs
@@ -84,6 +84,8 @@ where
 
     /// Returns the highest of the degrees of the polynomial's monomials with
     /// non-zero coefficients.
+    ///
+    /// This method is not constant time.
     pub fn degree(&self) -> usize {
         let mut deg = self.a.len().saturating_sub(1);
         for ai in self.a.iter().rev() {

--- a/secret-sharing/src/poly/univariate.rs
+++ b/secret-sharing/src/poly/univariate.rs
@@ -92,13 +92,6 @@ where
         self.a.get(i)
     }
 
-    /// Removes trailing zeros.
-    pub fn trim(&mut self) {
-        while self.a.len() > 1 && self.a[self.a.len() - 1].is_zero().into() {
-            _ = self.a.pop();
-        }
-    }
-
     /// Returns the byte representation of the polynomial.
     pub fn to_bytes(&self) -> Vec<u8> {
         let cap = Self::byte_size(self.a.len());
@@ -532,22 +525,6 @@ mod tests {
 
         // Test coefficients out of bounds.
         assert_eq!(p.coefficient(3), None);
-    }
-
-    #[test]
-    fn test_trim() {
-        let test_cases = vec![
-            (vec![0], vec![0]),
-            (vec![0, 0], vec![0]),
-            (vec![1, 2, 3], vec![1, 2, 3]),
-            (vec![1, 2, 3, 0, 0], vec![1, 2, 3]),
-        ];
-
-        for (before, after) in test_cases {
-            let mut p = Polynomial::with_coefficients(scalars(&before));
-            p.trim();
-            assert_eq!(p.a, scalars(&after));
-        }
     }
 
     #[test]

--- a/secret-sharing/src/shamir/dealer.rs
+++ b/secret-sharing/src/shamir/dealer.rs
@@ -39,12 +39,7 @@ where
 
     /// Generates shares of the secret for the given shareholders.
     pub fn make_shares(&self, xs: Vec<F>) -> Vec<Point<F>> {
-        let mut shares = Vec::with_capacity(xs.len());
-        for x in xs {
-            let share = self.make_share(x);
-            shares.push(share);
-        }
-        shares
+        xs.into_iter().map(|x| self.make_share(x)).collect()
     }
 
     /// Generates a share of the secret for the given shareholder.

--- a/secret-sharing/src/shamir/player.rs
+++ b/secret-sharing/src/shamir/player.rs
@@ -40,7 +40,7 @@ impl Player {
         self.threshold as usize + 1
     }
 
-    /// Returns true if shares are from distinct shareholders.
+    /// Returns true iff shares are from distinct shareholders.
     fn distinct_shares<F: PrimeField>(shares: &[Point<F>]) -> bool {
         // For a small number of shareholders, a brute-force approach should
         // suffice, and it doesn't require the prime field to be hashable.


### PR DESCRIPTION
Methods and functions in `churp` and `shamir` schemes are constant time only when dealing with sensitive data, as other operations (e.g. validation of input parameters) cannot reveal sensitive content. 