### PR TITLE
runtime/src/enclave_rpc: Support peer feedback for concurrent requests

### DIFF
--- a/.changelog/5872.feature.md
+++ b/.changelog/5872.feature.md
@@ -1,0 +1,1 @@
+runtime/src/enclave_rpc: Support peer feedback for concurrent requests

--- a/go/common/cache/lru/lru.go
+++ b/go/common/cache/lru/lru.go
@@ -181,23 +181,21 @@ func (c *Cache) getValueSize(value interface{}) uint64 {
 }
 
 // New creates a new LRU cache instance with the specified options.
-func New(options ...Option) (*Cache, error) {
+func New(options ...Option) *Cache {
 	c := &Cache{
 		lru:     list.New(),
 		entries: make(map[interface{}]*list.Element),
 	}
 
 	for _, v := range options {
-		if err := v(c); err != nil {
-			return nil, err
-		}
+		v(c)
 	}
 
-	return c, nil
+	return c
 }
 
 // Option is a configuration option used when instantiating a cache.
-type Option func(c *Cache) error
+type Option func(c *Cache)
 
 // Capacity sets the capacity of the new cache.  If the capacity is set
 // as `inBytes`, it is assumed that all values inserted will implement
@@ -205,17 +203,15 @@ type Option func(c *Cache) error
 //
 // If no capacity is specified, the cache will have an unlimited size.
 func Capacity(capacity uint64, inBytes bool) Option {
-	return func(c *Cache) error {
+	return func(c *Cache) {
 		c.capacityInBytes = inBytes
 		c.capacity = capacity
-		return nil
 	}
 }
 
 // OnEvict sets the on-evict callback.
 func OnEvict(fn OnEvictFunc) Option {
-	return func(c *Cache) error {
+	return func(c *Cache) {
 		c.onEvict = fn
-		return nil
 	}
 }

--- a/go/common/cache/lru/lru_test.go
+++ b/go/common/cache/lru/lru_test.go
@@ -19,18 +19,17 @@ func TestLRUCapacityEntries(t *testing.T) {
 		evictedKey, evictedValue interface{}
 	)
 
-	cache, err := New(
+	cache := New(
 		Capacity(uint64(cacheSize), false),
 		OnEvict(func(k, v interface{}) {
 			evictedKey, evictedValue = k, v
 			nrEvictCallbacks++
 		}),
 	)
-	require.NoError(err, "New")
 
 	entries := makeEntries(cacheSize)
 	for _, ent := range entries {
-		err = cache.Put(ent.key, ent)
+		err := cache.Put(ent.key, ent)
 		require.NoError(err, "Put")
 	}
 
@@ -61,7 +60,7 @@ func TestLRUCapacityEntries(t *testing.T) {
 	evictEnt := makeEntry("evictionTest")
 	entries = append(entries, evictEnt)
 
-	err = cache.Put(evictEnt.key, evictEnt)
+	err := cache.Put(evictEnt.key, evictEnt)
 	require.NoError(err, "Put - will evict")
 	require.Equal(1, nrEvictCallbacks, "Put - OnEvict called")
 	require.Equal(entries[order[0]].key, evictedKey, "Evict - key")
@@ -95,14 +94,13 @@ func TestLRUCapacityBytes(t *testing.T) {
 
 	const cacheSize = 5
 
-	cache, err := New(
+	cache := New(
 		Capacity(uint64(cacheSize*sha256.Size), true),
 	)
-	require.NoError(err, "New")
 
 	entries := makeEntries(cacheSize)
 	for _, ent := range entries {
-		err = cache.Put(ent.key, ent)
+		err := cache.Put(ent.key, ent)
 		require.NoError(err, "Put")
 	}
 
@@ -110,7 +108,7 @@ func TestLRUCapacityBytes(t *testing.T) {
 		key:   "huge entry - should fail",
 		value: make([]byte, 1024768),
 	}
-	err = cache.Put(hugeEnt.key, hugeEnt)
+	err := cache.Put(hugeEnt.key, hugeEnt)
 	require.Error(err, "Put - huge entry")
 
 	newEnt := makeEntry("new entry")
@@ -126,14 +124,13 @@ func TestLRURemoval(t *testing.T) {
 
 	const cacheSize = 5
 
-	cache, err := New(
+	cache := New(
 		Capacity(uint64(cacheSize*sha256.Size), true),
 	)
-	require.NoError(err, "New")
 
 	entries := makeEntries(cacheSize)
 	for _, ent := range entries {
-		err = cache.Put(ent.key, ent)
+		err := cache.Put(ent.key, ent)
 		require.NoError(err, "Put")
 	}
 

--- a/go/consensus/cometbft/beacon/beacon.go
+++ b/go/consensus/cometbft/beacon/beacon.go
@@ -398,10 +398,7 @@ func New(ctx context.Context, backend tmAPI.Backend) (ServiceClient, error) {
 		return nil, err
 	}
 
-	epochCache, err := lru.New(lru.Capacity(epochCacheCapacity, false))
-	if err != nil {
-		return nil, err
-	}
+	epochCache := lru.New(lru.Capacity(epochCacheCapacity, false))
 
 	sc := &serviceClient{
 		logger:            logging.GetLogger("cometbft/beacon"),

--- a/go/p2p/rpc/client.go
+++ b/go/p2p/rpc/client.go
@@ -46,7 +46,7 @@ type PeerFeedback interface {
 	// The peer will be ignored during peer selection.
 	RecordBadPeer()
 
-	// PeerID returns the id of the peer.
+	// PeerID returns the ID of the peer.
 	PeerID() core.PeerID
 }
 

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -480,7 +480,7 @@ type HostRPCCallRequest struct {
 
 	// Nodes are optional node identities in case the request should be forwarded to specific
 	// node instances and not to randomly chosen ones as selected by the host.
-	Nodes []signature.PublicKey `json:"nodes,omitempty"`
+	Nodes []signature.PublicKey `json:"nodes"`
 	// PeerFeedback contains optional peer feedback for the last RPC call under the given endpoint.
 	//
 	// This enables the runtime to notify the node whether the given peer should continue to be used
@@ -495,7 +495,7 @@ type HostRPCCallResponse struct {
 	// Response is a response to a HostRPCCallRequest.
 	Response []byte `json:"response"`
 	// Node is the identifier of the node that handled the request.
-	Node *signature.PublicKey `json:"node,omitempty"`
+	Node signature.PublicKey `json:"node"`
 }
 
 // HostStorageEndpoint is the host storage endpoint.

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -109,6 +109,8 @@ type Body struct {
 	// Host interface.
 	HostRPCCallRequest               *HostRPCCallRequest               `json:",omitempty"`
 	HostRPCCallResponse              *HostRPCCallResponse              `json:",omitempty"`
+	HostSubmitPeerFeedbackRequest    *HostSubmitPeerFeedbackRequest    `json:",omitempty"`
+	HostSubmitPeerFeedbackResponse   *Empty                            `json:",omitempty"`
 	HostStorageSyncRequest           *HostStorageSyncRequest           `json:",omitempty"`
 	HostStorageSyncResponse          *HostStorageSyncResponse          `json:",omitempty"`
 	HostLocalStorageGetRequest       *HostLocalStorageGetRequest       `json:",omitempty"`
@@ -474,13 +476,15 @@ type RuntimeConsensusSyncRequest struct {
 
 // HostRPCCallRequest is a host RPC call request message body.
 type HostRPCCallRequest struct {
-	Endpoint string          `json:"endpoint"`
-	Request  []byte          `json:"request"`
-	Kind     enclaverpc.Kind `json:"kind,omitempty"`
+	Endpoint  string          `json:"endpoint"`
+	RequestID uint64          `json:"request_id"`
+	Request   []byte          `json:"request"`
+	Kind      enclaverpc.Kind `json:"kind,omitempty"`
 
 	// Nodes are optional node identities in case the request should be forwarded to specific
 	// node instances and not to randomly chosen ones as selected by the host.
 	Nodes []signature.PublicKey `json:"nodes"`
+
 	// PeerFeedback contains optional peer feedback for the last RPC call under the given endpoint.
 	//
 	// This enables the runtime to notify the node whether the given peer should continue to be used
@@ -496,6 +500,21 @@ type HostRPCCallResponse struct {
 	Response []byte `json:"response"`
 	// Node is the identifier of the node that handled the request.
 	Node signature.PublicKey `json:"node"`
+}
+
+// HostSubmitPeerFeedbackRequest is a host submit peer feedback request message body.
+type HostSubmitPeerFeedbackRequest struct {
+	// Endpoint is the RPC endpoint.
+	Endpoint string `json:"endpoint"`
+
+	// RequestID is the ID of the RPC request to which the feedback belongs.
+	RequestID uint64 `json:"request_id"`
+
+	// PeerFeedback contains feedback related to the given RPC call.
+	//
+	// This enables the runtime to notify the node whether the given peer should continue to be used
+	// or not based on higher-level logic that lives in the runtime.
+	PeerFeedback enclaverpc.PeerFeedback `json:"peer_feedback"`
 }
 
 // HostStorageEndpoint is the host storage endpoint.

--- a/go/runtime/keymanager/api/api.go
+++ b/go/runtime/keymanager/api/api.go
@@ -13,12 +13,32 @@ const EnclaveRPCEndpoint = "key-manager"
 
 // Client is the key manager client interface.
 type Client interface {
-	// CallEnclave calls the key manager via remote EnclaveRPC.
+	// CallEnclaveDeprecated calls the key manager via remote EnclaveRPC.
 	//
 	// The node to which the call will be routed is chosen at random from the key manager committee
 	// members. The latter can be restricted by specifying a non-empty list of allowed nodes.
 	//
 	// The provided peer feedback is optional feedback on the peer that handled the last EnclaveRPC
 	// request (if any) which may be used to inform the routing decision.
-	CallEnclave(ctx context.Context, data []byte, nodes []signature.PublicKey, kind enclaverpc.Kind, pf *enclaverpc.PeerFeedback) ([]byte, signature.PublicKey, error)
+	//
+	// Deprecated: This method is deprecated and will be removed in future versions.
+	CallEnclaveDeprecated(ctx context.Context, data []byte, nodes []signature.PublicKey, kind enclaverpc.Kind, pf *enclaverpc.PeerFeedback) ([]byte, signature.PublicKey, error)
+
+	// CallEnclave calls the key manager via remote enclave RPC.
+	//
+	// The node to which the call will be routed is chosen at random from the key manager committee
+	// members. The latter can be restricted by specifying a non-empty list of allowed nodes.
+	CallEnclave(ctx context.Context, requestID uint64, data []byte, nodes []signature.PublicKey, kind enclaverpc.Kind) (*EnclaveResponse, error)
+
+	// SubmitPeerFeedback submits peer feedback for the given request.
+	SubmitPeerFeedback(requestID uint64, feedback enclaverpc.PeerFeedback)
+}
+
+// EnclaveResponse is the enclave response.
+type EnclaveResponse struct {
+	// Data contains the actual response data.
+	Data []byte
+
+	// Node is the public key of the node that generated the response.
+	Node signature.PublicKey
 }

--- a/go/runtime/registry/host.go
+++ b/go/runtime/registry/host.go
@@ -250,15 +250,9 @@ func (h *runtimeHostHandler) handleHostRPCCall(
 		if err != nil {
 			return nil, err
 		}
-		// Don't send node identity if the runtime doesn't support explicit key manager RPC calls.
-		if rq.Nodes == nil {
-			return &protocol.HostRPCCallResponse{
-				Response: res,
-			}, nil
-		}
 		return &protocol.HostRPCCallResponse{
 			Response: res,
-			Node:     &node,
+			Node:     node,
 		}, nil
 	default:
 		return nil, fmt.Errorf("endpoint not supported")

--- a/go/runtime/txpool/txpool.go
+++ b/go/runtime/txpool/txpool.go
@@ -882,13 +882,10 @@ func New(
 	host RuntimeHostProvisioner,
 	history history.History,
 	txPublisher TransactionPublisher,
-) (TransactionPool, error) {
+) TransactionPool {
 	initMetrics()
 
-	seenCache, err := lru.New(lru.Capacity(cfg.MaxLastSeenCacheSize, false))
-	if err != nil {
-		return nil, fmt.Errorf("error creating seen cache: %w", err)
-	}
+	seenCache := lru.New(lru.Capacity(cfg.MaxLastSeenCacheSize, false))
 
 	// The transaction check queue should be 10% larger than the transaction pool to allow for some
 	// buffer in case the schedule queue is full and is being rechecked.
@@ -921,5 +918,5 @@ func New(
 		mainQueue:            mq,
 		proposedTxs:          make(map[hash.Hash]*TxQueueMeta),
 		republishCh:          channels.NewRingChannel(1),
-	}, nil
+	}
 }

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -881,17 +881,13 @@ func NewNode(
 	n.RuntimeHostNode = rhn
 
 	// Prepare transaction pool.
-	txPool, err := txpool.New(runtime.ID(), txPoolCfg, n, runtime.History(), n)
-	if err != nil {
-		return nil, fmt.Errorf("error creating transaction pool: %w", err)
-	}
-	n.TxPool = txPool
+	n.TxPool = txpool.New(runtime.ID(), txPoolCfg, n, runtime.History(), n)
 
 	// Register transaction message handler as that is something that all workers must handle.
 	p2pHost.RegisterHandler(txTopic, &txMsgHandler{n})
 
 	// Register transaction sync service.
-	p2pHost.RegisterProtocolServer(txsync.NewServer(chainContext, runtime.ID(), txPool))
+	p2pHost.RegisterProtocolServer(txsync.NewServer(chainContext, runtime.ID(), n.TxPool))
 
 	return n, nil
 }

--- a/runtime/src/enclave_rpc/transport.rs
+++ b/runtime/src/enclave_rpc/transport.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use anyhow::{anyhow, Error as AnyError};
 use async_trait::async_trait;
@@ -7,51 +7,63 @@ use crate::{common::crypto::signature, types::Body, Protocol};
 
 use super::types;
 
+// Enclave's response.
+pub struct EnclaveResponse {
+    // Actual response data.
+    pub data: Vec<u8>,
+    // The public key of the node that generated the response.
+    pub node: signature::PublicKey,
+}
+
 /// An EnclaveRPC transport.
 #[async_trait]
 pub trait Transport: Send + Sync {
     async fn write_noise_session(
         &self,
+        request_id: u64,
         session_id: types::SessionID,
         data: Vec<u8>,
         untrusted_plaintext: String,
         nodes: Vec<signature::PublicKey>,
-    ) -> Result<(Vec<u8>, signature::PublicKey), AnyError> {
-        // Frame message.
+    ) -> Result<EnclaveResponse, AnyError> {
         let frame = types::Frame {
             session: session_id,
             untrusted_plaintext,
             payload: data,
         };
 
-        self.write_message_impl(cbor::to_vec(frame), types::Kind::NoiseSession, nodes)
-            .await
+        self.write_message_impl(
+            request_id,
+            cbor::to_vec(frame),
+            types::Kind::NoiseSession,
+            nodes,
+        )
+        .await
     }
 
     async fn write_insecure_query(
         &self,
+        request_id: u64,
         data: Vec<u8>,
         nodes: Vec<signature::PublicKey>,
-    ) -> Result<(Vec<u8>, signature::PublicKey), AnyError> {
-        self.write_message_impl(data, types::Kind::InsecureQuery, nodes)
+    ) -> Result<EnclaveResponse, AnyError> {
+        self.write_message_impl(request_id, data, types::Kind::InsecureQuery, nodes)
             .await
     }
 
     async fn write_message_impl(
         &self,
+        request_id: u64,
         data: Vec<u8>,
         kind: types::Kind,
         nodes: Vec<signature::PublicKey>,
-    ) -> Result<(Vec<u8>, signature::PublicKey), AnyError>;
+    ) -> Result<EnclaveResponse, AnyError>;
 
-    fn set_peer_feedback(&self, _pfid: u64, _peer_feedback: Option<types::PeerFeedback>) {
-        // Default implementation doesn't do anything.
-    }
-
-    fn get_peer_feedback_id(&self) -> u64 {
-        // Default implementation doesn't do anything.
-        0
-    }
+    async fn submit_peer_feedback(
+        &self,
+        request_id: u64,
+        peer_feedback: types::PeerFeedback,
+    ) -> Result<(), AnyError>;
 }
 
 /// A transport implementation which can be used from inside the runtime and uses the Runtime Host
@@ -59,8 +71,6 @@ pub trait Transport: Send + Sync {
 pub struct RuntimeTransport {
     pub protocol: Arc<Protocol>,
     pub endpoint: String,
-
-    peer_feedback: Mutex<(u64, Option<types::PeerFeedback>)>,
 }
 
 impl RuntimeTransport {
@@ -68,7 +78,6 @@ impl RuntimeTransport {
         Self {
             protocol,
             endpoint: endpoint.to_string(),
-            peer_feedback: Mutex::new((0, None)),
         }
     }
 }
@@ -77,51 +86,48 @@ impl RuntimeTransport {
 impl Transport for RuntimeTransport {
     async fn write_message_impl(
         &self,
+        request_id: u64,
         data: Vec<u8>,
         kind: types::Kind,
         nodes: Vec<signature::PublicKey>,
-    ) -> Result<(Vec<u8>, signature::PublicKey), AnyError> {
-        let peer_feedback = {
-            let mut pf = self.peer_feedback.lock().unwrap();
-            let peer_feedback = pf.1.take();
-
-            // If non-success feedback was propagated this means that the peer will be changed for
-            // subsequent requests. Increment pfid to make sure that we don't incorporate stale
-            // feedback.
-            if !matches!(peer_feedback, None | Some(types::PeerFeedback::Success)) {
-                pf.0 += 1;
-            }
-
-            peer_feedback
-        };
-
+    ) -> Result<EnclaveResponse, AnyError> {
         let rsp = self
             .protocol
             .call_host_async(Body::HostRPCCallRequest {
                 endpoint: self.endpoint.clone(),
+                request_id,
                 request: data,
                 kind,
                 nodes,
+            })
+            .await?;
+
+        match rsp {
+            Body::HostRPCCallResponse { response, node } => Ok(EnclaveResponse {
+                data: response,
+                node,
+            }),
+            _ => Err(anyhow!("bad response type")),
+        }
+    }
+
+    async fn submit_peer_feedback(
+        &self,
+        request_id: u64,
+        peer_feedback: types::PeerFeedback,
+    ) -> Result<(), AnyError> {
+        let rsp = self
+            .protocol
+            .call_host_async(Body::HostSubmitPeerFeedbackRequest {
+                endpoint: self.endpoint.clone(),
+                request_id,
                 peer_feedback,
             })
             .await?;
 
         match rsp {
-            Body::HostRPCCallResponse { response, node } => Ok((response, node)),
+            Body::HostSubmitPeerFeedbackResponse {} => Ok(()),
             _ => Err(anyhow!("bad response type")),
         }
-    }
-
-    fn set_peer_feedback(&self, pfid: u64, peer_feedback: Option<types::PeerFeedback>) {
-        let mut pf = self.peer_feedback.lock().unwrap();
-        if pf.0 != pfid {
-            return;
-        }
-
-        pf.1 = peer_feedback;
-    }
-
-    fn get_peer_feedback_id(&self) -> u64 {
-        self.peer_feedback.lock().unwrap().0
     }
 }

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -229,16 +229,21 @@ pub enum Body {
     // Host interface.
     HostRPCCallRequest {
         endpoint: String,
+        request_id: u64,
         request: Vec<u8>,
         kind: enclave_rpc::types::Kind,
         nodes: Vec<signature::PublicKey>,
-        #[cbor(optional, rename = "pf")]
-        peer_feedback: Option<enclave_rpc::types::PeerFeedback>,
     },
     HostRPCCallResponse {
         response: Vec<u8>,
         node: signature::PublicKey,
     },
+    HostSubmitPeerFeedbackRequest {
+        endpoint: String,
+        request_id: u64,
+        peer_feedback: enclave_rpc::types::PeerFeedback,
+    },
+    HostSubmitPeerFeedbackResponse {},
     HostStorageSyncRequest(StorageSyncRequestWithEndpoint),
     HostStorageSyncResponse(StorageSyncResponse),
     HostLocalStorageGetRequest {


### PR DESCRIPTION
Example logs:
```json
// First client.
{"caller":"keymanager.go:242","level":"debug","module":"worker/keymanager","msg":"received peer feedback from runtime","peer_feedback":"failure","request_id":11876174929579737116,"ts":"2024-09-30T11:13:55.971535462Z","valid":true}
{"caller":"keymanager.go:242","level":"debug","module":"worker/keymanager","msg":"received peer feedback from runtime","peer_feedback":"success","request_id":11876174929579737117,"ts":"2024-09-30T11:13:55.972354408Z","valid":true}
// No peers found error, so peer feedback is never stored.
{"caller":"keymanager.go:242","level":"debug","module":"worker/keymanager","msg":"received peer feedback from runtime","peer_feedback":"failure","request_id":11876174929579737118,"ts":"2024-09-30T11:13:55.972777804Z","valid":false}
// Second client.
{"caller":"keymanager.go:242","level":"debug","module":"worker/keymanager","msg":"received peer feedback from runtime","peer_feedback":"success","request_id":11876174933874704385,"ts":"2024-09-30T11:14:10.333719181Z","valid":true}
```