### PR TITLE
go/runtime/host/sandbox: Verify sandbox binary when needed

### DIFF
--- a/.changelog/6060.bugfix.md
+++ b/.changelog/6060.bugfix.md
@@ -1,0 +1,5 @@
+go/runtime/host/sandbox: Verify sandbox binary when needed
+
+Ensures validator nodes without configured runtimes and with the default
+runtime provisioner set to sandbox do not fail to start if bubblewrap
+is not installed.

--- a/go/oasis-test-runner/oasis/validator.go
+++ b/go/oasis-test-runner/oasis/validator.go
@@ -80,6 +80,7 @@ func (val *Validator) AddArgs(args *argBuilder) error {
 }
 
 func (val *Validator) ModifyConfig() error {
+	val.Config.Mode = config.ModeValidator
 	val.Config.Consensus.Validator = true
 
 	val.Config.Consensus.ListenAddress = allInterfacesAddr + ":" + strconv.Itoa(int(val.consensusPort))

--- a/go/runtime/host/sandbox/process/bwrap.go
+++ b/go/runtime/host/sandbox/process/bwrap.go
@@ -58,6 +58,14 @@ func (b *fdPipeBuilder) close() {
 
 // NewBubbleWrap creates a Bubblewrap-based sandbox.
 func NewBubbleWrap(cfg Config) (Process, error) {
+	// Make sure the sandbox binary exists.
+	if _, err := os.Stat(cfg.SandboxBinaryPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("sandbox binary not found")
+		}
+		return nil, fmt.Errorf("failed to stat sandbox binary: %w", err)
+	}
+
 	var fdPipes fdPipeBuilder
 	// Make sure the sandbox starts in the given time.
 	fdPipes.deadline = time.Now().Add(sandboxStartTimeout)

--- a/go/runtime/registry/config.go
+++ b/go/runtime/registry/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -158,11 +157,6 @@ func createProvisioner(
 		fallthrough
 	case rtConfig.RuntimeProvisionerSandboxed:
 		// Sandboxed provisioner, can be used with no TEE or with Intel SGX.
-		if !insecureNoSandbox {
-			if _, err = os.Stat(sandboxBinary); err != nil {
-				return nil, fmt.Errorf("failed to stat sandbox binary: %w", err)
-			}
-		}
 
 		// Configure the non-TEE provisioner.
 		provisioners[component.TEEKindNone], err = hostSandbox.NewProvisioner(hostSandbox.Config{

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -417,7 +417,7 @@ func (w *Worker) worker() {
 		case 1:
 			comp = comps[0]
 		default:
-			w.logger.Error("expected a single runtime component (got %d)", numComps)
+			w.logger.Error("expected one runtime component", "total", numComps)
 			return false
 		}
 
@@ -431,18 +431,18 @@ func (w *Worker) worker() {
 		return
 	}
 	if !comp.ID().IsRONL() {
-		w.logger.Error("expected a RONL key manager runtime component (got %d)", comp.ID())
+		w.logger.Error("expected RONL runtime component", "id", comp.ID())
 		return
 	}
 
 	// Provision the specified runtime component.
-	w.logger.Info("provisioning key manager runtime component",
+	w.logger.Info("provisioning runtime component",
 		"id", comp.ID(),
 		"version", comp.Version,
 	)
 
 	if err := w.ProvisionHostedRuntimeComponent(comp); err != nil {
-		w.logger.Error("failed to provision key manager runtime component",
+		w.logger.Error("failed to provision runtime component",
 			"err", err,
 			"id", comp.ID(),
 			"version", comp.Version,
@@ -468,7 +468,7 @@ func (w *Worker) worker() {
 
 	// Ensure that the runtime version is active.
 	if _, err := w.GetHostedRuntimeActiveVersion(); err != nil {
-		w.logger.Error("failed to activate key manager runtime component",
+		w.logger.Error("failed to activate runtime component",
 			"err", err,
 			"id", comp.ID(),
 			"version", comp.Version,


### PR DESCRIPTION
 Ensures validator nodes without configured runtimes and with the default runtime provisioner set to sandbox do not fail to start if bubblewrap is not installed.