### PR TITLE
go/beacon/api: Remove SetableBackend interface

### DIFF
--- a/go/beacon/api/api.go
+++ b/go/beacon/api/api.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
+	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 )
 
 const (
@@ -35,6 +36,15 @@ var (
 	// ErrBeaconNotAvailable is the error returned when a beacon is not
 	// available for the requested height for any reason.
 	ErrBeaconNotAvailable = errors.New(ModuleName, 2, "beacon: random beacon not available")
+
+	// MethodSetEpoch is the method name for setting epochs.
+	MethodSetEpoch = transaction.NewMethodName(ModuleName, "SetEpoch", EpochTime(0))
+
+	// Methods is a list of all methods supported by the beacon backend.
+	Methods = []transaction.MethodName{
+		MethodSetEpoch,
+		MethodVRFProve,
+	}
 )
 
 // EpochTime is the number of intervals (epochs) since a fixed instant
@@ -107,14 +117,6 @@ type Backend interface {
 
 	// ConsensusParameters returns the beacon consensus parameters.
 	ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error)
-}
-
-// SetableBackend is a Backend that supports setting the current epoch.
-type SetableBackend interface {
-	Backend
-
-	// SetEpoch sets the current epoch.
-	SetEpoch(context.Context, EpochTime) error
 }
 
 // Genesis is the genesis state.

--- a/go/consensus/cometbft/apps/beacon/api.go
+++ b/go/consensus/cometbft/apps/beacon/api.go
@@ -27,15 +27,6 @@ var (
 	// QueryApp is the query for filtering events procecessed by the
 	// beacon application.
 	QueryApp = api.QueryForApp(AppName)
-
-	// MethodSetEpoch is the method name for setting epochs.
-	MethodSetEpoch = transaction.NewMethodName(AppName, "SetEpoch", beacon.EpochTime(0))
-
-	// Methods is a list of all methods supported by the beacon application.
-	Methods = []transaction.MethodName{
-		MethodSetEpoch,
-		beacon.MethodVRFProve,
-	}
 )
 
 type internalBackend interface {

--- a/go/consensus/cometbft/apps/beacon/backend_insecure.go
+++ b/go/consensus/cometbft/apps/beacon/backend_insecure.go
@@ -135,9 +135,9 @@ func (impl *backendInsecure) ExecuteTx(
 	tx *transaction.Transaction,
 ) error {
 	switch tx.Method {
-	case MethodSetEpoch:
+	case beacon.MethodSetEpoch:
 		if !params.DebugMockBackend {
-			return fmt.Errorf("beacon: method '%s' is disabled via consensus", MethodSetEpoch)
+			return fmt.Errorf("beacon: method '%s' is disabled via consensus", beacon.MethodSetEpoch)
 		}
 		return impl.doTxSetEpoch(ctx, state, tx.Body)
 	default:

--- a/go/consensus/cometbft/apps/beacon/backend_vrf.go
+++ b/go/consensus/cometbft/apps/beacon/backend_vrf.go
@@ -243,9 +243,9 @@ func (impl *backendVRF) ExecuteTx(
 	switch tx.Method {
 	case beacon.MethodVRFProve:
 		return impl.doProveTx(ctx, state, params, tx)
-	case MethodSetEpoch:
+	case beacon.MethodSetEpoch:
 		if !params.DebugMockBackend {
-			return fmt.Errorf("beacon: method '%s' is disabled via consensus", MethodSetEpoch)
+			return fmt.Errorf("beacon: method '%s' is disabled via consensus", beacon.MethodSetEpoch)
 		}
 		return impl.doSetEpochTx(ctx, state, tx.Body)
 	default:

--- a/go/consensus/cometbft/apps/beacon/beacon.go
+++ b/go/consensus/cometbft/apps/beacon/beacon.go
@@ -40,7 +40,7 @@ func (app *Application) ID() uint8 {
 
 // Methods implements api.Application.
 func (app *Application) Methods() []transaction.MethodName {
-	return Methods
+	return beacon.Methods
 }
 
 // Blessed implements api.Application.

--- a/go/control/api/api.go
+++ b/go/control/api/api.go
@@ -235,10 +235,6 @@ type SeedStatus struct {
 // DebugModuleName is the module name for the debug controller service.
 const DebugModuleName = "control/debug"
 
-// ErrIncompatibleBackend is the error raised when the current beacon
-// backend does not support manually setting the current epoch.
-var ErrIncompatibleBackend = errors.New(DebugModuleName, 1, "debug: incompatible backend")
-
 // DebugController is a debug-only controller useful during tests.
 type DebugController interface {
 	// SetEpoch manually sets the current epoch to the given epoch.

--- a/go/governance/tests/tester.go
+++ b/go/governance/tests/tester.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	beaconTests "github.com/oasisprotocol/oasis-core/go/beacon/tests"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
@@ -376,10 +375,10 @@ WaitForSubmittedVote:
 	require.EqualValues(ev.Vote.Submitter, votes[0].Voter, "vote event should be equal to the queried vote")
 
 	// Transition to the voting close epoch.
-	timeSource := consensus.Beacon().(beacon.SetableBackend)
+	timeSource := consensus.Beacon()
 	currentEpoch, err := timeSource.GetEpoch(ctx, consensusAPI.HeightLatest)
 	require.NoError(err, "GetEpoch")
-	beaconTests.MustAdvanceEpochMulti(t, timeSource, consensus.Registry(), uint64(testState.proposal.ClosesAt.AbsDiff(currentEpoch)))
+	beaconTests.MustAdvanceEpochMulti(t, consensus, uint64(testState.proposal.ClosesAt.AbsDiff(currentEpoch)))
 
 	var proposal *api.Proposal
 

--- a/go/oasis-node/cmd/node/node_debug.go
+++ b/go/oasis-node/cmd/node/node_debug.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
+	"github.com/oasisprotocol/oasis-core/go/beacon/tests"
 	control "github.com/oasisprotocol/oasis-core/go/control/api"
 )
 
@@ -12,12 +13,7 @@ var _ control.DebugController = (*Node)(nil)
 
 // SetEpoch implements control.DebugController.
 func (n *Node) SetEpoch(ctx context.Context, epoch beacon.EpochTime) error {
-	mockTS, ok := n.Consensus.Beacon().(beacon.SetableBackend)
-	if !ok {
-		return control.ErrIncompatibleBackend
-	}
-
-	return mockTS.SetEpoch(ctx, epoch)
+	return tests.SetEpoch(ctx, epoch, n.Consensus)
 }
 
 // WaitNodesRegistered implements control.DebugController.

--- a/go/oasis-node/node_test.go
+++ b/go/oasis-node/node_test.go
@@ -13,7 +13,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	beaconTests "github.com/oasisprotocol/oasis-core/go/beacon/tests"
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
@@ -319,10 +318,8 @@ func testConsensusClient(t *testing.T, node *testNode) {
 }
 
 func testBeacon(t *testing.T, node *testNode) {
-	beaconTests.EpochtimeSetableImplementationTest(t, node.Consensus.Beacon())
-
-	timeSource := (node.Consensus.Beacon()).(beacon.SetableBackend)
-	beaconTests.BeaconImplementationTests(t, timeSource)
+	beaconTests.EpochtimeSetableImplementationTest(t, node.Consensus)
+	beaconTests.BeaconImplementationTests(t, node.Consensus)
 }
 
 func testStorage(t *testing.T, _ *testNode) {
@@ -410,8 +407,6 @@ func testGovernance(t *testing.T, node *testNode) {
 }
 
 func testExecutorWorker(t *testing.T, node *testNode) {
-	timeSource := (node.Consensus.Beacon()).(beacon.SetableBackend)
-
 	rt, err := node.RuntimeRegistry.GetRuntime(node.runtimeID)
 	require.NoError(t, err, "runtimeRegistry.GetRuntime")
 
@@ -422,8 +417,7 @@ func testExecutorWorker(t *testing.T, node *testNode) {
 		node.runtimeID,
 		node.commonCommitteeNode,
 		node.executorCommitteeNode,
-		timeSource,
-		node.Consensus.RootHash(),
+		node.Consensus,
 		rt.Storage(),
 	)
 }

--- a/go/oasis-test-runner/scenario/e2e/min_transact_balance.go
+++ b/go/oasis-test-runner/scenario/e2e/min_transact_balance.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/oasisprotocol/oasis-core/go/beacon/tests"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
 	"github.com/oasisprotocol/oasis-core/go/common/entity"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
-	tmbeacon "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/beacon"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
@@ -92,7 +92,7 @@ func (mtb *minTransactBalanceImpl) Fixture() (*oasis.NetworkFixture, error) {
 		return nil, err
 	}
 
-	beaconSignerAddr := staking.NewAddress(tmbeacon.TestSigner.Public())
+	beaconSignerAddr := staking.NewAddress(tests.TestSigner.Public())
 	f.Network.StakingGenesis = &staking.Genesis{
 		Parameters: staking.ConsensusParameters{
 			MinTransactBalance: *quantity.NewFromUint64(1000),

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -208,8 +208,7 @@ func testEpochTransitionBlock(t *testing.T, backend api.Backend, consensus conse
 	}
 
 	// Advance the epoch.
-	timeSource := consensus.Beacon().(beacon.SetableBackend)
-	beaconTests.MustAdvanceEpoch(t, timeSource)
+	beaconTests.MustAdvanceEpoch(t, consensus)
 
 	// Check for the expected post-epoch transition events.
 	for i, state := range states {
@@ -789,8 +788,7 @@ func (s *runtimeState) testRoundTimeoutWithEpochTransition(t *testing.T, backend
 	}
 
 	// Trigger an epoch transition while the timeout is armed.
-	timeSource := consensus.Beacon().(beacon.SetableBackend)
-	beaconTests.MustAdvanceEpoch(t, timeSource)
+	beaconTests.MustAdvanceEpoch(t, consensus)
 
 	// Next round must be an epoch transition.
 	parent, err := nextRuntimeBlock(ch, nil)

--- a/go/scheduler/tests/tester.go
+++ b/go/scheduler/tests/tester.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	beaconTests "github.com/oasisprotocol/oasis-core/go/beacon/tests"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
@@ -45,8 +44,7 @@ func SchedulerImplementationTests(t *testing.T, name string, identity *identity.
 	defer sub.Close()
 
 	// Advance the epoch.
-	timeSource := consensus.Beacon().(beacon.SetableBackend)
-	epoch := beaconTests.MustAdvanceEpoch(t, timeSource)
+	epoch := beaconTests.MustAdvanceEpoch(t, consensus)
 
 	ensureValidCommittees := func(expectedExecutor int) {
 		var executor *api.Committee
@@ -112,7 +110,7 @@ func SchedulerImplementationTests(t *testing.T, name string, identity *identity.
 	rt.Runtime.Constraints[api.KindComputeExecutor][api.RoleBackupWorker].MinPoolSize.Limit = 1
 	rt.MustRegister(t, consensus.Registry(), consensus)
 
-	epoch = beaconTests.MustAdvanceEpoch(t, timeSource)
+	epoch = beaconTests.MustAdvanceEpoch(t, consensus)
 
 	ensureValidCommittees(
 		3,

--- a/go/staking/tests/tester.go
+++ b/go/staking/tests/tester.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	beaconTests "github.com/oasisprotocol/oasis-core/go/beacon/tests"
 	"github.com/oasisprotocol/oasis-core/go/common/entity"
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
@@ -949,8 +948,7 @@ func testEscrowHelper( // nolint: gocyclo
 	require.Len(debs[destAccData.Address], 1, "one debonding delegation after reclaiming escrow")
 
 	// Advance epoch to trigger debonding.
-	timeSource := consensus.Beacon().(beacon.SetableBackend)
-	beaconTests.MustAdvanceEpoch(t, timeSource)
+	beaconTests.MustAdvanceEpoch(t, consensus)
 
 	// Wait for debonding period to pass.
 	select {


### PR DESCRIPTION
Removing `SetableBackend` interface, as transaction submission does not belong in the beacon backend implementation. This change also removes the dependency between the beacon backend and the consensus backend/transaction submission manager.