### PR TITLE
go/control: Show runtime block history indexer status

### DIFF
--- a/.changelog/5998.feature.md
+++ b/.changelog/5998.feature.md
@@ -1,0 +1,18 @@
+go/oasis-node: Display runtime block history indexer status
+
+A new field `indexer` has been added to the `oasis-node control status`
+output under the runtime status section. Unless keymanager runtime,
+this field displays:
+
+ 1. The status of runtime block history indexer.
+ 2. The last indexed round.
+
+Additionally, if history reindex is in progress, it also includes:
+
+- Batch size that is used during reindex.
+- Last consensus height that was indexed.
+- Start and end heights of reindex range.
+- ETA field, which specifies expected time of reindex completion.
+
+This is useful for the node operators, so that they can estimate when their
+node will be ready to accept runtime work.

--- a/go/control/api/api.go
+++ b/go/control/api/api.go
@@ -18,6 +18,7 @@ import (
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	block "github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	"github.com/oasisprotocol/oasis-core/go/runtime/bundle/component"
+	"github.com/oasisprotocol/oasis-core/go/runtime/history"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
 	upgrade "github.com/oasisprotocol/oasis-core/go/upgrade/api"
 	commonWorker "github.com/oasisprotocol/oasis-core/go/worker/common/api"
@@ -184,13 +185,14 @@ type RuntimeStatus struct {
 	// LastRetainedHash is the hash of the oldest retained block.
 	LastRetainedHash hash.Hash `json:"last_retained_hash"`
 
-	// Committee contains the runtime worker status in case this node is a (candidate) member of a
-	// runtime committee.
+	// Committee contains the runtime common committee worker status.
 	Committee *commonWorker.Status `json:"committee"`
 	// Executor contains the executor worker status in case this node is an executor node.
 	Executor *executorWorker.Status `json:"executor,omitempty"`
 	// Storage contains the storage worker status in case this node is a storage node.
 	Storage *storageWorker.Status `json:"storage,omitempty"`
+	// Indexer contains the runtime history indexer status in case this runtime has a block indexer.
+	Indexer *history.IndexerStatus `json:"indexer,omitempty"`
 
 	// Provisioner is the name of the runtime provisioner.
 	Provisioner string `json:"provisioner,omitempty"`

--- a/go/oasis-node/cmd/node/node_control.go
+++ b/go/oasis-node/cmd/node/node_control.go
@@ -319,6 +319,11 @@ func (n *Node) getRuntimeStatus(ctx context.Context) (map[common.Namespace]contr
 			}
 		}
 
+		// Fetch history indexer status.
+		if indexer, ok := n.RuntimeRegistry.Indexer(rt.ID()); ok {
+			status.Indexer = indexer.Status()
+		}
+
 		// Fetch provisioner type.
 		status.Provisioner = n.Provisioner.Name()
 

--- a/go/oasis-node/cmd/node/node_control.go
+++ b/go/oasis-node/cmd/node/node_control.go
@@ -208,6 +208,8 @@ func (n *Node) getRuntimeStatus(ctx context.Context) (map[common.Namespace]contr
 			continue
 		}
 
+		logger := n.logger.With("runtime_id", rt.ID())
+
 		var status control.RuntimeStatus
 
 		// Fetch runtime registry descriptor. Do not wait too long for the descriptor to become
@@ -221,10 +223,7 @@ func (n *Node) getRuntimeStatus(ctx context.Context) (map[common.Namespace]contr
 		case context.DeadlineExceeded:
 			// The descriptor may not yet be available. It is fine if we use nil in this case.
 		default:
-			n.logger.Error("failed to fetch registry descriptor",
-				"err", err,
-				"runtime_id", rt.ID(),
-			)
+			logger.Error("failed to fetch registry descriptor", "err", err)
 		}
 
 		// Fetch latest block as seen by this node.
@@ -244,10 +243,7 @@ func (n *Node) getRuntimeStatus(ctx context.Context) (map[common.Namespace]contr
 				Hash:      blk.Header.StateRoot,
 			}
 		default:
-			n.logger.Error("failed to fetch latest runtime block",
-				"err", err,
-				"runtime_id", rt.ID(),
-			)
+			logger.Error("failed to fetch latest runtime block", "err", err)
 		}
 
 		// Fetch latest genesis block as seen by this node.
@@ -260,10 +256,7 @@ func (n *Node) getRuntimeStatus(ctx context.Context) (map[common.Namespace]contr
 			status.GenesisRound = blk.Header.Round
 			status.GenesisHash = blk.Header.EncodedHash()
 		default:
-			n.logger.Error("failed to fetch genesis runtime block",
-				"err", err,
-				"runtime_id", rt.ID(),
-			)
+			logger.Error("failed to fetch genesis runtime block", "err", err)
 		}
 
 		// Fetch the oldest retained block.
@@ -273,10 +266,7 @@ func (n *Node) getRuntimeStatus(ctx context.Context) (map[common.Namespace]contr
 			status.LastRetainedRound = blk.Header.Round
 			status.LastRetainedHash = blk.Header.EncodedHash()
 		default:
-			n.logger.Error("failed to fetch last retained runtime block",
-				"err", err,
-				"runtime_id", rt.ID(),
-			)
+			logger.Error("failed to fetch last retained runtime block", "err", err)
 		}
 
 		// Take storage into account for last retained round.
@@ -284,9 +274,7 @@ func (n *Node) getRuntimeStatus(ctx context.Context) (map[common.Namespace]contr
 			lsb, ok := rt.Storage().(storage.LocalBackend)
 			switch ok {
 			case false:
-				n.logger.Error("local storage backend expected",
-					"runtime_id", rt.ID(),
-				)
+				logger.Error("local storage backend expected")
 			default:
 				// Update last retained round if storage earliest round is higher.
 				if earliest := lsb.NodeDB().GetEarliestVersion(); earliest > status.LastRetainedRound {
@@ -296,10 +284,9 @@ func (n *Node) getRuntimeStatus(ctx context.Context) (map[common.Namespace]contr
 						status.LastRetainedRound = blk.Header.Round
 						status.LastRetainedHash = blk.Header.EncodedHash()
 					default:
-						n.logger.Error("failed to fetch runtime block",
+						logger.Error("failed to fetch runtime block",
 							"err", err,
 							"round", earliest,
-							"runtime_id", rt.ID(),
 						)
 					}
 
@@ -312,10 +299,7 @@ func (n *Node) getRuntimeStatus(ctx context.Context) (map[common.Namespace]contr
 		if rtNode := n.CommonWorker.GetRuntime(rt.ID()); rtNode != nil {
 			status.Committee, err = rtNode.GetStatus()
 			if err != nil {
-				n.logger.Error("failed to fetch common committee worker status",
-					"err", err,
-					"runtime_id", rt.ID(),
-				)
+				logger.Error("failed to fetch common committee worker status", "err", err)
 			}
 		}
 
@@ -323,10 +307,7 @@ func (n *Node) getRuntimeStatus(ctx context.Context) (map[common.Namespace]contr
 		if execNode := n.ExecutorWorker.GetRuntime(rt.ID()); execNode != nil {
 			status.Executor, err = execNode.GetStatus()
 			if err != nil {
-				n.logger.Error("failed to fetch executor worker status",
-					"err", err,
-					"runtime_id", rt.ID(),
-				)
+				logger.Error("failed to fetch executor worker status", "err", err)
 			}
 		}
 
@@ -334,10 +315,7 @@ func (n *Node) getRuntimeStatus(ctx context.Context) (map[common.Namespace]contr
 		if storageNode := n.StorageWorker.GetRuntime(rt.ID()); storageNode != nil {
 			status.Storage, err = storageNode.GetStatus(ctx)
 			if err != nil {
-				n.logger.Error("failed to fetch storage worker status",
-					"err", err,
-					"runtime_id", rt.ID(),
-				)
+				logger.Error("failed to fetch storage worker status", "err", err)
 			}
 		}
 


### PR DESCRIPTION
Show block history indexer status, also closes #5998.



Rendexing:
```bash
      "indexer": {
        "status": "reindexing",
        "last_round": 3951368,
        "reindex_status": {
          "batch_size": 1000,
          "last_height": 18764680,
          "start_height": 18705681,
          "end_height": 25804727,
          "eta": "2025-03-28T19:30:00+01:00"
        }
      },
```
Indexing"

``` bash
      "indexer": {
        "status": "indexing",
        "last_round": xxxxxxx,
      },
```





