### PR TITLE
keymanager/src/client: Fetch churp key shares concurrently

### DIFF
--- a/.changelog/5863.internal.md
+++ b/.changelog/5863.internal.md
@@ -1,0 +1,1 @@
+keymanager/src/client: Fetch churp key shares concurrently

--- a/keymanager/src/churp/handler.rs
+++ b/keymanager/src/churp/handler.rs
@@ -620,11 +620,13 @@ impl<S: Suite> Instance<S> {
         }
 
         // Fetch from the remote node.
-        client.set_nodes(vec![node_id]);
-
         if handoff.needs_verification_matrix()? {
             // The remote verification matrix needs to be verified.
-            let vm = block_on(client.churp_verification_matrix(self.churp_id, status.handoff))?;
+            let vm = block_on(client.churp_verification_matrix(
+                self.churp_id,
+                status.handoff,
+                vec![node_id],
+            ))?;
             let checksum = self.checksum_verification_matrix_bytes(&vm, status.handoff);
             let status_checksum = status.checksum.ok_or(Error::InvalidHandoff)?; // Should never happen.
             if checksum != status_checksum {
@@ -640,6 +642,7 @@ impl<S: Suite> Instance<S> {
             self.churp_id,
             status.next_handoff,
             self.node_id,
+            vec![node_id],
         ))?;
         let point = scalar_from_bytes(&point).ok_or(Error::PointDecodingFailed)?;
 
@@ -669,11 +672,11 @@ impl<S: Suite> Instance<S> {
         }
 
         // Fetch from the remote node.
-        client.set_nodes(vec![node_id]);
         let point = block_on(client.churp_share_distribution_point(
             self.churp_id,
             status.next_handoff,
             self.node_id,
+            vec![node_id],
         ))?;
         let point = scalar_from_bytes(&point).ok_or(Error::PointDecodingFailed)?;
 
@@ -706,11 +709,11 @@ impl<S: Suite> Instance<S> {
         }
 
         // Fetch from the remote node.
-        client.set_nodes(vec![node_id]);
         let share = block_on(client.churp_bivariate_share(
             self.churp_id,
             status.next_handoff,
             self.node_id,
+            vec![node_id],
         ))?;
 
         // The remote verification matrix needs to be verified.
@@ -1131,7 +1134,6 @@ impl<S: Suite> Instance<S> {
             self.consensus_verifier.clone(),
             self.identity.clone(),
             1, // Not used, doesn't matter.
-            vec![],
         );
 
         Ok(client)

--- a/keymanager/src/client/interface.rs
+++ b/keymanager/src/client/interface.rs
@@ -69,17 +69,22 @@ pub trait KeyManagerClient: Send + Sync {
     async fn replicate_master_secret(
         &self,
         generation: u64,
+        nodes: Vec<PublicKey>,
     ) -> Result<VerifiableSecret, KeyManagerError>;
 
     /// Get a copy of the ephemeral secret for replication.
-    async fn replicate_ephemeral_secret(&self, epoch: EpochTime)
-        -> Result<Secret, KeyManagerError>;
+    async fn replicate_ephemeral_secret(
+        &self,
+        epoch: EpochTime,
+        nodes: Vec<PublicKey>,
+    ) -> Result<Secret, KeyManagerError>;
 
     /// Returns the verification matrix for the given handoff.
     async fn churp_verification_matrix(
         &self,
         churp_id: u8,
         epoch: EpochTime,
+        nodes: Vec<PublicKey>,
     ) -> Result<Vec<u8>, KeyManagerError>;
 
     /// Returns a switch point for the share reduction phase
@@ -89,6 +94,7 @@ pub trait KeyManagerClient: Send + Sync {
         churp_id: u8,
         epoch: EpochTime,
         node_id: PublicKey,
+        nodes: Vec<PublicKey>,
     ) -> Result<Vec<u8>, KeyManagerError>;
 
     /// Returns a switch point for the share distribution phase
@@ -98,6 +104,7 @@ pub trait KeyManagerClient: Send + Sync {
         churp_id: u8,
         epoch: EpochTime,
         node_id: PublicKey,
+        nodes: Vec<PublicKey>,
     ) -> Result<Vec<u8>, KeyManagerError>;
 
     /// Returns a bivariate share for the given handoff.
@@ -106,6 +113,7 @@ pub trait KeyManagerClient: Send + Sync {
         churp_id: u8,
         epoch: EpochTime,
         node_id: PublicKey,
+        nodes: Vec<PublicKey>,
     ) -> Result<EncodedVerifiableSecretShare, KeyManagerError>;
 
     /// Returns state key.
@@ -165,23 +173,26 @@ impl<T: ?Sized + KeyManagerClient> KeyManagerClient for Arc<T> {
     async fn replicate_master_secret(
         &self,
         generation: u64,
+        nodes: Vec<PublicKey>,
     ) -> Result<VerifiableSecret, KeyManagerError> {
-        KeyManagerClient::replicate_master_secret(&**self, generation).await
+        KeyManagerClient::replicate_master_secret(&**self, generation, nodes).await
     }
 
     async fn replicate_ephemeral_secret(
         &self,
         epoch: EpochTime,
+        nodes: Vec<PublicKey>,
     ) -> Result<Secret, KeyManagerError> {
-        KeyManagerClient::replicate_ephemeral_secret(&**self, epoch).await
+        KeyManagerClient::replicate_ephemeral_secret(&**self, epoch, nodes).await
     }
 
     async fn churp_verification_matrix(
         &self,
         churp_id: u8,
         epoch: EpochTime,
+        nodes: Vec<PublicKey>,
     ) -> Result<Vec<u8>, KeyManagerError> {
-        KeyManagerClient::churp_verification_matrix(&**self, churp_id, epoch).await
+        KeyManagerClient::churp_verification_matrix(&**self, churp_id, epoch, nodes).await
     }
 
     async fn churp_share_reduction_point(
@@ -189,8 +200,10 @@ impl<T: ?Sized + KeyManagerClient> KeyManagerClient for Arc<T> {
         churp_id: u8,
         epoch: EpochTime,
         node_id: PublicKey,
+        nodes: Vec<PublicKey>,
     ) -> Result<Vec<u8>, KeyManagerError> {
-        KeyManagerClient::churp_share_reduction_point(&**self, churp_id, epoch, node_id).await
+        KeyManagerClient::churp_share_reduction_point(&**self, churp_id, epoch, node_id, nodes)
+            .await
     }
 
     async fn churp_share_distribution_point(
@@ -198,8 +211,10 @@ impl<T: ?Sized + KeyManagerClient> KeyManagerClient for Arc<T> {
         churp_id: u8,
         epoch: EpochTime,
         node_id: PublicKey,
+        nodes: Vec<PublicKey>,
     ) -> Result<Vec<u8>, KeyManagerError> {
-        KeyManagerClient::churp_share_distribution_point(&**self, churp_id, epoch, node_id).await
+        KeyManagerClient::churp_share_distribution_point(&**self, churp_id, epoch, node_id, nodes)
+            .await
     }
 
     async fn churp_bivariate_share(
@@ -207,8 +222,9 @@ impl<T: ?Sized + KeyManagerClient> KeyManagerClient for Arc<T> {
         churp_id: u8,
         epoch: EpochTime,
         node_id: PublicKey,
+        nodes: Vec<PublicKey>,
     ) -> Result<EncodedVerifiableSecretShare, KeyManagerError> {
-        KeyManagerClient::churp_bivariate_share(&**self, churp_id, epoch, node_id).await
+        KeyManagerClient::churp_bivariate_share(&**self, churp_id, epoch, node_id, nodes).await
     }
 
     async fn churp_state_key(

--- a/keymanager/src/client/mock.rs
+++ b/keymanager/src/client/mock.rs
@@ -109,6 +109,7 @@ impl KeyManagerClient for MockClient {
     async fn replicate_master_secret(
         &self,
         _generation: u64,
+        _nodes: Vec<PublicKey>,
     ) -> Result<VerifiableSecret, KeyManagerError> {
         unimplemented!();
     }
@@ -116,6 +117,7 @@ impl KeyManagerClient for MockClient {
     async fn replicate_ephemeral_secret(
         &self,
         _epoch: EpochTime,
+        _nodes: Vec<PublicKey>,
     ) -> Result<Secret, KeyManagerError> {
         unimplemented!();
     }
@@ -124,6 +126,7 @@ impl KeyManagerClient for MockClient {
         &self,
         _churp_id: u8,
         _epoch: EpochTime,
+        _nodes: Vec<PublicKey>,
     ) -> Result<Vec<u8>, KeyManagerError> {
         unimplemented!();
     }
@@ -133,6 +136,7 @@ impl KeyManagerClient for MockClient {
         _churp_id: u8,
         _epoch: EpochTime,
         _node_id: PublicKey,
+        _nodes: Vec<PublicKey>,
     ) -> Result<Vec<u8>, KeyManagerError> {
         unimplemented!();
     }
@@ -142,6 +146,7 @@ impl KeyManagerClient for MockClient {
         _churp_id: u8,
         _epoch: EpochTime,
         _node_id: PublicKey,
+        _nodes: Vec<PublicKey>,
     ) -> Result<Vec<u8>, KeyManagerError> {
         unimplemented!();
     }
@@ -151,6 +156,7 @@ impl KeyManagerClient for MockClient {
         _churp_id: u8,
         _epoch: EpochTime,
         _node_id: PublicKey,
+        _nodes: Vec<PublicKey>,
     ) -> Result<EncodedVerifiableSecretShare, KeyManagerError> {
         unimplemented!();
     }

--- a/keymanager/src/runtime/secrets.rs
+++ b/keymanager/src/runtime/secrets.rs
@@ -467,7 +467,6 @@ impl Secrets {
             self.consensus_verifier.clone(),
             self.identity.clone(),
             1, // Not used, doesn't matter.
-            vec![],
         )
     }
 

--- a/keymanager/src/secrets/provider.rs
+++ b/keymanager/src/secrets/provider.rs
@@ -50,8 +50,11 @@ impl SecretProvider for KeyManagerSecretProvider {
                 inner.last_node = idx;
                 counter += 1;
 
-                inner.client.set_nodes(vec![inner.nodes[idx]]);
-                if let Ok(secret) = block_on(inner.client.replicate_master_secret(generation)) {
+                if let Ok(secret) = block_on(
+                    inner
+                        .client
+                        .replicate_master_secret(generation, vec![inner.nodes[idx]]),
+                ) {
                     return Some(secret);
                 }
             }
@@ -78,8 +81,11 @@ impl SecretProvider for KeyManagerSecretProvider {
                 inner.last_node = idx;
                 counter += 1;
 
-                inner.client.set_nodes(vec![inner.nodes[idx]]);
-                if let Ok(secret) = block_on(inner.client.replicate_ephemeral_secret(epoch)) {
+                if let Ok(secret) = block_on(
+                    inner
+                        .client
+                        .replicate_ephemeral_secret(epoch, vec![inner.nodes[idx]]),
+                ) {
                     return Some(secret);
                 }
             }

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -388,7 +388,6 @@ pub fn main_with_version(version: Version) {
             state.identity.clone(),
             1024,
             trusted_signers(),
-            vec![],
         ));
 
         let key_manager = km_client.clone();


### PR DESCRIPTION
Peer feedback, which should not work anymore when fetching key shares, will be fixed in another PR.