### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/go/consensus/cometbft/abci/prune_test.go
+++ b/go/consensus/cometbft/abci/prune_test.go
@@ -3,7 +3,6 @@ package abci
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,9 +19,7 @@ func TestPruneKeepN(t *testing.T) {
 	require := require.New(t)
 
 	// Create a new random temporary directory under /tmp.
-	dir, err := os.MkdirTemp("", "abci-prune.test.badger")
-	require.NoError(err, "TempDir")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create a Badger-backed Node DB.
 	ndb, err := mkvsBadgerDB.New(&mkvsDB.Config{

--- a/go/consensus/cometbft/db/badger/badger_test.go
+++ b/go/consensus/cometbft/db/badger/badger_test.go
@@ -1,7 +1,6 @@
 package badger
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -12,9 +11,7 @@ import (
 
 func TestBadgerCometBFTDB(t *testing.T) {
 	// Create a temporary directory to store the test database.
-	tmpDir, err := os.MkdirTemp("", "oasis-go-cometbft-db-test")
-	require.NoError(t, err, "Failed to create temporary directory.")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Create the database.
 	db, err := New(filepath.Join(tmpDir, "test"), false)

--- a/go/runtime/transaction/transaction_test.go
+++ b/go/runtime/transaction/transaction_test.go
@@ -3,7 +3,6 @@ package transaction
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -228,9 +227,7 @@ func TestTransactionLocalBackend(t *testing.T) {
 		err error
 	)
 
-	cfg.DB, err = os.MkdirTemp("", "oasis-rt-tx-tree-localdb-test")
-	require.NoError(err, "TempDir()")
-	defer os.RemoveAll(cfg.DB)
+	cfg.DB := t.TempDir()
 
 	db, err := database.New(&cfg)
 	require.NoError(err, "New()")


### PR DESCRIPTION
 TempDir returns a temporary directory for the test to use.The directory is automatically removed when the test and
all its subtests complete. More info  https://pkg.go.dev/testing#B.TempDir
