### PR TITLE
go/storage: Add automatic storage backend detection

### DIFF
--- a/.changelog/5876.cfg.md
+++ b/.changelog/5876.cfg.md
@@ -1,0 +1,12 @@
+The pathbadger storage backend is now the default for new nodes
+
+When a node is provisioned into an empty data directory it will default to
+using the `pathbadger` storage backend.
+
+For existing nodes, the storage backend is automatically detected based on
+the data directory. When multiple storage directories exist, the one most
+recently modified is used.
+
+In case one does not want this new behavior, it is still possible to set
+the `storage.backend` to `badger`/`pathbadger` to explicitly configure the
+desired storage backend and disable autodetection.

--- a/.changelog/5876.feature.md
+++ b/.changelog/5876.feature.md
@@ -1,0 +1,8 @@
+go/storage: Add automatic storage backend detection
+
+The new default storage backend is "auto" which attempts to detect the
+storage backend that should be used based on existing data directories.
+When none exist, "pathbadger" is used. When multiple exist, the most
+recently modified one is used.
+
+This should make newly deployed nodes default to pathbadger.

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -41,7 +41,7 @@ const (
 	defaultVRFInterval        = 20
 	defaultVRFSubmissionDelay = 5
 
-	defaultStorageBackend = database.BackendNamePathBadger
+	defaultStorageBackend = database.BackendNameAuto
 
 	logNodeFile        = "node.log"
 	logConsoleFile     = "console.log"

--- a/go/worker/storage/config/config.go
+++ b/go/worker/storage/config/config.go
@@ -35,14 +35,17 @@ type CheckpointerConfig struct {
 
 // Validate validates the configuration settings.
 func (c *Config) Validate() error {
-	_, err := db.GetBackendByName(c.Backend)
-	return err
+	if c.Backend != "auto" {
+		_, err := db.GetBackendByName(c.Backend)
+		return err
+	}
+	return nil
 }
 
 // DefaultConfig returns the default configuration settings.
 func DefaultConfig() Config {
 	return Config{
-		Backend:                "badger",
+		Backend:                "auto",
 		MaxCacheSize:           "64mb",
 		FetcherCount:           4,
 		PublicRPCEnabled:       false,


### PR DESCRIPTION
Fixes #5875 

The new default storage backend is "auto" which attempts to detect the storage backend that should be used based on existing data directories. When none exist, "pathbadger" is used. When multiple exist, the most recently modified one is used.

This should make newly deployed nodes default to pathbadger.