### PR TITLE
go/runtime/history: Ensure WatchBlocks emits increasing round sequence (no gaps)

### DIFF
--- a/.changelog/6079.bugfix.md
+++ b/.changelog/6079.bugfix.md
@@ -1,0 +1,9 @@
+go/runtime/history: Ensure `WatchBlocks` emits sequential round sequence
+
+Previously, if `WatchBlocks` was called on a node without local storage,
+blocks were not emitted during reindexing, causing gaps in the round sequence
+for clients.
+
+Existing behaviour has been improved, so that during initial reindex,
+subscribers are still not notified, however during any subsequent reindex,
+all block rounds are emitted.

--- a/go/roothash/api/history.go
+++ b/go/roothash/api/history.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
-	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 )
 
@@ -25,20 +24,6 @@ type BlockHistory interface {
 	// Must be called in order, sorted by round.
 	Commit(blk *AnnotatedBlock, roundResults *RoundResults, notify bool) error
 
-	// StorageSyncCheckpoint records the last storage round which was synced
-	// to runtime storage.
-	StorageSyncCheckpoint(round uint64) error
-
-	// LastStorageSyncedRound returns the last runtime round which was synced to storage.
-	LastStorageSyncedRound() (uint64, error)
-
-	// WatchBlocks returns a channel watching block rounds as they are committed.
-	// If node has local storage this includes waiting for the round to be synced into storage.
-	WatchBlocks() (<-chan *AnnotatedBlock, pubsub.ClosableSubscription, error)
-
-	// WaitRoundSynced waits for the specified round to be synced to storage.
-	WaitRoundSynced(ctx context.Context, round uint64) (uint64, error)
-
 	// LastConsensusHeight returns the last consensus height which was seen
 	// by block history.
 	LastConsensusHeight() (int64, error)
@@ -48,23 +33,4 @@ type BlockHistory interface {
 	//
 	// This method can return blocks not yet synced to storage.
 	GetCommittedBlock(ctx context.Context, round uint64) (*block.Block, error)
-
-	// GetBlock returns the block at a specific round.
-	// Passing the special value `RoundLatest` will return the latest block.
-	//
-	// This method returns blocks that are both committed and synced to storage.
-	GetBlock(ctx context.Context, round uint64) (*block.Block, error)
-
-	// GetAnnotatedBlock returns the annotated block at a specific round.
-	//
-	// Passing the special value `RoundLatest` will return the latest annotated block.
-	GetAnnotatedBlock(ctx context.Context, round uint64) (*AnnotatedBlock, error)
-
-	// GetEarliestBlock returns the earliest known block.
-	GetEarliestBlock(ctx context.Context) (*block.Block, error)
-
-	// GetRoundResults returns the round results for the given round.
-	//
-	// Passing the special value `RoundLatest` will return results for the latest round.
-	GetRoundResults(ctx context.Context, round uint64) (*RoundResults, error)
 }

--- a/go/roothash/api/history.go
+++ b/go/roothash/api/history.go
@@ -17,12 +17,10 @@ type BlockHistory interface {
 	// RuntimeID returns the runtime ID of the runtime this block history is for.
 	RuntimeID() common.Namespace
 
-	// Commit commits an annotated block into history. If notify is set to true,
-	// the watchers will be notified about the new block. Disable notify when
-	// doing reindexing.
+	// Commit commits an annotated block into history.
 	//
 	// Must be called in order, sorted by round.
-	Commit(blk *AnnotatedBlock, roundResults *RoundResults, notify bool) error
+	Commit(blk *AnnotatedBlock, roundResults *RoundResults) error
 
 	// LastConsensusHeight returns the last consensus height which was seen
 	// by block history.
@@ -33,4 +31,9 @@ type BlockHistory interface {
 	//
 	// This method can return blocks not yet synced to storage.
 	GetCommittedBlock(ctx context.Context, round uint64) (*block.Block, error)
+
+	// ReindexFinished marks an initial history reindex has finished.
+	//
+	// Calling this methods more then once has no additional side effect.
+	ReindexFinished()
 }

--- a/go/roothash/api/history.go
+++ b/go/roothash/api/history.go
@@ -25,13 +25,6 @@ type BlockHistory interface {
 	// Must be called in order, sorted by round.
 	Commit(blk *AnnotatedBlock, roundResults *RoundResults, notify bool) error
 
-	// ConsensusCheckpoint records the last consensus height which was processed
-	// by the roothash backend.
-	//
-	// This method can only be called once all roothash blocks for consensus
-	// heights <= height have been committed using Commit.
-	ConsensusCheckpoint(height int64) error
-
 	// StorageSyncCheckpoint records the last storage round which was synced
 	// to runtime storage.
 	StorageSyncCheckpoint(round uint64) error

--- a/go/runtime/history/db.go
+++ b/go/runtime/history/db.go
@@ -149,25 +149,6 @@ func (d *DB) metadata() (*dbMetadata, error) {
 	return meta, nil
 }
 
-func (d *DB) consensusCheckpoint(height int64) error {
-	return d.db.Update(func(tx *badger.Txn) error {
-		meta, err := d.queryGetMetadata(tx)
-		if err != nil {
-			return err
-		}
-
-		if height < meta.LastConsensusHeight {
-			return fmt.Errorf("runtime/history: consensus checkpoint at lower height (current: %d wanted: %d)",
-				meta.LastConsensusHeight,
-				height,
-			)
-		}
-
-		meta.LastConsensusHeight = height
-		return tx.Set(metadataKeyFmt.Encode(), cbor.Marshal(meta))
-	})
-}
-
 func (d *DB) commit(blk *roothash.AnnotatedBlock, roundResults *roothash.RoundResults) error {
 	return d.db.Update(func(tx *badger.Txn) error {
 		meta, err := d.queryGetMetadata(tx)

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -30,6 +30,39 @@ type Factory func(runtimeID common.Namespace, dataDir string) (History, error)
 type History interface {
 	roothash.BlockHistory
 
+	// StorageSyncCheckpoint records the last storage round which was synced
+	// to runtime storage.
+	StorageSyncCheckpoint(round uint64) error
+
+	// LastStorageSyncedRound returns the last runtime round which was synced to storage.
+	LastStorageSyncedRound() (uint64, error)
+
+	// WatchBlocks returns a channel watching block rounds as they are committed.
+	// If node has local storage this includes waiting for the round to be synced into storage.
+	WatchBlocks() (<-chan *roothash.AnnotatedBlock, pubsub.ClosableSubscription, error)
+
+	// WaitRoundSynced waits for the specified round to be synced to storage.
+	WaitRoundSynced(ctx context.Context, round uint64) (uint64, error)
+
+	// GetBlock returns the block at a specific round.
+	// Passing the special value `RoundLatest` will return the latest block.
+	//
+	// This method returns blocks that are both committed and synced to storage.
+	GetBlock(ctx context.Context, round uint64) (*block.Block, error)
+
+	// GetAnnotatedBlock returns the annotated block at a specific round.
+	//
+	// Passing the special value `RoundLatest` will return the latest annotated block.
+	GetAnnotatedBlock(ctx context.Context, round uint64) (*roothash.AnnotatedBlock, error)
+
+	// GetEarliestBlock returns the earliest known block.
+	GetEarliestBlock(ctx context.Context) (*block.Block, error)
+
+	// GetRoundResults returns the round results for the given round.
+	//
+	// Passing the special value `RoundLatest` will return results for the latest round.
+	GetRoundResults(ctx context.Context, round uint64) (*roothash.RoundResults, error)
+
 	// Pruner returns the history pruner.
 	Pruner() Pruner
 

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -3,7 +3,6 @@ package history
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
@@ -22,11 +21,7 @@ import (
 // DbFilename is the filename of the history database.
 const DbFilename = "history.db"
 
-var (
-	errNopHistory = errors.New("runtime/history: not supported")
-
-	_ History = (*runtimeHistory)(nil)
-)
+var _ History = (*runtimeHistory)(nil)
 
 // Factory is the runtime history factory interface.
 type Factory func(runtimeID common.Namespace, dataDir string) (History, error)
@@ -40,71 +35,6 @@ type History interface {
 
 	// Close closes the history keeper.
 	Close()
-}
-
-type nopHistory struct {
-	runtimeID common.Namespace
-}
-
-func (h *nopHistory) RuntimeID() common.Namespace {
-	return h.runtimeID
-}
-
-func (h *nopHistory) Commit(*roothash.AnnotatedBlock, *roothash.RoundResults, bool) error {
-	return errNopHistory
-}
-
-func (h *nopHistory) StorageSyncCheckpoint(uint64) error {
-	return errNopHistory
-}
-
-func (h *nopHistory) LastStorageSyncedRound() (uint64, error) {
-	return 0, errNopHistory
-}
-
-func (h *nopHistory) WatchBlocks() (<-chan *roothash.AnnotatedBlock, pubsub.ClosableSubscription, error) {
-	return nil, nil, errNopHistory
-}
-
-func (h *nopHistory) WaitRoundSynced(context.Context, uint64) (uint64, error) {
-	return 0, errNopHistory
-}
-
-func (h *nopHistory) LastConsensusHeight() (int64, error) {
-	return 0, errNopHistory
-}
-
-func (h *nopHistory) GetCommittedBlock(context.Context, uint64) (*block.Block, error) {
-	return nil, errNopHistory
-}
-
-func (h *nopHistory) GetBlock(context.Context, uint64) (*block.Block, error) {
-	return nil, errNopHistory
-}
-
-func (h *nopHistory) GetAnnotatedBlock(context.Context, uint64) (*roothash.AnnotatedBlock, error) {
-	return nil, errNopHistory
-}
-
-func (h *nopHistory) GetEarliestBlock(context.Context) (*block.Block, error) {
-	return nil, errNopHistory
-}
-
-func (h *nopHistory) GetRoundResults(context.Context, uint64) (*roothash.RoundResults, error) {
-	return nil, errNopHistory
-}
-
-func (h *nopHistory) Pruner() Pruner {
-	pruner, _ := NewNonePrunerFactory()(h.runtimeID, nil)
-	return pruner
-}
-
-func (h *nopHistory) Close() {
-}
-
-// NewNop creates a new no-op runtime history keeper.
-func NewNop(runtimeID common.Namespace) History {
-	return &nopHistory{runtimeID: runtimeID}
 }
 
 type runtimeHistory struct {

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -54,10 +54,6 @@ func (h *nopHistory) Commit(*roothash.AnnotatedBlock, *roothash.RoundResults, bo
 	return errNopHistory
 }
 
-func (h *nopHistory) ConsensusCheckpoint(int64) error {
-	return errNopHistory
-}
-
 func (h *nopHistory) StorageSyncCheckpoint(uint64) error {
 	return errNopHistory
 }
@@ -155,10 +151,6 @@ func (h *runtimeHistory) Commit(blk *roothash.AnnotatedBlock, roundResults *root
 	h.blocksNotifier.Broadcast(blk)
 
 	return nil
-}
-
-func (h *runtimeHistory) ConsensusCheckpoint(height int64) error {
-	return h.db.consensusCheckpoint(height)
 }
 
 func (h *runtimeHistory) StorageSyncCheckpoint(round uint64) error {


### PR DESCRIPTION
**What:**
After initial history reindex, node without local storage will notify subscribers about every block (even if during subsequent reindex) , ensuring sequential block rounds, just like is the case when node has local storage.**

Finally, we simplify `roothash.BlockHistory` interface as discussed here: https://github.com/oasisprotocol/oasis-core/pull/6050#discussion_r1965243125

**For comparison, node with local storage first waits for initial reindex to complete, and then starts syncing rounds with `worker.storage.committe.Node`, fetching missing rounds one by one, and notifying them with `StorageSyncCheckpoint`.  Subscriber in such scenario always receives blocks with no gaps. Finally, if they subscribe right after first reindex is done, they will still receive most blocks from initial reindex (since storage sync is slower then history reindex).

**Why:**
https://github.com/oasisprotocol/oasis-core/pull/6050#discussion_r1964078164 && https://github.com/oasisprotocol/oasis-core/pull/6050#discussion_r1963858917

**Possible considerations**
We might as well notify during first reindex (?), which would simplify things further. Not sure why current code in `master` was preventing notification during every reindex (if without local storage).