### PR TITLE
runtime/src/enclave_rpc/client: Fix panic on drop in async context

### DIFF
--- a/.changelog/5917.bugfix.md
+++ b/.changelog/5917.bugfix.md
@@ -1,0 +1,5 @@
+runtime/src/enclave_rpc/client: Fix panic on drop in async context
+
+The graceful shutdown of active sessions was removed, as they should
+not be closed when the RPC client is dropped. Instead, we should
+explicitly invoke the appropriate functions.

--- a/runtime/src/enclave_rpc/client.rs
+++ b/runtime/src/enclave_rpc/client.rs
@@ -23,7 +23,6 @@ use crate::{
         time::insecure_posix_time,
     },
     enclave_rpc::{session::Builder, types},
-    future::block_on,
     protocol::Protocol,
 };
 
@@ -620,19 +619,6 @@ impl RpcClient {
 
         #[cfg(not(test))]
         OsRng.next_u32()
-    }
-}
-
-impl Drop for RpcClient {
-    fn drop(&mut self) {
-        // Close all sessions after the client is dropped.
-        block_on(async {
-            let sessions = {
-                let mut sessions = self.sessions.lock().await;
-                sessions.drain()
-            };
-            self.close_all(sessions).await;
-        });
     }
 }
 


### PR DESCRIPTION
The graceful shutdown of active sessions was removed, as they should not be closed when the RPC client is dropped. Instead, we should explicitly invoke the appropriate functions.

Reasons:
- Blocking is not acceptable because drops should be fast, and sessions should be closed asynchronously.
- Spawning a new task is also not acceptable since drops should (mostly) be deterministic. There could be issues if the code following an implicit drop call relies on sessions being closed (not a problem yet).
- If the Tokio runtime stops and the async tasks spawned during the drop haven't completed, they will be destroyed without being executed.