### PR TITLE
go/runtime/host: Ensure processes get cleaned up on node termination

### DIFF
--- a/.changelog/6066.bugfix.md
+++ b/.changelog/6066.bugfix.md
@@ -1,0 +1,1 @@
+go/runtime/host: Ensure processes get cleaned up on node termination

--- a/go/runtime/host/sandbox/process/naked.go
+++ b/go/runtime/host/sandbox/process/naked.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"sync"
 	"syscall"
+
+	cmnSyscall "github.com/oasisprotocol/oasis-core/go/common/syscall"
 )
 
 type naked struct {
@@ -77,6 +79,7 @@ func NewNaked(cfg Config) (Process, error) {
 	}
 	cmd.Stderr = cfg.Stderr
 	cmd.ExtraFiles = cfg.extraFiles
+	cmd.SysProcAttr = cmnSyscall.CmdAttrs
 
 	// Write any bound data to respective files.
 	for path, reader := range cfg.BindData {


### PR DESCRIPTION
Fixes #6065 