### PR TITLE
go/consensus/cometbft/api/state: Organize immutable state

### DIFF
--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -111,8 +111,6 @@ func (m FeatureMask) Has(f FeatureMask) bool {
 
 // ClientBackend is a consensus interface used by clients that connect to the local full node.
 type ClientBackend interface {
-	TransactionAuthHandler
-
 	// SubmitTx submits a signed consensus transaction and waits for the transaction to be included
 	// in a block. Use SubmitTxNoWait if you only need to broadcast the transaction.
 	SubmitTx(ctx context.Context, tx *transaction.SignedTransaction) error
@@ -153,6 +151,10 @@ type ClientBackend interface {
 
 	// SubmitEvidence submits evidence of misbehavior.
 	SubmitEvidence(ctx context.Context, evidence *Evidence) error
+
+	// GetSignerNonce returns the nonce that should be used by the given
+	// signer for transmitting the next transaction.
+	GetSignerNonce(ctx context.Context, req *GetSignerNonceRequest) (uint64, error)
 
 	// GetTransactions returns a list of all transactions contained within a
 	// consensus block at a specific height.
@@ -428,14 +430,6 @@ type StatePruneHandler interface {
 	// times (e.g., if one of the handlers fails but others succeed
 	// and pruning is later retried).
 	Prune(height int64) error
-}
-
-// TransactionAuthHandler is the interface for handling transaction authentication
-// (checking nonces and fees).
-type TransactionAuthHandler interface {
-	// GetSignerNonce returns the nonce that should be used by the given
-	// signer for transmitting the next transaction.
-	GetSignerNonce(ctx context.Context, req *GetSignerNonceRequest) (uint64, error)
 }
 
 // EstimateGasRequest is a EstimateGas request.

--- a/go/consensus/cometbft/abci/state/state.go
+++ b/go/consensus/cometbft/abci/state/state.go
@@ -24,13 +24,13 @@ var (
 
 // ImmutableState is an immutable consensus backend state wrapper.
 type ImmutableState struct {
-	is *api.ImmutableState
+	state *api.ImmutableState
 }
 
 // NewImmutableState creates a new immutable consensus backend state wrapper.
 func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	return &ImmutableState{
-		is: api.NewImmutableState(tree),
+		state: api.NewImmutableState(tree),
 	}
 }
 
@@ -47,7 +47,7 @@ func NewImmutableStateAt(ctx context.Context, state api.ApplicationQueryState, v
 
 // ChainContext returns the stored chain context.
 func (s *ImmutableState) ChainContext(ctx context.Context) (string, error) {
-	chainContext, err := s.is.Get(ctx, chainContextKeyFmt.Encode())
+	chainContext, err := s.state.Get(ctx, chainContextKeyFmt.Encode())
 	if err != nil {
 		return "", api.UnavailableStateError(err)
 	}
@@ -56,7 +56,7 @@ func (s *ImmutableState) ChainContext(ctx context.Context) (string, error) {
 
 // ConsensusParameters returns the consensus parameters.
 func (s *ImmutableState) ConsensusParameters(ctx context.Context) (*consensusGenesis.Parameters, error) {
-	raw, err := s.is.Get(ctx, parametersKeyFmt.Encode())
+	raw, err := s.state.Get(ctx, parametersKeyFmt.Encode())
 	if err != nil {
 		return nil, api.UnavailableStateError(err)
 	}
@@ -90,7 +90,7 @@ func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
 //
 // NOTE: This method must only be called from InitChain context.
 func (s *MutableState) SetChainContext(ctx context.Context, chainContext string) error {
-	if err := s.is.CheckContextMode(ctx, []api.ContextMode{api.ContextInitChain}); err != nil {
+	if err := s.state.CheckContextMode(ctx, []api.ContextMode{api.ContextInitChain}); err != nil {
 		return err
 	}
 	err := s.ms.Insert(ctx, chainContextKeyFmt.Encode(), []byte(chainContext))
@@ -101,7 +101,7 @@ func (s *MutableState) SetChainContext(ctx context.Context, chainContext string)
 //
 // NOTE: This method must only be called from InitChain/EndBlock contexts.
 func (s *MutableState) SetConsensusParameters(ctx context.Context, params *consensusGenesis.Parameters) error {
-	if err := s.is.CheckContextMode(ctx, []api.ContextMode{api.ContextInitChain, api.ContextEndBlock}); err != nil {
+	if err := s.state.CheckContextMode(ctx, []api.ContextMode{api.ContextInitChain, api.ContextEndBlock}); err != nil {
 		return err
 	}
 	err := s.ms.Insert(ctx, parametersKeyFmt.Encode(), cbor.Marshal(params))

--- a/go/consensus/cometbft/abci/state/state.go
+++ b/go/consensus/cometbft/abci/state/state.go
@@ -28,8 +28,16 @@ type ImmutableState struct {
 }
 
 // NewImmutableState creates a new immutable consensus backend state wrapper.
-func NewImmutableState(ctx context.Context, state api.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := api.NewImmutableState(ctx, state, version)
+func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
+	return &ImmutableState{
+		is: api.NewImmutableState(tree),
+	}
+}
+
+// NewImmutableStateAt creates a new immutable consensus backend state wrapper
+// using the provided application query state and version.
+func NewImmutableStateAt(ctx context.Context, state api.ApplicationQueryState, version int64) (*ImmutableState, error) {
+	is, err := api.NewImmutableStateAt(ctx, state, version)
 	if err != nil {
 		return nil, err
 	}
@@ -73,10 +81,8 @@ type MutableState struct {
 // NewMutableState creates a new mutable consensus backend state wrapper.
 func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
 	return &MutableState{
-		ImmutableState: &ImmutableState{
-			&api.ImmutableState{ImmutableKeyValueTree: tree},
-		},
-		ms: tree,
+		ImmutableState: NewImmutableState(tree),
+		ms:             tree,
 	}
 }
 

--- a/go/consensus/cometbft/abci/state/state.go
+++ b/go/consensus/cometbft/abci/state/state.go
@@ -70,6 +70,16 @@ type MutableState struct {
 	ms mkvs.KeyValueTree
 }
 
+// NewMutableState creates a new mutable consensus backend state wrapper.
+func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
+	return &MutableState{
+		ImmutableState: &ImmutableState{
+			&api.ImmutableState{ImmutableKeyValueTree: tree},
+		},
+		ms: tree,
+	}
+}
+
 // SetChainContext sets the chain context.
 //
 // NOTE: This method must only be called from InitChain context.
@@ -90,14 +100,4 @@ func (s *MutableState) SetConsensusParameters(ctx context.Context, params *conse
 	}
 	err := s.ms.Insert(ctx, parametersKeyFmt.Encode(), cbor.Marshal(params))
 	return api.UnavailableStateError(err)
-}
-
-// NewMutableState creates a new mutable consensus backend state wrapper.
-func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
-	return &MutableState{
-		ImmutableState: &ImmutableState{
-			&api.ImmutableState{ImmutableKeyValueTree: tree},
-		},
-		ms: tree,
-	}
 }

--- a/go/consensus/cometbft/api/api.go
+++ b/go/consensus/cometbft/api/api.go
@@ -226,8 +226,6 @@ type Backend interface {
 // TransactionAuthHandler is the interface for ABCI applications that handle
 // authenticating transactions (checking nonces and fees).
 type TransactionAuthHandler interface {
-	consensus.TransactionAuthHandler
-
 	// AuthenticateTx authenticates the given transaction by making sure
 	// that the nonce is correct and deducts any fees as specified.
 	//

--- a/go/consensus/cometbft/api/api.go
+++ b/go/consensus/cometbft/api/api.go
@@ -214,9 +214,9 @@ type Backend interface {
 	// GetCometBFTBlock returns the CometBFT block at the specified height.
 	GetCometBFTBlock(ctx context.Context, height int64) (*cmttypes.Block, error)
 
-	// GetBlockResults returns the ABCI results from processing a block
+	// GetCometBFTBlockResults returns the ABCI results from processing a block
 	// at a specific height.
-	GetBlockResults(ctx context.Context, height int64) (*cmtrpctypes.ResultBlockResults, error)
+	GetCometBFTBlockResults(ctx context.Context, height int64) (*cmtrpctypes.ResultBlockResults, error)
 
 	// WatchCometBFTBlocks returns a stream of CometBFT blocks as they are
 	// returned via the `EventDataNewBlock` query.

--- a/go/consensus/cometbft/api/state.go
+++ b/go/consensus/cometbft/api/state.go
@@ -243,13 +243,13 @@ func (ms *mockApplicationState) UpdateMockApplicationStateConfig(cfg *MockApplic
 
 // ImmutableState is an immutable state wrapper.
 type ImmutableState struct {
-	mkvs.ImmutableKeyValueTree
+	tree mkvs.ImmutableKeyValueTree
 }
 
 // NewImmutableState creates a new immutable state wrapper.
 func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	return &ImmutableState{
-		ImmutableKeyValueTree: tree,
+		tree: tree,
 	}
 }
 
@@ -324,7 +324,17 @@ func (s *ImmutableState) CheckContextMode(ctx context.Context, allowedModes []Co
 //
 // After calling this method, the immutable state wrapper should not be used anymore.
 func (s *ImmutableState) Close() {
-	if tree, ok := s.ImmutableKeyValueTree.(mkvs.ClosableTree); ok {
+	if tree, ok := s.tree.(mkvs.ClosableTree); ok {
 		tree.Close()
 	}
+}
+
+// Get looks up an existing key.
+func (s *ImmutableState) Get(ctx context.Context, key []byte) ([]byte, error) {
+	return s.tree.Get(ctx, key)
+}
+
+// NewIterator returns a new iterator over the tree.
+func (s *ImmutableState) NewIterator(ctx context.Context, options ...mkvs.IteratorOption) mkvs.Iterator {
+	return s.tree.NewIterator(ctx, options...)
 }

--- a/go/consensus/cometbft/api/state.go
+++ b/go/consensus/cometbft/api/state.go
@@ -247,7 +247,15 @@ type ImmutableState struct {
 }
 
 // NewImmutableState creates a new immutable state wrapper.
-func NewImmutableState(ctx context.Context, state ApplicationQueryState, version int64) (*ImmutableState, error) {
+func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
+	return &ImmutableState{
+		ImmutableKeyValueTree: tree,
+	}
+}
+
+// NewImmutableStateAt creates a new immutable state wrapper
+// using the provided application query state and version.
+func NewImmutableStateAt(ctx context.Context, state ApplicationQueryState, version int64) (*ImmutableState, error) {
 	if state == nil {
 		return nil, ErrNoState
 	}

--- a/go/consensus/cometbft/apps/beacon/query.go
+++ b/go/consensus/cometbft/apps/beacon/query.go
@@ -25,7 +25,7 @@ type QueryFactory struct {
 
 // QueryAt returns the beacon query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := beaconState.NewImmutableState(ctx, sf.state, height)
+	state, err := beaconState.NewImmutableStateAt(ctx, sf.state, height)
 	if err != nil {
 		return nil, err
 	}

--- a/go/consensus/cometbft/apps/beacon/state/state.go
+++ b/go/consensus/cometbft/apps/beacon/state/state.go
@@ -42,8 +42,16 @@ type ImmutableState struct {
 }
 
 // NewImmutableState creates a new immutable beacon state wrapper.
-func NewImmutableState(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := abciAPI.NewImmutableState(ctx, state, version)
+func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
+	return &ImmutableState{
+		is: abciAPI.NewImmutableState(tree),
+	}
+}
+
+// NewImmutableStateAt creates a new immutable beacon state wrapper
+// using the provided application query state and version.
+func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
+	is, err := abciAPI.NewImmutableStateAt(ctx, state, version)
 	if err != nil {
 		return nil, err
 	}
@@ -147,10 +155,8 @@ type MutableState struct {
 // NewMutableState creates a new mutable beacon state wrapper.
 func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
 	return &MutableState{
-		ImmutableState: &ImmutableState{
-			&abciAPI.ImmutableState{ImmutableKeyValueTree: tree},
-		},
-		ms: tree,
+		ImmutableState: NewImmutableState(tree),
+		ms:             tree,
 	}
 }
 

--- a/go/consensus/cometbft/apps/beacon/state/state.go
+++ b/go/consensus/cometbft/apps/beacon/state/state.go
@@ -38,13 +38,13 @@ var (
 
 // ImmutableState is an immutable beacon state wrapper.
 type ImmutableState struct {
-	is *abciAPI.ImmutableState
+	state *abciAPI.ImmutableState
 }
 
 // NewImmutableState creates a new immutable beacon state wrapper.
 func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	return &ImmutableState{
-		is: abciAPI.NewImmutableState(tree),
+		state: abciAPI.NewImmutableState(tree),
 	}
 }
 
@@ -61,7 +61,7 @@ func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryStat
 
 // Beacon gets the current random beacon value.
 func (s *ImmutableState) Beacon(ctx context.Context) ([]byte, error) {
-	data, err := s.is.Get(ctx, beaconKeyFmt.Encode())
+	data, err := s.state.Get(ctx, beaconKeyFmt.Encode())
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -72,7 +72,7 @@ func (s *ImmutableState) Beacon(ctx context.Context) ([]byte, error) {
 }
 
 func (s *ImmutableState) GetEpoch(ctx context.Context) (beacon.EpochTime, int64, error) {
-	data, err := s.is.Get(ctx, epochCurrentKeyFmt.Encode())
+	data, err := s.state.Get(ctx, epochCurrentKeyFmt.Encode())
 	if err != nil {
 		return beacon.EpochInvalid, 0, abciAPI.UnavailableStateError(err)
 	}
@@ -88,7 +88,7 @@ func (s *ImmutableState) GetEpoch(ctx context.Context) (beacon.EpochTime, int64,
 }
 
 func (s *ImmutableState) GetFutureEpoch(ctx context.Context) (*beacon.EpochTimeState, error) {
-	data, err := s.is.Get(ctx, epochFutureKeyFmt.Encode())
+	data, err := s.state.Get(ctx, epochFutureKeyFmt.Encode())
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -104,7 +104,7 @@ func (s *ImmutableState) GetFutureEpoch(ctx context.Context) (*beacon.EpochTimeS
 }
 
 func (s *ImmutableState) ConsensusParameters(ctx context.Context) (*beacon.ConsensusParameters, error) {
-	data, err := s.is.Get(ctx, parametersKeyFmt.Encode())
+	data, err := s.state.Get(ctx, parametersKeyFmt.Encode())
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -120,7 +120,7 @@ func (s *ImmutableState) ConsensusParameters(ctx context.Context) (*beacon.Conse
 }
 
 func (s *ImmutableState) PendingMockEpoch(ctx context.Context) (*beacon.EpochTime, error) {
-	data, err := s.is.Get(ctx, epochPendingMockKeyFmt.Encode())
+	data, err := s.state.Get(ctx, epochPendingMockKeyFmt.Encode())
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -206,7 +206,7 @@ func (s *MutableState) ClearFutureEpoch(ctx context.Context) error {
 //
 // NOTE: This method must only be called from InitChain/EndBlock contexts.
 func (s *MutableState) SetConsensusParameters(ctx context.Context, params *beacon.ConsensusParameters) error {
-	if err := s.is.CheckContextMode(ctx, []abciAPI.ContextMode{abciAPI.ContextInitChain, abciAPI.ContextEndBlock}); err != nil {
+	if err := s.state.CheckContextMode(ctx, []abciAPI.ContextMode{abciAPI.ContextInitChain, abciAPI.ContextEndBlock}); err != nil {
 		return err
 	}
 	err := s.ms.Insert(ctx, parametersKeyFmt.Encode(), cbor.Marshal(params))

--- a/go/consensus/cometbft/apps/beacon/state/state_vrf.go
+++ b/go/consensus/cometbft/apps/beacon/state/state_vrf.go
@@ -14,7 +14,7 @@ import (
 var vrfStateKeyFmt = consensus.KeyFormat.New(0x46)
 
 func (s *ImmutableState) VRFState(ctx context.Context) (*beacon.VRFState, error) {
-	data, err := s.is.Get(ctx, vrfStateKeyFmt.Encode())
+	data, err := s.state.Get(ctx, vrfStateKeyFmt.Encode())
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}

--- a/go/consensus/cometbft/apps/governance/query.go
+++ b/go/consensus/cometbft/apps/governance/query.go
@@ -27,7 +27,7 @@ type QueryFactory struct {
 
 // QueryAt returns the governance query interface for a specific height.
 func (qf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := governanceState.NewImmutableState(ctx, qf.state, height)
+	state, err := governanceState.NewImmutableStateAt(ctx, qf.state, height)
 	if err != nil {
 		return nil, err
 	}

--- a/go/consensus/cometbft/apps/governance/state/state.go
+++ b/go/consensus/cometbft/apps/governance/state/state.go
@@ -55,8 +55,16 @@ type ImmutableState struct {
 }
 
 // NewImmutableState creates a new immutable governance state wrapper.
-func NewImmutableState(ctx context.Context, state api.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := api.NewImmutableState(ctx, state, version)
+func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
+	return &ImmutableState{
+		is: api.NewImmutableState(tree),
+	}
+}
+
+// NewImmutableStateAt creates a new immutable governance state wrapper
+// using the provided application query state and version.
+func NewImmutableStateAt(ctx context.Context, state api.ApplicationQueryState, version int64) (*ImmutableState, error) {
+	is, err := api.NewImmutableStateAt(ctx, state, version)
 	if err != nil {
 		return nil, err
 	}
@@ -259,10 +267,8 @@ type MutableState struct {
 // NewMutableState creates a new mutable governance state wrapper.
 func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
 	return &MutableState{
-		ImmutableState: &ImmutableState{
-			&api.ImmutableState{ImmutableKeyValueTree: tree},
-		},
-		ms: tree,
+		ImmutableState: NewImmutableState(tree),
+		ms:             tree,
 	}
 }
 

--- a/go/consensus/cometbft/apps/governance/state/state.go
+++ b/go/consensus/cometbft/apps/governance/state/state.go
@@ -49,12 +49,12 @@ var (
 	parametersKeyFmt = consensus.KeyFormat.New(0x85)
 )
 
-// ImmutableState is the immutable consensus state wrapper.
+// ImmutableState is an immutable governance state wrapper.
 type ImmutableState struct {
 	is *api.ImmutableState
 }
 
-// NewImmutableState returns immutable governance state.
+// NewImmutableState creates a new immutable governance state wrapper.
 func NewImmutableState(ctx context.Context, state api.ApplicationQueryState, version int64) (*ImmutableState, error) {
 	is, err := api.NewImmutableState(ctx, state, version)
 	if err != nil {
@@ -249,14 +249,14 @@ func (s *ImmutableState) ConsensusParameters(ctx context.Context) (*governance.C
 	return &params, nil
 }
 
-// MutableState is a mutable consensus state wrapper.
+// MutableState is a mutable governance state wrapper.
 type MutableState struct {
 	*ImmutableState
 
 	ms mkvs.KeyValueTree
 }
 
-// NewMutableState creates a new mutable governance state.
+// NewMutableState creates a new mutable governance state wrapper.
 func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
 	return &MutableState{
 		ImmutableState: &ImmutableState{

--- a/go/consensus/cometbft/apps/keymanager/churp/state/state.go
+++ b/go/consensus/cometbft/apps/keymanager/churp/state/state.go
@@ -27,13 +27,13 @@ var (
 
 // ImmutableState is an immutable key manager CHURP state wrapper.
 type ImmutableState struct {
-	is *abciAPI.ImmutableState
+	state *abciAPI.ImmutableState
 }
 
 // NewImmutableState creates a new immutable key manager CHURP state wrapper.
 func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	return &ImmutableState{
-		is: abciAPI.NewImmutableState(tree),
+		state: abciAPI.NewImmutableState(tree),
 	}
 }
 
@@ -49,7 +49,7 @@ func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryStat
 
 // ConsensusParameters returns the consensus parameters.
 func (st *ImmutableState) ConsensusParameters(ctx context.Context) (*churp.ConsensusParameters, error) {
-	raw, err := st.is.Get(ctx, parametersKeyFmt.Encode())
+	raw, err := st.state.Get(ctx, parametersKeyFmt.Encode())
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -66,7 +66,7 @@ func (st *ImmutableState) ConsensusParameters(ctx context.Context) (*churp.Conse
 
 // Status returns the CHURP status for the specified runtime and CHURP instance.
 func (st *ImmutableState) Status(ctx context.Context, runtimeID common.Namespace, churpID uint8) (*churp.Status, error) {
-	data, err := st.is.Get(ctx, statusKeyFmt.Encode(&runtimeID, churpID))
+	data, err := st.state.Get(ctx, statusKeyFmt.Encode(&runtimeID, churpID))
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -83,7 +83,7 @@ func (st *ImmutableState) Status(ctx context.Context, runtimeID common.Namespace
 
 // Statuses returns the CHURP statuses for the specified runtime.
 func (st *ImmutableState) Statuses(ctx context.Context, runtimeID common.Namespace) ([]*churp.Status, error) {
-	it := st.is.NewIterator(ctx)
+	it := st.state.NewIterator(ctx)
 	defer it.Close()
 
 	// We need to pre-hash the runtime ID, so we can compare it below.
@@ -117,7 +117,7 @@ func (st *ImmutableState) Statuses(ctx context.Context, runtimeID common.Namespa
 
 // AllStatuses returns the CHURP statuses for all runtimes.
 func (st *ImmutableState) AllStatuses(ctx context.Context) ([]*churp.Status, error) {
-	it := st.is.NewIterator(ctx)
+	it := st.state.NewIterator(ctx)
 	defer it.Close()
 
 	var statuses []*churp.Status
@@ -158,7 +158,7 @@ func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
 //
 // This method must only be called from InitChain or EndBlock contexts.
 func (st *MutableState) SetConsensusParameters(ctx context.Context, params *churp.ConsensusParameters) error {
-	if err := st.is.CheckContextMode(ctx, []abciAPI.ContextMode{abciAPI.ContextInitChain, abciAPI.ContextEndBlock}); err != nil {
+	if err := st.state.CheckContextMode(ctx, []abciAPI.ContextMode{abciAPI.ContextInitChain, abciAPI.ContextEndBlock}); err != nil {
 		return err
 	}
 	err := st.ms.Insert(ctx, parametersKeyFmt.Encode(), cbor.Marshal(params))

--- a/go/consensus/cometbft/apps/keymanager/churp/state/state.go
+++ b/go/consensus/cometbft/apps/keymanager/churp/state/state.go
@@ -25,9 +25,18 @@ var (
 	statusKeyFmt = consensus.KeyFormat.New(0x75, keyformat.H(&common.Namespace{}), uint8(0))
 )
 
-// ImmutableState is a immutable state wrapper.
+// ImmutableState is an immutable key manager CHURP state wrapper.
 type ImmutableState struct {
 	is *abciAPI.ImmutableState
+}
+
+// NewImmutableState creates a new immutable key manager CHURP state wrapper.
+func NewImmutableState(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
+	is, err := abciAPI.NewImmutableState(ctx, state, version)
+	if err != nil {
+		return nil, err
+	}
+	return &ImmutableState{is}, nil
 }
 
 // ConsensusParameters returns the consensus parameters.
@@ -122,20 +131,21 @@ func (st *ImmutableState) AllStatuses(ctx context.Context) ([]*churp.Status, err
 	return statuses, nil
 }
 
-// NewImmutableState creates a new immutable state wrapper.
-func NewImmutableState(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := abciAPI.NewImmutableState(ctx, state, version)
-	if err != nil {
-		return nil, err
-	}
-	return &ImmutableState{is}, nil
-}
-
-// MutableState is a mutable state wrapper.
+// MutableState is a mutable key manager CHURP state wrapper.
 type MutableState struct {
 	*ImmutableState
 
 	ms mkvs.KeyValueTree
+}
+
+// NewMutableState creates a new mutable key manager CHURP state wrapper.
+func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
+	return &MutableState{
+		ImmutableState: &ImmutableState{
+			&abciAPI.ImmutableState{ImmutableKeyValueTree: tree},
+		},
+		ms: tree,
+	}
 }
 
 // SetConsensusParameters updates the state using the provided consensus parameters.
@@ -153,14 +163,4 @@ func (st *MutableState) SetConsensusParameters(ctx context.Context, params *chur
 func (st *MutableState) SetStatus(ctx context.Context, status *churp.Status) error {
 	err := st.ms.Insert(ctx, statusKeyFmt.Encode(&status.RuntimeID, status.ID), cbor.Marshal(status))
 	return abciAPI.UnavailableStateError(err)
-}
-
-// NewMutableState creates a new mutable state wrapper.
-func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
-	return &MutableState{
-		ImmutableState: &ImmutableState{
-			&abciAPI.ImmutableState{ImmutableKeyValueTree: tree},
-		},
-		ms: tree,
-	}
 }

--- a/go/consensus/cometbft/apps/keymanager/churp/state/state.go
+++ b/go/consensus/cometbft/apps/keymanager/churp/state/state.go
@@ -31,8 +31,16 @@ type ImmutableState struct {
 }
 
 // NewImmutableState creates a new immutable key manager CHURP state wrapper.
-func NewImmutableState(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := abciAPI.NewImmutableState(ctx, state, version)
+func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
+	return &ImmutableState{
+		is: abciAPI.NewImmutableState(tree),
+	}
+}
+
+// NewImmutableStateAt creates a new immutable key manager CHURP state wrapper
+// using the provided application query state and version.
+func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
+	is, err := abciAPI.NewImmutableStateAt(ctx, state, version)
 	if err != nil {
 		return nil, err
 	}
@@ -141,10 +149,8 @@ type MutableState struct {
 // NewMutableState creates a new mutable key manager CHURP state wrapper.
 func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
 	return &MutableState{
-		ImmutableState: &ImmutableState{
-			&abciAPI.ImmutableState{ImmutableKeyValueTree: tree},
-		},
-		ms: tree,
+		ImmutableState: NewImmutableState(tree),
+		ms:             tree,
 	}
 }
 

--- a/go/consensus/cometbft/apps/keymanager/query.go
+++ b/go/consensus/cometbft/apps/keymanager/query.go
@@ -23,12 +23,12 @@ type QueryFactory struct {
 
 // QueryAt returns the key manager query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	secretsState, err := secretsState.NewImmutableState(ctx, sf.state, height)
+	secretsState, err := secretsState.NewImmutableStateAt(ctx, sf.state, height)
 	if err != nil {
 		return nil, err
 	}
 
-	churpState, err := churpState.NewImmutableState(ctx, sf.state, height)
+	churpState, err := churpState.NewImmutableStateAt(ctx, sf.state, height)
 	if err != nil {
 		return nil, err
 	}

--- a/go/consensus/cometbft/apps/keymanager/secrets/state/state.go
+++ b/go/consensus/cometbft/apps/keymanager/secrets/state/state.go
@@ -34,13 +34,13 @@ var (
 
 // ImmutableState is an immutable key manager secrets state wrapper.
 type ImmutableState struct {
-	is *abciAPI.ImmutableState
+	state *abciAPI.ImmutableState
 }
 
 // NewImmutableState creates a new immutable key manager secrets state wrapper.
 func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	return &ImmutableState{
-		is: abciAPI.NewImmutableState(tree),
+		state: abciAPI.NewImmutableState(tree),
 	}
 }
 
@@ -56,7 +56,7 @@ func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryStat
 
 // ConsensusParameters returns the key manager consensus parameters.
 func (st *ImmutableState) ConsensusParameters(ctx context.Context) (*secrets.ConsensusParameters, error) {
-	raw, err := st.is.Get(ctx, parametersKeyFmt.Encode())
+	raw, err := st.state.Get(ctx, parametersKeyFmt.Encode())
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -90,7 +90,7 @@ func (st *ImmutableState) Statuses(ctx context.Context) ([]*secrets.Status, erro
 }
 
 func (st *ImmutableState) getStatusesRaw(ctx context.Context) ([][]byte, error) {
-	it := st.is.NewIterator(ctx)
+	it := st.state.NewIterator(ctx)
 	defer it.Close()
 
 	var rawVec [][]byte
@@ -107,7 +107,7 @@ func (st *ImmutableState) getStatusesRaw(ctx context.Context) ([][]byte, error) 
 }
 
 func (st *ImmutableState) Status(ctx context.Context, id common.Namespace) (*secrets.Status, error) {
-	data, err := st.is.Get(ctx, statusKeyFmt.Encode(&id))
+	data, err := st.state.Get(ctx, statusKeyFmt.Encode(&id))
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -123,7 +123,7 @@ func (st *ImmutableState) Status(ctx context.Context, id common.Namespace) (*sec
 }
 
 func (st *ImmutableState) MasterSecret(ctx context.Context, id common.Namespace) (*secrets.SignedEncryptedMasterSecret, error) {
-	data, err := st.is.Get(ctx, masterSecretKeyFmt.Encode(&id))
+	data, err := st.state.Get(ctx, masterSecretKeyFmt.Encode(&id))
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -139,7 +139,7 @@ func (st *ImmutableState) MasterSecret(ctx context.Context, id common.Namespace)
 }
 
 func (st *ImmutableState) EphemeralSecret(ctx context.Context, id common.Namespace) (*secrets.SignedEncryptedEphemeralSecret, error) {
-	data, err := st.is.Get(ctx, ephemeralSecretKeyFmt.Encode(&id))
+	data, err := st.state.Get(ctx, ephemeralSecretKeyFmt.Encode(&id))
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -173,7 +173,7 @@ func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
 //
 // NOTE: This method must only be called from InitChain/EndBlock contexts.
 func (st *MutableState) SetConsensusParameters(ctx context.Context, params *secrets.ConsensusParameters) error {
-	if err := st.is.CheckContextMode(ctx, []abciAPI.ContextMode{abciAPI.ContextInitChain, abciAPI.ContextEndBlock}); err != nil {
+	if err := st.state.CheckContextMode(ctx, []abciAPI.ContextMode{abciAPI.ContextInitChain, abciAPI.ContextEndBlock}); err != nil {
 		return err
 	}
 	err := st.ms.Insert(ctx, parametersKeyFmt.Encode(), cbor.Marshal(params))

--- a/go/consensus/cometbft/apps/keymanager/secrets/state/state.go
+++ b/go/consensus/cometbft/apps/keymanager/secrets/state/state.go
@@ -38,8 +38,16 @@ type ImmutableState struct {
 }
 
 // NewImmutableState creates a new immutable key manager secrets state wrapper.
-func NewImmutableState(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := abciAPI.NewImmutableState(ctx, state, version)
+func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
+	return &ImmutableState{
+		is: abciAPI.NewImmutableState(tree),
+	}
+}
+
+// NewImmutableStateAt creates a new immutable key manager secrets state wrapper
+// using the provided application query state and version.
+func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
+	is, err := abciAPI.NewImmutableStateAt(ctx, state, version)
 	if err != nil {
 		return nil, err
 	}
@@ -156,10 +164,8 @@ type MutableState struct {
 // NewMutableState creates a new mutable key manager secrets state wrapper.
 func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
 	return &MutableState{
-		ImmutableState: &ImmutableState{
-			&abciAPI.ImmutableState{ImmutableKeyValueTree: tree},
-		},
-		ms: tree,
+		ImmutableState: NewImmutableState(tree),
+		ms:             tree,
 	}
 }
 

--- a/go/consensus/cometbft/apps/registry/query.go
+++ b/go/consensus/cometbft/apps/registry/query.go
@@ -34,7 +34,7 @@ type QueryFactory struct {
 
 // QueryAt returns the registry query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := registryState.NewImmutableState(ctx, sf.state, height)
+	state, err := registryState.NewImmutableStateAt(ctx, sf.state, height)
 	if err != nil {
 		return nil, err
 	}

--- a/go/consensus/cometbft/apps/registry/state/state.go
+++ b/go/consensus/cometbft/apps/registry/state/state.go
@@ -84,8 +84,16 @@ type ImmutableState struct {
 }
 
 // NewImmutableState creates a new immutable registry state wrapper.
-func NewImmutableState(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := abciAPI.NewImmutableState(ctx, state, version)
+func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
+	return &ImmutableState{
+		is: abciAPI.NewImmutableState(tree),
+	}
+}
+
+// NewImmutableStateAt creates a new immutable registry state wrapper
+// using the provided application query state and version.
+func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
+	is, err := abciAPI.NewImmutableStateAt(ctx, state, version)
 	if err != nil {
 		return nil, err
 	}
@@ -519,10 +527,8 @@ type MutableState struct {
 // NewMutableState creates a new mutable registry state wrapper.
 func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
 	return &MutableState{
-		ImmutableState: &ImmutableState{
-			&abciAPI.ImmutableState{ImmutableKeyValueTree: tree},
-		},
-		ms: tree,
+		ImmutableState: NewImmutableState(tree),
+		ms:             tree,
 	}
 }
 

--- a/go/consensus/cometbft/apps/registry/state/state.go
+++ b/go/consensus/cometbft/apps/registry/state/state.go
@@ -80,13 +80,13 @@ var (
 
 // ImmutableState is an immutable registry state wrapper.
 type ImmutableState struct {
-	is *abciAPI.ImmutableState
+	state *abciAPI.ImmutableState
 }
 
 // NewImmutableState creates a new immutable registry state wrapper.
 func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	return &ImmutableState{
-		is: abciAPI.NewImmutableState(tree),
+		state: abciAPI.NewImmutableState(tree),
 	}
 }
 
@@ -102,7 +102,7 @@ func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryStat
 }
 
 func (s *ImmutableState) getSignedEntityRaw(ctx context.Context, id signature.PublicKey) ([]byte, error) {
-	data, err := s.is.Get(ctx, signedEntityKeyFmt.Encode(&id))
+	data, err := s.state.Get(ctx, signedEntityKeyFmt.Encode(&id))
 	return data, abciAPI.UnavailableStateError(err)
 }
 
@@ -129,7 +129,7 @@ func (s *ImmutableState) Entity(ctx context.Context, id signature.PublicKey) (*e
 
 // Entities returns a list of all registered entities.
 func (s *ImmutableState) Entities(ctx context.Context) ([]*entity.Entity, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	var entities []*entity.Entity
@@ -157,7 +157,7 @@ func (s *ImmutableState) Entities(ctx context.Context) ([]*entity.Entity, error)
 
 // SignedEntities returns a list of all registered entities (signed).
 func (s *ImmutableState) SignedEntities(ctx context.Context) ([]*entity.SignedEntity, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	var entities []*entity.SignedEntity
@@ -180,7 +180,7 @@ func (s *ImmutableState) SignedEntities(ctx context.Context) ([]*entity.SignedEn
 }
 
 func (s *ImmutableState) getSignedNodeRaw(ctx context.Context, id signature.PublicKey) ([]byte, error) {
-	data, err := s.is.Get(ctx, signedNodeKeyFmt.Encode(&id))
+	data, err := s.state.Get(ctx, signedNodeKeyFmt.Encode(&id))
 	return data, abciAPI.UnavailableStateError(err)
 }
 
@@ -209,7 +209,7 @@ func (s *ImmutableState) Node(ctx context.Context, id signature.PublicKey) (*nod
 //
 // If you need to get the actual node descriptor, use NodeByConsensusAddress instead.
 func (s *ImmutableState) NodeIDByConsensusAddress(ctx context.Context, address []byte) (signature.PublicKey, error) {
-	rawID, err := s.is.Get(ctx, nodeByConsAddressKeyFmt.Encode(address))
+	rawID, err := s.state.Get(ctx, nodeByConsAddressKeyFmt.Encode(address))
 	if err != nil {
 		return signature.PublicKey{}, abciAPI.UnavailableStateError(err)
 	}
@@ -235,7 +235,7 @@ func (s *ImmutableState) NodeByConsensusAddress(ctx context.Context, address []b
 
 // Nodes returns a list of all registered nodes.
 func (s *ImmutableState) Nodes(ctx context.Context) ([]*node.Node, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	var nodes []*node.Node
@@ -264,7 +264,7 @@ func (s *ImmutableState) Nodes(ctx context.Context) ([]*node.Node, error) {
 
 // SignedNodes returns a list of all registered nodes (in signed form).
 func (s *ImmutableState) SignedNodes(ctx context.Context) ([]*node.MultiSignedNode, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	var nodes []*node.MultiSignedNode
@@ -287,7 +287,7 @@ func (s *ImmutableState) SignedNodes(ctx context.Context) ([]*node.MultiSignedNo
 }
 
 func (s *ImmutableState) getRuntime(ctx context.Context, keyFmt *keyformat.KeyFormat, id common.Namespace) (*registry.Runtime, error) {
-	raw, err := s.is.Get(ctx, keyFmt.Encode(&id))
+	raw, err := s.state.Get(ctx, keyFmt.Encode(&id))
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -330,7 +330,7 @@ func (s *ImmutableState) iterateRuntimes(
 	keyFmt *keyformat.KeyFormat,
 	cb func(*registry.Runtime) error,
 ) error {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	for it.Seek(keyFmt.Encode()); it.Valid(); it.Next() {
@@ -396,7 +396,7 @@ func (s *ImmutableState) AllRuntimes(ctx context.Context) ([]*registry.Runtime, 
 
 // NodeStatus returns a specific node status.
 func (s *ImmutableState) NodeStatus(ctx context.Context, id signature.PublicKey) (*registry.NodeStatus, error) {
-	value, err := s.is.Get(ctx, nodeStatusKeyFmt.Encode(&id))
+	value, err := s.state.Get(ctx, nodeStatusKeyFmt.Encode(&id))
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -414,7 +414,7 @@ func (s *ImmutableState) NodeStatus(ctx context.Context, id signature.PublicKey)
 // GetEntityNodes returns nodes registered by given entity.
 // Note that this returns both active and expired nodes.
 func (s *ImmutableState) GetEntityNodes(ctx context.Context, id signature.PublicKey) ([]*node.Node, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	hID := keyformat.PreHashed(id.Hash())
@@ -428,7 +428,7 @@ func (s *ImmutableState) GetEntityNodes(ctx context.Context, id signature.Public
 			break
 		}
 
-		rawSignedNode, err := s.is.Get(ctx, signedNodeKeyFmt.Encode(&hNodeID))
+		rawSignedNode, err := s.state.Get(ctx, signedNodeKeyFmt.Encode(&hNodeID))
 		if err != nil {
 			return nil, abciAPI.UnavailableStateError(err)
 		}
@@ -453,7 +453,7 @@ func (s *ImmutableState) GetEntityNodes(ctx context.Context, id signature.Public
 
 // HasEntityNodes checks whether an entity has any registered nodes.
 func (s *ImmutableState) HasEntityNodes(ctx context.Context, id signature.PublicKey) (bool, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	hID := keyformat.PreHashed(id.Hash())
@@ -469,7 +469,7 @@ func (s *ImmutableState) HasEntityNodes(ctx context.Context, id signature.Public
 
 // HasEntityRuntimes checks whether an entity has any registered runtimes.
 func (s *ImmutableState) HasEntityRuntimes(ctx context.Context, id signature.PublicKey) (bool, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	hID := keyformat.PreHashed(id.Hash())
@@ -485,7 +485,7 @@ func (s *ImmutableState) HasEntityRuntimes(ctx context.Context, id signature.Pub
 
 // ConsensusParameters returns the registry consensus parameters.
 func (s *ImmutableState) ConsensusParameters(ctx context.Context) (*registry.ConsensusParameters, error) {
-	raw, err := s.is.Get(ctx, parametersKeyFmt.Encode())
+	raw, err := s.state.Get(ctx, parametersKeyFmt.Encode())
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -502,7 +502,7 @@ func (s *ImmutableState) ConsensusParameters(ctx context.Context) (*registry.Con
 
 // NodeBySubKey looks up a specific node by its consensus, P2P or TLS key.
 func (s *ImmutableState) NodeBySubKey(ctx context.Context, key signature.PublicKey) (*node.Node, error) {
-	rawID, err := s.is.Get(ctx, keyMapKeyFmt.Encode(&key))
+	rawID, err := s.state.Get(ctx, keyMapKeyFmt.Encode(&key))
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -717,7 +717,7 @@ func (s *MutableState) SetNodeStatus(ctx context.Context, id signature.PublicKey
 //
 // NOTE: This method must only be called from InitChain/EndBlock contexts.
 func (s *MutableState) SetConsensusParameters(ctx context.Context, params *registry.ConsensusParameters) error {
-	if err := s.is.CheckContextMode(ctx, []abciAPI.ContextMode{abciAPI.ContextInitChain, abciAPI.ContextEndBlock}); err != nil {
+	if err := s.state.CheckContextMode(ctx, []abciAPI.ContextMode{abciAPI.ContextInitChain, abciAPI.ContextEndBlock}); err != nil {
 		return err
 	}
 	err := s.ms.Insert(ctx, parametersKeyFmt.Encode(), cbor.Marshal(params))

--- a/go/consensus/cometbft/apps/roothash/query.go
+++ b/go/consensus/cometbft/apps/roothash/query.go
@@ -32,7 +32,7 @@ type QueryFactory struct {
 
 // QueryAt returns the roothash query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := roothashState.NewImmutableState(ctx, sf.state, height)
+	state, err := roothashState.NewImmutableStateAt(ctx, sf.state, height)
 	if err != nil {
 		return nil, err
 	}

--- a/go/consensus/cometbft/apps/roothash/state/state.go
+++ b/go/consensus/cometbft/apps/roothash/state/state.go
@@ -67,8 +67,16 @@ type ImmutableState struct {
 }
 
 // NewImmutableState creates a new immutable roothash state wrapper.
-func NewImmutableState(ctx context.Context, state api.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := api.NewImmutableState(ctx, state, version)
+func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
+	return &ImmutableState{
+		is: api.NewImmutableState(tree),
+	}
+}
+
+// NewImmutableStateAt creates a new immutable roothash state wrapper
+// using the provided application query state and version.
+func NewImmutableStateAt(ctx context.Context, state api.ApplicationQueryState, version int64) (*ImmutableState, error) {
+	is, err := api.NewImmutableStateAt(ctx, state, version)
 	if err != nil {
 		return nil, err
 	}
@@ -378,10 +386,8 @@ type MutableState struct {
 // NewMutableState creates a new mutable roothash state wrapper.
 func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
 	return &MutableState{
-		ImmutableState: &ImmutableState{
-			&api.ImmutableState{ImmutableKeyValueTree: tree},
-		},
-		ms: tree,
+		ImmutableState: NewImmutableState(tree),
+		ms:             tree,
 	}
 }
 

--- a/go/consensus/cometbft/apps/roothash/state/state.go
+++ b/go/consensus/cometbft/apps/roothash/state/state.go
@@ -63,13 +63,13 @@ var (
 
 // ImmutableState is an immutable roothash state wrapper.
 type ImmutableState struct {
-	is *api.ImmutableState
+	state *api.ImmutableState
 }
 
 // NewImmutableState creates a new immutable roothash state wrapper.
 func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	return &ImmutableState{
-		is: api.NewImmutableState(tree),
+		state: api.NewImmutableState(tree),
 	}
 }
 
@@ -85,7 +85,7 @@ func NewImmutableStateAt(ctx context.Context, state api.ApplicationQueryState, v
 }
 
 func (s *ImmutableState) runtimesWithRoundTimeouts(ctx context.Context, height *int64) ([]common.Namespace, []int64, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	var startKey []byte
@@ -131,7 +131,7 @@ func (s *ImmutableState) RuntimesWithRoundTimeoutsAny(ctx context.Context) ([]co
 
 // RuntimeState returns the roothash runtime state for a specific runtime.
 func (s *ImmutableState) RuntimeState(ctx context.Context, id common.Namespace) (*roothash.RuntimeState, error) {
-	raw, err := s.is.Get(ctx, runtimeKeyFmt.Encode(&id))
+	raw, err := s.state.Get(ctx, runtimeKeyFmt.Encode(&id))
 	if err != nil {
 		return nil, api.UnavailableStateError(err)
 	}
@@ -148,7 +148,7 @@ func (s *ImmutableState) RuntimeState(ctx context.Context, id common.Namespace) 
 
 // LastRoundResults returns the last normal round results for a specific runtime.
 func (s *ImmutableState) LastRoundResults(ctx context.Context, id common.Namespace) (*roothash.RoundResults, error) {
-	raw, err := s.is.Get(ctx, lastRoundResultsKeyFmt.Encode(&id))
+	raw, err := s.state.Get(ctx, lastRoundResultsKeyFmt.Encode(&id))
 	if err != nil {
 		return nil, api.UnavailableStateError(err)
 	}
@@ -164,7 +164,7 @@ func (s *ImmutableState) LastRoundResults(ctx context.Context, id common.Namespa
 }
 
 func (s *ImmutableState) getRoot(ctx context.Context, id common.Namespace, kf *keyformat.KeyFormat) (hash.Hash, error) {
-	raw, err := s.is.Get(ctx, kf.Encode(&id))
+	raw, err := s.state.Get(ctx, kf.Encode(&id))
 	if err != nil {
 		return hash.Hash{}, api.UnavailableStateError(err)
 	}
@@ -191,7 +191,7 @@ func (s *ImmutableState) IORoot(ctx context.Context, id common.Namespace) (hash.
 
 // Runtimes returns the list of all roothash runtime states.
 func (s *ImmutableState) Runtimes(ctx context.Context) ([]*roothash.RuntimeState, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	var runtimes []*roothash.RuntimeState
@@ -215,7 +215,7 @@ func (s *ImmutableState) Runtimes(ctx context.Context) ([]*roothash.RuntimeState
 
 // ConsensusParameters returns the roothash consensus parameters.
 func (s *ImmutableState) ConsensusParameters(ctx context.Context) (*roothash.ConsensusParameters, error) {
-	raw, err := s.is.Get(ctx, parametersKeyFmt.Encode())
+	raw, err := s.state.Get(ctx, parametersKeyFmt.Encode())
 	if err != nil {
 		return nil, api.UnavailableStateError(err)
 	}
@@ -232,13 +232,13 @@ func (s *ImmutableState) ConsensusParameters(ctx context.Context) (*roothash.Con
 
 // EvidenceHashExists returns true if the evidence hash for the runtime exists.
 func (s *ImmutableState) EvidenceHashExists(ctx context.Context, runtimeID common.Namespace, round uint64, hash hash.Hash) (bool, error) {
-	data, err := s.is.Get(ctx, evidenceKeyFmt.Encode(&runtimeID, round, &hash))
+	data, err := s.state.Get(ctx, evidenceKeyFmt.Encode(&runtimeID, round, &hash))
 	return data != nil, api.UnavailableStateError(err)
 }
 
 // IncomingMessageQueueMeta returns the incoming message queue metadata for the given runtime.
 func (s *ImmutableState) IncomingMessageQueueMeta(ctx context.Context, runtimeID common.Namespace) (*message.IncomingMessageQueueMeta, error) {
-	raw, err := s.is.Get(ctx, inMsgQueueMetaKeyFmt.Encode(&runtimeID))
+	raw, err := s.state.Get(ctx, inMsgQueueMetaKeyFmt.Encode(&runtimeID))
 	if err != nil {
 		return nil, api.UnavailableStateError(err)
 	}
@@ -255,7 +255,7 @@ func (s *ImmutableState) IncomingMessageQueueMeta(ctx context.Context, runtimeID
 
 // IncomingMessageQueue returns a list of queued messages, starting with the passed offset.
 func (s *ImmutableState) IncomingMessageQueue(ctx context.Context, runtimeID common.Namespace, offset uint64, limit uint32) ([]*message.IncomingMessage, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	var msgs []*message.IncomingMessage
@@ -291,7 +291,7 @@ func (s *ImmutableState) IncomingMessageQueue(ctx context.Context, runtimeID com
 //
 // If no roots are present for the given runtime and round, nil is returned.
 func (s *ImmutableState) RoundRoots(ctx context.Context, runtimeID common.Namespace, round uint64) (*roothash.RoundRoots, error) {
-	raw, err := s.is.Get(ctx, pastRootsKeyFmt.Encode(&runtimeID, round))
+	raw, err := s.state.Get(ctx, pastRootsKeyFmt.Encode(&runtimeID, round))
 	if err != nil {
 		return nil, api.UnavailableStateError(err)
 	}
@@ -314,7 +314,7 @@ func (s *ImmutableState) RoundRoots(ctx context.Context, runtimeID common.Namesp
 // Keys of the returned map hold the round numbers and the values hold the
 // two roots for each round.
 func (s *ImmutableState) PastRoundRoots(ctx context.Context, runtimeID common.Namespace) (map[uint64]roothash.RoundRoots, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	// We need to pre-hash the runtime ID, so we can compare it below.
@@ -351,7 +351,7 @@ func (s *ImmutableState) PastRoundRoots(ctx context.Context, runtimeID common.Na
 // This is more efficient than calling len(PastRoundRoots(runtimeID)), as it
 // avoids deserialization.
 func (s *ImmutableState) PastRoundRootsCount(ctx context.Context, runtimeID common.Namespace) uint64 {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	// We need to pre-hash the runtime ID, so we can compare it below.
@@ -462,7 +462,7 @@ func (s *MutableState) ShrinkPastRoots(ctx context.Context, maxStoredRoots uint6
 
 		numPastRootsToDelete := numStoredRoots - maxStoredRoots
 
-		it := s.is.NewIterator(ctx)
+		it := s.state.NewIterator(ctx)
 
 		// We need to pre-hash the runtime ID, so we can compare it below.
 		hID := keyformat.PreHashed(id.Hash())
@@ -508,7 +508,7 @@ func (s *MutableState) SetLastRoundResults(ctx context.Context, runtimeID common
 //
 // NOTE: This method must only be called from InitChain/EndBlock contexts.
 func (s *MutableState) SetConsensusParameters(ctx context.Context, params *roothash.ConsensusParameters) error {
-	if err := s.is.CheckContextMode(ctx, []api.ContextMode{api.ContextInitChain, api.ContextEndBlock}); err != nil {
+	if err := s.state.CheckContextMode(ctx, []api.ContextMode{api.ContextInitChain, api.ContextEndBlock}); err != nil {
 		return err
 	}
 	err := s.ms.Insert(ctx, parametersKeyFmt.Encode(), cbor.Marshal(params))
@@ -536,7 +536,7 @@ func (s *MutableState) SetEvidenceHash(ctx context.Context, runtimeID common.Nam
 
 // RemoveExpiredEvidence removes expired evidence.
 func (s *MutableState) RemoveExpiredEvidence(ctx context.Context, runtimeID common.Namespace, minRound uint64) error {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	// We need to pre-hash the runtime ID, so we can compare it below.

--- a/go/consensus/cometbft/apps/roothash/state/state.go
+++ b/go/consensus/cometbft/apps/roothash/state/state.go
@@ -61,11 +61,12 @@ var (
 	pastRootsKeyFmt = consensus.KeyFormat.New(0x2a, keyformat.H(&common.Namespace{}), uint64(0))
 )
 
-// ImmutableState is the immutable roothash state wrapper.
+// ImmutableState is an immutable roothash state wrapper.
 type ImmutableState struct {
 	is *api.ImmutableState
 }
 
+// NewImmutableState creates a new immutable roothash state wrapper.
 func NewImmutableState(ctx context.Context, state api.ApplicationQueryState, version int64) (*ImmutableState, error) {
 	is, err := api.NewImmutableState(ctx, state, version)
 	if err != nil {
@@ -374,6 +375,7 @@ type MutableState struct {
 	ms mkvs.KeyValueTree
 }
 
+// NewMutableState creates a new mutable roothash state wrapper.
 func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
 	return &MutableState{
 		ImmutableState: &ImmutableState{

--- a/go/consensus/cometbft/apps/scheduler/query.go
+++ b/go/consensus/cometbft/apps/scheduler/query.go
@@ -25,13 +25,13 @@ type QueryFactory struct {
 
 // QueryAt returns the scheduler query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := schedulerState.NewImmutableState(ctx, sf.state, height)
+	state, err := schedulerState.NewImmutableStateAt(ctx, sf.state, height)
 	if err != nil {
 		return nil, err
 	}
 
 	// Some queries need access to the registry to give useful responses.
-	regState, err := registryState.NewImmutableState(ctx, sf.state, height)
+	regState, err := registryState.NewImmutableStateAt(ctx, sf.state, height)
 	if err != nil {
 		return nil, err
 	}

--- a/go/consensus/cometbft/apps/scheduler/state/state.go
+++ b/go/consensus/cometbft/apps/scheduler/state/state.go
@@ -40,9 +40,17 @@ type ImmutableState struct {
 	is *abciAPI.ImmutableState
 }
 
-// NewImmutableState creates a new immutable scheduler state wrapper.
-func NewImmutableState(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := abciAPI.NewImmutableState(ctx, state, version)
+// NewImmutableState creates a new immutable vault state wrapper.
+func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
+	return &ImmutableState{
+		is: abciAPI.NewImmutableState(tree),
+	}
+}
+
+// NewImmutableStateAt creates a new immutable scheduler state wrapper
+// using the provided application query state and version.
+func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
+	is, err := abciAPI.NewImmutableStateAt(ctx, state, version)
 	if err != nil {
 		return nil, err
 	}
@@ -184,10 +192,8 @@ type MutableState struct {
 // NewMutableState creates a new mutable scheduler state wrapper.
 func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
 	return &MutableState{
-		ImmutableState: &ImmutableState{
-			&abciAPI.ImmutableState{ImmutableKeyValueTree: tree},
-		},
-		ms: tree,
+		ImmutableState: NewImmutableState(tree),
+		ms:             tree,
 	}
 }
 

--- a/go/consensus/cometbft/apps/scheduler/state/state.go
+++ b/go/consensus/cometbft/apps/scheduler/state/state.go
@@ -37,13 +37,13 @@ var (
 
 // ImmutableState is an immutable scheduler state wrapper.
 type ImmutableState struct {
-	is *abciAPI.ImmutableState
+	state *abciAPI.ImmutableState
 }
 
 // NewImmutableState creates a new immutable vault state wrapper.
 func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	return &ImmutableState{
-		is: abciAPI.NewImmutableState(tree),
+		state: abciAPI.NewImmutableState(tree),
 	}
 }
 
@@ -60,7 +60,7 @@ func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryStat
 
 // Committee returns a specific elected committee.
 func (s *ImmutableState) Committee(ctx context.Context, kind api.CommitteeKind, runtimeID common.Namespace) (*api.Committee, error) {
-	raw, err := s.is.Get(ctx, committeeKeyFmt.Encode(uint8(kind), &runtimeID))
+	raw, err := s.state.Get(ctx, committeeKeyFmt.Encode(uint8(kind), &runtimeID))
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -77,7 +77,7 @@ func (s *ImmutableState) Committee(ctx context.Context, kind api.CommitteeKind, 
 
 // AllCommittees returns a list of all elected committees.
 func (s *ImmutableState) AllCommittees(ctx context.Context) ([]*api.Committee, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	var committees []*api.Committee
@@ -104,7 +104,7 @@ func (s *ImmutableState) AllCommittees(ctx context.Context) ([]*api.Committee, e
 
 // KindsCommittees returns a list of all committees of specific kinds.
 func (s *ImmutableState) KindsCommittees(ctx context.Context, kinds []api.CommitteeKind) ([]*api.Committee, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	var committees []*api.Committee
@@ -133,7 +133,7 @@ func (s *ImmutableState) KindsCommittees(ctx context.Context, kinds []api.Commit
 
 // CurrentValidators returns a list of current validators.
 func (s *ImmutableState) CurrentValidators(ctx context.Context) (map[signature.PublicKey]*api.Validator, error) {
-	raw, err := s.is.Get(ctx, validatorsCurrentKeyFmt.Encode())
+	raw, err := s.state.Get(ctx, validatorsCurrentKeyFmt.Encode())
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -150,7 +150,7 @@ func (s *ImmutableState) CurrentValidators(ctx context.Context) (map[signature.P
 
 // PendingValidators returns a list of pending validators.
 func (s *ImmutableState) PendingValidators(ctx context.Context) (map[signature.PublicKey]*api.Validator, error) {
-	raw, err := s.is.Get(ctx, validatorsPendingKeyFmt.Encode())
+	raw, err := s.state.Get(ctx, validatorsPendingKeyFmt.Encode())
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -167,7 +167,7 @@ func (s *ImmutableState) PendingValidators(ctx context.Context) (map[signature.P
 
 // ConsensusParameters returns scheduler consensus parameters.
 func (s *ImmutableState) ConsensusParameters(ctx context.Context) (*api.ConsensusParameters, error) {
-	raw, err := s.is.Get(ctx, parametersKeyFmt.Encode())
+	raw, err := s.state.Get(ctx, parametersKeyFmt.Encode())
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -229,7 +229,7 @@ func (s *MutableState) PutPendingValidators(ctx context.Context, validators map[
 //
 // NOTE: This method must only be called from InitChain/EndBlock contexts.
 func (s *MutableState) SetConsensusParameters(ctx context.Context, params *api.ConsensusParameters) error {
-	if err := s.is.CheckContextMode(ctx, []abciAPI.ContextMode{abciAPI.ContextInitChain, abciAPI.ContextEndBlock}); err != nil {
+	if err := s.state.CheckContextMode(ctx, []abciAPI.ContextMode{abciAPI.ContextInitChain, abciAPI.ContextEndBlock}); err != nil {
 		return err
 	}
 	err := s.ms.Insert(ctx, parametersKeyFmt.Encode(), cbor.Marshal(params))

--- a/go/consensus/cometbft/apps/staking/auth.go
+++ b/go/consensus/cometbft/apps/staking/auth.go
@@ -1,10 +1,8 @@
 package staking
 
 import (
-	"context"
 	"fmt"
 
-	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	"github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	stakingState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/staking/state"
@@ -12,20 +10,6 @@ import (
 )
 
 var _ api.TransactionAuthHandler = (*stakingApplication)(nil)
-
-// Implements api.TransactionAuthHandler.
-func (app *stakingApplication) GetSignerNonce(ctx context.Context, req *consensus.GetSignerNonceRequest) (uint64, error) {
-	q, err := app.QueryFactory().(*QueryFactory).QueryAt(ctx, req.Height)
-	if err != nil {
-		return 0, err
-	}
-
-	acct, err := q.Account(ctx, req.AccountAddress)
-	if err != nil {
-		return 0, err
-	}
-	return acct.General.Nonce, nil
-}
 
 // Implements api.TransactionAuthHandler.
 func (app *stakingApplication) AuthenticateTx(ctx *api.Context, tx *transaction.Transaction) error {

--- a/go/consensus/cometbft/apps/staking/query.go
+++ b/go/consensus/cometbft/apps/staking/query.go
@@ -38,7 +38,7 @@ type QueryFactory struct {
 
 // QueryAt returns the staking query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := stakingState.NewImmutableState(ctx, sf.state, height)
+	state, err := stakingState.NewImmutableStateAt(ctx, sf.state, height)
 	if err != nil {
 		return nil, err
 	}

--- a/go/consensus/cometbft/apps/staking/state/state.go
+++ b/go/consensus/cometbft/apps/staking/state/state.go
@@ -83,9 +83,19 @@ var (
 	logger = logging.GetLogger("cometbft/staking")
 )
 
-// ImmutableState is the immutable staking state wrapper.
+// ImmutableState is an immutable staking state wrapper.
 type ImmutableState struct {
 	is *abciAPI.ImmutableState
+}
+
+// NewImmutableState creates a new immutable staking state wrapper.
+func NewImmutableState(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
+	is, err := abciAPI.NewImmutableState(ctx, state, version)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ImmutableState{is}, nil
 }
 
 func (s *ImmutableState) loadStoredBalance(ctx context.Context, key *keyformat.KeyFormat) (*quantity.Quantity, error) {
@@ -585,20 +595,21 @@ func (s *ImmutableState) EpochSigning(ctx context.Context) (*EpochSigning, error
 	return &es, nil
 }
 
-func NewImmutableState(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := abciAPI.NewImmutableState(ctx, state, version)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ImmutableState{is}, nil
-}
-
 // MutableState is a mutable staking state wrapper.
 type MutableState struct {
 	*ImmutableState
 
 	ms mkvs.KeyValueTree
+}
+
+// NewMutableState creates a new mutable staking state wrapper.
+func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
+	return &MutableState{
+		ImmutableState: &ImmutableState{
+			&abciAPI.ImmutableState{ImmutableKeyValueTree: tree},
+		},
+		ms: tree,
+	}
 }
 
 func (s *MutableState) SetAccount(ctx context.Context, addr staking.Address, account *staking.Account) error {
@@ -1433,14 +1444,4 @@ func (s *MutableState) AddRewardSingleAttenuated(
 	}
 
 	return nil
-}
-
-// NewMutableState creates a new mutable staking state wrapper.
-func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
-	return &MutableState{
-		ImmutableState: &ImmutableState{
-			&abciAPI.ImmutableState{ImmutableKeyValueTree: tree},
-		},
-		ms: tree,
-	}
 }

--- a/go/consensus/cometbft/apps/staking/state/state.go
+++ b/go/consensus/cometbft/apps/staking/state/state.go
@@ -86,13 +86,13 @@ var (
 
 // ImmutableState is an immutable staking state wrapper.
 type ImmutableState struct {
-	is *abciAPI.ImmutableState
+	state *abciAPI.ImmutableState
 }
 
 // NewImmutableState creates a new immutable staking state wrapper.
 func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	return &ImmutableState{
-		is: api.NewImmutableState(tree),
+		state: api.NewImmutableState(tree),
 	}
 }
 
@@ -108,7 +108,7 @@ func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryStat
 }
 
 func (s *ImmutableState) loadStoredBalance(ctx context.Context, key *keyformat.KeyFormat) (*quantity.Quantity, error) {
-	value, err := s.is.Get(ctx, key.Encode())
+	value, err := s.state.Get(ctx, key.Encode())
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -135,7 +135,7 @@ func (s *ImmutableState) CommonPool(ctx context.Context) (*quantity.Quantity, er
 
 // ConsensusParameters returns the consensus parameters.
 func (s *ImmutableState) ConsensusParameters(ctx context.Context) (*staking.ConsensusParameters, error) {
-	raw, err := s.is.Get(ctx, parametersKeyFmt.Encode())
+	raw, err := s.state.Get(ctx, parametersKeyFmt.Encode())
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -189,7 +189,7 @@ func (s *ImmutableState) Thresholds(ctx context.Context) (map[staking.ThresholdK
 
 // Addresses returns the non-empty addresses from the staking ledger.
 func (s *ImmutableState) Addresses(ctx context.Context) ([]staking.Address, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	var addresses []staking.Address
@@ -209,7 +209,7 @@ func (s *ImmutableState) Addresses(ctx context.Context) ([]staking.Address, erro
 
 // CommissionScheduleAddresses returns addresses that have a non empty commission schedule configured.
 func (s *ImmutableState) CommissionScheduleAddresses(ctx context.Context) ([]staking.Address, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	var addresses []staking.Address
@@ -233,7 +233,7 @@ func (s *ImmutableState) Account(ctx context.Context, address staking.Address) (
 		return nil, fmt.Errorf("cometbft/staking: invalid account address: %s", address)
 	}
 
-	value, err := s.is.Get(ctx, accountKeyFmt.Encode(&address))
+	value, err := s.state.Get(ctx, accountKeyFmt.Encode(&address))
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -261,7 +261,7 @@ func (s *ImmutableState) EscrowBalance(ctx context.Context, address staking.Addr
 func (s *ImmutableState) Delegations(
 	ctx context.Context,
 ) (map[staking.Address]map[staking.Address]*staking.Delegation, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	delegations := make(map[staking.Address]map[staking.Address]*staking.Delegation)
@@ -293,7 +293,7 @@ func (s *ImmutableState) Delegation(
 	ctx context.Context,
 	delegatorAddr, escrowAddr staking.Address,
 ) (*staking.Delegation, error) {
-	value, err := s.is.Get(ctx, delegationKeyFmt.Encode(&escrowAddr, &delegatorAddr))
+	value, err := s.state.Get(ctx, delegationKeyFmt.Encode(&escrowAddr, &delegatorAddr))
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -312,7 +312,7 @@ func (s *ImmutableState) DelegationsFor(
 	ctx context.Context,
 	delegatorAddr staking.Address,
 ) (map[staking.Address]*staking.Delegation, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	delegations := make(map[staking.Address]*staking.Delegation)
@@ -343,7 +343,7 @@ func (s *ImmutableState) DelegationsTo(
 	ctx context.Context,
 	destAddr staking.Address,
 ) (map[staking.Address]*staking.Delegation, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	delegations := make(map[staking.Address]*staking.Delegation)
@@ -373,7 +373,7 @@ func (s *ImmutableState) DelegationsTo(
 func (s *ImmutableState) DebondingDelegations(
 	ctx context.Context,
 ) (map[staking.Address]map[staking.Address][]*staking.DebondingDelegation, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	delegations := make(map[staking.Address]map[staking.Address][]*staking.DebondingDelegation)
@@ -405,7 +405,7 @@ func (s *ImmutableState) DebondingDelegation(
 	delegatorAddr, escrowAddr staking.Address,
 	epoch beacon.EpochTime,
 ) (*staking.DebondingDelegation, error) {
-	value, err := s.is.Get(ctx, debondingDelegationKeyFmt.Encode(&delegatorAddr, &escrowAddr, uint64(epoch)))
+	value, err := s.state.Get(ctx, debondingDelegationKeyFmt.Encode(&delegatorAddr, &escrowAddr, uint64(epoch)))
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -424,7 +424,7 @@ func (s *ImmutableState) DebondingDelegationsFor(
 	ctx context.Context,
 	delegatorAddr staking.Address,
 ) (map[staking.Address][]*staking.DebondingDelegation, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	delegations := make(map[staking.Address][]*staking.DebondingDelegation)
@@ -455,7 +455,7 @@ func (s *ImmutableState) DebondingDelegationsTo(
 	ctx context.Context,
 	destAddr staking.Address,
 ) (map[staking.Address][]*staking.DebondingDelegation, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	delegations := make(map[staking.Address][]*staking.DebondingDelegation)
@@ -490,7 +490,7 @@ type DebondingQueueEntry struct {
 }
 
 func (s *ImmutableState) ExpiredDebondingQueue(ctx context.Context, epoch beacon.EpochTime) ([]*DebondingQueueEntry, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	var entries []*DebondingQueueEntry
@@ -586,7 +586,7 @@ func (es *EpochSigning) EligibleEntities(thresholdNumerator, thresholdDenominato
 }
 
 func (s *ImmutableState) EpochSigning(ctx context.Context) (*EpochSigning, error) {
-	value, err := s.is.Get(ctx, epochSigningKeyFmt.Encode())
+	value, err := s.state.Get(ctx, epochSigningKeyFmt.Encode())
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)
 	}
@@ -662,7 +662,7 @@ func (s *MutableState) SetCommonPool(ctx context.Context, q *quantity.Quantity) 
 //
 // NOTE: This method must only be called from InitChain/EndBlock contexts.
 func (s *MutableState) SetConsensusParameters(ctx context.Context, params *staking.ConsensusParameters) error {
-	if err := s.is.CheckContextMode(ctx, []abciAPI.ContextMode{abciAPI.ContextInitChain, abciAPI.ContextEndBlock}); err != nil {
+	if err := s.state.CheckContextMode(ctx, []abciAPI.ContextMode{abciAPI.ContextInitChain, abciAPI.ContextEndBlock}); err != nil {
 		return err
 	}
 	err := s.ms.Insert(ctx, parametersKeyFmt.Encode(), cbor.Marshal(params))
@@ -714,7 +714,7 @@ func (s *MutableState) SetDebondingDelegation(
 
 	// If a debonding delegation for the account and same end epoch already exists,
 	// merge the debonding delegations.
-	value, err := s.is.Get(ctx, key)
+	value, err := s.state.Get(ctx, key)
 	if err != nil {
 		return abciAPI.UnavailableStateError(err)
 	}

--- a/go/consensus/cometbft/apps/staking/state/state.go
+++ b/go/consensus/cometbft/apps/staking/state/state.go
@@ -15,6 +15,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	"github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs"
@@ -89,8 +90,16 @@ type ImmutableState struct {
 }
 
 // NewImmutableState creates a new immutable staking state wrapper.
-func NewImmutableState(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := abciAPI.NewImmutableState(ctx, state, version)
+func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
+	return &ImmutableState{
+		is: api.NewImmutableState(tree),
+	}
+}
+
+// NewImmutableStateAt creates a new immutable staking state wrapper
+// using the provided application query state and version.
+func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
+	is, err := abciAPI.NewImmutableStateAt(ctx, state, version)
 	if err != nil {
 		return nil, err
 	}
@@ -605,10 +614,8 @@ type MutableState struct {
 // NewMutableState creates a new mutable staking state wrapper.
 func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
 	return &MutableState{
-		ImmutableState: &ImmutableState{
-			&abciAPI.ImmutableState{ImmutableKeyValueTree: tree},
-		},
-		ms: tree,
+		ImmutableState: NewImmutableState(tree),
+		ms:             tree,
 	}
 }
 

--- a/go/consensus/cometbft/apps/vault/query.go
+++ b/go/consensus/cometbft/apps/vault/query.go
@@ -26,7 +26,7 @@ type QueryFactory struct {
 
 // QueryAt returns the vault query interface for a specific height.
 func (qf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := vaultState.NewImmutableState(ctx, qf.state, height)
+	state, err := vaultState.NewImmutableStateAt(ctx, qf.state, height)
 	if err != nil {
 		return nil, err
 	}

--- a/go/consensus/cometbft/apps/vault/state/state.go
+++ b/go/consensus/cometbft/apps/vault/state/state.go
@@ -40,8 +40,16 @@ type ImmutableState struct {
 }
 
 // NewImmutableState creates a new immutable vault state wrapper.
-func NewImmutableState(ctx context.Context, state api.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := api.NewImmutableState(ctx, state, version)
+func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
+	return &ImmutableState{
+		is: api.NewImmutableState(tree),
+	}
+}
+
+// NewImmutableStateAt creates a new immutable vault state wrapper
+// using the provided application query state and version.
+func NewImmutableStateAt(ctx context.Context, state api.ApplicationQueryState, version int64) (*ImmutableState, error) {
+	is, err := api.NewImmutableStateAt(ctx, state, version)
 	if err != nil {
 		return nil, err
 	}
@@ -197,10 +205,8 @@ type MutableState struct {
 // NewMutableState creates a new mutable vault state wrapper.
 func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
 	return &MutableState{
-		ImmutableState: &ImmutableState{
-			&api.ImmutableState{ImmutableKeyValueTree: tree},
-		},
-		ms: tree,
+		ImmutableState: NewImmutableState(tree),
+		ms:             tree,
 	}
 }
 

--- a/go/consensus/cometbft/apps/vault/state/state.go
+++ b/go/consensus/cometbft/apps/vault/state/state.go
@@ -36,13 +36,13 @@ var (
 
 // ImmutableState is an immutable vault state wrapper.
 type ImmutableState struct {
-	is *api.ImmutableState
+	state *api.ImmutableState
 }
 
 // NewImmutableState creates a new immutable vault state wrapper.
 func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	return &ImmutableState{
-		is: api.NewImmutableState(tree),
+		state: api.NewImmutableState(tree),
 	}
 }
 
@@ -59,7 +59,7 @@ func NewImmutableStateAt(ctx context.Context, state api.ApplicationQueryState, v
 
 // Vaults looks up all vaults.
 func (s *ImmutableState) Vaults(ctx context.Context) ([]*vault.Vault, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	var vaults []*vault.Vault
@@ -82,7 +82,7 @@ func (s *ImmutableState) Vaults(ctx context.Context) ([]*vault.Vault, error) {
 }
 
 func (s *ImmutableState) Vault(ctx context.Context, address staking.Address) (*vault.Vault, error) {
-	raw, err := s.is.Get(ctx, vaultKeyFmt.Encode(address))
+	raw, err := s.state.Get(ctx, vaultKeyFmt.Encode(address))
 	if err != nil {
 		return nil, api.UnavailableStateError(err)
 	}
@@ -98,7 +98,7 @@ func (s *ImmutableState) Vault(ctx context.Context, address staking.Address) (*v
 }
 
 func (s *ImmutableState) AddressState(ctx context.Context, vaultAddr staking.Address, address staking.Address) (*vault.AddressState, error) {
-	raw, err := s.is.Get(ctx, addressStateKeyFmt.Encode(vaultAddr, address))
+	raw, err := s.state.Get(ctx, addressStateKeyFmt.Encode(vaultAddr, address))
 	if err != nil {
 		return nil, api.UnavailableStateError(err)
 	}
@@ -114,7 +114,7 @@ func (s *ImmutableState) AddressState(ctx context.Context, vaultAddr staking.Add
 }
 
 func (s *ImmutableState) AddressStates(ctx context.Context, vaultAddr staking.Address) (map[staking.Address]*vault.AddressState, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	states := make(map[staking.Address]*vault.AddressState)
@@ -140,7 +140,7 @@ func (s *ImmutableState) AddressStates(ctx context.Context, vaultAddr staking.Ad
 }
 
 func (s *ImmutableState) PendingAction(ctx context.Context, vaultAddr staking.Address, nonce uint64) (*vault.PendingAction, error) {
-	raw, err := s.is.Get(ctx, pendingActionsKeyFmt.Encode(vaultAddr, nonce))
+	raw, err := s.state.Get(ctx, pendingActionsKeyFmt.Encode(vaultAddr, nonce))
 	if err != nil {
 		return nil, api.UnavailableStateError(err)
 	}
@@ -156,7 +156,7 @@ func (s *ImmutableState) PendingAction(ctx context.Context, vaultAddr staking.Ad
 }
 
 func (s *ImmutableState) PendingActions(ctx context.Context, vaultAddr staking.Address) ([]*vault.PendingAction, error) {
-	it := s.is.NewIterator(ctx)
+	it := s.state.NewIterator(ctx)
 	defer it.Close()
 
 	var actions []*vault.PendingAction
@@ -180,7 +180,7 @@ func (s *ImmutableState) PendingActions(ctx context.Context, vaultAddr staking.A
 
 // ConsensusParameters returns the vault consensus parameters.
 func (s *ImmutableState) ConsensusParameters(ctx context.Context) (*vault.ConsensusParameters, error) {
-	raw, err := s.is.Get(ctx, parametersKeyFmt.Encode())
+	raw, err := s.state.Get(ctx, parametersKeyFmt.Encode())
 	if err != nil {
 		return nil, api.UnavailableStateError(err)
 	}
@@ -265,7 +265,7 @@ func (s *MutableState) RemovePendingAction(ctx context.Context, vaultAddr stakin
 //
 // NOTE: This method must only be called from InitChain/EndBlock contexts.
 func (s *MutableState) SetConsensusParameters(ctx context.Context, params *vault.ConsensusParameters) error {
-	if err := s.is.CheckContextMode(ctx, []api.ContextMode{api.ContextInitChain, api.ContextEndBlock}); err != nil {
+	if err := s.state.CheckContextMode(ctx, []api.ContextMode{api.ContextInitChain, api.ContextEndBlock}); err != nil {
 		return err
 	}
 	err := s.ms.Insert(ctx, parametersKeyFmt.Encode(), cbor.Marshal(params))

--- a/go/consensus/cometbft/apps/vault/state/state.go
+++ b/go/consensus/cometbft/apps/vault/state/state.go
@@ -34,12 +34,12 @@ var (
 	parametersKeyFmt = consensus.KeyFormat.New(0x33)
 )
 
-// ImmutableState is the immutable consensus state wrapper.
+// ImmutableState is an immutable vault state wrapper.
 type ImmutableState struct {
 	is *api.ImmutableState
 }
 
-// NewImmutableState returns immutable vault state.
+// NewImmutableState creates a new immutable vault state wrapper.
 func NewImmutableState(ctx context.Context, state api.ApplicationQueryState, version int64) (*ImmutableState, error) {
 	is, err := api.NewImmutableState(ctx, state, version)
 	if err != nil {
@@ -194,7 +194,7 @@ type MutableState struct {
 	ms mkvs.KeyValueTree
 }
 
-// NewMutableState creates a new mutable vault state.
+// NewMutableState creates a new mutable vault state wrapper.
 func NewMutableState(tree mkvs.KeyValueTree) *MutableState {
 	return &MutableState{
 		ImmutableState: &ImmutableState{

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -587,7 +587,7 @@ func (n *commonNode) GetCometBFTBlock(ctx context.Context, height int64) (*cmtty
 }
 
 // Implements consensusAPI.Backend.
-func (n *commonNode) GetBlockResults(ctx context.Context, height int64) (*cmtcoretypes.ResultBlockResults, error) {
+func (n *commonNode) GetCometBFTBlockResults(ctx context.Context, height int64) (*cmtcoretypes.ResultBlockResults, error) {
 	if err := n.ensureStarted(ctx); err != nil {
 		return nil, err
 	}
@@ -700,7 +700,7 @@ func (n *commonNode) GetTransactionsWithResults(ctx context.Context, height int6
 		return nil, err
 	}
 
-	blockResults, err := n.GetBlockResults(ctx, height)
+	blockResults, err := n.GetCometBFTBlockResults(ctx, height)
 	if err != nil {
 		return nil, err
 	}

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -501,11 +501,6 @@ func (n *commonNode) SetTransactionAuthHandler(handler api.TransactionAuthHandle
 }
 
 // Implements consensusAPI.Backend.
-func (n *commonNode) TransactionAuthHandler() consensusAPI.TransactionAuthHandler {
-	return n.mux.TransactionAuthHandler()
-}
-
-// Implements consensusAPI.Backend.
 func (n *commonNode) EstimateGas(_ context.Context, req *consensusAPI.EstimateGasRequest) (transaction.Gas, error) {
 	return n.mux.EstimateGas(req.Signer, req.Transaction)
 }
@@ -557,7 +552,15 @@ func (n *commonNode) heightToCometBFTHeight(height int64) (int64, error) {
 
 // Implements consensusAPI.Backend.
 func (n *commonNode) GetSignerNonce(ctx context.Context, req *consensusAPI.GetSignerNonceRequest) (uint64, error) {
-	return n.mux.TransactionAuthHandler().GetSignerNonce(ctx, req)
+	acct, err := n.Staking().Account(ctx, &stakingAPI.OwnerQuery{
+		Height: req.Height,
+		Owner:  req.AccountAddress,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return acct.General.Nonce, nil
 }
 
 // Implements consensusAPI.Backend.

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -371,7 +371,7 @@ func (n *commonNode) StateToGenesis(ctx context.Context, blockHeight int64) (*ge
 	blockHeight = blk.Header.Height
 
 	// Query root consensus parameters.
-	cs, err := coreState.NewImmutableState(ctx, n.mux.State(), blockHeight)
+	cs, err := coreState.NewImmutableStateAt(ctx, n.mux.State(), blockHeight)
 	if err != nil {
 		return nil, err
 	}
@@ -507,7 +507,7 @@ func (n *commonNode) EstimateGas(_ context.Context, req *consensusAPI.EstimateGa
 
 // Implements consensusAPI.Backend.
 func (n *commonNode) MinGasPrice(ctx context.Context) (*quantity.Quantity, error) {
-	cs, err := coreState.NewImmutableState(ctx, n.mux.State(), consensusAPI.HeightLatest)
+	cs, err := coreState.NewImmutableStateAt(ctx, n.mux.State(), consensusAPI.HeightLatest)
 	if err != nil {
 		return nil, err
 	}
@@ -816,7 +816,7 @@ func (n *commonNode) GetParameters(ctx context.Context, height int64) (*consensu
 		return nil, fmt.Errorf("cometbft: failed to marshal consensus params: %w", err)
 	}
 
-	cs, err := coreState.NewImmutableState(ctx, n.mux.State(), height)
+	cs, err := coreState.NewImmutableStateAt(ctx, n.mux.State(), height)
 	if err != nil {
 		return nil, fmt.Errorf("cometbft: failed to initialize core consensus state: %w", err)
 	}

--- a/go/consensus/cometbft/governance/governance.go
+++ b/go/consensus/cometbft/governance/governance.go
@@ -95,7 +95,7 @@ func (sc *serviceClient) StateToGenesis(ctx context.Context, height int64) (*api
 func (sc *serviceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
 	var results *cmtrpctypes.ResultBlockResults
-	results, err := sc.backend.GetBlockResults(ctx, height)
+	results, err := sc.backend.GetCometBFTBlockResults(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft block results",
 			"err", err,

--- a/go/consensus/cometbft/registry/registry.go
+++ b/go/consensus/cometbft/registry/registry.go
@@ -168,7 +168,7 @@ func (sc *serviceClient) StateToGenesis(ctx context.Context, height int64) (*api
 func (sc *serviceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
 	var results *cmtrpctypes.ResultBlockResults
-	results, err := sc.backend.GetBlockResults(ctx, height)
+	results, err := sc.backend.GetCometBFTBlockResults(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft block results",
 			"err", err,

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -262,7 +262,7 @@ func (sc *serviceClient) ConsensusParameters(ctx context.Context, height int64) 
 func (sc *serviceClient) getEvents(ctx context.Context, height int64, txns [][]byte) ([]*api.Event, error) {
 	// Get block results at given height.
 	var results *cmtrpctypes.ResultBlockResults
-	results, err := sc.backend.GetBlockResults(ctx, height)
+	results, err := sc.backend.GetCometBFTBlockResults(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft block results",
 			"err", err,

--- a/go/consensus/cometbft/staking/staking.go
+++ b/go/consensus/cometbft/staking/staking.go
@@ -242,7 +242,7 @@ func (sc *serviceClient) StateToGenesis(ctx context.Context, height int64) (*api
 func (sc *serviceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
 	var results *cmtrpctypes.ResultBlockResults
-	results, err := sc.backend.GetBlockResults(ctx, height)
+	results, err := sc.backend.GetCometBFTBlockResults(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft block results",
 			"err", err,

--- a/go/consensus/cometbft/vault/vault.go
+++ b/go/consensus/cometbft/vault/vault.go
@@ -85,7 +85,7 @@ func (sc *serviceClient) StateToGenesis(ctx context.Context, height int64) (*api
 func (sc *serviceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
 	var results *cmtrpctypes.ResultBlockResults
-	results, err := sc.backend.GetBlockResults(ctx, height)
+	results, err := sc.backend.GetCometBFTBlockResults(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft block results",
 			"err", err,

--- a/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
+++ b/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
@@ -374,7 +374,7 @@ func dumpBeacon(ctx context.Context, qs *dumpQueryState) (*beacon.Genesis, error
 }
 
 func dumpConsensus(ctx context.Context, qs *dumpQueryState) (*consensus.Genesis, error) {
-	is, err := abciState.NewImmutableState(ctx, qs, qs.BlockHeight())
+	is, err := abciState.NewImmutableStateAt(ctx, qs, qs.BlockHeight())
 	if err != nil {
 		return nil, fmt.Errorf("dumpdb: failed to get consensus state: %w", err)
 	}


### PR DESCRIPTION
These changes unify constructors for immutable and mutable state and allow us to query the state by using a remote tree.