### PR TITLE
go/runtime: Split between tdx and mock qemu provisioner

### DIFF
--- a/go/runtime/host/provisioner/provisioner.go
+++ b/go/runtime/host/provisioner/provisioner.go
@@ -184,6 +184,7 @@ func createProvisioner(
 		PCS:                   qs,
 		Consensus:             consensus,
 		Identity:              identity,
+		InsecureMock:          insecureMock,
 		RuntimeAttestInterval: attestInterval,
 	})
 	if err != nil {


### PR DESCRIPTION
Part of https://github.com/oasisprotocol/oasis-web3-gateway/issues/711