### PR TITLE
go/runtime/host/tdx: Add support for persistent image overlay

### DIFF
--- a/.changelog/6005.feature.md
+++ b/.changelog/6005.feature.md
@@ -1,0 +1,1 @@
+go/runtime/host/tdx: Add support for persistent image overlay

--- a/go/oasis-test-runner/oasis/runtime.go
+++ b/go/oasis-test-runner/oasis/runtime.go
@@ -98,6 +98,7 @@ type DeploymentCfg struct {
 // ComponentCfg is a runtime component configuration.
 type ComponentCfg struct {
 	Kind     component.Kind              `json:"kind"`
+	Name     string                      `json:"name,omitempty"`
 	Version  version.Version             `json:"version"`
 	Binaries map[node.TEEHardware]string `json:"binaries"`
 }
@@ -281,6 +282,7 @@ func (rt *Runtime) toRuntimeBundle(deploymentIndex int) (*bundle.Bundle, error) 
 
 		comp := &bundle.Component{
 			Kind:    compCfg.Kind,
+			Name:    compCfg.Name,
 			Version: compCfg.Version,
 			ELF: &bundle.ELFMetadata{
 				Executable: elfBin,

--- a/go/oasis-test-runner/scenario/e2e/runtime/rofl.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/rofl.go
@@ -41,6 +41,7 @@ func (sc *roflImpl) Fixture() (*oasis.NetworkFixture, error) {
 	// Add ROFL component.
 	f.Runtimes[1].Deployments[0].Components = append(f.Runtimes[1].Deployments[0].Components, oasis.ComponentCfg{
 		Kind:     component.ROFL,
+		Name:     "test-rofl",
 		Binaries: sc.ResolveRuntimeBinaries(ROFLComponentBinary),
 	})
 

--- a/go/runtime/bundle/bundle_test.go
+++ b/go/runtime/bundle/bundle_test.go
@@ -140,6 +140,7 @@ func TestDetachedBundle(t *testing.T) {
 			// No RONL component in the manifest.
 			{
 				Kind: component.ROFL,
+				Name: "my-rofl-comp",
 				ELF: &ELFMetadata{
 					Executable: "runtime.bin",
 				},

--- a/go/runtime/bundle/component.go
+++ b/go/runtime/bundle/component.go
@@ -3,11 +3,22 @@ package bundle
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/runtime/bundle/component"
+)
+
+// componentNameRegexp is the regular expression for valid component names.
+var componentNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+const (
+	// minComponentNameLen is the minimum length of a valid component name.
+	minComponentNameLen = 3
+	// maxComponentNameLen is the maximum length of a valid component name.
+	maxComponentNameLen = 128
 )
 
 // ExplodedComponent is an exploded runtime component ready for execution.
@@ -118,6 +129,15 @@ func (c *Component) Validate() error {
 			return fmt.Errorf("RONL component cannot be disabled")
 		}
 	case component.ROFL:
+		if len(c.Name) < minComponentNameLen {
+			return fmt.Errorf("ROFL component name must be at least %d characters long", minComponentNameLen)
+		}
+		if len(c.Name) > maxComponentNameLen {
+			return fmt.Errorf("ROFL component name must be at most %d characters long", maxComponentNameLen)
+		}
+		if !componentNameRegexp.MatchString(c.Name) {
+			return fmt.Errorf("ROFL component name is invalid (must satisfy: %s)", componentNameRegexp)
+		}
 	default:
 		return fmt.Errorf("unknown component kind: '%s'", c.Kind)
 	}

--- a/go/runtime/bundle/component_test.go
+++ b/go/runtime/bundle/component_test.go
@@ -1,0 +1,40 @@
+package bundle
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/runtime/bundle/component"
+)
+
+func TestComponentValidation(t *testing.T) {
+	require := require.New(t)
+
+	// Test component names.
+	var comp Component
+	err := comp.Validate()
+	require.ErrorContains(err, "unknown component kind")
+	comp.Kind = component.ROFL
+
+	for _, tc := range []struct {
+		name string
+		err  string
+	}{
+		{"", "ROFL component name must be at least 3 characters long"},
+		{strings.Repeat("a", 129), "ROFL component name must be at most 128 characters long"},
+		{"my invalid component name", "ROFL component name is invalid"},
+		{"my.invalid.component.name", "ROFL component name is invalid"},
+		{"my:invalid:component:name", "ROFL component name is invalid"},
+		{"my-valid-component-name", ""},
+	} {
+		comp.Name = tc.name
+		err = comp.Validate()
+		if tc.err == "" {
+			require.NoError(err)
+		} else {
+			require.ErrorContains(err, tc.err)
+		}
+	}
+}

--- a/go/runtime/bundle/registry_test.go
+++ b/go/runtime/bundle/registry_test.go
@@ -31,6 +31,7 @@ func createSyntheticBundle(runtimeID common.Namespace, version version.Version, 
 		case component.ROFL:
 			manifest.Components = append(manifest.Components, &Component{
 				Kind:    component.ROFL,
+				Name:    "my-rofl-comp",
 				Version: version,
 			})
 		default:

--- a/go/runtime/registry/config.go
+++ b/go/runtime/registry/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -114,6 +115,7 @@ func createHostInfo(consensus consensus.Backend) (*hostProtocol.HostInfo, error)
 }
 
 func createProvisioner(
+	dataDir string,
 	commonStore *persistent.CommonStore,
 	identity *identity.Identity,
 	consensus consensus.Backend,
@@ -205,6 +207,7 @@ func createProvisioner(
 	// Configure TDX provisioner.
 	// TODO: Allow provisioner selection in the future, currently we only have QEMU.
 	provisioners[component.TEEKindTDX], err = hostTdx.NewQemu(hostTdx.QemuConfig{
+		DataDir:               filepath.Join(dataDir, RuntimesDir),
 		HostInfo:              hostInfo,
 		CommonStore:           commonStore,
 		PCS:                   qs,

--- a/go/runtime/registry/registry.go
+++ b/go/runtime/registry/registry.go
@@ -725,7 +725,7 @@ func New(
 	}
 
 	// Create runtime provisioner.
-	provisioner, err := createProvisioner(commonStore, identity, consensus, hostInfo, ias, qs)
+	provisioner, err := createProvisioner(dataDir, commonStore, identity, consensus, hostInfo, ias, qs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #5999 