### PR TITLE
go/consensus/cometbft/api: Simplify consensus backend

### DIFF
--- a/go/consensus/cometbft/abci/messages.go
+++ b/go/consensus/cometbft/abci/messages.go
@@ -7,17 +7,20 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 )
 
-var _ api.MessageDispatcher = (*messageDispatcher)(nil)
-
+// messageDispatcher dispatches messages to registered subscribers.
 type messageDispatcher struct {
 	subscriptions map[any][]api.MessageSubscriber
 }
 
+// newMessageDispatcher creates a new message dispatcher.
+func newMessageDispatcher() *messageDispatcher {
+	return &messageDispatcher{
+		subscriptions: make(map[any][]api.MessageSubscriber),
+	}
+}
+
 // Implements api.MessageDispatcher.
 func (md *messageDispatcher) Subscribe(kind any, ms api.MessageSubscriber) {
-	if md.subscriptions == nil {
-		md.subscriptions = make(map[any][]api.MessageSubscriber)
-	}
 	md.subscriptions[kind] = append(md.subscriptions[kind], ms)
 }
 

--- a/go/consensus/cometbft/abci/messages_test.go
+++ b/go/consensus/cometbft/abci/messages_test.go
@@ -63,7 +63,7 @@ func TestMessageDispatcher(t *testing.T) {
 	ctx := appState.NewContext(api.ContextBeginBlock)
 	defer ctx.Close()
 
-	var md messageDispatcher
+	md := newMessageDispatcher()
 
 	// Publish without subscribers should work.
 	res, err := md.Publish(ctx, testMessageA, &testMessage{foo: 42})

--- a/go/consensus/cometbft/abci/mux.go
+++ b/go/consensus/cometbft/abci/mux.go
@@ -179,7 +179,7 @@ func (a *ApplicationServer) EstimateGas(caller signature.PublicKey, tx *transact
 }
 
 // State returns the application state.
-func (a *ApplicationServer) State() api.ApplicationQueryState {
+func (a *ApplicationServer) State() api.ApplicationState {
 	return a.mux.state
 }
 
@@ -869,7 +869,7 @@ func (mux *abciMux) doRegister(app api.Application) error {
 	}
 	mux.rebuildAppLexOrdering() // Inefficient but not a lot of apps.
 
-	app.OnRegister(mux.state, &mux.md)
+	app.OnRegister(&mux.md)
 	mux.logger.Debug("Registered new application",
 		"app", app.Name(),
 	)

--- a/go/consensus/cometbft/api/api.go
+++ b/go/consensus/cometbft/api/api.go
@@ -202,10 +202,6 @@ func NewBlock(blk *cmttypes.Block) *consensus.Block {
 type Backend interface {
 	consensus.Backend
 
-	// SetTransactionAuthHandler configures the transaction fee handler for the
-	// ABCI multiplexer.
-	SetTransactionAuthHandler(TransactionAuthHandler) error
-
 	// GetCometBFTBlock returns the CometBFT block at the specified height.
 	GetCometBFTBlock(ctx context.Context, height int64) (*cmttypes.Block, error)
 

--- a/go/consensus/cometbft/api/app.go
+++ b/go/consensus/cometbft/api/app.go
@@ -78,7 +78,7 @@ type Application interface {
 
 	// OnRegister is the function that is called when the Application
 	// is registered with the multiplexer instance.
-	OnRegister(ApplicationState, MessageDispatcher)
+	OnRegister(MessageDispatcher)
 
 	// OnCleanup is the function that is called when the ApplicationServer
 	// has been halted.
@@ -115,7 +115,7 @@ type Extension interface {
 
 	// OnRegister is the function that is called when the Application
 	// is registered with the multiplexer instance.
-	OnRegister(ApplicationState, MessageDispatcher)
+	OnRegister(MessageDispatcher)
 
 	// ExecuteTx executes a transaction.
 	ExecuteTx(*Context, *transaction.Transaction) error

--- a/go/consensus/cometbft/api/app.go
+++ b/go/consensus/cometbft/api/app.go
@@ -76,9 +76,8 @@ type Application interface {
 	// depends on.
 	Dependencies() []string
 
-	// OnRegister is the function that is called when the Application
-	// is registered with the multiplexer instance.
-	OnRegister(MessageDispatcher)
+	// Subscribe subscribes to messages from other applications.
+	Subscribe()
 
 	// OnCleanup is the function that is called when the ApplicationServer
 	// has been halted.
@@ -112,10 +111,6 @@ type Application interface {
 type Extension interface {
 	// Methods returns the list of supported methods.
 	Methods() []transaction.MethodName
-
-	// OnRegister is the function that is called when the Application
-	// is registered with the multiplexer instance.
-	OnRegister(MessageDispatcher)
 
 	// ExecuteTx executes a transaction.
 	ExecuteTx(*Context, *transaction.Transaction) error

--- a/go/consensus/cometbft/api/app.go
+++ b/go/consensus/cometbft/api/app.go
@@ -76,10 +76,6 @@ type Application interface {
 	// depends on.
 	Dependencies() []string
 
-	// QueryFactory returns an application-specific query factory that
-	// can be used to construct new queries at specific block heights.
-	QueryFactory() any
-
 	// OnRegister is the function that is called when the Application
 	// is registered with the multiplexer instance.
 	OnRegister(ApplicationState, MessageDispatcher)

--- a/go/consensus/cometbft/api/app.go
+++ b/go/consensus/cometbft/api/app.go
@@ -53,8 +53,6 @@ func (nd *NoopMessageDispatcher) Publish(*Context, any, any) (any, error) {
 // Application is the interface implemented by multiplexed Oasis-specific
 // ABCI applications.
 type Application interface {
-	MessageSubscriber
-
 	// Name returns the name of the Application.
 	Name() string
 

--- a/go/consensus/cometbft/apps/beacon/beacon.go
+++ b/go/consensus/cometbft/apps/beacon/beacon.go
@@ -19,8 +19,6 @@ import (
 var prodEntropyCtx = []byte("EkB-tmnt")
 
 type Application struct {
-	state api.ApplicationState
-
 	backend internalBackend
 }
 
@@ -44,8 +42,7 @@ func (app *Application) Dependencies() []string {
 	return nil
 }
 
-func (app *Application) OnRegister(state api.ApplicationState, _ api.MessageDispatcher) {
-	app.state = state
+func (app *Application) OnRegister(api.MessageDispatcher) {
 }
 
 func (app *Application) OnCleanup() {

--- a/go/consensus/cometbft/apps/beacon/beacon.go
+++ b/go/consensus/cometbft/apps/beacon/beacon.go
@@ -77,11 +77,6 @@ func (app *Application) BeginBlock(ctx *api.Context) error {
 	return app.backend.OnBeginBlock(ctx, state, params)
 }
 
-// ExecuteMessage implements api.MessageSubscriber.
-func (app *Application) ExecuteMessage(*api.Context, any, any) (any, error) {
-	return nil, fmt.Errorf("beacon: unexpected message")
-}
-
 // ExecuteTx implements api.Application.
 func (app *Application) ExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {
 	if app.backend == nil {

--- a/go/consensus/cometbft/apps/beacon/beacon.go
+++ b/go/consensus/cometbft/apps/beacon/beacon.go
@@ -18,36 +18,50 @@ import (
 
 var prodEntropyCtx = []byte("EkB-tmnt")
 
+// Application is a beacon application.
 type Application struct {
 	backend internalBackend
 }
 
+// New constructs a new beacon application.
+func New() *Application {
+	return &Application{}
+}
+
+// Name implements api.Application.
 func (app *Application) Name() string {
 	return AppName
 }
 
+// ID implements api.Application.
 func (app *Application) ID() uint8 {
 	return AppID
 }
 
+// Methods implements api.Application.
 func (app *Application) Methods() []transaction.MethodName {
 	return Methods
 }
 
+// Blessed implements api.Application.
 func (app *Application) Blessed() bool {
 	return false
 }
 
+// Dependencies implements api.Application.
 func (app *Application) Dependencies() []string {
 	return nil
 }
 
-func (app *Application) OnRegister(api.MessageDispatcher) {
+// Subscribe implements api.Application.
+func (app *Application) Subscribe() {
 }
 
+// OnCleanup implements api.Application.
 func (app *Application) OnCleanup() {
 }
 
+// BeginBlock implements api.Application.
 func (app *Application) BeginBlock(ctx *api.Context) error {
 	state := beaconState.NewMutableState(ctx.State())
 
@@ -63,10 +77,12 @@ func (app *Application) BeginBlock(ctx *api.Context) error {
 	return app.backend.OnBeginBlock(ctx, state, params)
 }
 
+// ExecuteMessage implements api.MessageSubscriber.
 func (app *Application) ExecuteMessage(*api.Context, any, any) (any, error) {
 	return nil, fmt.Errorf("beacon: unexpected message")
 }
 
+// ExecuteTx implements api.Application.
 func (app *Application) ExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {
 	if app.backend == nil {
 		// Executing a transaction before BeginBlock -- likely during transaction simulation or
@@ -86,6 +102,7 @@ func (app *Application) ExecuteTx(ctx *api.Context, tx *transaction.Transaction)
 	return app.backend.ExecuteTx(ctx, state, params, tx)
 }
 
+// EndBlock implements api.Application.
 func (app *Application) EndBlock(*api.Context) (types.ResponseEndBlock, error) {
 	return types.ResponseEndBlock{}, nil
 }
@@ -125,11 +142,6 @@ func (app *Application) onNewBeacon(ctx *api.Context, value []byte) error {
 	ctx.EmitEvent(api.NewEventBuilder(app.Name()).TypedAttribute(&beacon.BeaconEvent{Beacon: value}))
 
 	return nil
-}
-
-// New constructs a new beacon application instance.
-func New() *Application {
-	return &Application{}
 }
 
 // insecureBlockEntropy returns insecure entropy based on deterministic block data.

--- a/go/consensus/cometbft/apps/beacon/query.go
+++ b/go/consensus/cometbft/apps/beacon/query.go
@@ -58,10 +58,6 @@ func (q *beaconQuerier) VRFState(ctx context.Context) (*beacon.VRFState, error) 
 	return q.state.VRFState(ctx)
 }
 
-func (app *Application) QueryFactory() any {
-	return &QueryFactory{app.state}
-}
-
 // NewQueryFactory returns a new QueryFactory backed by the given state
 // instance.
 func NewQueryFactory(state abciAPI.ApplicationQueryState) *QueryFactory {

--- a/go/consensus/cometbft/apps/governance/governance.go
+++ b/go/consensus/cometbft/apps/governance/governance.go
@@ -49,8 +49,7 @@ func (app *Application) Dependencies() []string {
 	return []string{registryapp.AppName, schedulerapp.AppName, stakingapp.AppName}
 }
 
-func (app *Application) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
-	app.state = state
+func (app *Application) OnRegister(md api.MessageDispatcher) {
 	app.md = md
 
 	// Subscribe to messages emitted by other apps.
@@ -637,6 +636,8 @@ func (app *Application) EndBlock(ctx *api.Context) (types.ResponseEndBlock, erro
 }
 
 // New constructs a new governance application instance.
-func New() *Application {
-	return &Application{}
+func New(state api.ApplicationState) *Application {
+	return &Application{
+		state: state,
+	}
 }

--- a/go/consensus/cometbft/apps/governance/query.go
+++ b/go/consensus/cometbft/apps/governance/query.go
@@ -64,10 +64,6 @@ func (q *governanceQuerier) ConsensusParameters(ctx context.Context) (*governanc
 	return q.state.ConsensusParameters(ctx)
 }
 
-func (app *Application) QueryFactory() any {
-	return &QueryFactory{app.state}
-}
-
 // NewQueryFactory returns a new QueryFactory backed by the given state
 // instance.
 func NewQueryFactory(state abciAPI.ApplicationQueryState) *QueryFactory {

--- a/go/consensus/cometbft/apps/keymanager/churp/ext.go
+++ b/go/consensus/cometbft/apps/keymanager/churp/ext.go
@@ -19,9 +19,10 @@ type churpExt struct {
 }
 
 // New creates a new CHRUP extension for the key manager application.
-func New(appName string) tmapi.Extension {
+func New(appName string, state tmapi.ApplicationState) tmapi.Extension {
 	return &churpExt{
 		appName: appName,
+		state:   state,
 	}
 }
 
@@ -31,8 +32,7 @@ func (ext *churpExt) Methods() []transaction.MethodName {
 }
 
 // OnRegister implements api.Extension.
-func (ext *churpExt) OnRegister(state tmapi.ApplicationState, _ tmapi.MessageDispatcher) {
-	ext.state = state
+func (ext *churpExt) OnRegister(tmapi.MessageDispatcher) {
 }
 
 // ExecuteTx implements api.Extension.

--- a/go/consensus/cometbft/apps/keymanager/churp/ext.go
+++ b/go/consensus/cometbft/apps/keymanager/churp/ext.go
@@ -31,10 +31,6 @@ func (ext *churpExt) Methods() []transaction.MethodName {
 	return churp.Methods
 }
 
-// OnRegister implements api.Extension.
-func (ext *churpExt) OnRegister(tmapi.MessageDispatcher) {
-}
-
 // ExecuteTx implements api.Extension.
 func (ext *churpExt) ExecuteTx(ctx *tmapi.Context, tx *transaction.Transaction) error {
 	switch tx.Method {

--- a/go/consensus/cometbft/apps/keymanager/keymanager.go
+++ b/go/consensus/cometbft/apps/keymanager/keymanager.go
@@ -91,11 +91,6 @@ func (app *Application) BeginBlock(ctx *tmapi.Context) error {
 	return nil
 }
 
-// ExecuteMessage implements api.MessageSubscriber.
-func (app *Application) ExecuteMessage(*tmapi.Context, any, any) (any, error) {
-	return nil, fmt.Errorf("keymanager: unexpected message")
-}
-
 // ExecuteTx implements api.Application.
 func (app *Application) ExecuteTx(ctx *tmapi.Context, tx *transaction.Transaction) error {
 	ctx.SetPriority(AppPriority)

--- a/go/consensus/cometbft/apps/keymanager/query.go
+++ b/go/consensus/cometbft/apps/keymanager/query.go
@@ -46,10 +46,6 @@ func (q *keymanagerQuerier) Churp() churp.Query {
 	return churp.NewQuery(q.churpState)
 }
 
-func (app *Application) QueryFactory() any {
-	return &QueryFactory{app.state}
-}
-
 // NewQueryFactory returns a new QueryFactory backed by the given state
 // instance.
 func NewQueryFactory(state abciAPI.ApplicationQueryState) *QueryFactory {

--- a/go/consensus/cometbft/apps/keymanager/secrets/ext.go
+++ b/go/consensus/cometbft/apps/keymanager/secrets/ext.go
@@ -19,9 +19,10 @@ type secretsExt struct {
 }
 
 // New creates a new master and ephemeral secrets extension for the key manager application.
-func New(appName string) tmapi.Extension {
+func New(appName string, state tmapi.ApplicationState) tmapi.Extension {
 	return &secretsExt{
 		appName: appName,
+		state:   state,
 	}
 }
 
@@ -31,8 +32,7 @@ func (ext *secretsExt) Methods() []transaction.MethodName {
 }
 
 // OnRegister implements api.Extension.
-func (ext *secretsExt) OnRegister(state tmapi.ApplicationState, _ tmapi.MessageDispatcher) {
-	ext.state = state
+func (ext *secretsExt) OnRegister(_ tmapi.MessageDispatcher) {
 }
 
 // ExecuteTx implements api.Extension.

--- a/go/consensus/cometbft/apps/keymanager/secrets/ext.go
+++ b/go/consensus/cometbft/apps/keymanager/secrets/ext.go
@@ -31,10 +31,6 @@ func (ext *secretsExt) Methods() []transaction.MethodName {
 	return secrets.Methods
 }
 
-// OnRegister implements api.Extension.
-func (ext *secretsExt) OnRegister(_ tmapi.MessageDispatcher) {
-}
-
 // ExecuteTx implements api.Extension.
 func (ext *secretsExt) ExecuteTx(ctx *tmapi.Context, tx *transaction.Transaction) error {
 	state := state.NewMutableState(ctx.State())

--- a/go/consensus/cometbft/apps/registry/query.go
+++ b/go/consensus/cometbft/apps/registry/query.go
@@ -125,10 +125,6 @@ func (q *registryQuerier) ConsensusParameters(ctx context.Context) (*registry.Co
 	return q.state.ConsensusParameters(ctx)
 }
 
-func (app *Application) QueryFactory() any {
-	return &QueryFactory{app.state}
-}
-
 // NewQueryFactory returns a new QueryFactory backed by the given state
 // instance.
 func NewQueryFactory(state abciAPI.ApplicationQueryState) *QueryFactory {

--- a/go/consensus/cometbft/apps/registry/registry.go
+++ b/go/consensus/cometbft/apps/registry/registry.go
@@ -48,8 +48,7 @@ func (app *Application) Dependencies() []string {
 	return []string{stakingapp.AppName}
 }
 
-func (app *Application) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
-	app.state = state
+func (app *Application) OnRegister(md api.MessageDispatcher) {
 	app.md = md
 
 	// Subscribe to messages emitted by other apps.
@@ -258,6 +257,8 @@ func (app *Application) onRegistryEpochChanged(ctx *api.Context, registryEpoch b
 }
 
 // New constructs a new registry application instance.
-func New() *Application {
-	return &Application{}
+func New(state api.ApplicationState) *Application {
+	return &Application{
+		state: state,
+	}
 }

--- a/go/consensus/cometbft/apps/registry/registry.go
+++ b/go/consensus/cometbft/apps/registry/registry.go
@@ -23,43 +23,58 @@ import (
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
+// Application is a registry application.
 type Application struct {
 	state api.ApplicationState
 	md    api.MessageDispatcher
 }
 
+// New constructs a new registry application.
+func New(state api.ApplicationState, md api.MessageDispatcher) *Application {
+	return &Application{
+		state: state,
+		md:    md,
+	}
+}
+
+// Name implements api.Application.
 func (app *Application) Name() string {
 	return AppName
 }
 
+// ID implements api.Application.
 func (app *Application) ID() uint8 {
 	return AppID
 }
 
+// Methods implements api.Application.
 func (app *Application) Methods() []transaction.MethodName {
 	return registry.Methods
 }
 
+// Blessed implements api.Application.
 func (app *Application) Blessed() bool {
 	return false
 }
 
+// Dependencies implements api.Application.
 func (app *Application) Dependencies() []string {
 	return []string{stakingapp.AppName}
 }
 
-func (app *Application) OnRegister(md api.MessageDispatcher) {
-	app.md = md
-
+// Subscribe implements api.Application.
+func (app *Application) Subscribe() {
 	// Subscribe to messages emitted by other apps.
-	md.Subscribe(roothashApi.RuntimeMessageRegistry, app)
-	md.Subscribe(governanceApi.MessageChangeParameters, app)
-	md.Subscribe(governanceApi.MessageValidateParameterChanges, app)
+	app.md.Subscribe(roothashApi.RuntimeMessageRegistry, app)
+	app.md.Subscribe(governanceApi.MessageChangeParameters, app)
+	app.md.Subscribe(governanceApi.MessageValidateParameterChanges, app)
 }
 
+// OnCleanup implements api.Application.
 func (app *Application) OnCleanup() {
 }
 
+// BeginBlock implements api.Application.
 func (app *Application) BeginBlock(ctx *api.Context) error {
 	// XXX: With PR#1889 this can be a differnet interval.
 	if changed, registryEpoch := app.state.EpochChanged(ctx); changed {
@@ -68,6 +83,7 @@ func (app *Application) BeginBlock(ctx *api.Context) error {
 	return nil
 }
 
+// ExecuteMessage implements api.MessageSubscriber.
 func (app *Application) ExecuteMessage(ctx *api.Context, kind, msg any) (any, error) {
 	switch kind {
 	case roothashApi.RuntimeMessageRegistry:
@@ -254,11 +270,4 @@ func (app *Application) onRegistryEpochChanged(ctx *api.Context, registryEpoch b
 	ctx.EmitEvent(api.NewEventBuilder(app.Name()).TypedAttribute(&registry.NodeListEpochEvent{}))
 
 	return nil
-}
-
-// New constructs a new registry application instance.
-func New(state api.ApplicationState) *Application {
-	return &Application{
-		state: state,
-	}
 }

--- a/go/consensus/cometbft/apps/roothash/query.go
+++ b/go/consensus/cometbft/apps/roothash/query.go
@@ -89,10 +89,6 @@ func (q *rootHashQuerier) ConsensusParameters(ctx context.Context) (*roothash.Co
 	return q.state.ConsensusParameters(ctx)
 }
 
-func (app *Application) QueryFactory() any {
-	return &QueryFactory{app.state}
-}
-
 // NewQueryFactory returns a new QueryFactory backed by the given state
 // instance.
 func NewQueryFactory(state abciAPI.ApplicationQueryState) *QueryFactory {

--- a/go/consensus/cometbft/apps/roothash/roothash.go
+++ b/go/consensus/cometbft/apps/roothash/roothash.go
@@ -9,6 +9,7 @@ import (
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
+	"github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	governanceApi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/governance/api"
 	registryApi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/registry/api"
@@ -52,8 +53,7 @@ func (app *Application) Dependencies() []string {
 	return []string{schedulerapp.AppName, stakingapp.AppName}
 }
 
-func (app *Application) OnRegister(state tmapi.ApplicationState, md tmapi.MessageDispatcher) {
-	app.state = state
+func (app *Application) OnRegister(md tmapi.MessageDispatcher) {
 	app.md = md
 
 	// Subscribe to messages emitted by other apps.
@@ -398,8 +398,9 @@ func (app *Application) EndBlock(ctx *tmapi.Context) (types.ResponseEndBlock, er
 }
 
 // New constructs a new roothash application instance.
-func New(ecn tmapi.ExecutorCommitmentNotifier) *Application {
+func New(state api.ApplicationState, ecn tmapi.ExecutorCommitmentNotifier) *Application {
 	return &Application{
-		ecn: ecn,
+		state: state,
+		ecn:   ecn,
 	}
 }

--- a/go/consensus/cometbft/apps/scheduler/query.go
+++ b/go/consensus/cometbft/apps/scheduler/query.go
@@ -63,10 +63,6 @@ func (q *schedulerQuerier) ConsensusParameters(ctx context.Context) (*scheduler.
 	return q.state.ConsensusParameters(ctx)
 }
 
-func (app *Application) QueryFactory() any {
-	return &QueryFactory{app.state}
-}
-
 // NewQueryFactory returns a new QueryFactory backed by the given state
 // instance.
 func NewQueryFactory(state abciAPI.ApplicationQueryState) *QueryFactory {

--- a/go/consensus/cometbft/apps/scheduler/scheduler.go
+++ b/go/consensus/cometbft/apps/scheduler/scheduler.go
@@ -67,8 +67,7 @@ func (app *Application) Dependencies() []string {
 	return []string{beaconapp.AppName, registryapp.AppName, stakingapp.AppName}
 }
 
-func (app *Application) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
-	app.state = state
+func (app *Application) OnRegister(md api.MessageDispatcher) {
 	app.md = md
 
 	// Subscribe to messages emitted by other apps.
@@ -629,6 +628,8 @@ func stakingAddressMapToSortedSlice(m map[staking.Address]bool) []staking.Addres
 }
 
 // New constructs a new scheduler application instance.
-func New() *Application {
-	return &Application{}
+func New(state api.ApplicationState) *Application {
+	return &Application{
+		state: state,
+	}
 }

--- a/go/consensus/cometbft/apps/staking/query.go
+++ b/go/consensus/cometbft/apps/staking/query.go
@@ -192,10 +192,6 @@ func (q *stakingQuerier) ConsensusParameters(ctx context.Context) (*staking.Cons
 	return q.state.ConsensusParameters(ctx)
 }
 
-func (app *Application) QueryFactory() any {
-	return &QueryFactory{app.state}
-}
-
 // NewQueryFactory returns a new QueryFactory backed by the given state
 // instance.
 func NewQueryFactory(state abciAPI.ApplicationQueryState) *QueryFactory {

--- a/go/consensus/cometbft/apps/staking/staking.go
+++ b/go/consensus/cometbft/apps/staking/staking.go
@@ -44,8 +44,7 @@ func (app *Application) Dependencies() []string {
 	return nil
 }
 
-func (app *Application) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
-	app.state = state
+func (app *Application) OnRegister(md api.MessageDispatcher) {
 	app.md = md
 
 	// Subscribe to messages emitted by other apps.
@@ -317,6 +316,8 @@ func (app *Application) onEpochChange(ctx *api.Context, epoch beacon.EpochTime) 
 }
 
 // New constructs a new staking application instance.
-func New() *Application {
-	return &Application{}
+func New(state api.ApplicationState) *Application {
+	return &Application{
+		state: state,
+	}
 }

--- a/go/consensus/cometbft/apps/supplementarysanity/supplementarysanity.go
+++ b/go/consensus/cometbft/apps/supplementarysanity/supplementarysanity.go
@@ -68,11 +68,6 @@ func (app *Application) Subscribe() {
 func (app *Application) OnCleanup() {
 }
 
-// ExecuteMessage implements api.MessageSubscriber.
-func (app *Application) ExecuteMessage(*api.Context, any, any) (any, error) {
-	return nil, fmt.Errorf("supplementarysanity: unexpected message")
-}
-
 // ExecuteTx implements api.Application.
 func (app *Application) ExecuteTx(*api.Context, *transaction.Transaction) error {
 	return fmt.Errorf("supplementarysanity: unexpected transaction")

--- a/go/consensus/cometbft/apps/supplementarysanity/supplementarysanity.go
+++ b/go/consensus/cometbft/apps/supplementarysanity/supplementarysanity.go
@@ -14,11 +14,7 @@ import (
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
 )
 
-var (
-	logger = logging.GetLogger("supplementarysanity")
-
-	_ api.Application = (*Application)(nil)
-)
+var logger = logging.GetLogger("supplementarysanity")
 
 // Application is a non-normative mux app that performs additional checks on the consensus state.
 // It should not alter the CometBFT application state.
@@ -31,48 +27,68 @@ type Application struct {
 	checkHeight     int64
 }
 
+// New constructs a new supplementarysanity application.
+func New(state api.ApplicationState, interval int64) *Application {
+	return &Application{
+		state:    state,
+		interval: interval,
+	}
+}
+
+// Name implements api.Application.
 func (app *Application) Name() string {
 	return AppName
 }
 
+// ID implements api.Application.
 func (app *Application) ID() uint8 {
 	return AppID
 }
 
+// Methods implements api.Application.
 func (app *Application) Methods() []transaction.MethodName {
 	return nil
 }
 
+// Blessed implements api.Application.
 func (app *Application) Blessed() bool {
 	return false
 }
 
+// Dependencies implements api.Application.
 func (app *Application) Dependencies() []string {
 	return []string{stakingState.AppName}
 }
 
-func (app *Application) OnRegister(api.MessageDispatcher) {
+// Subscribe implements api.Application.
+func (app *Application) Subscribe() {
 }
 
+// OnCleanup implements api.Application.
 func (app *Application) OnCleanup() {
 }
 
+// ExecuteMessage implements api.MessageSubscriber.
 func (app *Application) ExecuteMessage(*api.Context, any, any) (any, error) {
 	return nil, fmt.Errorf("supplementarysanity: unexpected message")
 }
 
+// ExecuteTx implements api.Application.
 func (app *Application) ExecuteTx(*api.Context, *transaction.Transaction) error {
 	return fmt.Errorf("supplementarysanity: unexpected transaction")
 }
 
+// InitChain implements api.Application.
 func (app *Application) InitChain(*api.Context, types.RequestInitChain, *genesis.Document) error {
 	return nil
 }
 
+// BeginBlock implements api.Application.
 func (app *Application) BeginBlock(*api.Context) error {
 	return nil
 }
 
+// EndBlock implements api.Application.
 func (app *Application) EndBlock(ctx *api.Context) (types.ResponseEndBlock, error) {
 	return types.ResponseEndBlock{}, app.endBlockImpl(ctx)
 }
@@ -129,11 +145,4 @@ func (app *Application) endBlockImpl(ctx *api.Context) error {
 	}
 
 	return nil
-}
-
-func New(state api.ApplicationState, interval int64) *Application {
-	return &Application{
-		state:    state,
-		interval: interval,
-	}
 }

--- a/go/consensus/cometbft/apps/supplementarysanity/supplementarysanity.go
+++ b/go/consensus/cometbft/apps/supplementarysanity/supplementarysanity.go
@@ -51,10 +51,6 @@ func (app *Application) Dependencies() []string {
 	return []string{stakingState.AppName}
 }
 
-func (app *Application) QueryFactory() any {
-	return nil
-}
-
 func (app *Application) OnRegister(state api.ApplicationState, _ api.MessageDispatcher) {
 	app.state = state
 }

--- a/go/consensus/cometbft/apps/supplementarysanity/supplementarysanity.go
+++ b/go/consensus/cometbft/apps/supplementarysanity/supplementarysanity.go
@@ -51,8 +51,7 @@ func (app *Application) Dependencies() []string {
 	return []string{stakingState.AppName}
 }
 
-func (app *Application) OnRegister(state api.ApplicationState, _ api.MessageDispatcher) {
-	app.state = state
+func (app *Application) OnRegister(api.MessageDispatcher) {
 }
 
 func (app *Application) OnCleanup() {
@@ -132,8 +131,9 @@ func (app *Application) endBlockImpl(ctx *api.Context) error {
 	return nil
 }
 
-func New(interval uint64) *Application {
+func New(state api.ApplicationState, interval int64) *Application {
 	return &Application{
-		interval: int64(interval),
+		state:    state,
+		interval: interval,
 	}
 }

--- a/go/consensus/cometbft/apps/vault/query.go
+++ b/go/consensus/cometbft/apps/vault/query.go
@@ -59,10 +59,6 @@ func (q *vaultQuerier) ConsensusParameters(ctx context.Context) (*vault.Consensu
 	return q.state.ConsensusParameters(ctx)
 }
 
-func (app *Application) QueryFactory() any {
-	return &QueryFactory{app.state}
-}
-
 // NewQueryFactory returns a new QueryFactory backed by the given state instance.
 func NewQueryFactory(state abciAPI.ApplicationQueryState) *QueryFactory {
 	return &QueryFactory{state}

--- a/go/consensus/cometbft/apps/vault/vault.go
+++ b/go/consensus/cometbft/apps/vault/vault.go
@@ -13,19 +13,31 @@ import (
 	vault "github.com/oasisprotocol/oasis-core/go/vault/api"
 )
 
+// Application is a vault application.
 type Application struct {
 	state api.ApplicationState
 	md    api.MessageDispatcher
 }
 
+// New constructs a new vault application.
+func New(state api.ApplicationState, md api.MessageDispatcher) *Application {
+	return &Application{
+		state: state,
+		md:    md,
+	}
+}
+
+// Name implements api.Application.
 func (app *Application) Name() string {
 	return AppName
 }
 
+// ID implements api.Application.
 func (app *Application) ID() uint8 {
 	return AppID
 }
 
+// Methods implements api.Application.
 func (app *Application) Methods() []transaction.MethodName {
 	return vault.Methods
 }
@@ -40,26 +52,29 @@ func (app *Application) Enabled(ctx *api.Context) (bool, error) {
 	return params.Enabled, nil
 }
 
+// Blessed implements api.Application.
 func (app *Application) Blessed() bool {
 	return false
 }
 
+// Dependencies implements api.Application.
 func (app *Application) Dependencies() []string {
 	return []string{stakingapp.AppName}
 }
 
-func (app *Application) OnRegister(md api.MessageDispatcher) {
-	app.md = md
-
+// Subscribe implements api.Application.
+func (app *Application) Subscribe() {
 	// Subscribe to messages emitted by other apps.
-	md.Subscribe(stakingApi.MessageAccountHook, app)
-	md.Subscribe(governanceApi.MessageChangeParameters, app)
-	md.Subscribe(governanceApi.MessageValidateParameterChanges, app)
+	app.md.Subscribe(stakingApi.MessageAccountHook, app)
+	app.md.Subscribe(governanceApi.MessageChangeParameters, app)
+	app.md.Subscribe(governanceApi.MessageValidateParameterChanges, app)
 }
 
+// OnCleanup implements api.Application.
 func (app *Application) OnCleanup() {
 }
 
+// ExecuteTx implements api.Application.
 func (app *Application) ExecuteTx(ctx *api.Context, tx *transaction.Transaction) error {
 	ctx.SetPriority(AppPriority)
 
@@ -87,6 +102,7 @@ func (app *Application) ExecuteTx(ctx *api.Context, tx *transaction.Transaction)
 	}
 }
 
+// ExecuteMessage implements api.MessageSubscriber.
 func (app *Application) ExecuteMessage(ctx *api.Context, kind, msg any) (any, error) {
 	switch kind {
 	case stakingApi.MessageAccountHook:
@@ -104,17 +120,12 @@ func (app *Application) ExecuteMessage(ctx *api.Context, kind, msg any) (any, er
 	}
 }
 
+// BeginBlock implements api.Application.
 func (app *Application) BeginBlock(_ *api.Context) error {
 	return nil
 }
 
+// EndBlock implements api.Application.
 func (app *Application) EndBlock(_ *api.Context) (types.ResponseEndBlock, error) {
 	return types.ResponseEndBlock{}, nil
-}
-
-// New constructs a new vault application instance.
-func New(state api.ApplicationState) *Application {
-	return &Application{
-		state: state,
-	}
 }

--- a/go/consensus/cometbft/apps/vault/vault.go
+++ b/go/consensus/cometbft/apps/vault/vault.go
@@ -48,8 +48,7 @@ func (app *Application) Dependencies() []string {
 	return []string{stakingapp.AppName}
 }
 
-func (app *Application) OnRegister(state api.ApplicationState, md api.MessageDispatcher) {
-	app.state = state
+func (app *Application) OnRegister(md api.MessageDispatcher) {
 	app.md = md
 
 	// Subscribe to messages emitted by other apps.
@@ -114,6 +113,8 @@ func (app *Application) EndBlock(_ *api.Context) (types.ResponseEndBlock, error)
 }
 
 // New constructs a new vault application instance.
-func New() *Application {
-	return &Application{}
+func New(state api.ApplicationState) *Application {
+	return &Application{
+		state: state,
+	}
 }

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -310,7 +310,7 @@ func (n *commonNode) initialize() error {
 	}
 
 	// Configure the staking application as a fee handler.
-	if err := n.parentNode.SetTransactionAuthHandler(stakingApp); err != nil {
+	if err := n.mux.SetTransactionAuthHandler(stakingApp); err != nil {
 		return err
 	}
 
@@ -481,11 +481,6 @@ func (n *commonNode) Governance() governanceAPI.Backend {
 // Implements consensusAPI.Backend.
 func (n *commonNode) Vault() vaultAPI.Backend {
 	return n.vault
-}
-
-// Implements consensusAPI.Backend.
-func (n *commonNode) SetTransactionAuthHandler(handler api.TransactionAuthHandler) error {
-	return n.mux.SetTransactionAuthHandler(handler)
 }
 
 // Implements consensusAPI.Backend.

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -231,6 +231,7 @@ func (n *commonNode) initialize() error {
 
 	// Fetch the application state.
 	state := n.mux.State()
+	md := n.mux.MessageDispatcher()
 
 	// Initialize consensus backend querier.
 	n.querier = abci.NewQueryFactory(state)
@@ -275,13 +276,13 @@ func (n *commonNode) initialize() error {
 
 	// Register CometBFT applications.
 	beaconApp := beaconApp.New()
-	governanceApp := governanceApp.New(state)
+	governanceApp := governanceApp.New(state, md)
 	keymanagerApp := keymanagerApp.New(state)
-	registryApp := registryApp.New(state)
-	roothashApp := roothashApp.New(state, n.roothash)
-	schedulerApp := schedulerApp.New(state)
-	stakingApp := stakingApp.New(state)
-	vaultApp := vaultApp.New(state)
+	registryApp := registryApp.New(state, md)
+	roothashApp := roothashApp.New(state, md, n.roothash)
+	schedulerApp := schedulerApp.New(state, md)
+	stakingApp := stakingApp.New(state, md)
+	vaultApp := vaultApp.New(state, md)
 
 	apps := []api.Application{
 		beaconApp,
@@ -297,6 +298,7 @@ func (n *commonNode) initialize() error {
 		if err := n.mux.Register(app); err != nil {
 			return fmt.Errorf("failed to register app: %w", err)
 		}
+		app.Subscribe()
 	}
 
 	// Enable supplementary sanity checks when enabled.

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -229,56 +229,59 @@ func (n *commonNode) initialize() error {
 		}
 	}
 
+	// Fetch the application state.
+	state := n.mux.State()
+
 	// Initialize consensus backend querier.
-	n.querier = abci.NewQueryFactory(n.mux.State())
+	n.querier = abci.NewQueryFactory(state)
 
 	// Initialize the beacon/epochtime backend.
-	n.beacon = tmbeacon.New(n.ctx, n.baseEpoch, n.baseHeight, n.parentNode, beaconApp.NewQueryFactory(n.mux.State()))
+	n.beacon = tmbeacon.New(n.ctx, n.baseEpoch, n.baseHeight, n.parentNode, beaconApp.NewQueryFactory(state))
 	n.serviceClients = append(n.serviceClients, n.beacon)
 	if err := n.mux.SetEpochtime(n.beacon); err != nil {
 		return err
 	}
 
 	// Initialize the rest of backends.
-	n.keymanager = tmkeymanager.New(n.ctx, keymanagerApp.NewQueryFactory(n.mux.State()))
+	n.keymanager = tmkeymanager.New(n.ctx, keymanagerApp.NewQueryFactory(state))
 	n.serviceClients = append(n.serviceClients, n.keymanager)
 
-	n.registry = tmregistry.New(n.ctx, n.parentNode, registryApp.NewQueryFactory(n.mux.State()))
+	n.registry = tmregistry.New(n.ctx, n.parentNode, registryApp.NewQueryFactory(state))
 	if cmmetrics.Enabled() {
 		n.svcMgr.RegisterCleanupOnly(registry.NewMetricsUpdater(n.ctx, n.registry), "registry metrics updater")
 	}
 	n.serviceClients = append(n.serviceClients, n.registry)
 	n.svcMgr.RegisterCleanupOnly(n.registry, "registry backend")
 
-	n.staking = tmstaking.New(n.parentNode, stakingApp.NewQueryFactory(n.mux.State()))
+	n.staking = tmstaking.New(n.parentNode, stakingApp.NewQueryFactory(state))
 	n.serviceClients = append(n.serviceClients, n.staking)
 	n.svcMgr.RegisterCleanupOnly(n.staking, "staking backend")
 
-	n.scheduler = tmscheduler.New(schedulerApp.NewQueryFactory(n.mux.State()))
+	n.scheduler = tmscheduler.New(schedulerApp.NewQueryFactory(state))
 	n.serviceClients = append(n.serviceClients, n.scheduler)
 	n.svcMgr.RegisterCleanupOnly(n.scheduler, "scheduler backend")
 
-	n.roothash = tmroothash.New(n.ctx, n.parentNode, roothashApp.NewQueryFactory(n.mux.State()))
+	n.roothash = tmroothash.New(n.ctx, n.parentNode, roothashApp.NewQueryFactory(state))
 	n.serviceClients = append(n.serviceClients, n.roothash)
 	n.svcMgr.RegisterCleanupOnly(n.roothash, "roothash backend")
 
-	n.governance = tmgovernance.New(n.parentNode, governanceApp.NewQueryFactory(n.mux.State()))
+	n.governance = tmgovernance.New(n.parentNode, governanceApp.NewQueryFactory(state))
 	n.serviceClients = append(n.serviceClients, n.governance)
 	n.svcMgr.RegisterCleanupOnly(n.governance, "governance backend")
 
-	n.vault = tmvault.New(n.parentNode, vaultApp.NewQueryFactory(n.mux.State()))
+	n.vault = tmvault.New(n.parentNode, vaultApp.NewQueryFactory(state))
 	n.serviceClients = append(n.serviceClients, n.vault)
 	n.svcMgr.RegisterCleanupOnly(n.vault, "vault backend")
 
 	// Register CometBFT applications.
 	beaconApp := beaconApp.New()
-	governanceApp := governanceApp.New()
-	keymanagerApp := keymanagerApp.New()
-	registryApp := registryApp.New()
-	roothashApp := roothashApp.New(n.roothash)
-	schedulerApp := schedulerApp.New()
-	stakingApp := stakingApp.New()
-	vaultApp := vaultApp.New()
+	governanceApp := governanceApp.New(state)
+	keymanagerApp := keymanagerApp.New(state)
+	registryApp := registryApp.New(state)
+	roothashApp := roothashApp.New(state, n.roothash)
+	schedulerApp := schedulerApp.New(state)
+	stakingApp := stakingApp.New(state)
+	vaultApp := vaultApp.New(state)
 
 	apps := []api.Application{
 		beaconApp,
@@ -298,7 +301,7 @@ func (n *commonNode) initialize() error {
 
 	// Enable supplementary sanity checks when enabled.
 	if config.GlobalConfig.Consensus.SupplementarySanity.Enabled {
-		app := supplementarysanityApp.New(config.GlobalConfig.Consensus.SupplementarySanity.Interval)
+		app := supplementarysanityApp.New(state, int64(config.GlobalConfig.Consensus.SupplementarySanity.Interval))
 		if err := n.mux.Register(app); err != nil {
 			return fmt.Errorf("failed to register supplementary sanity check app: %w", err)
 		}

--- a/go/consensus/cometbft/registry/registry.go
+++ b/go/consensus/cometbft/registry/registry.go
@@ -171,6 +171,7 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 		)
 		return nil, err
 	}
+
 	// Get transactions at given height.
 	txns, err := sc.backend.GetTransactions(ctx, height)
 	if err != nil {

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -245,12 +245,23 @@ func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) 
 	return q.ConsensusParameters(ctx)
 }
 
-func (sc *ServiceClient) getEvents(ctx context.Context, height int64, txns [][]byte) ([]*api.Event, error) {
+// GetEvents implements api.Backend.
+func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
 	var results *cmtrpctypes.ResultBlockResults
 	results, err := sc.backend.GetCometBFTBlockResults(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft block results",
+			"err", err,
+			"height", height,
+		)
+		return nil, err
+	}
+
+	// Get transactions at given height.
+	txns, err := sc.backend.GetTransactions(ctx, height)
+	if err != nil {
+		sc.logger.Error("failed to get cometbft transactions",
 			"err", err,
 			"height", height,
 		)
@@ -289,21 +300,6 @@ func (sc *ServiceClient) getEvents(ctx context.Context, height int64, txns [][]b
 	events = append(events, blockEvs...)
 
 	return events, nil
-}
-
-// GetEvents implements api.Backend.
-func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
-	// Get transactions at given height.
-	txns, err := sc.backend.GetTransactions(ctx, height)
-	if err != nil {
-		sc.logger.Error("failed to get cometbft transactions",
-			"err", err,
-			"height", height,
-		)
-		return nil, err
-	}
-
-	return sc.getEvents(ctx, height, txns)
 }
 
 // Cleanup implements api.Backend.


### PR DESCRIPTION
These changes reduce the CometBFT consensus backend interface to a minimal set of methods, all of which can be implemented by a light client backend.