### PR TITLE
Hacky benchmark of history reindex

### DIFF
--- a/.changelog/5738.feature.md
+++ b/.changelog/5738.feature.md
@@ -1,0 +1,4 @@
+go/roothahs: Optimize runtime history reindex
+
+During runtime history reindex, we batch 1000 writes at the same time,
+resulting in 2x speed-up of history reindex.

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -402,7 +402,7 @@ func (sc *serviceClient) reindexBlocks(currentHeight int64, bh api.BlockHistory)
 		sc.logger.Error("failed to get last indexed height",
 			"err", err,
 		)
-		return lastRound, fmt.Errorf("failed to get last indexed height: %w", err)
+		return 0, fmt.Errorf("failed to get last indexed height: %w", err)
 	}
 	// +1 since we want the last non-seen height.
 	lastHeight++
@@ -410,7 +410,7 @@ func (sc *serviceClient) reindexBlocks(currentHeight int64, bh api.BlockHistory)
 	// Take prune strategy into account.
 	lastRetainedHeight, err := sc.backend.GetLastRetainedVersion(sc.ctx)
 	if err != nil {
-		return lastRound, fmt.Errorf("failed to get last retained height: %w", err)
+		return 0, fmt.Errorf("failed to get last retained height: %w", err)
 	}
 	if lastHeight < lastRetainedHeight {
 		logger.Debug("last height pruned, skipping until last retained",
@@ -423,7 +423,7 @@ func (sc *serviceClient) reindexBlocks(currentHeight int64, bh api.BlockHistory)
 	// Take initial genesis height into account.
 	genesisDoc, err := sc.backend.GetGenesisDocument(sc.ctx)
 	if err != nil {
-		return lastRound, fmt.Errorf("failed to get genesis document: %w", err)
+		return 0, fmt.Errorf("failed to get genesis document: %w", err)
 	}
 	if lastHeight < genesisDoc.Height {
 		lastHeight = genesisDoc.Height
@@ -446,7 +446,7 @@ func (sc *serviceClient) reindexBlocks(currentHeight int64, bh api.BlockHistory)
 				"err", err,
 				"height", height,
 			)
-			return lastRound, fmt.Errorf("failed to get cometbft block results: %w", err)
+			return 0, fmt.Errorf("failed to get cometbft block results: %w", err)
 		}
 
 		// Index block.

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -387,7 +387,7 @@ func (sc *serviceClient) getRuntimeNotifiers(id common.Namespace) *runtimeBroker
 	return notifiers
 }
 
-func (sc *serviceClient) reindexBlocks(currentHeight int64, bh api.BlockHistory) (uint64, error) {
+func (sc *serviceClient) reindexBlocks(ctx context.Context, currentHeight int64, bh api.BlockHistory) (uint64, error) {
 	lastRound := api.RoundInvalid
 	if currentHeight <= 0 {
 		return lastRound, nil
@@ -500,9 +500,22 @@ func (sc *serviceClient) reindexBlocks(currentHeight int64, bh api.BlockHistory)
 			if !evRtID.Equal(&runtimeID) {
 				continue
 			}
-			if err = sc.processFinalizedEvent(sc.ctx, height, *evRtID, &ev.Round, true); err != nil {
-				return 0, fmt.Errorf("failed to process finalized event: %w", err)
+
+			annBlk, roundResults, err := sc.fetchFinalizedRound(ctx, height, runtimeID, &ev.Round)
+			if err != nil {
+				return 0, fmt.Errorf("failed to fetch roothash finalized round: %w", err)
 			}
+			err = bh.Commit(annBlk, roundResults, false)
+			if err != nil {
+				sc.logger.Error("failed to commit block to history keeper",
+					"err", err,
+					"runtime_id", runtimeID,
+					"height", height,
+					"round", annBlk.Block.Header.Round,
+				)
+				return 0, fmt.Errorf("failed to commit block to history keeper: %w", err)
+			}
+
 			lastRound = ev.Round
 		}
 	}
@@ -573,7 +586,7 @@ func (sc *serviceClient) DeliverCommand(ctx context.Context, height int64, cmd i
 		}
 
 		// Emit latest block.
-		if err := sc.processFinalizedEvent(ctx, rs.LastBlockHeight, tr.runtimeID, nil, false); err != nil {
+		if err := sc.processFinalizedEvent(ctx, rs.LastBlockHeight, tr.runtimeID, nil); err != nil {
 			sc.logger.Warn("failed to emit latest block",
 				"err", err,
 				"runtime_id", tr.runtimeID,
@@ -607,7 +620,7 @@ func (sc *serviceClient) DeliverEvent(ctx context.Context, height int64, tx cmtt
 		if sc.trackedRuntime[ev.RuntimeID] == nil {
 			continue
 		}
-		if err = sc.processFinalizedEvent(ctx, height, ev.RuntimeID, &ev.Finalized.Round, false); err != nil { //nolint:gosec
+		if err = sc.processFinalizedEvent(ctx, height, ev.RuntimeID, &ev.Finalized.Round); err != nil { //nolint:gosec
 			return fmt.Errorf("roothash: failed to process finalized event: %w", err)
 		}
 	}
@@ -626,7 +639,6 @@ func (sc *serviceClient) processFinalizedEvent(
 	height int64,
 	runtimeID common.Namespace,
 	round *uint64,
-	isReindex bool,
 ) (err error) {
 	tr := sc.trackedRuntime[runtimeID]
 	if tr == nil {
@@ -661,10 +673,10 @@ func (sc *serviceClient) processFinalizedEvent(
 
 		// Perform reindex if required.
 		lastRound := api.RoundInvalid
-		if !isReindex && !tr.reindexDone {
+		if !tr.reindexDone {
 			// Note that we need to reindex up to the previous height as the current height is
 			// already being processed right now.
-			if lastRound, err = sc.reindexBlocks(height-1, tr.blockHistory); err != nil {
+			if lastRound, err = sc.reindexBlocks(ctx, height-1, tr.blockHistory); err != nil {
 				sc.logger.Error("failed to reindex blocks",
 					"err", err,
 					"runtime_id", runtimeID,
@@ -684,7 +696,7 @@ func (sc *serviceClient) processFinalizedEvent(
 				"round", annBlk.Block.Header.Round,
 			)
 
-			err = tr.blockHistory.Commit(annBlk, roundResults, !isReindex)
+			err = tr.blockHistory.Commit(annBlk, roundResults, true)
 			if err != nil {
 				sc.logger.Error("failed to commit block to history keeper",
 					"err", err,
@@ -695,11 +707,6 @@ func (sc *serviceClient) processFinalizedEvent(
 				return fmt.Errorf("failed to commit block to history keeper: %w", err)
 			}
 		}
-	}
-
-	// Skip emitting events if we are reindexing.
-	if isReindex {
-		return nil
 	}
 
 	notifiers := sc.getRuntimeNotifiers(runtimeID)

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -448,7 +448,7 @@ func (sc *serviceClient) reindexBlocks(ctx context.Context, currentHeight int64,
 		if err != nil {
 			return 0, fmt.Errorf("failed to commit batch to history keeper: %w", err)
 		}
-		if last != api.RoundInvalid && last > lastRound {
+		if last != api.RoundInvalid && (lastRound == api.RoundInvalid || last > lastRound) {
 			lastRound = last
 		}
 	}

--- a/go/roothash/api/history.go
+++ b/go/roothash/api/history.go
@@ -25,6 +25,13 @@ type BlockHistory interface {
 	// Must be called in order, sorted by round.
 	Commit(blk *AnnotatedBlock, roundResults *RoundResults, notify bool) error
 
+	// CommitBatch commits annotated blocks and corresponding round results,
+	// into runtime history.
+	//
+	// Watcher will not be notified about new blocks since this method is only
+	// meant to be used during reindex.
+	CommitBatch(blks []*AnnotatedBlock, roundResults []*RoundResults) error
+
 	// ConsensusCheckpoint records the last consensus height which was processed
 	// by the roothash backend.
 	//

--- a/go/runtime/history/db.go
+++ b/go/runtime/history/db.go
@@ -223,33 +223,33 @@ func (d *DB) commitBatch(blks []*roothash.AnnotatedBlock, roundResults []*rootha
 	}
 
 	return d.db.Update(func(tx *badger.Txn) error {
-		meta, err := d.queryGetMetadata(tx)
-		if err != nil {
-			return err
-		}
+		// meta, err := d.queryGetMetadata(tx)
+		// if err != nil {
+		// 	return err
+		// }
 
 		for i, blk := range blks {
-			rtID := blk.Block.Header.Namespace
-			if !rtID.Equal(&meta.RuntimeID) {
-				return fmt.Errorf("runtime/history: runtime mismatch (expected: %s got: %s)",
-					meta.RuntimeID,
-					rtID,
-				)
-			}
+			// rtID := blk.Block.Header.Namespace
+			// if !rtID.Equal(&meta.RuntimeID) {
+			// 	return fmt.Errorf("runtime/history: runtime mismatch (expected: %s got: %s)",
+			// 		meta.RuntimeID,
+			// 		rtID,
+			// 	)
+			// }
 
-			if blk.Height < meta.LastConsensusHeight {
-				return fmt.Errorf("runtime/history: commit at lower consensus height (current: %d wanted: %d)",
-					meta.LastConsensusHeight,
-					blk.Height,
-				)
-			}
+			// if blk.Height < meta.LastConsensusHeight {
+			// 	return fmt.Errorf("runtime/history: commit at lower consensus height (current: %d wanted: %d)",
+			// 		meta.LastConsensusHeight,
+			// 		blk.Height,
+			// 	)
+			// }
 
-			if blk.Block.Header.Round <= meta.LastRound && meta.LastConsensusHeight != 0 {
-				return fmt.Errorf("runtime/history: commit at lower round (current: %d wanted: %d)",
-					meta.LastRound,
-					blk.Block.Header.Round,
-				)
-			}
+			// if blk.Block.Header.Round <= meta.LastRound && meta.LastConsensusHeight != 0 {
+			// 	return fmt.Errorf("runtime/history: commit at lower round (current: %d wanted: %d)",
+			// 		meta.LastRound,
+			// 		blk.Block.Header.Round,
+			// 	)
+			// }
 
 			if err := tx.Set(blockKeyFmt.Encode(blk.Block.Header.Round), cbor.Marshal(blk)); err != nil {
 				return err
@@ -258,12 +258,13 @@ func (d *DB) commitBatch(blks []*roothash.AnnotatedBlock, roundResults []*rootha
 			if err := tx.Set(roundResultsKeyFmt.Encode(blk.Block.Header.Round), cbor.Marshal(roundResults[i])); err != nil {
 				return err
 			}
-			meta.LastRound = blk.Block.Header.Round
-			if blk.Height > meta.LastConsensusHeight {
-				meta.LastConsensusHeight = blk.Height
-			}
+			// meta.LastRound = blk.Block.Header.Round
+			// if blk.Height > meta.LastConsensusHeight {
+			// 	meta.LastConsensusHeight = blk.Height
+			// }
 		}
-		return tx.Set(metadataKeyFmt.Encode(), cbor.Marshal(meta))
+		// return tx.Set(metadataKeyFmt.Encode(), cbor.Marshal(meta))
+		return nil
 	})
 }
 

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -54,6 +54,10 @@ func (h *nopHistory) Commit(*roothash.AnnotatedBlock, *roothash.RoundResults, bo
 	return errNopHistory
 }
 
+func (h *nopHistory) CommitBatch([]*roothash.AnnotatedBlock, []*roothash.RoundResults) error {
+	return errNopHistory
+}
+
 func (h *nopHistory) ConsensusCheckpoint(int64) error {
 	return errNopHistory
 }
@@ -155,6 +159,10 @@ func (h *runtimeHistory) Commit(blk *roothash.AnnotatedBlock, roundResults *root
 	h.blocksNotifier.Broadcast(blk)
 
 	return nil
+}
+
+func (h *runtimeHistory) CommitBatch(blks []*roothash.AnnotatedBlock, roundResults []*roothash.RoundResults) error {
+	return h.db.commitBatch(blks, roundResults)
 }
 
 func (h *runtimeHistory) ConsensusCheckpoint(height int64) error {


### PR DESCRIPTION
Hacky Bench-marking only:

# Warning
Ignore code quality etc, this is benchmark only. Corner case logic is also probably off sometimes, logs are also often just copied.

```bash
 prune:
        strategy: none
```
batching has minor bug if you are doing prunning.

# How to benchmark
Change: 
* `writeWorkers` if you want to write in parallel
* `batchSize` if you want to batch`
* `readWorkers` if withing a batch processing you want to fetch consensus blocks and data in parallel.

** `writeWorkers=1` + `batchSize=1` should give you same benchmark as is on the `main`.** 


grepping for `history reindex0` should output relevant logs.