### PR TITLE
go/runtime/bundle: Don't abort when some manifests cannot be loaded

### DIFF
--- a/go/runtime/bundle/manager.go
+++ b/go/runtime/bundle/manager.go
@@ -508,12 +508,20 @@ func (m *Manager) loadManifests() ([]*ExplodedManifest, error) {
 
 		b, err := os.ReadFile(filepath.Join(dir, manifestName))
 		if err != nil {
-			return nil, fmt.Errorf("failed to read manifest: %w", err)
+			m.logger.Warn("skipping unreadable manifest",
+				"path", dir,
+				"err", err,
+			)
+			continue
 		}
 
 		var manifest Manifest
 		if err = json.Unmarshal(b, &manifest); err != nil {
-			return nil, fmt.Errorf("failed to parse manifest: %w", err)
+			m.logger.Warn("skipping malformed manifest",
+				"path", dir,
+				"err", err,
+			)
+			continue
 		}
 
 		m.logger.Info("manifest loaded",


### PR DESCRIPTION
When upgrading from earlier versions the exploded bundle directory may contain non-bundle subdirectories which should not cause the loader to fail.