### PR TITLE
go/runtime/registry: Remove runtime host handler factory

### DIFF
--- a/go/oasis-node/cmd/node/node_control.go
+++ b/go/oasis-node/cmd/node/node_control.go
@@ -342,10 +342,7 @@ func (n *Node) getRuntimeStatus(ctx context.Context) (map[common.Namespace]contr
 		}
 
 		// Fetch provisioner type.
-		status.Provisioner = "none"
-		if provisioner := rt.HostProvisioner(); provisioner != nil {
-			status.Provisioner = provisioner.Name()
-		}
+		status.Provisioner = n.Provisioner.Name()
 
 		// Fetch the status of all components associated with the runtime.
 		for _, comp := range n.RuntimeRegistry.GetBundleRegistry().Components(rt.ID()) {

--- a/go/runtime/host/provisioner/provisioner.go
+++ b/go/runtime/host/provisioner/provisioner.go
@@ -1,0 +1,203 @@
+package provisioner
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/oasisprotocol/oasis-core/go/common/identity"
+	"github.com/oasisprotocol/oasis-core/go/common/persistent"
+	"github.com/oasisprotocol/oasis-core/go/common/sgx/pcs"
+	"github.com/oasisprotocol/oasis-core/go/config"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	"github.com/oasisprotocol/oasis-core/go/ias"
+	iasAPI "github.com/oasisprotocol/oasis-core/go/ias/api"
+	cmdFlags "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
+	"github.com/oasisprotocol/oasis-core/go/runtime/bundle/component"
+	rtConfig "github.com/oasisprotocol/oasis-core/go/runtime/config"
+	runtimeHost "github.com/oasisprotocol/oasis-core/go/runtime/host"
+	hostComposite "github.com/oasisprotocol/oasis-core/go/runtime/host/composite"
+	hostLoadBalance "github.com/oasisprotocol/oasis-core/go/runtime/host/loadbalance"
+	hostMock "github.com/oasisprotocol/oasis-core/go/runtime/host/mock"
+	hostProtocol "github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
+	hostSandbox "github.com/oasisprotocol/oasis-core/go/runtime/host/sandbox"
+	hostSgx "github.com/oasisprotocol/oasis-core/go/runtime/host/sgx"
+	hostTdx "github.com/oasisprotocol/oasis-core/go/runtime/host/tdx"
+	"github.com/oasisprotocol/oasis-core/go/runtime/registry"
+)
+
+// New creates a new runtime provisioner.
+//
+// This helper function creates a provisioner capable of provisioning runtimes
+// with or without a Trusted Execution Environment (TEE), such as Intel SGX
+// or TDX. If the debug mock flag is enabled, the TEE will be mocked.
+func New(
+	dataDir string,
+	commonStore *persistent.CommonStore,
+	identity *identity.Identity,
+	consensus consensus.Backend,
+) (runtimeHost.Provisioner, error) {
+	// Initialize the IAS proxy client.
+	ias, err := ias.New(identity)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize IAS proxy client: %w", err)
+	}
+
+	// Configure host environment information.
+	hostInfo, err := createHostInfo(consensus)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the PCS client and quote service.
+	qs, err := createCachingQuoteService(commonStore)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create runtime provisioner.
+	return createProvisioner(dataDir, commonStore, identity, consensus, hostInfo, ias, qs)
+}
+
+func createHostInfo(consensus consensus.Backend) (*hostProtocol.HostInfo, error) {
+	cs, err := consensus.GetStatus(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get consensus layer status: %w", err)
+	}
+
+	chainCtx, err := consensus.GetChainContext(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get chain context: %w", err)
+	}
+
+	return &hostProtocol.HostInfo{
+		ConsensusBackend:         cs.Backend,
+		ConsensusProtocolVersion: cs.Version,
+		ConsensusChainContext:    chainCtx,
+	}, nil
+}
+
+func createCachingQuoteService(commonStore *persistent.CommonStore) (pcs.QuoteService, error) {
+	pc, err := pcs.NewHTTPClient(&pcs.HTTPClientConfig{
+		// TODO: Support configuring the API key.
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create PCS HTTP client: %w", err)
+	}
+
+	qs := pcs.NewCachingQuoteService(pc, commonStore)
+
+	return qs, nil
+}
+
+func createProvisioner(
+	dataDir string,
+	commonStore *persistent.CommonStore,
+	identity *identity.Identity,
+	consensus consensus.Backend,
+	hostInfo *hostProtocol.HostInfo,
+	ias []iasAPI.Endpoint,
+	qs pcs.QuoteService,
+) (runtimeHost.Provisioner, error) {
+	var err error
+	var insecureNoSandbox bool
+
+	attestInterval := config.GlobalConfig.Runtime.AttestInterval
+	sandboxBinary := config.GlobalConfig.Runtime.SandboxBinary
+	sgxLoader := config.GlobalConfig.Runtime.SGXLoader
+	insecureMock := config.GlobalConfig.Runtime.DebugMockTEE
+
+	// Support legacy configuration where the runtime environment determines
+	// whether the TEE should be mocked.
+	if config.GlobalConfig.Runtime.Environment == rtConfig.RuntimeEnvironmentSGXMock {
+		insecureMock = true
+	}
+
+	// Register provisioners based on the configured provisioner.
+	provisioners := make(map[component.TEEKind]runtimeHost.Provisioner)
+	switch p := config.GlobalConfig.Runtime.Provisioner; p {
+	case rtConfig.RuntimeProvisionerMock:
+		// Mock provisioner, only supported when the runtime requires no TEE hardware.
+		if !cmdFlags.DebugDontBlameOasis() {
+			return nil, fmt.Errorf("mock provisioner requires use of unsafe debug flags")
+		}
+
+		provisioners[component.TEEKindNone] = hostMock.NewProvisioner()
+	case rtConfig.RuntimeProvisionerUnconfined:
+		// Unconfined provisioner, can be used with no TEE or with Intel SGX.
+		if !cmdFlags.DebugDontBlameOasis() {
+			return nil, fmt.Errorf("unconfined provisioner requires use of unsafe debug flags")
+		}
+
+		insecureNoSandbox = true
+
+		fallthrough
+	case rtConfig.RuntimeProvisionerSandboxed:
+		// Sandboxed provisioner, can be used with no TEE or with Intel SGX.
+
+		// Configure the non-TEE provisioner.
+		provisioners[component.TEEKindNone], err = hostSandbox.NewProvisioner(hostSandbox.Config{
+			HostInfo:          hostInfo,
+			InsecureNoSandbox: insecureNoSandbox,
+			SandboxBinaryPath: sandboxBinary,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create runtime provisioner: %w", err)
+		}
+
+		// Configure the Intel SGX provisioner.
+		if insecureMock && !cmdFlags.DebugDontBlameOasis() {
+			return nil, fmt.Errorf("mock SGX requires use of unsafe debug flags")
+		}
+
+		if !insecureMock && sgxLoader == "" {
+			// SGX may be needed, but we don't have a loader configured.
+			break
+		}
+
+		provisioners[component.TEEKindSGX], err = hostSgx.NewProvisioner(hostSgx.Config{
+			HostInfo:              hostInfo,
+			CommonStore:           commonStore,
+			LoaderPath:            sgxLoader,
+			IAS:                   ias,
+			PCS:                   qs,
+			Consensus:             consensus,
+			Identity:              identity,
+			SandboxBinaryPath:     sandboxBinary,
+			InsecureNoSandbox:     insecureNoSandbox,
+			InsecureMock:          insecureMock,
+			RuntimeAttestInterval: attestInterval,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create SGX runtime provisioner: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported runtime provisioner: %s", p)
+	}
+
+	// Configure TDX provisioner.
+	// TODO: Allow provisioner selection in the future, currently we only have QEMU.
+	provisioners[component.TEEKindTDX], err = hostTdx.NewQemuProvisioner(hostTdx.QemuConfig{
+		DataDir:               filepath.Join(dataDir, registry.RuntimesDir),
+		HostInfo:              hostInfo,
+		CommonStore:           commonStore,
+		PCS:                   qs,
+		Consensus:             consensus,
+		Identity:              identity,
+		RuntimeAttestInterval: attestInterval,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create TDX runtime provisioner: %w", err)
+	}
+
+	// Configure optional load balancing.
+	for tee, rp := range provisioners {
+		numInstances := int(config.GlobalConfig.Runtime.LoadBalancer.NumInstances)
+		provisioners[tee] = hostLoadBalance.NewProvisioner(rp, numInstances)
+	}
+
+	// Create a composite provisioner to provision the individual components.
+	provisioner := hostComposite.NewProvisioner(provisioners)
+
+	return provisioner, nil
+}

--- a/go/runtime/registry/handler.go
+++ b/go/runtime/registry/handler.go
@@ -44,9 +44,6 @@ type RuntimeHostHandlerEnvironment interface {
 // RuntimeHostHandlerFactory is an interface that can be used to create new runtime handlers and
 // notifiers when provisioning hosted runtimes.
 type RuntimeHostHandlerFactory interface {
-	// GetRuntime returns the registered runtime for which a runtime host handler is to be created.
-	GetRuntime() Runtime
-
 	// NewRuntimeHostHandler creates a new runtime host handler.
 	NewRuntimeHostHandler() host.RuntimeHandler
 }

--- a/go/runtime/registry/handler.go
+++ b/go/runtime/registry/handler.go
@@ -41,13 +41,6 @@ type RuntimeHostHandlerEnvironment interface {
 	GetRuntimeRegistry() Registry
 }
 
-// RuntimeHostHandlerFactory is an interface that can be used to create new runtime handlers and
-// notifiers when provisioning hosted runtimes.
-type RuntimeHostHandlerFactory interface {
-	// NewRuntimeHostHandler creates a new runtime host handler.
-	NewRuntimeHostHandler() host.RuntimeHandler
-}
-
 // RuntimeHostHandler is a runtime host handler suitable for compute runtimes. It provides the
 // required set of methods for interacting with the outside world.
 type runtimeHostHandler struct {

--- a/go/runtime/registry/handler.go
+++ b/go/runtime/registry/handler.go
@@ -49,9 +49,6 @@ type RuntimeHostHandlerFactory interface {
 
 	// NewRuntimeHostHandler creates a new runtime host handler.
 	NewRuntimeHostHandler() host.RuntimeHandler
-
-	// NewRuntimeHostNotifier creates a new runtime host notifier.
-	NewRuntimeHostNotifier(host host.Runtime) protocol.Notifier
 }
 
 // RuntimeHostHandler is a runtime host handler suitable for compute runtimes. It provides the

--- a/go/runtime/registry/host.go
+++ b/go/runtime/registry/host.go
@@ -29,8 +29,7 @@ type RuntimeHostNode struct {
 }
 
 // NewRuntimeHostNode creates a new runtime host node.
-func NewRuntimeHostNode(factory RuntimeHostHandlerFactory) (*RuntimeHostNode, error) {
-	runtime := factory.GetRuntime()
+func NewRuntimeHostNode(runtime Runtime, factory RuntimeHostHandlerFactory) (*RuntimeHostNode, error) {
 	h := composite.NewHost(runtime.ID())
 	rr := host.NewRichRuntime(h)
 

--- a/go/runtime/registry/host.go
+++ b/go/runtime/registry/host.go
@@ -12,7 +12,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/composite"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/multi"
-	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 )
 
 // RuntimeHostNode provides methods for nodes that need to host runtimes.
@@ -23,7 +22,6 @@ type RuntimeHostNode struct {
 	rr   host.RichRuntime
 
 	runtime     Runtime
-	notifier    protocol.Notifier
 	handler     host.RuntimeHandler
 	provisioner host.Provisioner
 
@@ -36,7 +34,6 @@ func NewRuntimeHostNode(factory RuntimeHostHandlerFactory) (*RuntimeHostNode, er
 	h := composite.NewHost(runtime.ID())
 	rr := host.NewRichRuntime(h)
 
-	notifier := factory.NewRuntimeHostNotifier(h)
 	handler := factory.NewRuntimeHostHandler()
 	provisioner := runtime.HostProvisioner()
 
@@ -44,7 +41,6 @@ func NewRuntimeHostNode(factory RuntimeHostHandlerFactory) (*RuntimeHostNode, er
 		host:        h,
 		rr:          rr,
 		runtime:     runtime,
-		notifier:    notifier,
 		handler:     handler,
 		provisioner: provisioner,
 		rofls:       make(map[component.ID]version.Version),
@@ -98,11 +94,6 @@ func (n *RuntimeHostNode) ProvisionHostedRuntimeComponent(comp *bundle.ExplodedC
 // GetHostedRuntime returns the hosted runtime.
 func (n *RuntimeHostNode) GetHostedRuntime() host.RichRuntime {
 	return n.rr
-}
-
-// GetRuntimeHostNotifier returns the runtime host notifier.
-func (n *RuntimeHostNode) GetRuntimeHostNotifier() protocol.Notifier {
-	return n.notifier
 }
 
 // GetHostedRuntimeActiveVersion returns the version of the active runtime.

--- a/go/runtime/registry/host.go
+++ b/go/runtime/registry/host.go
@@ -29,11 +29,10 @@ type RuntimeHostNode struct {
 }
 
 // NewRuntimeHostNode creates a new runtime host node.
-func NewRuntimeHostNode(runtime Runtime, factory RuntimeHostHandlerFactory) (*RuntimeHostNode, error) {
+func NewRuntimeHostNode(runtime Runtime, handler host.RuntimeHandler) (*RuntimeHostNode, error) {
 	h := composite.NewHost(runtime.ID())
 	rr := host.NewRichRuntime(h)
 
-	handler := factory.NewRuntimeHostHandler()
 	provisioner := runtime.HostProvisioner()
 
 	return &RuntimeHostNode{

--- a/go/runtime/registry/host.go
+++ b/go/runtime/registry/host.go
@@ -22,18 +22,16 @@ type RuntimeHostNode struct {
 	rr   host.RichRuntime
 
 	runtime     Runtime
-	handler     host.RuntimeHandler
 	provisioner host.Provisioner
+	handler     host.RuntimeHandler
 
 	rofls map[component.ID]version.Version
 }
 
 // NewRuntimeHostNode creates a new runtime host node.
-func NewRuntimeHostNode(runtime Runtime, handler host.RuntimeHandler) (*RuntimeHostNode, error) {
+func NewRuntimeHostNode(runtime Runtime, provisioner host.Provisioner, handler host.RuntimeHandler) (*RuntimeHostNode, error) {
 	h := composite.NewHost(runtime.ID())
 	rr := host.NewRichRuntime(h)
-
-	provisioner := runtime.HostProvisioner()
 
 	return &RuntimeHostNode{
 		host:        h,

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -859,6 +859,7 @@ func NewNode(
 	chainContext string,
 	hostNode control.NodeController,
 	runtime runtimeRegistry.Runtime,
+	provisioner host.Provisioner,
 	rtRegistry runtimeRegistry.Registry,
 	identity *identity.Identity,
 	keymanager keymanager.Backend,
@@ -909,7 +910,7 @@ func NewNode(
 	handler := runtimeRegistry.NewRuntimeHostHandler(&nodeEnvironment{n}, n.Runtime, n.Consensus)
 
 	// Prepare the runtime host node helpers.
-	rhn, err := runtimeRegistry.NewRuntimeHostNode(runtime, handler)
+	rhn, err := runtimeRegistry.NewRuntimeHostNode(runtime, provisioner, handler)
 	if err != nil {
 		return nil, err
 	}

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -906,7 +906,7 @@ func NewNode(
 	n.KeyManagerClient = NewKeyManagerClientWrapper(p2pHost, consensus, chainContext, n.logger)
 
 	// Prepare the runtime host node helpers.
-	rhn, err := runtimeRegistry.NewRuntimeHostNode(n)
+	rhn, err := runtimeRegistry.NewRuntimeHostNode(runtime, n)
 	if err != nil {
 		return nil, err
 	}

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -20,12 +20,13 @@ import (
 	keymanager "github.com/oasisprotocol/oasis-core/go/keymanager/api"
 	cmmetrics "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/metrics"
 	p2pAPI "github.com/oasisprotocol/oasis-core/go/p2p/api"
-	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
+	p2pProtocol "github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	runtime "github.com/oasisprotocol/oasis-core/go/runtime/api"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
+	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	"github.com/oasisprotocol/oasis-core/go/runtime/txpool"
 	tpConfig "github.com/oasisprotocol/oasis-core/go/runtime/txpool/config"
@@ -158,6 +159,7 @@ type Node struct {
 	Group            *Group
 	P2P              p2pAPI.Service
 	TxPool           txpool.TransactionPool
+	notifier         protocol.Notifier
 
 	txTopic string
 
@@ -704,18 +706,17 @@ func (n *Node) worker() {
 	n.updateHostedRuntimeVersionLocked()
 	n.CrossNode.Unlock()
 
-	// Start the runtime and its notifier.
+	// Start the runtime.
 	hrt := n.GetHostedRuntime()
-	hrtNotifier := n.GetRuntimeHostNotifier()
-
 	hrtEventCh, hrtSub := hrt.WatchEvents()
 	defer hrtSub.Close()
 
 	hrt.Start()
 	defer hrt.Stop()
 
-	hrtNotifier.Start()
-	defer hrtNotifier.Stop()
+	// Start the runtime's notifier.
+	n.notifier.Start()
+	defer n.notifier.Stop()
 
 	// Enter the main processing loop.
 	initialized := false
@@ -879,7 +880,7 @@ func NewNode(
 		return nil, err
 	}
 
-	txTopic := protocol.NewTopicKindTxID(chainContext, runtime.ID())
+	txTopic := p2pProtocol.NewTopicKindTxID(chainContext, runtime.ID())
 
 	n := &Node{
 		ChainContext:    chainContext,
@@ -910,6 +911,9 @@ func NewNode(
 		return nil, err
 	}
 	n.RuntimeHostNode = rhn
+
+	// Prepare the runtime host notifier.
+	n.notifier = runtimeRegistry.NewRuntimeHostNotifier(runtime, rhn.GetHostedRuntime(), consensus)
 
 	// Prepare transaction pool.
 	n.TxPool = txpool.New(runtime.ID(), txPoolCfg, rhn.GetHostedRuntime(), runtime.History(), n)

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -905,8 +905,11 @@ func NewNode(
 	// Prepare the key manager client wrapper.
 	n.KeyManagerClient = NewKeyManagerClientWrapper(p2pHost, consensus, chainContext, n.logger)
 
+	// Prepare the runtime host handler.
+	handler := runtimeRegistry.NewRuntimeHostHandler(&nodeEnvironment{n}, n.Runtime, n.Consensus)
+
 	// Prepare the runtime host node helpers.
-	rhn, err := runtimeRegistry.NewRuntimeHostNode(runtime, n)
+	rhn, err := runtimeRegistry.NewRuntimeHostNode(runtime, handler)
 	if err != nil {
 		return nil, err
 	}

--- a/go/worker/common/committee/runtime_host.go
+++ b/go/worker/common/committee/runtime_host.go
@@ -9,11 +9,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/runtime/txpool"
 )
 
-// GetRuntime implements RuntimeHostHandlerFactory.
-func (n *Node) GetRuntime() runtimeRegistry.Runtime {
-	return n.Runtime
-}
-
 // NewRuntimeHostHandler implements RuntimeHostHandlerFactory.
 func (n *Node) NewRuntimeHostHandler() host.RuntimeHandler {
 	return runtimeRegistry.NewRuntimeHostHandler(&nodeEnvironment{n}, n.Runtime, n.Consensus)

--- a/go/worker/common/committee/runtime_host.go
+++ b/go/worker/common/committee/runtime_host.go
@@ -4,7 +4,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
 	consensusAPI "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
-	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 	runtimeKeymanager "github.com/oasisprotocol/oasis-core/go/runtime/keymanager/api"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	"github.com/oasisprotocol/oasis-core/go/runtime/txpool"
@@ -18,11 +17,6 @@ func (n *Node) GetRuntime() runtimeRegistry.Runtime {
 // NewRuntimeHostHandler implements RuntimeHostHandlerFactory.
 func (n *Node) NewRuntimeHostHandler() host.RuntimeHandler {
 	return runtimeRegistry.NewRuntimeHostHandler(&nodeEnvironment{n}, n.Runtime, n.Consensus)
-}
-
-// NewRuntimeHostNotifier implements RuntimeHostHandlerFactory.
-func (n *Node) NewRuntimeHostNotifier(host host.Runtime) protocol.Notifier {
-	return runtimeRegistry.NewRuntimeHostNotifier(n.Runtime, host, n.Consensus)
 }
 
 type nodeEnvironment struct {

--- a/go/worker/common/committee/runtime_host.go
+++ b/go/worker/common/committee/runtime_host.go
@@ -3,16 +3,10 @@ package committee
 import (
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
 	consensusAPI "github.com/oasisprotocol/oasis-core/go/consensus/api"
-	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	runtimeKeymanager "github.com/oasisprotocol/oasis-core/go/runtime/keymanager/api"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	"github.com/oasisprotocol/oasis-core/go/runtime/txpool"
 )
-
-// NewRuntimeHostHandler implements RuntimeHostHandlerFactory.
-func (n *Node) NewRuntimeHostHandler() host.RuntimeHandler {
-	return runtimeRegistry.NewRuntimeHostHandler(&nodeEnvironment{n}, n.Runtime, n.Consensus)
-}
 
 type nodeEnvironment struct {
 	n *Node

--- a/go/worker/common/worker.go
+++ b/go/worker/common/worker.go
@@ -12,6 +12,7 @@ import (
 	control "github.com/oasisprotocol/oasis-core/go/control/api"
 	keymanagerApi "github.com/oasisprotocol/oasis-core/go/keymanager/api"
 	p2p "github.com/oasisprotocol/oasis-core/go/p2p/api"
+	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	"github.com/oasisprotocol/oasis-core/go/worker/common/committee"
 )
@@ -30,6 +31,7 @@ type Worker struct {
 	P2P             p2p.Service
 	KeyManager      keymanagerApi.Backend
 	RuntimeRegistry runtimeRegistry.Registry
+	Provisioner     host.Provisioner
 
 	runtimes map[common.Namespace]*committee.Node
 
@@ -161,6 +163,7 @@ func (w *Worker) registerRuntime(runtime runtimeRegistry.Runtime) error {
 		w.ChainContext,
 		w.HostNode,
 		runtime,
+		w.Provisioner,
 		w.RuntimeRegistry,
 		w.Identity,
 		w.KeyManager,
@@ -192,6 +195,7 @@ func New(
 	p2p p2p.Service,
 	keyManager keymanagerApi.Backend,
 	runtimeRegistry runtimeRegistry.Registry,
+	provisioner host.Provisioner,
 ) (*Worker, error) {
 	var enabled bool
 	switch config.GlobalConfig.Mode {
@@ -223,6 +227,7 @@ func New(
 		P2P:             p2p,
 		KeyManager:      keyManager,
 		RuntimeRegistry: runtimeRegistry,
+		Provisioner:     provisioner,
 		runtimes:        make(map[common.Namespace]*committee.Node),
 		ctx:             ctx,
 		cancelCtx:       cancelCtx,

--- a/go/worker/keymanager/handler.go
+++ b/go/worker/keymanager/handler.go
@@ -6,7 +6,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
 	consensusAPI "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
-	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 	runtimeKeymanager "github.com/oasisprotocol/oasis-core/go/runtime/keymanager/api"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	"github.com/oasisprotocol/oasis-core/go/runtime/txpool"
@@ -28,11 +27,6 @@ func (w *Worker) NewRuntimeHostHandler() host.RuntimeHandler {
 		w:     w,
 		kmCli: kmCli,
 	}, w.runtime, w.commonWorker.Consensus)
-}
-
-// NewRuntimeHostNotifier implements workerCommon.RuntimeHostHandlerFactory.
-func (w *Worker) NewRuntimeHostNotifier(host host.Runtime) protocol.Notifier {
-	return runtimeRegistry.NewRuntimeHostNotifier(w.runtime, host, w.commonWorker.Consensus)
 }
 
 type workerEnvironment struct {

--- a/go/worker/keymanager/handler.go
+++ b/go/worker/keymanager/handler.go
@@ -5,34 +5,18 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
 	consensusAPI "github.com/oasisprotocol/oasis-core/go/consensus/api"
-	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	runtimeKeymanager "github.com/oasisprotocol/oasis-core/go/runtime/keymanager/api"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	"github.com/oasisprotocol/oasis-core/go/runtime/txpool"
-	committeeCommon "github.com/oasisprotocol/oasis-core/go/worker/common/committee"
 )
-
-// NewRuntimeHostHandler implements workerCommon.RuntimeHostHandlerFactory.
-func (w *Worker) NewRuntimeHostHandler() host.RuntimeHandler {
-	kmCli := committeeCommon.NewKeyManagerClientWrapper(w.commonWorker.P2P, w.commonWorker.Consensus, w.commonWorker.ChainContext, w.logger)
-	runtimeID := w.runtime.ID()
-	kmCli.SetKeyManagerID(&runtimeID)
-
-	return runtimeRegistry.NewRuntimeHostHandler(&workerEnvironment{
-		w:     w,
-		kmCli: kmCli,
-	}, w.runtime, w.commonWorker.Consensus)
-}
 
 type workerEnvironment struct {
 	w *Worker
-
-	kmCli *committeeCommon.KeyManagerClientWrapper
 }
 
 // GetKeyManagerClient implements RuntimeHostHandlerEnvironment.
 func (env *workerEnvironment) GetKeyManagerClient() (runtimeKeymanager.Client, error) {
-	return env.kmCli, nil
+	return env.w.keyManagerClient, nil
 }
 
 // GetTxPool implements RuntimeHostHandlerEnvironment.

--- a/go/worker/keymanager/handler.go
+++ b/go/worker/keymanager/handler.go
@@ -12,11 +12,6 @@ import (
 	committeeCommon "github.com/oasisprotocol/oasis-core/go/worker/common/committee"
 )
 
-// GetRuntime implements workerCommon.RuntimeHostHandlerFactory.
-func (w *Worker) GetRuntime() runtimeRegistry.Runtime {
-	return w.runtime
-}
-
 // NewRuntimeHostHandler implements workerCommon.RuntimeHostHandlerFactory.
 func (w *Worker) NewRuntimeHostHandler() host.RuntimeHandler {
 	kmCli := committeeCommon.NewKeyManagerClientWrapper(w.commonWorker.P2P, w.commonWorker.Consensus, w.commonWorker.ChainContext, w.logger)

--- a/go/worker/keymanager/init.go
+++ b/go/worker/keymanager/init.go
@@ -9,6 +9,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/config"
 	"github.com/oasisprotocol/oasis-core/go/keymanager/api"
+	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	workerCommon "github.com/oasisprotocol/oasis-core/go/worker/common"
 	committeeCommon "github.com/oasisprotocol/oasis-core/go/worker/common/committee"
@@ -22,6 +23,7 @@ func New(
 	commonWorker *workerCommon.Worker,
 	r *registration.Worker,
 	backend api.Backend,
+	provisioner host.Provisioner,
 ) (*Worker, error) {
 	var enabled bool
 	switch config.GlobalConfig.Mode {
@@ -79,7 +81,7 @@ func New(
 	handler := runtimeRegistry.NewRuntimeHostHandler(&workerEnvironment{w}, w.runtime, w.commonWorker.Consensus)
 
 	// Prepare the runtime host node helpers.
-	w.RuntimeHostNode, err = runtimeRegistry.NewRuntimeHostNode(w.runtime, handler)
+	w.RuntimeHostNode, err = runtimeRegistry.NewRuntimeHostNode(w.runtime, provisioner, handler)
 	if err != nil {
 		return nil, fmt.Errorf("worker/keymanager: failed to create runtime host helpers: %w", err)
 	}

--- a/go/worker/keymanager/init.go
+++ b/go/worker/keymanager/init.go
@@ -76,6 +76,9 @@ func New(
 		return nil, fmt.Errorf("worker/keymanager: failed to create runtime host helpers: %w", err)
 	}
 
+	// Prepare the runtime host notifier.
+	w.notifier = runtimeRegistry.NewRuntimeHostNotifier(w.runtime, w.RuntimeHostNode.GetHostedRuntime(), commonWorker.Consensus)
+
 	// Prepare watchers.
 	w.kmNodeWatcher = newKmNodeWatcher(w.runtimeID, commonWorker.Consensus, w.peerMap, w.accessList, w.commonWorker.P2P.PeerManager().PeerTagger())
 	w.kmRuntimeWatcher = newKmRuntimeWatcher(w.runtimeID, commonWorker.Consensus, w.accessList)

--- a/go/worker/keymanager/init.go
+++ b/go/worker/keymanager/init.go
@@ -71,7 +71,7 @@ func New(
 	}
 
 	// Prepare the runtime host node helpers.
-	w.RuntimeHostNode, err = runtimeRegistry.NewRuntimeHostNode(w)
+	w.RuntimeHostNode, err = runtimeRegistry.NewRuntimeHostNode(w.runtime, w)
 	if err != nil {
 		return nil, fmt.Errorf("worker/keymanager: failed to create runtime host helpers: %w", err)
 	}

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -76,6 +76,7 @@ type Worker struct { // nolint: maligned
 	commonWorker *workerCommon.Worker
 	roleProvider registration.RoleProvider
 	backend      api.Backend
+	notifier     protocol.Notifier
 
 	enabled bool
 }
@@ -453,18 +454,17 @@ func (w *Worker) worker() {
 	// Set the runtime to the specified version.
 	w.SetHostedRuntimeVersion(&comp.Version, nil)
 
-	// Start the runtime and its notifier.
+	// Start the runtime.
 	hrt := w.GetHostedRuntime()
-	hrtNotifier := w.GetRuntimeHostNotifier()
-
 	hrtEventCh, hrtSub := hrt.WatchEvents()
 	defer hrtSub.Close()
 
 	hrt.Start()
 	defer hrt.Stop()
 
-	hrtNotifier.Start()
-	defer hrtNotifier.Stop()
+	// Start the runtime host notifier.
+	w.notifier.Start()
+	defer w.notifier.Stop()
 
 	// Ensure that the runtime version is active.
 	if _, err := w.GetHostedRuntimeActiveVersion(); err != nil {

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -29,6 +29,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	workerCommon "github.com/oasisprotocol/oasis-core/go/worker/common"
+	commonCommittee "github.com/oasisprotocol/oasis-core/go/worker/common/committee"
 	workerKeymanager "github.com/oasisprotocol/oasis-core/go/worker/keymanager/api"
 	"github.com/oasisprotocol/oasis-core/go/worker/registration"
 )
@@ -73,10 +74,11 @@ type Worker struct { // nolint: maligned
 	peerMap    *PeerMap
 	accessList *AccessList
 
-	commonWorker *workerCommon.Worker
-	roleProvider registration.RoleProvider
-	backend      api.Backend
-	notifier     protocol.Notifier
+	commonWorker     *workerCommon.Worker
+	roleProvider     registration.RoleProvider
+	backend          api.Backend
+	notifier         protocol.Notifier
+	keyManagerClient *commonCommittee.KeyManagerClientWrapper
 
 	enabled bool
 }


### PR DESCRIPTION
Refactored committee node:
- Removed `RuntimeHostHandlerFactory` as it is more cleaner to pass parameters to the constructor instead of passing a factory.
- Removed handler and notifier from the committee node, so that we can easier stop/start the notifier.
- Removed host provisioner (which is now generalized to provision any runtime) from the runtime registry, as it doesn't belong there.
  - It is now globally avaliable to common worker which provisions runtimes and to the key manager worker which provisions key manager runtime (maybe we need to move up also handler and notifier).

Related to:
- #6014 