### PR TITLE
runtime: Remove obsolete feature rpc_peer_id

### DIFF
--- a/.changelog/5867.internal.md
+++ b/.changelog/5867.internal.md
@@ -1,0 +1,1 @@
+runtime: Remove obsolete feature rpc_peer_id

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -191,8 +191,6 @@ type Features struct {
 	// KeyManagerStatusUpdates is a feature specifying that the runtime supports updating
 	// key manager's status.
 	KeyManagerStatusUpdates bool `json:"key_manager_status_updates,omitempty"`
-	// RPCPeerID is a feature specifying that the runtime supports RPC peer IDs.
-	RPCPeerID bool `json:"rpc_peer_id,omitempty"`
 	// EndorsedCapabilityTEE is a feature specifying that the runtime supports endorsed TEE
 	// capabilities.
 	EndorsedCapabilityTEE bool `json:"endorsed_capability_tee,omitempty"`

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -180,24 +180,13 @@ func (w *Worker) CallEnclave(ctx context.Context, data []byte, kind enclaverpc.K
 		RuntimeRPCCallRequest: &protocol.RuntimeRPCCallRequest{
 			Request: data,
 			Kind:    kind,
+			PeerID:  []byte(peerID),
 		},
 	}
 
 	rt := w.GetHostedRuntime()
 	if rt == nil {
 		return nil, fmt.Errorf("not initialized")
-	}
-	rtInfo, err := rt.GetInfo(ctx)
-	if err != nil {
-		w.logger.Error("failed to fetch runtime features",
-			"err", err,
-		)
-		return nil, fmt.Errorf("not initialized")
-	}
-
-	// Only include PeerIDs if the runtime supports it.
-	if rtInfo.Features.RPCPeerID {
-		req.RuntimeRPCCallRequest.PeerID = []byte(peerID)
 	}
 
 	response, err := rt.Call(ctx, req)

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -377,9 +377,6 @@ pub struct Features {
     /// A feature specifying that the runtime supports updating key manager's status.
     #[cbor(optional)]
     pub key_manager_status_updates: bool,
-    /// A feature specifying that the runtime supports RPC peer IDs.
-    #[cbor(optional)]
-    pub rpc_peer_id: bool,
     /// A feature specifying that the runtime supports endorsed TEE capabilities.
     #[cbor(optional)]
     pub endorsed_capability_tee: bool,
@@ -391,7 +388,6 @@ impl Default for Features {
             schedule_control: None,
             key_manager_quote_policy_updates: true,
             key_manager_status_updates: true,
-            rpc_peer_id: true,
             endorsed_capability_tee: true,
         }
     }


### PR DESCRIPTION
I think that this can be removed.