### PR TITLE
go/roothash: Batch history reindex writes 

### DIFF
--- a/.changelog/6069.feature.md
+++ b/.changelog/6069.feature.md
@@ -1,0 +1,4 @@
+go/roothash: Optimize runtime history reindex
+
+During runtime history reindex, we batch writes resulting in significant
+speed-up of history reindex.

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -368,7 +368,7 @@ func (sc *serviceClient) reindexBlocks(ctx context.Context, currentHeight int64,
 		sc.logger.Error("failed to get last indexed height",
 			"err", err,
 		)
-		return lastRound, fmt.Errorf("failed to get last indexed height: %w", err)
+		return 0, fmt.Errorf("failed to get last indexed height: %w", err)
 	}
 	// +1 since we want the last non-seen height.
 	lastHeight++
@@ -376,7 +376,7 @@ func (sc *serviceClient) reindexBlocks(ctx context.Context, currentHeight int64,
 	// Take prune strategy into account.
 	lastRetainedHeight, err := sc.backend.GetLastRetainedVersion(ctx)
 	if err != nil {
-		return lastRound, fmt.Errorf("failed to get last retained height: %w", err)
+		return 0, fmt.Errorf("failed to get last retained height: %w", err)
 	}
 	if lastHeight < lastRetainedHeight {
 		logger.Debug("last height pruned, skipping until last retained",
@@ -389,7 +389,7 @@ func (sc *serviceClient) reindexBlocks(ctx context.Context, currentHeight int64,
 	// Take initial genesis height into account.
 	genesisDoc, err := sc.backend.GetGenesisDocument(ctx)
 	if err != nil {
-		return lastRound, fmt.Errorf("failed to get genesis document: %w", err)
+		return 0, fmt.Errorf("failed to get genesis document: %w", err)
 	}
 	if lastHeight < genesisDoc.Height {
 		lastHeight = genesisDoc.Height
@@ -412,7 +412,7 @@ func (sc *serviceClient) reindexBlocks(ctx context.Context, currentHeight int64,
 				"err", err,
 				"height", height,
 			)
-			return lastRound, fmt.Errorf("failed to get cometbft block results: %w", err)
+			return 0, fmt.Errorf("failed to get cometbft block results: %w", err)
 		}
 
 		// Index block.

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -616,39 +616,9 @@ func (sc *serviceClient) processFinalizedEvent(
 	}
 
 	// Process finalized event.
-	var blk *block.Block
-	if blk, err = sc.getLatestBlockAt(ctx, runtimeID, height); err != nil {
-		sc.logger.Error("failed to fetch latest block",
-			"err", err,
-			"height", height,
-			"runtime_id", runtimeID,
-		)
-		return fmt.Errorf("roothash: failed to fetch latest block: %w", err)
-	}
-	if round != nil && blk.Header.Round != *round {
-		sc.logger.Error("finalized event/query round mismatch",
-			"block_round", blk.Header.Round,
-			"event_round", *round,
-		)
-		return fmt.Errorf("roothash: finalized event/query round mismatch")
-	}
-
-	roundResults, err := sc.GetLastRoundResults(ctx, &api.RuntimeRequest{
-		RuntimeID: runtimeID,
-		Height:    height,
-	})
+	annBlk, roundResults, err := sc.fetchFinalizedRound(ctx, height, runtimeID, round)
 	if err != nil {
-		sc.logger.Error("failed to fetch round results",
-			"err", err,
-			"height", height,
-			"runtime_id", runtimeID,
-		)
-		return fmt.Errorf("roothash: failed to fetch round results: %w", err)
-	}
-
-	annBlk := &api.AnnotatedBlock{
-		Height: height,
-		Block:  blk,
+		return fmt.Errorf("failed to fetch roothash finalized round: %w", err)
 	}
 
 	// Commit the block to history if needed.
@@ -673,11 +643,11 @@ func (sc *serviceClient) processFinalizedEvent(
 		// Only commit the block in case it was not already committed during reindex. Note that even
 		// in case we only reindex up to height-1 this can still happen on the first emitted block
 		// since that height is not guaranteed to be the one that contains a round finalized event.
-		if lastRound == api.RoundInvalid || blk.Header.Round > lastRound {
+		if lastRound == api.RoundInvalid || annBlk.Block.Header.Round > lastRound {
 			sc.logger.Debug("commit block",
 				"runtime_id", runtimeID,
 				"height", height,
-				"round", blk.Header.Round,
+				"round", annBlk.Block.Header.Round,
 			)
 
 			err = tr.blockHistory.Commit(annBlk, roundResults, !isReindex)
@@ -686,7 +656,7 @@ func (sc *serviceClient) processFinalizedEvent(
 					"err", err,
 					"runtime_id", runtimeID,
 					"height", height,
-					"round", blk.Header.Round,
+					"round", annBlk.Block.Header.Round,
 				)
 				return fmt.Errorf("failed to commit block to history keeper: %w", err)
 			}
@@ -700,11 +670,54 @@ func (sc *serviceClient) processFinalizedEvent(
 
 	notifiers := sc.getRuntimeNotifiers(runtimeID)
 	notifiers.blockNotifier.Broadcast(annBlk)
-	sc.allBlockNotifier.Broadcast(blk)
+	sc.allBlockNotifier.Broadcast(annBlk.Block)
 
 	tr.height = height
 
 	return nil
+}
+
+func (sc *serviceClient) fetchFinalizedRound(
+	ctx context.Context,
+	height int64,
+	runtimeID common.Namespace,
+	round *uint64,
+) (*api.AnnotatedBlock, *api.RoundResults, error) {
+	blk, err := sc.getLatestBlockAt(ctx, runtimeID, height)
+	if err != nil {
+		sc.logger.Error("failed to fetch latest block",
+			"err", err,
+			"height", height,
+			"runtime_id", runtimeID,
+		)
+		return nil, nil, fmt.Errorf("roothash: failed to fetch latest block: %w", err)
+	}
+	if round != nil && blk.Header.Round != *round {
+		sc.logger.Error("finalized event/query round mismatch",
+			"block_round", blk.Header.Round,
+			"event_round", *round,
+		)
+		return nil, nil, fmt.Errorf("roothash: finalized event/query round mismatch")
+	}
+
+	roundResults, err := sc.GetLastRoundResults(ctx, &api.RuntimeRequest{
+		RuntimeID: runtimeID,
+		Height:    height,
+	})
+	if err != nil {
+		sc.logger.Error("failed to fetch round results",
+			"err", err,
+			"height", height,
+			"runtime_id", runtimeID,
+		)
+		return nil, nil, fmt.Errorf("roothash: failed to fetch round results: %w", err)
+	}
+
+	annBlk := &api.AnnotatedBlock{
+		Height: height,
+		Block:  blk,
+	}
+	return annBlk, roundResults, nil
 }
 
 // EventsFromCometBFT extracts staking events from CometBFT events.

--- a/go/roothash/api/history.go
+++ b/go/roothash/api/history.go
@@ -18,12 +18,27 @@ type BlockHistory interface {
 	// RuntimeID returns the runtime ID of the runtime this block history is for.
 	RuntimeID() common.Namespace
 
-	// Commit commits an annotated block into history. If notify is set to true,
-	// the watchers will be notified about the new block. Disable notify when
-	// doing reindexing.
+	// Commit commits an annotated block with corresponding round results.
 	//
-	// Must be called in order, sorted by round.
-	Commit(blk *AnnotatedBlock, roundResults *RoundResults, notify bool) error
+	// If notify is set to true, the watchers will be notified about the new block.
+	//
+	// Any sequence of Commit and CommitBatch calls is valid as long as as blocks
+	// are sorted by round.
+	//
+	// Returns an error if a block at higher or equal round was already committed.
+	Commit(blk *AnnotatedBlock, result *RoundResults, notify bool) error
+
+	// CommitBatch commits annotated blocks with corresponding round results.
+	//
+	// If notify is set to true, the watchers will be notified about all
+	// blocks in batch.
+	//
+	// Within a batch, blocks should be sorted by round. Any sequence of Commit
+	// and CommitBatch calls is valid as long as blocks are sorted by round.
+	//
+	// Returns an error if a block at higher or equal round than the first item
+	// in a batch was already committed.
+	CommitBatch(blks []*AnnotatedBlock, results []*RoundResults, notify bool) error
 
 	// StorageSyncCheckpoint records the last storage round which was synced
 	// to runtime storage.

--- a/go/roothash/api/history.go
+++ b/go/roothash/api/history.go
@@ -25,13 +25,6 @@ type BlockHistory interface {
 	// Must be called in order, sorted by round.
 	Commit(blk *AnnotatedBlock, roundResults *RoundResults, notify bool) error
 
-	// ConsensusCheckpoint records the last consensus height which was processed
-	// by the roothash backend.
-	//
-	// This method can only be called once all roothash blocks for consensus
-	// heights <= height have been committed using Commit.
-	ConsensusCheckpoint(height int64) error
-
 	// StorageSyncCheckpoint records the last storage round which was synced
 	// to runtime storage.
 	StorageSyncCheckpoint(round uint64) error

--- a/go/runtime/history/db.go
+++ b/go/runtime/history/db.go
@@ -149,25 +149,6 @@ func (d *DB) metadata() (*dbMetadata, error) {
 	return meta, nil
 }
 
-func (d *DB) consensusCheckpoint(height int64) error {
-	return d.db.Update(func(tx *badger.Txn) error {
-		meta, err := d.queryGetMetadata(tx)
-		if err != nil {
-			return err
-		}
-
-		if height < meta.LastConsensusHeight {
-			return fmt.Errorf("runtime/history: consensus checkpoint at lower height (current: %d wanted: %d)",
-				meta.LastConsensusHeight,
-				height,
-			)
-		}
-
-		meta.LastConsensusHeight = height
-		return tx.Set(metadataKeyFmt.Encode(), cbor.Marshal(meta))
-	})
-}
-
 func (d *DB) commit(blk *roothash.AnnotatedBlock, roundResults *roothash.RoundResults) error {
 	return d.db.Update(func(tx *badger.Txn) error {
 		meta, err := d.queryGetMetadata(tx)

--- a/go/runtime/history/db.go
+++ b/go/runtime/history/db.go
@@ -149,48 +149,59 @@ func (d *DB) metadata() (*dbMetadata, error) {
 	return meta, nil
 }
 
-func (d *DB) commit(blk *roothash.AnnotatedBlock, roundResults *roothash.RoundResults) error {
+func (d *DB) commit(blks []*roothash.AnnotatedBlock, results []*roothash.RoundResults) error {
+	if len(blks) != len(results) {
+		return fmt.Errorf("length mismatch (blocks: %d round results: %d)",
+			len(blks),
+			len(results),
+		)
+	}
+	if len(blks) == 0 {
+		return nil
+	}
+
 	return d.db.Update(func(tx *badger.Txn) error {
 		meta, err := d.queryGetMetadata(tx)
 		if err != nil {
 			return err
 		}
 
-		rtID := blk.Block.Header.Namespace
-		if !rtID.Equal(&meta.RuntimeID) {
-			return fmt.Errorf("runtime/history: runtime mismatch (expected: %s got: %s)",
-				meta.RuntimeID,
-				rtID,
-			)
-		}
+		for i, blk := range blks {
+			rtID := blk.Block.Header.Namespace
+			if !rtID.Equal(&meta.RuntimeID) {
+				return fmt.Errorf("runtime mismatch (expected: %s got: %s)",
+					meta.RuntimeID,
+					rtID,
+				)
+			}
 
-		if blk.Height < meta.LastConsensusHeight {
-			return fmt.Errorf("runtime/history: commit at lower consensus height (current: %d wanted: %d)",
-				meta.LastConsensusHeight,
-				blk.Height,
-			)
-		}
+			if blk.Height < meta.LastConsensusHeight {
+				return fmt.Errorf("commit at lower consensus height (current: %d wanted: %d)",
+					meta.LastConsensusHeight,
+					blk.Height,
+				)
+			}
 
-		if blk.Block.Header.Round <= meta.LastRound && meta.LastConsensusHeight != 0 {
-			return fmt.Errorf("runtime/history: commit at lower round (current: %d wanted: %d)",
-				meta.LastRound,
-				blk.Block.Header.Round,
-			)
-		}
+			if blk.Block.Header.Round <= meta.LastRound && meta.LastConsensusHeight != 0 {
+				return fmt.Errorf("commit at lower or equal round (current: %d wanted: %d)",
+					meta.LastRound,
+					blk.Block.Header.Round,
+				)
+			}
 
-		if err = tx.Set(blockKeyFmt.Encode(blk.Block.Header.Round), cbor.Marshal(blk)); err != nil {
-			return err
-		}
+			if err := tx.Set(blockKeyFmt.Encode(blk.Block.Header.Round), cbor.Marshal(blk)); err != nil {
+				return err
+			}
 
-		if err = tx.Set(roundResultsKeyFmt.Encode(blk.Block.Header.Round), cbor.Marshal(roundResults)); err != nil {
-			return err
-		}
+			if err := tx.Set(roundResultsKeyFmt.Encode(blk.Block.Header.Round), cbor.Marshal(results[i])); err != nil {
+				return err
+			}
 
-		meta.LastRound = blk.Block.Header.Round
-		if blk.Height > meta.LastConsensusHeight {
-			meta.LastConsensusHeight = blk.Height
+			meta.LastRound = blk.Block.Header.Round
+			if blk.Height > meta.LastConsensusHeight {
+				meta.LastConsensusHeight = blk.Height
+			}
 		}
-
 		return tx.Set(metadataKeyFmt.Encode(), cbor.Marshal(meta))
 	})
 }

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -54,10 +54,6 @@ func (h *nopHistory) Commit(*roothash.AnnotatedBlock, *roothash.RoundResults, bo
 	return errNopHistory
 }
 
-func (h *nopHistory) ConsensusCheckpoint(int64) error {
-	return errNopHistory
-}
-
 func (h *nopHistory) StorageSyncCheckpoint(uint64) error {
 	return errNopHistory
 }
@@ -155,10 +151,6 @@ func (h *runtimeHistory) Commit(blk *roothash.AnnotatedBlock, roundResults *root
 	h.blocksNotifier.Broadcast(blk)
 
 	return nil
-}
-
-func (h *runtimeHistory) ConsensusCheckpoint(height int64) error {
-	return h.db.consensusCheckpoint(height)
 }
 
 func (h *runtimeHistory) StorageSyncCheckpoint(round uint64) error {

--- a/go/runtime/history/history_test.go
+++ b/go/runtime/history/history_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 )
@@ -170,6 +171,121 @@ func TestHistory(t *testing.T) {
 	require.Equal(roundResults, gotResults, "GetRoundResults should return the correct results")
 }
 
+func TestCommitBatch(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	dataDir, err := os.MkdirTemp("", "oasis-runtime-history-test_")
+	require.NoError(err, "TempDir")
+	defer os.RemoveAll(dataDir)
+
+	runtimeID1 := common.NewTestNamespaceFromSeed([]byte("history test ns 1"), 0)
+	runtimeID2 := common.NewTestNamespaceFromSeed([]byte("history test ns 2"), 0)
+
+	prunerFactory := NewNonePrunerFactory()
+	history, err := New(runtimeID1, dataDir, prunerFactory, true)
+	require.NoError(err, "New")
+
+	require.Equal(runtimeID1, history.RuntimeID())
+
+	// Sample data.
+	blk1 := roothash.AnnotatedBlock{
+		Height: 1,
+		Block:  block.NewGenesisBlock(runtimeID1, 0),
+	}
+	blk2 := roothash.AnnotatedBlock{
+		Height: 3,
+		Block:  block.NewGenesisBlock(runtimeID2, 0),
+	}
+	blk2.Block.Header.Round = 1
+	results1 := &roothash.RoundResults{
+		Messages: []*roothash.MessageEvent{
+			{Module: "", Code: 0, Index: 0},
+			{Module: "", Code: 0, Index: 1},
+		},
+	}
+	results2 := &roothash.RoundResults{
+		Messages: []*roothash.MessageEvent{
+			{Module: "", Code: 1, Index: 0},
+		},
+	}
+
+	err = history.CommitBatch(nil, nil, true)
+	require.NoError(err, "CommitBatch should succeed for empty batch")
+
+	err = history.CommitBatch([]*roothash.AnnotatedBlock{&blk1, &blk2},
+		[]*roothash.RoundResults{results1},
+		true,
+	)
+	require.Error(err, "CommitBatch should fail when slices don't have equal size")
+
+	err = history.CommitBatch([]*roothash.AnnotatedBlock{&blk1, &blk2},
+		[]*roothash.RoundResults{results1, results2},
+		true,
+	)
+	require.Error(err, "CommitBatch should fail when different runtimes IDs")
+
+	copy(blk2.Block.Header.Namespace[:], blk1.Block.Header.Namespace[:])
+
+	// Commit batch in wrong order: round 1 and 0 at consenus height 3 and 1.
+	err = history.CommitBatch([]*roothash.AnnotatedBlock{&blk2, &blk1},
+		[]*roothash.RoundResults{results2, results1},
+		true,
+	)
+	require.Error(err, "CommitBatch should fail for unordered batch")
+
+	// Commit batch round 0 and 1 at consenus height 1 and 3.
+	err = history.CommitBatch([]*roothash.AnnotatedBlock{&blk1, &blk2},
+		[]*roothash.RoundResults{results1, results2},
+		true,
+	)
+	require.NoError(err, "CommitBatch")
+
+	lastHeight, err := history.LastConsensusHeight()
+	require.NoError(err, "LastConsensusHeight")
+	require.EqualValues(3, lastHeight)
+
+	gotBlock, err := history.GetCommittedBlock(ctx, 0)
+	require.NoError(err, "GetCommittedBlock(0)")
+	require.Equal(blk1.Block, gotBlock, "GetCommittedBlock should return the correct block")
+
+	gotBlock, err = history.GetCommittedBlock(ctx, api.RoundLatest)
+	require.NoError(err, "GetCommittedBlock(RoundLatest)")
+	require.Equal(blk2.Block, gotBlock, "GetCommittedBlock should return the correct block")
+
+	// Commit for the latest height and round should fail
+	err = history.Commit(&blk2, nil, true)
+	require.Error(err, "Commit should fail for same consensus height")
+
+	// Commit for the latest round should fail.
+	blk2.Height = 4
+	err = history.Commit(&blk2, nil, true)
+	require.Error(err, "Commit should fail for same round")
+
+	// Commit after batch commit should succeed when round and height increases.
+	blk2.Block.Header.Round = 2
+	err = history.Commit(&blk2, nil, true)
+	require.NoError(err, "Commit")
+
+	err = history.StorageSyncCheckpoint(2)
+	require.NoError(err, "StorageSyncCheckpoint should work")
+
+	gotAnnBlk, err := history.GetAnnotatedBlock(ctx, 2)
+	require.NoError(err, "GetAnnotatedBlock")
+	require.Equal(&blk2, gotAnnBlk, "GetAnnotatedBlock should return the correct block")
+
+	// Try committing another batch after a single commit.
+	blk1.Height = 5
+	blk2.Height = 7
+	blk1.Block.Header.Round = 5
+	blk2.Block.Header.Round = 6
+	err = history.CommitBatch([]*roothash.AnnotatedBlock{&blk1, &blk2},
+		[]*roothash.RoundResults{nil, nil},
+		false,
+	)
+	require.NoError(err, "CommitBatch")
+}
+
 func testWatchBlocks(t *testing.T, history History, expectedRound uint64) {
 	t.Helper()
 	require := require.New(t)
@@ -228,6 +344,8 @@ func TestWatchBlocks(t *testing.T) {
 			{Module: "", Code: 1, Index: 0},
 		},
 	}
+	blocks := []*roothash.AnnotatedBlock{&blk1, &blk2}
+	results := []*roothash.RoundResults{results1, nil}
 
 	// Test history with local storage.
 	prunerFactory := NewNonePrunerFactory()
@@ -235,8 +353,8 @@ func TestWatchBlocks(t *testing.T) {
 	require.NoError(err, "New")
 	// No blocks should be received.
 	testWatchBlocks(t, history, 0)
-	// Commit a block.
-	err = history.Commit(&blk1, results1, true) // notify=true
+	// Commit a block and notify.
+	err = history.Commit(&blk1, results1, true)
 	require.NoError(err, "Commit")
 	// No blocks should be received.
 	testWatchBlocks(t, history, 0)
@@ -281,7 +399,43 @@ func TestWatchBlocks(t *testing.T) {
 	require.NoError(err, "WaitRoundSynced")
 	require.EqualValues(11, r, "WaitRoundSynced")
 	// Committing storage checkpoint should panic.
-	assert.Panics(t, func() { _ = history.StorageSyncCheckpoint(11) }, "StorageSyncCheckpoint should panic")
+	assert.Panics(t, func() { _ = history.StorageSyncCheckpoint(10) }, "StorageSyncCheckpoint should panic")
+
+	// Test history with local storage and batching.
+	dataDir3, err := os.MkdirTemp("", "oasis-runtime-history-test_")
+	require.NoError(err, "TempDir")
+	defer os.RemoveAll(dataDir3)
+	history, err = New(runtimeID, dataDir3, prunerFactory, true)
+	require.NoError(err, "New")
+	testWatchBlocks(t, history, 0)
+	// Commit batch without notifying.
+	err = history.CommitBatch(blocks, results, false)
+	require.NoError(err, "CommitBatch")
+	// In case of a local storage, we broadcast blocks when
+	// StorageSyncCheckpoint is called, regardless of notify flag.
+	testWatchBlocks(t, history, 0)
+	err = history.StorageSyncCheckpoint(10)
+	require.NoError(err, "StorageSyncCheckpoint")
+	testWatchBlocks(t, history, 10)
+	err = history.StorageSyncCheckpoint(11)
+	require.NoError(err, "StorageSyncCheckpoint")
+	// Wait synced round so that notifier processes it.
+	_, err = history.WaitRoundSynced(ctx, 11)
+	require.NoError(err, "WaitRoundSynced")
+	testWatchBlocks(t, history, 11)
+
+	// Test history without local storage and with batching.
+	dataDir4, err := os.MkdirTemp("", "oasis-runtime-history-test_")
+	require.NoError(err, "TempDir")
+	defer os.RemoveAll(dataDir4)
+	history, err = New(runtimeID, dataDir4, prunerFactory, false)
+	require.NoError(err, "New")
+	testWatchBlocks(t, history, 0)
+	// Commit batch without notifying.
+	err = history.CommitBatch(blocks, results, false)
+	require.NoError(err, "CommitBatch")
+	// No block should be received since we set notify to false.
+	testWatchBlocks(t, history, 0)
 }
 
 type testPruneHandler struct {
@@ -331,8 +485,11 @@ func TestHistoryPrune(t *testing.T) {
 	}
 	history.Pruner().RegisterHandler(&ph)
 
-	// Create some blocks.
-	for i := 0; i <= 50; i++ {
+	const n = 51
+
+	blks := make([]*roothash.AnnotatedBlock, n)
+	results := make([]*roothash.RoundResults, n)
+	for i := 0; i < n; i++ {
 		blk := roothash.AnnotatedBlock{
 			Height: int64(i),
 			Block:  block.NewGenesisBlock(runtimeID, 0),
@@ -346,18 +503,31 @@ func TestHistoryPrune(t *testing.T) {
 				{Module: "", Code: 0, Index: 1},
 			}
 		}
-
 		roundResults := &roothash.RoundResults{
 			Messages: msgResults,
 		}
-
-		err = history.Commit(&blk, roundResults, true)
-		require.NoError(err, "Commit")
-
-		err = history.StorageSyncCheckpoint(blk.Block.Header.Round)
-		require.NoError(err, "StorageSyncCheckpoint")
+		blks[i] = &blk
+		results[i] = roundResults
 	}
 
+	// Commit first 30 blocks in a batch of 10.
+	err = history.CommitBatch(blks[:10], results[:10], false)
+	require.NoError(err, "Commit")
+	err = history.CommitBatch(blks[10:20], results[10:20], false)
+	require.NoError(err, "Commit")
+	err = history.CommitBatch(blks[20:30], results[20:30], false)
+	require.NoError(err, "Commit")
+
+	// Commit remaining 20 blocks one by one.
+	for i := 30; i < n; i++ {
+		err = history.Commit(blks[i], results[i], true)
+		require.NoError(err, "Commit")
+	}
+	// Simulate storage syncing.
+	for i := 0; i < n; i++ {
+		err = history.StorageSyncCheckpoint(blks[i].Block.Header.Round)
+		require.NoError(err, "StorageSyncCheckpoint")
+	}
 	// No more blocks after this point.
 
 	// Wait for pruning to complete.
@@ -384,7 +554,7 @@ func TestHistoryPrune(t *testing.T) {
 	}
 
 	// Ensure we can only lookup the last 10 blocks.
-	for i := 0; i <= 50; i++ {
+	for i := 0; i < n; i++ {
 		_, err = history.GetBlock(ctx, uint64(i))
 		if i <= 40 {
 			require.Error(err, "GetBlock should fail for pruned block %d", i)


### PR DESCRIPTION
Closes #6069 
# What 

During history reindex, we now batch `1000` writes at the same time.

# Why
As from the [benchmarks](https://docs.google.com/document/d/1Lq-Qe6jrrLUSKIkLLsIGOrfb31Ivi-hZKP0wAC50V1E/edit?tab=t.0#heading=h.rg3qm3z5hci9), this already gives 2-3x performance gain for the single threaded program.

Given its simplicity and the fact, that it will be required by all possible solutions, this is a natural start.