### PR TITLE
go/consensus/cometbft/full: Decouple apps from client services

### DIFF
--- a/go/consensus/cometbft/abci/query.go
+++ b/go/consensus/cometbft/abci/query.go
@@ -1,0 +1,49 @@
+package abci
+
+import (
+	"context"
+
+	consensusState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/abci/state"
+	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
+	consensusGenesis "github.com/oasisprotocol/oasis-core/go/consensus/genesis"
+)
+
+// Query is the consensus backend query interface.
+type Query interface {
+	ChainContext(ctx context.Context) (string, error)
+	ConsensusParameters(ctx context.Context) (*consensusGenesis.Parameters, error)
+}
+
+// QueryFactory is the consensus backend query factory.
+type QueryFactory struct {
+	state abciAPI.ApplicationQueryState
+}
+
+// NewQueryFactory returns a new QueryFactory backed by the given state
+// instance.
+func NewQueryFactory(state abciAPI.ApplicationQueryState) *QueryFactory {
+	return &QueryFactory{state}
+}
+
+// QueryAt returns the consensus backend query interface for a specific height.
+func (f *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
+	state, err := abciAPI.NewImmutableStateAt(ctx, f.state, height)
+	if err != nil {
+		return nil, err
+	}
+	return &consensusQuerier{
+		state: consensusState.NewImmutableState(state),
+	}, nil
+}
+
+type consensusQuerier struct {
+	state *consensusState.ImmutableState
+}
+
+func (q *consensusQuerier) ChainContext(ctx context.Context) (string, error) {
+	return q.state.ChainContext(ctx)
+}
+
+func (q *consensusQuerier) ConsensusParameters(ctx context.Context) (*consensusGenesis.Parameters, error) {
+	return q.state.ConsensusParameters(ctx)
+}

--- a/go/consensus/cometbft/abci/state/state.go
+++ b/go/consensus/cometbft/abci/state/state.go
@@ -34,17 +34,6 @@ func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	}
 }
 
-// NewImmutableStateAt creates a new immutable consensus backend state wrapper
-// using the provided application query state and version.
-func NewImmutableStateAt(ctx context.Context, state api.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := api.NewImmutableStateAt(ctx, state, version)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ImmutableState{is}, nil
-}
-
 // ChainContext returns the stored chain context.
 func (s *ImmutableState) ChainContext(ctx context.Context) (string, error) {
 	chainContext, err := s.state.Get(ctx, chainContextKeyFmt.Encode())

--- a/go/consensus/cometbft/api/api.go
+++ b/go/consensus/cometbft/api/api.go
@@ -202,11 +202,6 @@ func NewBlock(blk *cmttypes.Block) *consensus.Block {
 type Backend interface {
 	consensus.Backend
 
-	// RegisterApplication registers an ABCI multiplexer application
-	// with this service instance and check that its dependencies are
-	// registered.
-	RegisterApplication(Application) error
-
 	// SetTransactionAuthHandler configures the transaction fee handler for the
 	// ABCI multiplexer.
 	SetTransactionAuthHandler(TransactionAuthHandler) error

--- a/go/consensus/cometbft/apps/beacon/backend_insecure.go
+++ b/go/consensus/cometbft/apps/beacon/backend_insecure.go
@@ -13,7 +13,7 @@ import (
 )
 
 type backendInsecure struct {
-	app *beaconApplication
+	app *Application
 }
 
 func (impl *backendInsecure) OnInitChain(

--- a/go/consensus/cometbft/apps/beacon/backend_vrf.go
+++ b/go/consensus/cometbft/apps/beacon/backend_vrf.go
@@ -22,7 +22,7 @@ import (
 var vrfAlphaDomainsep = []byte("oasis-core:vrf/alpha")
 
 type backendVRF struct {
-	app *beaconApplication
+	app *Application
 }
 
 func (impl *backendVRF) OnInitChain(

--- a/go/consensus/cometbft/apps/beacon/genesis.go
+++ b/go/consensus/cometbft/apps/beacon/genesis.go
@@ -12,7 +12,7 @@ import (
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
 )
 
-func (app *beaconApplication) InitChain(ctx *api.Context, _ types.RequestInitChain, doc *genesis.Document) error {
+func (app *Application) InitChain(ctx *api.Context, _ types.RequestInitChain, doc *genesis.Document) error {
 	params := &doc.Beacon.Parameters
 
 	// Note: If we ever decide that we need a beacon for the 0th epoch
@@ -38,7 +38,7 @@ func (app *beaconApplication) InitChain(ctx *api.Context, _ types.RequestInitCha
 	return nil
 }
 
-func (app *beaconApplication) doInitBackend(params *beacon.ConsensusParameters) error {
+func (app *Application) doInitBackend(params *beacon.ConsensusParameters) error {
 	if app.backend != nil {
 		return nil
 	}

--- a/go/consensus/cometbft/apps/beacon/query.go
+++ b/go/consensus/cometbft/apps/beacon/query.go
@@ -24,36 +24,38 @@ type QueryFactory struct {
 }
 
 // QueryAt returns the beacon query interface for a specific height.
-func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := beaconState.NewImmutableStateAt(ctx, sf.state, height)
+func (f *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
+	state, err := abciAPI.NewImmutableStateAt(ctx, f.state, height)
 	if err != nil {
 		return nil, err
 	}
-	return &beaconQuerier{state}, nil
+	return &beaconQuerier{
+		state: beaconState.NewImmutableState(state),
+	}, nil
 }
 
 type beaconQuerier struct {
 	state *beaconState.ImmutableState
 }
 
-func (bq *beaconQuerier) Beacon(ctx context.Context) ([]byte, error) {
-	return bq.state.Beacon(ctx)
+func (q *beaconQuerier) Beacon(ctx context.Context) ([]byte, error) {
+	return q.state.Beacon(ctx)
 }
 
-func (bq *beaconQuerier) Epoch(ctx context.Context) (beacon.EpochTime, int64, error) {
-	return bq.state.GetEpoch(ctx)
+func (q *beaconQuerier) Epoch(ctx context.Context) (beacon.EpochTime, int64, error) {
+	return q.state.GetEpoch(ctx)
 }
 
-func (bq *beaconQuerier) FutureEpoch(ctx context.Context) (*beacon.EpochTimeState, error) {
-	return bq.state.GetFutureEpoch(ctx)
+func (q *beaconQuerier) FutureEpoch(ctx context.Context) (*beacon.EpochTimeState, error) {
+	return q.state.GetFutureEpoch(ctx)
 }
 
-func (bq *beaconQuerier) ConsensusParameters(ctx context.Context) (*beacon.ConsensusParameters, error) {
-	return bq.state.ConsensusParameters(ctx)
+func (q *beaconQuerier) ConsensusParameters(ctx context.Context) (*beacon.ConsensusParameters, error) {
+	return q.state.ConsensusParameters(ctx)
 }
 
-func (bq *beaconQuerier) VRFState(ctx context.Context) (*beacon.VRFState, error) {
-	return bq.state.VRFState(ctx)
+func (q *beaconQuerier) VRFState(ctx context.Context) (*beacon.VRFState, error) {
+	return q.state.VRFState(ctx)
 }
 
 func (app *beaconApplication) QueryFactory() any {

--- a/go/consensus/cometbft/apps/beacon/query.go
+++ b/go/consensus/cometbft/apps/beacon/query.go
@@ -58,7 +58,7 @@ func (q *beaconQuerier) VRFState(ctx context.Context) (*beacon.VRFState, error) 
 	return q.state.VRFState(ctx)
 }
 
-func (app *beaconApplication) QueryFactory() any {
+func (app *Application) QueryFactory() any {
 	return &QueryFactory{app.state}
 }
 

--- a/go/consensus/cometbft/apps/beacon/state/state.go
+++ b/go/consensus/cometbft/apps/beacon/state/state.go
@@ -48,17 +48,6 @@ func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	}
 }
 
-// NewImmutableStateAt creates a new immutable beacon state wrapper
-// using the provided application query state and version.
-func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := abciAPI.NewImmutableStateAt(ctx, state, version)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ImmutableState{is}, nil
-}
-
 // Beacon gets the current random beacon value.
 func (s *ImmutableState) Beacon(ctx context.Context) ([]byte, error) {
 	data, err := s.state.Get(ctx, beaconKeyFmt.Encode())

--- a/go/consensus/cometbft/apps/governance/genesis.go
+++ b/go/consensus/cometbft/apps/governance/genesis.go
@@ -12,7 +12,7 @@ import (
 	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
 )
 
-func (app *governanceApplication) InitChain(ctx *abciAPI.Context, _ types.RequestInitChain, doc *genesis.Document) error {
+func (app *Application) InitChain(ctx *abciAPI.Context, _ types.RequestInitChain, doc *genesis.Document) error {
 	st := doc.Governance
 
 	epoch, err := app.state.GetCurrentEpoch(ctx)

--- a/go/consensus/cometbft/apps/governance/genesis_test.go
+++ b/go/consensus/cometbft/apps/governance/genesis_test.go
@@ -41,7 +41,7 @@ func TestInitChain(t *testing.T) {
 	defer ctx.Close()
 
 	state := governanceState.NewMutableState(ctx.State())
-	app := &governanceApplication{
+	app := &Application{
 		state: appState,
 	}
 

--- a/go/consensus/cometbft/apps/governance/governance.go
+++ b/go/consensus/cometbft/apps/governance/governance.go
@@ -24,34 +24,32 @@ import (
 	upgrade "github.com/oasisprotocol/oasis-core/go/upgrade/api"
 )
 
-var _ api.Application = (*governanceApplication)(nil)
-
-type governanceApplication struct {
+type Application struct {
 	state api.ApplicationState
 	md    api.MessageDispatcher
 }
 
-func (app *governanceApplication) Name() string {
+func (app *Application) Name() string {
 	return AppName
 }
 
-func (app *governanceApplication) ID() uint8 {
+func (app *Application) ID() uint8 {
 	return AppID
 }
 
-func (app *governanceApplication) Methods() []transaction.MethodName {
+func (app *Application) Methods() []transaction.MethodName {
 	return governance.Methods
 }
 
-func (app *governanceApplication) Blessed() bool {
+func (app *Application) Blessed() bool {
 	return false
 }
 
-func (app *governanceApplication) Dependencies() []string {
+func (app *Application) Dependencies() []string {
 	return []string{registryapp.AppName, schedulerapp.AppName, stakingapp.AppName}
 }
 
-func (app *governanceApplication) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
+func (app *Application) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
 	app.state = state
 	app.md = md
 
@@ -62,10 +60,10 @@ func (app *governanceApplication) OnRegister(state api.ApplicationState, md api.
 	md.Subscribe(governanceApi.MessageValidateParameterChanges, app)
 }
 
-func (app *governanceApplication) OnCleanup() {
+func (app *Application) OnCleanup() {
 }
 
-func (app *governanceApplication) ExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {
+func (app *Application) ExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {
 	state := governanceState.NewMutableState(ctx.State())
 
 	ctx.Logger().Debug("executing governance tx",
@@ -99,7 +97,7 @@ func (app *governanceApplication) ExecuteTx(ctx *api.Context, tx *transaction.Tr
 	}
 }
 
-func (app *governanceApplication) ExecuteMessage(ctx *api.Context, kind, msg any) (any, error) {
+func (app *Application) ExecuteMessage(ctx *api.Context, kind, msg any) (any, error) {
 	switch kind {
 	case roothashApi.RuntimeMessageGovernance:
 		m := msg.(*message.GovernanceMessage)
@@ -127,7 +125,7 @@ func (app *governanceApplication) ExecuteMessage(ctx *api.Context, kind, msg any
 	}
 }
 
-func (app *governanceApplication) BeginBlock(ctx *api.Context) error {
+func (app *Application) BeginBlock(ctx *api.Context) error {
 	// Check if epoch has changed.
 	epochChanged, epoch := app.state.EpochChanged(ctx)
 	if !epochChanged {
@@ -209,7 +207,7 @@ func (app *governanceApplication) BeginBlock(ctx *api.Context) error {
 // executeProposal executed the proposal.
 //
 // The method modifies the passed proposal.
-func (app *governanceApplication) executeProposal(ctx *api.Context, state *governanceState.MutableState, proposal *governance.Proposal) error {
+func (app *Application) executeProposal(ctx *api.Context, state *governanceState.MutableState, proposal *governance.Proposal) error {
 	// If proposal execution fails, the proposal's state is changed to StateFailed.
 	proposal.State = governance.StateFailed
 
@@ -355,7 +353,7 @@ func validatorsEscrow(
 // closeProposal closes an active proposal.
 //
 // This method modifies the passed proposal.
-func (app *governanceApplication) closeProposal(
+func (app *Application) closeProposal(
 	ctx *api.Context,
 	state *governanceState.MutableState,
 	stakingState *stakingState.ImmutableState,
@@ -498,7 +496,7 @@ func subShares(validatorVoteShares map[governance.Vote]quantity.Quantity, vote g
 	return nil
 }
 
-func (app *governanceApplication) EndBlock(ctx *api.Context) (types.ResponseEndBlock, error) {
+func (app *Application) EndBlock(ctx *api.Context) (types.ResponseEndBlock, error) {
 	// Check if epoch has changed.
 	epochChanged, epoch := app.state.EpochChanged(ctx)
 	if !epochChanged {
@@ -639,6 +637,6 @@ func (app *governanceApplication) EndBlock(ctx *api.Context) (types.ResponseEndB
 }
 
 // New constructs a new governance application instance.
-func New() api.Application {
-	return &governanceApplication{}
+func New() *Application {
+	return &Application{}
 }

--- a/go/consensus/cometbft/apps/governance/governance_test.go
+++ b/go/consensus/cometbft/apps/governance/governance_test.go
@@ -216,7 +216,7 @@ func TestCloseProposal(t *testing.T) {
 
 	// Setup governance state.
 	state := governanceState.NewMutableState(ctx.State())
-	app := &governanceApplication{
+	app := &Application{
 		state: appState,
 	}
 
@@ -472,7 +472,7 @@ func TestExecuteProposal(t *testing.T) {
 
 	// Setup governance state.
 	state := governanceState.NewMutableState(ctx.State())
-	app := &governanceApplication{
+	app := &Application{
 		state: appState,
 	}
 	// Consensus parameters.
@@ -630,7 +630,7 @@ func TestBeginBlock(t *testing.T) {
 	defer ctx.Close()
 	state := governanceState.NewMutableState(ctx.State())
 
-	app := &governanceApplication{
+	app := &Application{
 		state: appState,
 	}
 
@@ -743,7 +743,7 @@ func TestEndBlock(t *testing.T) {
 	defer ctx.Close()
 	state := governanceState.NewMutableState(ctx.State())
 
-	app := &governanceApplication{
+	app := &Application{
 		state: appState,
 	}
 

--- a/go/consensus/cometbft/apps/governance/messages.go
+++ b/go/consensus/cometbft/apps/governance/messages.go
@@ -10,7 +10,7 @@ import (
 	upgrade "github.com/oasisprotocol/oasis-core/go/upgrade/api"
 )
 
-func (app *governanceApplication) completeStateSync(ctx *api.Context) (any, error) {
+func (app *Application) completeStateSync(ctx *api.Context) (any, error) {
 	// State sync has just completed, check whether there are any pending upgrades to make
 	// sure we don't miss them after the sync.
 	state := governanceState.NewMutableState(ctx.State())
@@ -36,7 +36,7 @@ func (app *governanceApplication) completeStateSync(ctx *api.Context) (any, erro
 	return nil, nil
 }
 
-func (app *governanceApplication) changeParameters(ctx *api.Context, msg any, apply bool) (any, error) {
+func (app *Application) changeParameters(ctx *api.Context, msg any, apply bool) (any, error) {
 	// Unmarshal changes and check if they should be applied to this module.
 	proposal, ok := msg.(*governance.ChangeParametersProposal)
 	if !ok {

--- a/go/consensus/cometbft/apps/governance/messages_test.go
+++ b/go/consensus/cometbft/apps/governance/messages_test.go
@@ -20,7 +20,7 @@ func TestChangeParameters(t *testing.T) {
 
 	// Setup state.
 	state := governanceState.NewMutableState(ctx.State())
-	app := &governanceApplication{
+	app := &Application{
 		state: appState,
 	}
 	params := &governance.ConsensusParameters{

--- a/go/consensus/cometbft/apps/governance/query.go
+++ b/go/consensus/cometbft/apps/governance/query.go
@@ -26,40 +26,42 @@ type QueryFactory struct {
 }
 
 // QueryAt returns the governance query interface for a specific height.
-func (qf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := governanceState.NewImmutableStateAt(ctx, qf.state, height)
+func (f *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
+	state, err := abciAPI.NewImmutableStateAt(ctx, f.state, height)
 	if err != nil {
 		return nil, err
 	}
-	return &governanceQuerier{state}, nil
+	return &governanceQuerier{
+		state: governanceState.NewImmutableState(state),
+	}, nil
 }
 
 type governanceQuerier struct {
 	state *governanceState.ImmutableState
 }
 
-func (gq *governanceQuerier) ActiveProposals(ctx context.Context) ([]*governance.Proposal, error) {
-	return gq.state.ActiveProposals(ctx)
+func (q *governanceQuerier) ActiveProposals(ctx context.Context) ([]*governance.Proposal, error) {
+	return q.state.ActiveProposals(ctx)
 }
 
-func (gq *governanceQuerier) Proposals(ctx context.Context) ([]*governance.Proposal, error) {
-	return gq.state.Proposals(ctx)
+func (q *governanceQuerier) Proposals(ctx context.Context) ([]*governance.Proposal, error) {
+	return q.state.Proposals(ctx)
 }
 
-func (gq *governanceQuerier) Proposal(ctx context.Context, id uint64) (*governance.Proposal, error) {
-	return gq.state.Proposal(ctx, id)
+func (q *governanceQuerier) Proposal(ctx context.Context, id uint64) (*governance.Proposal, error) {
+	return q.state.Proposal(ctx, id)
 }
 
-func (gq *governanceQuerier) Votes(ctx context.Context, id uint64) ([]*governance.VoteEntry, error) {
-	return gq.state.Votes(ctx, id)
+func (q *governanceQuerier) Votes(ctx context.Context, id uint64) ([]*governance.VoteEntry, error) {
+	return q.state.Votes(ctx, id)
 }
 
-func (gq *governanceQuerier) PendingUpgrades(ctx context.Context) ([]*upgrade.Descriptor, error) {
-	return gq.state.PendingUpgrades(ctx)
+func (q *governanceQuerier) PendingUpgrades(ctx context.Context) ([]*upgrade.Descriptor, error) {
+	return q.state.PendingUpgrades(ctx)
 }
 
-func (gq *governanceQuerier) ConsensusParameters(ctx context.Context) (*governance.ConsensusParameters, error) {
-	return gq.state.ConsensusParameters(ctx)
+func (q *governanceQuerier) ConsensusParameters(ctx context.Context) (*governance.ConsensusParameters, error) {
+	return q.state.ConsensusParameters(ctx)
 }
 
 func (app *governanceApplication) QueryFactory() any {

--- a/go/consensus/cometbft/apps/governance/query.go
+++ b/go/consensus/cometbft/apps/governance/query.go
@@ -64,7 +64,7 @@ func (q *governanceQuerier) ConsensusParameters(ctx context.Context) (*governanc
 	return q.state.ConsensusParameters(ctx)
 }
 
-func (app *governanceApplication) QueryFactory() any {
+func (app *Application) QueryFactory() any {
 	return &QueryFactory{app.state}
 }
 

--- a/go/consensus/cometbft/apps/governance/state/state.go
+++ b/go/consensus/cometbft/apps/governance/state/state.go
@@ -61,17 +61,6 @@ func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	}
 }
 
-// NewImmutableStateAt creates a new immutable governance state wrapper
-// using the provided application query state and version.
-func NewImmutableStateAt(ctx context.Context, state api.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := api.NewImmutableStateAt(ctx, state, version)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ImmutableState{is}, nil
-}
-
 // NextProposalIdentifier looks up the next proposal identifier.
 func (s *ImmutableState) NextProposalIdentifier(ctx context.Context) (uint64, error) {
 	keyRaw, err := s.state.Get(ctx, nextProposalIdentifierKeyFmt.Encode())

--- a/go/consensus/cometbft/apps/governance/transactions.go
+++ b/go/consensus/cometbft/apps/governance/transactions.go
@@ -17,7 +17,7 @@ import (
 	upgradeAPI "github.com/oasisprotocol/oasis-core/go/upgrade/api"
 )
 
-func (app *governanceApplication) submitProposal(
+func (app *Application) submitProposal(
 	ctx *api.Context,
 	state *governanceState.MutableState,
 	proposalContent *governance.ProposalContent,
@@ -215,7 +215,7 @@ func (app *governanceApplication) submitProposal(
 	return proposal, nil
 }
 
-func (app *governanceApplication) castVote(
+func (app *Application) castVote(
 	ctx *api.Context,
 	state *governanceState.MutableState,
 	proposalVote *governance.ProposalVote,

--- a/go/consensus/cometbft/apps/governance/transactions_test.go
+++ b/go/consensus/cometbft/apps/governance/transactions_test.go
@@ -44,7 +44,7 @@ func TestSubmitProposal(t *testing.T) {
 
 	// Setup governance state.
 	state := governanceState.NewMutableState(ctx.State())
-	app := &governanceApplication{
+	app := &Application{
 		state: appState,
 	}
 
@@ -305,7 +305,7 @@ func TestCastVote(t *testing.T) {
 
 	// Setup governance state.
 	state := governanceState.NewMutableState(ctx.State())
-	app := &governanceApplication{
+	app := &Application{
 		state: appState,
 	}
 	params := &governance.ConsensusParameters{

--- a/go/consensus/cometbft/apps/keymanager/churp/state/state.go
+++ b/go/consensus/cometbft/apps/keymanager/churp/state/state.go
@@ -37,16 +37,6 @@ func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	}
 }
 
-// NewImmutableStateAt creates a new immutable key manager CHURP state wrapper
-// using the provided application query state and version.
-func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := abciAPI.NewImmutableStateAt(ctx, state, version)
-	if err != nil {
-		return nil, err
-	}
-	return &ImmutableState{is}, nil
-}
-
 // ConsensusParameters returns the consensus parameters.
 func (st *ImmutableState) ConsensusParameters(ctx context.Context) (*churp.ConsensusParameters, error) {
 	raw, err := st.state.Get(ctx, parametersKeyFmt.Encode())

--- a/go/consensus/cometbft/apps/keymanager/genesis.go
+++ b/go/consensus/cometbft/apps/keymanager/genesis.go
@@ -9,7 +9,7 @@ import (
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
 )
 
-func (app *keymanagerApplication) InitChain(ctx *tmapi.Context, req types.RequestInitChain, doc *genesis.Document) error {
+func (app *Application) InitChain(ctx *tmapi.Context, req types.RequestInitChain, doc *genesis.Document) error {
 	b, _ := json.Marshal(doc.KeyManager)
 	ctx.Logger().Debug("InitChain: Genesis state",
 		"state", string(b),

--- a/go/consensus/cometbft/apps/keymanager/keymanager.go
+++ b/go/consensus/cometbft/apps/keymanager/keymanager.go
@@ -15,7 +15,7 @@ import (
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 )
 
-type keymanagerApplication struct {
+type Application struct {
 	state tmapi.ApplicationState
 
 	exts         []tmapi.Extension
@@ -24,32 +24,32 @@ type keymanagerApplication struct {
 }
 
 // Name implements api.Application.
-func (app *keymanagerApplication) Name() string {
+func (app *Application) Name() string {
 	return AppName
 }
 
 // ID implements api.Application.
-func (app *keymanagerApplication) ID() uint8 {
+func (app *Application) ID() uint8 {
 	return AppID
 }
 
 // Methods implements api.Application.
-func (app *keymanagerApplication) Methods() []transaction.MethodName {
+func (app *Application) Methods() []transaction.MethodName {
 	return app.methods
 }
 
 // Blessed implements api.Application.
-func (app *keymanagerApplication) Blessed() bool {
+func (app *Application) Blessed() bool {
 	return false
 }
 
 // Dependencies implements api.Application.
-func (app *keymanagerApplication) Dependencies() []string {
+func (app *Application) Dependencies() []string {
 	return []string{registryapp.AppName}
 }
 
 // OnRegister implements api.Application.
-func (app *keymanagerApplication) OnRegister(state tmapi.ApplicationState, md tmapi.MessageDispatcher) {
+func (app *Application) OnRegister(state tmapi.ApplicationState, md tmapi.MessageDispatcher) {
 	app.state = state
 
 	for _, ext := range app.exts {
@@ -58,10 +58,10 @@ func (app *keymanagerApplication) OnRegister(state tmapi.ApplicationState, md tm
 }
 
 // OnCleanup implements api.Application.
-func (app *keymanagerApplication) OnCleanup() {}
+func (app *Application) OnCleanup() {}
 
 // BeginBlock implements api.Application.
-func (app *keymanagerApplication) BeginBlock(ctx *tmapi.Context) error {
+func (app *Application) BeginBlock(ctx *tmapi.Context) error {
 	// Prioritize application-specific logic.
 	if changed, _ := app.state.EpochChanged(ctx); changed {
 		if err := suspendRuntimes(ctx); err != nil {
@@ -80,12 +80,12 @@ func (app *keymanagerApplication) BeginBlock(ctx *tmapi.Context) error {
 }
 
 // ExecuteMessage implements api.Application.
-func (app *keymanagerApplication) ExecuteMessage(*tmapi.Context, any, any) (any, error) {
+func (app *Application) ExecuteMessage(*tmapi.Context, any, any) (any, error) {
 	return nil, fmt.Errorf("keymanager: unexpected message")
 }
 
 // ExecuteTx implements api.Application.
-func (app *keymanagerApplication) ExecuteTx(ctx *tmapi.Context, tx *transaction.Transaction) error {
+func (app *Application) ExecuteTx(ctx *tmapi.Context, tx *transaction.Transaction) error {
 	ctx.SetPriority(AppPriority)
 
 	ext, ok := app.extsByMethod[tx.Method]
@@ -97,7 +97,7 @@ func (app *keymanagerApplication) ExecuteTx(ctx *tmapi.Context, tx *transaction.
 }
 
 // EndBlock implements api.Application.
-func (app *keymanagerApplication) EndBlock(*tmapi.Context) (types.ResponseEndBlock, error) {
+func (app *Application) EndBlock(*tmapi.Context) (types.ResponseEndBlock, error) {
 	return types.ResponseEndBlock{}, nil
 }
 
@@ -159,7 +159,7 @@ func suspendRuntimes(ctx *tmapi.Context) error {
 	return nil
 }
 
-func (app *keymanagerApplication) registerExtensions(exts ...tmapi.Extension) {
+func (app *Application) registerExtensions(exts ...tmapi.Extension) {
 	for _, ext := range exts {
 		for _, m := range ext.Methods() {
 			if _, ok := app.extsByMethod[m]; ok {
@@ -173,8 +173,8 @@ func (app *keymanagerApplication) registerExtensions(exts ...tmapi.Extension) {
 }
 
 // New constructs a new keymanager application instance.
-func New() tmapi.Application {
-	app := keymanagerApplication{
+func New() *Application {
+	app := Application{
 		exts:         make([]tmapi.Extension, 0),
 		methods:      make([]transaction.MethodName, 0),
 		extsByMethod: make(map[transaction.MethodName]tmapi.Extension),

--- a/go/consensus/cometbft/apps/keymanager/messages.go
+++ b/go/consensus/cometbft/apps/keymanager/messages.go
@@ -11,7 +11,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/keymanager/secrets"
 )
 
-func (app *keymanagerApplication) changeParameters(ctx *api.Context, msg any, apply bool) (any, error) {
+func (app *Application) changeParameters(ctx *api.Context, msg any, apply bool) (any, error) {
 	// Unmarshal changes and check if they should be applied to this module.
 	proposal, ok := msg.(*governance.ChangeParametersProposal)
 	if !ok {

--- a/go/consensus/cometbft/apps/keymanager/messages_test.go
+++ b/go/consensus/cometbft/apps/keymanager/messages_test.go
@@ -22,7 +22,7 @@ func TestChangeParameters(t *testing.T) {
 
 	// Setup state.
 	state := secretsState.NewMutableState(ctx.State())
-	app := &keymanagerApplication{
+	app := &Application{
 		state: appState,
 	}
 	params := &secrets.ConsensusParameters{

--- a/go/consensus/cometbft/apps/keymanager/query.go
+++ b/go/consensus/cometbft/apps/keymanager/query.go
@@ -46,7 +46,7 @@ func (q *keymanagerQuerier) Churp() churp.Query {
 	return churp.NewQuery(q.churpState)
 }
 
-func (app *keymanagerApplication) QueryFactory() any {
+func (app *Application) QueryFactory() any {
 	return &QueryFactory{app.state}
 }
 

--- a/go/consensus/cometbft/apps/keymanager/query.go
+++ b/go/consensus/cometbft/apps/keymanager/query.go
@@ -22,20 +22,14 @@ type QueryFactory struct {
 }
 
 // QueryAt returns the key manager query interface for a specific height.
-func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	secretsState, err := secretsState.NewImmutableStateAt(ctx, sf.state, height)
+func (f *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
+	state, err := abciAPI.NewImmutableStateAt(ctx, f.state, height)
 	if err != nil {
 		return nil, err
 	}
-
-	churpState, err := churpState.NewImmutableStateAt(ctx, sf.state, height)
-	if err != nil {
-		return nil, err
-	}
-
 	return &keymanagerQuerier{
-		secretsState: secretsState,
-		churpState:   churpState,
+		secretsState: secretsState.NewImmutableState(state),
+		churpState:   churpState.NewImmutableState(state),
 	}, nil
 }
 
@@ -44,12 +38,12 @@ type keymanagerQuerier struct {
 	churpState   *churpState.ImmutableState
 }
 
-func (kq *keymanagerQuerier) Secrets() secrets.Query {
-	return secrets.NewQuery(kq.secretsState)
+func (q *keymanagerQuerier) Secrets() secrets.Query {
+	return secrets.NewQuery(q.secretsState)
 }
 
-func (kq *keymanagerQuerier) Churp() churp.Query {
-	return churp.NewQuery(kq.churpState)
+func (q *keymanagerQuerier) Churp() churp.Query {
+	return churp.NewQuery(q.churpState)
 }
 
 func (app *keymanagerApplication) QueryFactory() any {

--- a/go/consensus/cometbft/apps/keymanager/secrets/state/state.go
+++ b/go/consensus/cometbft/apps/keymanager/secrets/state/state.go
@@ -44,16 +44,6 @@ func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	}
 }
 
-// NewImmutableStateAt creates a new immutable key manager secrets state wrapper
-// using the provided application query state and version.
-func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := abciAPI.NewImmutableStateAt(ctx, state, version)
-	if err != nil {
-		return nil, err
-	}
-	return &ImmutableState{is}, nil
-}
-
 // ConsensusParameters returns the key manager consensus parameters.
 func (st *ImmutableState) ConsensusParameters(ctx context.Context) (*secrets.ConsensusParameters, error) {
 	raw, err := st.state.Get(ctx, parametersKeyFmt.Encode())

--- a/go/consensus/cometbft/apps/registry/genesis.go
+++ b/go/consensus/cometbft/apps/registry/genesis.go
@@ -16,7 +16,7 @@ import (
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 )
 
-func (app *registryApplication) InitChain(ctx *abciAPI.Context, _ types.RequestInitChain, doc *genesis.Document) error {
+func (app *Application) InitChain(ctx *abciAPI.Context, _ types.RequestInitChain, doc *genesis.Document) error {
 	st := doc.Registry
 
 	b, _ := json.Marshal(st)

--- a/go/consensus/cometbft/apps/registry/messages.go
+++ b/go/consensus/cometbft/apps/registry/messages.go
@@ -10,7 +10,7 @@ import (
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 )
 
-func (app *registryApplication) changeParameters(ctx *api.Context, msg any, apply bool) (any, error) {
+func (app *Application) changeParameters(ctx *api.Context, msg any, apply bool) (any, error) {
 	// Unmarshal changes and check if they should be applied to this module.
 	proposal, ok := msg.(*governance.ChangeParametersProposal)
 	if !ok {

--- a/go/consensus/cometbft/apps/registry/messages_test.go
+++ b/go/consensus/cometbft/apps/registry/messages_test.go
@@ -20,7 +20,7 @@ func TestChangeParameters(t *testing.T) {
 
 	// Setup state.
 	state := registryState.NewMutableState(ctx.State())
-	app := &registryApplication{
+	app := &Application{
 		state: appState,
 	}
 	params := &registry.ConsensusParameters{

--- a/go/consensus/cometbft/apps/registry/query.go
+++ b/go/consensus/cometbft/apps/registry/query.go
@@ -125,7 +125,7 @@ func (q *registryQuerier) ConsensusParameters(ctx context.Context) (*registry.Co
 	return q.state.ConsensusParameters(ctx)
 }
 
-func (app *registryApplication) QueryFactory() any {
+func (app *Application) QueryFactory() any {
 	return &QueryFactory{app.state}
 }
 

--- a/go/consensus/cometbft/apps/registry/query.go
+++ b/go/consensus/cometbft/apps/registry/query.go
@@ -33,12 +33,16 @@ type QueryFactory struct {
 }
 
 // QueryAt returns the registry query interface for a specific height.
-func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := registryState.NewImmutableStateAt(ctx, sf.state, height)
+func (f *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
+	state, err := abciAPI.NewImmutableStateAt(ctx, f.state, height)
 	if err != nil {
 		return nil, err
 	}
-	return &registryQuerier{sf.state, state, height}, nil
+	return &registryQuerier{
+		queryState: f.state,
+		state:      registryState.NewImmutableState(state),
+		height:     height,
+	}, nil
 }
 
 type registryQuerier struct {
@@ -47,21 +51,21 @@ type registryQuerier struct {
 	height     int64
 }
 
-func (rq *registryQuerier) Entity(ctx context.Context, id signature.PublicKey) (*entity.Entity, error) {
-	return rq.state.Entity(ctx, id)
+func (q *registryQuerier) Entity(ctx context.Context, id signature.PublicKey) (*entity.Entity, error) {
+	return q.state.Entity(ctx, id)
 }
 
-func (rq *registryQuerier) Entities(ctx context.Context) ([]*entity.Entity, error) {
-	return rq.state.Entities(ctx)
+func (q *registryQuerier) Entities(ctx context.Context) ([]*entity.Entity, error) {
+	return q.state.Entities(ctx)
 }
 
-func (rq *registryQuerier) Node(ctx context.Context, id signature.PublicKey) (*node.Node, error) {
-	epoch, err := rq.queryState.GetEpoch(ctx, rq.height)
+func (q *registryQuerier) Node(ctx context.Context, id signature.PublicKey) (*node.Node, error) {
+	epoch, err := q.queryState.GetEpoch(ctx, q.height)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get epoch: %w", err)
 	}
 
-	node, err := rq.state.Node(ctx, id)
+	node, err := q.state.Node(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -73,21 +77,21 @@ func (rq *registryQuerier) Node(ctx context.Context, id signature.PublicKey) (*n
 	return node, nil
 }
 
-func (rq *registryQuerier) NodeByConsensusAddress(ctx context.Context, address []byte) (*node.Node, error) {
-	return rq.state.NodeByConsensusAddress(ctx, address)
+func (q *registryQuerier) NodeByConsensusAddress(ctx context.Context, address []byte) (*node.Node, error) {
+	return q.state.NodeByConsensusAddress(ctx, address)
 }
 
-func (rq *registryQuerier) NodeStatus(ctx context.Context, id signature.PublicKey) (*registry.NodeStatus, error) {
-	return rq.state.NodeStatus(ctx, id)
+func (q *registryQuerier) NodeStatus(ctx context.Context, id signature.PublicKey) (*registry.NodeStatus, error) {
+	return q.state.NodeStatus(ctx, id)
 }
 
-func (rq *registryQuerier) Nodes(ctx context.Context) ([]*node.Node, error) {
-	epoch, err := rq.queryState.GetEpoch(ctx, rq.height)
+func (q *registryQuerier) Nodes(ctx context.Context) ([]*node.Node, error) {
+	epoch, err := q.queryState.GetEpoch(ctx, q.height)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get epoch: %w", err)
 	}
 
-	nodes, err := rq.state.Nodes(ctx)
+	nodes, err := q.state.Nodes(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -103,22 +107,22 @@ func (rq *registryQuerier) Nodes(ctx context.Context) ([]*node.Node, error) {
 	return filteredNodes, nil
 }
 
-func (rq *registryQuerier) Runtime(ctx context.Context, id common.Namespace, includeSuspended bool) (*registry.Runtime, error) {
+func (q *registryQuerier) Runtime(ctx context.Context, id common.Namespace, includeSuspended bool) (*registry.Runtime, error) {
 	if includeSuspended {
-		return rq.state.AnyRuntime(ctx, id)
+		return q.state.AnyRuntime(ctx, id)
 	}
-	return rq.state.Runtime(ctx, id)
+	return q.state.Runtime(ctx, id)
 }
 
-func (rq *registryQuerier) Runtimes(ctx context.Context, includeSuspended bool) ([]*registry.Runtime, error) {
+func (q *registryQuerier) Runtimes(ctx context.Context, includeSuspended bool) ([]*registry.Runtime, error) {
 	if includeSuspended {
-		return rq.state.AllRuntimes(ctx)
+		return q.state.AllRuntimes(ctx)
 	}
-	return rq.state.Runtimes(ctx)
+	return q.state.Runtimes(ctx)
 }
 
-func (rq *registryQuerier) ConsensusParameters(ctx context.Context) (*registry.ConsensusParameters, error) {
-	return rq.state.ConsensusParameters(ctx)
+func (q *registryQuerier) ConsensusParameters(ctx context.Context) (*registry.ConsensusParameters, error) {
+	return q.state.ConsensusParameters(ctx)
 }
 
 func (app *registryApplication) QueryFactory() any {

--- a/go/consensus/cometbft/apps/registry/registry.go
+++ b/go/consensus/cometbft/apps/registry/registry.go
@@ -23,34 +23,32 @@ import (
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
-var _ api.Application = (*registryApplication)(nil)
-
-type registryApplication struct {
+type Application struct {
 	state api.ApplicationState
 	md    api.MessageDispatcher
 }
 
-func (app *registryApplication) Name() string {
+func (app *Application) Name() string {
 	return AppName
 }
 
-func (app *registryApplication) ID() uint8 {
+func (app *Application) ID() uint8 {
 	return AppID
 }
 
-func (app *registryApplication) Methods() []transaction.MethodName {
+func (app *Application) Methods() []transaction.MethodName {
 	return registry.Methods
 }
 
-func (app *registryApplication) Blessed() bool {
+func (app *Application) Blessed() bool {
 	return false
 }
 
-func (app *registryApplication) Dependencies() []string {
+func (app *Application) Dependencies() []string {
 	return []string{stakingapp.AppName}
 }
 
-func (app *registryApplication) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
+func (app *Application) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
 	app.state = state
 	app.md = md
 
@@ -60,10 +58,10 @@ func (app *registryApplication) OnRegister(state api.ApplicationState, md api.Me
 	md.Subscribe(governanceApi.MessageValidateParameterChanges, app)
 }
 
-func (app *registryApplication) OnCleanup() {
+func (app *Application) OnCleanup() {
 }
 
-func (app *registryApplication) BeginBlock(ctx *api.Context) error {
+func (app *Application) BeginBlock(ctx *api.Context) error {
 	// XXX: With PR#1889 this can be a differnet interval.
 	if changed, registryEpoch := app.state.EpochChanged(ctx); changed {
 		return app.onRegistryEpochChanged(ctx, registryEpoch)
@@ -71,7 +69,7 @@ func (app *registryApplication) BeginBlock(ctx *api.Context) error {
 	return nil
 }
 
-func (app *registryApplication) ExecuteMessage(ctx *api.Context, kind, msg any) (any, error) {
+func (app *Application) ExecuteMessage(ctx *api.Context, kind, msg any) (any, error) {
 	switch kind {
 	case roothashApi.RuntimeMessageRegistry:
 		m := msg.(*message.RegistryMessage)
@@ -94,7 +92,7 @@ func (app *registryApplication) ExecuteMessage(ctx *api.Context, kind, msg any) 
 	}
 }
 
-func (app *registryApplication) ExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {
+func (app *Application) ExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {
 	state := registryState.NewMutableState(ctx.State())
 
 	ctx.SetPriority(AppPriority)
@@ -153,11 +151,11 @@ func (app *registryApplication) ExecuteTx(ctx *api.Context, tx *transaction.Tran
 	}
 }
 
-func (app *registryApplication) EndBlock(*api.Context) (types.ResponseEndBlock, error) {
+func (app *Application) EndBlock(*api.Context) (types.ResponseEndBlock, error) {
 	return types.ResponseEndBlock{}, nil
 }
 
-func (app *registryApplication) onRegistryEpochChanged(ctx *api.Context, registryEpoch beacon.EpochTime) (err error) {
+func (app *Application) onRegistryEpochChanged(ctx *api.Context, registryEpoch beacon.EpochTime) (err error) {
 	regState := registryState.NewMutableState(ctx.State())
 	stakeState := stakingState.NewMutableState(ctx.State())
 
@@ -260,6 +258,6 @@ func (app *registryApplication) onRegistryEpochChanged(ctx *api.Context, registr
 }
 
 // New constructs a new registry application instance.
-func New() api.Application {
-	return &registryApplication{}
+func New() *Application {
+	return &Application{}
 }

--- a/go/consensus/cometbft/apps/registry/state/state.go
+++ b/go/consensus/cometbft/apps/registry/state/state.go
@@ -90,17 +90,6 @@ func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	}
 }
 
-// NewImmutableStateAt creates a new immutable registry state wrapper
-// using the provided application query state and version.
-func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := abciAPI.NewImmutableStateAt(ctx, state, version)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ImmutableState{is}, nil
-}
-
 func (s *ImmutableState) getSignedEntityRaw(ctx context.Context, id signature.PublicKey) ([]byte, error) {
 	data, err := s.state.Get(ctx, signedEntityKeyFmt.Encode(&id))
 	return data, abciAPI.UnavailableStateError(err)

--- a/go/consensus/cometbft/apps/registry/transactions.go
+++ b/go/consensus/cometbft/apps/registry/transactions.go
@@ -16,7 +16,7 @@ import (
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
-func (app *registryApplication) registerEntity(
+func (app *Application) registerEntity(
 	ctx *api.Context,
 	state *registryState.MutableState,
 	sigEnt *entity.SignedEntity,
@@ -96,7 +96,7 @@ func (app *registryApplication) registerEntity(
 	return nil
 }
 
-func (app *registryApplication) deregisterEntity(ctx *api.Context, state *registryState.MutableState) error {
+func (app *Application) deregisterEntity(ctx *api.Context, state *registryState.MutableState) error {
 	if ctx.IsCheckOnly() {
 		return nil
 	}
@@ -183,7 +183,7 @@ func (app *registryApplication) deregisterEntity(ctx *api.Context, state *regist
 	return nil
 }
 
-func (app *registryApplication) registerNode( // nolint: gocyclo
+func (app *Application) registerNode( // nolint: gocyclo
 	ctx *api.Context,
 	state *registryState.MutableState,
 	sigNode *node.MultiSignedNode,
@@ -482,7 +482,7 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 	return nil
 }
 
-func (app *registryApplication) unfreezeNode(
+func (app *Application) unfreezeNode(
 	ctx *api.Context,
 	state *registryState.MutableState,
 	unfreeze *registry.UnfreezeNode,
@@ -557,7 +557,7 @@ func (app *registryApplication) unfreezeNode(
 	return nil
 }
 
-func (app *registryApplication) registerRuntime( // nolint: gocyclo
+func (app *Application) registerRuntime( // nolint: gocyclo
 	ctx *api.Context,
 	state *registryState.MutableState,
 	rt *registry.Runtime,
@@ -760,7 +760,7 @@ func (app *registryApplication) registerRuntime( // nolint: gocyclo
 	return rt, nil
 }
 
-func (app *registryApplication) proveFreshness(
+func (app *Application) proveFreshness(
 	ctx *api.Context,
 	state *registryState.MutableState,
 ) error {

--- a/go/consensus/cometbft/apps/registry/transactions_test.go
+++ b/go/consensus/cometbft/apps/registry/transactions_test.go
@@ -32,7 +32,7 @@ func TestRegisterNode(t *testing.T) {
 	defer ctx.Close()
 
 	var md abciAPI.NoopMessageDispatcher
-	app := registryApplication{appState, &md}
+	app := Application{appState, &md}
 	state := registryState.NewMutableState(ctx.State())
 	stakeState := stakingState.NewMutableState(ctx.State())
 	beaconState := beaconState.NewMutableState(ctx.State())
@@ -677,7 +677,7 @@ func TestRegisterRuntime(t *testing.T) {
 	defer ctx.Close()
 
 	var md abciAPI.NoopMessageDispatcher
-	app := registryApplication{appState, &md}
+	app := Application{appState, &md}
 
 	state := registryState.NewMutableState(ctx.State())
 	stakeState := stakingState.NewMutableState(ctx.State())
@@ -856,7 +856,7 @@ func TestProofFreshness(t *testing.T) {
 	defer ctx.Close()
 
 	var md abciAPI.NoopMessageDispatcher
-	app := registryApplication{appState, &md}
+	app := Application{appState, &md}
 	state := registryState.NewMutableState(ctx.State())
 
 	setTEEFeaturesFn := func(TEEFeatures *node.TEEFeatures) {

--- a/go/consensus/cometbft/apps/roothash/finalization.go
+++ b/go/consensus/cometbft/apps/roothash/finalization.go
@@ -18,7 +18,7 @@ import (
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
-func (app *rootHashApplication) tryFinalizeRounds(
+func (app *Application) tryFinalizeRounds(
 	ctx *tmapi.Context,
 ) error {
 	for _, runtimeID := range roothashApi.RuntimesToFinalize(ctx) {
@@ -33,7 +33,7 @@ func (app *rootHashApplication) tryFinalizeRounds(
 	return nil
 }
 
-func (app *rootHashApplication) tryFinalizeRound(
+func (app *Application) tryFinalizeRound(
 	ctx *tmapi.Context,
 	runtimeID common.Namespace,
 	timeout bool,
@@ -64,7 +64,7 @@ func (app *rootHashApplication) tryFinalizeRound(
 	return nil
 }
 
-func (app *rootHashApplication) tryFinalizeRoundInsideTx( //nolint: gocyclo
+func (app *Application) tryFinalizeRoundInsideTx( //nolint: gocyclo
 	ctx *tmapi.Context,
 	rtState *roothash.RuntimeState,
 	timeout bool,
@@ -279,7 +279,7 @@ func (app *rootHashApplication) tryFinalizeRoundInsideTx( //nolint: gocyclo
 	return app.finalizeBlock(ctx, rtState, block.Normal, &sc.Commitment.Header.Header)
 }
 
-func (app *rootHashApplication) finalizeBlock(ctx *tmapi.Context, rtState *roothash.RuntimeState, hdrType block.HeaderType, hdr *commitment.ComputeResultsHeader) error {
+func (app *Application) finalizeBlock(ctx *tmapi.Context, rtState *roothash.RuntimeState, hdrType block.HeaderType, hdr *commitment.ComputeResultsHeader) error {
 	// Generate a new block.
 	blk := block.NewEmptyBlock(rtState.LastBlock, uint64(ctx.Now().Unix()), hdrType)
 
@@ -331,7 +331,7 @@ func (app *rootHashApplication) finalizeBlock(ctx *tmapi.Context, rtState *rooth
 	return rearmRoundTimeout(ctx, rtState.Runtime.ID, blk.Header.Round, prevTimeout, rtState.NextTimeout)
 }
 
-func (app *rootHashApplication) failRound(
+func (app *Application) failRound(
 	ctx *tmapi.Context,
 	rtState *roothash.RuntimeState,
 	err error,

--- a/go/consensus/cometbft/apps/roothash/genesis.go
+++ b/go/consensus/cometbft/apps/roothash/genesis.go
@@ -15,7 +15,7 @@ import (
 	roothashAPI "github.com/oasisprotocol/oasis-core/go/roothash/api"
 )
 
-func (app *rootHashApplication) InitChain(ctx *abciAPI.Context, _ types.RequestInitChain, doc *genesisAPI.Document) error {
+func (app *Application) InitChain(ctx *abciAPI.Context, _ types.RequestInitChain, doc *genesisAPI.Document) error {
 	st := doc.RootHash
 
 	state := roothashState.NewMutableState(ctx.State())

--- a/go/consensus/cometbft/apps/roothash/messages.go
+++ b/go/consensus/cometbft/apps/roothash/messages.go
@@ -53,7 +53,7 @@ func verifyRuntimeMessages(
 	return nil
 }
 
-func (app *rootHashApplication) removeRuntimeMessages(
+func (app *Application) removeRuntimeMessages(
 	ctx *tmapi.Context,
 	state *roothashState.MutableState,
 	runtimeID common.Namespace,
@@ -103,7 +103,7 @@ func (app *rootHashApplication) removeRuntimeMessages(
 	return nil
 }
 
-func (app *rootHashApplication) processRuntimeMessages(
+func (app *Application) processRuntimeMessages(
 	ctx *tmapi.Context,
 	rtState *roothash.RuntimeState,
 	msgs []message.Message,
@@ -168,7 +168,7 @@ func (app *rootHashApplication) processRuntimeMessages(
 	return events, nil
 }
 
-func (app *rootHashApplication) doBeforeSchedule(ctx *tmapi.Context, msg any) (any, error) {
+func (app *Application) doBeforeSchedule(ctx *tmapi.Context, msg any) (any, error) {
 	epoch := msg.(beacon.EpochTime)
 
 	ctx.Logger().Debug("processing liveness statistics before scheduling",
@@ -195,7 +195,7 @@ func (app *rootHashApplication) doBeforeSchedule(ctx *tmapi.Context, msg any) (a
 	return nil, nil
 }
 
-func (app *rootHashApplication) changeParameters(ctx *tmapi.Context, msg any, apply bool) (any, error) {
+func (app *Application) changeParameters(ctx *tmapi.Context, msg any, apply bool) (any, error) {
 	// Unmarshal changes and check if they should be applied to this module.
 	proposal, ok := msg.(*governance.ChangeParametersProposal)
 	if !ok {

--- a/go/consensus/cometbft/apps/roothash/messages_test.go
+++ b/go/consensus/cometbft/apps/roothash/messages_test.go
@@ -23,7 +23,7 @@ func TestChangeParameters(t *testing.T) {
 
 	// Setup state.
 	state := roothashState.NewMutableState(ctx.State())
-	app := &rootHashApplication{
+	app := &Application{
 		state: appState,
 	}
 	params := &roothash.ConsensusParameters{
@@ -139,7 +139,7 @@ func advanceRuntimeState(require *require.Assertions, ctx *abciAPI.Context, gene
 	return blk
 }
 
-func changeMaxPastRootsStored(require *require.Assertions, app *rootHashApplication, ctx *abciAPI.Context, state *roothashState.MutableState, newMaxPRS uint64) {
+func changeMaxPastRootsStored(require *require.Assertions, app *Application, ctx *abciAPI.Context, state *roothashState.MutableState, newMaxPRS uint64) {
 	// Prepare proposal for changing the number of roots stored.
 	changes := roothash.ConsensusParameterChanges{
 		MaxPastRootsStored: &newMaxPRS,
@@ -168,7 +168,7 @@ func TestMaxPastRootsStoredMulti(t *testing.T) {
 
 	// Setup state.
 	state := roothashState.NewMutableState(ctx.State())
-	_ = &rootHashApplication{
+	_ = &Application{
 		state: appState,
 	}
 	params := &roothash.ConsensusParameters{
@@ -288,7 +288,7 @@ func TestChangeMaxPastRootsStored(t *testing.T) {
 
 	// Setup state.
 	state := roothashState.NewMutableState(ctx.State())
-	app := &rootHashApplication{
+	app := &Application{
 		state: appState,
 	}
 	params := &roothash.ConsensusParameters{

--- a/go/consensus/cometbft/apps/roothash/query.go
+++ b/go/consensus/cometbft/apps/roothash/query.go
@@ -31,60 +31,62 @@ type QueryFactory struct {
 }
 
 // QueryAt returns the roothash query interface for a specific height.
-func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := roothashState.NewImmutableStateAt(ctx, sf.state, height)
+func (f *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
+	state, err := abciAPI.NewImmutableStateAt(ctx, f.state, height)
 	if err != nil {
 		return nil, err
 	}
-	return &rootHashQuerier{state}, nil
+	return &rootHashQuerier{
+		state: roothashState.NewImmutableState(state),
+	}, nil
 }
 
 type rootHashQuerier struct {
 	state *roothashState.ImmutableState
 }
 
-func (rq *rootHashQuerier) LatestBlock(ctx context.Context, id common.Namespace) (*block.Block, error) {
-	runtime, err := rq.state.RuntimeState(ctx, id)
+func (q *rootHashQuerier) LatestBlock(ctx context.Context, id common.Namespace) (*block.Block, error) {
+	runtime, err := q.state.RuntimeState(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 	return runtime.LastBlock, nil
 }
 
-func (rq *rootHashQuerier) GenesisBlock(ctx context.Context, id common.Namespace) (*block.Block, error) {
-	runtime, err := rq.state.RuntimeState(ctx, id)
+func (q *rootHashQuerier) GenesisBlock(ctx context.Context, id common.Namespace) (*block.Block, error) {
+	runtime, err := q.state.RuntimeState(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 	return runtime.GenesisBlock, nil
 }
 
-func (rq *rootHashQuerier) RuntimeState(ctx context.Context, id common.Namespace) (*roothash.RuntimeState, error) {
-	return rq.state.RuntimeState(ctx, id)
+func (q *rootHashQuerier) RuntimeState(ctx context.Context, id common.Namespace) (*roothash.RuntimeState, error) {
+	return q.state.RuntimeState(ctx, id)
 }
 
-func (rq *rootHashQuerier) LastRoundResults(ctx context.Context, id common.Namespace) (*roothash.RoundResults, error) {
-	return rq.state.LastRoundResults(ctx, id)
+func (q *rootHashQuerier) LastRoundResults(ctx context.Context, id common.Namespace) (*roothash.RoundResults, error) {
+	return q.state.LastRoundResults(ctx, id)
 }
 
-func (rq *rootHashQuerier) RoundRoots(ctx context.Context, id common.Namespace, round uint64) (*roothash.RoundRoots, error) {
-	return rq.state.RoundRoots(ctx, id, round)
+func (q *rootHashQuerier) RoundRoots(ctx context.Context, id common.Namespace, round uint64) (*roothash.RoundRoots, error) {
+	return q.state.RoundRoots(ctx, id, round)
 }
 
-func (rq *rootHashQuerier) PastRoundRoots(ctx context.Context, id common.Namespace) (map[uint64]roothash.RoundRoots, error) {
-	return rq.state.PastRoundRoots(ctx, id)
+func (q *rootHashQuerier) PastRoundRoots(ctx context.Context, id common.Namespace) (map[uint64]roothash.RoundRoots, error) {
+	return q.state.PastRoundRoots(ctx, id)
 }
 
-func (rq *rootHashQuerier) IncomingMessageQueueMeta(ctx context.Context, id common.Namespace) (*message.IncomingMessageQueueMeta, error) {
-	return rq.state.IncomingMessageQueueMeta(ctx, id)
+func (q *rootHashQuerier) IncomingMessageQueueMeta(ctx context.Context, id common.Namespace) (*message.IncomingMessageQueueMeta, error) {
+	return q.state.IncomingMessageQueueMeta(ctx, id)
 }
 
-func (rq *rootHashQuerier) IncomingMessageQueue(ctx context.Context, id common.Namespace, offset uint64, limit uint32) ([]*message.IncomingMessage, error) {
-	return rq.state.IncomingMessageQueue(ctx, id, offset, limit)
+func (q *rootHashQuerier) IncomingMessageQueue(ctx context.Context, id common.Namespace, offset uint64, limit uint32) ([]*message.IncomingMessage, error) {
+	return q.state.IncomingMessageQueue(ctx, id, offset, limit)
 }
 
-func (rq *rootHashQuerier) ConsensusParameters(ctx context.Context) (*roothash.ConsensusParameters, error) {
-	return rq.state.ConsensusParameters(ctx)
+func (q *rootHashQuerier) ConsensusParameters(ctx context.Context) (*roothash.ConsensusParameters, error) {
+	return q.state.ConsensusParameters(ctx)
 }
 
 func (app *rootHashApplication) QueryFactory() any {

--- a/go/consensus/cometbft/apps/roothash/query.go
+++ b/go/consensus/cometbft/apps/roothash/query.go
@@ -89,7 +89,7 @@ func (q *rootHashQuerier) ConsensusParameters(ctx context.Context) (*roothash.Co
 	return q.state.ConsensusParameters(ctx)
 }
 
-func (app *rootHashApplication) QueryFactory() any {
+func (app *Application) QueryFactory() any {
 	return &QueryFactory{app.state}
 }
 

--- a/go/consensus/cometbft/apps/roothash/state/state.go
+++ b/go/consensus/cometbft/apps/roothash/state/state.go
@@ -73,17 +73,6 @@ func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	}
 }
 
-// NewImmutableStateAt creates a new immutable roothash state wrapper
-// using the provided application query state and version.
-func NewImmutableStateAt(ctx context.Context, state api.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := api.NewImmutableStateAt(ctx, state, version)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ImmutableState{is}, nil
-}
-
 func (s *ImmutableState) runtimesWithRoundTimeouts(ctx context.Context, height *int64) ([]common.Namespace, []int64, error) {
 	it := s.state.NewIterator(ctx)
 	defer it.Close()

--- a/go/consensus/cometbft/apps/roothash/timeout.go
+++ b/go/consensus/cometbft/apps/roothash/timeout.go
@@ -16,7 +16,7 @@ const (
 	backupWorkerTimeoutFactorDenominator = 10
 )
 
-func (app *rootHashApplication) processRoundTimeouts(ctx *tmapi.Context) error {
+func (app *Application) processRoundTimeouts(ctx *tmapi.Context) error {
 	state := roothashState.NewMutableState(ctx.State())
 
 	roundTimeouts, err := state.RuntimesWithRoundTimeouts(ctx, ctx.BlockHeight()+1) // Current height is ctx.BlockHeight() + 1
@@ -33,7 +33,7 @@ func (app *rootHashApplication) processRoundTimeouts(ctx *tmapi.Context) error {
 	return nil
 }
 
-func (app *rootHashApplication) processRoundTimeout(ctx *tmapi.Context, runtimeID common.Namespace) error {
+func (app *Application) processRoundTimeout(ctx *tmapi.Context, runtimeID common.Namespace) error {
 	ctx.Logger().Warn("round timeout expired, forcing finalization",
 		"runtime_id", runtimeID,
 		logging.LogEvent, roothash.LogEventTimerFired,

--- a/go/consensus/cometbft/apps/roothash/transactions.go
+++ b/go/consensus/cometbft/apps/roothash/transactions.go
@@ -18,7 +18,7 @@ import (
 
 // getRuntimeState fetches the current runtime state and performs common
 // processing and error handling.
-func (app *rootHashApplication) getRuntimeState(
+func (app *Application) getRuntimeState(
 	ctx *abciAPI.Context,
 	state *roothashState.MutableState,
 	id common.Namespace,
@@ -41,7 +41,7 @@ func (app *rootHashApplication) getRuntimeState(
 	return rtState, nil
 }
 
-func (app *rootHashApplication) executorCommit(
+func (app *Application) executorCommit(
 	ctx *abciAPI.Context,
 	state *roothashState.MutableState,
 	cc *roothash.ExecutorCommit,
@@ -173,7 +173,7 @@ func (app *rootHashApplication) executorCommit(
 	return nil
 }
 
-func (app *rootHashApplication) submitEvidence(
+func (app *Application) submitEvidence(
 	ctx *abciAPI.Context,
 	state *roothashState.MutableState,
 	evidence *roothash.Evidence,
@@ -292,7 +292,7 @@ func (app *rootHashApplication) submitEvidence(
 	return nil
 }
 
-func (app *rootHashApplication) submitMsg(
+func (app *Application) submitMsg(
 	ctx *abciAPI.Context,
 	state *roothashState.MutableState,
 	msg *roothash.SubmitMsg,

--- a/go/consensus/cometbft/apps/roothash/transactions_test.go
+++ b/go/consensus/cometbft/apps/roothash/transactions_test.go
@@ -129,7 +129,7 @@ func TestMessagesGasEstimation(t *testing.T) {
 
 	// Create a test message dispatcher that fakes gas estimation.
 	var md testMsgDispatcher
-	app := rootHashApplication{appState, &md, nil}
+	app := Application{appState, &md, nil}
 
 	// Generate a private key for the single node in this test.
 	sk, err := memorySigner.NewSigner(rand.Reader)
@@ -487,7 +487,7 @@ func TestEvidence(t *testing.T) {
 	err = expiredCommitment2.Sign(sk, runtime.ID)
 	require.NoError(err, "expiredCommitment2.Sign")
 	var md testMsgDispatcher
-	app := rootHashApplication{appState, &md, nil}
+	app := Application{appState, &md, nil}
 
 	ctx = appState.NewContext(abciAPI.ContextDeliverTx)
 	defer ctx.Close()
@@ -638,7 +638,7 @@ func TestSubmitMsg(t *testing.T) {
 	defer ctx.Close()
 
 	var md testMsgDispatcher
-	app := rootHashApplication{appState, &md, nil}
+	app := Application{appState, &md, nil}
 
 	// Generate a private key for the caller.
 	skCaller, err := memorySigner.NewSigner(rand.Reader)

--- a/go/consensus/cometbft/apps/scheduler/debug_force.go
+++ b/go/consensus/cometbft/apps/scheduler/debug_force.go
@@ -17,7 +17,7 @@ type debugForceElectState struct {
 	elected map[signature.PublicKey]bool
 }
 
-func (app *schedulerApplication) debugForceElect(
+func (app *Application) debugForceElect(
 	ctx *api.Context,
 	schedulerParameters *scheduler.ConsensusParameters,
 	rt *registry.Runtime,
@@ -95,7 +95,7 @@ forceLoop:
 	return true, elected, state
 }
 
-func (app *schedulerApplication) debugForceRoles(
+func (app *Application) debugForceRoles(
 	ctx *api.Context,
 	state *debugForceElectState,
 	elected []*scheduler.CommitteeNode,

--- a/go/consensus/cometbft/apps/scheduler/genesis.go
+++ b/go/consensus/cometbft/apps/scheduler/genesis.go
@@ -19,7 +19,7 @@ import (
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
-func (app *schedulerApplication) InitChain(ctx *abciAPI.Context, req types.RequestInitChain, doc *genesis.Document) error {
+func (app *Application) InitChain(ctx *abciAPI.Context, req types.RequestInitChain, doc *genesis.Document) error {
 	var err error
 	state := schedulerState.NewMutableState(ctx.State())
 	if err = state.SetConsensusParameters(ctx, &doc.Scheduler.Parameters); err != nil {

--- a/go/consensus/cometbft/apps/scheduler/messages.go
+++ b/go/consensus/cometbft/apps/scheduler/messages.go
@@ -10,7 +10,7 @@ import (
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 )
 
-func (app *schedulerApplication) changeParameters(ctx *api.Context, msg any, apply bool) (any, error) {
+func (app *Application) changeParameters(ctx *api.Context, msg any, apply bool) (any, error) {
 	// Unmarshal changes and check if they should be applied to this module.
 	proposal, ok := msg.(*governance.ChangeParametersProposal)
 	if !ok {

--- a/go/consensus/cometbft/apps/scheduler/messages_test.go
+++ b/go/consensus/cometbft/apps/scheduler/messages_test.go
@@ -20,7 +20,7 @@ func TestChangeParameters(t *testing.T) {
 
 	// Setup state.
 	state := schedulerState.NewMutableState(ctx.State())
-	app := &schedulerApplication{
+	app := &Application{
 		state: appState,
 	}
 	params := &scheduler.ConsensusParameters{

--- a/go/consensus/cometbft/apps/scheduler/query.go
+++ b/go/consensus/cometbft/apps/scheduler/query.go
@@ -23,20 +23,22 @@ type QueryFactory struct {
 }
 
 // QueryAt returns the scheduler query interface for a specific height.
-func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := schedulerState.NewImmutableStateAt(ctx, sf.state, height)
+func (f *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
+	state, err := abciAPI.NewImmutableStateAt(ctx, f.state, height)
 	if err != nil {
 		return nil, err
 	}
-	return &schedulerQuerier{state}, nil
+	return &schedulerQuerier{
+		state: schedulerState.NewImmutableState(state),
+	}, nil
 }
 
 type schedulerQuerier struct {
 	state *schedulerState.ImmutableState
 }
 
-func (sq *schedulerQuerier) Validators(ctx context.Context) ([]*scheduler.Validator, error) {
-	vals, err := sq.state.CurrentValidators(ctx)
+func (q *schedulerQuerier) Validators(ctx context.Context) ([]*scheduler.Validator, error) {
+	vals, err := q.state.CurrentValidators(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -49,16 +51,16 @@ func (sq *schedulerQuerier) Validators(ctx context.Context) ([]*scheduler.Valida
 	return ret, nil
 }
 
-func (sq *schedulerQuerier) AllCommittees(ctx context.Context) ([]*scheduler.Committee, error) {
-	return sq.state.AllCommittees(ctx)
+func (q *schedulerQuerier) AllCommittees(ctx context.Context) ([]*scheduler.Committee, error) {
+	return q.state.AllCommittees(ctx)
 }
 
-func (sq *schedulerQuerier) KindsCommittees(ctx context.Context, kinds []scheduler.CommitteeKind) ([]*scheduler.Committee, error) {
-	return sq.state.KindsCommittees(ctx, kinds)
+func (q *schedulerQuerier) KindsCommittees(ctx context.Context, kinds []scheduler.CommitteeKind) ([]*scheduler.Committee, error) {
+	return q.state.KindsCommittees(ctx, kinds)
 }
 
-func (sq *schedulerQuerier) ConsensusParameters(ctx context.Context) (*scheduler.ConsensusParameters, error) {
-	return sq.state.ConsensusParameters(ctx)
+func (q *schedulerQuerier) ConsensusParameters(ctx context.Context) (*scheduler.ConsensusParameters, error) {
+	return q.state.ConsensusParameters(ctx)
 }
 
 func (app *schedulerApplication) QueryFactory() any {

--- a/go/consensus/cometbft/apps/scheduler/query.go
+++ b/go/consensus/cometbft/apps/scheduler/query.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
-	registryState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/registry/state"
 	schedulerState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/scheduler/state"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 )
@@ -29,19 +28,11 @@ func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error
 	if err != nil {
 		return nil, err
 	}
-
-	// Some queries need access to the registry to give useful responses.
-	regState, err := registryState.NewImmutableStateAt(ctx, sf.state, height)
-	if err != nil {
-		return nil, err
-	}
-
-	return &schedulerQuerier{state, regState}, nil
+	return &schedulerQuerier{state}, nil
 }
 
 type schedulerQuerier struct {
-	state    *schedulerState.ImmutableState
-	regState *registryState.ImmutableState
+	state *schedulerState.ImmutableState
 }
 
 func (sq *schedulerQuerier) Validators(ctx context.Context) ([]*scheduler.Validator, error) {

--- a/go/consensus/cometbft/apps/scheduler/query.go
+++ b/go/consensus/cometbft/apps/scheduler/query.go
@@ -63,7 +63,7 @@ func (q *schedulerQuerier) ConsensusParameters(ctx context.Context) (*scheduler.
 	return q.state.ConsensusParameters(ctx)
 }
 
-func (app *schedulerApplication) QueryFactory() any {
+func (app *Application) QueryFactory() any {
 	return &QueryFactory{app.state}
 }
 

--- a/go/consensus/cometbft/apps/scheduler/scheduler_test.go
+++ b/go/consensus/cometbft/apps/scheduler/scheduler_test.go
@@ -90,7 +90,7 @@ func TestElectCommittee(t *testing.T) {
 	ctx := appState.NewContext(api.ContextBeginBlock)
 	defer ctx.Close()
 
-	app := &schedulerApplication{
+	app := &Application{
 		state: appState,
 	}
 

--- a/go/consensus/cometbft/apps/scheduler/shuffle.go
+++ b/go/consensus/cometbft/apps/scheduler/shuffle.go
@@ -146,7 +146,7 @@ func shuffleValidatorsByEntropy(
 	return shuffled, nil
 }
 
-func (app *schedulerApplication) electCommittee( //nolint: gocyclo
+func (app *Application) electCommittee( //nolint: gocyclo
 	ctx *api.Context,
 	schedulerParameters *scheduler.ConsensusParameters,
 	beaconState *beaconState.MutableState,

--- a/go/consensus/cometbft/apps/scheduler/state/state.go
+++ b/go/consensus/cometbft/apps/scheduler/state/state.go
@@ -47,17 +47,6 @@ func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	}
 }
 
-// NewImmutableStateAt creates a new immutable scheduler state wrapper
-// using the provided application query state and version.
-func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := abciAPI.NewImmutableStateAt(ctx, state, version)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ImmutableState{is}, nil
-}
-
 // Committee returns a specific elected committee.
 func (s *ImmutableState) Committee(ctx context.Context, kind api.CommitteeKind, runtimeID common.Namespace) (*api.Committee, error) {
 	raw, err := s.state.Get(ctx, committeeKeyFmt.Encode(uint8(kind), &runtimeID))

--- a/go/consensus/cometbft/apps/staking/auth.go
+++ b/go/consensus/cometbft/apps/staking/auth.go
@@ -9,15 +9,15 @@ import (
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
-var _ api.TransactionAuthHandler = (*stakingApplication)(nil)
+var _ api.TransactionAuthHandler = (*Application)(nil)
 
 // Implements api.TransactionAuthHandler.
-func (app *stakingApplication) AuthenticateTx(ctx *api.Context, tx *transaction.Transaction) error {
+func (app *Application) AuthenticateTx(ctx *api.Context, tx *transaction.Transaction) error {
 	return stakingState.AuthenticateAndPayFees(ctx, ctx.TxSigner(), tx.Nonce, tx.Fee)
 }
 
 // Implements api.TransactionAuthHandler.
-func (app *stakingApplication) PostExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {
+func (app *Application) PostExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {
 	if !ctx.IsCheckOnly() {
 		// Do not do anything outside CheckTx.
 		return nil

--- a/go/consensus/cometbft/apps/staking/auth.go
+++ b/go/consensus/cometbft/apps/staking/auth.go
@@ -11,12 +11,12 @@ import (
 
 var _ api.TransactionAuthHandler = (*Application)(nil)
 
-// Implements api.TransactionAuthHandler.
+// AuthenticateTx implements api.TransactionAuthHandler.
 func (app *Application) AuthenticateTx(ctx *api.Context, tx *transaction.Transaction) error {
 	return stakingState.AuthenticateAndPayFees(ctx, ctx.TxSigner(), tx.Nonce, tx.Fee)
 }
 
-// Implements api.TransactionAuthHandler.
+// PostExecuteTx implements api.TransactionAuthHandler.
 func (app *Application) PostExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {
 	if !ctx.IsCheckOnly() {
 		// Do not do anything outside CheckTx.

--- a/go/consensus/cometbft/apps/staking/fees.go
+++ b/go/consensus/cometbft/apps/staking/fees.go
@@ -13,7 +13,7 @@ import (
 // disburseFeesP disburses fees to the proposer and persists the voters' and next proposer's shares of the fees.
 //
 // In case of errors the state may be inconsistent.
-func (app *stakingApplication) disburseFeesP(
+func (app *Application) disburseFeesP(
 	ctx *abciAPI.Context,
 	stakeState *stakingState.MutableState,
 	proposerEntity *signature.PublicKey,
@@ -111,7 +111,7 @@ func (app *stakingApplication) disburseFeesP(
 // disburseFeesVQ disburses persisted fees to the voters and next proposer.
 //
 // In case of errors the state may be inconsistent.
-func (app *stakingApplication) disburseFeesVQ(
+func (app *Application) disburseFeesVQ(
 	ctx *abciAPI.Context,
 	stakeState *stakingState.MutableState,
 	proposerEntity *signature.PublicKey,

--- a/go/consensus/cometbft/apps/staking/genesis.go
+++ b/go/consensus/cometbft/apps/staking/genesis.go
@@ -13,7 +13,7 @@ import (
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
-func (app *stakingApplication) initParameters(ctx *abciAPI.Context, state *stakingState.MutableState, st *staking.Genesis) error {
+func (app *Application) initParameters(ctx *abciAPI.Context, state *stakingState.MutableState, st *staking.Genesis) error {
 	if err := st.Parameters.SanityCheck(); err != nil {
 		return fmt.Errorf("cometbft/staking: sanity check failed: %w", err)
 	}
@@ -24,7 +24,7 @@ func (app *stakingApplication) initParameters(ctx *abciAPI.Context, state *staki
 	return nil
 }
 
-func (app *stakingApplication) initCommonPool(ctx *abciAPI.Context, st *staking.Genesis, totalSupply *quantity.Quantity) error {
+func (app *Application) initCommonPool(ctx *abciAPI.Context, st *staking.Genesis, totalSupply *quantity.Quantity) error {
 	if !st.CommonPool.IsValid() {
 		return fmt.Errorf("cometbft/staking: invalid genesis state CommonPool")
 	}
@@ -38,7 +38,7 @@ func (app *stakingApplication) initCommonPool(ctx *abciAPI.Context, st *staking.
 	return nil
 }
 
-func (app *stakingApplication) initLastBlockFees(ctx *abciAPI.Context, st *staking.Genesis, totalSupply *quantity.Quantity) error {
+func (app *Application) initLastBlockFees(ctx *abciAPI.Context, st *staking.Genesis, totalSupply *quantity.Quantity) error {
 	if !st.LastBlockFees.IsValid() {
 		return fmt.Errorf("cometbft/staking: invalid genesis state LastBlockFees")
 	}
@@ -63,7 +63,7 @@ func (app *stakingApplication) initLastBlockFees(ctx *abciAPI.Context, st *staki
 	return nil
 }
 
-func (app *stakingApplication) initGovernanceDeposits(ctx *abciAPI.Context, state *stakingState.MutableState, st *staking.Genesis, totalSupply *quantity.Quantity) error {
+func (app *Application) initGovernanceDeposits(ctx *abciAPI.Context, state *stakingState.MutableState, st *staking.Genesis, totalSupply *quantity.Quantity) error {
 	if !st.GovernanceDeposits.IsValid() {
 		return fmt.Errorf("cometbft/staking: invalid genesis state GovernanceDeposits")
 	}
@@ -80,7 +80,7 @@ func (app *stakingApplication) initGovernanceDeposits(ctx *abciAPI.Context, stat
 	return nil
 }
 
-func (app *stakingApplication) initLedger(
+func (app *Application) initLedger(
 	ctx *abciAPI.Context,
 	state *stakingState.MutableState,
 	st *staking.Genesis,
@@ -150,7 +150,7 @@ func (app *stakingApplication) initLedger(
 	return nil
 }
 
-func (app *stakingApplication) initTotalSupply(
+func (app *Application) initTotalSupply(
 	ctx *abciAPI.Context,
 	state *stakingState.MutableState,
 	st *staking.Genesis,
@@ -174,7 +174,7 @@ func (app *stakingApplication) initTotalSupply(
 	return nil
 }
 
-func (app *stakingApplication) initDelegations(ctx *abciAPI.Context, state *stakingState.MutableState, st *staking.Genesis) error {
+func (app *Application) initDelegations(ctx *abciAPI.Context, state *stakingState.MutableState, st *staking.Genesis) error {
 	for escrowAddr, delegations := range st.Delegations {
 		if !escrowAddr.IsValid() {
 			return fmt.Errorf("cometbft/staking: failed to set genesis delegations to %s: address is invalid",
@@ -227,7 +227,7 @@ func (app *stakingApplication) initDelegations(ctx *abciAPI.Context, state *stak
 	return nil
 }
 
-func (app *stakingApplication) initDebondingDelegations(ctx *abciAPI.Context, state *stakingState.MutableState, st *staking.Genesis) error {
+func (app *Application) initDebondingDelegations(ctx *abciAPI.Context, state *stakingState.MutableState, st *staking.Genesis) error {
 	for escrowAddr, delegators := range st.DebondingDelegations {
 		if !escrowAddr.IsValid() {
 			return fmt.Errorf("cometbft/staking: failed to set genesis debonding delegations to %s: address is invalid",
@@ -286,7 +286,7 @@ func (app *stakingApplication) initDebondingDelegations(ctx *abciAPI.Context, st
 }
 
 // InitChain initializes the chain from genesis.
-func (app *stakingApplication) InitChain(ctx *abciAPI.Context, _ types.RequestInitChain, doc *genesis.Document) error {
+func (app *Application) InitChain(ctx *abciAPI.Context, _ types.RequestInitChain, doc *genesis.Document) error {
 	st := &doc.Staking
 
 	var (

--- a/go/consensus/cometbft/apps/staking/messages.go
+++ b/go/consensus/cometbft/apps/staking/messages.go
@@ -11,7 +11,7 @@ import (
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
-func (app *stakingApplication) changeParameters(ctx *api.Context, msg any, apply bool) (any, error) {
+func (app *Application) changeParameters(ctx *api.Context, msg any, apply bool) (any, error) {
 	proposal, ok := msg.(*governance.ChangeParametersProposal)
 	if !ok {
 		return nil, fmt.Errorf("staking: failed to type assert change parameters proposal")

--- a/go/consensus/cometbft/apps/staking/messages_test.go
+++ b/go/consensus/cometbft/apps/staking/messages_test.go
@@ -21,7 +21,7 @@ func TestChangeParameters(t *testing.T) {
 
 	// Setup state.
 	state := stakingState.NewMutableState(ctx.State())
-	app := &stakingApplication{
+	app := &Application{
 		state: appState,
 	}
 	params := &staking.ConsensusParameters{

--- a/go/consensus/cometbft/apps/staking/proposing_rewards.go
+++ b/go/consensus/cometbft/apps/staking/proposing_rewards.go
@@ -13,7 +13,7 @@ import (
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
-func (app *stakingApplication) resolveEntityIDFromProposer(
+func (app *Application) resolveEntityIDFromProposer(
 	ctx *abciAPI.Context,
 	regState *registryState.MutableState,
 ) (*signature.PublicKey, error) {
@@ -33,7 +33,7 @@ func (app *stakingApplication) resolveEntityIDFromProposer(
 	return &proposerNode.EntityID, nil
 }
 
-func (app *stakingApplication) rewardBlockProposing(
+func (app *Application) rewardBlockProposing(
 	ctx *abciAPI.Context,
 	stakeState *stakingState.MutableState,
 	proposingEntity *signature.PublicKey,

--- a/go/consensus/cometbft/apps/staking/query.go
+++ b/go/consensus/cometbft/apps/staking/query.go
@@ -192,7 +192,7 @@ func (q *stakingQuerier) ConsensusParameters(ctx context.Context) (*staking.Cons
 	return q.state.ConsensusParameters(ctx)
 }
 
-func (app *stakingApplication) QueryFactory() any {
+func (app *Application) QueryFactory() any {
 	return &QueryFactory{app.state}
 }
 

--- a/go/consensus/cometbft/apps/staking/signing_rewards.go
+++ b/go/consensus/cometbft/apps/staking/signing_rewards.go
@@ -10,7 +10,7 @@ import (
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
-func (app *stakingApplication) updateEpochSigning(
+func (app *Application) updateEpochSigning(
 	ctx *abciAPI.Context,
 	stakeState *stakingState.MutableState,
 	signingEntities []signature.PublicKey,
@@ -31,7 +31,7 @@ func (app *stakingApplication) updateEpochSigning(
 	return nil
 }
 
-func (app *stakingApplication) rewardEpochSigning(ctx *abciAPI.Context, time beacon.EpochTime) error {
+func (app *Application) rewardEpochSigning(ctx *abciAPI.Context, time beacon.EpochTime) error {
 	stakeState := stakingState.NewMutableState(ctx.State())
 
 	params, err := stakeState.ConsensusParameters(ctx)

--- a/go/consensus/cometbft/apps/staking/staking.go
+++ b/go/consensus/cometbft/apps/staking/staking.go
@@ -19,34 +19,32 @@ import (
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
-var _ api.Application = (*stakingApplication)(nil)
-
-type stakingApplication struct {
+type Application struct {
 	state api.ApplicationState
 	md    api.MessageDispatcher
 }
 
-func (app *stakingApplication) Name() string {
+func (app *Application) Name() string {
 	return AppName
 }
 
-func (app *stakingApplication) ID() uint8 {
+func (app *Application) ID() uint8 {
 	return AppID
 }
 
-func (app *stakingApplication) Methods() []transaction.MethodName {
+func (app *Application) Methods() []transaction.MethodName {
 	return staking.Methods
 }
 
-func (app *stakingApplication) Blessed() bool {
+func (app *Application) Blessed() bool {
 	return false
 }
 
-func (app *stakingApplication) Dependencies() []string {
+func (app *Application) Dependencies() []string {
 	return nil
 }
 
-func (app *stakingApplication) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
+func (app *Application) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
 	app.state = state
 	app.md = md
 
@@ -56,10 +54,10 @@ func (app *stakingApplication) OnRegister(state api.ApplicationState, md api.Mes
 	md.Subscribe(governanceApi.MessageValidateParameterChanges, app)
 }
 
-func (app *stakingApplication) OnCleanup() {
+func (app *Application) OnCleanup() {
 }
 
-func (app *stakingApplication) BeginBlock(ctx *api.Context) error {
+func (app *Application) BeginBlock(ctx *api.Context) error {
 	regState := registryState.NewMutableState(ctx.State())
 	stakeState := stakingState.NewMutableState(ctx.State())
 
@@ -121,7 +119,7 @@ func (app *stakingApplication) BeginBlock(ctx *api.Context) error {
 	return nil
 }
 
-func (app *stakingApplication) ExecuteMessage(ctx *api.Context, kind, msg any) (any, error) {
+func (app *Application) ExecuteMessage(ctx *api.Context, kind, msg any) (any, error) {
 	switch kind {
 	case roothashApi.RuntimeMessageStaking:
 		state := stakingState.NewMutableState(ctx.State())
@@ -150,7 +148,7 @@ func (app *stakingApplication) ExecuteMessage(ctx *api.Context, kind, msg any) (
 	}
 }
 
-func (app *stakingApplication) ExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {
+func (app *Application) ExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {
 	state := stakingState.NewMutableState(ctx.State())
 
 	ctx.SetPriority(AppPriority)
@@ -214,7 +212,7 @@ func (app *stakingApplication) ExecuteTx(ctx *api.Context, tx *transaction.Trans
 	}
 }
 
-func (app *stakingApplication) EndBlock(ctx *api.Context) (types.ResponseEndBlock, error) {
+func (app *Application) EndBlock(ctx *api.Context) (types.ResponseEndBlock, error) {
 	fees := stakingState.BlockFees(ctx)
 	if err := app.disburseFeesP(ctx, stakingState.NewMutableState(ctx.State()), stakingState.BlockProposer(ctx), &fees); err != nil {
 		return types.ResponseEndBlock{}, fmt.Errorf("disburse fees proposer: %w", err)
@@ -226,7 +224,7 @@ func (app *stakingApplication) EndBlock(ctx *api.Context) (types.ResponseEndBloc
 	return types.ResponseEndBlock{}, nil
 }
 
-func (app *stakingApplication) onEpochChange(ctx *api.Context, epoch beacon.EpochTime) error {
+func (app *Application) onEpochChange(ctx *api.Context, epoch beacon.EpochTime) error {
 	state := stakingState.NewMutableState(ctx.State())
 
 	// Delegation unbonding after debonding period elapses.
@@ -319,6 +317,6 @@ func (app *stakingApplication) onEpochChange(ctx *api.Context, epoch beacon.Epoc
 }
 
 // New constructs a new staking application instance.
-func New() api.Application {
-	return &stakingApplication{}
+func New() *Application {
+	return &Application{}
 }

--- a/go/consensus/cometbft/apps/staking/state/state.go
+++ b/go/consensus/cometbft/apps/staking/state/state.go
@@ -96,17 +96,6 @@ func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	}
 }
 
-// NewImmutableStateAt creates a new immutable staking state wrapper
-// using the provided application query state and version.
-func NewImmutableStateAt(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := abciAPI.NewImmutableStateAt(ctx, state, version)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ImmutableState{is}, nil
-}
-
 func (s *ImmutableState) loadStoredBalance(ctx context.Context, key *keyformat.KeyFormat) (*quantity.Quantity, error) {
 	value, err := s.state.Get(ctx, key.Encode())
 	if err != nil {

--- a/go/consensus/cometbft/apps/staking/transactions.go
+++ b/go/consensus/cometbft/apps/staking/transactions.go
@@ -22,7 +22,7 @@ func isTransferPermitted(params *staking.ConsensusParameters, fromAddr staking.A
 	return
 }
 
-func (app *stakingApplication) transfer(ctx *api.Context, state *stakingState.MutableState, xfer *staking.Transfer) (*staking.TransferResult, error) {
+func (app *Application) transfer(ctx *api.Context, state *stakingState.MutableState, xfer *staking.Transfer) (*staking.TransferResult, error) {
 	if ctx.IsCheckOnly() {
 		return nil, nil
 	}
@@ -74,7 +74,7 @@ func (app *stakingApplication) transfer(ctx *api.Context, state *stakingState.Mu
 	}, nil
 }
 
-func (app *stakingApplication) transferImpl(
+func (app *Application) transferImpl(
 	ctx *api.Context,
 	state *stakingState.MutableState,
 	params *staking.ConsensusParameters,
@@ -160,7 +160,7 @@ func (app *stakingApplication) transferImpl(
 	return nil
 }
 
-func (app *stakingApplication) burn(ctx *api.Context, state *stakingState.MutableState, burn *staking.Burn) error {
+func (app *Application) burn(ctx *api.Context, state *stakingState.MutableState, burn *staking.Burn) error {
 	if ctx.IsCheckOnly() {
 		return nil
 	}
@@ -187,7 +187,7 @@ func (app *stakingApplication) burn(ctx *api.Context, state *stakingState.Mutabl
 	return app.burnImpl(ctx, state, params, fromAddr, &burn.Amount)
 }
 
-func (app *stakingApplication) burnImpl(
+func (app *Application) burnImpl(
 	ctx *api.Context,
 	state *stakingState.MutableState,
 	params *staking.ConsensusParameters,
@@ -255,7 +255,7 @@ func (app *stakingApplication) burnImpl(
 	return nil
 }
 
-func (app *stakingApplication) addEscrow(ctx *api.Context, state *stakingState.MutableState, escrow *staking.Escrow) (*staking.AddEscrowResult, error) {
+func (app *Application) addEscrow(ctx *api.Context, state *stakingState.MutableState, escrow *staking.Escrow) (*staking.AddEscrowResult, error) {
 	if ctx.IsCheckOnly() {
 		return nil, nil
 	}
@@ -374,7 +374,7 @@ func (app *stakingApplication) addEscrow(ctx *api.Context, state *stakingState.M
 	}, nil
 }
 
-func (app *stakingApplication) reclaimEscrow(ctx *api.Context, state *stakingState.MutableState, reclaim *staking.ReclaimEscrow) (*staking.ReclaimEscrowResult, error) {
+func (app *Application) reclaimEscrow(ctx *api.Context, state *stakingState.MutableState, reclaim *staking.ReclaimEscrow) (*staking.ReclaimEscrowResult, error) {
 	// No sense if there is nothing to reclaim.
 	if reclaim.Shares.IsZero() {
 		return nil, staking.ErrInvalidArgument
@@ -531,7 +531,7 @@ func (app *stakingApplication) reclaimEscrow(ctx *api.Context, state *stakingSta
 	}, nil
 }
 
-func (app *stakingApplication) amendCommissionSchedule(
+func (app *Application) amendCommissionSchedule(
 	ctx *api.Context,
 	state *stakingState.MutableState,
 	amendCommissionSchedule *staking.AmendCommissionSchedule,
@@ -601,7 +601,7 @@ func (app *stakingApplication) amendCommissionSchedule(
 	return nil
 }
 
-func (app *stakingApplication) allow(
+func (app *Application) allow(
 	ctx *api.Context,
 	state *stakingState.MutableState,
 	allow *staking.Allow,
@@ -699,7 +699,7 @@ func (app *stakingApplication) allow(
 	return nil
 }
 
-func (app *stakingApplication) withdraw(
+func (app *Application) withdraw(
 	ctx *api.Context,
 	state *stakingState.MutableState,
 	withdraw *staking.Withdraw,

--- a/go/consensus/cometbft/apps/staking/transactions_test.go
+++ b/go/consensus/cometbft/apps/staking/transactions_test.go
@@ -76,7 +76,7 @@ func TestReservedAddresses(t *testing.T) {
 	})
 	require.NoError(err, "setting staking consensus parameters should not error")
 
-	app := &stakingApplication{
+	app := &Application{
 		state: appState,
 	}
 
@@ -130,7 +130,7 @@ func TestAllow(t *testing.T) {
 
 	stakeState := stakingState.NewMutableState(ctx.State())
 
-	app := &stakingApplication{
+	app := &Application{
 		state: appState,
 	}
 
@@ -322,7 +322,7 @@ func TestWithdraw(t *testing.T) {
 
 	stakeState := stakingState.NewMutableState(ctx.State())
 
-	app := &stakingApplication{
+	app := &Application{
 		state: appState,
 	}
 
@@ -638,7 +638,7 @@ func TestAddEscrow(t *testing.T) {
 
 	stakeState := stakingState.NewMutableState(ctx.State())
 
-	app := &stakingApplication{
+	app := &Application{
 		state: appState,
 	}
 
@@ -772,7 +772,7 @@ func TestAllowEscrowMessages(t *testing.T) {
 	defer ctx.Close()
 
 	stakeState := stakingState.NewMutableState(ctx.State())
-	app := &stakingApplication{
+	app := &Application{
 		state: appState,
 	}
 	err = stakeState.SetConsensusParameters(ctx, &staking.ConsensusParameters{
@@ -864,7 +864,7 @@ func TestTransfer(t *testing.T) {
 
 	stakeState := stakingState.NewMutableState(ctx.State())
 
-	app := &stakingApplication{
+	app := &Application{
 		state: appState,
 	}
 
@@ -976,7 +976,7 @@ func TestBurn(t *testing.T) {
 
 	stakeState := stakingState.NewMutableState(ctx.State())
 
-	app := &stakingApplication{
+	app := &Application{
 		state: appState,
 	}
 
@@ -1075,7 +1075,7 @@ func TestAmendCommissionSchedule(t *testing.T) {
 	})
 	require.NoError(err, "setting staking consensus parameters should not error")
 
-	app := &stakingApplication{
+	app := &Application{
 		state: appState,
 	}
 

--- a/go/consensus/cometbft/apps/staking/votes.go
+++ b/go/consensus/cometbft/apps/staking/votes.go
@@ -11,7 +11,7 @@ import (
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 )
 
-func (app *stakingApplication) resolveEntityIDsFromVotes(
+func (app *Application) resolveEntityIDsFromVotes(
 	ctx *abciAPI.Context,
 	regState *registryState.MutableState,
 	lastCommitInfo types.CommitInfo,

--- a/go/consensus/cometbft/apps/supplementarysanity/supplementarysanity.go
+++ b/go/consensus/cometbft/apps/supplementarysanity/supplementarysanity.go
@@ -17,72 +17,72 @@ import (
 var (
 	logger = logging.GetLogger("supplementarysanity")
 
-	_ api.Application = (*supplementarySanityApplication)(nil)
+	_ api.Application = (*Application)(nil)
 )
 
-// supplementarySanityApplication is a non-normative mux app that performs additional checks on the consensus state.
+// Application is a non-normative mux app that performs additional checks on the consensus state.
 // It should not alter the CometBFT application state.
 // It's okay for it to have this additional local state, because it won't affect anything that needs to be agreed upon
 // in consensus.
-type supplementarySanityApplication struct {
+type Application struct {
 	state           api.ApplicationState
 	interval        int64
 	currentInterval int64
 	checkHeight     int64
 }
 
-func (app *supplementarySanityApplication) Name() string {
+func (app *Application) Name() string {
 	return AppName
 }
 
-func (app *supplementarySanityApplication) ID() uint8 {
+func (app *Application) ID() uint8 {
 	return AppID
 }
 
-func (app *supplementarySanityApplication) Methods() []transaction.MethodName {
+func (app *Application) Methods() []transaction.MethodName {
 	return nil
 }
 
-func (app *supplementarySanityApplication) Blessed() bool {
+func (app *Application) Blessed() bool {
 	return false
 }
 
-func (app *supplementarySanityApplication) Dependencies() []string {
+func (app *Application) Dependencies() []string {
 	return []string{stakingState.AppName}
 }
 
-func (app *supplementarySanityApplication) QueryFactory() any {
+func (app *Application) QueryFactory() any {
 	return nil
 }
 
-func (app *supplementarySanityApplication) OnRegister(state api.ApplicationState, _ api.MessageDispatcher) {
+func (app *Application) OnRegister(state api.ApplicationState, _ api.MessageDispatcher) {
 	app.state = state
 }
 
-func (app *supplementarySanityApplication) OnCleanup() {
+func (app *Application) OnCleanup() {
 }
 
-func (app *supplementarySanityApplication) ExecuteMessage(*api.Context, any, any) (any, error) {
+func (app *Application) ExecuteMessage(*api.Context, any, any) (any, error) {
 	return nil, fmt.Errorf("supplementarysanity: unexpected message")
 }
 
-func (app *supplementarySanityApplication) ExecuteTx(*api.Context, *transaction.Transaction) error {
+func (app *Application) ExecuteTx(*api.Context, *transaction.Transaction) error {
 	return fmt.Errorf("supplementarysanity: unexpected transaction")
 }
 
-func (app *supplementarySanityApplication) InitChain(*api.Context, types.RequestInitChain, *genesis.Document) error {
+func (app *Application) InitChain(*api.Context, types.RequestInitChain, *genesis.Document) error {
 	return nil
 }
 
-func (app *supplementarySanityApplication) BeginBlock(*api.Context) error {
+func (app *Application) BeginBlock(*api.Context) error {
 	return nil
 }
 
-func (app *supplementarySanityApplication) EndBlock(ctx *api.Context) (types.ResponseEndBlock, error) {
+func (app *Application) EndBlock(ctx *api.Context) (types.ResponseEndBlock, error) {
 	return types.ResponseEndBlock{}, app.endBlockImpl(ctx)
 }
 
-func (app *supplementarySanityApplication) endBlockImpl(ctx *api.Context) error {
+func (app *Application) endBlockImpl(ctx *api.Context) error {
 	height := ctx.BlockHeight()
 
 	if height == 1 {
@@ -136,8 +136,8 @@ func (app *supplementarySanityApplication) endBlockImpl(ctx *api.Context) error 
 	return nil
 }
 
-func New(interval uint64) api.Application {
-	return &supplementarySanityApplication{
+func New(interval uint64) *Application {
+	return &Application{
 		interval: int64(interval),
 	}
 }

--- a/go/consensus/cometbft/apps/vault/action.go
+++ b/go/consensus/cometbft/apps/vault/action.go
@@ -8,7 +8,7 @@ import (
 
 // executeAction executes a given action in the context of a vault. Assumes the action has already
 // been validated before execution.
-func (app *vaultApplication) executeAction(ctx *api.Context, vlt *vault.Vault, action *vault.Action) error {
+func (app *Application) executeAction(ctx *api.Context, vlt *vault.Vault, action *vault.Action) error {
 	switch {
 	case action.Suspend != nil:
 		// Suspend a vault.

--- a/go/consensus/cometbft/apps/vault/genesis.go
+++ b/go/consensus/cometbft/apps/vault/genesis.go
@@ -53,14 +53,14 @@ func (app *vaultApplication) InitChain(ctx *abciAPI.Context, _ types.RequestInit
 }
 
 // Genesis exports current state in genesis format.
-func (vq *vaultQuerier) Genesis(ctx context.Context) (*vault.Genesis, error) {
-	params, err := vq.state.ConsensusParameters(ctx)
+func (q *vaultQuerier) Genesis(ctx context.Context) (*vault.Genesis, error) {
+	params, err := q.state.ConsensusParameters(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	// Vaults.
-	vaults, err := vq.state.Vaults(ctx)
+	vaults, err := q.state.Vaults(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -70,13 +70,13 @@ func (vq *vaultQuerier) Genesis(ctx context.Context) (*vault.Genesis, error) {
 	states := make(map[staking.Address]map[staking.Address]*vault.AddressState)
 	for _, vlt := range vaults {
 		var actions []*vault.PendingAction
-		actions, err = vq.state.PendingActions(ctx, vlt.Address())
+		actions, err = q.state.PendingActions(ctx, vlt.Address())
 		if err != nil {
 			return nil, err
 		}
 
 		var vaultStates map[staking.Address]*vault.AddressState
-		vaultStates, err := vq.state.AddressStates(ctx, vlt.Address())
+		vaultStates, err := q.state.AddressStates(ctx, vlt.Address())
 		if err != nil {
 			return nil, err
 		}

--- a/go/consensus/cometbft/apps/vault/genesis.go
+++ b/go/consensus/cometbft/apps/vault/genesis.go
@@ -13,7 +13,7 @@ import (
 	vault "github.com/oasisprotocol/oasis-core/go/vault/api"
 )
 
-func (app *vaultApplication) InitChain(ctx *abciAPI.Context, _ types.RequestInitChain, doc *genesis.Document) error {
+func (app *Application) InitChain(ctx *abciAPI.Context, _ types.RequestInitChain, doc *genesis.Document) error {
 	st := doc.Vault
 	if st == nil {
 		return nil

--- a/go/consensus/cometbft/apps/vault/genesis_test.go
+++ b/go/consensus/cometbft/apps/vault/genesis_test.go
@@ -91,7 +91,7 @@ func TestInitChain(t *testing.T) {
 	defer ctx.Close()
 
 	state := vaultState.NewMutableState(ctx.State())
-	app := &vaultApplication{
+	app := &Application{
 		state: appState,
 	}
 

--- a/go/consensus/cometbft/apps/vault/messages.go
+++ b/go/consensus/cometbft/apps/vault/messages.go
@@ -12,7 +12,7 @@ import (
 	vault "github.com/oasisprotocol/oasis-core/go/vault/api"
 )
 
-func (app *vaultApplication) changeParameters(ctx *api.Context, msg any, apply bool) (any, error) {
+func (app *Application) changeParameters(ctx *api.Context, msg any, apply bool) (any, error) {
 	// Unmarshal changes and check if they should be applied to this module.
 	proposal, ok := msg.(*governance.ChangeParametersProposal)
 	if !ok {
@@ -56,7 +56,7 @@ func (app *vaultApplication) changeParameters(ctx *api.Context, msg any, apply b
 }
 
 // invokeAccountHook processes an account hook invocation.
-func (app *vaultApplication) invokeAccountHook(ctx *api.Context, msg any) (any, error) {
+func (app *Application) invokeAccountHook(ctx *api.Context, msg any) (any, error) {
 	ahi, ok := msg.(stakingApi.AccountHookInvocation)
 	if !ok {
 		return nil, nil

--- a/go/consensus/cometbft/apps/vault/query.go
+++ b/go/consensus/cometbft/apps/vault/query.go
@@ -59,7 +59,7 @@ func (q *vaultQuerier) ConsensusParameters(ctx context.Context) (*vault.Consensu
 	return q.state.ConsensusParameters(ctx)
 }
 
-func (app *vaultApplication) QueryFactory() any {
+func (app *Application) QueryFactory() any {
 	return &QueryFactory{app.state}
 }
 

--- a/go/consensus/cometbft/apps/vault/query.go
+++ b/go/consensus/cometbft/apps/vault/query.go
@@ -25,36 +25,38 @@ type QueryFactory struct {
 }
 
 // QueryAt returns the vault query interface for a specific height.
-func (qf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := vaultState.NewImmutableStateAt(ctx, qf.state, height)
+func (f *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
+	state, err := abciAPI.NewImmutableStateAt(ctx, f.state, height)
 	if err != nil {
 		return nil, err
 	}
-	return &vaultQuerier{state}, nil
+	return &vaultQuerier{
+		state: vaultState.NewImmutableState(state),
+	}, nil
 }
 
 type vaultQuerier struct {
 	state *vaultState.ImmutableState
 }
 
-func (vq *vaultQuerier) Vaults(ctx context.Context) ([]*vault.Vault, error) {
-	return vq.state.Vaults(ctx)
+func (q *vaultQuerier) Vaults(ctx context.Context) ([]*vault.Vault, error) {
+	return q.state.Vaults(ctx)
 }
 
-func (vq *vaultQuerier) Vault(ctx context.Context, address staking.Address) (*vault.Vault, error) {
-	return vq.state.Vault(ctx, address)
+func (q *vaultQuerier) Vault(ctx context.Context, address staking.Address) (*vault.Vault, error) {
+	return q.state.Vault(ctx, address)
 }
 
-func (vq *vaultQuerier) AddressState(ctx context.Context, vault staking.Address, address staking.Address) (*vault.AddressState, error) {
-	return vq.state.AddressState(ctx, vault, address)
+func (q *vaultQuerier) AddressState(ctx context.Context, vault staking.Address, address staking.Address) (*vault.AddressState, error) {
+	return q.state.AddressState(ctx, vault, address)
 }
 
-func (vq *vaultQuerier) PendingActions(ctx context.Context, address staking.Address) ([]*vault.PendingAction, error) {
-	return vq.state.PendingActions(ctx, address)
+func (q *vaultQuerier) PendingActions(ctx context.Context, address staking.Address) ([]*vault.PendingAction, error) {
+	return q.state.PendingActions(ctx, address)
 }
 
-func (vq *vaultQuerier) ConsensusParameters(ctx context.Context) (*vault.ConsensusParameters, error) {
-	return vq.state.ConsensusParameters(ctx)
+func (q *vaultQuerier) ConsensusParameters(ctx context.Context) (*vault.ConsensusParameters, error) {
+	return q.state.ConsensusParameters(ctx)
 }
 
 func (app *vaultApplication) QueryFactory() any {

--- a/go/consensus/cometbft/apps/vault/state/state.go
+++ b/go/consensus/cometbft/apps/vault/state/state.go
@@ -46,17 +46,6 @@ func NewImmutableState(tree mkvs.ImmutableKeyValueTree) *ImmutableState {
 	}
 }
 
-// NewImmutableStateAt creates a new immutable vault state wrapper
-// using the provided application query state and version.
-func NewImmutableStateAt(ctx context.Context, state api.ApplicationQueryState, version int64) (*ImmutableState, error) {
-	is, err := api.NewImmutableStateAt(ctx, state, version)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ImmutableState{is}, nil
-}
-
 // Vaults looks up all vaults.
 func (s *ImmutableState) Vaults(ctx context.Context) ([]*vault.Vault, error) {
 	it := s.state.NewIterator(ctx)

--- a/go/consensus/cometbft/apps/vault/transactions.go
+++ b/go/consensus/cometbft/apps/vault/transactions.go
@@ -10,7 +10,7 @@ import (
 	vault "github.com/oasisprotocol/oasis-core/go/vault/api"
 )
 
-func (app *vaultApplication) create(ctx *api.Context, create *vault.Create) error {
+func (app *Application) create(ctx *api.Context, create *vault.Create) error {
 	state := vaultState.NewMutableState(ctx.State())
 	params, err := state.ConsensusParameters(ctx)
 	if err != nil {
@@ -64,7 +64,7 @@ func (app *vaultApplication) create(ctx *api.Context, create *vault.Create) erro
 	return nil
 }
 
-func (app *vaultApplication) authorizeAction(ctx *api.Context, authAction *vault.AuthorizeAction) error {
+func (app *Application) authorizeAction(ctx *api.Context, authAction *vault.AuthorizeAction) error {
 	state := vaultState.NewMutableState(ctx.State())
 	params, err := state.ConsensusParameters(ctx)
 	if err != nil {
@@ -190,7 +190,7 @@ func (app *vaultApplication) authorizeAction(ctx *api.Context, authAction *vault
 	return nil
 }
 
-func (app *vaultApplication) cancelAction(ctx *api.Context, cancelAction *vault.CancelAction) error {
+func (app *Application) cancelAction(ctx *api.Context, cancelAction *vault.CancelAction) error {
 	// Validate arguments.
 	if err := cancelAction.Validate(); err != nil {
 		return fmt.Errorf("%w: %w", vault.ErrInvalidArgument, err)

--- a/go/consensus/cometbft/apps/vault/transactions_test.go
+++ b/go/consensus/cometbft/apps/vault/transactions_test.go
@@ -29,7 +29,7 @@ func TestCreate(t *testing.T) {
 	ctx := appState.NewContext(abciAPI.ContextEndBlock)
 	defer ctx.Close()
 
-	app := &vaultApplication{
+	app := &Application{
 		state: appState,
 	}
 
@@ -222,7 +222,7 @@ func TestAuthorizeCancelAction(t *testing.T) {
 	defer ctx.Close()
 
 	md := &testMsgDispatcher{}
-	app := &vaultApplication{
+	app := &Application{
 		state: appState,
 		md:    md,
 	}

--- a/go/consensus/cometbft/apps/vault/vault.go
+++ b/go/consensus/cometbft/apps/vault/vault.go
@@ -38,7 +38,7 @@ func (app *vaultApplication) Methods() []transaction.MethodName {
 
 // Enabled implements api.TogglableApplication and api.TogglableMessageSubscriber.
 func (app *vaultApplication) Enabled(ctx *api.Context) (bool, error) {
-	state := vaultState.NewMutableState(ctx.State())
+	state := vaultState.NewImmutableState(ctx.State())
 	params, err := state.ConsensusParameters(ctx)
 	if err != nil {
 		return false, err

--- a/go/consensus/cometbft/beacon/beacon.go
+++ b/go/consensus/cometbft/beacon/beacon.go
@@ -31,13 +31,8 @@ var TestSigner = memorySigner.NewTestSigner("oasis-core epochtime mock key seed"
 // epochCacheCapacity is the capacity of the epoch LRU cache.
 const epochCacheCapacity = 128
 
-// ServiceClient is the beacon service client interface.
-type ServiceClient interface {
-	beaconAPI.Backend
-	tmAPI.ServiceClient
-}
-
-type serviceClient struct {
+// ServiceClient is the beacon service client.
+type ServiceClient struct {
 	sync.RWMutex
 	tmAPI.BaseServiceClient
 
@@ -63,7 +58,7 @@ type serviceClient struct {
 	baseBlock int64
 }
 
-func (sc *serviceClient) StateToGenesis(ctx context.Context, height int64) (*beaconAPI.Genesis, error) {
+func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*beaconAPI.Genesis, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -72,7 +67,7 @@ func (sc *serviceClient) StateToGenesis(ctx context.Context, height int64) (*bea
 	return q.Genesis(ctx)
 }
 
-func (sc *serviceClient) ConsensusParameters(ctx context.Context, height int64) (*beaconAPI.ConsensusParameters, error) {
+func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) (*beaconAPI.ConsensusParameters, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, fmt.Errorf("beacon: genesis query failed: %w", err)
@@ -81,11 +76,11 @@ func (sc *serviceClient) ConsensusParameters(ctx context.Context, height int64) 
 	return q.ConsensusParameters(ctx)
 }
 
-func (sc *serviceClient) GetBaseEpoch(context.Context) (beaconAPI.EpochTime, error) {
+func (sc *ServiceClient) GetBaseEpoch(context.Context) (beaconAPI.EpochTime, error) {
 	return sc.baseEpoch, nil
 }
 
-func (sc *serviceClient) GetEpoch(ctx context.Context, height int64) (beaconAPI.EpochTime, error) {
+func (sc *ServiceClient) GetEpoch(ctx context.Context, height int64) (beaconAPI.EpochTime, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return beaconAPI.EpochInvalid, err
@@ -95,7 +90,7 @@ func (sc *serviceClient) GetEpoch(ctx context.Context, height int64) (beaconAPI.
 	return epoch, err
 }
 
-func (sc *serviceClient) GetFutureEpoch(ctx context.Context, height int64) (*beaconAPI.EpochTimeState, error) {
+func (sc *ServiceClient) GetFutureEpoch(ctx context.Context, height int64) (*beaconAPI.EpochTimeState, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -104,7 +99,7 @@ func (sc *serviceClient) GetFutureEpoch(ctx context.Context, height int64) (*bea
 	return q.FutureEpoch(ctx)
 }
 
-func (sc *serviceClient) GetEpochBlock(ctx context.Context, epoch beaconAPI.EpochTime) (int64, error) {
+func (sc *ServiceClient) GetEpochBlock(ctx context.Context, epoch beaconAPI.EpochTime) (int64, error) {
 	now, currentBlk := sc.currentEpochBlock()
 	switch {
 	case epoch == now:
@@ -171,7 +166,7 @@ func (sc *serviceClient) GetEpochBlock(ctx context.Context, epoch beaconAPI.Epoc
 	return 0, fmt.Errorf("failed to find historic epoch")
 }
 
-func (sc *serviceClient) WaitEpoch(ctx context.Context, epoch beaconAPI.EpochTime) error {
+func (sc *ServiceClient) WaitEpoch(ctx context.Context, epoch beaconAPI.EpochTime) error {
 	ch, sub, err := sc.WatchEpochs(ctx)
 	if err != nil {
 		return err
@@ -195,7 +190,7 @@ func (sc *serviceClient) WaitEpoch(ctx context.Context, epoch beaconAPI.EpochTim
 	}
 }
 
-func (sc *serviceClient) WatchEpochs(_ context.Context) (<-chan beaconAPI.EpochTime, pubsub.ClosableSubscription, error) {
+func (sc *ServiceClient) WatchEpochs(_ context.Context) (<-chan beaconAPI.EpochTime, pubsub.ClosableSubscription, error) {
 	typedCh := make(chan beaconAPI.EpochTime)
 	sub := sc.epochNotifier.Subscribe()
 	sub.Unwrap(typedCh)
@@ -203,7 +198,7 @@ func (sc *serviceClient) WatchEpochs(_ context.Context) (<-chan beaconAPI.EpochT
 	return typedCh, sub, nil
 }
 
-func (sc *serviceClient) WatchLatestEpoch(context.Context) (<-chan beaconAPI.EpochTime, pubsub.ClosableSubscription, error) {
+func (sc *ServiceClient) WatchLatestEpoch(context.Context) (<-chan beaconAPI.EpochTime, pubsub.ClosableSubscription, error) {
 	typedCh := make(chan beaconAPI.EpochTime)
 	sub := sc.epochNotifier.SubscribeBuffered(1)
 	sub.Unwrap(typedCh)
@@ -211,7 +206,7 @@ func (sc *serviceClient) WatchLatestEpoch(context.Context) (<-chan beaconAPI.Epo
 	return typedCh, sub, nil
 }
 
-func (sc *serviceClient) GetBeacon(ctx context.Context, height int64) ([]byte, error) {
+func (sc *ServiceClient) GetBeacon(ctx context.Context, height int64) ([]byte, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -220,7 +215,7 @@ func (sc *serviceClient) GetBeacon(ctx context.Context, height int64) ([]byte, e
 	return q.Beacon(ctx)
 }
 
-func (sc *serviceClient) GetVRFState(ctx context.Context, height int64) (*beaconAPI.VRFState, error) {
+func (sc *ServiceClient) GetVRFState(ctx context.Context, height int64) (*beaconAPI.VRFState, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -229,7 +224,7 @@ func (sc *serviceClient) GetVRFState(ctx context.Context, height int64) (*beacon
 	return q.VRFState(ctx)
 }
 
-func (sc *serviceClient) WatchLatestVRFEvent(context.Context) (<-chan *beaconAPI.VRFEvent, *pubsub.Subscription, error) {
+func (sc *ServiceClient) WatchLatestVRFEvent(context.Context) (<-chan *beaconAPI.VRFEvent, *pubsub.Subscription, error) {
 	typedCh := make(chan *beaconAPI.VRFEvent)
 	sub := sc.vrfNotifier.Subscribe()
 	sub.Unwrap(typedCh)
@@ -237,7 +232,7 @@ func (sc *serviceClient) WatchLatestVRFEvent(context.Context) (<-chan *beaconAPI
 	return typedCh, sub, nil
 }
 
-func (sc *serviceClient) SetEpoch(ctx context.Context, epoch beaconAPI.EpochTime) error {
+func (sc *ServiceClient) SetEpoch(ctx context.Context, epoch beaconAPI.EpochTime) error {
 	ch, sub, err := sc.WatchEpochs(ctx)
 	if err != nil {
 		return fmt.Errorf("epochtime: watch epochs failed: %w", err)
@@ -266,11 +261,11 @@ func (sc *serviceClient) SetEpoch(ctx context.Context, epoch beaconAPI.EpochTime
 	}
 }
 
-func (sc *serviceClient) ServiceDescriptor() tmAPI.ServiceDescriptor {
+func (sc *ServiceClient) ServiceDescriptor() tmAPI.ServiceDescriptor {
 	return tmAPI.NewStaticServiceDescriptor("beacon", app.EventType, []cmtpubsub.Query{app.QueryApp})
 }
 
-func (sc *serviceClient) DeliverBlock(ctx context.Context, blk *cmttypes.Block) error {
+func (sc *ServiceClient) DeliverBlock(ctx context.Context, blk *cmttypes.Block) error {
 	if sc.initialNotify {
 		return nil
 	}
@@ -307,7 +302,7 @@ func (sc *serviceClient) DeliverBlock(ctx context.Context, blk *cmttypes.Block) 
 	return nil
 }
 
-func (sc *serviceClient) DeliverEvent(_ context.Context, height int64, _ cmttypes.Tx, ev *cmtabcitypes.Event) error {
+func (sc *ServiceClient) DeliverEvent(_ context.Context, height int64, _ cmttypes.Tx, ev *cmtabcitypes.Event) error {
 	for _, pair := range ev.GetAttributes() {
 		key := pair.GetKey()
 		val := pair.GetValue()
@@ -341,7 +336,7 @@ func (sc *serviceClient) DeliverEvent(_ context.Context, height int64, _ cmttype
 	return nil
 }
 
-func (sc *serviceClient) updateCachedEpoch(height int64, epoch beaconAPI.EpochTime) bool {
+func (sc *ServiceClient) updateCachedEpoch(height int64, epoch beaconAPI.EpochTime) bool {
 	sc.Lock()
 	defer sc.Unlock()
 
@@ -361,7 +356,7 @@ func (sc *serviceClient) updateCachedEpoch(height int64, epoch beaconAPI.EpochTi
 	return false
 }
 
-func (sc *serviceClient) updateCachedVRFEvent(event *beaconAPI.VRFEvent) bool {
+func (sc *ServiceClient) updateCachedVRFEvent(event *beaconAPI.VRFEvent) bool {
 	sc.Lock()
 	defer sc.Unlock()
 
@@ -381,7 +376,7 @@ func (sc *serviceClient) updateCachedVRFEvent(event *beaconAPI.VRFEvent) bool {
 	return false
 }
 
-func (sc *serviceClient) currentEpochBlock() (beaconAPI.EpochTime, int64) {
+func (sc *ServiceClient) currentEpochBlock() (beaconAPI.EpochTime, int64) {
 	sc.RLock()
 	defer sc.RUnlock()
 
@@ -389,7 +384,7 @@ func (sc *serviceClient) currentEpochBlock() (beaconAPI.EpochTime, int64) {
 }
 
 // New constructs a new CometBFT backed beacon and epochtime backend instance.
-func New(ctx context.Context, backend tmAPI.Backend) (ServiceClient, error) {
+func New(ctx context.Context, backend tmAPI.Backend) (*ServiceClient, error) {
 	// Initialize and register the CometBFT service component.
 	a := app.New()
 	if err := backend.RegisterApplication(a); err != nil {
@@ -398,7 +393,7 @@ func New(ctx context.Context, backend tmAPI.Backend) (ServiceClient, error) {
 
 	epochCache := lru.New(lru.Capacity(epochCacheCapacity, false))
 
-	sc := &serviceClient{
+	sc := &ServiceClient{
 		logger:            logging.GetLogger("cometbft/beacon"),
 		querier:           a.QueryFactory().(*app.QueryFactory),
 		backend:           backend,

--- a/go/consensus/cometbft/beacon/beacon.go
+++ b/go/consensus/cometbft/beacon/beacon.go
@@ -388,7 +388,7 @@ func (sc *serviceClient) currentEpochBlock() (beaconAPI.EpochTime, int64) {
 	return sc.epoch, sc.epochCurrentBlock
 }
 
-// New constructs a new CometBFT backed beacon and epochtime Backend instance.
+// New constructs a new CometBFT backed beacon and epochtime backend instance.
 func New(ctx context.Context, backend tmAPI.Backend) (ServiceClient, error) {
 	// Initialize and register the CometBFT service component.
 	a := app.New()

--- a/go/consensus/cometbft/cometbft.go
+++ b/go/consensus/cometbft/cometbft.go
@@ -36,6 +36,8 @@ func New(
 		Genesis:            genesis,
 		GenesisDoc:         genesisDoc,
 		GenesisHeight:      doc.Height,
+		BaseEpoch:          doc.Beacon.Base,
+		BaseHeight:         doc.Height,
 		PublicKeyBlacklist: doc.Consensus.Parameters.PublicKeyBlacklist,
 	}
 

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -305,7 +305,7 @@ func (n *commonNode) initialize() error {
 	}
 
 	// Configure the staking application as a fee handler.
-	if err := n.parentNode.SetTransactionAuthHandler(stakingApp.(api.TransactionAuthHandler)); err != nil {
+	if err := n.parentNode.SetTransactionAuthHandler(stakingApp); err != nil {
 		return err
 	}
 

--- a/go/consensus/cometbft/governance/governance.go
+++ b/go/consensus/cometbft/governance/governance.go
@@ -260,7 +260,7 @@ func EventsFromCometBFT(
 	return events, errs
 }
 
-// New constructs a new CometBFT backed governance Backend instance.
+// New constructs a new CometBFT backed governance backend instance.
 func New(backend tmapi.Backend) (ServiceClient, error) {
 	// Initialize and register the CometBFT service component.
 	a := app.New()

--- a/go/consensus/cometbft/governance/governance.go
+++ b/go/consensus/cometbft/governance/governance.go
@@ -256,17 +256,11 @@ func EventsFromCometBFT(
 }
 
 // New constructs a new CometBFT backed governance backend instance.
-func New(backend tmapi.Backend) (*ServiceClient, error) {
-	// Initialize and register the CometBFT service component.
-	a := app.New()
-	if err := backend.RegisterApplication(a); err != nil {
-		return nil, err
-	}
-
+func New(backend tmapi.Backend, querier *app.QueryFactory) (*ServiceClient, error) {
 	return &ServiceClient{
 		logger:        logging.GetLogger("cometbft/staking"),
 		backend:       backend,
-		querier:       a.QueryFactory().(*app.QueryFactory),
+		querier:       querier,
 		eventNotifier: pubsub.NewBroker(false),
 	}, nil
 }

--- a/go/consensus/cometbft/governance/governance.go
+++ b/go/consensus/cometbft/governance/governance.go
@@ -256,11 +256,11 @@ func EventsFromCometBFT(
 }
 
 // New constructs a new CometBFT backed governance backend instance.
-func New(backend tmapi.Backend, querier *app.QueryFactory) (*ServiceClient, error) {
+func New(backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
 	return &ServiceClient{
 		logger:        logging.GetLogger("cometbft/staking"),
 		backend:       backend,
 		querier:       querier,
 		eventNotifier: pubsub.NewBroker(false),
-	}, nil
+	}
 }

--- a/go/consensus/cometbft/governance/governance.go
+++ b/go/consensus/cometbft/governance/governance.go
@@ -159,12 +159,12 @@ func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) 
 func (sc *ServiceClient) Cleanup() {
 }
 
-// Implements api.ServiceClient.
+// ServiceDescriptor implements api.ServiceClient.
 func (sc *ServiceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
 	return tmapi.NewStaticServiceDescriptor(api.ModuleName, app.EventType, []cmtpubsub.Query{app.QueryApp})
 }
 
-// Implements api.ServiceClient.
+// DeliverEvent implements api.ServiceClient.
 func (sc *ServiceClient) DeliverEvent(_ context.Context, height int64, tx cmttypes.Tx, ev *cmtabcitypes.Event) error {
 	events, err := EventsFromCometBFT(tx, height, []cmtabcitypes.Event{*ev})
 	if err != nil {

--- a/go/consensus/cometbft/governance/governance.go
+++ b/go/consensus/cometbft/governance/governance.go
@@ -21,13 +21,8 @@ import (
 	upgrade "github.com/oasisprotocol/oasis-core/go/upgrade/api"
 )
 
-// ServiceClient is the governance service client interface.
-type ServiceClient interface {
-	api.Backend
-	tmapi.ServiceClient
-}
-
-type serviceClient struct {
+// ServiceClient is the governance service client.
+type ServiceClient struct {
 	tmapi.BaseServiceClient
 
 	logger *logging.Logger
@@ -38,7 +33,7 @@ type serviceClient struct {
 	eventNotifier *pubsub.Broker
 }
 
-func (sc *serviceClient) ActiveProposals(ctx context.Context, height int64) ([]*api.Proposal, error) {
+func (sc *ServiceClient) ActiveProposals(ctx context.Context, height int64) ([]*api.Proposal, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -47,7 +42,7 @@ func (sc *serviceClient) ActiveProposals(ctx context.Context, height int64) ([]*
 	return q.ActiveProposals(ctx)
 }
 
-func (sc *serviceClient) Proposals(ctx context.Context, height int64) ([]*api.Proposal, error) {
+func (sc *ServiceClient) Proposals(ctx context.Context, height int64) ([]*api.Proposal, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -56,7 +51,7 @@ func (sc *serviceClient) Proposals(ctx context.Context, height int64) ([]*api.Pr
 	return q.Proposals(ctx)
 }
 
-func (sc *serviceClient) Proposal(ctx context.Context, query *api.ProposalQuery) (*api.Proposal, error) {
+func (sc *ServiceClient) Proposal(ctx context.Context, query *api.ProposalQuery) (*api.Proposal, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
@@ -65,7 +60,7 @@ func (sc *serviceClient) Proposal(ctx context.Context, query *api.ProposalQuery)
 	return q.Proposal(ctx, query.ProposalID)
 }
 
-func (sc *serviceClient) Votes(ctx context.Context, query *api.ProposalQuery) ([]*api.VoteEntry, error) {
+func (sc *ServiceClient) Votes(ctx context.Context, query *api.ProposalQuery) ([]*api.VoteEntry, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
@@ -74,7 +69,7 @@ func (sc *serviceClient) Votes(ctx context.Context, query *api.ProposalQuery) ([
 	return q.Votes(ctx, query.ProposalID)
 }
 
-func (sc *serviceClient) PendingUpgrades(ctx context.Context, height int64) ([]*upgrade.Descriptor, error) {
+func (sc *ServiceClient) PendingUpgrades(ctx context.Context, height int64) ([]*upgrade.Descriptor, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -83,7 +78,7 @@ func (sc *serviceClient) PendingUpgrades(ctx context.Context, height int64) ([]*
 	return q.PendingUpgrades(ctx)
 }
 
-func (sc *serviceClient) StateToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
+func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -92,7 +87,7 @@ func (sc *serviceClient) StateToGenesis(ctx context.Context, height int64) (*api
 	return q.Genesis(ctx)
 }
 
-func (sc *serviceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
+func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
 	var results *cmtrpctypes.ResultBlockResults
 	results, err := sc.backend.GetCometBFTBlockResults(ctx, height)
@@ -144,7 +139,7 @@ func (sc *serviceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 	return events, nil
 }
 
-func (sc *serviceClient) WatchEvents(context.Context) (<-chan *api.Event, pubsub.ClosableSubscription, error) {
+func (sc *ServiceClient) WatchEvents(context.Context) (<-chan *api.Event, pubsub.ClosableSubscription, error) {
 	typedCh := make(chan *api.Event)
 	sub := sc.eventNotifier.Subscribe()
 	sub.Unwrap(typedCh)
@@ -152,7 +147,7 @@ func (sc *serviceClient) WatchEvents(context.Context) (<-chan *api.Event, pubsub
 	return typedCh, sub, nil
 }
 
-func (sc *serviceClient) ConsensusParameters(ctx context.Context, height int64) (*api.ConsensusParameters, error) {
+func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) (*api.ConsensusParameters, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -161,16 +156,16 @@ func (sc *serviceClient) ConsensusParameters(ctx context.Context, height int64) 
 	return q.ConsensusParameters(ctx)
 }
 
-func (sc *serviceClient) Cleanup() {
+func (sc *ServiceClient) Cleanup() {
 }
 
 // Implements api.ServiceClient.
-func (sc *serviceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
+func (sc *ServiceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
 	return tmapi.NewStaticServiceDescriptor(api.ModuleName, app.EventType, []cmtpubsub.Query{app.QueryApp})
 }
 
 // Implements api.ServiceClient.
-func (sc *serviceClient) DeliverEvent(_ context.Context, height int64, tx cmttypes.Tx, ev *cmtabcitypes.Event) error {
+func (sc *ServiceClient) DeliverEvent(_ context.Context, height int64, tx cmttypes.Tx, ev *cmtabcitypes.Event) error {
 	events, err := EventsFromCometBFT(tx, height, []cmtabcitypes.Event{*ev})
 	if err != nil {
 		return fmt.Errorf("governance: failed to process cometbft events: %w", err)
@@ -261,14 +256,14 @@ func EventsFromCometBFT(
 }
 
 // New constructs a new CometBFT backed governance backend instance.
-func New(backend tmapi.Backend) (ServiceClient, error) {
+func New(backend tmapi.Backend) (*ServiceClient, error) {
 	// Initialize and register the CometBFT service component.
 	a := app.New()
 	if err := backend.RegisterApplication(a); err != nil {
 		return nil, err
 	}
 
-	return &serviceClient{
+	return &ServiceClient{
 		logger:        logging.GetLogger("cometbft/staking"),
 		backend:       backend,
 		querier:       a.QueryFactory().(*app.QueryFactory),

--- a/go/consensus/cometbft/keymanager/churp/client.go
+++ b/go/consensus/cometbft/keymanager/churp/client.go
@@ -114,7 +114,7 @@ func (sc *ServiceClient) DeliverEvent(ev *cmtabcitypes.Event) error {
 
 // New constructs a new CometBFT backed key manager CHURP management Backend
 // instance.
-func New(ctx context.Context, querier *app.QueryFactory) (*ServiceClient, error) {
+func New(ctx context.Context, querier *app.QueryFactory) *ServiceClient {
 	sc := ServiceClient{
 		logger:  logging.GetLogger("cometbft/keymanager/churp"),
 		querier: querier,
@@ -134,5 +134,5 @@ func New(ctx context.Context, querier *app.QueryFactory) (*ServiceClient, error)
 		}
 	})
 
-	return &sc, nil
+	return &sc
 }

--- a/go/consensus/cometbft/keymanager/keymanager.go
+++ b/go/consensus/cometbft/keymanager/keymanager.go
@@ -70,14 +70,7 @@ func (sc *ServiceClient) DeliverEvent(_ context.Context, _ int64, _ cmttypes.Tx,
 
 // New constructs a new CometBFT backed key manager management Backend
 // instance.
-func New(ctx context.Context, backend tmapi.Backend) (*ServiceClient, error) {
-	a := app.New()
-	if err := backend.RegisterApplication(a); err != nil {
-		return nil, fmt.Errorf("cometbft/keymanager: failed to register app: %w", err)
-	}
-
-	querier := a.QueryFactory().(*app.QueryFactory)
-
+func New(ctx context.Context, querier *app.QueryFactory) (*ServiceClient, error) {
 	secretsClient, err := secrets.New(ctx, querier)
 	if err != nil {
 		return nil, fmt.Errorf("cometbft/keymanager: failed to create secrets client: %w", err)

--- a/go/consensus/cometbft/keymanager/keymanager.go
+++ b/go/consensus/cometbft/keymanager/keymanager.go
@@ -26,7 +26,7 @@ type ServiceClient struct {
 	churpClient   *churp.ServiceClient
 }
 
-// Implements api.Backend.
+// StateToGenesis implements api.Backend.
 func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
 	secretsGenesis, err := sc.secretsClient.StateToGenesis(ctx, height)
 	if err != nil {
@@ -44,22 +44,22 @@ func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*api
 	}, nil
 }
 
-// Implements api.Backend.
+// Secrets implements api.Backend.
 func (sc *ServiceClient) Secrets() secretsAPI.Backend {
 	return sc.secretsClient
 }
 
-// Implements api.Backend.
+// Churp implements api.Backend.
 func (sc *ServiceClient) Churp() churpAPI.Backend {
 	return sc.churpClient
 }
 
-// Implements api.ServiceClient.
+// ServiceDescriptor implements api.ServiceClient.
 func (sc *ServiceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
 	return tmapi.NewStaticServiceDescriptor(api.ModuleName, app.EventType, []cmtpubsub.Query{app.QueryApp})
 }
 
-// Implements api.ServiceClient.
+// DeliverEvent implements api.ServiceClient.
 func (sc *ServiceClient) DeliverEvent(_ context.Context, _ int64, _ cmttypes.Tx, ev *cmtabcitypes.Event) error {
 	if err := sc.secretsClient.DeliverEvent(ev); err != nil {
 		return err

--- a/go/consensus/cometbft/keymanager/keymanager.go
+++ b/go/consensus/cometbft/keymanager/keymanager.go
@@ -4,7 +4,6 @@ package keymanager
 
 import (
 	"context"
-	"fmt"
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
 	cmtpubsub "github.com/cometbft/cometbft/libs/pubsub"
@@ -70,21 +69,9 @@ func (sc *ServiceClient) DeliverEvent(_ context.Context, _ int64, _ cmttypes.Tx,
 
 // New constructs a new CometBFT backed key manager management Backend
 // instance.
-func New(ctx context.Context, querier *app.QueryFactory) (*ServiceClient, error) {
-	secretsClient, err := secrets.New(ctx, querier)
-	if err != nil {
-		return nil, fmt.Errorf("cometbft/keymanager: failed to create secrets client: %w", err)
+func New(ctx context.Context, querier *app.QueryFactory) *ServiceClient {
+	return &ServiceClient{
+		secretsClient: secrets.New(ctx, querier),
+		churpClient:   churp.New(ctx, querier),
 	}
-
-	churpClient, err := churp.New(ctx, querier)
-	if err != nil {
-		return nil, fmt.Errorf("cometbft/keymanager: failed to create churp client: %w", err)
-	}
-
-	sc := ServiceClient{
-		secretsClient: secretsClient,
-		churpClient:   churpClient,
-	}
-
-	return &sc, nil
 }

--- a/go/consensus/cometbft/keymanager/secrets/client.go
+++ b/go/consensus/cometbft/keymanager/secrets/client.go
@@ -138,7 +138,7 @@ func (sc *ServiceClient) DeliverEvent(ev *cmtabcitypes.Event) error {
 
 // New constructs a new CometBFT backed key manager secrets management Backend
 // instance.
-func New(ctx context.Context, querier *app.QueryFactory) (*ServiceClient, error) {
+func New(ctx context.Context, querier *app.QueryFactory) *ServiceClient {
 	sc := ServiceClient{
 		logger:            logging.GetLogger("cometbft/keymanager/secrets"),
 		querier:           querier,
@@ -160,5 +160,5 @@ func New(ctx context.Context, querier *app.QueryFactory) (*ServiceClient, error)
 		}
 	})
 
-	return &sc, nil
+	return &sc
 }

--- a/go/consensus/cometbft/registry/registry.go
+++ b/go/consensus/cometbft/registry/registry.go
@@ -375,7 +375,7 @@ func (sc *serviceClient) getNodeList(ctx context.Context, height int64) (*api.No
 	}, nil
 }
 
-// New constructs a new CometBFT backed registry Backend instance.
+// New constructs a new CometBFT backed registry backend instance.
 func New(ctx context.Context, backend tmapi.Backend) (ServiceClient, error) {
 	// Initialize and register the CometBFT service component.
 	a := app.New()

--- a/go/consensus/cometbft/registry/registry.go
+++ b/go/consensus/cometbft/registry/registry.go
@@ -371,17 +371,11 @@ func (sc *ServiceClient) getNodeList(ctx context.Context, height int64) (*api.No
 }
 
 // New constructs a new CometBFT backed registry backend instance.
-func New(ctx context.Context, backend tmapi.Backend) (*ServiceClient, error) {
-	// Initialize and register the CometBFT service component.
-	a := app.New()
-	if err := backend.RegisterApplication(a); err != nil {
-		return nil, err
-	}
-
+func New(ctx context.Context, backend tmapi.Backend, querier *app.QueryFactory) (*ServiceClient, error) {
 	sc := &ServiceClient{
 		logger:         logging.GetLogger("cometbft/registry"),
 		backend:        backend,
-		querier:        a.QueryFactory().(*app.QueryFactory),
+		querier:        querier,
 		entityNotifier: pubsub.NewBroker(false),
 		nodeNotifier:   pubsub.NewBroker(false),
 		eventNotifier:  pubsub.NewBroker(false),

--- a/go/consensus/cometbft/registry/registry.go
+++ b/go/consensus/cometbft/registry/registry.go
@@ -228,12 +228,12 @@ func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) 
 	return q.ConsensusParameters(ctx)
 }
 
-// Implements api.ServiceClient.
+// ServiceDescriptor implements api.ServiceClient.
 func (sc *ServiceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
 	return tmapi.NewStaticServiceDescriptor(api.ModuleName, app.EventType, []cmtpubsub.Query{app.QueryApp})
 }
 
-// Implements api.ServiceClient.
+// DeliverEvent implements api.ServiceClient.
 func (sc *ServiceClient) DeliverEvent(ctx context.Context, height int64, tx cmttypes.Tx, ev *cmtabcitypes.Event) error {
 	events, nodeListEvents, err := EventsFromCometBFT(tx, height, []cmtabcitypes.Event{*ev})
 	if err != nil {

--- a/go/consensus/cometbft/registry/registry.go
+++ b/go/consensus/cometbft/registry/registry.go
@@ -371,7 +371,7 @@ func (sc *ServiceClient) getNodeList(ctx context.Context, height int64) (*api.No
 }
 
 // New constructs a new CometBFT backed registry backend instance.
-func New(ctx context.Context, backend tmapi.Backend, querier *app.QueryFactory) (*ServiceClient, error) {
+func New(ctx context.Context, backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
 	sc := &ServiceClient{
 		logger:         logging.GetLogger("cometbft/registry"),
 		backend:        backend,
@@ -407,5 +407,5 @@ func New(ctx context.Context, backend tmapi.Backend, querier *app.QueryFactory) 
 		}
 	})
 
-	return sc, nil
+	return sc
 }

--- a/go/consensus/cometbft/registry/registry.go
+++ b/go/consensus/cometbft/registry/registry.go
@@ -24,13 +24,8 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/registry/api"
 )
 
-// ServiceClient is the registry service client interface.
-type ServiceClient interface {
-	api.Backend
-	tmapi.ServiceClient
-}
-
-type serviceClient struct {
+// ServiceClient is the registry service client.
+type ServiceClient struct {
 	tmapi.BaseServiceClient
 
 	logger *logging.Logger
@@ -50,7 +45,7 @@ type NodeListEpochInternalEvent struct {
 	Height int64 `json:"height"`
 }
 
-func (sc *serviceClient) GetEntity(ctx context.Context, query *api.IDQuery) (*entity.Entity, error) {
+func (sc *ServiceClient) GetEntity(ctx context.Context, query *api.IDQuery) (*entity.Entity, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
@@ -59,7 +54,7 @@ func (sc *serviceClient) GetEntity(ctx context.Context, query *api.IDQuery) (*en
 	return q.Entity(ctx, query.ID)
 }
 
-func (sc *serviceClient) GetEntities(ctx context.Context, height int64) ([]*entity.Entity, error) {
+func (sc *ServiceClient) GetEntities(ctx context.Context, height int64) ([]*entity.Entity, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -68,7 +63,7 @@ func (sc *serviceClient) GetEntities(ctx context.Context, height int64) ([]*enti
 	return q.Entities(ctx)
 }
 
-func (sc *serviceClient) WatchEntities(context.Context) (<-chan *api.EntityEvent, pubsub.ClosableSubscription, error) {
+func (sc *ServiceClient) WatchEntities(context.Context) (<-chan *api.EntityEvent, pubsub.ClosableSubscription, error) {
 	typedCh := make(chan *api.EntityEvent)
 	sub := sc.entityNotifier.Subscribe()
 	sub.Unwrap(typedCh)
@@ -76,7 +71,7 @@ func (sc *serviceClient) WatchEntities(context.Context) (<-chan *api.EntityEvent
 	return typedCh, sub, nil
 }
 
-func (sc *serviceClient) GetNode(ctx context.Context, query *api.IDQuery) (*node.Node, error) {
+func (sc *ServiceClient) GetNode(ctx context.Context, query *api.IDQuery) (*node.Node, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
@@ -85,7 +80,7 @@ func (sc *serviceClient) GetNode(ctx context.Context, query *api.IDQuery) (*node
 	return q.Node(ctx, query.ID)
 }
 
-func (sc *serviceClient) GetNodeStatus(ctx context.Context, query *api.IDQuery) (*api.NodeStatus, error) {
+func (sc *ServiceClient) GetNodeStatus(ctx context.Context, query *api.IDQuery) (*api.NodeStatus, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
@@ -94,7 +89,7 @@ func (sc *serviceClient) GetNodeStatus(ctx context.Context, query *api.IDQuery) 
 	return q.NodeStatus(ctx, query.ID)
 }
 
-func (sc *serviceClient) GetNodes(ctx context.Context, height int64) ([]*node.Node, error) {
+func (sc *ServiceClient) GetNodes(ctx context.Context, height int64) ([]*node.Node, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -103,7 +98,7 @@ func (sc *serviceClient) GetNodes(ctx context.Context, height int64) ([]*node.No
 	return q.Nodes(ctx)
 }
 
-func (sc *serviceClient) GetNodeByConsensusAddress(ctx context.Context, query *api.ConsensusAddressQuery) (*node.Node, error) {
+func (sc *ServiceClient) GetNodeByConsensusAddress(ctx context.Context, query *api.ConsensusAddressQuery) (*node.Node, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
@@ -112,7 +107,7 @@ func (sc *serviceClient) GetNodeByConsensusAddress(ctx context.Context, query *a
 	return q.NodeByConsensusAddress(ctx, query.Address)
 }
 
-func (sc *serviceClient) WatchNodes(context.Context) (<-chan *api.NodeEvent, pubsub.ClosableSubscription, error) {
+func (sc *ServiceClient) WatchNodes(context.Context) (<-chan *api.NodeEvent, pubsub.ClosableSubscription, error) {
 	typedCh := make(chan *api.NodeEvent)
 	sub := sc.nodeNotifier.Subscribe()
 	sub.Unwrap(typedCh)
@@ -120,7 +115,7 @@ func (sc *serviceClient) WatchNodes(context.Context) (<-chan *api.NodeEvent, pub
 	return typedCh, sub, nil
 }
 
-func (sc *serviceClient) WatchNodeList(context.Context) (<-chan *api.NodeList, pubsub.ClosableSubscription, error) {
+func (sc *ServiceClient) WatchNodeList(context.Context) (<-chan *api.NodeList, pubsub.ClosableSubscription, error) {
 	typedCh := make(chan *api.NodeList)
 	sub := sc.nodeListNotifier.Subscribe()
 	sub.Unwrap(typedCh)
@@ -128,7 +123,7 @@ func (sc *serviceClient) WatchNodeList(context.Context) (<-chan *api.NodeList, p
 	return typedCh, sub, nil
 }
 
-func (sc *serviceClient) GetRuntime(ctx context.Context, query *api.GetRuntimeQuery) (*api.Runtime, error) {
+func (sc *ServiceClient) GetRuntime(ctx context.Context, query *api.GetRuntimeQuery) (*api.Runtime, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
@@ -137,7 +132,7 @@ func (sc *serviceClient) GetRuntime(ctx context.Context, query *api.GetRuntimeQu
 	return q.Runtime(ctx, query.ID, query.IncludeSuspended)
 }
 
-func (sc *serviceClient) WatchRuntimes(_ context.Context) (<-chan *api.Runtime, pubsub.ClosableSubscription, error) {
+func (sc *ServiceClient) WatchRuntimes(_ context.Context) (<-chan *api.Runtime, pubsub.ClosableSubscription, error) {
 	typedCh := make(chan *api.Runtime)
 	sub := sc.runtimeNotifier.Subscribe()
 	sub.Unwrap(typedCh)
@@ -145,10 +140,10 @@ func (sc *serviceClient) WatchRuntimes(_ context.Context) (<-chan *api.Runtime, 
 	return typedCh, sub, nil
 }
 
-func (sc *serviceClient) Cleanup() {
+func (sc *ServiceClient) Cleanup() {
 }
 
-func (sc *serviceClient) GetRuntimes(ctx context.Context, query *api.GetRuntimesQuery) ([]*api.Runtime, error) {
+func (sc *ServiceClient) GetRuntimes(ctx context.Context, query *api.GetRuntimesQuery) ([]*api.Runtime, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
@@ -156,7 +151,7 @@ func (sc *serviceClient) GetRuntimes(ctx context.Context, query *api.GetRuntimes
 	return q.Runtimes(ctx, query.IncludeSuspended)
 }
 
-func (sc *serviceClient) StateToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
+func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -165,7 +160,7 @@ func (sc *serviceClient) StateToGenesis(ctx context.Context, height int64) (*api
 	return q.Genesis(ctx)
 }
 
-func (sc *serviceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
+func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
 	var results *cmtrpctypes.ResultBlockResults
 	results, err := sc.backend.GetCometBFTBlockResults(ctx, height)
@@ -217,7 +212,7 @@ func (sc *serviceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 }
 
 // WatchEvents implements api.Backend.
-func (sc *serviceClient) WatchEvents(_ context.Context) (<-chan *api.Event, pubsub.ClosableSubscription, error) {
+func (sc *ServiceClient) WatchEvents(_ context.Context) (<-chan *api.Event, pubsub.ClosableSubscription, error) {
 	typedCh := make(chan *api.Event)
 	sub := sc.eventNotifier.Subscribe()
 	sub.Unwrap(typedCh)
@@ -225,7 +220,7 @@ func (sc *serviceClient) WatchEvents(_ context.Context) (<-chan *api.Event, pubs
 	return typedCh, sub, nil
 }
 
-func (sc *serviceClient) ConsensusParameters(ctx context.Context, height int64) (*api.ConsensusParameters, error) {
+func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) (*api.ConsensusParameters, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -234,12 +229,12 @@ func (sc *serviceClient) ConsensusParameters(ctx context.Context, height int64) 
 }
 
 // Implements api.ServiceClient.
-func (sc *serviceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
+func (sc *ServiceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
 	return tmapi.NewStaticServiceDescriptor(api.ModuleName, app.EventType, []cmtpubsub.Query{app.QueryApp})
 }
 
 // Implements api.ServiceClient.
-func (sc *serviceClient) DeliverEvent(ctx context.Context, height int64, tx cmttypes.Tx, ev *cmtabcitypes.Event) error {
+func (sc *ServiceClient) DeliverEvent(ctx context.Context, height int64, tx cmttypes.Tx, ev *cmtabcitypes.Event) error {
 	events, nodeListEvents, err := EventsFromCometBFT(tx, height, []cmtabcitypes.Event{*ev})
 	if err != nil {
 		return fmt.Errorf("scheduler: failed to process cometbft events: %w", err)
@@ -356,7 +351,7 @@ func EventsFromCometBFT(
 	return events, nodeListEvents, errs
 }
 
-func (sc *serviceClient) getNodeList(ctx context.Context, height int64) (*api.NodeList, error) {
+func (sc *ServiceClient) getNodeList(ctx context.Context, height int64) (*api.NodeList, error) {
 	// Generate the nodelist.
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
@@ -376,14 +371,14 @@ func (sc *serviceClient) getNodeList(ctx context.Context, height int64) (*api.No
 }
 
 // New constructs a new CometBFT backed registry backend instance.
-func New(ctx context.Context, backend tmapi.Backend) (ServiceClient, error) {
+func New(ctx context.Context, backend tmapi.Backend) (*ServiceClient, error) {
 	// Initialize and register the CometBFT service component.
 	a := app.New()
 	if err := backend.RegisterApplication(a); err != nil {
 		return nil, err
 	}
 
-	sc := &serviceClient{
+	sc := &ServiceClient{
 		logger:         logging.GetLogger("cometbft/registry"),
 		backend:        backend,
 		querier:        a.QueryFactory().(*app.QueryFactory),

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -63,7 +63,7 @@ type ServiceClient struct {
 	trackedRuntimes map[common.Namespace]*trackedRuntime
 }
 
-// Implements api.Backend.
+// GetGenesisBlock implements api.Backend.
 func (sc *ServiceClient) GetGenesisBlock(ctx context.Context, request *api.RuntimeRequest) (*block.Block, error) {
 	// First check if we have the genesis blocks cached. They are immutable so easy
 	// to cache to avoid repeated requests to the CometBFT app.
@@ -92,7 +92,7 @@ func (sc *ServiceClient) GetGenesisBlock(ctx context.Context, request *api.Runti
 	return blk, nil
 }
 
-// Implements api.Backend.
+// GetLatestBlock implements api.Backend.
 func (sc *ServiceClient) GetLatestBlock(ctx context.Context, request *api.RuntimeRequest) (*block.Block, error) {
 	return sc.getLatestBlockAt(ctx, request.RuntimeID, request.Height)
 }
@@ -106,7 +106,7 @@ func (sc *ServiceClient) getLatestBlockAt(ctx context.Context, runtimeID common.
 	return q.LatestBlock(ctx, runtimeID)
 }
 
-// Implements api.Backend.
+// GetRuntimeState implements api.Backend.
 func (sc *ServiceClient) GetRuntimeState(ctx context.Context, request *api.RuntimeRequest) (*api.RuntimeState, error) {
 	q, err := sc.querier.QueryAt(ctx, request.Height)
 	if err != nil {
@@ -116,7 +116,7 @@ func (sc *ServiceClient) GetRuntimeState(ctx context.Context, request *api.Runti
 	return q.RuntimeState(ctx, request.RuntimeID)
 }
 
-// Implements api.Backend.
+// GetLastRoundResults implements api.Backend.
 func (sc *ServiceClient) GetLastRoundResults(ctx context.Context, request *api.RuntimeRequest) (*api.RoundResults, error) {
 	q, err := sc.querier.QueryAt(ctx, request.Height)
 	if err != nil {
@@ -144,7 +144,7 @@ func (sc *ServiceClient) GetPastRoundRoots(ctx context.Context, request *api.Run
 	return q.PastRoundRoots(ctx, request.RuntimeID)
 }
 
-// Implements api.Backend.
+// GetIncomingMessageQueueMeta implements api.Backend.
 func (sc *ServiceClient) GetIncomingMessageQueueMeta(ctx context.Context, request *api.RuntimeRequest) (*message.IncomingMessageQueueMeta, error) {
 	q, err := sc.querier.QueryAt(ctx, request.Height)
 	if err != nil {
@@ -154,7 +154,7 @@ func (sc *ServiceClient) GetIncomingMessageQueueMeta(ctx context.Context, reques
 	return q.IncomingMessageQueueMeta(ctx, request.RuntimeID)
 }
 
-// Implements api.Backend.
+// GetIncomingMessageQueue implements api.Backend.
 func (sc *ServiceClient) GetIncomingMessageQueue(ctx context.Context, request *api.InMessageQueueRequest) ([]*message.IncomingMessage, error) {
 	q, err := sc.querier.QueryAt(ctx, request.Height)
 	if err != nil {
@@ -164,7 +164,7 @@ func (sc *ServiceClient) GetIncomingMessageQueue(ctx context.Context, request *a
 	return q.IncomingMessageQueue(ctx, request.RuntimeID, request.Offset, request.Limit)
 }
 
-// Implements api.Backend.
+// WatchBlocks implements api.Backend.
 func (sc *ServiceClient) WatchBlocks(_ context.Context, id common.Namespace) (<-chan *api.AnnotatedBlock, pubsub.ClosableSubscription, error) {
 	notifiers := sc.getRuntimeNotifiers(id)
 	sub := notifiers.blockNotifier.Subscribe()
@@ -183,7 +183,7 @@ func (sc *ServiceClient) WatchAllBlocks() (<-chan *block.Block, *pubsub.Subscrip
 	return ch, sub
 }
 
-// Implements api.Backend.
+// WatchEvents implements api.Backend.
 func (sc *ServiceClient) WatchEvents(_ context.Context, id common.Namespace) (<-chan *api.Event, pubsub.ClosableSubscription, error) {
 	notifiers := sc.getRuntimeNotifiers(id)
 	sub := notifiers.eventNotifier.Subscribe()
@@ -194,7 +194,7 @@ func (sc *ServiceClient) WatchEvents(_ context.Context, id common.Namespace) (<-
 	return ch, sub, nil
 }
 
-// Implements api.Backend.
+// WatchExecutorCommitments implements api.Backend.
 func (sc *ServiceClient) WatchExecutorCommitments(_ context.Context, id common.Namespace) (<-chan *commitment.ExecutorCommitment, pubsub.ClosableSubscription, error) {
 	notifiers := sc.getRuntimeNotifiers(id)
 	sub := notifiers.ecNotifier.Subscribe()
@@ -226,7 +226,7 @@ func (sc *ServiceClient) trackRuntime(id common.Namespace) {
 	sc.queryCh <- app.QueryForRuntime(id)
 }
 
-// Implements api.Backend.
+// StateToGenesis implements api.Backend.
 func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
@@ -291,7 +291,7 @@ func (sc *ServiceClient) getEvents(ctx context.Context, height int64, txns [][]b
 	return events, nil
 }
 
-// Implements api.Backend.
+// GetEvents implements api.Backend.
 func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get transactions at given height.
 	txns, err := sc.backend.GetTransactions(ctx, height)
@@ -306,7 +306,7 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 	return sc.getEvents(ctx, height, txns)
 }
 
-// Implements api.Backend.
+// Cleanup implements api.Backend.
 func (sc *ServiceClient) Cleanup() {
 }
 
@@ -327,12 +327,12 @@ func (sc *ServiceClient) getRuntimeNotifiers(id common.Namespace) *runtimeBroker
 	return notifiers
 }
 
-// Implements api.ServiceClient.
+// ServiceDescriptor implements api.ServiceClient.
 func (sc *ServiceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
 	return tmapi.NewServiceDescriptor(api.ModuleName, app.EventType, sc.queryCh)
 }
 
-// Implements api.ServiceClient.
+// DeliverBlock implements api.ServiceClient.
 func (sc *ServiceClient) DeliverBlock(ctx context.Context, blk *cmttypes.Block) error {
 	sc.mu.RLock()
 	trs := slices.Collect(maps.Values(sc.trackedRuntimes))
@@ -373,7 +373,7 @@ func (sc *ServiceClient) DeliverBlock(ctx context.Context, blk *cmttypes.Block) 
 	return nil
 }
 
-// Implements api.ServiceClient.
+// DeliverEvent implements api.ServiceClient.
 func (sc *ServiceClient) DeliverEvent(ctx context.Context, height int64, tx cmttypes.Tx, ev *cmtabcitypes.Event) error {
 	events, err := EventsFromCometBFT(tx, height, []cmtabcitypes.Event{*ev})
 	if err != nil {
@@ -496,7 +496,7 @@ func (sc *ServiceClient) fetchBlock(ctx context.Context, runtimeID common.Namesp
 	}, nil
 }
 
-// Implements api.ExecutorCommitmentNotifier.
+// DeliverExecutorCommitment implements api.ExecutorCommitmentNotifier.
 func (sc *ServiceClient) DeliverExecutorCommitment(runtimeID common.Namespace, ec *commitment.ExecutorCommitment) {
 	notifiers := sc.getRuntimeNotifiers(runtimeID)
 	notifiers.ecNotifier.Broadcast(ec)

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -601,29 +601,18 @@ EventLoop:
 }
 
 // New constructs a new CometBFT-based root hash backend.
-func New(
-	ctx context.Context,
-	backend tmapi.Backend,
-) (*ServiceClient, error) {
-	sc := ServiceClient{
+func New(ctx context.Context, backend tmapi.Backend, querier *app.QueryFactory) (*ServiceClient, error) {
+	return &ServiceClient{
 		ctx:              ctx,
 		logger:           logging.GetLogger("cometbft/roothash"),
 		backend:          backend,
+		querier:          querier,
 		allBlockNotifier: pubsub.NewBroker(false),
 		runtimeNotifiers: make(map[common.Namespace]*runtimeBrokers),
 		genesisBlocks:    make(map[common.Namespace]*block.Block),
 		queryCh:          make(chan cmtpubsub.Query, runtimeRegistry.MaxRuntimeCount),
 		trackedRuntimes:  make(map[common.Namespace]*trackedRuntime),
-	}
-
-	// Initialize and register the CometBFT service component.
-	a := app.New(&sc)
-	if err := backend.RegisterApplication(a); err != nil {
-		return nil, err
-	}
-	sc.querier = a.QueryFactory().(*app.QueryFactory)
-
-	return &sc, nil
+	}, nil
 }
 
 func init() {

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -601,7 +601,7 @@ EventLoop:
 }
 
 // New constructs a new CometBFT-based root hash backend.
-func New(ctx context.Context, backend tmapi.Backend, querier *app.QueryFactory) (*ServiceClient, error) {
+func New(ctx context.Context, backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
 	return &ServiceClient{
 		ctx:              ctx,
 		logger:           logging.GetLogger("cometbft/roothash"),
@@ -612,7 +612,7 @@ func New(ctx context.Context, backend tmapi.Backend, querier *app.QueryFactory) 
 		genesisBlocks:    make(map[common.Namespace]*block.Block),
 		queryCh:          make(chan cmtpubsub.Query, runtimeRegistry.MaxRuntimeCount),
 		trackedRuntimes:  make(map[common.Namespace]*trackedRuntime),
-	}, nil
+	}
 }
 
 func init() {

--- a/go/consensus/cometbft/scheduler/scheduler.go
+++ b/go/consensus/cometbft/scheduler/scheduler.go
@@ -137,16 +137,10 @@ func (sc *ServiceClient) DeliverEvent(ctx context.Context, height int64, _ cmtty
 }
 
 // New constructs a new CometBFT-based scheduler backend instance.
-func New(backend tmapi.Backend) (*ServiceClient, error) {
-	// Initialze and register the CometBFT service component.
-	a := app.New()
-	if err := backend.RegisterApplication(a); err != nil {
-		return nil, err
-	}
-
+func New(querier *app.QueryFactory) (*ServiceClient, error) {
 	sc := &ServiceClient{
 		logger:  logging.GetLogger("cometbft/scheduler"),
-		querier: a.QueryFactory().(*app.QueryFactory),
+		querier: querier,
 	}
 	sc.notifier = pubsub.NewBrokerEx(func(ch channels.Channel) {
 		currentCommittees, err := sc.getCurrentCommittees()

--- a/go/consensus/cometbft/scheduler/scheduler.go
+++ b/go/consensus/cometbft/scheduler/scheduler.go
@@ -137,7 +137,7 @@ func (sc *ServiceClient) DeliverEvent(ctx context.Context, height int64, _ cmtty
 }
 
 // New constructs a new CometBFT-based scheduler backend instance.
-func New(querier *app.QueryFactory) (*ServiceClient, error) {
+func New(querier *app.QueryFactory) *ServiceClient {
 	sc := &ServiceClient{
 		logger:  logging.GetLogger("cometbft/scheduler"),
 		querier: querier,
@@ -155,5 +155,5 @@ func New(querier *app.QueryFactory) (*ServiceClient, error) {
 		}
 	})
 
-	return sc, nil
+	return sc
 }

--- a/go/consensus/cometbft/scheduler/scheduler.go
+++ b/go/consensus/cometbft/scheduler/scheduler.go
@@ -95,12 +95,12 @@ func (sc *ServiceClient) getCurrentCommittees() ([]*api.Committee, error) {
 	return q.AllCommittees(context.TODO())
 }
 
-// Implements api.ServiceClient.
+// ServiceDescriptor implements api.ServiceClient.
 func (sc *ServiceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
 	return tmapi.NewStaticServiceDescriptor(api.ModuleName, app.EventType, []cmtpubsub.Query{app.QueryApp})
 }
 
-// Implements api.ServiceClient.
+// DeliverEvent implements api.ServiceClient.
 func (sc *ServiceClient) DeliverEvent(ctx context.Context, height int64, _ cmttypes.Tx, ev *cmtabcitypes.Event) error {
 	for _, pair := range ev.GetAttributes() {
 		if events.IsAttributeKind(pair.GetKey(), &api.ElectedEvent{}) {

--- a/go/consensus/cometbft/scheduler/scheduler.go
+++ b/go/consensus/cometbft/scheduler/scheduler.go
@@ -141,7 +141,7 @@ func (sc *serviceClient) DeliverEvent(ctx context.Context, height int64, _ cmtty
 	return nil
 }
 
-// New constructs a new CometBFT-based scheduler Backend instance.
+// New constructs a new CometBFT-based scheduler backend instance.
 func New(backend tmapi.Backend) (ServiceClient, error) {
 	// Initialze and register the CometBFT service component.
 	a := app.New()

--- a/go/consensus/cometbft/staking/staking.go
+++ b/go/consensus/cometbft/staking/staking.go
@@ -306,12 +306,12 @@ func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) 
 func (sc *ServiceClient) Cleanup() {
 }
 
-// Implements api.ServiceClient.
+// ServiceDescriptor implements api.ServiceClient.
 func (sc *ServiceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
 	return tmapi.NewStaticServiceDescriptor(api.ModuleName, app.EventType, []cmtpubsub.Query{app.QueryApp})
 }
 
-// Implements api.ServiceClient.
+// DeliverEvent implements api.ServiceClient.
 func (sc *ServiceClient) DeliverEvent(_ context.Context, height int64, tx cmttypes.Tx, ev *cmtabcitypes.Event) error {
 	events, err := EventsFromCometBFT(tx, height, []cmtabcitypes.Event{*ev})
 	if err != nil {

--- a/go/consensus/cometbft/staking/staking.go
+++ b/go/consensus/cometbft/staking/staking.go
@@ -437,7 +437,7 @@ func EventsFromCometBFT(
 	return events, errs
 }
 
-// New constructs a new CometBFT backed staking Backend instance.
+// New constructs a new CometBFT backed staking backend instance.
 func New(backend tmapi.Backend) (ServiceClient, error) {
 	// Initialize and register the CometBFT service component.
 	a := app.New()

--- a/go/consensus/cometbft/staking/staking.go
+++ b/go/consensus/cometbft/staking/staking.go
@@ -433,11 +433,11 @@ func EventsFromCometBFT(
 }
 
 // New constructs a new CometBFT backed staking backend instance.
-func New(backend tmapi.Backend, querier *app.QueryFactory) (*ServiceClient, error) {
+func New(backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
 	return &ServiceClient{
 		logger:        logging.GetLogger("cometbft/staking"),
 		backend:       backend,
 		querier:       querier,
 		eventNotifier: pubsub.NewBroker(false),
-	}, nil
+	}
 }

--- a/go/consensus/cometbft/staking/staking.go
+++ b/go/consensus/cometbft/staking/staking.go
@@ -433,22 +433,11 @@ func EventsFromCometBFT(
 }
 
 // New constructs a new CometBFT backed staking backend instance.
-func New(backend tmapi.Backend) (*ServiceClient, error) {
-	// Initialize and register the CometBFT service component.
-	a := app.New()
-	if err := backend.RegisterApplication(a); err != nil {
-		return nil, err
-	}
-
-	// Configure the staking application as a fee handler.
-	if err := backend.SetTransactionAuthHandler(a.(tmapi.TransactionAuthHandler)); err != nil {
-		return nil, err
-	}
-
+func New(backend tmapi.Backend, querier *app.QueryFactory) (*ServiceClient, error) {
 	return &ServiceClient{
 		logger:        logging.GetLogger("cometbft/staking"),
 		backend:       backend,
-		querier:       a.QueryFactory().(*app.QueryFactory),
+		querier:       querier,
 		eventNotifier: pubsub.NewBroker(false),
 	}, nil
 }

--- a/go/consensus/cometbft/staking/staking.go
+++ b/go/consensus/cometbft/staking/staking.go
@@ -21,13 +21,8 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
-// ServiceClient is the scheduler service client interface.
-type ServiceClient interface {
-	api.Backend
-	tmapi.ServiceClient
-}
-
-type serviceClient struct {
+// ServiceClient is the scheduler service client.
+type ServiceClient struct {
 	tmapi.BaseServiceClient
 
 	logger *logging.Logger
@@ -38,7 +33,7 @@ type serviceClient struct {
 	eventNotifier *pubsub.Broker
 }
 
-func (sc *serviceClient) TokenSymbol(ctx context.Context, height int64) (string, error) {
+func (sc *ServiceClient) TokenSymbol(ctx context.Context, height int64) (string, error) {
 	params, err := sc.ConsensusParameters(ctx, height)
 	if err != nil {
 		return "", err
@@ -57,7 +52,7 @@ func (sc *serviceClient) TokenSymbol(ctx context.Context, height int64) (string,
 	return genesis.Staking.TokenSymbol, nil
 }
 
-func (sc *serviceClient) TokenValueExponent(ctx context.Context, height int64) (uint8, error) {
+func (sc *ServiceClient) TokenValueExponent(ctx context.Context, height int64) (uint8, error) {
 	params, err := sc.ConsensusParameters(ctx, height)
 	if err != nil {
 		return 0, err
@@ -76,7 +71,7 @@ func (sc *serviceClient) TokenValueExponent(ctx context.Context, height int64) (
 	return genesis.Staking.TokenValueExponent, nil
 }
 
-func (sc *serviceClient) TotalSupply(ctx context.Context, height int64) (*quantity.Quantity, error) {
+func (sc *ServiceClient) TotalSupply(ctx context.Context, height int64) (*quantity.Quantity, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -85,7 +80,7 @@ func (sc *serviceClient) TotalSupply(ctx context.Context, height int64) (*quanti
 	return q.TotalSupply(ctx)
 }
 
-func (sc *serviceClient) CommonPool(ctx context.Context, height int64) (*quantity.Quantity, error) {
+func (sc *ServiceClient) CommonPool(ctx context.Context, height int64) (*quantity.Quantity, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -94,7 +89,7 @@ func (sc *serviceClient) CommonPool(ctx context.Context, height int64) (*quantit
 	return q.CommonPool(ctx)
 }
 
-func (sc *serviceClient) LastBlockFees(ctx context.Context, height int64) (*quantity.Quantity, error) {
+func (sc *ServiceClient) LastBlockFees(ctx context.Context, height int64) (*quantity.Quantity, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -103,7 +98,7 @@ func (sc *serviceClient) LastBlockFees(ctx context.Context, height int64) (*quan
 	return q.LastBlockFees(ctx)
 }
 
-func (sc *serviceClient) GovernanceDeposits(ctx context.Context, height int64) (*quantity.Quantity, error) {
+func (sc *ServiceClient) GovernanceDeposits(ctx context.Context, height int64) (*quantity.Quantity, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -112,7 +107,7 @@ func (sc *serviceClient) GovernanceDeposits(ctx context.Context, height int64) (
 	return q.GovernanceDeposits(ctx)
 }
 
-func (sc *serviceClient) Threshold(ctx context.Context, query *api.ThresholdQuery) (*quantity.Quantity, error) {
+func (sc *ServiceClient) Threshold(ctx context.Context, query *api.ThresholdQuery) (*quantity.Quantity, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
@@ -121,7 +116,7 @@ func (sc *serviceClient) Threshold(ctx context.Context, query *api.ThresholdQuer
 	return q.Threshold(ctx, query.Kind)
 }
 
-func (sc *serviceClient) Addresses(ctx context.Context, height int64) ([]api.Address, error) {
+func (sc *ServiceClient) Addresses(ctx context.Context, height int64) ([]api.Address, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -130,7 +125,7 @@ func (sc *serviceClient) Addresses(ctx context.Context, height int64) ([]api.Add
 	return q.Addresses(ctx)
 }
 
-func (sc *serviceClient) CommissionScheduleAddresses(ctx context.Context, height int64) ([]api.Address, error) {
+func (sc *ServiceClient) CommissionScheduleAddresses(ctx context.Context, height int64) ([]api.Address, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -139,7 +134,7 @@ func (sc *serviceClient) CommissionScheduleAddresses(ctx context.Context, height
 	return q.CommissionScheduleAddresses(ctx)
 }
 
-func (sc *serviceClient) Account(ctx context.Context, query *api.OwnerQuery) (*api.Account, error) {
+func (sc *ServiceClient) Account(ctx context.Context, query *api.OwnerQuery) (*api.Account, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
@@ -148,7 +143,7 @@ func (sc *serviceClient) Account(ctx context.Context, query *api.OwnerQuery) (*a
 	return q.Account(ctx, query.Owner)
 }
 
-func (sc *serviceClient) DelegationsFor(ctx context.Context, query *api.OwnerQuery) (map[api.Address]*api.Delegation, error) {
+func (sc *ServiceClient) DelegationsFor(ctx context.Context, query *api.OwnerQuery) (map[api.Address]*api.Delegation, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
@@ -157,7 +152,7 @@ func (sc *serviceClient) DelegationsFor(ctx context.Context, query *api.OwnerQue
 	return q.DelegationsFor(ctx, query.Owner)
 }
 
-func (sc *serviceClient) DelegationInfosFor(ctx context.Context, query *api.OwnerQuery) (map[api.Address]*api.DelegationInfo, error) {
+func (sc *ServiceClient) DelegationInfosFor(ctx context.Context, query *api.OwnerQuery) (map[api.Address]*api.DelegationInfo, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
@@ -166,7 +161,7 @@ func (sc *serviceClient) DelegationInfosFor(ctx context.Context, query *api.Owne
 	return q.DelegationInfosFor(ctx, query.Owner)
 }
 
-func (sc *serviceClient) DelegationsTo(ctx context.Context, query *api.OwnerQuery) (map[api.Address]*api.Delegation, error) {
+func (sc *ServiceClient) DelegationsTo(ctx context.Context, query *api.OwnerQuery) (map[api.Address]*api.Delegation, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
@@ -175,7 +170,7 @@ func (sc *serviceClient) DelegationsTo(ctx context.Context, query *api.OwnerQuer
 	return q.DelegationsTo(ctx, query.Owner)
 }
 
-func (sc *serviceClient) DebondingDelegationsFor(ctx context.Context, query *api.OwnerQuery) (map[api.Address][]*api.DebondingDelegation, error) {
+func (sc *ServiceClient) DebondingDelegationsFor(ctx context.Context, query *api.OwnerQuery) (map[api.Address][]*api.DebondingDelegation, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
@@ -184,7 +179,7 @@ func (sc *serviceClient) DebondingDelegationsFor(ctx context.Context, query *api
 	return q.DebondingDelegationsFor(ctx, query.Owner)
 }
 
-func (sc *serviceClient) DebondingDelegationInfosFor(ctx context.Context, query *api.OwnerQuery) (map[api.Address][]*api.DebondingDelegationInfo, error) {
+func (sc *ServiceClient) DebondingDelegationInfosFor(ctx context.Context, query *api.OwnerQuery) (map[api.Address][]*api.DebondingDelegationInfo, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
@@ -193,7 +188,7 @@ func (sc *serviceClient) DebondingDelegationInfosFor(ctx context.Context, query 
 	return q.DebondingDelegationInfosFor(ctx, query.Owner)
 }
 
-func (sc *serviceClient) DebondingDelegationsTo(ctx context.Context, query *api.OwnerQuery) (map[api.Address][]*api.DebondingDelegation, error) {
+func (sc *ServiceClient) DebondingDelegationsTo(ctx context.Context, query *api.OwnerQuery) (map[api.Address][]*api.DebondingDelegation, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
@@ -202,7 +197,7 @@ func (sc *serviceClient) DebondingDelegationsTo(ctx context.Context, query *api.
 	return q.DebondingDelegationsTo(ctx, query.Owner)
 }
 
-func (sc *serviceClient) Allowance(ctx context.Context, query *api.AllowanceQuery) (*quantity.Quantity, error) {
+func (sc *ServiceClient) Allowance(ctx context.Context, query *api.AllowanceQuery) (*quantity.Quantity, error) {
 	acct, err := sc.Account(ctx, &api.OwnerQuery{
 		Height: query.Height,
 		Owner:  query.Owner,
@@ -215,7 +210,7 @@ func (sc *serviceClient) Allowance(ctx context.Context, query *api.AllowanceQuer
 	return &allowance, nil
 }
 
-func (sc *serviceClient) StateToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
+func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
 	// Query the staking genesis state.
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
@@ -239,7 +234,7 @@ func (sc *serviceClient) StateToGenesis(ctx context.Context, height int64) (*api
 	return genesis, nil
 }
 
-func (sc *serviceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
+func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
 	var results *cmtrpctypes.ResultBlockResults
 	results, err := sc.backend.GetCometBFTBlockResults(ctx, height)
@@ -291,7 +286,7 @@ func (sc *serviceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 	return events, nil
 }
 
-func (sc *serviceClient) WatchEvents(context.Context) (<-chan *api.Event, pubsub.ClosableSubscription, error) {
+func (sc *ServiceClient) WatchEvents(context.Context) (<-chan *api.Event, pubsub.ClosableSubscription, error) {
 	typedCh := make(chan *api.Event)
 	sub := sc.eventNotifier.Subscribe()
 	sub.Unwrap(typedCh)
@@ -299,7 +294,7 @@ func (sc *serviceClient) WatchEvents(context.Context) (<-chan *api.Event, pubsub
 	return typedCh, sub, nil
 }
 
-func (sc *serviceClient) ConsensusParameters(ctx context.Context, height int64) (*api.ConsensusParameters, error) {
+func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) (*api.ConsensusParameters, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
@@ -308,16 +303,16 @@ func (sc *serviceClient) ConsensusParameters(ctx context.Context, height int64) 
 	return q.ConsensusParameters(ctx)
 }
 
-func (sc *serviceClient) Cleanup() {
+func (sc *ServiceClient) Cleanup() {
 }
 
 // Implements api.ServiceClient.
-func (sc *serviceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
+func (sc *ServiceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
 	return tmapi.NewStaticServiceDescriptor(api.ModuleName, app.EventType, []cmtpubsub.Query{app.QueryApp})
 }
 
 // Implements api.ServiceClient.
-func (sc *serviceClient) DeliverEvent(_ context.Context, height int64, tx cmttypes.Tx, ev *cmtabcitypes.Event) error {
+func (sc *ServiceClient) DeliverEvent(_ context.Context, height int64, tx cmttypes.Tx, ev *cmtabcitypes.Event) error {
 	events, err := EventsFromCometBFT(tx, height, []cmtabcitypes.Event{*ev})
 	if err != nil {
 		return fmt.Errorf("staking: failed to process cometbft events: %w", err)
@@ -438,7 +433,7 @@ func EventsFromCometBFT(
 }
 
 // New constructs a new CometBFT backed staking backend instance.
-func New(backend tmapi.Backend) (ServiceClient, error) {
+func New(backend tmapi.Backend) (*ServiceClient, error) {
 	// Initialize and register the CometBFT service component.
 	a := app.New()
 	if err := backend.RegisterApplication(a); err != nil {
@@ -450,7 +445,7 @@ func New(backend tmapi.Backend) (ServiceClient, error) {
 		return nil, err
 	}
 
-	return &serviceClient{
+	return &ServiceClient{
 		logger:        logging.GetLogger("cometbft/staking"),
 		backend:       backend,
 		querier:       a.QueryFactory().(*app.QueryFactory),

--- a/go/consensus/cometbft/vault/vault.go
+++ b/go/consensus/cometbft/vault/vault.go
@@ -149,12 +149,12 @@ func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) 
 func (sc *ServiceClient) Cleanup() {
 }
 
-// Implements api.ServiceClient.
+// ServiceDescriptor implements api.ServiceClient.
 func (sc *ServiceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
 	return tmapi.NewStaticServiceDescriptor(vault.ModuleName, app.EventType, []cmtpubsub.Query{app.QueryApp})
 }
 
-// Implements api.ServiceClient.
+// DeliverEvent implements api.ServiceClient.
 func (sc *ServiceClient) DeliverEvent(_ context.Context, height int64, tx cmttypes.Tx, ev *cmtabcitypes.Event) error {
 	events, err := EventsFromCometBFT(tx, height, []cmtabcitypes.Event{*ev})
 	if err != nil {

--- a/go/consensus/cometbft/vault/vault.go
+++ b/go/consensus/cometbft/vault/vault.go
@@ -264,11 +264,11 @@ func EventsFromCometBFT(
 }
 
 // New constructs a new CometBFT backed vault backend instance.
-func New(backend tmapi.Backend, querier *app.QueryFactory) (*ServiceClient, error) {
+func New(backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
 	return &ServiceClient{
 		logger:        logging.GetLogger("cometbft/vault"),
 		backend:       backend,
 		querier:       querier,
 		eventNotifier: pubsub.NewBroker(false),
-	}, nil
+	}
 }

--- a/go/consensus/cometbft/vault/vault.go
+++ b/go/consensus/cometbft/vault/vault.go
@@ -268,7 +268,7 @@ func EventsFromCometBFT(
 	return events, errs
 }
 
-// New constructs a new CometBFT backed vault Backend instance.
+// New constructs a new CometBFT backed vault backend instance.
 func New(backend tmapi.Backend) (ServiceClient, error) {
 	// Initialize and register the CometBFT service component.
 	a := app.New()

--- a/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
+++ b/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
@@ -16,7 +16,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/config"
 	"github.com/oasisprotocol/oasis-core/go/consensus/cometbft/abci"
-	abciState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/abci/state"
 	cmtAPI "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	beaconApp "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/beacon"
 	governanceApp "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/governance"
@@ -374,11 +373,12 @@ func dumpBeacon(ctx context.Context, qs *dumpQueryState) (*beacon.Genesis, error
 }
 
 func dumpConsensus(ctx context.Context, qs *dumpQueryState) (*consensus.Genesis, error) {
-	is, err := abciState.NewImmutableStateAt(ctx, qs, qs.BlockHeight())
+	qf := abci.NewQueryFactory(qs)
+	q, err := qf.QueryAt(ctx, qs.BlockHeight())
 	if err != nil {
-		return nil, fmt.Errorf("dumpdb: failed to get consensus state: %w", err)
+		return nil, fmt.Errorf("dumpdb: failed to create consensus query: %w", err)
 	}
-	params, err := is.ConsensusParameters(ctx)
+	params, err := q.ConsensusParameters(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("dumpdb: failed to get consensus params: %w", err)
 	}

--- a/go/sentry/sentry.go
+++ b/go/sentry/sentry.go
@@ -38,7 +38,7 @@ func (b *backend) GetAddresses(context.Context) (*api.SentryAddresses, error) {
 	}, nil
 }
 
-// New constructs a new sentry Backend instance.
+// New constructs a new sentry backend instance.
 func New(
 	consensusBackend consensus.Backend,
 	identity *identity.Identity,

--- a/go/storage/database/database.go
+++ b/go/storage/database/database.go
@@ -46,7 +46,7 @@ type databaseBackend struct {
 	readOnly bool
 }
 
-// New constructs a new database backed storage Backend instance.
+// New constructs a new database backed storage backend instance.
 func New(cfg *api.Config) (api.LocalBackend, error) {
 	if err := autoDetectBackend(cfg); err != nil {
 		return nil, err


### PR DESCRIPTION
These changes move us closer to allowing an arbitrary querier to be plugged into a client service. This should be useful for light backend clients, as they can create their own querier with a verified trust root, and use read-syncer to fetch state data from a remote node.