### PR TITLE
go/runtime/config: Add default bundle registry

### DIFF
--- a/.changelog/5962.cfg.md
+++ b/.changelog/5962.cfg.md
@@ -19,10 +19,10 @@ The following configuration options have been added:
 
 - `runtime.runtimes.config` is the runtime local configuration,
 
-- `runtime.runtimes.repositories` is the list of runtime specific URLs
+- `runtime.runtimes.registries` is the list of runtime specific URLs
    used to fetch runtime bundle metadata,
 
-- `runtime.repositories` is the list of global URLs used to fetch
+- `runtime.registries` is the list of global URLs used to fetch
    runtime bundle metadata,
 
 - `runtime.max_bundle_size` is the maximum allowed bundle size.

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -304,7 +304,7 @@ func (km *Keymanager) ModifyConfig() error {
 
 	km.Config.Runtime.Runtimes = append(km.Config.Runtime.Runtimes, rtCfg)
 	km.Config.Runtime.Paths = append(km.Config.Runtime.Paths, km.runtime.BundlePaths()...)
-	km.Config.Runtime.Repositories = []string{fmt.Sprintf("http://127.0.0.1:%d", km.net.getProvisionedPort(netPortRepository))}
+	km.Config.Runtime.Registries = []string{fmt.Sprintf("http://127.0.0.1:%d", km.net.getProvisionedPort(netPortRegistry))}
 
 	km.Config.Keymanager.RuntimeID = km.runtime.ID().String()
 	km.Config.Keymanager.PrivatePeerPubKeys = km.privatePeerPubKeys

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -56,7 +56,7 @@ const (
 	nodePortP2P       = "p2p"
 	nodePortP2PSeed   = "p2p-seed"
 	nodePortPprof     = "pprof"
-	netPortRepository = "repository"
+	netPortRegistry   = "registry"
 
 	allInterfacesAddr = "tcp://0.0.0.0"
 	localhostAddr     = "tcp://127.0.0.1"
@@ -303,7 +303,7 @@ func (n *Node) Start() error {
 		n.Config.Runtime.Paths = append(n.Config.Runtime.Paths, hosted.runtime.BundlePaths()...)
 	}
 
-	n.Config.Runtime.Repositories = []string{fmt.Sprintf("http://127.0.0.1:%d", n.net.getProvisionedPort(netPortRepository))}
+	n.Config.Runtime.Registries = []string{fmt.Sprintf("http://127.0.0.1:%d", n.net.getProvisionedPort(netPortRegistry))}
 
 	if n.consensus.EnableArchiveMode {
 		n.Config.Mode = config.ModeArchive

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_upgrade.go
@@ -72,7 +72,7 @@ func (sc *KmUpgradeImpl) Run(ctx context.Context, childEnv *env.Env) error {
 	}
 
 	// Determine the port on which the nodes are trying to fetch bundles.
-	rawURL := sc.Net.Clients()[0].Config.Runtime.Repositories[0]
+	rawURL := sc.Net.Clients()[0].Config.Runtime.Registries[0]
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
 		return err

--- a/go/oasis-test-runner/scenario/e2e/runtime/runtime_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/runtime_upgrade.go
@@ -80,7 +80,7 @@ func (sc *runtimeUpgradeImpl) Run(ctx context.Context, childEnv *env.Env) error 
 	}
 
 	// Determine the port on which the nodes are trying to fetch bundles.
-	rawURL := sc.Net.Clients()[0].Config.Runtime.Repositories[0]
+	rawURL := sc.Net.Clients()[0].Config.Runtime.Registries[0]
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
 		return err

--- a/go/runtime/bundle/discovery.go
+++ b/go/runtime/bundle/discovery.go
@@ -99,17 +99,17 @@ func (d *Discovery) Init() error {
 		return err
 	}
 
-	// Validate global repository URLs.
-	globalBaseURLs, err := validateAndNormalizeURLs(config.GlobalConfig.Runtime.Repositories)
+	// Validate global registry URLs.
+	globalBaseURLs, err := validateAndNormalizeURLs(config.GlobalConfig.Runtime.Registries)
 	if err != nil {
 		return err
 	}
 
-	// Validate each runtime's repository URLs.
+	// Validate each runtime's registry URLs.
 	runtimeBaseURLs := make(map[common.Namespace][]string)
 
 	for _, runtime := range config.GlobalConfig.Runtime.Runtimes {
-		urls, err := validateAndNormalizeURLs(runtime.Repositories)
+		urls, err := validateAndNormalizeURLs(runtime.Registries)
 		if err != nil {
 			return err
 		}

--- a/go/runtime/config/config.go
+++ b/go/runtime/config/config.go
@@ -131,8 +131,8 @@ type Config struct {
 	// LoadBalancer is the load balancer configuration.
 	LoadBalancer LoadBalancerConfig `yaml:"load_balancer,omitempty"`
 
-	// Repositories is the list of URLs used to fetch runtime bundle metadata.
-	Repositories []string `yaml:"repositories,omitempty"`
+	// Registries is the list of URLs used to fetch runtime bundle metadata.
+	Registries []string `yaml:"registries,omitempty"`
 
 	// MaxBundleSize is the maximum allowed bundle size.
 	//
@@ -187,8 +187,8 @@ type RuntimeConfig struct {
 	// Config contains runtime local configuration.
 	Config map[string]interface{} `yaml:"config,omitempty"`
 
-	// Repositories is the list of URLs used to fetch runtime bundle metadata.
-	Repositories []string `yaml:"repositories,omitempty"`
+	// Registries is the list of URLs used to fetch runtime bundle metadata.
+	Registries []string `yaml:"registries,omitempty"`
 }
 
 // Validate validates the runtime configuration.
@@ -351,6 +351,6 @@ func DefaultConfig() Config {
 		LoadBalancer: LoadBalancerConfig{
 			NumInstances: 0,
 		},
-		Repositories: []string{oasisBundleRegistryURL},
+		Registries: []string{oasisBundleRegistryURL},
 	}
 }

--- a/go/runtime/config/config.go
+++ b/go/runtime/config/config.go
@@ -12,6 +12,9 @@ import (
 	tpConfig "github.com/oasisprotocol/oasis-core/go/runtime/txpool/config"
 )
 
+// oasisBundleRegistryURL is the URL of the metadata folder in the Oasis bundle registry.
+const oasisBundleRegistryURL = "https://raw.githubusercontent.com/oasisprotocol/bundle-registry/main/metadata/"
+
 // RuntimeProvisioner is the runtime provisioner.
 type RuntimeProvisioner string
 
@@ -348,5 +351,6 @@ func DefaultConfig() Config {
 		LoadBalancer: LoadBalancerConfig{
 			NumInstances: 0,
 		},
+		Repositories: []string{oasisBundleRegistryURL},
 	}
 }

--- a/go/runtime/config/config.go
+++ b/go/runtime/config/config.go
@@ -131,7 +131,11 @@ type Config struct {
 	// LoadBalancer is the load balancer configuration.
 	LoadBalancer LoadBalancerConfig `yaml:"load_balancer,omitempty"`
 
-	// Registries is the list of URLs used to fetch runtime bundle metadata.
+	// Registries is the list of base URLs used to fetch runtime bundle metadata.
+	//
+	// The actual metadata URLs are constructed by appending the manifest hash
+	// to the base URL. Therefore, the provided URLs don't need to be valid
+	// endpoints themselves, only the constructed URLs need to be valid.
 	Registries []string `yaml:"registries,omitempty"`
 
 	// MaxBundleSize is the maximum allowed bundle size.
@@ -187,7 +191,11 @@ type RuntimeConfig struct {
 	// Config contains runtime local configuration.
 	Config map[string]interface{} `yaml:"config,omitempty"`
 
-	// Registries is the list of URLs used to fetch runtime bundle metadata.
+	// Registries is the list of base URLs used to fetch runtime bundle metadata.
+	//
+	// The actual metadata URLs are constructed by appending the manifest hash
+	// to the base URL. Therefore, the provided URLs don't need to be valid
+	// endpoints themselves, only the constructed URLs need to be valid.
 	Registries []string `yaml:"registries,omitempty"`
 }
 


### PR DESCRIPTION
Renaming also repository to registry, as the URL doesn't necessary point to a repository. 