### PR TITLE
keymanager: Add mock trusted signers for debug mock SGX builds

### DIFF
--- a/.changelog/5852.internal.md
+++ b/.changelog/5852.internal.md
@@ -1,0 +1,1 @@
+keymanager: Add mock trusted signers for debug mock SGX builds


### PR DESCRIPTION
Useful after #5851 to allow configuring the set of mock trusted signers used by net runner.