### PR TITLE
runtime/src/transaction: Fix is_supported call to wrapped dispatcher

### DIFF
--- a/.changelog/6058.bugfix.md
+++ b/.changelog/6058.bugfix.md
@@ -1,0 +1,1 @@
+runtime/src/transaction: Fix is_supported call to wrapped dispatcher

--- a/runtime/src/transaction/dispatcher.rs
+++ b/runtime/src/transaction/dispatcher.rs
@@ -92,6 +92,10 @@ pub trait Dispatcher: Send + Sync {
 }
 
 impl<T: Dispatcher + ?Sized> Dispatcher for Box<T> {
+    fn is_supported(&self) -> bool {
+        T::is_supported(&**self)
+    }
+
     fn execute_batch(
         &self,
         ctx: Context,
@@ -132,6 +136,10 @@ impl<T: Dispatcher + ?Sized> Dispatcher for Box<T> {
 }
 
 impl<T: Dispatcher + ?Sized> Dispatcher for Arc<T> {
+    fn is_supported(&self) -> bool {
+        T::is_supported(&**self)
+    }
+
     fn execute_batch(
         &self,
         ctx: Context,


### PR DESCRIPTION
Fixing `Box::<NoopDispatcher>::default().is_supported()` which returned `true` for ROFL apps.