### PR TITLE
Periodically clean up cached bundles directory 

### DIFF
--- a/.changelog/5737.feature.md
+++ b/.changelog/5737.feature.md
@@ -1,0 +1,1 @@
+go/runtime/bundle: Cleanup bundles on a runtime upgrade

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -51,6 +51,11 @@ func (v Version) Cmp(other Version) int {
 	return int(v.Patch) - int(other.Patch)
 }
 
+// Less checks if the version is strictly less than the given version.
+func (v Version) Less(other Version) bool {
+	return v.Cmp(other) < 0
+}
+
 // ToU64 returns the version as platform-dependent uint64.
 func (v Version) ToU64() uint64 {
 	return (uint64(v.Major) << 32) | (uint64(v.Minor) << 16) | (uint64(v.Patch))

--- a/go/common/version/version_test.go
+++ b/go/common/version/version_test.go
@@ -269,3 +269,27 @@ func TestProtocolVersionCompatible(t *testing.T) {
 		require.Equal(t, v.isCompatible, Versions.Compatible(v.versions()), v.msg)
 	}
 }
+
+func TestLess(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		v1       Version
+		v2       Version
+		expected bool
+	}{
+		{"v1 less than v2 (major)", Version{1, 1, 1}, Version{2, 1, 1}, true},
+		{"v1 less than v2 (minor)", Version{1, 1, 1}, Version{1, 2, 1}, true},
+		{"v1 less than v2 (patch)", Version{1, 1, 1}, Version{1, 1, 2}, true},
+		{"v1 greater than v2 (major)", Version{1, 1, 1}, Version{0, 1, 1}, false},
+		{"v1 greater than v2 (minor)", Version{1, 1, 1}, Version{1, 0, 1}, false},
+		{"v1 greater than v2 (patch)", Version{1, 1, 1}, Version{1, 1, 0}, false},
+		{"v1 equal to v2", Version{1, 1, 1}, Version{1, 1, 1}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.v1.Less(tc.v2)
+			if result != tc.expected {
+				t.Errorf("Less(%v, %v) = %v, want %v", tc.v1, tc.v2, result, tc.expected)
+			}
+		})
+	}
+}

--- a/go/runtime/bundle/manager.go
+++ b/go/runtime/bundle/manager.go
@@ -197,15 +197,15 @@ func (m *Manager) run(ctx context.Context) {
 			return
 		}
 
-		m.Download()
+		m.download()
 	}
 }
 
-// Queue updates the checksums of bundles pending download for the given runtime.
+// Download updates the checksums of bundles pending download for the given runtime.
 //
 // Any existing checksums in the download queue for the given runtime are removed
 // and replaced with the given ones.
-func (m *Manager) Queue(runtimeID common.Namespace, manifestHashes []hash.Hash) {
+func (m *Manager) Download(runtimeID common.Namespace, manifestHashes []hash.Hash) {
 	// Download bundles only for the configured runtimes.
 	if _, ok := m.runtimeIDs[runtimeID]; !ok {
 		return
@@ -242,8 +242,8 @@ func (m *Manager) Queue(runtimeID common.Namespace, manifestHashes []hash.Hash) 
 	}
 }
 
-// Download tries to download bundles in the queue.
-func (m *Manager) Download() {
+// download tries to download bundles in the queue.
+func (m *Manager) download() {
 	for runtimeID := range m.runtimeIDs {
 		m.downloadBundles(runtimeID)
 	}

--- a/go/runtime/bundle/manager_test.go
+++ b/go/runtime/bundle/manager_test.go
@@ -23,7 +23,7 @@ func (r *mockStore) HasManifest(hash hash.Hash) bool {
 	return ok
 }
 
-func (r *mockStore) AddManifest(manifest *Manifest, _ string) error {
+func (r *mockStore) AddManifest(manifest *ExplodedManifest) error {
 	r.manifestHashes[manifest.Hash()] = struct{}{}
 	return nil
 }
@@ -33,12 +33,14 @@ func TestRegisterManifest(t *testing.T) {
 	manager, err := NewManager("", nil, store)
 	require.NoError(t, err)
 
-	manifests := map[string]*Manifest{
-		"dir1": {
-			Name: "manifest1",
+	manifests := []*ExplodedManifest{
+		{
+			Manifest:        &Manifest{Name: "manifest1"},
+			ExplodedDataDir: "dir1",
 		},
-		"dir2": {
-			Name: "manifest2",
+		{
+			Manifest:        &Manifest{Name: "manifest2"},
+			ExplodedDataDir: "dir2",
 		},
 	}
 

--- a/go/runtime/bundle/manager_test.go
+++ b/go/runtime/bundle/manager_test.go
@@ -28,6 +28,14 @@ func (r *mockStore) AddManifest(manifest *ExplodedManifest) error {
 	return nil
 }
 
+func (r *mockStore) Manifests() []*ExplodedManifest {
+	panic("not implemented")
+}
+
+func (r *mockStore) RemoveManifest(hash.Hash) bool {
+	panic("not implemented")
+}
+
 func TestRegisterManifest(t *testing.T) {
 	store := newMockStore()
 	manager, err := NewManager("", nil, store)

--- a/go/runtime/bundle/manifest.go
+++ b/go/runtime/bundle/manifest.go
@@ -15,6 +15,15 @@ const (
 	manifestName = manifestPath + "/MANIFEST.MF"
 )
 
+// ExplodedManifest is manifest with corresponding exploded bundle dir.
+type ExplodedManifest struct {
+	*Manifest
+
+	// ExplodedDataDir is the path to the data directory where the bundle
+	// represented by manifest has been extracted.
+	ExplodedDataDir string
+}
+
 // Manifest is a deserialized runtime bundle manifest.
 type Manifest struct {
 	// Name is the optional human readable runtime name.

--- a/go/runtime/bundle/registry_test.go
+++ b/go/runtime/bundle/registry_test.go
@@ -88,16 +88,16 @@ func TestRegistry(t *testing.T) {
 
 	// Add manifests to the registry.
 	for i := 0; i < 3; i++ {
-		err = registry.AddManifest(bnds[i].Manifest, "")
+		err = registry.AddManifest(&ExplodedManifest{bnds[i].Manifest, ""})
 		require.NoError(t, err)
 	}
 
 	// Attempt to add the first manifest again (duplicate hash).
-	err = registry.AddManifest(bnds[0].Manifest, "")
+	err = registry.AddManifest(&ExplodedManifest{bnds[0].Manifest, ""})
 	require.NoError(t, err)
 
 	// Attempt to add the fourth manifest (duplicate RONL component).
-	err = registry.AddManifest(bnds[3].Manifest, "")
+	err = registry.AddManifest(&ExplodedManifest{bnds[3].Manifest, ""})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "duplicate component 'ronl', version '1.0.0', for runtime '8000000000000000000000000000000000000000000000000000000000000001'")
 

--- a/go/runtime/registry/registry.go
+++ b/go/runtime/registry/registry.go
@@ -388,11 +388,26 @@ func (r *runtime) run(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-epoCh:
+		case epoch := <-epoCh:
 			if up := r.updateActiveDescriptor(ctx); up && !activeInitialized {
 				close(r.activeDescriptorCh)
 				activeInitialized = true
 			}
+
+			// Trigger clean-up for bundles less than active version.
+			r.RLock()
+			rt := r.activeDescriptor
+			r.RUnlock()
+			if rt == nil {
+				continue
+			}
+
+			active := rt.ActiveDeployment(epoch)
+			if active == nil {
+				continue
+			}
+
+			r.bundleManager.Cleanup(rt.ID, active.Version)
 		case rt := <-regCh:
 			if !rt.ID.Equal(&r.id) {
 				continue

--- a/go/runtime/registry/registry.go
+++ b/go/runtime/registry/registry.go
@@ -446,7 +446,7 @@ func (r *runtime) run(ctx context.Context) {
 				}
 			}
 
-			r.bundleManager.Queue(r.id, manifestHashes)
+			r.bundleManager.Download(r.id, manifestHashes)
 		}
 	}
 }


### PR DESCRIPTION
# What
* #5737 
* ~Furthermore, we fix the current bug (`master`) of not being able to remove runtime from the configuration (see https://github.com/oasisprotocol/oasis-core/pull/5976#issuecomment-2587690157)~ -> done as part of https://github.com/oasisprotocol/oasis-core/pull/6003

# Why
Save on disk usage/ease the maintenance.

# How
1. ~Regular and detached exploded bundles no longer present in the config, are removed during discovery startup. This way we are not blocking initialization~ -> Done here https://github.com/oasisprotocol/oasis-core/pull/6003
2. Regular bundles with version lower then active are removed by watching new epochs and checking if bundle registry has bundles lower than the active version for the current epoch.

# How to test

## e2e
```bash
.buildkite/scripts/test_e2e.sh --scenario e2e.runtime.runtime-upgrade
```

