### PR TITLE
keymanager: Expose runtime ID and RSK in the key manager client

### DIFF
--- a/.changelog/5865.internal.md
+++ b/.changelog/5865.internal.md
@@ -1,0 +1,1 @@
+keymanager: Expose runtime ID and RSK in the key manager client

--- a/keymanager/src/client/interface.rs
+++ b/keymanager/src/client/interface.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use oasis_core_runtime::{common::crypto::signature::PublicKey, consensus::beacon::EpochTime};
+use oasis_core_runtime::{
+    common::{crypto::signature::PublicKey, namespace::Namespace},
+    consensus::beacon::EpochTime,
+};
 
 use crate::{
     api::KeyManagerError,
@@ -14,6 +17,13 @@ use crate::{
 /// Key manager client interface.
 #[async_trait]
 pub trait KeyManagerClient: Send + Sync {
+    /// Key manager runtime identifier this client is connected to. It may be `None` in case the
+    /// identifier is not known yet (e.g. the client has not yet been initialized).
+    fn runtime_id(&self) -> Option<Namespace>;
+
+    /// Key manager runtime signing key used to sign messages from the key manager.
+    fn runtime_signing_key(&self) -> Option<PublicKey>;
+
     /// Clear local key cache.
     ///
     /// This will make the client re-fetch the keys from the key manager.
@@ -108,6 +118,14 @@ pub trait KeyManagerClient: Send + Sync {
 
 #[async_trait]
 impl<T: ?Sized + KeyManagerClient> KeyManagerClient for Arc<T> {
+    fn runtime_id(&self) -> Option<Namespace> {
+        KeyManagerClient::runtime_id(&**self)
+    }
+
+    fn runtime_signing_key(&self) -> Option<PublicKey> {
+        KeyManagerClient::runtime_signing_key(&**self)
+    }
+
     fn clear_cache(&self) {
         KeyManagerClient::clear_cache(&**self)
     }

--- a/keymanager/src/client/mock.rs
+++ b/keymanager/src/client/mock.rs
@@ -4,7 +4,10 @@ use std::{collections::HashMap, sync::Mutex};
 use async_trait::async_trait;
 
 use oasis_core_runtime::{
-    common::crypto::signature::{PublicKey, Signature},
+    common::{
+        crypto::signature::{PublicKey, Signature},
+        namespace::Namespace,
+    },
     consensus::beacon::EpochTime,
 };
 
@@ -35,6 +38,14 @@ impl MockClient {
 
 #[async_trait]
 impl KeyManagerClient for MockClient {
+    fn runtime_id(&self) -> Option<Namespace> {
+        Some(Namespace::default())
+    }
+
+    fn runtime_signing_key(&self) -> Option<PublicKey> {
+        None
+    }
+
     fn clear_cache(&self) {}
 
     async fn get_or_create_keys(


### PR DESCRIPTION
Fixes #5864 