### PR TITLE
go/consensus/cometbft/config: Move light client config

### DIFF
--- a/.changelog/6115.cfg.md
+++ b/.changelog/6115.cfg.md
@@ -1,0 +1,22 @@
+go/consensus/cometbft/config: Move light client config
+
+The consensus light client is currently used only for consensus state
+synchronization. However, in the future, stateless clients will also rely
+on it. Therefore, we have moved the trust root configuration to a dedicated
+section.
+
+The following configuration options have been removed:
+
+- `consensus.state_sync.trust_period`,
+
+- `consensus.state_sync.trust_height`,
+
+- `consensus.state_sync.trust_hash`.
+
+The following configuration options have been added:
+
+- `consensus.light_client.trust.period`,
+
+- `consensus.light_client.trust.height`,
+
+- `consensus.light_client.trust.hash`.

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -378,9 +378,6 @@ type Backend interface {
 	// complete.
 	Synced() <-chan struct{}
 
-	// ConsensusKey returns the consensus signing key.
-	ConsensusKey() signature.PublicKey
-
 	// GetAddresses returns the consensus backend addresses.
 	GetAddresses() ([]node.ConsensusAddress, error)
 

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -339,11 +339,6 @@ func (n *commonNode) Cleanup() {
 }
 
 // Implements consensusAPI.Backend.
-func (n *commonNode) ConsensusKey() signature.PublicKey {
-	return n.identity.ConsensusSigner.Public()
-}
-
-// Implements consensusAPI.Backend.
 func (n *commonNode) GetAddresses() ([]node.ConsensusAddress, error) {
 	u, err := common.GetExternalAddress()
 	if err != nil {

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -859,13 +859,13 @@ func (n *commonNode) SupportedFeatures() consensusAPI.FeatureMask {
 // Implements consensusAPI.Backend.
 func (n *commonNode) GetStatus(ctx context.Context) (*consensusAPI.Status, error) {
 	status := &consensusAPI.Status{
-		Version:  version.ConsensusProtocol,
-		Backend:  api.BackendName,
-		Features: n.SupportedFeatures(),
+		Version:       version.ConsensusProtocol,
+		Backend:       api.BackendName,
+		Features:      n.SupportedFeatures(),
+		ChainContext:  n.chainContext,
+		GenesisHeight: n.genesisHeight,
 	}
 
-	status.ChainContext = n.chainContext
-	status.GenesisHeight = n.genesisHeight
 	if n.started() {
 		// Only attempt to fetch blocks in case the consensus service has started as otherwise
 		// requests will block.

--- a/go/consensus/cometbft/full/full.go
+++ b/go/consensus/cometbft/full/full.go
@@ -723,14 +723,14 @@ func (t *fullService) lazyInit() error { // nolint: gocyclo
 
 			// Enable state sync in the configuration.
 			cometConfig.StateSync.Enable = true
-			cometConfig.StateSync.TrustHash = config.GlobalConfig.Consensus.StateSync.TrustHash
+			cometConfig.StateSync.TrustHash = config.GlobalConfig.Consensus.LightClient.Trust.Hash
 
 			// Create new state sync state provider.
 			cfg := lightAPI.ClientConfig{
 				GenesisDocument: t.genesisDoc,
 				TrustOptions: cmtlight.TrustOptions{
-					Period: config.GlobalConfig.Consensus.StateSync.TrustPeriod,
-					Height: int64(config.GlobalConfig.Consensus.StateSync.TrustHeight),
+					Period: config.GlobalConfig.Consensus.LightClient.Trust.Period,
+					Height: int64(config.GlobalConfig.Consensus.LightClient.Trust.Height),
 					Hash:   cometConfig.StateSync.TrustHashBytes(),
 				},
 			}

--- a/go/consensus/cometbft/light/service.go
+++ b/go/consensus/cometbft/light/service.go
@@ -216,7 +216,7 @@ func (c *client) worker() {
 
 	tmc, err := cmtlight.NewClientFromTrustedStore(
 		tmChainID,
-		config.GlobalConfig.Consensus.StateSync.TrustPeriod,
+		config.GlobalConfig.Consensus.LightClient.Trust.Period,
 		providers[0],  // Primary provider.
 		providers[1:], // Witnesses.
 		c.store,

--- a/go/consensus/p2p/light/server.go
+++ b/go/consensus/p2p/light/server.go
@@ -38,18 +38,12 @@ func (s *service) HandleRequest(ctx context.Context, method string, body cbor.Ra
 		if err := cbor.Unmarshal(body, &rq); err != nil {
 			return nil, rpc.ErrBadRequest
 		}
-
-		lb, err := s.consensus.GetParameters(ctx, rq)
-		if err != nil {
-			return nil, err
-		}
-		return lb, nil
+		return s.consensus.GetParameters(ctx, rq)
 	case MethodSubmitEvidence:
 		var rq consensus.Evidence
 		if err := cbor.Unmarshal(body, &rq); err != nil {
 			return nil, rpc.ErrBadRequest
 		}
-
 		return nil, s.consensus.SubmitEvidence(ctx, &rq)
 	default:
 		return nil, rpc.ErrMethodNotSupported

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -9,6 +9,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx"
+	"github.com/oasisprotocol/oasis-core/go/consensus/cometbft/config"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/log"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
@@ -142,6 +143,12 @@ type ConsensusFixture struct { // nolint: maligned
 
 	// EnableArchiveMode enables the archive node mode.
 	EnableArchiveMode bool `json:"enable_archive_mode,omitempty"`
+
+	// StateSync contains state sync configuration.
+	StateSync config.StateSyncConfig `yaml:"state_sync,omitempty"`
+
+	// LightClient contains light client configuration.
+	LightClient config.LightClientConfig `json:"light_client,omitempty"`
 }
 
 // NodeFixture is a common subset of settings for node-backed fixtures.

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -17,7 +17,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	"github.com/oasisprotocol/oasis-core/go/runtime/bundle"
-	runtimeCfg "github.com/oasisprotocol/oasis-core/go/runtime/config"
 	runtimeConfig "github.com/oasisprotocol/oasis-core/go/runtime/config"
 	keymanagerConfig "github.com/oasisprotocol/oasis-core/go/worker/keymanager/config"
 )
@@ -298,7 +297,7 @@ func (km *Keymanager) ModifyConfig() error {
 	km.Config.Runtime.SGXLoader = km.net.cfg.RuntimeSGXLoaderBinary
 	km.Config.Runtime.AttestInterval = km.net.cfg.RuntimeAttestInterval
 
-	rtCfg := runtimeCfg.RuntimeConfig{
+	rtCfg := runtimeConfig.RuntimeConfig{
 		ID: km.runtime.cfgSave.id,
 	}
 

--- a/go/oasis-test-runner/oasis/network.go
+++ b/go/oasis-test-runner/oasis/network.go
@@ -689,11 +689,9 @@ func (net *Network) startOasisNode(
 		}
 		cfg.Common.InternalSocketPath = node.customGrpcSocketPath
 	}
-	if node.consensusStateSync != nil {
-		cfg.Consensus.StateSync.Enabled = true
-		cfg.Consensus.StateSync.TrustHeight = node.consensusStateSync.TrustHeight
-		cfg.Consensus.StateSync.TrustHash = node.consensusStateSync.TrustHash
-	}
+	cfg.Consensus.StateSync = node.consensus.StateSync
+	cfg.Consensus.LightClient = node.consensus.LightClient
+
 	if net.Config().Metrics.Address != "" {
 		cfg.Metrics.Mode = metrics.MetricsModePush
 		cfg.Metrics.Address = net.Config().Metrics.Address

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -20,6 +20,7 @@ import (
 	commonNode "github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/config"
 	"github.com/oasisprotocol/oasis-core/go/consensus/cometbft/abci"
+	cmtConfig "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/config"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/log"
@@ -61,12 +62,6 @@ const (
 	allInterfacesAddr = "tcp://0.0.0.0"
 	localhostAddr     = "tcp://127.0.0.1"
 )
-
-// ConsensusStateSyncCfg is a node's consensus state sync configuration.
-type ConsensusStateSyncCfg struct {
-	TrustHeight uint64
-	TrustHash   string
-}
 
 // Feature is a feature or worker hosted by a concrete oasis-node process.
 type Feature interface {
@@ -116,7 +111,6 @@ type Node struct { // nolint: maligned
 	logWatcherHandlerFactories               []log.WatcherHandlerFactory
 
 	consensus            ConsensusFixture
-	consensusStateSync   *ConsensusStateSyncCfg
 	customGrpcSocketPath string
 
 	pprofPort uint16
@@ -426,13 +420,20 @@ func (n *Node) Consensus() ConsensusFixture {
 	return n.consensus
 }
 
-// SetConsensusStateSync configures whether a node should perform consensus
-// state sync.
-func (n *Node) SetConsensusStateSync(cfg *ConsensusStateSyncCfg) {
+// EnableConsensusStateSync enables consensus state sync.
+func (n *Node) EnableConsensusStateSync() {
 	n.Lock()
 	defer n.Unlock()
 
-	n.consensusStateSync = cfg
+	n.consensus.StateSync.Enabled = true
+}
+
+// ConfigureConsensusLightClient configures consensus light client.
+func (n *Node) ConfigureConsensusLightClient(trust cmtConfig.TrustConfig) {
+	n.Lock()
+	defer n.Unlock()
+
+	n.consensus.LightClient.Trust = trust
 }
 
 func (n *Node) setProvisionedIdentity(seed string) error {

--- a/go/oasis-test-runner/scenario/e2e/consensus_state_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/consensus_state_sync.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	"github.com/oasisprotocol/oasis-core/go/consensus/cometbft/config"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/log"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
@@ -97,10 +98,12 @@ func (sc *consensusStateSyncImpl) Run(ctx context.Context, _ *env.Env) error {
 
 	// Configure state sync for the consensus validator.
 	val := sc.Net.Validators()[lastValidator]
-	val.SetConsensusStateSync(&oasis.ConsensusStateSyncCfg{
-		TrustHeight: uint64(blk.Height),
-		TrustHash:   blk.Hash.Hex(),
+	val.ConfigureConsensusLightClient(config.TrustConfig{
+		Period: time.Hour,
+		Height: uint64(blk.Height),
+		Hash:   blk.Hash.Hex(),
 	})
+	val.EnableConsensusStateSync()
 
 	if err = val.Start(); err != nil {
 		return fmt.Errorf("failed to start validator: %w", err)

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_early_state_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_early_state_sync.go
@@ -8,6 +8,7 @@ import (
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	"github.com/oasisprotocol/oasis-core/go/consensus/cometbft/config"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/log"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
@@ -168,10 +169,12 @@ func (sc *storageEarlyStateSyncImpl) Run(ctx context.Context, childEnv *env.Env)
 	// Configure state sync for the compute node.
 	sc.Logger.Info("starting compute node with state sync")
 	worker = sc.Net.ComputeWorkers()[0]
-	worker.SetConsensusStateSync(&oasis.ConsensusStateSyncCfg{
-		TrustHeight: uint64(latest.Height),
-		TrustHash:   latest.Hash.Hex(),
+	worker.ConfigureConsensusLightClient(config.TrustConfig{
+		Period: time.Hour,
+		Height: uint64(latest.Height),
+		Hash:   latest.Hash.Hex(),
 	})
+	worker.EnableConsensusStateSync()
 
 	if err := worker.Start(); err != nil {
 		return fmt.Errorf("can't start compute worker 0: %w", err)

--- a/go/oasis-test-runner/scenario/e2e/runtime/storage_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/storage_sync.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	"github.com/oasisprotocol/oasis-core/go/consensus/cometbft/config"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/log"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
@@ -204,10 +205,12 @@ func (sc *storageSyncImpl) Run(ctx context.Context, childEnv *env.Env) error { /
 
 	// Configure state sync for the last compute node.
 	lateWorker = sc.Net.ComputeWorkers()[4]
-	lateWorker.SetConsensusStateSync(&oasis.ConsensusStateSyncCfg{
-		TrustHeight: uint64(latest.Height),
-		TrustHash:   latest.Hash.Hex(),
+	lateWorker.ConfigureConsensusLightClient(config.TrustConfig{
+		Period: time.Hour,
+		Height: uint64(latest.Height),
+		Hash:   latest.Hash.Hex(),
 	})
+	lateWorker.EnableConsensusStateSync()
 
 	if err = lateWorker.Start(); err != nil {
 		return fmt.Errorf("can't start second late compute worker: %w", err)


### PR DESCRIPTION
The consensus light client is currently used only for consensus state synchronization. However, in the future, stateless clients will also rely on it. Therefore, we have moved the trust root configuration to a dedicated section.