### PR TITLE
go/runtime/bundle/manifest: Fix legacy manifest version

### DIFF
--- a/go/oasis-node/cmd/node/node_control.go
+++ b/go/oasis-node/cmd/node/node_control.go
@@ -13,6 +13,7 @@ import (
 	cmdFlags "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
 	p2p "github.com/oasisprotocol/oasis-core/go/p2p/api"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
+	"github.com/oasisprotocol/oasis-core/go/runtime/bundle/component"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
 	upgrade "github.com/oasisprotocol/oasis-core/go/upgrade/api"
 	keymanagerWorker "github.com/oasisprotocol/oasis-core/go/worker/keymanager/api"
@@ -359,7 +360,12 @@ func (n *Node) getBundleStatus() ([]control.BundleStatus, error) {
 	bundles := make([]control.BundleStatus, 0, len(manifests))
 
 	for _, manifest := range manifests {
-		explodedComponents, err := bundleRegistry.GetComponents(manifest.ID, manifest.GetVersion())
+		ronl := manifest.GetComponentByID(component.ID_RONL)
+		if ronl == nil {
+			continue
+		}
+
+		explodedComponents, err := bundleRegistry.GetComponents(manifest.ID, ronl.Version)
 		if err != nil {
 			return nil, err
 		}

--- a/go/runtime/bundle/bundle.go
+++ b/go/runtime/bundle/bundle.go
@@ -575,16 +575,6 @@ func Open(fn string, opts ...OpenOption) (_ *Bundle, err error) {
 		return nil, err
 	}
 
-	// Support legacy manifests where the runtime version is defined at the top level.
-	if bnd.Manifest.Version.ToU64() > 0 {
-		for _, comp := range bnd.Manifest.Components {
-			if comp.ID().IsRONL() {
-				comp.Version = bnd.Manifest.Version
-				break
-			}
-		}
-	}
-
 	return bnd, nil
 }
 

--- a/go/runtime/bundle/manifest_test.go
+++ b/go/runtime/bundle/manifest_test.go
@@ -107,6 +107,23 @@ const testManifestLegacyJSON = `
 }
 `
 
+const testManifestLegacyVersionJSON = `
+{
+  "name": "name",
+  "id": "0000000000000000000000000000000000000000000000000000000000000000",
+  "version": {
+    "major": 1,
+    "minor": 2,
+    "patch": 3
+  },
+  "components": [
+    {
+      "kind": "ronl"
+    }
+  ]
+}
+`
+
 func TestManifestHash_EmptyJSON(t *testing.T) {
 	var manifest Manifest
 	err := json.Unmarshal([]byte(testManifestEmptyJSON), &manifest)
@@ -126,6 +143,23 @@ func TestManifestHash_LegacyJSON(t *testing.T) {
 	err := json.Unmarshal([]byte(testManifestLegacyJSON), &manifest)
 	require.NoError(t, err)
 	require.Equal(t, "bd2987c59d2c672dee5c723b2d01adf6a7030c67efa368c342b54f887c1fe188", manifest.Hash().String())
+}
+
+func TestManifestHash_LegacyVersionJSON(t *testing.T) {
+	var manifest Manifest
+	err := json.Unmarshal([]byte(testManifestLegacyVersionJSON), &manifest)
+	require.NoError(t, err)
+
+	// Verify that the manifest version is correctly copied to the RONL component.
+	ronl := manifest.GetComponentByID(component.ID_RONL)
+	require.NotNil(t, ronl)
+	require.Equal(t, manifest.Version, ronl.Version)
+
+	// Ensure that the manifest hash remains unchanged even if the version is copied.
+	newHash := manifest.Hash()
+	ronl.Version = version.Version{}
+	legacyHash := manifest.Hash()
+	require.Equal(t, legacyHash, newHash)
 }
 
 func TestManifestHash_EmptyManifest(t *testing.T) {


### PR DESCRIPTION
The current solution for handling legacy manifest version updated the RONL component version after the bundle was opened. This was not the best solution as that changed the manifest hash. Furthermore, if the manager read the manifest directly from the exploded data directory, the RONL component version did't not change, causing problems if the node was restarted with cached bundles.