### PR TITLE
rust: Bump ring to 0.17.13

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,5 @@
 [advisories]
 ignore = [
     "RUSTSEC-2023-0071", # Does not affect our current use of the library.
+    "RUSTSEC-2024-0437", # Ignoring until dependencies are upgraded to protobuf v3.
 ]

--- a/.changelog/6104.internal.md
+++ b/.changelog/6104.internal.md
@@ -1,0 +1,1 @@
+rust: Bump ring to 0.17.13

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,9 +442,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cexpr"
@@ -2556,15 +2559,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "getrandom",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]


### PR DESCRIPTION
```
Crate:     protobuf
Version:   2.28.0
Title:     Crash due to uncontrolled recursion in protobuf crate
Date:      2024-12-12
ID:        RUSTSEC-2024-0437
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0437
Solution:  No fixed upgrade is available!
Dependency tree:
protobuf 2.28.0
├── protoc-rust 2.28.0
│   └── aesm-client 0.6.0
│       └── oasis-core-runtime-loader 0.0.0
├── protobuf-codegen 2.28.0
│   └── protoc-rust 2.28.0
└── aesm-client 0.6.0
```

```
Crate:     ring
Version:   0.17.8
Title:     Some AES functions may panic when overflow checking is enabled.
Date:      2025-03-06
ID:        RUSTSEC-2025-0009
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0009
Solution:  Upgrade to >=0.17.12
Dependency tree:
ring 0.17.8
└── rustls-webpki 0.102.8
    ├── rustls-mbedcrypto-provider 0.1.0
    │   └── simple-rofl 0.0.0
    └── rustls 0.23.18
        ├── simple-rofl 0.0.0
        ├── rustls-mbedtls-provider-utils 0.2.0
        │   ├── rustls-mbedpki-provider 0.2.0
        │   │   └── simple-rofl 0.0.0
        │   └── rustls-mbedcrypto-provider 0.1.0
        ├── rustls-mbedpki-provider 0.2.0
        └── rustls-mbedcrypto-provider 0.1.0
```