### PR TITLE
go/runtime/bundle: Explode bundle into an arbitrary directory

### DIFF
--- a/go/runtime/bundle/bundle_test.go
+++ b/go/runtime/bundle/bundle_test.go
@@ -111,12 +111,12 @@ func TestBundle(t *testing.T) {
 	})
 
 	t.Run("Explode", func(t *testing.T) {
-		_, err := bundle.WriteExploded(tmpDir)
+		err := bundle.WriteExploded(tmpDir)
 		require.NoError(t, err, "WriteExploded")
 
 		// Abuse the fact that we do an integrity check if the bundle
 		// is already exploded.
-		_, err = bundle.WriteExploded(tmpDir)
+		err = bundle.WriteExploded(tmpDir)
 		require.NoError(t, err, "WriteExploded(again)")
 	})
 }
@@ -179,12 +179,12 @@ func TestDetachedBundle(t *testing.T) {
 	})
 
 	t.Run("Explode", func(t *testing.T) {
-		_, err := bundle.WriteExploded(tmpDir)
+		err := bundle.WriteExploded(tmpDir)
 		require.NoError(t, err, "WriteExploded")
 
 		// Abuse the fact that we do an integrity check if the bundle
 		// is already exploded.
-		_, err = bundle.WriteExploded(tmpDir)
+		err = bundle.WriteExploded(tmpDir)
 		require.NoError(t, err, "WriteExploded(again)")
 	})
 }

--- a/go/runtime/bundle/manager.go
+++ b/go/runtime/bundle/manager.go
@@ -674,8 +674,8 @@ func (m *Manager) explodeBundle(path string, opts ...OpenOption) (*ExplodedManif
 	}
 	defer bnd.Close()
 
-	dir, err := bnd.WriteExploded(m.dataDir)
-	if err != nil {
+	dir := bnd.ExplodedPath(m.dataDir)
+	if err = bnd.WriteExploded(dir); err != nil {
 		return nil, fmt.Errorf("failed to explode bundle: %w", err)
 	}
 

--- a/go/runtime/host/sandbox/provisioner_test.go
+++ b/go/runtime/host/sandbox/provisioner_test.go
@@ -29,10 +29,8 @@ func TestProvisionerSandbox(t *testing.T) {
 	require.NoError(t, err, "bundle.Open")
 
 	tmpDir := t.TempDir()
-	_, err = bnd.WriteExploded(tmpDir)
+	err = bnd.WriteExploded(tmpDir)
 	require.NoError(t, err, "bnd.WriteExploded")
-
-	explodedDataDir := bnd.ExplodedPath(tmpDir, "")
 
 	cfg := host.Config{
 		Name: bnd.Manifest.Name,
@@ -42,7 +40,7 @@ func TestProvisionerSandbox(t *testing.T) {
 	for _, comp := range bnd.Manifest.Components {
 		cfg.Component = &bundle.ExplodedComponent{
 			Component:       comp,
-			ExplodedDataDir: explodedDataDir,
+			ExplodedDataDir: tmpDir,
 		}
 
 		t.Run(fmt.Sprintf("Naked %s", comp.ID()), func(t *testing.T) {

--- a/go/runtime/host/sgx/provisioner_test.go
+++ b/go/runtime/host/sgx/provisioner_test.go
@@ -52,10 +52,8 @@ func TestProvisionerSGX(t *testing.T) {
 	require.NoError(err, "bundle.Open")
 
 	tmpDir := t.TempDir()
-	_, err = bnd.WriteExploded(tmpDir)
+	err = bnd.WriteExploded(tmpDir)
 	require.NoError(err, "bnd.WriteExploded")
-
-	explodedDataDir := bnd.ExplodedPath(tmpDir, "")
 
 	ias, err := iasHttp.New(&iasHttp.Config{
 		SPID:               "9b3085a55a5863f7cc66b380dcad0082",
@@ -79,7 +77,7 @@ func TestProvisionerSGX(t *testing.T) {
 	for _, comp := range bnd.Manifest.Components {
 		cfg.Component = &bundle.ExplodedComponent{
 			Component:       comp,
-			ExplodedDataDir: explodedDataDir,
+			ExplodedDataDir: tmpDir,
 		}
 
 		t.Run(fmt.Sprintf("Naked %s", comp.ID()), func(t *testing.T) {


### PR DESCRIPTION
Maybe this will be useful in the future. I’m not sure yet and don’t want to throw away the changes.