### PR TITLE
 go/roothash: Remove RoundResults from history reindex

### DIFF
--- a/go/roothash/api/history.go
+++ b/go/roothash/api/history.go
@@ -15,7 +15,7 @@ type BlockHistory interface {
 	// RuntimeID returns the runtime ID of the runtime this block history is for.
 	RuntimeID() common.Namespace
 
-	// Commit commits an annotated block with corresponding round results.
+	// Commit commits an annotated block.
 	//
 	// If notify is set to true, the watchers will be notified about the new block.
 	//
@@ -23,9 +23,9 @@ type BlockHistory interface {
 	// are sorted by round.
 	//
 	// Returns an error if a block at higher or equal round was already committed.
-	Commit(blk *AnnotatedBlock, result *RoundResults, notify bool) error
+	Commit(blk *AnnotatedBlock, notify bool) error
 
-	// CommitBatch commits annotated blocks with corresponding round results.
+	// CommitBatch commits annotated blocks.
 	//
 	// If notify is set to true, the watchers will be notified about all
 	// blocks in batch.
@@ -35,7 +35,7 @@ type BlockHistory interface {
 	//
 	// Returns an error if a block at higher or equal round than the first item
 	// in a batch was already committed.
-	CommitBatch(blks []*AnnotatedBlock, results []*RoundResults, notify bool) error
+	CommitBatch(blks []*AnnotatedBlock, notify bool) error
 
 	// StorageSyncCheckpoint records the last storage round which was synced
 	// to runtime storage.
@@ -74,9 +74,4 @@ type BlockHistory interface {
 
 	// GetEarliestBlock returns the earliest known block.
 	GetEarliestBlock(ctx context.Context) (*block.Block, error)
-
-	// GetRoundResults returns the round results for the given round.
-	//
-	// Passing the special value `RoundLatest` will return results for the latest round.
-	GetRoundResults(ctx context.Context, round uint64) (*RoundResults, error)
 }

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -3,7 +3,6 @@ package history
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
@@ -22,11 +21,7 @@ import (
 // DbFilename is the filename of the history database.
 const DbFilename = "history.db"
 
-var (
-	errNopHistory = errors.New("runtime/history: not supported")
-
-	_ History = (*runtimeHistory)(nil)
-)
+var _ History = (*runtimeHistory)(nil)
 
 // Factory is the runtime history factory interface.
 type Factory func(runtimeID common.Namespace, dataDir string) (History, error)
@@ -40,75 +35,6 @@ type History interface {
 
 	// Close closes the history keeper.
 	Close()
-}
-
-type nopHistory struct {
-	runtimeID common.Namespace
-}
-
-func (h *nopHistory) RuntimeID() common.Namespace {
-	return h.runtimeID
-}
-
-func (h *nopHistory) Commit(*roothash.AnnotatedBlock, *roothash.RoundResults, bool) error {
-	return errNopHistory
-}
-
-func (h *nopHistory) CommitBatch([]*roothash.AnnotatedBlock, []*roothash.RoundResults, bool) error {
-	return errNopHistory
-}
-
-func (h *nopHistory) StorageSyncCheckpoint(uint64) error {
-	return errNopHistory
-}
-
-func (h *nopHistory) LastStorageSyncedRound() (uint64, error) {
-	return 0, errNopHistory
-}
-
-func (h *nopHistory) WatchBlocks() (<-chan *roothash.AnnotatedBlock, pubsub.ClosableSubscription, error) {
-	return nil, nil, errNopHistory
-}
-
-func (h *nopHistory) WaitRoundSynced(context.Context, uint64) (uint64, error) {
-	return 0, errNopHistory
-}
-
-func (h *nopHistory) LastConsensusHeight() (int64, error) {
-	return 0, errNopHistory
-}
-
-func (h *nopHistory) GetCommittedBlock(context.Context, uint64) (*block.Block, error) {
-	return nil, errNopHistory
-}
-
-func (h *nopHistory) GetBlock(context.Context, uint64) (*block.Block, error) {
-	return nil, errNopHistory
-}
-
-func (h *nopHistory) GetAnnotatedBlock(context.Context, uint64) (*roothash.AnnotatedBlock, error) {
-	return nil, errNopHistory
-}
-
-func (h *nopHistory) GetEarliestBlock(context.Context) (*block.Block, error) {
-	return nil, errNopHistory
-}
-
-func (h *nopHistory) GetRoundResults(context.Context, uint64) (*roothash.RoundResults, error) {
-	return nil, errNopHistory
-}
-
-func (h *nopHistory) Pruner() Pruner {
-	pruner, _ := NewNonePrunerFactory()(h.runtimeID, nil)
-	return pruner
-}
-
-func (h *nopHistory) Close() {
-}
-
-// NewNop creates a new no-op runtime history keeper.
-func NewNop(runtimeID common.Namespace) History {
-	return &nopHistory{runtimeID: runtimeID}
 }
 
 type runtimeHistory struct {

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -64,16 +64,16 @@ func (h *runtimeHistory) RuntimeID() common.Namespace {
 	return h.runtimeID
 }
 
-func (h *runtimeHistory) Commit(blk *roothash.AnnotatedBlock, result *roothash.RoundResults, notify bool) error {
-	return h.CommitBatch([]*roothash.AnnotatedBlock{blk}, []*roothash.RoundResults{result}, notify)
+func (h *runtimeHistory) Commit(blk *roothash.AnnotatedBlock, notify bool) error {
+	return h.CommitBatch([]*roothash.AnnotatedBlock{blk}, notify)
 }
 
-func (h *runtimeHistory) CommitBatch(blks []*roothash.AnnotatedBlock, results []*roothash.RoundResults, notify bool) error {
-	if len(blks) == 0 && len(results) == 0 {
+func (h *runtimeHistory) CommitBatch(blks []*roothash.AnnotatedBlock, notify bool) error {
+	if len(blks) == 0 {
 		return nil
 	}
 
-	if err := h.db.commit(blks, results); err != nil {
+	if err := h.db.commit(blks); err != nil {
 		return err
 	}
 
@@ -239,17 +239,6 @@ func (h *runtimeHistory) GetEarliestBlock(ctx context.Context) (*block.Block, er
 		return nil, err
 	}
 	return annBlk.Block, nil
-}
-
-func (h *runtimeHistory) GetRoundResults(ctx context.Context, round uint64) (*roothash.RoundResults, error) {
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
-	}
-	resolvedRound, err := h.resolveRound(round, true)
-	if err != nil {
-		return nil, err
-	}
-	return h.db.getRoundResults(resolvedRound)
 }
 
 func (h *runtimeHistory) Pruner() Pruner {

--- a/go/runtime/history/prune.go
+++ b/go/runtime/history/prune.go
@@ -120,15 +120,11 @@ func (p *keepLastPruner) Prune(latestRound uint64) error {
 				break
 			}
 
-			if err := tx.Delete(roundResultsKeyFmt.Encode(round)); err != nil {
+			if err := tx.Delete(item.KeyCopy(nil)); err != nil {
 				if err == badger.ErrTxnTooBig {
 					// We can't prune any more rounds in this transaction.
 					break
 				}
-				return err
-			}
-
-			if err := tx.Delete(item.KeyCopy(nil)); err != nil {
 				return err
 			}
 

--- a/go/worker/compute/executor/committee/prune.go
+++ b/go/worker/compute/executor/committee/prune.go
@@ -8,7 +8,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/worker/common/committee"
 )
 
-// pruneHandler is a prune handler that prevents pruning of the last successful round.
+// pruneHandler is a prune handler that prevents pruning of the last normal round.
 type pruneHandler struct {
 	commonNode *committee.Node
 }
@@ -18,8 +18,9 @@ func (p *pruneHandler) Prune(rounds []uint64) error {
 	height := p.commonNode.CurrentBlockHeight
 	p.commonNode.CrossNode.Unlock()
 
-	// Make sure we never prune past the last successful round as we need that round in history so
-	// we can fetch any needed round results.
+	// Make sure we never prune past the last normal round, as some runtimes will do historic queries
+	// for things that are not available in the last consensus state (e.g. delegation/undelegation
+	// events that happened while the runtime was suspended or not producing blocks).
 	state, err := p.commonNode.Consensus.RootHash().GetRuntimeState(context.Background(), &roothash.RuntimeRequest{
 		RuntimeID: p.commonNode.Runtime.ID(),
 		Height:    height,


### PR DESCRIPTION
`RoundResults` are now on-chain so there is no need to reindex them anymore. See [thread](https://oasisprotocol.slack.com/archives/C075WCGDNJ0/p1741098222045169) for more context.

Related to #5738, I have confirmed this increases our history reindex ~30%, which is in line with what [existing benchmarks](https://docs.google.com/document/d/1Lq-Qe6jrrLUSKIkLLsIGOrfb31Ivi-hZKP0wAC50V1E/edit?tab=t.0#heading=h.2fkeolp01q4u) predict.