### PR TITLE
go/roothash/api: Change invalid round value

### DIFF
--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -27,8 +27,10 @@ const (
 	// ModuleName is a unique module name for the roothash module.
 	ModuleName = "roothash"
 
+	// RoundLatest is a special round number always referring to the latest round.
+	RoundLatest uint64 = math.MaxUint64
 	// RoundInvalid is a special round number that refers to an invalid round.
-	RoundInvalid uint64 = math.MaxUint64
+	RoundInvalid uint64 = math.MaxUint64 - 1
 	// TimeoutNever is the timeout value that never expires.
 	TimeoutNever int64 = 0
 

--- a/go/roothash/api/history.go
+++ b/go/roothash/api/history.go
@@ -8,9 +8,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 )
 
-// RoundLatest is a special round number always referring to the latest round.
-const RoundLatest = RoundInvalid
-
 // BlockHistory is the root hash block history keeper interface.
 //
 // All methods operate on a specific runtime.

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -250,7 +250,7 @@ func (h *runtimeHistory) resolveRound(round uint64, includeStorage bool) (uint64
 		// Determine the last round in case RoundLatest has been passed.
 		meta, err := h.db.metadata()
 		if err != nil {
-			return roothash.RoundInvalid, err
+			return 0, err
 		}
 		h.syncRoundLock.RLock()
 		defer h.syncRoundLock.RUnlock()
@@ -264,7 +264,7 @@ func (h *runtimeHistory) resolveRound(round uint64, includeStorage bool) (uint64
 		defer h.syncRoundLock.RUnlock()
 		// Ensure round exists.
 		if includeStorage && h.hasLocalStorage && h.lastStorageSyncedRound < round {
-			return roothash.RoundInvalid, roothash.ErrNotFound
+			return 0, roothash.ErrNotFound
 		}
 		return round, nil
 	}


### PR DESCRIPTION
The latest round and the invalid round now have unique values, allowing us to distinguish between the two.