### PR TITLE
go/consensus/cometbft/api: Simplify consensus service client

### DIFF
--- a/go/consensus/cometbft/api/api.go
+++ b/go/consensus/cometbft/api/api.go
@@ -299,8 +299,6 @@ func NewServiceDescriptor(name, eventType string, queryCh <-chan cmtpubsub.Query
 func NewStaticServiceDescriptor(name, eventType string, queries []cmtpubsub.Query) ServiceDescriptor {
 	ch := make(chan cmtpubsub.Query)
 	go func() {
-		defer close(ch)
-
 		for _, q := range queries {
 			ch <- q
 		}

--- a/go/consensus/cometbft/api/api_test.go
+++ b/go/consensus/cometbft/api/api_test.go
@@ -19,6 +19,4 @@ func TestServiceDescriptor(t *testing.T) {
 	require.Equal("test_type", sd.EventType())
 	recvQ1 := <-sd.Queries()
 	require.EqualValues(q1, recvQ1, "received query should be correct")
-	_, ok := <-sd.Queries()
-	require.False(ok, "query channel must be closed")
 }

--- a/go/consensus/cometbft/beacon/beacon.go
+++ b/go/consensus/cometbft/beacon/beacon.go
@@ -271,18 +271,17 @@ func (sc *serviceClient) ServiceDescriptor() tmAPI.ServiceDescriptor {
 	return tmAPI.NewStaticServiceDescriptor("beacon", app.EventType, []cmtpubsub.Query{app.QueryApp})
 }
 
-func (sc *serviceClient) DeliverBlock(ctx context.Context, height int64) error {
+func (sc *serviceClient) DeliverBlock(ctx context.Context, blk *cmttypes.Block) error {
 	if sc.initialNotify {
 		return nil
 	}
 
-	q, err := sc.querier.QueryAt(ctx, height)
+	q, err := sc.querier.QueryAt(ctx, blk.Height)
 	if err != nil {
 		return fmt.Errorf("epochtime: failed to query state: %w", err)
 	}
 
-	var epoch beaconAPI.EpochTime
-	epoch, height, err = q.Epoch(ctx)
+	epoch, height, err := q.Epoch(ctx)
 	if err != nil {
 		return fmt.Errorf("epochtime: failed to query epoch: %w", err)
 	}


### PR DESCRIPTION
This will remove `DeliverCommand` from consensus `ServiceClient`, making the API more clean and limited only to two methods `DeliverBlock` and `DeliverEvents`. As a result, anyone with access to blocks and events can now run the client.