### PR TITLE
Fix flaky history reindex test

### DIFF
--- a/go/oasis-test-runner/scenario/e2e/runtime/history_reindex.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/history_reindex.go
@@ -80,7 +80,7 @@ func (sc *historyReindexImpl) Run(ctx context.Context, childEnv *env.Env) error 
 	}
 	err = sc.waitForClientRuntimeBlock(ctx, computeCtrl.RuntimeClient, 10)
 	if err != nil {
-		return fmt.Errorf("failed to wait for runtime block: %w", err)
+		return fmt.Errorf("failed to wait for runtime block (node: %s): %w", compute.Name, err)
 	}
 
 	// Reindex existing runtime blocks and start indexing new ones.
@@ -92,7 +92,12 @@ func (sc *historyReindexImpl) Run(ctx context.Context, childEnv *env.Env) error 
 
 	// Verify that indexing works.
 	if err := sc.waitForClientRuntimeBlock(ctx, sc.Net.ClientController().RuntimeClient, 20); err != nil {
-		return fmt.Errorf("failed to wait for runtime block: %w", err)
+		return fmt.Errorf("failed to wait for runtime block (node: %s): %w", client.Name, err)
+	}
+
+	// Ensure that the compute worker indexes all blocks as well.
+	if err := sc.waitForClientRuntimeBlock(ctx, computeCtrl.RuntimeClient, 20); err != nil {
+		return fmt.Errorf("failed to wait for runtime block (node: %s): %w", compute.Name, err)
 	}
 
 	// Verify (re)indexed runtime blocks.


### PR DESCRIPTION
History reindex e2e test is flaky: https://buildkite.com/oasisprotocol/oasis-core-ci/builds/15043#0195ef94-e784-49d4-aebc-187f01a818c1.

Even though compute node is producing blocks, its indexer may still be behind the client...