### PR TITLE
go/keymanager/api: Fix key manager client

### DIFF
--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -206,6 +206,9 @@ type ClientBackend interface {
 
 	// Vault returns the vault backend.
 	Vault() vault.Backend
+
+	// KeyManager returns the keymanager backend.
+	KeyManager() keymanager.Backend
 }
 
 // Block is a consensus block.
@@ -402,9 +405,6 @@ type ServicesBackend interface {
 
 	// SubmissionManager returns the transaction submission manager.
 	SubmissionManager() SubmissionManager
-
-	// KeyManager returns the keymanager backend.
-	KeyManager() keymanager.Backend
 }
 
 // TransactionAuthHandler is the interface for handling transaction authentication

--- a/go/consensus/api/grpc.go
+++ b/go/consensus/api/grpc.go
@@ -692,19 +692,27 @@ func RegisterService(server *grpc.Server, service ClientBackend) {
 	server.RegisterService(&serviceDesc, service)
 }
 
-type consensusClient struct {
+// Client is a gRPC consensus client.
+type Client struct {
 	conn *grpc.ClientConn
 }
 
-func (c *consensusClient) SubmitTx(ctx context.Context, tx *transaction.SignedTransaction) error {
+// NewClient creates a new gRPC consensus client.
+func NewClient(c *grpc.ClientConn) *Client {
+	return &Client{
+		conn: c,
+	}
+}
+
+func (c *Client) SubmitTx(ctx context.Context, tx *transaction.SignedTransaction) error {
 	return c.conn.Invoke(ctx, methodSubmitTx.FullName(), tx, nil)
 }
 
-func (c *consensusClient) SubmitTxNoWait(ctx context.Context, tx *transaction.SignedTransaction) error {
+func (c *Client) SubmitTxNoWait(ctx context.Context, tx *transaction.SignedTransaction) error {
 	return c.conn.Invoke(ctx, methodSubmitTxNoWait.FullName(), tx, nil)
 }
 
-func (c *consensusClient) SubmitTxWithProof(ctx context.Context, tx *transaction.SignedTransaction) (*transaction.Proof, error) {
+func (c *Client) SubmitTxWithProof(ctx context.Context, tx *transaction.SignedTransaction) (*transaction.Proof, error) {
 	var proof transaction.Proof
 	if err := c.conn.Invoke(ctx, methodSubmitTxWithProof.FullName(), tx, &proof); err != nil {
 		return nil, err
@@ -712,7 +720,7 @@ func (c *consensusClient) SubmitTxWithProof(ctx context.Context, tx *transaction
 	return &proof, nil
 }
 
-func (c *consensusClient) StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error) {
+func (c *Client) StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error) {
 	var rsp genesis.Document
 	if err := c.conn.Invoke(ctx, methodStateToGenesis.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -720,7 +728,7 @@ func (c *consensusClient) StateToGenesis(ctx context.Context, height int64) (*ge
 	return &rsp, nil
 }
 
-func (c *consensusClient) EstimateGas(ctx context.Context, req *EstimateGasRequest) (transaction.Gas, error) {
+func (c *Client) EstimateGas(ctx context.Context, req *EstimateGasRequest) (transaction.Gas, error) {
 	var gas transaction.Gas
 	if err := c.conn.Invoke(ctx, methodEstimateGas.FullName(), req, &gas); err != nil {
 		return transaction.Gas(0), err
@@ -728,7 +736,7 @@ func (c *consensusClient) EstimateGas(ctx context.Context, req *EstimateGasReque
 	return gas, nil
 }
 
-func (c *consensusClient) MinGasPrice(ctx context.Context) (*quantity.Quantity, error) {
+func (c *Client) MinGasPrice(ctx context.Context) (*quantity.Quantity, error) {
 	var rsp quantity.Quantity
 	if err := c.conn.Invoke(ctx, methodMinGasPrice.FullName(), nil, &rsp); err != nil {
 		return nil, err
@@ -736,7 +744,7 @@ func (c *consensusClient) MinGasPrice(ctx context.Context) (*quantity.Quantity, 
 	return &rsp, nil
 }
 
-func (c *consensusClient) GetSignerNonce(ctx context.Context, req *GetSignerNonceRequest) (uint64, error) {
+func (c *Client) GetSignerNonce(ctx context.Context, req *GetSignerNonceRequest) (uint64, error) {
 	var nonce uint64
 	if err := c.conn.Invoke(ctx, methodGetSignerNonce.FullName(), req, &nonce); err != nil {
 		return nonce, err
@@ -744,7 +752,7 @@ func (c *consensusClient) GetSignerNonce(ctx context.Context, req *GetSignerNonc
 	return nonce, nil
 }
 
-func (c *consensusClient) GetBlock(ctx context.Context, height int64) (*Block, error) {
+func (c *Client) GetBlock(ctx context.Context, height int64) (*Block, error) {
 	var rsp Block
 	if err := c.conn.Invoke(ctx, methodGetBlock.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -752,7 +760,7 @@ func (c *consensusClient) GetBlock(ctx context.Context, height int64) (*Block, e
 	return &rsp, nil
 }
 
-func (c *consensusClient) GetLightBlock(ctx context.Context, height int64) (*LightBlock, error) {
+func (c *Client) GetLightBlock(ctx context.Context, height int64) (*LightBlock, error) {
 	var rsp LightBlock
 	if err := c.conn.Invoke(ctx, methodGetLightBlock.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -760,7 +768,7 @@ func (c *consensusClient) GetLightBlock(ctx context.Context, height int64) (*Lig
 	return &rsp, nil
 }
 
-func (c *consensusClient) GetTransactions(ctx context.Context, height int64) ([][]byte, error) {
+func (c *Client) GetTransactions(ctx context.Context, height int64) ([][]byte, error) {
 	var rsp [][]byte
 	if err := c.conn.Invoke(ctx, methodGetTransactions.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -768,7 +776,7 @@ func (c *consensusClient) GetTransactions(ctx context.Context, height int64) ([]
 	return rsp, nil
 }
 
-func (c *consensusClient) GetTransactionsWithResults(ctx context.Context, height int64) (*TransactionsWithResults, error) {
+func (c *Client) GetTransactionsWithResults(ctx context.Context, height int64) (*TransactionsWithResults, error) {
 	var rsp TransactionsWithResults
 	if err := c.conn.Invoke(ctx, methodGetTransactionsWithResults.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -776,7 +784,7 @@ func (c *consensusClient) GetTransactionsWithResults(ctx context.Context, height
 	return &rsp, nil
 }
 
-func (c *consensusClient) GetTransactionsWithProofs(ctx context.Context, height int64) (*TransactionsWithProofs, error) {
+func (c *Client) GetTransactionsWithProofs(ctx context.Context, height int64) (*TransactionsWithProofs, error) {
 	var rsp TransactionsWithProofs
 	if err := c.conn.Invoke(ctx, methodGetTransactionsWithProofs.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -784,7 +792,7 @@ func (c *consensusClient) GetTransactionsWithProofs(ctx context.Context, height 
 	return &rsp, nil
 }
 
-func (c *consensusClient) GetUnconfirmedTransactions(ctx context.Context) ([][]byte, error) {
+func (c *Client) GetUnconfirmedTransactions(ctx context.Context) ([][]byte, error) {
 	var rsp [][]byte
 	if err := c.conn.Invoke(ctx, methodGetUnconfirmedTransactions.FullName(), nil, &rsp); err != nil {
 		return nil, err
@@ -793,7 +801,7 @@ func (c *consensusClient) GetUnconfirmedTransactions(ctx context.Context) ([][]b
 }
 
 type stateReadSync struct {
-	c *consensusClient
+	c *Client
 }
 
 // Implements syncer.ReadSyncer.
@@ -823,11 +831,11 @@ func (rs *stateReadSync) SyncIterate(ctx context.Context, request *syncer.Iterat
 	return &rsp, nil
 }
 
-func (c *consensusClient) State() syncer.ReadSyncer {
+func (c *Client) State() syncer.ReadSyncer {
 	return &stateReadSync{c}
 }
 
-func (c *consensusClient) GetGenesisDocument(ctx context.Context) (*genesis.Document, error) {
+func (c *Client) GetGenesisDocument(ctx context.Context) (*genesis.Document, error) {
 	var rsp genesis.Document
 	if err := c.conn.Invoke(ctx, methodGetGenesisDocument.FullName(), nil, &rsp); err != nil {
 		return nil, err
@@ -835,7 +843,7 @@ func (c *consensusClient) GetGenesisDocument(ctx context.Context) (*genesis.Docu
 	return &rsp, nil
 }
 
-func (c *consensusClient) GetChainContext(ctx context.Context) (string, error) {
+func (c *Client) GetChainContext(ctx context.Context) (string, error) {
 	var rsp string
 	if err := c.conn.Invoke(ctx, methodGetChainContext.FullName(), nil, &rsp); err != nil {
 		return "", err
@@ -843,7 +851,7 @@ func (c *consensusClient) GetChainContext(ctx context.Context) (string, error) {
 	return rsp, nil
 }
 
-func (c *consensusClient) GetStatus(ctx context.Context) (*Status, error) {
+func (c *Client) GetStatus(ctx context.Context) (*Status, error) {
 	var rsp Status
 	if err := c.conn.Invoke(ctx, methodGetStatus.FullName(), nil, &rsp); err != nil {
 		return nil, err
@@ -851,7 +859,7 @@ func (c *consensusClient) GetStatus(ctx context.Context) (*Status, error) {
 	return &rsp, nil
 }
 
-func (c *consensusClient) GetNextBlockState(ctx context.Context) (*NextBlockState, error) {
+func (c *Client) GetNextBlockState(ctx context.Context) (*NextBlockState, error) {
 	var rsp NextBlockState
 	if err := c.conn.Invoke(ctx, methodGetNextBlockState.FullName(), nil, &rsp); err != nil {
 		return nil, err
@@ -859,7 +867,7 @@ func (c *consensusClient) GetNextBlockState(ctx context.Context) (*NextBlockStat
 	return &rsp, nil
 }
 
-func (c *consensusClient) GetParameters(ctx context.Context, height int64) (*Parameters, error) {
+func (c *Client) GetParameters(ctx context.Context, height int64) (*Parameters, error) {
 	var rsp Parameters
 	if err := c.conn.Invoke(ctx, methodGetParameters.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -867,11 +875,11 @@ func (c *consensusClient) GetParameters(ctx context.Context, height int64) (*Par
 	return &rsp, nil
 }
 
-func (c *consensusClient) SubmitEvidence(ctx context.Context, evidence *Evidence) error {
+func (c *Client) SubmitEvidence(ctx context.Context, evidence *Evidence) error {
 	return c.conn.Invoke(ctx, methodSubmitEvidence.FullName(), evidence, nil)
 }
 
-func (c *consensusClient) WatchBlocks(ctx context.Context) (<-chan *Block, pubsub.ClosableSubscription, error) {
+func (c *Client) WatchBlocks(ctx context.Context) (<-chan *Block, pubsub.ClosableSubscription, error) {
 	ctx, sub := pubsub.NewContextSubscription(ctx)
 
 	stream, err := c.conn.NewStream(ctx, &serviceDesc.Streams[0], methodWatchBlocks.FullName())
@@ -906,41 +914,34 @@ func (c *consensusClient) WatchBlocks(ctx context.Context) (<-chan *Block, pubsu
 	return ch, sub, nil
 }
 
-func (c *consensusClient) Beacon() beacon.Backend {
-	return beacon.NewBeaconClient(c.conn)
+func (c *Client) Beacon() beacon.Backend {
+	return beacon.NewClient(c.conn)
 }
 
-func (c *consensusClient) Registry() registry.Backend {
-	return registry.NewRegistryClient(c.conn)
+func (c *Client) Registry() registry.Backend {
+	return registry.NewClient(c.conn)
 }
 
-func (c *consensusClient) Staking() staking.Backend {
-	return staking.NewStakingClient(c.conn)
+func (c *Client) Staking() staking.Backend {
+	return staking.NewClient(c.conn)
 }
 
-func (c *consensusClient) Scheduler() scheduler.Backend {
-	return scheduler.NewSchedulerClient(c.conn)
+func (c *Client) Scheduler() scheduler.Backend {
+	return scheduler.NewClient(c.conn)
 }
 
-func (c *consensusClient) Governance() governance.Backend {
-	return governance.NewGovernanceClient(c.conn)
+func (c *Client) Governance() governance.Backend {
+	return governance.NewClient(c.conn)
 }
 
-func (c *consensusClient) RootHash() roothash.Backend {
-	return roothash.NewRootHashClient(c.conn)
+func (c *Client) RootHash() roothash.Backend {
+	return roothash.NewClient(c.conn)
 }
 
-func (c *consensusClient) Vault() vault.Backend {
-	return vault.NewVaultClient(c.conn)
+func (c *Client) Vault() vault.Backend {
+	return vault.NewClient(c.conn)
 }
 
-func (c *consensusClient) KeyManager() keymanager.Backend {
-	return keymanager.NewKeymanagerClient(c.conn)
-}
-
-// NewConsensusClient creates a new gRPC consensus client service.
-func NewConsensusClient(c *grpc.ClientConn) ClientBackend {
-	return &consensusClient{
-		conn: c,
-	}
+func (c *Client) KeyManager() keymanager.Backend {
+	return keymanager.NewClient(c.conn)
 }

--- a/go/consensus/api/grpc.go
+++ b/go/consensus/api/grpc.go
@@ -12,6 +12,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
 	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
+	keymanager "github.com/oasisprotocol/oasis-core/go/keymanager/api"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
@@ -931,6 +932,10 @@ func (c *consensusClient) RootHash() roothash.Backend {
 
 func (c *consensusClient) Vault() vault.Backend {
 	return vault.NewVaultClient(c.conn)
+}
+
+func (c *consensusClient) KeyManager() keymanager.Backend {
+	return keymanager.NewKeymanagerClient(c.conn)
 }
 
 // NewConsensusClient creates a new gRPC consensus client service.

--- a/go/consensus/cometbft/keymanager/churp/client.go
+++ b/go/consensus/cometbft/keymanager/churp/client.go
@@ -73,12 +73,12 @@ func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*chu
 }
 
 // WatchStatuses implements churp.Backend.
-func (sc *ServiceClient) WatchStatuses() (<-chan *churp.Status, *pubsub.Subscription) {
+func (sc *ServiceClient) WatchStatuses(context.Context) (<-chan *churp.Status, pubsub.ClosableSubscription, error) {
 	sub := sc.statusNotifier.Subscribe()
 	ch := make(chan *churp.Status)
 	sub.Unwrap(ch)
 
-	return ch, sub
+	return ch, sub, nil
 }
 
 func (sc *ServiceClient) DeliverEvent(ev *cmtabcitypes.Event) error {

--- a/go/consensus/cometbft/keymanager/secrets/client.go
+++ b/go/consensus/cometbft/keymanager/secrets/client.go
@@ -44,12 +44,12 @@ func (sc *ServiceClient) GetStatuses(ctx context.Context, height int64) ([]*secr
 	return q.Secrets().Statuses(ctx)
 }
 
-func (sc *ServiceClient) WatchStatuses() (<-chan *secrets.Status, *pubsub.Subscription) {
+func (sc *ServiceClient) WatchStatuses(context.Context) (<-chan *secrets.Status, pubsub.ClosableSubscription, error) {
 	sub := sc.statusNotifier.Subscribe()
 	ch := make(chan *secrets.Status)
 	sub.Unwrap(ch)
 
-	return ch, sub
+	return ch, sub, nil
 }
 
 func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*secrets.Genesis, error) {
@@ -79,20 +79,20 @@ func (sc *ServiceClient) GetEphemeralSecret(ctx context.Context, query *registry
 	return q.Secrets().EphemeralSecret(ctx, query.ID)
 }
 
-func (sc *ServiceClient) WatchMasterSecrets() (<-chan *secrets.SignedEncryptedMasterSecret, *pubsub.Subscription) {
+func (sc *ServiceClient) WatchMasterSecrets(context.Context) (<-chan *secrets.SignedEncryptedMasterSecret, pubsub.ClosableSubscription, error) {
 	sub := sc.mstSecretNotifier.Subscribe()
 	ch := make(chan *secrets.SignedEncryptedMasterSecret)
 	sub.Unwrap(ch)
 
-	return ch, sub
+	return ch, sub, nil
 }
 
-func (sc *ServiceClient) WatchEphemeralSecrets() (<-chan *secrets.SignedEncryptedEphemeralSecret, *pubsub.Subscription) {
+func (sc *ServiceClient) WatchEphemeralSecrets(context.Context) (<-chan *secrets.SignedEncryptedEphemeralSecret, pubsub.ClosableSubscription, error) {
 	sub := sc.ephSecretNotifier.Subscribe()
 	ch := make(chan *secrets.SignedEncryptedEphemeralSecret)
 	sub.Unwrap(ch)
 
-	return ch, sub
+	return ch, sub, nil
 }
 
 func (sc *ServiceClient) DeliverEvent(ev *cmtabcitypes.Event) error {

--- a/go/control/api/grpc.go
+++ b/go/control/api/grpc.go
@@ -270,19 +270,27 @@ func RegisterService(server *grpc.Server, service NodeController) {
 	server.RegisterService(&serviceDesc, service)
 }
 
-type nodeControllerClient struct {
+// NodeControllerClient is a gRPC node controller client.
+type NodeControllerClient struct {
 	conn *grpc.ClientConn
 }
 
-func (c *nodeControllerClient) RequestShutdown(ctx context.Context, wait bool) error {
+// NewNodeControllerClient creates a new gRPC node controller client.
+func NewNodeControllerClient(c *grpc.ClientConn) *NodeControllerClient {
+	return &NodeControllerClient{
+		conn: c,
+	}
+}
+
+func (c *NodeControllerClient) RequestShutdown(ctx context.Context, wait bool) error {
 	return c.conn.Invoke(ctx, methodRequestShutdown.FullName(), wait, nil)
 }
 
-func (c *nodeControllerClient) WaitSync(ctx context.Context) error {
+func (c *NodeControllerClient) WaitSync(ctx context.Context) error {
 	return c.conn.Invoke(ctx, methodWaitSync.FullName(), nil, nil)
 }
 
-func (c *nodeControllerClient) IsSynced(ctx context.Context) (bool, error) {
+func (c *NodeControllerClient) IsSynced(ctx context.Context) (bool, error) {
 	var rsp bool
 	if err := c.conn.Invoke(ctx, methodIsSynced.FullName(), nil, &rsp); err != nil {
 		return false, err
@@ -290,11 +298,11 @@ func (c *nodeControllerClient) IsSynced(ctx context.Context) (bool, error) {
 	return rsp, nil
 }
 
-func (c *nodeControllerClient) WaitReady(ctx context.Context) error {
+func (c *NodeControllerClient) WaitReady(ctx context.Context) error {
 	return c.conn.Invoke(ctx, methodWaitReady.FullName(), nil, nil)
 }
 
-func (c *nodeControllerClient) IsReady(ctx context.Context) (bool, error) {
+func (c *NodeControllerClient) IsReady(ctx context.Context) (bool, error) {
 	var rsp bool
 	if err := c.conn.Invoke(ctx, methodIsReady.FullName(), nil, &rsp); err != nil {
 		return false, err
@@ -302,15 +310,15 @@ func (c *nodeControllerClient) IsReady(ctx context.Context) (bool, error) {
 	return rsp, nil
 }
 
-func (c *nodeControllerClient) UpgradeBinary(ctx context.Context, descriptor *upgradeApi.Descriptor) error {
+func (c *NodeControllerClient) UpgradeBinary(ctx context.Context, descriptor *upgradeApi.Descriptor) error {
 	return c.conn.Invoke(ctx, methodUpgradeBinary.FullName(), descriptor, nil)
 }
 
-func (c *nodeControllerClient) CancelUpgrade(ctx context.Context, descriptor *upgradeApi.Descriptor) error {
+func (c *NodeControllerClient) CancelUpgrade(ctx context.Context, descriptor *upgradeApi.Descriptor) error {
 	return c.conn.Invoke(ctx, methodCancelUpgrade.FullName(), descriptor, nil)
 }
 
-func (c *nodeControllerClient) GetStatus(ctx context.Context) (*Status, error) {
+func (c *NodeControllerClient) GetStatus(ctx context.Context) (*Status, error) {
 	var rsp Status
 	if err := c.conn.Invoke(ctx, methodGetStatus.FullName(), nil, &rsp); err != nil {
 		return nil, err
@@ -318,15 +326,10 @@ func (c *nodeControllerClient) GetStatus(ctx context.Context) (*Status, error) {
 	return &rsp, nil
 }
 
-func (c *nodeControllerClient) AddBundle(ctx context.Context, path string) error {
+func (c *NodeControllerClient) AddBundle(ctx context.Context, path string) error {
 	var rsp Status
 	if err := c.conn.Invoke(ctx, methodAddBundle.FullName(), path, &rsp); err != nil {
 		return err
 	}
 	return nil
-}
-
-// NewNodeControllerClient creates a new gRPC node controller client service.
-func NewNodeControllerClient(c *grpc.ClientConn) NodeController {
-	return &nodeControllerClient{c}
 }

--- a/go/control/api/grpc_debug.go
+++ b/go/control/api/grpc_debug.go
@@ -87,19 +87,22 @@ func RegisterDebugService(server *grpc.Server, service DebugController) {
 	server.RegisterService(&debugServiceDesc, service)
 }
 
-type debugControllerClient struct {
+// DebugControllerClient is a gRPC debug controller client.
+type DebugControllerClient struct {
 	conn *grpc.ClientConn
 }
 
-func (c *debugControllerClient) SetEpoch(ctx context.Context, epoch beacon.EpochTime) error {
+// NewDebugControllerClient creates a new gRPC debug controller client.
+func NewDebugControllerClient(c *grpc.ClientConn) *DebugControllerClient {
+	return &DebugControllerClient{
+		conn: c,
+	}
+}
+
+func (c *DebugControllerClient) SetEpoch(ctx context.Context, epoch beacon.EpochTime) error {
 	return c.conn.Invoke(ctx, methodSetEpoch.FullName(), epoch, nil)
 }
 
-func (c *debugControllerClient) WaitNodesRegistered(ctx context.Context, count int) error {
+func (c *DebugControllerClient) WaitNodesRegistered(ctx context.Context, count int) error {
 	return c.conn.Invoke(ctx, methodWaitNodesRegistered.FullName(), count, nil)
-}
-
-// NewDebugControllerClient creates a new gRPC debug controller client service.
-func NewDebugControllerClient(c *grpc.ClientConn) DebugController {
-	return &debugControllerClient{c}
 }

--- a/go/governance/api/grpc.go
+++ b/go/governance/api/grpc.go
@@ -298,11 +298,19 @@ func RegisterService(server *grpc.Server, service Backend) {
 	server.RegisterService(&serviceDesc, service)
 }
 
-type governanceClient struct {
+// Client is a gRPC governance client.
+type Client struct {
 	conn *grpc.ClientConn
 }
 
-func (c *governanceClient) ActiveProposals(ctx context.Context, height int64) ([]*Proposal, error) {
+// NewClient creates a new gRPC governance client.
+func NewClient(c *grpc.ClientConn) *Client {
+	return &Client{
+		conn: c,
+	}
+}
+
+func (c *Client) ActiveProposals(ctx context.Context, height int64) ([]*Proposal, error) {
 	var rsp []*Proposal
 	if err := c.conn.Invoke(ctx, methodActiveProposals.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -310,7 +318,7 @@ func (c *governanceClient) ActiveProposals(ctx context.Context, height int64) ([
 	return rsp, nil
 }
 
-func (c *governanceClient) Proposals(ctx context.Context, height int64) ([]*Proposal, error) {
+func (c *Client) Proposals(ctx context.Context, height int64) ([]*Proposal, error) {
 	var rsp []*Proposal
 	if err := c.conn.Invoke(ctx, methodProposals.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -318,7 +326,7 @@ func (c *governanceClient) Proposals(ctx context.Context, height int64) ([]*Prop
 	return rsp, nil
 }
 
-func (c *governanceClient) Proposal(ctx context.Context, request *ProposalQuery) (*Proposal, error) {
+func (c *Client) Proposal(ctx context.Context, request *ProposalQuery) (*Proposal, error) {
 	var rsp Proposal
 	if err := c.conn.Invoke(ctx, methodProposal.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -326,7 +334,7 @@ func (c *governanceClient) Proposal(ctx context.Context, request *ProposalQuery)
 	return &rsp, nil
 }
 
-func (c *governanceClient) Votes(ctx context.Context, request *ProposalQuery) ([]*VoteEntry, error) {
+func (c *Client) Votes(ctx context.Context, request *ProposalQuery) ([]*VoteEntry, error) {
 	var rsp []*VoteEntry
 	if err := c.conn.Invoke(ctx, methodVotes.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -334,7 +342,7 @@ func (c *governanceClient) Votes(ctx context.Context, request *ProposalQuery) ([
 	return rsp, nil
 }
 
-func (c *governanceClient) PendingUpgrades(ctx context.Context, height int64) ([]*upgrade.Descriptor, error) {
+func (c *Client) PendingUpgrades(ctx context.Context, height int64) ([]*upgrade.Descriptor, error) {
 	var rsp []*upgrade.Descriptor
 	if err := c.conn.Invoke(ctx, methodPendingUpgrades.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -342,7 +350,7 @@ func (c *governanceClient) PendingUpgrades(ctx context.Context, height int64) ([
 	return rsp, nil
 }
 
-func (c *governanceClient) StateToGenesis(ctx context.Context, height int64) (*Genesis, error) {
+func (c *Client) StateToGenesis(ctx context.Context, height int64) (*Genesis, error) {
 	var rsp Genesis
 	if err := c.conn.Invoke(ctx, methodStateToGenesis.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -350,7 +358,7 @@ func (c *governanceClient) StateToGenesis(ctx context.Context, height int64) (*G
 	return &rsp, nil
 }
 
-func (c *governanceClient) ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error) {
+func (c *Client) ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error) {
 	var rsp ConsensusParameters
 	if err := c.conn.Invoke(ctx, methodConsensusParameters.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -358,7 +366,7 @@ func (c *governanceClient) ConsensusParameters(ctx context.Context, height int64
 	return &rsp, nil
 }
 
-func (c *governanceClient) GetEvents(ctx context.Context, height int64) ([]*Event, error) {
+func (c *Client) GetEvents(ctx context.Context, height int64) ([]*Event, error) {
 	var rsp []*Event
 	if err := c.conn.Invoke(ctx, methodGetEvents.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -366,7 +374,7 @@ func (c *governanceClient) GetEvents(ctx context.Context, height int64) ([]*Even
 	return rsp, nil
 }
 
-func (c *governanceClient) WatchEvents(ctx context.Context) (<-chan *Event, pubsub.ClosableSubscription, error) {
+func (c *Client) WatchEvents(ctx context.Context) (<-chan *Event, pubsub.ClosableSubscription, error) {
 	ctx, sub := pubsub.NewContextSubscription(ctx)
 
 	stream, err := c.conn.NewStream(ctx, &serviceDesc.Streams[0], methodWatchEvents.FullName())
@@ -401,10 +409,5 @@ func (c *governanceClient) WatchEvents(ctx context.Context) (<-chan *Event, pubs
 	return ch, sub, nil
 }
 
-func (c *governanceClient) Cleanup() {
-}
-
-// NewGovernanceClient creates a new gRPC governance client service.
-func NewGovernanceClient(c *grpc.ClientConn) Backend {
-	return &governanceClient{c}
+func (c *Client) Cleanup() {
 }

--- a/go/ias/api/grpc.go
+++ b/go/ias/api/grpc.go
@@ -112,11 +112,19 @@ func RegisterService(server *grpc.Server, service Endpoint) {
 	server.RegisterService(&serviceDesc, service)
 }
 
-type endpointClient struct {
+// Client is a gRPC IAS endpoint client.
+type Client struct {
 	conn *grpc.ClientConn
 }
 
-func (c *endpointClient) VerifyEvidence(ctx context.Context, evidence *Evidence) (*ias.AVRBundle, error) {
+// NewClient creates a new gRPC IAS endpoint client.
+func NewClient(c *grpc.ClientConn) *Client {
+	return &Client{
+		conn: c,
+	}
+}
+
+func (c *Client) VerifyEvidence(ctx context.Context, evidence *Evidence) (*ias.AVRBundle, error) {
 	var rsp ias.AVRBundle
 	if err := c.conn.Invoke(ctx, methodVerifyEvidence.FullName(), evidence, &rsp); err != nil {
 		return nil, err
@@ -124,7 +132,7 @@ func (c *endpointClient) VerifyEvidence(ctx context.Context, evidence *Evidence)
 	return &rsp, nil
 }
 
-func (c *endpointClient) GetSPIDInfo(ctx context.Context) (*SPIDInfo, error) {
+func (c *Client) GetSPIDInfo(ctx context.Context) (*SPIDInfo, error) {
 	var rsp SPIDInfo
 	if err := c.conn.Invoke(ctx, methodGetSPIDInfo.FullName(), nil, &rsp); err != nil {
 		return nil, err
@@ -132,7 +140,7 @@ func (c *endpointClient) GetSPIDInfo(ctx context.Context) (*SPIDInfo, error) {
 	return &rsp, nil
 }
 
-func (c *endpointClient) GetSigRL(ctx context.Context, epidGID uint32) ([]byte, error) {
+func (c *Client) GetSigRL(ctx context.Context, epidGID uint32) ([]byte, error) {
 	var rsp []byte
 	if err := c.conn.Invoke(ctx, methodGetSigRL.FullName(), epidGID, &rsp); err != nil {
 		return nil, err
@@ -140,10 +148,5 @@ func (c *endpointClient) GetSigRL(ctx context.Context, epidGID uint32) ([]byte, 
 	return rsp, nil
 }
 
-func (c *endpointClient) Cleanup() {
-}
-
-// NewEndpointClient creates a new gRPC IAS endpoint client service.
-func NewEndpointClient(c *grpc.ClientConn) Endpoint {
-	return &endpointClient{c}
+func (c *Client) Cleanup() {
 }

--- a/go/ias/proxy/client/client.go
+++ b/go/ias/proxy/client/client.go
@@ -122,7 +122,7 @@ func New(identity *identity.Identity, addresses []string) ([]api.Endpoint, error
 
 		clients = append(clients, &proxyClient{
 			conn:     conn,
-			endpoint: api.NewEndpointClient(conn),
+			endpoint: api.NewClient(conn),
 			logger:   logger,
 		})
 	}

--- a/go/keymanager/api/grpc.go
+++ b/go/keymanager/api/grpc.go
@@ -61,13 +61,13 @@ func RegisterService(server *grpc.Server, service Backend) {
 	churp.RegisterService(server, service.Churp())
 }
 
-// Client is a gRPC keymanager client.
+// Client is a gRPC key manager client.
 type Client struct {
 	conn *grpc.ClientConn
 }
 
-// NewKeymanagerClient creates a new gRPC keymanager client.
-func NewKeymanagerClient(c *grpc.ClientConn) Backend {
+// NewClient creates a new gRPC key manager client.
+func NewClient(c *grpc.ClientConn) *Client {
 	return &Client{
 		conn: c,
 	}

--- a/go/keymanager/api/grpc.go
+++ b/go/keymanager/api/grpc.go
@@ -1,36 +1,90 @@
 package api
 
 import (
+	"context"
+
 	"google.golang.org/grpc"
 
+	cmnGrpc "github.com/oasisprotocol/oasis-core/go/common/grpc"
 	"github.com/oasisprotocol/oasis-core/go/keymanager/churp"
 	"github.com/oasisprotocol/oasis-core/go/keymanager/secrets"
 )
 
+var (
+	// serviceName is the gRPC service name.
+	serviceName = cmnGrpc.NewServiceName("KeyManager")
+
+	// methodStateToGenesis is the StateToGenesis method.
+	methodStateToGenesis = serviceName.NewMethod("StateToGenesis", int64(0))
+
+	// serviceDesc is the gRPC service descriptor.
+	serviceDesc = grpc.ServiceDesc{
+		ServiceName: string(serviceName),
+		HandlerType: (*Backend)(nil),
+		Methods: []grpc.MethodDesc{
+			{
+				MethodName: methodStateToGenesis.ShortName(),
+				Handler:    handlerStateToGenesis,
+			},
+		},
+	}
+)
+
+func handlerStateToGenesis(
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var height int64
+	if err := dec(&height); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(Backend).StateToGenesis(ctx, height)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodStateToGenesis.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).StateToGenesis(ctx, req.(int64))
+	}
+	return interceptor(ctx, height, info, handler)
+}
+
 // RegisterService registers a new keymanager backend service with the given gRPC server.
 func RegisterService(server *grpc.Server, service Backend) {
+	server.RegisterService(&serviceDesc, service)
+
 	secrets.RegisterService(server, service.Secrets())
 	churp.RegisterService(server, service.Churp())
 }
 
-// KeymanagerClient is a gRPC keymanager client.
-type KeymanagerClient struct {
-	secretsClient *secrets.Client
-	churpClient   *churp.Client
+// Client is a gRPC keymanager client.
+type Client struct {
+	conn *grpc.ClientConn
 }
 
-func (c *KeymanagerClient) Secrets() *secrets.Client {
-	return c.secretsClient
-}
-
-func (c *KeymanagerClient) Churp() *churp.Client {
-	return c.churpClient
-}
-
-// NewKeymanagerClient creates a new gRPC keymanager client service.
-func NewKeymanagerClient(c *grpc.ClientConn) *KeymanagerClient {
-	return &KeymanagerClient{
-		secretsClient: secrets.NewClient(c),
-		churpClient:   churp.NewClient(c),
+// NewKeymanagerClient creates a new gRPC keymanager client.
+func NewKeymanagerClient(c *grpc.ClientConn) Backend {
+	return &Client{
+		conn: c,
 	}
+}
+
+func (c *Client) StateToGenesis(ctx context.Context, height int64) (*Genesis, error) {
+	var resp *Genesis
+	if err := c.conn.Invoke(ctx, methodStateToGenesis.FullName(), height, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *Client) Secrets() secrets.Backend {
+	return secrets.NewClient(c.conn)
+}
+
+func (c *Client) Churp() churp.Backend {
+	return churp.NewClient(c.conn)
 }

--- a/go/keymanager/api/grpc.go
+++ b/go/keymanager/api/grpc.go
@@ -2,61 +2,16 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"google.golang.org/grpc"
 
-	cmnGrpc "github.com/oasisprotocol/oasis-core/go/common/grpc"
 	"github.com/oasisprotocol/oasis-core/go/keymanager/churp"
 	"github.com/oasisprotocol/oasis-core/go/keymanager/secrets"
 )
 
-var (
-	// serviceName is the gRPC service name.
-	serviceName = cmnGrpc.NewServiceName("KeyManager")
-
-	// methodStateToGenesis is the StateToGenesis method.
-	methodStateToGenesis = serviceName.NewMethod("StateToGenesis", int64(0))
-
-	// serviceDesc is the gRPC service descriptor.
-	serviceDesc = grpc.ServiceDesc{
-		ServiceName: string(serviceName),
-		HandlerType: (*Backend)(nil),
-		Methods: []grpc.MethodDesc{
-			{
-				MethodName: methodStateToGenesis.ShortName(),
-				Handler:    handlerStateToGenesis,
-			},
-		},
-	}
-)
-
-func handlerStateToGenesis(
-	srv interface{},
-	ctx context.Context,
-	dec func(interface{}) error,
-	interceptor grpc.UnaryServerInterceptor,
-) (interface{}, error) {
-	var height int64
-	if err := dec(&height); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(Backend).StateToGenesis(ctx, height)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: methodStateToGenesis.FullName(),
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(Backend).StateToGenesis(ctx, req.(int64))
-	}
-	return interceptor(ctx, height, info, handler)
-}
-
 // RegisterService registers a new keymanager backend service with the given gRPC server.
 func RegisterService(server *grpc.Server, service Backend) {
-	server.RegisterService(&serviceDesc, service)
-
 	secrets.RegisterService(server, service.Secrets())
 	churp.RegisterService(server, service.Churp())
 }
@@ -73,12 +28,8 @@ func NewClient(c *grpc.ClientConn) *Client {
 	}
 }
 
-func (c *Client) StateToGenesis(ctx context.Context, height int64) (*Genesis, error) {
-	var resp *Genesis
-	if err := c.conn.Invoke(ctx, methodStateToGenesis.FullName(), height, &resp); err != nil {
-		return nil, err
-	}
-	return resp, nil
+func (c *Client) StateToGenesis(context.Context, int64) (*Genesis, error) {
+	return nil, fmt.Errorf("keymanager: not supported")
 }
 
 func (c *Client) Secrets() secrets.Backend {

--- a/go/keymanager/churp/backend.go
+++ b/go/keymanager/churp/backend.go
@@ -26,7 +26,7 @@ type Backend interface {
 	// containing CHURP statuses as they change over time.
 	//
 	// Upon subscription the current statuses are sent immediately.
-	WatchStatuses() (<-chan *Status, *pubsub.Subscription)
+	WatchStatuses(context.Context) (<-chan *Status, pubsub.ClosableSubscription, error)
 
 	// StateToGenesis returns the genesis state at specified block height.
 	StateToGenesis(context.Context, int64) (*Genesis, error)

--- a/go/keymanager/churp/grpc.go
+++ b/go/keymanager/churp/grpc.go
@@ -212,12 +212,12 @@ func RegisterService(server *grpc.Server, service Backend) {
 	server.RegisterService(&serviceDesc, service)
 }
 
-// Client is a gRPC keymanager CHURP client.
+// Client is a gRPC key manager CHURP client.
 type Client struct {
 	conn *grpc.ClientConn
 }
 
-// NewClient creates a new gRPC keymanager CHURP client.
+// NewClient creates a new gRPC key manager CHURP client.
 func NewClient(c *grpc.ClientConn) *Client {
 	return &Client{c}
 }

--- a/go/keymanager/churp/grpc.go
+++ b/go/keymanager/churp/grpc.go
@@ -14,6 +14,8 @@ var (
 	// serviceName is the gRPC service name.
 	serviceName = cmnGrpc.NewServiceName("KeyManager.Churp")
 
+	// methodStateToGenesis is the StateToGenesis method.
+	methodStateToGenesis = serviceName.NewMethod("StateToGenesis", int64(0))
 	// methodConsensusParameters is the ConsensusParameters method.
 	methodConsensusParameters = serviceName.NewMethod("ConsensusParameters", int64(0))
 	// methodStatus is the Status method.
@@ -31,6 +33,10 @@ var (
 		ServiceName: string(serviceName),
 		HandlerType: (*Backend)(nil),
 		Methods: []grpc.MethodDesc{
+			{
+				MethodName: methodStateToGenesis.ShortName(),
+				Handler:    handlerStateToGenesis,
+			},
 			{
 				MethodName: methodConsensusParameters.ShortName(),
 				Handler:    handlerConsensusParameters,
@@ -57,6 +63,29 @@ var (
 		},
 	}
 )
+
+func handlerStateToGenesis(
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var height int64
+	if err := dec(&height); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(Backend).StateToGenesis(ctx, height)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodStateToGenesis.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).StateToGenesis(ctx, req.(int64))
+	}
+	return interceptor(ctx, height, info, handler)
+}
 
 func handlerConsensusParameters(
 	srv interface{},
@@ -156,7 +185,10 @@ func handlerWatchStatuses(srv interface{}, stream grpc.ServerStream) error {
 	}
 
 	ctx := stream.Context()
-	ch, sub := srv.(Backend).WatchStatuses()
+	ch, sub, err := srv.(Backend).WatchStatuses(ctx)
+	if err != nil {
+		return err
+	}
 	defer sub.Close()
 
 	for {
@@ -180,9 +212,22 @@ func RegisterService(server *grpc.Server, service Backend) {
 	server.RegisterService(&serviceDesc, service)
 }
 
-// Client is a gRPC keymanager secrets client.
+// Client is a gRPC keymanager CHURP client.
 type Client struct {
 	conn *grpc.ClientConn
+}
+
+// NewClient creates a new gRPC keymanager CHURP client.
+func NewClient(c *grpc.ClientConn) *Client {
+	return &Client{c}
+}
+
+func (c *Client) StateToGenesis(ctx context.Context, height int64) (*Genesis, error) {
+	var resp *Genesis
+	if err := c.conn.Invoke(ctx, methodStateToGenesis.FullName(), height, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 func (c *Client) ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error) {
@@ -201,12 +246,12 @@ func (c *Client) Status(ctx context.Context, query *StatusQuery) (*Status, error
 	return &resp, nil
 }
 
-func (c *Client) Statuses(ctx context.Context, query *registry.NamespaceQuery) (*Status, error) {
-	var resp Status
+func (c *Client) Statuses(ctx context.Context, query *registry.NamespaceQuery) ([]*Status, error) {
+	var resp []*Status
 	if err := c.conn.Invoke(ctx, methodStatuses.FullName(), query, &resp); err != nil {
 		return nil, err
 	}
-	return &resp, nil
+	return resp, nil
 }
 
 func (c *Client) AllStatuses(ctx context.Context, height int64) ([]*Status, error) {
@@ -250,9 +295,4 @@ func (c *Client) WatchStatuses(ctx context.Context) (<-chan *Status, pubsub.Clos
 	}()
 
 	return ch, sub, nil
-}
-
-// NewClient creates a new gRPC keymanager CHURP client service.
-func NewClient(c *grpc.ClientConn) *Client {
-	return &Client{c}
 }

--- a/go/keymanager/secrets/api.go
+++ b/go/keymanager/secrets/api.go
@@ -196,7 +196,7 @@ type Backend interface {
 	// containing the key manager statuses as it changes over time.
 	//
 	// Upon subscription the current status is sent immediately.
-	WatchStatuses() (<-chan *Status, *pubsub.Subscription)
+	WatchStatuses(context.Context) (<-chan *Status, pubsub.ClosableSubscription, error)
 
 	// StateToGenesis returns the genesis state at specified block height.
 	StateToGenesis(context.Context, int64) (*Genesis, error)
@@ -205,13 +205,13 @@ type Backend interface {
 	GetMasterSecret(context.Context, *registry.NamespaceQuery) (*SignedEncryptedMasterSecret, error)
 
 	// WatchMasterSecrets returns a channel that produces a stream of master secrets.
-	WatchMasterSecrets() (<-chan *SignedEncryptedMasterSecret, *pubsub.Subscription)
+	WatchMasterSecrets(context.Context) (<-chan *SignedEncryptedMasterSecret, pubsub.ClosableSubscription, error)
 
 	// GetEphemeralSecret returns the key manager ephemeral secret.
 	GetEphemeralSecret(context.Context, *registry.NamespaceQuery) (*SignedEncryptedEphemeralSecret, error)
 
 	// WatchEphemeralSecrets returns a channel that produces a stream of ephemeral secrets.
-	WatchEphemeralSecrets() (<-chan *SignedEncryptedEphemeralSecret, *pubsub.Subscription)
+	WatchEphemeralSecrets(context.Context) (<-chan *SignedEncryptedEphemeralSecret, pubsub.ClosableSubscription, error)
 }
 
 // NewUpdatePolicyTx creates a new policy update transaction.

--- a/go/keymanager/secrets/grpc.go
+++ b/go/keymanager/secrets/grpc.go
@@ -282,12 +282,12 @@ func RegisterService(server *grpc.Server, service Backend) {
 	server.RegisterService(&serviceDesc, service)
 }
 
-// Client is a gRPC keymanager secrets client.
+// Client is a gRPC key manager secrets client.
 type Client struct {
 	conn *grpc.ClientConn
 }
 
-// NewClient creates a new gRPC keymanager secrets client.
+// NewClient creates a new gRPC key manager secrets client.
 func NewClient(c *grpc.ClientConn) *Client {
 	return &Client{c}
 }

--- a/go/keymanager/secrets/grpc.go
+++ b/go/keymanager/secrets/grpc.go
@@ -280,6 +280,7 @@ func handlerWatchEphemeralSecrets(srv interface{}, stream grpc.ServerStream) err
 // RegisterService registers a new keymanager secrets backend service with the given gRPC server.
 func RegisterService(server *grpc.Server, service Backend) {
 	server.RegisterService(&serviceDesc, service)
+	server.RegisterService(&deprecatedServiceDesc, service)
 }
 
 // Client is a gRPC key manager secrets client.

--- a/go/keymanager/secrets/grpc.go
+++ b/go/keymanager/secrets/grpc.go
@@ -12,8 +12,10 @@ import (
 
 var (
 	// serviceName is the gRPC service name.
-	serviceName = cmnGrpc.NewServiceName("KeyManager")
+	serviceName = cmnGrpc.NewServiceName("KeyManager.Secrets")
 
+	// methodStateToGenesis is the StateToGenesis method.
+	methodStateToGenesis = serviceName.NewMethod("StateToGenesis", int64(0))
 	// methodGetStatus is the GetStatus method.
 	methodGetStatus = serviceName.NewMethod("GetStatus", registry.NamespaceQuery{})
 	// methodGetStatuses is the GetStatuses method.
@@ -35,6 +37,10 @@ var (
 		ServiceName: string(serviceName),
 		HandlerType: (*Backend)(nil),
 		Methods: []grpc.MethodDesc{
+			{
+				MethodName: methodStateToGenesis.ShortName(),
+				Handler:    handlerStateToGenesis,
+			},
 			{
 				MethodName: methodGetStatus.ShortName(),
 				Handler:    handlerGetStatus,
@@ -71,6 +77,29 @@ var (
 		},
 	}
 )
+
+func handlerStateToGenesis(
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var height int64
+	if err := dec(&height); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(Backend).StateToGenesis(ctx, height)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodStateToGenesis.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).StateToGenesis(ctx, req.(int64))
+	}
+	return interceptor(ctx, height, info, handler)
+}
 
 func handlerGetStatus(
 	srv interface{},
@@ -170,7 +199,10 @@ func handlerWatchStatuses(srv interface{}, stream grpc.ServerStream) error {
 	}
 
 	ctx := stream.Context()
-	ch, sub := srv.(Backend).WatchStatuses()
+	ch, sub, err := srv.(Backend).WatchStatuses(ctx)
+	if err != nil {
+		return err
+	}
 	defer sub.Close()
 
 	for {
@@ -195,7 +227,10 @@ func handlerWatchMasterSecrets(srv interface{}, stream grpc.ServerStream) error 
 	}
 
 	ctx := stream.Context()
-	ch, sub := srv.(Backend).WatchMasterSecrets()
+	ch, sub, err := srv.(Backend).WatchMasterSecrets(ctx)
+	if err != nil {
+		return err
+	}
 	defer sub.Close()
 
 	for {
@@ -220,7 +255,10 @@ func handlerWatchEphemeralSecrets(srv interface{}, stream grpc.ServerStream) err
 	}
 
 	ctx := stream.Context()
-	ch, sub := srv.(Backend).WatchEphemeralSecrets()
+	ch, sub, err := srv.(Backend).WatchEphemeralSecrets(ctx)
+	if err != nil {
+		return err
+	}
 	defer sub.Close()
 
 	for {
@@ -247,6 +285,19 @@ func RegisterService(server *grpc.Server, service Backend) {
 // Client is a gRPC keymanager secrets client.
 type Client struct {
 	conn *grpc.ClientConn
+}
+
+// NewClient creates a new gRPC keymanager secrets client.
+func NewClient(c *grpc.ClientConn) *Client {
+	return &Client{c}
+}
+
+func (c *Client) StateToGenesis(ctx context.Context, height int64) (*Genesis, error) {
+	var resp *Genesis
+	if err := c.conn.Invoke(ctx, methodStateToGenesis.FullName(), height, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 func (c *Client) GetStatus(ctx context.Context, query *registry.NamespaceQuery) (*Status, error) {
@@ -384,9 +435,4 @@ func (c *Client) WatchEphemeralSecrets(ctx context.Context) (<-chan *SignedEncry
 	}()
 
 	return ch, sub, nil
-}
-
-// NewClient creates a new gRPC keymanager secrets client service.
-func NewClient(c *grpc.ClientConn) *Client {
-	return &Client{c}
 }

--- a/go/keymanager/secrets/grpc_deprecated.go
+++ b/go/keymanager/secrets/grpc_deprecated.go
@@ -1,0 +1,76 @@
+package secrets
+
+import (
+	"google.golang.org/grpc"
+
+	cmnGrpc "github.com/oasisprotocol/oasis-core/go/common/grpc"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+)
+
+var (
+	// deprecatedServiceName is the deprecated gRPC service name.
+	deprecatedServiceName = cmnGrpc.NewServiceName("KeyManager")
+
+	// deprecatedStateToGenesis is the deprecated StateToGenesis method.
+	deprecatedStateToGenesis = deprecatedServiceName.NewMethod("StateToGenesis", int64(0))
+	// deprecatedGetStatus is the deprecated GetStatus method.
+	deprecatedGetStatus = deprecatedServiceName.NewMethod("GetStatus", registry.NamespaceQuery{})
+	// deprecatedGetStatuses is the deprecated GetStatuses method.
+	deprecatedGetStatuses = deprecatedServiceName.NewMethod("GetStatuses", int64(0))
+	// deprecatedGetMasterSecret is the deprecated GetMasterSecret method.
+	deprecatedGetMasterSecret = deprecatedServiceName.NewMethod("GetMasterSecret", registry.NamespaceQuery{})
+	// deprecatedGetEphemeralSecret is the deprecated GetEphemeralSecret method.
+	deprecatedGetEphemeralSecret = deprecatedServiceName.NewMethod("GetEphemeralSecret", registry.NamespaceQuery{})
+
+	// deprecatedWatchStatuses is the WatchStatuses method.
+	deprecatedWatchStatuses = deprecatedServiceName.NewMethod("WatchStatuses", nil)
+	// deprecatedWatchMasterSecrets is the deprecated WatchMasterSecrets method.
+	deprecatedWatchMasterSecrets = deprecatedServiceName.NewMethod("WatchMasterSecrets", nil)
+	// deprecatedWatchEphemeralSecrets is the deprecated WatchEphemeralSecrets method.
+	deprecatedWatchEphemeralSecrets = deprecatedServiceName.NewMethod("WatchEphemeralSecrets", nil)
+
+	// deprecatedServiceDesc is the deprecated gRPC service descriptor.
+	deprecatedServiceDesc = grpc.ServiceDesc{
+		ServiceName: string(deprecatedServiceName),
+		HandlerType: (*Backend)(nil),
+		Methods: []grpc.MethodDesc{
+			{
+				MethodName: deprecatedStateToGenesis.ShortName(),
+				Handler:    handlerStateToGenesis,
+			},
+			{
+				MethodName: deprecatedGetStatus.ShortName(),
+				Handler:    handlerGetStatus,
+			},
+			{
+				MethodName: deprecatedGetStatuses.ShortName(),
+				Handler:    handlerGetStatuses,
+			},
+			{
+				MethodName: deprecatedGetMasterSecret.ShortName(),
+				Handler:    handlerGetMasterSecret,
+			},
+			{
+				MethodName: deprecatedGetEphemeralSecret.ShortName(),
+				Handler:    handlerGetEphemeralSecret,
+			},
+		},
+		Streams: []grpc.StreamDesc{
+			{
+				StreamName:    deprecatedWatchStatuses.ShortName(),
+				Handler:       handlerWatchStatuses,
+				ServerStreams: true,
+			},
+			{
+				StreamName:    deprecatedWatchMasterSecrets.ShortName(),
+				Handler:       handlerWatchMasterSecrets,
+				ServerStreams: true,
+			},
+			{
+				StreamName:    deprecatedWatchEphemeralSecrets.ShortName(),
+				Handler:       handlerWatchEphemeralSecrets,
+				ServerStreams: true,
+			},
+		},
+	}
+)

--- a/go/oasis-node/cmd/consensus/consensus.go
+++ b/go/oasis-node/cmd/consensus/consensus.go
@@ -75,7 +75,7 @@ func doConnect(cmd *cobra.Command) (*grpc.ClientConn, consensus.ClientBackend) {
 		os.Exit(1)
 	}
 
-	client := consensus.NewConsensusClient(conn)
+	client := consensus.NewClient(conn)
 	return conn, client
 }
 

--- a/go/oasis-node/cmd/control/runtime_stats.go
+++ b/go/oasis-node/cmd/control/runtime_stats.go
@@ -188,7 +188,7 @@ func doRuntimeStats(cmd *cobra.Command, args []string) { //nolint:gocyclo
 
 	// Connect to the node
 	conn, _ := doConnectOnly(cmd)
-	consensus := consensusAPI.NewConsensusClient(conn)
+	consensus := consensusAPI.NewClient(conn)
 
 	// Fixup the start/end heights if they were not specified (or are 0)
 	if startHeight == 0 {
@@ -239,8 +239,8 @@ func doRuntimeStats(cmd *cobra.Command, args []string) { //nolint:gocyclo
 		roundDiscrepancy bool
 	)
 
-	roothash := roothashAPI.NewRootHashClient(conn)
-	reg := registryAPI.NewRegistryClient(conn)
+	roothash := roothashAPI.NewClient(conn)
+	reg := registryAPI.NewClient(conn)
 	nodeToEntity := make(map[signature.PublicKey]signature.PublicKey)
 
 	for height := int64(startHeight); height < int64(endHeight); height++ {

--- a/go/oasis-node/cmd/debug/beacon/beacon.go
+++ b/go/oasis-node/cmd/debug/beacon/beacon.go
@@ -44,7 +44,7 @@ func doConnect(cmd *cobra.Command) (*grpc.ClientConn, beacon.Backend) {
 		os.Exit(1)
 	}
 
-	client := beacon.NewBeaconClient(conn)
+	client := beacon.NewClient(conn)
 
 	return conn, client
 }

--- a/go/oasis-node/cmd/debug/storage/storage.go
+++ b/go/oasis-node/cmd/debug/storage/storage.go
@@ -110,9 +110,9 @@ func doCheckRoots(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
 
 	conn, _ := cmdControl.DoConnect(cmd)
-	client := runtimeClient.NewRuntimeClient(conn)
-	storageWorkerClient := storageWorkerAPI.NewStorageWorkerClient(conn)
-	storageClient := storageAPI.NewStorageClient(conn)
+	client := runtimeClient.NewClient(conn)
+	storageWorkerClient := storageWorkerAPI.NewClient(conn)
+	storageClient := storageAPI.NewClient(conn)
 	defer conn.Close()
 
 	var id common.Namespace

--- a/go/oasis-node/cmd/debug/txsource/txsource.go
+++ b/go/oasis-node/cmd/debug/txsource/txsource.go
@@ -102,7 +102,7 @@ func doRun(cmd *cobra.Command, _ []string) error {
 	defer conn.Close()
 
 	// Set up the consensus client and submission manager.
-	cnsc := consensus.NewConsensusClient(conn)
+	cnsc := consensus.NewClient(conn)
 	pd, err := pricediscovery.NewStatic(viper.GetUint64(CfgGasPrice))
 	if err != nil {
 		return fmt.Errorf("failed to create submission manager: %w", err)

--- a/go/oasis-node/cmd/debug/txsource/workload/commission.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/commission.go
@@ -363,7 +363,7 @@ func (c *commission) Run(
 	}
 	c.address = staking.NewAddress(c.signer.Public())
 
-	stakingClient := staking.NewStakingClient(conn)
+	stakingClient := staking.NewClient(conn)
 
 	params, err := stakingClient.ConsensusParameters(ctx, consensus.HeightLatest)
 	if err != nil {

--- a/go/oasis-node/cmd/debug/txsource/workload/delegation.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/delegation.go
@@ -219,7 +219,7 @@ func (d *delegation) Run(
 		}
 	}
 
-	stakingClient := staking.NewStakingClient(conn)
+	stakingClient := staking.NewClient(conn)
 
 	for {
 		switch rng.Intn(2) {

--- a/go/oasis-node/cmd/debug/txsource/workload/queries.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/queries.go
@@ -886,13 +886,13 @@ func (q *queries) Run(
 
 	q.control = control.NewNodeControllerClient(conn)
 	q.consensus = cnsc
-	q.beacon = beacon.NewBeaconClient(conn)
-	q.registry = registry.NewRegistryClient(conn)
-	q.runtime = runtimeClient.NewRuntimeClient(conn)
-	q.scheduler = scheduler.NewSchedulerClient(conn)
-	q.governance = governance.NewGovernanceClient(conn)
-	q.staking = staking.NewStakingClient(conn)
-	q.roothash = roothash.NewRootHashClient(conn)
+	q.beacon = beacon.NewClient(conn)
+	q.registry = registry.NewClient(conn)
+	q.runtime = runtimeClient.NewClient(conn)
+	q.scheduler = scheduler.NewClient(conn)
+	q.governance = governance.NewClient(conn)
+	q.staking = staking.NewClient(conn)
+	q.roothash = roothash.NewClient(conn)
 
 	q.stakingParams, err = q.staking.ConsensusParameters(ctx, consensus.HeightLatest)
 	if err != nil {

--- a/go/oasis-node/cmd/debug/txsource/workload/registration.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/registration.go
@@ -173,7 +173,7 @@ func (r *registration) Run( // nolint: gocyclo
 	// Initialize base workload.
 	r.BaseWorkload.Init(cnsc, sm, fundingAccount)
 
-	beacon := beacon.NewBeaconClient(conn)
+	beacon := beacon.NewClient(conn)
 	ctx := context.Background()
 	var err error
 

--- a/go/oasis-node/cmd/debug/txsource/workload/runtime.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/runtime.go
@@ -799,7 +799,7 @@ func (r *runtime) Run(
 	// Initialize base workload.
 	r.BaseWorkload.Init(cnsc, sm, fundingAccount)
 
-	beacon := beacon.NewBeaconClient(conn)
+	beacon := beacon.NewClient(conn)
 	ctx := context.Background()
 
 	// Simple-keyvalue runtime.
@@ -819,7 +819,7 @@ func (r *runtime) Run(
 	}
 
 	// Set up the runtime client.
-	rtc := runtimeClient.NewRuntimeClient(conn)
+	rtc := runtimeClient.NewClient(conn)
 
 	// Wait for 3rd epoch, so that runtimes are up and running.
 	r.Logger.Info("waiting for 3rd epoch")

--- a/go/oasis-node/cmd/debug/txsource/workload/transfer.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/transfer.go
@@ -276,7 +276,7 @@ func (t *transfer) Run(
 	}
 
 	// Read all the account info up front.
-	stakingClient := staking.NewStakingClient(conn)
+	stakingClient := staking.NewClient(conn)
 	for i := range t.accounts {
 		if err := t.TransferFunds(ctx, fundingAccount, t.accounts[i].address, transferAmount); err != nil {
 			return fmt.Errorf("workload/transfer: account funding failure: %w", err)

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -657,7 +657,7 @@ func doDumpGenesis(cmd *cobra.Command, _ []string) {
 	}
 	defer conn.Close()
 
-	client := consensus.NewConsensusClient(conn)
+	client := consensus.NewClient(conn)
 
 	height, err := cmd.Flags().GetInt64(cfgBlockHeight)
 	if err != nil {

--- a/go/oasis-node/cmd/governance/governance.go
+++ b/go/oasis-node/cmd/governance/governance.go
@@ -97,7 +97,7 @@ func doConnect(cmd *cobra.Command) (*grpc.ClientConn, governance.Backend) {
 		os.Exit(1)
 	}
 
-	client := governance.NewGovernanceClient(conn)
+	client := governance.NewClient(conn)
 	return conn, client
 }
 

--- a/go/oasis-node/cmd/ias/auth_registry.go
+++ b/go/oasis-node/cmd/ias/auth_registry.go
@@ -66,7 +66,7 @@ func (auth *registryAuthenticator) watchRuntimes(ctx context.Context, conn *grpc
 	err error,
 ) {
 	op := func() error {
-		client = registry.NewRegistryClient(conn)
+		client = registry.NewClient(conn)
 
 		// Subscribe to runtimes.
 		ch, sub, err = client.WatchRuntimes(ctx)
@@ -94,7 +94,7 @@ func (auth *registryAuthenticator) watchEpochs(ctx context.Context, conn *grpc.C
 	err error,
 ) {
 	op := func() error {
-		client := beacon.NewBeaconClient(conn)
+		client := beacon.NewClient(conn)
 
 		// Subscribe to epochs.
 		ch, sub, err = client.WatchEpochs(ctx)

--- a/go/oasis-node/cmd/registry/entity/entity.go
+++ b/go/oasis-node/cmd/registry/entity/entity.go
@@ -96,7 +96,7 @@ func doConnect(cmd *cobra.Command) (*grpc.ClientConn, registry.Backend) {
 		os.Exit(1)
 	}
 
-	client := registry.NewRegistryClient(conn)
+	client := registry.NewClient(conn)
 	return conn, client
 }
 

--- a/go/oasis-node/cmd/registry/node/node.go
+++ b/go/oasis-node/cmd/registry/node/node.go
@@ -89,7 +89,7 @@ func doConnect(cmd *cobra.Command) (*grpc.ClientConn, registry.Backend) {
 		os.Exit(1)
 	}
 
-	client := registry.NewRegistryClient(conn)
+	client := registry.NewClient(conn)
 	return conn, client
 }
 

--- a/go/oasis-node/cmd/registry/runtime/runtime.go
+++ b/go/oasis-node/cmd/registry/runtime/runtime.go
@@ -67,7 +67,7 @@ func doConnect(cmd *cobra.Command) (*grpc.ClientConn, registry.Backend) {
 		os.Exit(1)
 	}
 
-	client := registry.NewRegistryClient(conn)
+	client := registry.NewClient(conn)
 	return conn, client
 }
 

--- a/go/oasis-node/cmd/stake/account.go
+++ b/go/oasis-node/cmd/stake/account.go
@@ -162,7 +162,7 @@ func doAccountInfo(cmd *cobra.Command, _ []string) {
 
 	height := viper.GetInt64(CfgHeight)
 
-	consensusClient := consensus.NewConsensusClient(conn)
+	consensusClient := consensus.NewClient(conn)
 
 	// If height is latest height, take height from latest block.
 	if height == consensus.HeightLatest {

--- a/go/oasis-node/cmd/stake/stake.go
+++ b/go/oasis-node/cmd/stake/stake.go
@@ -70,7 +70,7 @@ func doConnect(cmd *cobra.Command) (*grpc.ClientConn, api.Backend) {
 		os.Exit(1)
 	}
 
-	client := api.NewStakingClient(conn)
+	client := api.NewClient(conn)
 	return conn, client
 }
 

--- a/go/oasis-node/node_test.go
+++ b/go/oasis-node/node_test.go
@@ -316,7 +316,7 @@ func testConsensusClient(t *testing.T, node *testNode) {
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err, "Dial")
 
-	client := consensusAPI.NewConsensusClient(conn)
+	client := consensusAPI.NewClient(conn)
 	consensusTests.ConsensusImplementationTests(t, client)
 }
 
@@ -354,7 +354,7 @@ func testSchedulerClient(t *testing.T, node *testNode) {
 	require.NoError(t, err, "Dial")
 	defer conn.Close()
 
-	client := scheduler.NewSchedulerClient(conn)
+	client := scheduler.NewClient(conn)
 	schedulerTests.SchedulerImplementationTests(t, "client", node.Identity, client, node.Consensus)
 }
 
@@ -369,7 +369,7 @@ func testStakingClient(t *testing.T, node *testNode) {
 	require.NoError(t, err, "Dial")
 	defer conn.Close()
 
-	client := staking.NewStakingClient(conn)
+	client := staking.NewClient(conn)
 	stakingTests.StakingClientImplementationTests(t, client, node.Consensus)
 }
 
@@ -387,7 +387,7 @@ func testRootHash(t *testing.T, node *testNode) {
 		require.NoError(t, err, "Dial")
 		defer conn.Close()
 
-		client := roothash.NewRootHashClient(conn)
+		client := roothash.NewClient(conn)
 		roothashTests.RootHashImplementationTests(t, client, node.Consensus, node.Identity)
 	})
 }
@@ -406,7 +406,7 @@ func testGovernance(t *testing.T, node *testNode) {
 		require.NoError(t, err, "Dial")
 		defer conn.Close()
 
-		client := governance.NewGovernanceClient(conn)
+		client := governance.NewClient(conn)
 		governanceTests.GovernanceImplementationTests(t, client, node.Consensus, node.entity, node.entitySigner)
 	})
 }
@@ -443,7 +443,7 @@ func testRuntimeClient(t *testing.T, node *testNode) {
 		require.NoError(t, err, "Dial")
 		defer conn.Close()
 
-		cli := runtimeClient.NewRuntimeClient(conn)
+		cli := runtimeClient.NewClient(conn)
 		clientTests.ClientImplementationTests(t, cli, node.runtimeID)
 	})
 }
@@ -462,7 +462,7 @@ func testVault(t *testing.T, node *testNode) {
 		require.NoError(t, err, "Dial")
 		defer conn.Close()
 
-		client := vault.NewVaultClient(conn)
+		client := vault.NewClient(conn)
 		vaultTests.VaultImplementationTests(t, client, node.Consensus)
 	})
 }

--- a/go/oasis-test-runner/oasis/controller.go
+++ b/go/oasis-test-runner/oasis/controller.go
@@ -12,7 +12,7 @@ import (
 	keymanager "github.com/oasisprotocol/oasis-core/go/keymanager/api"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
-	runtimeClient "github.com/oasisprotocol/oasis-core/go/runtime/client/api"
+	runtime "github.com/oasisprotocol/oasis-core/go/runtime/client/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
 	vault "github.com/oasisprotocol/oasis-core/go/vault/api"
@@ -31,7 +31,7 @@ type Controller struct {
 	Governance    governance.Backend
 	Registry      registry.Backend
 	Roothash      roothash.Backend
-	RuntimeClient runtimeClient.RuntimeClient
+	RuntimeClient runtime.RuntimeClient
 	Storage       storage.Backend
 	Keymanager    keymanager.Backend
 	Vault         vault.Backend
@@ -61,18 +61,18 @@ func NewController(socketPath string) (*Controller, error) {
 	return &Controller{
 		DebugController: control.NewDebugControllerClient(conn),
 		NodeController:  control.NewNodeControllerClient(conn),
-		Beacon:          beacon.NewBeaconClient(conn),
-		Consensus:       consensus.NewConsensusClient(conn),
-		Staking:         staking.NewStakingClient(conn),
-		Governance:      governance.NewGovernanceClient(conn),
-		Registry:        registry.NewRegistryClient(conn),
-		Roothash:        roothash.NewRootHashClient(conn),
-		RuntimeClient:   runtimeClient.NewRuntimeClient(conn),
-		Storage:         storage.NewStorageClient(conn),
-		Keymanager:      keymanager.NewKeymanagerClient(conn),
-		Vault:           vault.NewVaultClient(conn),
+		Beacon:          beacon.NewClient(conn),
+		Consensus:       consensus.NewClient(conn),
+		Staking:         staking.NewClient(conn),
+		Governance:      governance.NewClient(conn),
+		Registry:        registry.NewClient(conn),
+		Roothash:        roothash.NewClient(conn),
+		RuntimeClient:   runtime.NewClient(conn),
+		Storage:         storage.NewClient(conn),
+		Keymanager:      keymanager.NewClient(conn),
+		Vault:           vault.NewClient(conn),
 
-		StorageWorker: workerStorage.NewStorageWorkerClient(conn),
+		StorageWorker: workerStorage.NewClient(conn),
 
 		conn: conn,
 	}, nil

--- a/go/oasis-test-runner/oasis/controller.go
+++ b/go/oasis-test-runner/oasis/controller.go
@@ -33,7 +33,7 @@ type Controller struct {
 	Roothash      roothash.Backend
 	RuntimeClient runtimeClient.RuntimeClient
 	Storage       storage.Backend
-	Keymanager    *keymanager.KeymanagerClient
+	Keymanager    keymanager.Backend
 	Vault         vault.Backend
 
 	StorageWorker workerStorage.StorageWorker

--- a/go/oasis-test-runner/scenario/e2e/runtime/sentry.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/sentry.go
@@ -207,7 +207,7 @@ func (s *sentryImpl) Run(ctx context.Context, childEnv *env.Env) error { // noli
 		return fmt.Errorf("sentry: dial error: %w", err)
 	}
 	defer conn.Close()
-	sentry0Client := api.NewSentryClient(conn)
+	sentry0Client := api.NewClient(conn)
 	_, err = sentry0Client.GetAddresses(ctx)
 	s.Logger.Debug("sentry0.GetAddress without cert", "err", err)
 	if status.Code(err) != codes.PermissionDenied {
@@ -227,7 +227,7 @@ func (s *sentryImpl) Run(ctx context.Context, childEnv *env.Env) error { // noli
 		return fmt.Errorf("sentry: dial error: %w", err)
 	}
 	defer conn.Close()
-	sentry0Client = api.NewSentryClient(conn)
+	sentry0Client = api.NewClient(conn)
 	_, err = sentry0Client.GetAddresses(ctx)
 	s.Logger.Debug("sentry0.GetAddress with validator1 sentry cert", "err", err)
 	if status.Code(err) != codes.PermissionDenied {
@@ -247,7 +247,7 @@ func (s *sentryImpl) Run(ctx context.Context, childEnv *env.Env) error { // noli
 		return fmt.Errorf("sentry: dial error: %w", err)
 	}
 	defer conn.Close()
-	sentry0Client = api.NewSentryClient(conn)
+	sentry0Client = api.NewClient(conn)
 	_, err = sentry0Client.GetAddresses(ctx)
 	s.Logger.Debug("sentry0.GetAddress with validator0 sentry cert", "err", err)
 	if err != nil {

--- a/go/registry/api/grpc.go
+++ b/go/registry/api/grpc.go
@@ -526,11 +526,19 @@ func RegisterService(server *grpc.Server, service Backend) {
 	server.RegisterService(&serviceDesc, service)
 }
 
-type registryClient struct {
+// Client is a gRPC registry client.
+type Client struct {
 	conn *grpc.ClientConn
 }
 
-func (c *registryClient) GetEntity(ctx context.Context, query *IDQuery) (*entity.Entity, error) {
+// NewClient creates a new gRPC registry client.
+func NewClient(c *grpc.ClientConn) *Client {
+	return &Client{
+		conn: c,
+	}
+}
+
+func (c *Client) GetEntity(ctx context.Context, query *IDQuery) (*entity.Entity, error) {
 	var rsp entity.Entity
 	if err := c.conn.Invoke(ctx, methodGetEntity.FullName(), query, &rsp); err != nil {
 		return nil, err
@@ -538,7 +546,7 @@ func (c *registryClient) GetEntity(ctx context.Context, query *IDQuery) (*entity
 	return &rsp, nil
 }
 
-func (c *registryClient) GetEntities(ctx context.Context, height int64) ([]*entity.Entity, error) {
+func (c *Client) GetEntities(ctx context.Context, height int64) ([]*entity.Entity, error) {
 	var rsp []*entity.Entity
 	if err := c.conn.Invoke(ctx, methodGetEntities.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -546,7 +554,7 @@ func (c *registryClient) GetEntities(ctx context.Context, height int64) ([]*enti
 	return rsp, nil
 }
 
-func (c *registryClient) WatchEntities(ctx context.Context) (<-chan *EntityEvent, pubsub.ClosableSubscription, error) {
+func (c *Client) WatchEntities(ctx context.Context) (<-chan *EntityEvent, pubsub.ClosableSubscription, error) {
 	ctx, sub := pubsub.NewContextSubscription(ctx)
 
 	stream, err := c.conn.NewStream(ctx, &serviceDesc.Streams[0], methodWatchEntities.FullName())
@@ -581,7 +589,7 @@ func (c *registryClient) WatchEntities(ctx context.Context) (<-chan *EntityEvent
 	return ch, sub, nil
 }
 
-func (c *registryClient) GetNode(ctx context.Context, query *IDQuery) (*node.Node, error) {
+func (c *Client) GetNode(ctx context.Context, query *IDQuery) (*node.Node, error) {
 	var rsp node.Node
 	if err := c.conn.Invoke(ctx, methodGetNode.FullName(), query, &rsp); err != nil {
 		return nil, err
@@ -589,7 +597,7 @@ func (c *registryClient) GetNode(ctx context.Context, query *IDQuery) (*node.Nod
 	return &rsp, nil
 }
 
-func (c *registryClient) GetNodeByConsensusAddress(ctx context.Context, query *ConsensusAddressQuery) (*node.Node, error) {
+func (c *Client) GetNodeByConsensusAddress(ctx context.Context, query *ConsensusAddressQuery) (*node.Node, error) {
 	var rsp node.Node
 	if err := c.conn.Invoke(ctx, methodGetNodeByConsensusAddress.FullName(), query, &rsp); err != nil {
 		return nil, err
@@ -597,7 +605,7 @@ func (c *registryClient) GetNodeByConsensusAddress(ctx context.Context, query *C
 	return &rsp, nil
 }
 
-func (c *registryClient) GetNodeStatus(ctx context.Context, query *IDQuery) (*NodeStatus, error) {
+func (c *Client) GetNodeStatus(ctx context.Context, query *IDQuery) (*NodeStatus, error) {
 	var rsp NodeStatus
 	if err := c.conn.Invoke(ctx, methodGetNodeStatus.FullName(), query, &rsp); err != nil {
 		return nil, err
@@ -605,7 +613,7 @@ func (c *registryClient) GetNodeStatus(ctx context.Context, query *IDQuery) (*No
 	return &rsp, nil
 }
 
-func (c *registryClient) GetNodes(ctx context.Context, height int64) ([]*node.Node, error) {
+func (c *Client) GetNodes(ctx context.Context, height int64) ([]*node.Node, error) {
 	var rsp []*node.Node
 	if err := c.conn.Invoke(ctx, methodGetNodes.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -613,7 +621,7 @@ func (c *registryClient) GetNodes(ctx context.Context, height int64) ([]*node.No
 	return rsp, nil
 }
 
-func (c *registryClient) WatchNodes(ctx context.Context) (<-chan *NodeEvent, pubsub.ClosableSubscription, error) {
+func (c *Client) WatchNodes(ctx context.Context) (<-chan *NodeEvent, pubsub.ClosableSubscription, error) {
 	ctx, sub := pubsub.NewContextSubscription(ctx)
 
 	stream, err := c.conn.NewStream(ctx, &serviceDesc.Streams[1], methodWatchNodes.FullName())
@@ -648,7 +656,7 @@ func (c *registryClient) WatchNodes(ctx context.Context) (<-chan *NodeEvent, pub
 	return ch, sub, nil
 }
 
-func (c *registryClient) WatchNodeList(ctx context.Context) (<-chan *NodeList, pubsub.ClosableSubscription, error) {
+func (c *Client) WatchNodeList(ctx context.Context) (<-chan *NodeList, pubsub.ClosableSubscription, error) {
 	ctx, sub := pubsub.NewContextSubscription(ctx)
 
 	stream, err := c.conn.NewStream(ctx, &serviceDesc.Streams[2], methodWatchNodeList.FullName())
@@ -683,7 +691,7 @@ func (c *registryClient) WatchNodeList(ctx context.Context) (<-chan *NodeList, p
 	return ch, sub, nil
 }
 
-func (c *registryClient) GetRuntime(ctx context.Context, query *GetRuntimeQuery) (*Runtime, error) {
+func (c *Client) GetRuntime(ctx context.Context, query *GetRuntimeQuery) (*Runtime, error) {
 	var rsp Runtime
 	if err := c.conn.Invoke(ctx, methodGetRuntime.FullName(), query, &rsp); err != nil {
 		return nil, err
@@ -691,7 +699,7 @@ func (c *registryClient) GetRuntime(ctx context.Context, query *GetRuntimeQuery)
 	return &rsp, nil
 }
 
-func (c *registryClient) GetRuntimes(ctx context.Context, query *GetRuntimesQuery) ([]*Runtime, error) {
+func (c *Client) GetRuntimes(ctx context.Context, query *GetRuntimesQuery) ([]*Runtime, error) {
 	var rsp []*Runtime
 	if err := c.conn.Invoke(ctx, methodGetRuntimes.FullName(), query, &rsp); err != nil {
 		return nil, err
@@ -699,7 +707,7 @@ func (c *registryClient) GetRuntimes(ctx context.Context, query *GetRuntimesQuer
 	return rsp, nil
 }
 
-func (c *registryClient) WatchRuntimes(ctx context.Context) (<-chan *Runtime, pubsub.ClosableSubscription, error) {
+func (c *Client) WatchRuntimes(ctx context.Context) (<-chan *Runtime, pubsub.ClosableSubscription, error) {
 	ctx, sub := pubsub.NewContextSubscription(ctx)
 
 	stream, err := c.conn.NewStream(ctx, &serviceDesc.Streams[3], methodWatchRuntimes.FullName())
@@ -734,7 +742,7 @@ func (c *registryClient) WatchRuntimes(ctx context.Context) (<-chan *Runtime, pu
 	return ch, sub, nil
 }
 
-func (c *registryClient) StateToGenesis(ctx context.Context, height int64) (*Genesis, error) {
+func (c *Client) StateToGenesis(ctx context.Context, height int64) (*Genesis, error) {
 	var rsp Genesis
 	if err := c.conn.Invoke(ctx, methodStateToGenesis.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -742,7 +750,7 @@ func (c *registryClient) StateToGenesis(ctx context.Context, height int64) (*Gen
 	return &rsp, nil
 }
 
-func (c *registryClient) GetEvents(ctx context.Context, height int64) ([]*Event, error) {
+func (c *Client) GetEvents(ctx context.Context, height int64) ([]*Event, error) {
 	var rsp []*Event
 	if err := c.conn.Invoke(ctx, methodGetEvents.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -750,7 +758,7 @@ func (c *registryClient) GetEvents(ctx context.Context, height int64) ([]*Event,
 	return rsp, nil
 }
 
-func (c *registryClient) WatchEvents(ctx context.Context) (<-chan *Event, pubsub.ClosableSubscription, error) {
+func (c *Client) WatchEvents(ctx context.Context) (<-chan *Event, pubsub.ClosableSubscription, error) {
 	ctx, sub := pubsub.NewContextSubscription(ctx)
 
 	stream, err := c.conn.NewStream(ctx, &serviceDesc.Streams[0], methodWatchEvents.FullName())
@@ -785,7 +793,7 @@ func (c *registryClient) WatchEvents(ctx context.Context) (<-chan *Event, pubsub
 	return ch, sub, nil
 }
 
-func (c *registryClient) ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error) {
+func (c *Client) ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error) {
 	var rsp ConsensusParameters
 	if err := c.conn.Invoke(ctx, methodConsensusParameters.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -793,10 +801,5 @@ func (c *registryClient) ConsensusParameters(ctx context.Context, height int64) 
 	return &rsp, nil
 }
 
-func (c *registryClient) Cleanup() {
-}
-
-// NewRegistryClient creates a new gRPC registry client service.
-func NewRegistryClient(c *grpc.ClientConn) Backend {
-	return &registryClient{c}
+func (c *Client) Cleanup() {
 }

--- a/go/roothash/api/grpc.go
+++ b/go/roothash/api/grpc.go
@@ -462,11 +462,19 @@ func RegisterService(server *grpc.Server, service Backend) {
 	server.RegisterService(&serviceDesc, service)
 }
 
-type roothashClient struct {
+// Client is a gRPC roothash client.
+type Client struct {
 	conn *grpc.ClientConn
 }
 
-func (c *roothashClient) GetGenesisBlock(ctx context.Context, request *RuntimeRequest) (*block.Block, error) {
+// NewClient creates a new gRPC roothash client.
+func NewClient(c *grpc.ClientConn) *Client {
+	return &Client{
+		conn: c,
+	}
+}
+
+func (c *Client) GetGenesisBlock(ctx context.Context, request *RuntimeRequest) (*block.Block, error) {
 	var rsp block.Block
 	if err := c.conn.Invoke(ctx, methodGetGenesisBlock.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -474,7 +482,7 @@ func (c *roothashClient) GetGenesisBlock(ctx context.Context, request *RuntimeRe
 	return &rsp, nil
 }
 
-func (c *roothashClient) GetLatestBlock(ctx context.Context, request *RuntimeRequest) (*block.Block, error) {
+func (c *Client) GetLatestBlock(ctx context.Context, request *RuntimeRequest) (*block.Block, error) {
 	var rsp block.Block
 	if err := c.conn.Invoke(ctx, methodGetLatestBlock.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -482,7 +490,7 @@ func (c *roothashClient) GetLatestBlock(ctx context.Context, request *RuntimeReq
 	return &rsp, nil
 }
 
-func (c *roothashClient) GetRuntimeState(ctx context.Context, request *RuntimeRequest) (*RuntimeState, error) {
+func (c *Client) GetRuntimeState(ctx context.Context, request *RuntimeRequest) (*RuntimeState, error) {
 	var rsp RuntimeState
 	if err := c.conn.Invoke(ctx, methodGetRuntimeState.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -490,7 +498,7 @@ func (c *roothashClient) GetRuntimeState(ctx context.Context, request *RuntimeRe
 	return &rsp, nil
 }
 
-func (c *roothashClient) GetLastRoundResults(ctx context.Context, request *RuntimeRequest) (*RoundResults, error) {
+func (c *Client) GetLastRoundResults(ctx context.Context, request *RuntimeRequest) (*RoundResults, error) {
 	var rsp RoundResults
 	if err := c.conn.Invoke(ctx, methodGetLastRoundResults.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -498,7 +506,7 @@ func (c *roothashClient) GetLastRoundResults(ctx context.Context, request *Runti
 	return &rsp, nil
 }
 
-func (c *roothashClient) GetRoundRoots(ctx context.Context, request *RoundRootsRequest) (*RoundRoots, error) {
+func (c *Client) GetRoundRoots(ctx context.Context, request *RoundRootsRequest) (*RoundRoots, error) {
 	var rsp RoundRoots
 	if err := c.conn.Invoke(ctx, methodGetRoundRoots.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -506,7 +514,7 @@ func (c *roothashClient) GetRoundRoots(ctx context.Context, request *RoundRootsR
 	return &rsp, nil
 }
 
-func (c *roothashClient) GetPastRoundRoots(ctx context.Context, request *RuntimeRequest) (map[uint64]RoundRoots, error) {
+func (c *Client) GetPastRoundRoots(ctx context.Context, request *RuntimeRequest) (map[uint64]RoundRoots, error) {
 	var rsp map[uint64]RoundRoots
 	if err := c.conn.Invoke(ctx, methodGetPastRoundRoots.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -514,7 +522,7 @@ func (c *roothashClient) GetPastRoundRoots(ctx context.Context, request *Runtime
 	return rsp, nil
 }
 
-func (c *roothashClient) GetIncomingMessageQueueMeta(ctx context.Context, request *RuntimeRequest) (*message.IncomingMessageQueueMeta, error) {
+func (c *Client) GetIncomingMessageQueueMeta(ctx context.Context, request *RuntimeRequest) (*message.IncomingMessageQueueMeta, error) {
 	var rsp message.IncomingMessageQueueMeta
 	if err := c.conn.Invoke(ctx, methodGetIncomingMessageQueueMeta.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -522,7 +530,7 @@ func (c *roothashClient) GetIncomingMessageQueueMeta(ctx context.Context, reques
 	return &rsp, nil
 }
 
-func (c *roothashClient) GetIncomingMessageQueue(ctx context.Context, request *InMessageQueueRequest) ([]*message.IncomingMessage, error) {
+func (c *Client) GetIncomingMessageQueue(ctx context.Context, request *InMessageQueueRequest) ([]*message.IncomingMessage, error) {
 	var rsp []*message.IncomingMessage
 	if err := c.conn.Invoke(ctx, methodGetIncomingMessageQueue.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -530,11 +538,11 @@ func (c *roothashClient) GetIncomingMessageQueue(ctx context.Context, request *I
 	return rsp, nil
 }
 
-func (c *roothashClient) TrackRuntime(context.Context, BlockHistory) error {
+func (c *Client) TrackRuntime(context.Context, BlockHistory) error {
 	return ErrInvalidArgument
 }
 
-func (c *roothashClient) StateToGenesis(ctx context.Context, height int64) (*Genesis, error) {
+func (c *Client) StateToGenesis(ctx context.Context, height int64) (*Genesis, error) {
 	var rsp Genesis
 	if err := c.conn.Invoke(ctx, methodStateToGenesis.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -542,7 +550,7 @@ func (c *roothashClient) StateToGenesis(ctx context.Context, height int64) (*Gen
 	return &rsp, nil
 }
 
-func (c *roothashClient) ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error) {
+func (c *Client) ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error) {
 	var rsp ConsensusParameters
 	if err := c.conn.Invoke(ctx, methodConsensusParameters.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -550,7 +558,7 @@ func (c *roothashClient) ConsensusParameters(ctx context.Context, height int64) 
 	return &rsp, nil
 }
 
-func (c *roothashClient) GetEvents(ctx context.Context, height int64) ([]*Event, error) {
+func (c *Client) GetEvents(ctx context.Context, height int64) ([]*Event, error) {
 	var rsp []*Event
 	if err := c.conn.Invoke(ctx, methodGetEvents.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -558,10 +566,10 @@ func (c *roothashClient) GetEvents(ctx context.Context, height int64) ([]*Event,
 	return rsp, nil
 }
 
-func (c *roothashClient) Cleanup() {
+func (c *Client) Cleanup() {
 }
 
-func (c *roothashClient) WatchBlocks(ctx context.Context, runtimeID common.Namespace) (<-chan *AnnotatedBlock, pubsub.ClosableSubscription, error) {
+func (c *Client) WatchBlocks(ctx context.Context, runtimeID common.Namespace) (<-chan *AnnotatedBlock, pubsub.ClosableSubscription, error) {
 	ctx, sub := pubsub.NewContextSubscription(ctx)
 
 	stream, err := c.conn.NewStream(ctx, &serviceDesc.Streams[0], methodWatchBlocks.FullName())
@@ -596,7 +604,7 @@ func (c *roothashClient) WatchBlocks(ctx context.Context, runtimeID common.Names
 	return ch, sub, nil
 }
 
-func (c *roothashClient) WatchEvents(ctx context.Context, runtimeID common.Namespace) (<-chan *Event, pubsub.ClosableSubscription, error) {
+func (c *Client) WatchEvents(ctx context.Context, runtimeID common.Namespace) (<-chan *Event, pubsub.ClosableSubscription, error) {
 	ctx, sub := pubsub.NewContextSubscription(ctx)
 
 	stream, err := c.conn.NewStream(ctx, &serviceDesc.Streams[1], methodWatchEvents.FullName())
@@ -631,7 +639,7 @@ func (c *roothashClient) WatchEvents(ctx context.Context, runtimeID common.Names
 	return ch, sub, nil
 }
 
-func (c *roothashClient) WatchExecutorCommitments(ctx context.Context, runtimeID common.Namespace) (<-chan *commitment.ExecutorCommitment, pubsub.ClosableSubscription, error) {
+func (c *Client) WatchExecutorCommitments(ctx context.Context, runtimeID common.Namespace) (<-chan *commitment.ExecutorCommitment, pubsub.ClosableSubscription, error) {
 	ctx, sub := pubsub.NewContextSubscription(ctx)
 
 	stream, err := c.conn.NewStream(ctx, &serviceDesc.Streams[1], methodWatchExecutorCommitments.FullName())
@@ -664,11 +672,4 @@ func (c *roothashClient) WatchExecutorCommitments(ctx context.Context, runtimeID
 	}()
 
 	return ch, sub, nil
-}
-
-// NewRootHashClient creates a new gRPC roothash client service.
-func NewRootHashClient(c *grpc.ClientConn) Backend {
-	return &roothashClient{
-		conn: c,
-	}
 }

--- a/go/runtime/client/api/grpc.go
+++ b/go/runtime/client/api/grpc.go
@@ -544,11 +544,19 @@ func RegisterService(server *grpc.Server, service RuntimeClient) {
 	server.RegisterService(&serviceDesc, service)
 }
 
-type runtimeClient struct {
+// Client is a gRPC runtime client.
+type Client struct {
 	conn *grpc.ClientConn
 }
 
-func (c *runtimeClient) SubmitTx(ctx context.Context, request *SubmitTxRequest) ([]byte, error) {
+// NewClient creates a new gRPC runtime client.
+func NewClient(c *grpc.ClientConn) *Client {
+	return &Client{
+		conn: c,
+	}
+}
+
+func (c *Client) SubmitTx(ctx context.Context, request *SubmitTxRequest) ([]byte, error) {
 	var rsp []byte
 	if err := c.conn.Invoke(ctx, methodSubmitTx.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -556,7 +564,7 @@ func (c *runtimeClient) SubmitTx(ctx context.Context, request *SubmitTxRequest) 
 	return rsp, nil
 }
 
-func (c *runtimeClient) SubmitTxMeta(ctx context.Context, request *SubmitTxRequest) (*SubmitTxMetaResponse, error) {
+func (c *Client) SubmitTxMeta(ctx context.Context, request *SubmitTxRequest) (*SubmitTxMetaResponse, error) {
 	var rsp SubmitTxMetaResponse
 	if err := c.conn.Invoke(ctx, methodSubmitTxMeta.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -564,15 +572,15 @@ func (c *runtimeClient) SubmitTxMeta(ctx context.Context, request *SubmitTxReque
 	return &rsp, nil
 }
 
-func (c *runtimeClient) SubmitTxNoWait(ctx context.Context, request *SubmitTxRequest) error {
+func (c *Client) SubmitTxNoWait(ctx context.Context, request *SubmitTxRequest) error {
 	return c.conn.Invoke(ctx, methodSubmitTxNoWait.FullName(), request, nil)
 }
 
-func (c *runtimeClient) CheckTx(ctx context.Context, request *CheckTxRequest) error {
+func (c *Client) CheckTx(ctx context.Context, request *CheckTxRequest) error {
 	return c.conn.Invoke(ctx, methodCheckTx.FullName(), request, nil)
 }
 
-func (c *runtimeClient) GetGenesisBlock(ctx context.Context, runtimeID common.Namespace) (*block.Block, error) {
+func (c *Client) GetGenesisBlock(ctx context.Context, runtimeID common.Namespace) (*block.Block, error) {
 	var rsp block.Block
 	if err := c.conn.Invoke(ctx, methodGetGenesisBlock.FullName(), runtimeID, &rsp); err != nil {
 		return nil, err
@@ -580,7 +588,7 @@ func (c *runtimeClient) GetGenesisBlock(ctx context.Context, runtimeID common.Na
 	return &rsp, nil
 }
 
-func (c *runtimeClient) GetBlock(ctx context.Context, request *GetBlockRequest) (*block.Block, error) {
+func (c *Client) GetBlock(ctx context.Context, request *GetBlockRequest) (*block.Block, error) {
 	var rsp block.Block
 	if err := c.conn.Invoke(ctx, methodGetBlock.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -588,7 +596,7 @@ func (c *runtimeClient) GetBlock(ctx context.Context, request *GetBlockRequest) 
 	return &rsp, nil
 }
 
-func (c *runtimeClient) GetLastRetainedBlock(ctx context.Context, runtimeID common.Namespace) (*block.Block, error) {
+func (c *Client) GetLastRetainedBlock(ctx context.Context, runtimeID common.Namespace) (*block.Block, error) {
 	var rsp block.Block
 	if err := c.conn.Invoke(ctx, methodGetLastRetainedBlock.FullName(), runtimeID, &rsp); err != nil {
 		return nil, err
@@ -596,7 +604,7 @@ func (c *runtimeClient) GetLastRetainedBlock(ctx context.Context, runtimeID comm
 	return &rsp, nil
 }
 
-func (c *runtimeClient) GetTransactions(ctx context.Context, request *GetTransactionsRequest) ([][]byte, error) {
+func (c *Client) GetTransactions(ctx context.Context, request *GetTransactionsRequest) ([][]byte, error) {
 	var rsp [][]byte
 	if err := c.conn.Invoke(ctx, methodGetTransactions.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -604,7 +612,7 @@ func (c *runtimeClient) GetTransactions(ctx context.Context, request *GetTransac
 	return rsp, nil
 }
 
-func (c *runtimeClient) GetTransactionsWithResults(ctx context.Context, request *GetTransactionsRequest) ([]*TransactionWithResults, error) {
+func (c *Client) GetTransactionsWithResults(ctx context.Context, request *GetTransactionsRequest) ([]*TransactionWithResults, error) {
 	var rsp []*TransactionWithResults
 	if err := c.conn.Invoke(ctx, methodGetTransactionsWithResults.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -612,7 +620,7 @@ func (c *runtimeClient) GetTransactionsWithResults(ctx context.Context, request 
 	return rsp, nil
 }
 
-func (c *runtimeClient) GetUnconfirmedTransactions(ctx context.Context, runtimeID common.Namespace) ([][]byte, error) {
+func (c *Client) GetUnconfirmedTransactions(ctx context.Context, runtimeID common.Namespace) ([][]byte, error) {
 	var rsp [][]byte
 	if err := c.conn.Invoke(ctx, methodGetUnconfirmedTransactions.FullName(), runtimeID, &rsp); err != nil {
 		return nil, err
@@ -620,7 +628,7 @@ func (c *runtimeClient) GetUnconfirmedTransactions(ctx context.Context, runtimeI
 	return rsp, nil
 }
 
-func (c *runtimeClient) GetEvents(ctx context.Context, request *GetEventsRequest) ([]*Event, error) {
+func (c *Client) GetEvents(ctx context.Context, request *GetEventsRequest) ([]*Event, error) {
 	var rsp []*Event
 	if err := c.conn.Invoke(ctx, methodGetEvents.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -628,7 +636,7 @@ func (c *runtimeClient) GetEvents(ctx context.Context, request *GetEventsRequest
 	return rsp, nil
 }
 
-func (c *runtimeClient) Query(ctx context.Context, request *QueryRequest) (*QueryResponse, error) {
+func (c *Client) Query(ctx context.Context, request *QueryRequest) (*QueryResponse, error) {
 	var rsp QueryResponse
 	if err := c.conn.Invoke(ctx, methodQuery.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -637,7 +645,7 @@ func (c *runtimeClient) Query(ctx context.Context, request *QueryRequest) (*Quer
 }
 
 type stateReadSync struct {
-	c *runtimeClient
+	c *Client
 }
 
 // Implements syncer.ReadSyncer.
@@ -667,11 +675,11 @@ func (rs *stateReadSync) SyncIterate(ctx context.Context, request *syncer.Iterat
 	return &rsp, nil
 }
 
-func (c *runtimeClient) State() syncer.ReadSyncer {
+func (c *Client) State() syncer.ReadSyncer {
 	return &stateReadSync{c}
 }
 
-func (c *runtimeClient) WatchBlocks(ctx context.Context, runtimeID common.Namespace) (<-chan *roothash.AnnotatedBlock, pubsub.ClosableSubscription, error) {
+func (c *Client) WatchBlocks(ctx context.Context, runtimeID common.Namespace) (<-chan *roothash.AnnotatedBlock, pubsub.ClosableSubscription, error) {
 	ctx, sub := pubsub.NewContextSubscription(ctx)
 
 	stream, err := c.conn.NewStream(ctx, &serviceDesc.Streams[0], methodWatchBlocks.FullName())
@@ -704,11 +712,4 @@ func (c *runtimeClient) WatchBlocks(ctx context.Context, runtimeID common.Namesp
 	}()
 
 	return ch, sub, nil
-}
-
-// NewRuntimeClient creates a new gRPC runtime client service.
-func NewRuntimeClient(c *grpc.ClientConn) RuntimeClient {
-	return &runtimeClient{
-		conn: c,
-	}
 }

--- a/go/runtime/registry/notifier.go
+++ b/go/runtime/registry/notifier.go
@@ -144,7 +144,13 @@ func (n *runtimeHostNotifier) watchKmPolicyUpdates(ctx context.Context, kmRtID *
 	n.logger.Debug("watching key manager policy updates", "keymanager", kmRtID)
 
 	// Subscribe to key manager status updates (policy might change).
-	stCh, stSub := n.consensus.KeyManager().Secrets().WatchStatuses()
+	stCh, stSub, err := n.consensus.KeyManager().Secrets().WatchStatuses(ctx)
+	if err != nil {
+		n.logger.Error("failed to watch key manager secrets statuses",
+			"err", err,
+		)
+		return
+	}
 	defer stSub.Close()
 
 	// Subscribe to epoch transitions (quote policy might change).

--- a/go/sentry/api/grpc.go
+++ b/go/sentry/api/grpc.go
@@ -53,19 +53,22 @@ func RegisterService(server *grpc.Server, service Backend) {
 	server.RegisterService(&serviceDesc, service)
 }
 
-type sentryClient struct {
+// Client is a gRPC sentry client.
+type Client struct {
 	conn *grpc.ClientConn
 }
 
-func (c *sentryClient) GetAddresses(ctx context.Context) (*SentryAddresses, error) {
+// NewClient creates a new gRPC sentry client.
+func NewClient(c *grpc.ClientConn) *Client {
+	return &Client{
+		conn: c,
+	}
+}
+
+func (c *Client) GetAddresses(ctx context.Context) (*SentryAddresses, error) {
 	var rsp SentryAddresses
 	if err := c.conn.Invoke(ctx, methodGetAddresses.FullName(), nil, &rsp); err != nil {
 		return nil, err
 	}
 	return &rsp, nil
-}
-
-// NewSentryClient creates a new gRPC sentry client service.
-func NewSentryClient(c *grpc.ClientConn) Backend {
-	return &sentryClient{c}
 }

--- a/go/sentry/client/client.go
+++ b/go/sentry/client/client.go
@@ -59,7 +59,7 @@ func (c *Client) createConnection() error {
 		return err
 	}
 	c.conn = conn
-	c.Backend = api.NewSentryClient(conn)
+	c.Backend = api.NewClient(conn)
 
 	return nil
 }

--- a/go/staking/api/grpc.go
+++ b/go/staking/api/grpc.go
@@ -647,11 +647,19 @@ func RegisterService(server *grpc.Server, service Backend) {
 	server.RegisterService(&serviceDesc, service)
 }
 
-type stakingClient struct {
+// Client is a gRPC staking client.
+type Client struct {
 	conn *grpc.ClientConn
 }
 
-func (c *stakingClient) TokenSymbol(ctx context.Context, height int64) (string, error) {
+// NewClient creates a new gRPC staking client.
+func NewClient(c *grpc.ClientConn) *Client {
+	return &Client{
+		conn: c,
+	}
+}
+
+func (c *Client) TokenSymbol(ctx context.Context, height int64) (string, error) {
 	var rsp string
 	if err := c.conn.Invoke(ctx, methodTokenSymbol.FullName(), height, &rsp); err != nil {
 		return "", err
@@ -659,7 +667,7 @@ func (c *stakingClient) TokenSymbol(ctx context.Context, height int64) (string, 
 	return rsp, nil
 }
 
-func (c *stakingClient) TokenValueExponent(ctx context.Context, height int64) (uint8, error) {
+func (c *Client) TokenValueExponent(ctx context.Context, height int64) (uint8, error) {
 	var rsp uint8
 	if err := c.conn.Invoke(ctx, methodTokenValueExponent.FullName(), height, &rsp); err != nil {
 		return 0, err
@@ -667,7 +675,7 @@ func (c *stakingClient) TokenValueExponent(ctx context.Context, height int64) (u
 	return rsp, nil
 }
 
-func (c *stakingClient) TotalSupply(ctx context.Context, height int64) (*quantity.Quantity, error) {
+func (c *Client) TotalSupply(ctx context.Context, height int64) (*quantity.Quantity, error) {
 	var rsp quantity.Quantity
 	if err := c.conn.Invoke(ctx, methodTotalSupply.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -675,7 +683,7 @@ func (c *stakingClient) TotalSupply(ctx context.Context, height int64) (*quantit
 	return &rsp, nil
 }
 
-func (c *stakingClient) CommonPool(ctx context.Context, height int64) (*quantity.Quantity, error) {
+func (c *Client) CommonPool(ctx context.Context, height int64) (*quantity.Quantity, error) {
 	var rsp quantity.Quantity
 	if err := c.conn.Invoke(ctx, methodCommonPool.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -683,7 +691,7 @@ func (c *stakingClient) CommonPool(ctx context.Context, height int64) (*quantity
 	return &rsp, nil
 }
 
-func (c *stakingClient) LastBlockFees(ctx context.Context, height int64) (*quantity.Quantity, error) {
+func (c *Client) LastBlockFees(ctx context.Context, height int64) (*quantity.Quantity, error) {
 	var rsp quantity.Quantity
 	if err := c.conn.Invoke(ctx, methodLastBlockFees.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -691,7 +699,7 @@ func (c *stakingClient) LastBlockFees(ctx context.Context, height int64) (*quant
 	return &rsp, nil
 }
 
-func (c *stakingClient) GovernanceDeposits(ctx context.Context, height int64) (*quantity.Quantity, error) {
+func (c *Client) GovernanceDeposits(ctx context.Context, height int64) (*quantity.Quantity, error) {
 	var rsp quantity.Quantity
 	if err := c.conn.Invoke(ctx, methodGovernanceDeposits.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -699,7 +707,7 @@ func (c *stakingClient) GovernanceDeposits(ctx context.Context, height int64) (*
 	return &rsp, nil
 }
 
-func (c *stakingClient) Threshold(ctx context.Context, query *ThresholdQuery) (*quantity.Quantity, error) {
+func (c *Client) Threshold(ctx context.Context, query *ThresholdQuery) (*quantity.Quantity, error) {
 	var rsp quantity.Quantity
 	if err := c.conn.Invoke(ctx, methodThreshold.FullName(), query, &rsp); err != nil {
 		return nil, err
@@ -707,7 +715,7 @@ func (c *stakingClient) Threshold(ctx context.Context, query *ThresholdQuery) (*
 	return &rsp, nil
 }
 
-func (c *stakingClient) Addresses(ctx context.Context, height int64) ([]Address, error) {
+func (c *Client) Addresses(ctx context.Context, height int64) ([]Address, error) {
 	var rsp []Address
 	if err := c.conn.Invoke(ctx, methodAddresses.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -715,7 +723,7 @@ func (c *stakingClient) Addresses(ctx context.Context, height int64) ([]Address,
 	return rsp, nil
 }
 
-func (c *stakingClient) CommissionScheduleAddresses(ctx context.Context, height int64) ([]Address, error) {
+func (c *Client) CommissionScheduleAddresses(ctx context.Context, height int64) ([]Address, error) {
 	var rsp []Address
 	if err := c.conn.Invoke(ctx, methodCommissionScheduleAddresses.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -723,7 +731,7 @@ func (c *stakingClient) CommissionScheduleAddresses(ctx context.Context, height 
 	return rsp, nil
 }
 
-func (c *stakingClient) Account(ctx context.Context, query *OwnerQuery) (*Account, error) {
+func (c *Client) Account(ctx context.Context, query *OwnerQuery) (*Account, error) {
 	var rsp Account
 	if err := c.conn.Invoke(ctx, methodAccount.FullName(), query, &rsp); err != nil {
 		return nil, err
@@ -731,7 +739,7 @@ func (c *stakingClient) Account(ctx context.Context, query *OwnerQuery) (*Accoun
 	return &rsp, nil
 }
 
-func (c *stakingClient) DelegationsFor(ctx context.Context, query *OwnerQuery) (map[Address]*Delegation, error) {
+func (c *Client) DelegationsFor(ctx context.Context, query *OwnerQuery) (map[Address]*Delegation, error) {
 	var rsp map[Address]*Delegation
 	if err := c.conn.Invoke(ctx, methodDelegationsFor.FullName(), query, &rsp); err != nil {
 		return nil, err
@@ -739,7 +747,7 @@ func (c *stakingClient) DelegationsFor(ctx context.Context, query *OwnerQuery) (
 	return rsp, nil
 }
 
-func (c *stakingClient) DelegationInfosFor(ctx context.Context, query *OwnerQuery) (map[Address]*DelegationInfo, error) {
+func (c *Client) DelegationInfosFor(ctx context.Context, query *OwnerQuery) (map[Address]*DelegationInfo, error) {
 	var rsp map[Address]*DelegationInfo
 	if err := c.conn.Invoke(ctx, methodDelegationInfosFor.FullName(), query, &rsp); err != nil {
 		return nil, err
@@ -747,7 +755,7 @@ func (c *stakingClient) DelegationInfosFor(ctx context.Context, query *OwnerQuer
 	return rsp, nil
 }
 
-func (c *stakingClient) DelegationsTo(ctx context.Context, query *OwnerQuery) (map[Address]*Delegation, error) {
+func (c *Client) DelegationsTo(ctx context.Context, query *OwnerQuery) (map[Address]*Delegation, error) {
 	var rsp map[Address]*Delegation
 	if err := c.conn.Invoke(ctx, methodDelegationsTo.FullName(), query, &rsp); err != nil {
 		return nil, err
@@ -755,7 +763,7 @@ func (c *stakingClient) DelegationsTo(ctx context.Context, query *OwnerQuery) (m
 	return rsp, nil
 }
 
-func (c *stakingClient) DebondingDelegationsFor(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegation, error) {
+func (c *Client) DebondingDelegationsFor(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegation, error) {
 	var rsp map[Address][]*DebondingDelegation
 	if err := c.conn.Invoke(ctx, methodDebondingDelegationsFor.FullName(), query, &rsp); err != nil {
 		return nil, err
@@ -763,7 +771,7 @@ func (c *stakingClient) DebondingDelegationsFor(ctx context.Context, query *Owne
 	return rsp, nil
 }
 
-func (c *stakingClient) DebondingDelegationInfosFor(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegationInfo, error) {
+func (c *Client) DebondingDelegationInfosFor(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegationInfo, error) {
 	var rsp map[Address][]*DebondingDelegationInfo
 	if err := c.conn.Invoke(ctx, methodDebondingDelegationInfosFor.FullName(), query, &rsp); err != nil {
 		return nil, err
@@ -771,7 +779,7 @@ func (c *stakingClient) DebondingDelegationInfosFor(ctx context.Context, query *
 	return rsp, nil
 }
 
-func (c *stakingClient) DebondingDelegationsTo(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegation, error) {
+func (c *Client) DebondingDelegationsTo(ctx context.Context, query *OwnerQuery) (map[Address][]*DebondingDelegation, error) {
 	var rsp map[Address][]*DebondingDelegation
 	if err := c.conn.Invoke(ctx, methodDebondingDelegationsTo.FullName(), query, &rsp); err != nil {
 		return nil, err
@@ -779,7 +787,7 @@ func (c *stakingClient) DebondingDelegationsTo(ctx context.Context, query *Owner
 	return rsp, nil
 }
 
-func (c *stakingClient) Allowance(ctx context.Context, query *AllowanceQuery) (*quantity.Quantity, error) {
+func (c *Client) Allowance(ctx context.Context, query *AllowanceQuery) (*quantity.Quantity, error) {
 	var rsp quantity.Quantity
 	if err := c.conn.Invoke(ctx, methodAllowance.FullName(), query, &rsp); err != nil {
 		return nil, err
@@ -787,7 +795,7 @@ func (c *stakingClient) Allowance(ctx context.Context, query *AllowanceQuery) (*
 	return &rsp, nil
 }
 
-func (c *stakingClient) StateToGenesis(ctx context.Context, height int64) (*Genesis, error) {
+func (c *Client) StateToGenesis(ctx context.Context, height int64) (*Genesis, error) {
 	var rsp Genesis
 	if err := c.conn.Invoke(ctx, methodStateToGenesis.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -795,7 +803,7 @@ func (c *stakingClient) StateToGenesis(ctx context.Context, height int64) (*Gene
 	return &rsp, nil
 }
 
-func (c *stakingClient) ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error) {
+func (c *Client) ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error) {
 	var rsp ConsensusParameters
 	if err := c.conn.Invoke(ctx, methodConsensusParameters.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -803,7 +811,7 @@ func (c *stakingClient) ConsensusParameters(ctx context.Context, height int64) (
 	return &rsp, nil
 }
 
-func (c *stakingClient) GetEvents(ctx context.Context, height int64) ([]*Event, error) {
+func (c *Client) GetEvents(ctx context.Context, height int64) ([]*Event, error) {
 	var rsp []*Event
 	if err := c.conn.Invoke(ctx, methodGetEvents.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -811,7 +819,7 @@ func (c *stakingClient) GetEvents(ctx context.Context, height int64) ([]*Event, 
 	return rsp, nil
 }
 
-func (c *stakingClient) WatchEvents(ctx context.Context) (<-chan *Event, pubsub.ClosableSubscription, error) {
+func (c *Client) WatchEvents(ctx context.Context) (<-chan *Event, pubsub.ClosableSubscription, error) {
 	ctx, sub := pubsub.NewContextSubscription(ctx)
 
 	stream, err := c.conn.NewStream(ctx, &serviceDesc.Streams[0], methodWatchEvents.FullName())
@@ -846,10 +854,5 @@ func (c *stakingClient) WatchEvents(ctx context.Context) (<-chan *Event, pubsub.
 	return ch, sub, nil
 }
 
-func (c *stakingClient) Cleanup() {
-}
-
-// NewStakingClient creates a new gRPC staking client service.
-func NewStakingClient(c *grpc.ClientConn) Backend {
-	return &stakingClient{c}
+func (c *Client) Cleanup() {
 }

--- a/go/vault/api/grpc.go
+++ b/go/vault/api/grpc.go
@@ -268,11 +268,19 @@ func RegisterService(server *grpc.Server, service Backend) {
 	server.RegisterService(&serviceDesc, service)
 }
 
-type vaultClient struct {
+// Client is a gRPC vault client.
+type Client struct {
 	conn *grpc.ClientConn
 }
 
-func (c *vaultClient) Vaults(ctx context.Context, height int64) ([]*Vault, error) {
+// NewClient creates a new gRPC vault client.
+func NewClient(c *grpc.ClientConn) *Client {
+	return &Client{
+		conn: c,
+	}
+}
+
+func (c *Client) Vaults(ctx context.Context, height int64) ([]*Vault, error) {
 	var rsp []*Vault
 	if err := c.conn.Invoke(ctx, methodVaults.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -280,7 +288,7 @@ func (c *vaultClient) Vaults(ctx context.Context, height int64) ([]*Vault, error
 	return rsp, nil
 }
 
-func (c *vaultClient) Vault(ctx context.Context, request *VaultQuery) (*Vault, error) {
+func (c *Client) Vault(ctx context.Context, request *VaultQuery) (*Vault, error) {
 	var rsp Vault
 	if err := c.conn.Invoke(ctx, methodVault.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -288,7 +296,7 @@ func (c *vaultClient) Vault(ctx context.Context, request *VaultQuery) (*Vault, e
 	return &rsp, nil
 }
 
-func (c *vaultClient) AddressState(ctx context.Context, request *AddressQuery) (*AddressState, error) {
+func (c *Client) AddressState(ctx context.Context, request *AddressQuery) (*AddressState, error) {
 	var rsp AddressState
 	if err := c.conn.Invoke(ctx, methodAddressState.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -296,7 +304,7 @@ func (c *vaultClient) AddressState(ctx context.Context, request *AddressQuery) (
 	return &rsp, nil
 }
 
-func (c *vaultClient) PendingActions(ctx context.Context, request *VaultQuery) ([]*PendingAction, error) {
+func (c *Client) PendingActions(ctx context.Context, request *VaultQuery) ([]*PendingAction, error) {
 	var rsp []*PendingAction
 	if err := c.conn.Invoke(ctx, methodPendingActions.FullName(), request, &rsp); err != nil {
 		return nil, err
@@ -304,7 +312,7 @@ func (c *vaultClient) PendingActions(ctx context.Context, request *VaultQuery) (
 	return rsp, nil
 }
 
-func (c *vaultClient) StateToGenesis(ctx context.Context, height int64) (*Genesis, error) {
+func (c *Client) StateToGenesis(ctx context.Context, height int64) (*Genesis, error) {
 	var rsp Genesis
 	if err := c.conn.Invoke(ctx, methodStateToGenesis.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -312,7 +320,7 @@ func (c *vaultClient) StateToGenesis(ctx context.Context, height int64) (*Genesi
 	return &rsp, nil
 }
 
-func (c *vaultClient) ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error) {
+func (c *Client) ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error) {
 	var rsp ConsensusParameters
 	if err := c.conn.Invoke(ctx, methodConsensusParameters.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -320,7 +328,7 @@ func (c *vaultClient) ConsensusParameters(ctx context.Context, height int64) (*C
 	return &rsp, nil
 }
 
-func (c *vaultClient) GetEvents(ctx context.Context, height int64) ([]*Event, error) {
+func (c *Client) GetEvents(ctx context.Context, height int64) ([]*Event, error) {
 	var rsp []*Event
 	if err := c.conn.Invoke(ctx, methodGetEvents.FullName(), height, &rsp); err != nil {
 		return nil, err
@@ -328,7 +336,7 @@ func (c *vaultClient) GetEvents(ctx context.Context, height int64) ([]*Event, er
 	return rsp, nil
 }
 
-func (c *vaultClient) WatchEvents(ctx context.Context) (<-chan *Event, pubsub.ClosableSubscription, error) {
+func (c *Client) WatchEvents(ctx context.Context) (<-chan *Event, pubsub.ClosableSubscription, error) {
 	ctx, sub := pubsub.NewContextSubscription(ctx)
 
 	stream, err := c.conn.NewStream(ctx, &serviceDesc.Streams[0], methodWatchEvents.FullName())
@@ -363,10 +371,5 @@ func (c *vaultClient) WatchEvents(ctx context.Context) (<-chan *Event, pubsub.Cl
 	return ch, sub, nil
 }
 
-func (c *vaultClient) Cleanup() {
-}
-
-// NewVaultClient creates a new gRPC vault client service.
-func NewVaultClient(c *grpc.ClientConn) Backend {
-	return &vaultClient{c}
+func (c *Client) Cleanup() {
 }

--- a/go/worker/common/committee/keymanager.go
+++ b/go/worker/common/committee/keymanager.go
@@ -337,7 +337,13 @@ func (nt *nodeTracker) Nodes(nodes []signature.PublicKey) map[core.PeerID]signat
 }
 
 func (nt *nodeTracker) trackKeymanagerNodes(ctx context.Context) {
-	stCh, stSub := nt.consensus.KeyManager().Secrets().WatchStatuses()
+	stCh, stSub, err := nt.consensus.KeyManager().Secrets().WatchStatuses(ctx)
+	if err != nil {
+		nt.logger.Error("failed to watch key manager secrets statuses",
+			"err", err,
+		)
+		return
+	}
 	defer stSub.Close()
 
 	for {

--- a/go/worker/keymanager/churp.go
+++ b/go/worker/keymanager/churp.go
@@ -228,7 +228,13 @@ func (w *churpWorker) work(ctx context.Context, _ host.RichRuntime) {
 		"node_id", w.kmWorker.nodeID,
 	)
 
-	stCh, stSub := w.kmWorker.backend.Churp().WatchStatuses()
+	stCh, stSub, err := w.kmWorker.backend.Churp().WatchStatuses(ctx)
+	if err != nil {
+		w.logger.Error("failed to watch statuses",
+			"err", err,
+		)
+		return
+	}
 	defer stSub.Close()
 
 	epoCh, epoSub, err := w.kmWorker.commonWorker.Consensus.Beacon().WatchEpochs(ctx)

--- a/go/worker/keymanager/secrets.go
+++ b/go/worker/keymanager/secrets.go
@@ -307,15 +307,33 @@ func (w *secretsWorker) work(ctx context.Context, hrt host.RichRuntime) {
 	defer hrtSub.Close()
 
 	// Subscribe to key manager status updates.
-	statusCh, statusSub := w.backend.Secrets().WatchStatuses()
+	statusCh, statusSub, err := w.backend.Secrets().WatchStatuses(ctx)
+	if err != nil {
+		w.logger.Error("failed to watch statuses",
+			"err", err,
+		)
+		return
+	}
 	defer statusSub.Close()
 
 	// Subscribe to key manager master secret publications.
-	mstCh, mstSub := w.backend.Secrets().WatchMasterSecrets()
+	mstCh, mstSub, err := w.backend.Secrets().WatchMasterSecrets(ctx)
+	if err != nil {
+		w.logger.Error("failed to watch master secrets",
+			"err", err,
+		)
+		return
+	}
 	defer mstSub.Close()
 
 	// Subscribe to key manager ephemeral secret publications.
-	ephCh, ephSub := w.backend.Secrets().WatchEphemeralSecrets()
+	ephCh, ephSub, err := w.backend.Secrets().WatchEphemeralSecrets(ctx)
+	if err != nil {
+		w.logger.Error("failed to watch ephemeral secrets",
+			"err", err,
+		)
+		return
+	}
 	defer ephSub.Close()
 
 	// Subscribe to epoch transitions in order to know when we need to choose

--- a/go/worker/storage/api/grpc.go
+++ b/go/worker/storage/api/grpc.go
@@ -86,11 +86,19 @@ func RegisterService(server *grpc.Server, service StorageWorker) {
 	server.RegisterService(&serviceDesc, service)
 }
 
-type storageWorkerClient struct {
+// Client is a gRPC worker storage client.
+type Client struct {
 	conn *grpc.ClientConn
 }
 
-func (c *storageWorkerClient) GetLastSyncedRound(ctx context.Context, req *GetLastSyncedRoundRequest) (*GetLastSyncedRoundResponse, error) {
+// NewClient creates a new gRPC worker storage client.
+func NewClient(c *grpc.ClientConn) *Client {
+	return &Client{
+		conn: c,
+	}
+}
+
+func (c *Client) GetLastSyncedRound(ctx context.Context, req *GetLastSyncedRoundRequest) (*GetLastSyncedRoundResponse, error) {
 	var rsp GetLastSyncedRoundResponse
 	if err := c.conn.Invoke(ctx, methodGetLastSyncedRound.FullName(), req, &rsp); err != nil {
 		return nil, err
@@ -98,12 +106,6 @@ func (c *storageWorkerClient) GetLastSyncedRound(ctx context.Context, req *GetLa
 	return &rsp, nil
 }
 
-func (c *storageWorkerClient) PauseCheckpointer(ctx context.Context, req *PauseCheckpointerRequest) error {
+func (c *Client) PauseCheckpointer(ctx context.Context, req *PauseCheckpointerRequest) error {
 	return c.conn.Invoke(ctx, methodPauseCheckpointer.FullName(), req, nil)
-}
-
-// NewStorageWorkerClient creates a new gRPC transaction scheduler
-// client service.
-func NewStorageWorkerClient(c *grpc.ClientConn) StorageWorker {
-	return &storageWorkerClient{c}
 }


### PR DESCRIPTION
Moving key manager backend from `ServicesBackend` to `ClientBackend`.

I also refactored clients, trying to follow these guidelines: 
- First define struct, then implement constructor, and finally implement all methods.
- Accept interfaces, return structs. 