### PR TITLE
secret-sharing: Exclude default subtle and p384 features

### DIFF
--- a/secret-sharing/Cargo.toml
+++ b/secret-sharing/Cargo.toml
@@ -5,19 +5,15 @@ authors = ["Oasis Protocol Foundation <info@oasisprotocol.org>"]
 edition = "2018"
 
 [dependencies]
-
-# Third party.
-anyhow = "1.0"
-group = "0.13.0"
-p384 = { version = "0.13.0", features = ["hash2curve"] }
-rand_core = "0.6.4"
-sha3 = "0.10.8"
-subtle = "2.6.1"
-thiserror = "1.0"
-
-# Fuzzing.
-honggfuzz = "0.5.55"
-rand = "0.8.5"
+anyhow = { version = "1.0" }
+group = { version = "0.13", default-features = false }
+honggfuzz = { version = "0.5" }
+p384 = { version = "0.13", default-features = false, features = ["hash2curve"] }
+rand = { version = "0.8" }
+rand_core = { version = "0.6" }
+sha3 = { version = "0.10" }
+subtle = { version = "2.6", default-features = false }
+thiserror = { version = "1.0" }
 
 [[bin]]
 name = "fuzz-vss"


### PR DESCRIPTION
The default features, such as ecdh, ecdsa, pem, and others, are not needed.