### PR TITLE
go/common/grpc: allow non-tls connections to loopback addresses

### DIFF
--- a/.changelog/5878.feature.md
+++ b/.changelog/5878.feature.md
@@ -1,0 +1,1 @@
+go/common/grpc: allow non-tls connections to loopback addresses

--- a/go/common/grpc/grpc.go
+++ b/go/common/grpc/grpc.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -701,6 +702,60 @@ func Dial(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	}
 	dialOpts = append(dialOpts, opts...)
 	return grpc.Dial(target, dialOpts...)
+}
+
+// IsSocketAddress checks if the gRPC address is a socket address.
+func IsSocketAddress(addr string) bool {
+	if strings.HasPrefix(addr, "unix:") || strings.HasPrefix(addr, "unix-abstract:") {
+		return true
+	}
+	if strings.HasPrefix(addr, "vsock:") {
+		return true
+	}
+	return false
+}
+
+// IsLocalAddress checks if the gRPC address points to a local socket or loopback address.
+//
+// This function takes a conservative approach and may return false for complex addresses
+// such as those with authorities or non-standard schemes.
+//
+// The expected format for the gRPC address is specified at:
+// https://github.com/grpc/grpc/blob/master/doc/naming.md
+func IsLocalAddress(addr string) bool {
+	// Sockets are considered local.
+	if IsSocketAddress(addr) {
+		return true
+	}
+
+	// Strip dns: scheme if present, other schemes are not supported.
+	if strings.HasPrefix(addr, "dns:") {
+		addr = strings.TrimPrefix(addr, "dns:")
+
+		// If authority is present, consider the address non-local as it might rely on complex resolver logic.
+		if strings.HasPrefix(addr, "//") {
+			return false
+		}
+	}
+
+	// Validate the address.
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// Try parsing with a port.
+		host, _, err = net.SplitHostPort(addr + ":" + "80")
+		if err != nil {
+			// This means that the scheme was not trimmed (e.g. was not 'dns:').
+			// Consider such addresses non-local as they might rely on complex resolver logic.
+			return false
+		}
+		// The address is parsed fine with port attached, continue.
+	}
+
+	ip, err := net.LookupIP(host)
+	if err != nil || len(ip) == 0 {
+		return false
+	}
+	return ip[0].IsLoopback()
 }
 
 func init() {

--- a/go/common/grpc/grpc_test.go
+++ b/go/common/grpc/grpc_test.go
@@ -1,0 +1,45 @@
+package grpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsLocalRPC(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		addr     string
+		expected bool
+	}{
+		// Invalid inputs.
+		{"Empty", "", false},
+		{"Invalid scheme", "test:localhost:8080", false},
+
+		// Local unix sockets/vsock.
+		{"Local unix socket", "unix:///tmp/socket", true},
+		{"Local unix socket (abstract)", "unix-abstract:abstract_path", true},
+		{"Local vsock", "vsock:2:12345", true},
+
+		// Loopback addresses.
+		{"Local IPv4 loopback", "127.0.0.1:8080", true},
+		{"Local IPv4 loopback no port", "127.0.0.1", true},
+		{"Local IPv6 loopback", "[::1]:8080", true},
+		{"Local IPv6 loopback no port", "[::1]", true},
+		{"Localhost no port", "localhost", true},
+		{"Localhost", "localhost:8080", true},
+		{"Localhost explicit scheme", "dns:localhost:8080", true},
+
+		// Non-local addresses.
+		{"Non-local address", "example.com", false},
+		{"Non-local address with port", "example.com:8080", false},
+		{"Non-local with explicit scheme", "dns:example.com", false},
+		{"Non-local with authority", "dns://authority/example.com:8080", false},
+
+		// Complex addresses (conservatively considered non-local).
+		{"Localhost with authority", "dns://authority/localhost:8080", false},
+		{"Localhost non-standard scheme", "test:localhost:8080", false},
+	} {
+		require.Equal(t, tc.expected, IsLocalAddress(tc.addr), tc.name+": "+tc.addr)
+	}
+}


### PR DESCRIPTION
This usecase came up in https://github.com/oasisprotocol/oasis-web3-gateway/pull/626 where we want to expose the node from docker via a port (since this works better cross-platform than exposing the socket via a volume).

It was requested that both `oasis-node` and `oasis-cli` work with the exposed endpoint, for better developer experience.

--- 

The added `CfgInsecureLoopback` might be a bit over the top, I'm not sure if we should keep it or not. We could always drop TLS for loopback address. But this could break any existing setup if someone did setup proper TLS with trusted certs on his local setup, so that's why I added it.


The `IsLocalAddress` is made public so that it can be reused in `oasis-sdk` and we won't need to duplicate the not most intuitive gRPC address parsing logic (https://github.com/oasisprotocol/oasis-sdk/pull/2013).