### PR TITLE
refactor: replace golang.org/x/exp with stdlib

### DIFF
--- a/tests/upgrade/pre/scenario/e2e/upgrade.go
+++ b/tests/upgrade/pre/scenario/e2e/upgrade.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"


### PR DESCRIPTION
Since Go 1.21, the functions in x/exp used here can already be replaced by functions from the standard library.