### PR TITLE
go/runtime/registry: Simplify creation of provisioners

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -354,7 +354,7 @@ steps:
       - .buildkite/scripts/test_e2e.sh --timeout 20m --scenario e2e/runtime/runtime-encryption
     env:
       OASIS_TEE_HARDWARE: intel-sgx
-      OASIS_UNSAFE_MOCK_SGX: "1"
+      OASIS_UNSAFE_MOCK_TEE: "1"
       OASIS_UNSAFE_SKIP_AVR_VERIFY: "1"
       OASIS_E2E_COVERAGE: enable
       TEST_BASE_DIR: /tmp

--- a/.changelog/5975.cfg.md
+++ b/.changelog/5975.cfg.md
@@ -1,0 +1,47 @@
+go/runtime/config: Support selection of TEE kind
+
+The node operator can now specify the kind of Trusted Execution Environment
+(TEE) in which the runtime component should run. If no TEE is specified,
+it is automatically selected, with TDX and SGX taking precedence over ELF.
+
+The following configuration option has been deprecated:
+
+- `runtime.environment`
+
+The following configuration options have been added:
+
+- `runtime.debug_mock_tee` to enable TEE mocking for testing,
+
+- `runtime.runtimes.components.tee` to specify the TEE for a component.
+
+These changes affect the configuration of the client node if the runtime
+bundle contains both TEE and non-TEE binaries. In such cases, the node
+operator must explicitly configure the runtime to avoid running in a TEE
+environment.
+
+Configuring non-TEE Paratime Client Node:
+
+```
+mode: client
+# ... sections not relevant are omitted ...
+runtime:
+  paths:
+    - {{ runtime_orc_path }}
+  runtimes:
+  - id: {{ runtime_id }}
+    components:
+    - id: ronl
+      tee: none # Don't run in SGX or TDX!
+```
+
+Configuring TEE Paratime Client Node:
+
+```
+mode: client
+# ... sections not relevant are omitted ...
+runtime:
+  paths:
+    - {{ runtime_orc_path }}
+  sgx_loader: /node/bin/oasis-core-runtime-loader
+  # environment: sgx # Deprecated, can be removed.
+```

--- a/.changelog/5975.internal.md
+++ b/.changelog/5975.internal.md
@@ -1,0 +1,3 @@
+go/oasis-test-runner: Generalize OASIS_UNSAFE_MOCK_SGX flag
+
+Flag OASIS_UNSAFE_MOCK_SGX was renamed to OASIS_UNSAFE_MOCK_TEE.

--- a/common.mk
+++ b/common.mk
@@ -352,8 +352,8 @@ endif
 # https://goreleaser.com/customization/build/#define-build-tag
 export GORELEASER_CURRENT_TAG := $(RELEASE_TAG)
 
-# If mock SGX is configured, define extra runtime build flags.
-ifdef OASIS_UNSAFE_MOCK_SGX
+# If mock TEE is configured, define extra runtime build flags.
+ifdef OASIS_UNSAFE_MOCK_TEE
 	OASIS_RUNTIME_NONSGX_FLAGS := --features debug-mock-sgx
 else
 	OASIS_RUNTIME_NONSGX_FLAGS :=

--- a/go/oasis-test-runner/oasis/network.go
+++ b/go/oasis-test-runner/oasis/network.go
@@ -41,7 +41,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/log"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis/cli"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
-	runtimeConfig "github.com/oasisprotocol/oasis-core/go/runtime/config"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
@@ -684,7 +683,7 @@ func (net *Network) startOasisNode(
 			extraArgs = extraArgs.debugTCBLaxVerify()
 		}
 		if os.Getenv("OASIS_UNSAFE_MOCK_SGX") != "" {
-			cfg.Runtime.Environment = runtimeConfig.RuntimeEnvironmentSGXMock
+			cfg.Runtime.DebugMockTEE = true
 		}
 	} else {
 		baseArgs = append(baseArgs, "--"+cmdFlags.CfgGenesisFile, net.GenesisPath())

--- a/go/oasis-test-runner/oasis/network.go
+++ b/go/oasis-test-runner/oasis/network.go
@@ -682,7 +682,7 @@ func (net *Network) startOasisNode(
 		if os.Getenv("OASIS_UNSAFE_LAX_AVR_VERIFY") != "" {
 			extraArgs = extraArgs.debugTCBLaxVerify()
 		}
-		if os.Getenv("OASIS_UNSAFE_MOCK_SGX") != "" {
+		if os.Getenv("OASIS_UNSAFE_MOCK_TEE") != "" {
 			cfg.Runtime.DebugMockTEE = true
 		}
 	} else {

--- a/go/runtime/bundle/component.go
+++ b/go/runtime/bundle/component.go
@@ -132,11 +132,6 @@ func (c *Component) IsNetworkAllowed() bool {
 	}
 }
 
-// IsTEERequired returns true iff the component only provides TEE executables.
-func (c *Component) IsTEERequired() bool {
-	return c.Executable == "" && c.ELF == nil && c.TEEKind() != component.TEEKindNone
-}
-
 // TEEKind returns the kind of TEE supported by the component.
 func (c *Component) TEEKind() component.TEEKind {
 	switch {

--- a/go/runtime/bundle/component.go
+++ b/go/runtime/bundle/component.go
@@ -14,6 +14,10 @@ import (
 type ExplodedComponent struct {
 	*Component
 
+	// TEEKind specifies the kind of Trusted Execution Environment (TEE)
+	// in which the component should run.
+	TEEKind component.TEEKind
+
 	// Detached is true iff the bundle containing the component does not
 	// include a RONL component.
 	Detached bool

--- a/go/runtime/config/config.go
+++ b/go/runtime/config/config.go
@@ -61,11 +61,6 @@ const (
 	// Use of this runtime environment is only allowed if DebugDontBlameOasis flag is set.
 	RuntimeEnvironmentSGXMock RuntimeEnvironment = "sgx-mock"
 
-	// RuntimeEnvironmentELF specifies to run the runtime in the OS address space.
-	//
-	// Use of this runtime environment is only allowed if DebugDontBlameOasis flag is set.
-	RuntimeEnvironmentELF RuntimeEnvironment = "elf"
-
 	// RuntimeEnvironmentAuto specifies to run the runtime in the most appropriate location.
 	RuntimeEnvironmentAuto RuntimeEnvironment = "auto"
 )
@@ -231,7 +226,6 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("sgx_loader must be set when using sgx environment")
 		}
 	case RuntimeEnvironmentSGXMock:
-	case RuntimeEnvironmentELF:
 	case RuntimeEnvironmentAuto:
 	default:
 		return fmt.Errorf("unknown runtime environment: %s", c.Environment)

--- a/go/runtime/config/config.go
+++ b/go/runtime/config/config.go
@@ -79,10 +79,11 @@ type Config struct {
 	// Path to the sandbox binary (bubblewrap).
 	SandboxBinary string `yaml:"sandbox_binary,omitempty"`
 
-	// Path to SGXS runtime loader binary (for SGX runtimes).
+	// Path to SGX runtime loader binary (for SGX runtimes).
 	SGXLoader string `yaml:"sgx_loader,omitempty"`
 
 	// The runtime environment (sgx, elf, auto).
+	// NOTE: This may go away in the future, use `DebugMockTEE` instead.
 	Environment RuntimeEnvironment `yaml:"environment,omitempty"`
 
 	// History pruner configuration.
@@ -117,6 +118,11 @@ type Config struct {
 	//
 	// If not specified, a default value is used.
 	MaxBundleSize string `yaml:"max_bundle_size,omitempty"`
+
+	// DebugMockTEE enables mocking of the Trusted Execution Environment (TEE).
+	//
+	// This flag can only be used if the DebugDontBlameOasis flag is set.
+	DebugMockTEE bool `yaml:"debug_mock_tee,omitempty"`
 }
 
 // GetComponent returns the configuration for the given component

--- a/go/runtime/host/composite/composite.go
+++ b/go/runtime/host/composite/composite.go
@@ -203,9 +203,9 @@ func (p *provisioner) NewRuntime(cfg host.Config) (host.Runtime, error) {
 	if comp == nil {
 		return nil, fmt.Errorf("host/composite: component not available")
 	}
-	provisioner, ok := p.kinds[comp.TEEKind()]
+	provisioner, ok := p.kinds[comp.TEEKind]
 	if !ok {
-		return nil, fmt.Errorf("host/composite: provisioner for kind '%s' is not available", comp.TEEKind())
+		return nil, fmt.Errorf("host/composite: provisioner for kind '%s' is not available", comp.TEEKind)
 	}
 	return provisioner.NewRuntime(cfg)
 }

--- a/go/runtime/host/sgx/sgx.go
+++ b/go/runtime/host/sgx/sgx.go
@@ -284,7 +284,7 @@ func (s *sgxProvisioner) getSandboxConfig(rtCfg host.Config, conn sandbox.Connec
 		return cfg, nil
 	}
 
-	if comp.TEEKind() != component.TEEKindSGX {
+	if comp.SGX == nil {
 		return process.Config{}, fmt.Errorf("component '%s' is not an SGX component", comp.ID())
 	}
 

--- a/go/runtime/host/tdx/qemu.go
+++ b/go/runtime/host/tdx/qemu.go
@@ -109,7 +109,7 @@ func (q *qemuProvisioner) getSandboxConfig(rtCfg host.Config, _ sandbox.Connecto
 	if err != nil {
 		return process.Config{}, err
 	}
-	if comp.TEEKind() != component.TEEKindTDX {
+	if comp.TDX == nil {
 		return process.Config{}, fmt.Errorf("component '%s' is not a TDX component", comp.ID())
 	}
 

--- a/go/runtime/registry/config.go
+++ b/go/runtime/registry/config.go
@@ -116,7 +116,13 @@ func createProvisioner(
 	attestInterval := config.GlobalConfig.Runtime.AttestInterval
 	sandboxBinary := config.GlobalConfig.Runtime.SandboxBinary
 	sgxLoader := config.GlobalConfig.Runtime.SGXLoader
-	runtimeEnv := config.GlobalConfig.Runtime.Environment
+	insecureMock := config.GlobalConfig.Runtime.DebugMockTEE
+
+	// Support legacy configuration where the runtime environment determines
+	// whether the TEE should be mocked.
+	if config.GlobalConfig.Runtime.Environment == rtConfig.RuntimeEnvironmentSGXMock {
+		insecureMock = true
+	}
 
 	// Register provisioners based on the configured provisioner.
 	provisioners := make(map[component.TEEKind]runtimeHost.Provisioner)
@@ -156,7 +162,6 @@ func createProvisioner(
 		}
 
 		// Configure the Intel SGX provisioner.
-		insecureMock := runtimeEnv == rtConfig.RuntimeEnvironmentSGXMock
 		if insecureMock && !cmdFlags.DebugDontBlameOasis() {
 			return nil, fmt.Errorf("mock SGX requires use of unsafe debug flags")
 		}

--- a/go/runtime/registry/config.go
+++ b/go/runtime/registry/config.go
@@ -107,39 +107,18 @@ func createProvisioner(
 	identity *identity.Identity,
 	consensus consensus.Backend,
 	hostInfo *hostProtocol.HostInfo,
-	bundleRegistry bundle.Registry,
 	ias []ias.Endpoint,
 	qs pcs.QuoteService,
 ) (runtimeHost.Provisioner, error) {
 	var err error
+	var insecureNoSandbox bool
 
-	// By default start with the environment specified in configuration.
+	attestInterval := config.GlobalConfig.Runtime.AttestInterval
+	sandboxBinary := config.GlobalConfig.Runtime.SandboxBinary
+	sgxLoader := config.GlobalConfig.Runtime.SGXLoader
 	runtimeEnv := config.GlobalConfig.Runtime.Environment
 
-	// If the runtime environment is set to automatic selection and at least
-	// one bundle has a component that requires the use of a TEE, force a TEE
-	// environment to simplify configuration.
-	func() {
-		if runtimeEnv != rtConfig.RuntimeEnvironmentAuto {
-			return
-		}
-		for _, manifest := range bundleRegistry.GetManifests() {
-			for _, comp := range manifest.GetAvailableComponents() {
-				if comp.IsTEERequired() {
-					runtimeEnv = rtConfig.RuntimeEnvironmentSGX
-					return
-				}
-			}
-		}
-	}()
-
-	isEnvSGX := runtimeEnv == rtConfig.RuntimeEnvironmentSGX || runtimeEnv == rtConfig.RuntimeEnvironmentSGXMock
-	forceNoSGX := config.GlobalConfig.Mode.IsClientOnly() && !isEnvSGX
-
 	// Register provisioners based on the configured provisioner.
-	var insecureNoSandbox bool
-	sandboxBinary := config.GlobalConfig.Runtime.SandboxBinary
-	attestInterval := config.GlobalConfig.Runtime.AttestInterval
 	provisioners := make(map[component.TEEKind]runtimeHost.Provisioner)
 	switch p := config.GlobalConfig.Runtime.Provisioner; p {
 	case rtConfig.RuntimeProvisionerMock:
@@ -177,46 +156,31 @@ func createProvisioner(
 		}
 
 		// Configure the Intel SGX provisioner.
-		switch sgxLoader := config.GlobalConfig.Runtime.SGXLoader; {
-		case forceNoSGX:
-			// Remap SGX to non-SGX when forced to do so.
-			provisioners[component.TEEKindSGX], err = hostSandbox.New(hostSandbox.Config{
-				HostInfo:          hostInfo,
-				InsecureNoSandbox: insecureNoSandbox,
-				SandboxBinaryPath: sandboxBinary,
-			})
-			if err != nil {
-				return nil, fmt.Errorf("failed to create runtime provisioner: %w", err)
-			}
-		case sgxLoader == "" && runtimeEnv == rtConfig.RuntimeEnvironmentSGX:
-			// SGX environment is forced, but we don't have the needed loader.
-			return nil, fmt.Errorf("SGX runtime environment requires setting the SGX loader")
-		case sgxLoader == "" && runtimeEnv != rtConfig.RuntimeEnvironmentSGXMock:
+		insecureMock := runtimeEnv == rtConfig.RuntimeEnvironmentSGXMock
+		if insecureMock && !cmdFlags.DebugDontBlameOasis() {
+			return nil, fmt.Errorf("mock SGX requires use of unsafe debug flags")
+		}
+
+		if !insecureMock && sgxLoader == "" {
 			// SGX may be needed, but we don't have a loader configured.
 			break
-		default:
-			// Configure mock SGX if configured and we are in a debug mode.
-			insecureMock := runtimeEnv == rtConfig.RuntimeEnvironmentSGXMock
-			if insecureMock && !cmdFlags.DebugDontBlameOasis() {
-				return nil, fmt.Errorf("mock SGX requires use of unsafe debug flags")
-			}
+		}
 
-			provisioners[component.TEEKindSGX], err = hostSgx.New(hostSgx.Config{
-				HostInfo:              hostInfo,
-				CommonStore:           commonStore,
-				LoaderPath:            sgxLoader,
-				IAS:                   ias,
-				PCS:                   qs,
-				Consensus:             consensus,
-				Identity:              identity,
-				SandboxBinaryPath:     sandboxBinary,
-				InsecureNoSandbox:     insecureNoSandbox,
-				InsecureMock:          insecureMock,
-				RuntimeAttestInterval: attestInterval,
-			})
-			if err != nil {
-				return nil, fmt.Errorf("failed to create SGX runtime provisioner: %w", err)
-			}
+		provisioners[component.TEEKindSGX], err = hostSgx.New(hostSgx.Config{
+			HostInfo:              hostInfo,
+			CommonStore:           commonStore,
+			LoaderPath:            sgxLoader,
+			IAS:                   ias,
+			PCS:                   qs,
+			Consensus:             consensus,
+			Identity:              identity,
+			SandboxBinaryPath:     sandboxBinary,
+			InsecureNoSandbox:     insecureNoSandbox,
+			InsecureMock:          insecureMock,
+			RuntimeAttestInterval: attestInterval,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create SGX runtime provisioner: %w", err)
 		}
 	default:
 		return nil, fmt.Errorf("unsupported runtime provisioner: %s", p)

--- a/go/runtime/registry/config.go
+++ b/go/runtime/registry/config.go
@@ -134,8 +134,7 @@ func createProvisioner(
 	}()
 
 	isEnvSGX := runtimeEnv == rtConfig.RuntimeEnvironmentSGX || runtimeEnv == rtConfig.RuntimeEnvironmentSGXMock
-	forceNoSGX := (config.GlobalConfig.Mode.IsClientOnly() && !isEnvSGX) ||
-		(cmdFlags.DebugDontBlameOasis() && runtimeEnv == rtConfig.RuntimeEnvironmentELF)
+	forceNoSGX := config.GlobalConfig.Mode.IsClientOnly() && !isEnvSGX
 
 	// Register provisioners based on the configured provisioner.
 	var insecureNoSandbox bool

--- a/go/worker/keymanager/secrets.go
+++ b/go/worker/keymanager/secrets.go
@@ -601,6 +601,7 @@ func (w *secretsWorker) registerNode(rsp *secrets.SignedInitResponse, version ve
 	w.logger.Info("registering key manager",
 		"is_secure", rsp.InitResponse.IsSecure,
 		"checksum", hex.EncodeToString(rsp.InitResponse.Checksum),
+		"next_checksum", hex.EncodeToString(rsp.InitResponse.NextChecksum),
 		"policy_checksum", hex.EncodeToString(rsp.InitResponse.PolicyChecksum),
 		"rsk", rsp.InitResponse.RSK,
 		"next_rsk", rsp.InitResponse.NextRSK,


### PR DESCRIPTION
Trying to remove the bundle registry dependency from the `createProvisioner` function, as nodes should generally not have any bundles stored locally upon their initial startup.

These changes also decouple the creation of provisioners from TEE selection. Previously, only client nodes could choose the TEE in which a component would run. Now, node operators can specify the TEE for each component, provided the component supports the chosen TEE. If no TEE is specified, it is automatically selected, with TDX and SGX taking precedence over ELF.

How to configure nonSGX client:
```yaml
runtime:
  paths: # Can be replaced with bundle repository url.
    - {{ runtime_orc_path }} 
  runtimes:
  - id: {{ runtime_id }}
    components:
    - id: ronl
      tee: none # Do not run in SGX or TDX!
```

How to configure SGX client:
```yaml
runtime:
  paths: # Can be replaced with bundle repository url, if you also specify runtime ids.
    - {{ runtime_orc_path }}
  sgx_loader: /node/bin/oasis-core-runtime-loader
```


How to mock SGX:
```yaml
runtime:
  paths: # Can be replaced with bundle repository url, if you also specify runtime ids.
    - {{ runtime_orc_path }}
  debug_mock_tee: true
```