### PR TITLE
go/roothash: Parallelize history reindexes

### DIFF
--- a/.changelog/6031.feature.md
+++ b/.changelog/6031.feature.md
@@ -5,6 +5,5 @@ relative to each other. By parallelizing this process, we significantly
 speed-up history reindex, when multiple runtimes are configured.
 
 Moreover, this change resolves an existing issue, where adding a new runtime
-could cause the reindexing of all other runtimes to be delayed until the newly
-added runtime completes reindexing, even if those other runtimes were only
-a few rounds away from sync.
+causes the reindexing and event processing of all other runtimes to be
+blocked when the newly added runtime starts its history reindex.

--- a/.changelog/6031.feature.md
+++ b/.changelog/6031.feature.md
@@ -1,0 +1,10 @@
+`go/consensus/cometbft/roothash: Parallelize history reindex
+
+Previously, the history reindexing of runtimes was performed sequentially
+relative to each other. By parallelizing this process, we significantly
+speed-up history reindex, when multiple runtimes are configured.
+
+Moreover, this change resolves an existing issue, where adding a new runtime
+could cause the reindexing of all other runtimes to be delayed until the newly
+added runtime completes reindexing, even if those other runtimes were only
+a few rounds away from sync.


### PR DESCRIPTION
Part of #5738 

# What
1. Run multiple history reindexes in parallel:
     * Bottleneck will always be iteration over all consensus blocks...
     * However in case of `n` runtimes we already gain almost `n` speed-up, since reindex was sequentiall for each runtime until now.
2. >One additional related thing that I remember from the past is that we currently block starting any runtimes until all have completed the history reindex. This could likely be improved as well. But probably belongs in a separate issue.
    * This was the case if you added new runtime, so you needed to reindex it. ~If the first received reindex command was for this new runtime, you were blocking ready status of all other runtimes, that might be only few heights behind... This is also fixed here~. This was the case the moment you started reindexing new runtime, since you were also blocking receiving events for other runtimes, even if their history has been reindexed prior to the new runtime history reindex started -> will fix the changelog.


# How to test/benchmark

I am running local testnet with `sapphire`, `emerald` and `cipher` set. I start with synced consensus. I deleted the `data/runtimes` datadir, to trigger history reindex from the start. Before this change it took around 6h (2h per runtime) for it to finish. Now it happens in ~2h20min (in parallel).

## TODO

Benchmark history reindex whilst doing consensus sync.

