### PR TITLE
docs: Fix environment variable quoting

### DIFF
--- a/.buildkite/rust/build_runtime.sh
+++ b/.buildkite/rust/build_runtime.sh
@@ -54,7 +54,7 @@ pushd $src_dir
             ;;
         *)
             # Build non-SGX runtime. Checking KM policy requires SGX, disable it.
-            CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/default" OASIS_UNSAFE_SKIP_KM_POLICY="1" cargo build --release --locked
+            CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/default" OASIS_UNSAFE_SKIP_KM_POLICY=1 cargo build --release --locked
 
             # Build SGX runtime.
             export CFLAGS_x86_64_fortanix_unknown_sgx="-isystem/usr/include/x86_64-linux-gnu -mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening"

--- a/.buildkite/rust/common.sh
+++ b/.buildkite/rust/common.sh
@@ -7,6 +7,6 @@ source .buildkite/scripts/common.sh
 ####################
 # Set up environment
 ####################
-export OASIS_UNSAFE_SKIP_AVR_VERIFY="1"
-export OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES="1"
-export RUST_BACKTRACE="1"
+export OASIS_UNSAFE_SKIP_AVR_VERIFY=1
+export OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1
+export RUST_BACKTRACE=1

--- a/docs/development-setup/building.md
+++ b/docs/development-setup/building.md
@@ -12,9 +12,9 @@ To build everything required for running an Oasis node locally, simply execute
 the following in the top-level directory:
 
 ```
-export OASIS_UNSAFE_SKIP_AVR_VERIFY="1"
-export OASIS_UNSAFE_SKIP_KM_POLICY="1"
-export OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES="1"
+export OASIS_UNSAFE_SKIP_AVR_VERIFY=1
+export OASIS_UNSAFE_SKIP_KM_POLICY=1
+export OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1
 make
 ```
 
@@ -22,7 +22,7 @@ To build BadgerDB without `jemalloc` support (and avoid installing `jemalloc`
 on your system), set
 
 ```
-export OASIS_BADGER_NO_JEMALLOC="1"
+export OASIS_BADGER_NO_JEMALLOC=1
 ```
 
 Not using `jemalloc` is fine for development purposes.
@@ -38,8 +38,8 @@ Compilation procedure under SGX environment is similar to the non-SGX with
 slightly different environmental variables set:
 
 ```
-export OASIS_UNSAFE_SKIP_AVR_VERIFY="1"
-export OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES="1"
+export OASIS_UNSAFE_SKIP_AVR_VERIFY=1
+export OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1
 make
 ```
 

--- a/docs/development-setup/prerequisites.md
+++ b/docs/development-setup/prerequisites.md
@@ -177,7 +177,7 @@ Core:
 
 * (**OPTIONAL**) [jemalloc] (version 5.2.1, built with `'je_'` jemalloc-prefix)
 
-  Alternatively set `OASIS_BADGER_NO_JEMALLOC="1"` environment variable when
+  Alternatively set `OASIS_BADGER_NO_JEMALLOC=1` environment variable when
   building `oasis-node` code, to build [BadgerDB] without `jemalloc` support.
 
   Download and install `jemalloc` with:


### PR DESCRIPTION
I was going through the development environment setup instructions again when setting up my new workstation and noticed that we use unnecessary quotes when setting up the Oasis environment variables (`export OASIS_...="1"`) -- there is no need to use quotes there, since we're setting the variable to a single word.