### PR TITLE
 go/consensus/cometbft/roothash: Remove history from roothash service

### DIFF
--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -141,6 +141,9 @@ type ClientBackend interface {
 	// client verification.
 	GetLightBlock(ctx context.Context, height int64) (*LightBlock, error)
 
+	// GetLastRetainedHeight returns the height of the oldest retained consensus block.
+	GetLastRetainedHeight(ctx context.Context) (int64, error)
+
 	// State returns a MKVS read syncer that can be used to read consensus state from a remote node
 	// and verify it against the trusted local root.
 	State() syncer.ReadSyncer

--- a/go/consensus/api/grpc.go
+++ b/go/consensus/api/grpc.go
@@ -43,6 +43,8 @@ var (
 	methodGetBlock = serviceName.NewMethod("GetBlock", int64(0))
 	// methodGetLightBlock is the GetLightBlock method.
 	methodGetLightBlock = serviceName.NewMethod("GetLightBlock", int64(0))
+	// methodGetLastRetainedHeight is the GetLastRetainedHeight method.
+	methodGetLastRetainedHeight = serviceName.NewMethod("GetLastRetainedHeight", nil)
 	// methodGetTransactions is the GetTransactions method.
 	methodGetTransactions = serviceName.NewMethod("GetTransactions", int64(0))
 	// methodGetTransactionsWithResults is the GetTransactionsWithResults method.
@@ -113,6 +115,10 @@ var (
 			{
 				MethodName: methodGetLightBlock.ShortName(),
 				Handler:    handlerGetLightBlock,
+			},
+			{
+				MethodName: methodGetLastRetainedHeight.ShortName(),
+				Handler:    handlerGetLastRetainedHeight,
 			},
 			{
 				MethodName: methodGetTransactions.ShortName(),
@@ -378,6 +384,25 @@ func handlerGetLightBlock(
 		return srv.(ClientBackend).GetLightBlock(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
+}
+
+func handlerGetLastRetainedHeight(
+	srv interface{},
+	ctx context.Context,
+	_ func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	if interceptor == nil {
+		return srv.(ClientBackend).GetLastRetainedHeight(ctx)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodGetLastRetainedHeight.FullName(),
+	}
+	handler := func(ctx context.Context, _ interface{}) (interface{}, error) {
+		return srv.(ClientBackend).GetLastRetainedHeight(ctx)
+	}
+	return interceptor(ctx, nil, info, handler)
 }
 
 func handlerGetTransactions(
@@ -766,6 +791,14 @@ func (c *Client) GetLightBlock(ctx context.Context, height int64) (*LightBlock, 
 		return nil, err
 	}
 	return &rsp, nil
+}
+
+func (c *Client) GetLastRetainedHeight(ctx context.Context) (int64, error) {
+	var height int64
+	if err := c.conn.Invoke(ctx, methodGetLastRetainedHeight.FullName(), nil, &height); err != nil {
+		return 0, err
+	}
+	return height, nil
 }
 
 func (c *Client) GetTransactions(ctx context.Context, height int64) ([][]byte, error) {

--- a/go/consensus/cometbft/api/api.go
+++ b/go/consensus/cometbft/api/api.go
@@ -222,10 +222,6 @@ type Backend interface {
 	// returned via the `EventDataNewBlock` query.
 	WatchCometBFTBlocks() (<-chan *cmttypes.Block, *pubsub.Subscription, error)
 
-	// GetLastRetainedVersion returns the earliest retained version the ABCI
-	// state.
-	GetLastRetainedVersion(ctx context.Context) (int64, error)
-
 	// Pruner returns the state pruner.
 	Pruner() StatePruner
 }

--- a/go/consensus/cometbft/beacon/beacon.go
+++ b/go/consensus/cometbft/beacon/beacon.go
@@ -120,7 +120,7 @@ func (sc *serviceClient) GetEpochBlock(ctx context.Context, epoch beaconAPI.Epoc
 		return cachedHeight.(int64), nil
 	}
 
-	lowHeight, err := sc.backend.GetLastRetainedVersion(ctx)
+	lowHeight, err := sc.backend.GetLastRetainedHeight(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to query last retained version: %w", err)
 	}

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -588,15 +588,6 @@ func (n *commonNode) GetBlockResults(ctx context.Context, height int64) (*cmtcor
 }
 
 // Implements consensusAPI.Backend.
-func (n *commonNode) GetLastRetainedVersion(ctx context.Context) (int64, error) {
-	if err := n.ensureStarted(ctx); err != nil {
-		return -1, err
-	}
-	state := store.LoadBlockStoreState(n.blockStoreDB)
-	return state.Base, nil
-}
-
-// Implements consensusAPI.Backend.
 func (n *commonNode) GetBlock(ctx context.Context, height int64) (*consensusAPI.Block, error) {
 	blk, err := n.GetCometBFTBlock(ctx, height)
 	if err != nil {
@@ -658,13 +649,14 @@ func (n *commonNode) GetLightBlock(ctx context.Context, height int64) (*consensu
 
 // Implements consensusAPI.Backend.
 func (n *commonNode) GetLastRetainedHeight(ctx context.Context) (int64, error) {
-	height, err := n.GetLastRetainedVersion(ctx)
-	if err != nil {
+	if err := n.ensureStarted(ctx); err != nil {
 		return 0, err
 	}
+	state := store.LoadBlockStoreState(n.blockStoreDB)
+
 	// Some pruning configurations return 0 instead of a valid block height.
 	// Clamp those to the genesis height.
-	return max(height, n.genesis.Height), nil
+	return max(state.Base, n.genesis.Height), nil
 }
 
 // Implements consensusAPI.Backend.

--- a/go/consensus/cometbft/full/full.go
+++ b/go/consensus/cometbft/full/full.go
@@ -136,7 +136,10 @@ func (t *fullService) Start() error {
 		// Start event dispatchers for all the service clients.
 		t.serviceClientsWg.Add(len(t.serviceClients))
 		for _, svc := range t.serviceClients {
-			go t.serviceClientWorker(t.ctx, svc)
+			go func() {
+				defer t.serviceClientsWg.Done()
+				t.serviceClientWorker(t.ctx, svc)
+			}()
 		}
 		// Start sync checker.
 		go t.syncWorker()

--- a/go/consensus/cometbft/full/services.go
+++ b/go/consensus/cometbft/full/services.go
@@ -15,8 +15,6 @@ import (
 
 // serviceClientWorker manages block and event notifications for all service clients.
 func (t *fullService) serviceClientWorker(ctx context.Context, svc api.ServiceClient) {
-	defer t.serviceClientsWg.Done()
-
 	sd := svc.ServiceDescriptor()
 	if sd == nil {
 		// Some services don't actually need a worker.

--- a/go/consensus/cometbft/light/service.go
+++ b/go/consensus/cometbft/light/service.go
@@ -179,15 +179,10 @@ func (c *client) worker() {
 	}
 
 	// Store earliest block into trust store.
-	lastRetainedHeight, err := c.consensus.(cmtAPI.Backend).GetLastRetainedVersion(c.ctx)
+	lastRetainedHeight, err := c.consensus.GetLastRetainedHeight(c.ctx)
 	if err != nil {
 		c.logger.Error("failed to get last retained height from consensus", "err", err)
 		return
-	}
-	// Some pruning configurations return 0 instead of a valid block height. Clamp those to the
-	// genesis height.
-	if lastRetainedHeight < c.genesis.Height {
-		lastRetainedHeight = c.genesis.Height
 	}
 	if err = trustLocalBlock(c.ctx, lastRetainedHeight); err != nil {
 		c.logger.Error("failed to store last retained block into trust store", "err", err)

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -27,10 +27,7 @@ import (
 	runtimeRegistry "github.com/oasisprotocol/oasis-core/go/runtime/registry"
 )
 
-const (
-	crashPointBlockBeforeIndex = "roothash.before_index"
-	reindexWriteBatchSize      = 1000
-)
+const crashPointBlockBeforeIndex = "roothash.before_index"
 
 // ServiceClient is the roothash service client interface.
 type ServiceClient interface {

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -585,7 +585,7 @@ func (sc *serviceClient) DeliverCommand(ctx context.Context, height int64, cmd i
 		})
 		if err != nil {
 			sc.logger.Warn("failed to get runtime state for latest block",
-				"err",
+				"err", err,
 				"runtime_id", tr.runtimeID,
 				"height", height,
 			)
@@ -809,7 +809,7 @@ EventLoop:
 				// An executor commit has been processed.
 				var e api.ExecutorCommittedEvent
 				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("roothash: corrupt ExecutorComitted event: %w", err))
+					errs = errors.Join(errs, fmt.Errorf("roothash: corrupt ExecutorCommitted event: %w", err))
 					continue EventLoop
 				}
 

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -46,15 +46,12 @@ type runtimeBrokers struct {
 
 type trackedRuntime struct {
 	runtimeID common.Namespace
-
-	height       int64
-	blockHistory api.BlockHistory
-	reindexDone  bool
+	height    int64
+	round     uint64
 }
 
 type cmdTrackRuntime struct {
-	runtimeID    common.Namespace
-	blockHistory api.BlockHistory
+	runtimeID common.Namespace
 }
 
 type serviceClient struct {
@@ -187,7 +184,7 @@ func (sc *serviceClient) WatchBlocks(_ context.Context, id common.Namespace) (<-
 	sub.Unwrap(ch)
 
 	// Start tracking this runtime if we are not tracking it yet.
-	if err := sc.trackRuntime(sc.ctx, id, nil); err != nil {
+	if err := sc.trackRuntime(sc.ctx, id); err != nil {
 		sub.Close()
 		return nil, nil, err
 	}
@@ -211,7 +208,7 @@ func (sc *serviceClient) WatchEvents(_ context.Context, id common.Namespace) (<-
 	sub.Unwrap(ch)
 
 	// Start tracking this runtime if we are not tracking it yet.
-	if err := sc.trackRuntime(sc.ctx, id, nil); err != nil {
+	if err := sc.trackRuntime(sc.ctx, id); err != nil {
 		sub.Close()
 		return nil, nil, err
 	}
@@ -227,7 +224,7 @@ func (sc *serviceClient) WatchExecutorCommitments(_ context.Context, id common.N
 	sub.Unwrap(ch)
 
 	// Start tracking this runtime if we are not tracking it yet.
-	if err := sc.trackRuntime(sc.ctx, id, nil); err != nil {
+	if err := sc.trackRuntime(sc.ctx, id); err != nil {
 		sub.Close()
 		return nil, nil, err
 	}
@@ -236,15 +233,14 @@ func (sc *serviceClient) WatchExecutorCommitments(_ context.Context, id common.N
 }
 
 // Implements api.Backend.
-func (sc *serviceClient) TrackRuntime(ctx context.Context, history api.BlockHistory) error {
+func (sc *serviceClient) TrackRuntime(_ context.Context, history api.BlockHistory) error {
 	sc.pruneHandler.trackRuntime(history)
-	return sc.trackRuntime(ctx, history.RuntimeID(), history)
+	return nil
 }
 
-func (sc *serviceClient) trackRuntime(ctx context.Context, id common.Namespace, history api.BlockHistory) error {
+func (sc *serviceClient) trackRuntime(ctx context.Context, id common.Namespace) error {
 	cmd := &cmdTrackRuntime{
-		runtimeID:    id,
-		blockHistory: history,
+		runtimeID: id,
 	}
 
 	select {
@@ -356,195 +352,6 @@ func (sc *serviceClient) getRuntimeNotifiers(id common.Namespace) *runtimeBroker
 	return notifiers
 }
 
-func (sc *serviceClient) reindexBlocks(ctx context.Context, currentHeight int64, bh api.BlockHistory) (uint64, error) {
-	lastRound := api.RoundInvalid
-	if currentHeight <= 0 {
-		return lastRound, nil
-	}
-
-	runtimeID := bh.RuntimeID()
-	logger := sc.logger.With("runtime_id", runtimeID)
-
-	var err error
-	var lastHeight int64
-	if lastHeight, err = bh.LastConsensusHeight(); err != nil {
-		logger.Error("failed to get last indexed height",
-			"err", err,
-		)
-		return 0, fmt.Errorf("failed to get last indexed height: %w", err)
-	}
-	// +1 since we want the last non-seen height.
-	lastHeight++
-
-	// Take prune strategy into account.
-	lastRetainedHeight, err := sc.backend.GetLastRetainedVersion(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get last retained height: %w", err)
-	}
-	if lastHeight < lastRetainedHeight {
-		logger.Debug("last height pruned, skipping until last retained",
-			"last_retained_height", lastRetainedHeight,
-			"last_height", lastHeight,
-		)
-		lastHeight = lastRetainedHeight
-	}
-
-	// Take initial genesis height into account.
-	genesisDoc, err := sc.backend.GetGenesisDocument(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get genesis document: %w", err)
-	}
-	if lastHeight < genesisDoc.Height {
-		lastHeight = genesisDoc.Height
-	}
-
-	// Scan all blocks between last indexed height and current height.
-	logger.Info("reindexing blocks",
-		"last_height", lastHeight,
-		"current_height", currentHeight,
-		logging.LogEvent, api.LogEventHistoryReindexing,
-	)
-
-	for height := lastHeight; height <= currentHeight; height += reindexWriteBatchSize {
-		end := height + reindexWriteBatchSize - 1
-		if end > currentHeight {
-			end = currentHeight
-		}
-		last, err := sc.reindexBatch(ctx, runtimeID, bh, height, end)
-		if err != nil {
-			return 0, fmt.Errorf("failed to reindex batch: %w", err)
-		}
-		if last != api.RoundInvalid {
-			// New rounds indexed.
-			lastRound = last
-		}
-	}
-
-	if lastRound == api.RoundInvalid {
-		logger.Debug("no new round reindexed, return latest known round")
-		switch blk, err := bh.GetCommittedBlock(ctx, api.RoundLatest); err {
-		case api.ErrNotFound:
-		case nil:
-			lastRound = blk.Header.Round
-		default:
-			return lastRound, fmt.Errorf("failed to get latest block: %w", err)
-		}
-	}
-
-	logger.Info("block reindex complete",
-		"last_round", lastRound,
-	)
-
-	return lastRound, nil
-}
-
-func (sc *serviceClient) reindexBatch(
-	ctx context.Context,
-	runtimeID common.Namespace,
-	bh api.BlockHistory,
-	start int64,
-	end int64,
-) (uint64, error) {
-	logger := sc.logger.With("runtime_id", runtimeID)
-
-	logger.Debug("reindexing batch",
-		"start", start,
-		"end", end,
-	)
-
-	lastRound := api.RoundInvalid
-	var blocks []*api.AnnotatedBlock
-	for height := start; height <= end; height++ {
-		results, err := sc.backend.GetBlockResults(ctx, height)
-		if err != nil {
-			// XXX: could soft-fail first few heights in case more heights were
-			// pruned right after the GetLastRetainedVersion query.
-			logger.Error("failed to get cometbft block results",
-				"err", err,
-				"height", height,
-			)
-			return 0, fmt.Errorf("failed to get cometbft block results: %w", err)
-		}
-
-		// Index block.
-		tmEvents := results.BeginBlockEvents
-		for _, txResults := range results.TxsResults {
-			tmEvents = append(tmEvents, txResults.Events...)
-		}
-		tmEvents = append(tmEvents, results.EndBlockEvents...)
-		for _, tmEv := range tmEvents {
-			if tmEv.GetType() != app.EventType {
-				continue
-			}
-
-			var evRtID *common.Namespace
-			var ev *api.FinalizedEvent
-			for _, pair := range tmEv.GetAttributes() {
-				key := pair.GetKey()
-				val := pair.GetValue()
-
-				switch {
-				case eventsAPI.IsAttributeKind(key, &api.RuntimeIDAttribute{}):
-					if evRtID != nil {
-						return 0, fmt.Errorf("roothash: duplicate runtime ID attribute")
-					}
-
-					var rtAttribute api.RuntimeIDAttribute
-					if err = eventsAPI.DecodeValue(val, &rtAttribute); err != nil {
-						return 0, fmt.Errorf("roothash: corrupt runtime ID: %w", err)
-					}
-					evRtID = &rtAttribute.ID
-
-				case eventsAPI.IsAttributeKind(key, &api.FinalizedEvent{}):
-					var e api.FinalizedEvent
-					if err = eventsAPI.DecodeValue(val, &e); err != nil {
-						logger.Error("failed to unmarshal finalized event",
-							"err", err,
-							"height", height,
-						)
-						return 0, fmt.Errorf("failed to unmarshal finalized event: %w", err)
-					}
-					ev = &e
-				default:
-				}
-			}
-
-			// Only process finalized events.
-			if ev == nil {
-				continue
-			}
-			// Only process events for the given runtime.
-			if !evRtID.Equal(&runtimeID) {
-				continue
-			}
-
-			annBlk, err := sc.fetchAnnotatedBlock(ctx, height, runtimeID, &ev.Round)
-			if err != nil {
-				return 0, fmt.Errorf("failed to fetch annotated block: %w", err)
-			}
-			blocks = append(blocks, annBlk)
-			logger.Debug("block added to batch",
-				"height", height,
-				"round", annBlk.Block.Header.Round,
-			)
-
-			lastRound = ev.Round
-		}
-	}
-
-	// Do not notify watchers during history reindex.
-	err := bh.CommitBatch(blocks, false)
-	if err != nil {
-		logger.Error("failed to commit batch",
-			"err", err,
-			"start", start,
-			"end", end,
-		)
-		return 0, fmt.Errorf("failed to commit batch: %w", err)
-	}
-	return lastRound, nil
-}
-
 // Implements api.ServiceClient.
 func (sc *serviceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
 	return tmapi.NewServiceDescriptor(api.ModuleName, app.EventType, sc.queryCh, sc.cmdCh)
@@ -555,25 +362,22 @@ func (sc *serviceClient) DeliverCommand(ctx context.Context, height int64, cmd i
 	switch c := cmd.(type) {
 	case *cmdTrackRuntime:
 		// Request to track a new runtime.
-		etr := sc.trackedRuntime[c.runtimeID]
-		if etr != nil {
-			// Ignore duplicate runtime tracking requests unless this updates the block history.
-			if etr.blockHistory != nil || c.blockHistory == nil {
-				break
-			}
-		} else {
-			sc.logger.Debug("tracking new runtime",
-				"runtime_id", c.runtimeID,
-				"height", height,
-			)
+		if _, ok := sc.trackedRuntime[c.runtimeID]; ok {
+			// Ignore duplicate runtime tracking requests.
+			return nil
 		}
 
-		// We need to start watching a new block history.
+		sc.logger.Debug("tracking new runtime",
+			"runtime_id", c.runtimeID,
+			"height", height,
+		)
+
 		tr := &trackedRuntime{
-			runtimeID:    c.runtimeID,
-			blockHistory: c.blockHistory,
+			runtimeID: c.runtimeID,
+			round:     api.RoundInvalid,
 		}
 		sc.trackedRuntime[c.runtimeID] = tr
+
 		// Request subscription to events for this runtime.
 		sc.queryCh <- app.QueryForRuntime(tr.runtimeID)
 
@@ -584,24 +388,27 @@ func (sc *serviceClient) DeliverCommand(ctx context.Context, height int64, cmd i
 			Height:    height,
 		})
 		if err != nil {
-			sc.logger.Warn("failed to get runtime state for latest block",
+			sc.logger.Warn("failed to get runtime state",
 				"err", err,
 				"runtime_id", tr.runtimeID,
 				"height", height,
 			)
-			return nil
+			return fmt.Errorf("roothash: failed to get runtime state: %w", err)
+		}
+		annBlk := &api.AnnotatedBlock{
+			Height: rs.LastBlockHeight,
+			Block:  rs.LastBlock,
 		}
 
-		// Emit latest block.
-		if err := sc.processFinalizedEvent(ctx, rs.LastBlockHeight, tr.runtimeID, nil); err != nil {
+		// Emit the latest block.
+		if err := sc.emitLatestBlock(tr, annBlk); err != nil {
 			sc.logger.Warn("failed to emit latest block",
 				"err", err,
 				"runtime_id", tr.runtimeID,
 				"height", height,
 			)
+			return fmt.Errorf("roothash: failed to emit latest block: %w", err)
 		}
-		// Make sure we reindex again when receiving the first event.
-		tr.reindexDone = false
 	default:
 		return fmt.Errorf("roothash: unknown command: %T", cmd)
 	}
@@ -624,13 +431,78 @@ func (sc *serviceClient) DeliverEvent(ctx context.Context, height int64, tx cmtt
 		}
 
 		// Only process finalized events for tracked runtimes.
-		if sc.trackedRuntime[ev.RuntimeID] == nil {
+		tr, ok := sc.trackedRuntime[ev.RuntimeID]
+		if !ok {
 			continue
 		}
-		if err = sc.processFinalizedEvent(ctx, height, ev.RuntimeID, &ev.Finalized.Round); err != nil { //nolint:gosec
-			return fmt.Errorf("roothash: failed to process finalized event: %w", err)
+
+		// Fetch the latest block.
+		blk, err := sc.getLatestBlockAt(ctx, tr.runtimeID, height)
+		if err != nil {
+			sc.logger.Error("failed to fetch latest block",
+				"err", err,
+				"height", height,
+				"runtime_id", tr.runtimeID,
+			)
+			return fmt.Errorf("roothash: failed to fetch latest block: %w", err)
+		}
+		if blk.Header.Round != ev.Finalized.Round {
+			sc.logger.Error("block round mismatch",
+				"height", height,
+				"round", blk.Header.Round,
+				"expected_round", ev.Finalized.Round,
+			)
+			return fmt.Errorf("roothash: block round mismatch")
+		}
+		annBlk := &api.AnnotatedBlock{
+			Height: height,
+			Block:  blk,
+		}
+
+		// Emit the latest block.
+		if err = sc.emitLatestBlock(tr, annBlk); err != nil {
+			return fmt.Errorf("roothash: failed to emit latest block: %w", err)
 		}
 	}
+
+	return nil
+}
+
+func (sc *serviceClient) emitLatestBlock(tr *trackedRuntime, annBlk *api.AnnotatedBlock) error {
+	if tr.round != api.RoundInvalid {
+		switch {
+		case annBlk.Block.Header.Round <= tr.round:
+			// This can occur if a block is finalized immediately after we
+			// subscribe to runtime events.
+			sc.logger.Warn("skipping outdated block",
+				"height", annBlk.Height,
+				"round", annBlk.Block.Header.Round,
+				"last_height", tr.height,
+				"last_round", tr.round,
+			)
+			return nil
+		case annBlk.Block.Header.Round == tr.round+1:
+			// Blocks should be processed sequentially.
+		default:
+			// Detected a gap in block rounds. While recovery might be possible
+			// by fetching the missing blocks, it's unlikely we can fully recover.
+			// For now, enforce strict error handling and address if necessary later.
+			sc.logger.Error("unexpected block round",
+				"height", annBlk.Height,
+				"round", annBlk.Block.Header.Round,
+				"last_height", tr.height,
+				"last_round", tr.round,
+			)
+			return fmt.Errorf("unexpected block round")
+		}
+	}
+
+	notifiers := sc.getRuntimeNotifiers(tr.runtimeID)
+	notifiers.blockNotifier.Broadcast(annBlk)
+	sc.allBlockNotifier.Broadcast(annBlk.Block)
+
+	tr.height = annBlk.Height
+	tr.round = annBlk.Block.Header.Round
 
 	return nil
 }
@@ -639,120 +511,6 @@ func (sc *serviceClient) DeliverEvent(ctx context.Context, height int64, tx cmtt
 func (sc *serviceClient) DeliverExecutorCommitment(runtimeID common.Namespace, ec *commitment.ExecutorCommitment) {
 	notifiers := sc.getRuntimeNotifiers(runtimeID)
 	notifiers.ecNotifier.Broadcast(ec)
-}
-
-func (sc *serviceClient) processFinalizedEvent(
-	ctx context.Context,
-	height int64,
-	runtimeID common.Namespace,
-	round *uint64,
-) (err error) {
-	tr := sc.trackedRuntime[runtimeID]
-	if tr == nil {
-		sc.logger.Error("runtime not tracked",
-			"runtime_id", runtimeID,
-			"tracked_runtimes", sc.trackedRuntime,
-		)
-		return fmt.Errorf("roothash: runtime not tracked: %s", runtimeID)
-	}
-	defer func() {
-		// If there was an error, flag the tracked runtime for reindex.
-		if err == nil {
-			return
-		}
-
-		tr.reindexDone = false
-	}()
-
-	if height <= tr.height {
-		return nil
-	}
-
-	// Process finalized event.
-	annBlk, err := sc.fetchAnnotatedBlock(ctx, height, runtimeID, round)
-	if err != nil {
-		return fmt.Errorf("failed to fetch annotated block: %w", err)
-	}
-
-	// Commit the block to history if needed.
-	if tr.blockHistory != nil {
-		crash.Here(crashPointBlockBeforeIndex)
-
-		// Perform reindex if required.
-		lastRound := api.RoundInvalid
-		if !tr.reindexDone {
-			// Note that we need to reindex up to the previous height as the current height is
-			// already being processed right now.
-			if lastRound, err = sc.reindexBlocks(ctx, height-1, tr.blockHistory); err != nil {
-				sc.logger.Error("failed to reindex blocks",
-					"err", err,
-					"runtime_id", runtimeID,
-				)
-				return fmt.Errorf("failed to reindex blocks: %w", err)
-			}
-			tr.reindexDone = true
-		}
-
-		// Only commit the block in case it was not already committed during reindex. Note that even
-		// in case we only reindex up to height-1 this can still happen on the first emitted block
-		// since that height is not guaranteed to be the one that contains a round finalized event.
-		if lastRound == api.RoundInvalid || annBlk.Block.Header.Round > lastRound {
-			sc.logger.Debug("commit block",
-				"runtime_id", runtimeID,
-				"height", height,
-				"round", annBlk.Block.Header.Round,
-			)
-
-			err = tr.blockHistory.Commit(annBlk, true)
-			if err != nil {
-				sc.logger.Error("failed to commit block to history keeper",
-					"err", err,
-					"runtime_id", runtimeID,
-					"height", height,
-					"round", annBlk.Block.Header.Round,
-				)
-				return fmt.Errorf("failed to commit block to history keeper: %w", err)
-			}
-		}
-	}
-
-	notifiers := sc.getRuntimeNotifiers(runtimeID)
-	notifiers.blockNotifier.Broadcast(annBlk)
-	sc.allBlockNotifier.Broadcast(annBlk.Block)
-
-	tr.height = height
-
-	return nil
-}
-
-func (sc *serviceClient) fetchAnnotatedBlock(
-	ctx context.Context,
-	height int64,
-	runtimeID common.Namespace,
-	round *uint64,
-) (*api.AnnotatedBlock, error) {
-	blk, err := sc.getLatestBlockAt(ctx, runtimeID, height)
-	if err != nil {
-		sc.logger.Error("failed to fetch latest block",
-			"err", err,
-			"height", height,
-			"runtime_id", runtimeID,
-		)
-		return nil, fmt.Errorf("roothash: failed to fetch latest block: %w", err)
-	}
-	if round != nil && blk.Header.Round != *round {
-		sc.logger.Error("finalized event/query round mismatch",
-			"block_round", blk.Header.Round,
-			"event_round", *round,
-		)
-		return nil, fmt.Errorf("roothash: finalized event/query round mismatch")
-	}
-
-	annBlk := &api.AnnotatedBlock{
-		Height: height,
-		Block:  blk,
-	}
-	return annBlk, nil
 }
 
 // EventsFromCometBFT extracts staking events from CometBFT events.

--- a/go/oasis-node/cmd/common/background/service_manager.go
+++ b/go/oasis-node/cmd/common/background/service_manager.go
@@ -53,9 +53,9 @@ func (m *ServiceManager) Wait() {
 
 	select {
 	case <-m.stopCh:
-		m.logger.Info("programatic termination requested")
+		m.logger.Info("programmatic termination requested")
 	case m.termSvc = <-m.termCh:
-		m.logger.Info("background task terminated, propagating")
+		m.logger.Info("background task terminated, propagating", "task", m.termSvc.Name())
 	case <-sigCh:
 		m.logger.Info("user requested termination")
 	}

--- a/go/oasis-node/cmd/storage/storage.go
+++ b/go/oasis-node/cmd/storage/storage.go
@@ -117,7 +117,7 @@ type migrateHelper struct {
 	displayHelper
 
 	ctx     context.Context
-	history history.History
+	history roothash.BlockHistory
 	roots   map[hash.Hash]node.RootType
 }
 

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_early_state_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_early_state_sync.go
@@ -153,7 +153,7 @@ func (sc *storageEarlyStateSyncImpl) Run(ctx context.Context, childEnv *env.Env)
 	// Start the second (non-state syncing) compute node.
 	sc.Logger.Info("starting compute node without state sync")
 
-	readyCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	readyCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
 	worker := sc.Net.ComputeWorkers()[1]

--- a/go/roothash/api/history.go
+++ b/go/roothash/api/history.go
@@ -48,6 +48,9 @@ type BlockHistory interface {
 	// If node has local storage this includes waiting for the round to be synced into storage.
 	WatchBlocks() (<-chan *AnnotatedBlock, pubsub.ClosableSubscription, error)
 
+	// WatchCommittedBlocks returns a channel watching block rounds as they are committed.
+	WatchCommittedBlocks() (<-chan *AnnotatedBlock, pubsub.ClosableSubscription, error)
+
 	// WaitRoundSynced waits for the specified round to be synced to storage.
 	WaitRoundSynced(ctx context.Context, round uint64) (uint64, error)
 

--- a/go/roothash/api/history.go
+++ b/go/roothash/api/history.go
@@ -15,27 +15,21 @@ type BlockHistory interface {
 	// RuntimeID returns the runtime ID of the runtime this block history is for.
 	RuntimeID() common.Namespace
 
-	// Commit commits an annotated block.
-	//
-	// If notify is set to true, the watchers will be notified about the new block.
-	//
-	// Any sequence of Commit and CommitBatch calls is valid as long as as blocks
-	// are sorted by round.
-	//
-	// Returns an error if a block at higher or equal round was already committed.
-	Commit(blk *AnnotatedBlock, notify bool) error
+	// Initialized returns a channel that will be closed when the block history
+	// is initialized and ready to service requests.
+	Initialized() <-chan struct{}
 
-	// CommitBatch commits annotated blocks.
+	// SetInitialized marks the block history as initialized.
+	SetInitialized() error
+
+	// Commit commits annotated blocks.
 	//
-	// If notify is set to true, the watchers will be notified about all
-	// blocks in batch.
-	//
-	// Within a batch, blocks should be sorted by round. Any sequence of Commit
-	// and CommitBatch calls is valid as long as blocks are sorted by round.
+	// Within a batch, blocks should be sorted by round. Any sequence of commit
+	// calls is valid as long as blocks are sorted by round.
 	//
 	// Returns an error if a block at higher or equal round than the first item
 	// in a batch was already committed.
-	CommitBatch(blks []*AnnotatedBlock, notify bool) error
+	Commit(blks []*AnnotatedBlock) error
 
 	// StorageSyncCheckpoint records the last storage round which was synced
 	// to runtime storage.
@@ -49,6 +43,10 @@ type BlockHistory interface {
 	WatchBlocks() (<-chan *AnnotatedBlock, pubsub.ClosableSubscription, error)
 
 	// WatchCommittedBlocks returns a channel watching block rounds as they are committed.
+	//
+	// The latest block if any will get pushed to the stream immediately.
+	// Subsequent blocks will be pushed into the stream as they are
+	// committed.
 	WatchCommittedBlocks() (<-chan *AnnotatedBlock, pubsub.ClosableSubscription, error)
 
 	// WaitRoundSynced waits for the specified round to be synced to storage.

--- a/go/runtime/history/history_test.go
+++ b/go/runtime/history/history_test.go
@@ -11,12 +11,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
-	"github.com/oasisprotocol/oasis-core/go/roothash/api"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 )
 
-const recvTimeout = 1 * time.Second
+const recvTimeout = time.Second
 
 func TestHistory(t *testing.T) {
 	require := require.New(t)
@@ -208,7 +207,7 @@ func TestCommitBatch(t *testing.T) {
 	require.NoError(err, "GetCommittedBlock(0)")
 	require.Equal(blk1.Block, gotBlock, "GetCommittedBlock should return the correct block")
 
-	gotBlock, err = history.GetCommittedBlock(ctx, api.RoundLatest)
+	gotBlock, err = history.GetCommittedBlock(ctx, roothash.RoundLatest)
 	require.NoError(err, "GetCommittedBlock(RoundLatest)")
 	require.Equal(blk2.Block, gotBlock, "GetCommittedBlock should return the correct block")
 

--- a/go/runtime/history/indexer.go
+++ b/go/runtime/history/indexer.go
@@ -1,0 +1,323 @@
+package history
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	cmnBackoff "github.com/oasisprotocol/oasis-core/go/common/backoff"
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	cmSync "github.com/oasisprotocol/oasis-core/go/common/sync"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
+)
+
+const (
+	batchSize        = 1000
+	maxPendingBlocks = 10
+)
+
+// BlockIndexer is responsible for indexing and committing finalized
+// runtime blocks from the consensus into the runtime history.
+type BlockIndexer struct {
+	startOne cmSync.One
+
+	consensus consensus.Backend
+	history   History
+
+	logger *logging.Logger
+}
+
+// NewBlockIndexer creates a new block indexer.
+func NewBlockIndexer(consensus consensus.Backend, history History) *BlockIndexer {
+	logger := logging.GetLogger("runtime/history/indexer").With("runtime_id", history.RuntimeID())
+
+	return &BlockIndexer{
+		startOne:  cmSync.NewOne(),
+		consensus: consensus,
+		history:   history,
+		logger:    logger,
+	}
+}
+
+// Start starts the indexer.
+func (bi *BlockIndexer) Start() {
+	bi.startOne.TryStart(bi.run)
+}
+
+// Stop halts the indexer.
+func (bi *BlockIndexer) Stop() {
+	bi.startOne.TryStop()
+}
+
+func (bi *BlockIndexer) run(ctx context.Context) {
+	bi.logger.Info("starting")
+
+	// Subscribe to new runtime blocks.
+	blkCh, blkSub, err := bi.consensus.RootHash().WatchBlocks(ctx, bi.history.RuntimeID())
+	if err != nil {
+		bi.logger.Error("failed to watch blocks",
+			"err", err,
+		)
+		return
+	}
+	defer blkSub.Close()
+
+	// Reindex blocks up to the latest.
+	if err = bi.reindex(ctx, blkCh); err != nil {
+		bi.logger.Error("failed to reindex blocks",
+			"err", err,
+		)
+		return
+	}
+
+	// Mark that reindex has completed.
+	if err = bi.history.SetInitialized(); err != nil {
+		bi.logger.Error("failed to initialize block history",
+			"err", err,
+		)
+		return
+	}
+
+	// Index new blocks.
+	bi.index(ctx, blkCh)
+	bi.logger.Info("stopping")
+}
+
+func (bi *BlockIndexer) index(ctx context.Context, blkCh <-chan *roothash.AnnotatedBlock) {
+	bi.logger.Debug("indexing")
+
+	retry := time.Duration(math.MaxInt64)
+	boff := cmnBackoff.NewExponentialBackOff()
+	boff.Reset()
+
+	blks := make([]*roothash.AnnotatedBlock, 0, 1)
+	for {
+		select {
+		case blk := <-blkCh:
+			blks = append(blks, blk)
+		case <-time.After(retry):
+		case <-ctx.Done():
+			bi.logger.Info("stopping")
+			return
+		}
+
+		if len(blks) > maxPendingBlocks {
+			bi.logger.Error("too many pending blocks for commit, terminating")
+			return
+		}
+
+		if err := bi.commitBlocks(blks); err != nil {
+			retry = boff.NextBackOff()
+			continue
+		}
+
+		blks = blks[:0]
+		retry = math.MaxInt64
+		boff.Reset()
+	}
+}
+
+func (bi *BlockIndexer) reindex(ctx context.Context, blkCh <-chan *roothash.AnnotatedBlock) error {
+	bi.logger.Debug("reindexing",
+		logging.LogEvent, roothash.LogEventHistoryReindexing,
+	)
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	reindexCh := make(chan int64, 1)
+	reindexDoneCh := make(chan int64, 1)
+
+	// Start a goroutine to handle reindex requests.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		retry := time.Duration(math.MaxInt64)
+		boff := cmnBackoff.NewExponentialBackOff()
+		boff.Reset()
+
+		var height int64
+		for {
+			select {
+			case height = <-reindexCh:
+			case <-time.After(retry):
+			case <-ctx.Done():
+				return
+			}
+			// Reindex blocks up to the specified height.
+			if err := bi.reindexTo(ctx, height); err != nil {
+				bi.logger.Error("failed to reindex blocks",
+					"err", err,
+					"height", height,
+				)
+				retry = boff.NextBackOff()
+				continue
+			}
+			retry = math.MaxInt64
+			boff.Reset()
+			// Notify that reindex has been completed.
+			sendToChannel(reindexDoneCh, height)
+		}
+	}()
+
+	// Reindex blocks up to the latest block.
+	var blk *roothash.AnnotatedBlock
+	for {
+		select {
+		case blk = <-blkCh:
+			// Send a new request with the latest height.
+			sendToChannel(reindexCh, blk.Height)
+			continue
+		case height := <-reindexDoneCh:
+			// Stop once reindex catches up.
+			if height != blk.Height {
+				continue
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		break
+	}
+
+	// Commit the last block manually, if the height at which the block
+	// was published is not available due to state sync from a newer height.
+	// This ensures that there is always at least one block in the history.
+	height, err := bi.history.LastConsensusHeight()
+	if err != nil {
+		bi.logger.Error("failed to fetch last consensus height",
+			"err", err,
+		)
+		return err
+	}
+	if height != blk.Height {
+		if err := bi.commitBlocks([]*roothash.AnnotatedBlock{blk}); err != nil {
+			return err
+		}
+	}
+
+	bi.logger.Debug("reindex completed")
+	return nil
+}
+
+func (bi *BlockIndexer) reindexTo(ctx context.Context, height int64) error {
+	lastHeight, err := bi.history.LastConsensusHeight()
+	if err != nil {
+		bi.logger.Error("failed to get last indexed height",
+			"err", err,
+		)
+		return fmt.Errorf("failed to get last indexed height: %w", err)
+	}
+	lastHeight++ // +1 since we want the last non-seen height.
+
+	lastRetainedHeight, err := bi.consensus.GetLastRetainedHeight(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get last retained height: %w", err)
+	}
+
+	if lastHeight < lastRetainedHeight {
+		bi.logger.Debug("skipping pruned heights",
+			"last_retained_height", lastRetainedHeight,
+			"last_height", lastHeight,
+		)
+		lastHeight = lastRetainedHeight
+	}
+
+	for start := lastHeight; start <= height; start += batchSize {
+		end := min(start+batchSize-1, height)
+		if err = bi.reindexRange(ctx, start, end); err != nil {
+			return fmt.Errorf("failed to reindex batch: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (bi *BlockIndexer) reindexRange(ctx context.Context, start int64, end int64) error {
+	bi.logger.Debug("reindexing blocks",
+		"start_height", start,
+		"end_height", end,
+	)
+
+	var blocks []*roothash.AnnotatedBlock
+	for height := start; height <= end; height++ {
+		state, err := bi.consensus.RootHash().GetRuntimeState(ctx, &roothash.RuntimeRequest{
+			RuntimeID: bi.history.RuntimeID(),
+			Height:    height,
+		})
+		switch {
+		case err == nil:
+		case errors.Is(err, consensus.ErrVersionNotFound):
+			bi.logger.Debug("failed to get runtime state, probably pruned",
+				"err", err,
+				"height", height,
+			)
+			continue
+		case errors.Is(err, roothash.ErrInvalidRuntime):
+			bi.logger.Debug("failed to get runtime state, probably no state yet",
+				"err", err,
+				"height", height,
+			)
+			continue
+		default:
+			bi.logger.Error("failed to get runtime state",
+				"err", err,
+				"height", height,
+			)
+			return fmt.Errorf("failed to get runtime state: %w", err)
+		}
+		if state.LastBlockHeight != height {
+			// No new block at this height, skipping.
+			continue
+		}
+
+		blk := &roothash.AnnotatedBlock{
+			Height: state.LastBlockHeight,
+			Block:  state.LastBlock,
+		}
+		blocks = append(blocks, blk)
+	}
+
+	if err := bi.commitBlocks(blocks); err != nil {
+		return err
+	}
+
+	bi.logger.Debug("block reindex completed")
+	return nil
+}
+
+func (bi *BlockIndexer) commitBlocks(blocks []*roothash.AnnotatedBlock) error {
+	if len(blocks) == 0 {
+		return nil
+	}
+
+	bi.logger.Debug("committing blocks",
+		"start_round", blocks[0].Block.Header.Round,
+		"end_round", blocks[len(blocks)-1].Block.Header.Round,
+	)
+
+	if err := bi.history.Commit(blocks); err != nil {
+		bi.logger.Error("failed to commit blocks",
+			"err", err,
+		)
+		return fmt.Errorf("failed to commit blocks: %w", err)
+	}
+
+	return nil
+}
+
+// sendToChannel sends a value to the channel, overwriting any pending value.
+func sendToChannel[T any](ch chan T, value T) {
+	select {
+	case <-ch:
+	default:
+	}
+	ch <- value
+}

--- a/go/worker/client/committee/node.go
+++ b/go/worker/client/committee/node.go
@@ -174,9 +174,6 @@ func (n *Node) CheckTx(ctx context.Context, tx []byte) (*protocol.CheckTxResult,
 
 func (n *Node) Query(ctx context.Context, round uint64, method string, args []byte, comp *component.ID) ([]byte, error) {
 	hrt := n.commonNode.GetHostedRuntime()
-	if hrt == nil {
-		return nil, api.ErrNoHostedRuntime
-	}
 
 	// Fetch the active descriptor so we can get the current message limits.
 	n.commonNode.CrossNode.Lock()

--- a/go/worker/common/worker.go
+++ b/go/worker/common/worker.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
@@ -35,10 +34,8 @@ type Worker struct {
 
 	runtimes map[common.Namespace]*committee.Node
 
-	ctx       context.Context
-	cancelCtx context.CancelFunc
-	quitCh    chan struct{}
-	initCh    chan struct{}
+	quitCh chan struct{}
+	initCh chan struct{}
 
 	logger *logging.Logger
 }
@@ -105,8 +102,6 @@ func (w *Worker) Stop() {
 
 		rt.Stop()
 	}
-
-	w.cancelCtx()
 }
 
 // Enabled returns if worker is enabled.
@@ -213,8 +208,6 @@ func New(
 		return nil, fmt.Errorf("worker/common: failed to initialize config: %w", err)
 	}
 
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
 	w := &Worker{
 		enabled:         enabled,
 		cfg:             *cfg,
@@ -229,8 +222,6 @@ func New(
 		RuntimeRegistry: runtimeRegistry,
 		Provisioner:     provisioner,
 		runtimes:        make(map[common.Namespace]*committee.Node),
-		ctx:             ctx,
-		cancelCtx:       cancelCtx,
 		quitCh:          make(chan struct{}),
 		initCh:          make(chan struct{}),
 		logger:          logging.GetLogger("worker/common"),


### PR DESCRIPTION
The runtime history should be built on top of the roothash service, using observed blocks for block reindexing and round syncing. The roothash service should broadcast blocks as soon as they are finalized in consensus, whereas the block history should broadcast blocks only after they have been reindexed or synced.

Now, we have 3 ways to observe runtime blocks:

1. Method `consensus.RootHash().WatchBlocks` returns blocks immediately once they are finalized in the consensus.
2. Method `rt.History().WatchCommittedBlocks` returns blocks immediately once they are committed to local storage.
3. Method `rt.History().WatchBlocks` returns blocks immediately once they are committed and synced to local storage.

Comparing methods to previous solution:
- Previous 1 == Current 2