### PR TITLE
go/consensus/cometbft: Remove context from backend constructors

### DIFF
--- a/go/common/grpc/testing/ping.go
+++ b/go/common/grpc/testing/ping.go
@@ -107,11 +107,11 @@ func (s *pingServer) WatchPings(ctx context.Context, _ *PingQuery) (<-chan *Ping
 			}
 		}
 	}()
-	typedCh := make(chan *PingResponse)
+	ch := make(chan *PingResponse)
 	sub := pingNotifier.Subscribe()
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 // RegisterService registers a new ping server service with the given gRPC server.

--- a/go/common/pubsub/pubsub.go
+++ b/go/common/pubsub/pubsub.go
@@ -94,7 +94,7 @@ type OnSubscribeHook func(channels.Channel)
 // Note: The returned subscription's channel will have an unbounded
 // capacity, use SubscribeBuffered to use a bounded ring channel.
 func (b *Broker) Subscribe() *Subscription {
-	return b.SubscribeEx(int64(channels.Infinity), nil)
+	return b.SubscribeEx(nil)
 }
 
 // SubscribeBuffered subscribes to the Broker's broadcasts, and returns a
@@ -104,7 +104,7 @@ func (b *Broker) Subscribe() *Subscription {
 // oldest value will be discarded. In case buffer is negative (or zero) an
 // unbounded channel is used.
 func (b *Broker) SubscribeBuffered(buffer int64) *Subscription {
-	return b.SubscribeEx(buffer, nil)
+	return b.SubscribeBufferedEx(buffer, nil)
 }
 
 // SubscribeEx subscribes to the Broker's broadcasts, and returns a
@@ -112,9 +112,23 @@ func (b *Broker) SubscribeBuffered(buffer int64) *Subscription {
 // addition it also takes a per-subscription on-subscribe callback
 // hook.
 //
+// Note: The returned subscription's channel will have an unbounded
+// capacity, use SubscribeBufferedEx to use a bounded ring channel.
+//
 // Note: If there is a Broker wide hook set, it will be called
 // after the per-subscription hook is called.
-func (b *Broker) SubscribeEx(buffer int64, onSubscribeHook OnSubscribeHook) *Subscription {
+func (b *Broker) SubscribeEx(onSubscribeHook OnSubscribeHook) *Subscription {
+	return b.SubscribeBufferedEx(int64(channels.Infinity), onSubscribeHook)
+}
+
+// SubscribeBufferedEx subscribes to the Broker's broadcasts, and returns a
+// subscription handle that can be used to receive broadcasts.  In
+// addition it also takes a per-subscription on-subscribe callback
+// hook.
+//
+// Note: If there is a Broker wide hook set, it will be called
+// after the per-subscription hook is called.
+func (b *Broker) SubscribeBufferedEx(buffer int64, onSubscribeHook OnSubscribeHook) *Subscription {
 	var ch channels.Channel
 	if buffer <= 0 {
 		ch = channels.NewInfiniteChannel()

--- a/go/common/pubsub/pubsub_test.go
+++ b/go/common/pubsub/pubsub_test.go
@@ -17,7 +17,7 @@ func TestPubSub(t *testing.T) {
 	t.Run("BasicInfinity", testBasicInfinity)
 	t.Run("BasicOverwriting", testBasicOverwriting)
 	t.Run("PubLastOnSubscribe", testLastOnSubscribe)
-	t.Run("SubscribeEx", testSubscribeEx)
+	t.Run("SubscribeBufferedEx", testSubscribeBufferedEx)
 	t.Run("NewBrokerEx", testNewBrokerEx)
 }
 
@@ -121,7 +121,7 @@ func testLastOnSubscribe(t *testing.T) {
 	}
 }
 
-func testSubscribeEx(t *testing.T) {
+func testSubscribeBufferedEx(t *testing.T) {
 	broker := NewBroker(false)
 	var callbackCh channels.Channel
 	callback := func(ch channels.Channel) {
@@ -132,7 +132,7 @@ func testSubscribeEx(t *testing.T) {
 		int64(channels.Infinity),
 		bufferSize,
 	} {
-		sub := broker.SubscribeEx(b, callback)
+		sub := broker.SubscribeBufferedEx(b, callback)
 
 		require.NotNil(t, sub.ch, "Subscription, inner channel")
 		require.Equal(t, sub.ch, callbackCh, "Callback channel != Subscription, inner channel")

--- a/go/common/pubsub/pubsub_test.go
+++ b/go/common/pubsub/pubsub_test.go
@@ -25,13 +25,13 @@ func testBasicInfinity(t *testing.T) {
 	broker := NewBroker(false)
 
 	sub := broker.Subscribe()
-	typedCh := make(chan int)
-	sub.Unwrap(typedCh)
+	ch := make(chan int)
+	sub.Unwrap(ch)
 
 	// Test a single broadcast/receive.
 	broker.Broadcast(23)
 	select {
-	case v := <-typedCh:
+	case v := <-ch:
 		require.Equal(t, 23, v, "Single Broadcast())")
 	case <-time.After(recvTimeout):
 		t.Fatalf("Failed to receive value, initial Broadcast()")
@@ -43,7 +43,7 @@ func testBasicInfinity(t *testing.T) {
 	}
 	for i := 0; i < 10; i++ {
 		select {
-		case v := <-typedCh:
+		case v := <-ch:
 			require.Equal(t, i, v, "Buffered Broadcast()")
 		case <-time.After(recvTimeout):
 			t.Fatalf("Failed to receive value, buffered Broadcast()")
@@ -58,13 +58,13 @@ func testBasicOverwriting(t *testing.T) {
 	broker := NewBroker(false)
 
 	sub := broker.SubscribeBuffered(bufferSize)
-	typedCh := make(chan int)
-	sub.Unwrap(typedCh)
+	ch := make(chan int)
+	sub.Unwrap(ch)
 
 	// Test a single broadcast/receive.
 	broker.Broadcast(23)
 	select {
-	case v := <-typedCh:
+	case v := <-ch:
 		require.Equal(t, 23, v, "Single Broadcast())")
 	case <-time.After(recvTimeout):
 		t.Fatalf("Failed to receive value, initial Broadcast()")
@@ -89,7 +89,7 @@ func testBasicOverwriting(t *testing.T) {
 	}
 	for _, i := range expected {
 		select {
-		case v := <-typedCh:
+		case v := <-ch:
 			require.Equal(t, i, v, "Buffered Broadcast()")
 		case <-time.After(recvTimeout):
 			t.Fatalf("Failed to receive value, buffered Broadcast()")
@@ -109,11 +109,11 @@ func testLastOnSubscribe(t *testing.T) {
 		bufferSize,
 	} {
 		sub := broker.SubscribeBuffered(b)
-		typedCh := make(chan int)
-		sub.Unwrap(typedCh)
+		ch := make(chan int)
+		sub.Unwrap(ch)
 
 		select {
-		case v := <-typedCh:
+		case v := <-ch:
 			require.Equal(t, 23, v, "Last Broadcast()")
 		case <-time.After(recvTimeout):
 			t.Fatalf("Failed to receive value, last Broadcast() on Subscribe()")

--- a/go/consensus/cometbft/apps/roothash/genesis.go
+++ b/go/consensus/cometbft/apps/roothash/genesis.go
@@ -54,7 +54,7 @@ func (app *Application) InitChain(ctx *abciAPI.Context, _ types.RequestInitChain
 }
 
 func (rq *rootHashQuerier) Genesis(ctx context.Context) (*roothashAPI.Genesis, error) {
-	runtimes, err := rq.state.Runtimes(ctx)
+	runtimes, err := rq.state.RuntimeStates(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch runtimes: %w", err)
 	}

--- a/go/consensus/cometbft/apps/supplementarysanity/checks.go
+++ b/go/consensus/cometbft/apps/supplementarysanity/checks.go
@@ -81,7 +81,7 @@ func checkRootHash(ctx *abciAPI.Context, _ beacon.EpochTime) error {
 	st := roothashState.NewMutableState(ctx.State())
 
 	// Check blocks.
-	runtimes, err := st.Runtimes(ctx)
+	runtimes, err := st.RuntimeStates(ctx)
 	if err != nil {
 		return fmt.Errorf("Runtimes(): %w", err)
 	}

--- a/go/consensus/cometbft/beacon/beacon.go
+++ b/go/consensus/cometbft/beacon/beacon.go
@@ -199,20 +199,20 @@ func (sc *ServiceClient) WaitEpoch(ctx context.Context, epoch beaconAPI.EpochTim
 
 func (sc *ServiceClient) WatchEpochs(context.Context) (<-chan beaconAPI.EpochTime, pubsub.ClosableSubscription, error) {
 	hook := sc.epochNotifierHook()
-	typedCh := make(chan beaconAPI.EpochTime)
+	ch := make(chan beaconAPI.EpochTime)
 	sub := sc.epochNotifier.SubscribeEx(hook)
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 func (sc *ServiceClient) WatchLatestEpoch(context.Context) (<-chan beaconAPI.EpochTime, pubsub.ClosableSubscription, error) {
 	hook := sc.epochNotifierHook()
-	typedCh := make(chan beaconAPI.EpochTime)
+	ch := make(chan beaconAPI.EpochTime)
 	sub := sc.epochNotifier.SubscribeBufferedEx(1, hook)
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 func (sc *ServiceClient) GetBeacon(ctx context.Context, height int64) ([]byte, error) {
@@ -235,11 +235,11 @@ func (sc *ServiceClient) GetVRFState(ctx context.Context, height int64) (*beacon
 
 func (sc *ServiceClient) WatchLatestVRFEvent(context.Context) (<-chan *beaconAPI.VRFEvent, *pubsub.Subscription, error) {
 	hook := sc.vrfNotifierHook()
-	typedCh := make(chan *beaconAPI.VRFEvent)
+	ch := make(chan *beaconAPI.VRFEvent)
 	sub := sc.vrfNotifier.SubscribeEx(hook)
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 func (sc *ServiceClient) ServiceDescriptor() tmapi.ServiceDescriptor {

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -237,17 +237,17 @@ func (n *commonNode) initialize() error {
 	n.querier = abci.NewQueryFactory(state)
 
 	// Initialize the beacon/epochtime backend.
-	n.beacon = tmbeacon.New(n.ctx, n.baseEpoch, n.baseHeight, n.parentNode, beaconApp.NewQueryFactory(state))
+	n.beacon = tmbeacon.New(n.baseEpoch, n.baseHeight, n.parentNode, beaconApp.NewQueryFactory(state))
 	n.serviceClients = append(n.serviceClients, n.beacon)
 	if err := n.mux.SetEpochtime(n.beacon); err != nil {
 		return err
 	}
 
 	// Initialize the rest of backends.
-	n.keymanager = tmkeymanager.New(n.ctx, keymanagerApp.NewQueryFactory(state))
+	n.keymanager = tmkeymanager.New(keymanagerApp.NewQueryFactory(state))
 	n.serviceClients = append(n.serviceClients, n.keymanager)
 
-	n.registry = tmregistry.New(n.ctx, n.parentNode, registryApp.NewQueryFactory(state))
+	n.registry = tmregistry.New(n.parentNode, registryApp.NewQueryFactory(state))
 	if cmmetrics.Enabled() {
 		n.svcMgr.RegisterCleanupOnly(registry.NewMetricsUpdater(n.ctx, n.registry), "registry metrics updater")
 	}
@@ -262,7 +262,7 @@ func (n *commonNode) initialize() error {
 	n.serviceClients = append(n.serviceClients, n.scheduler)
 	n.svcMgr.RegisterCleanupOnly(n.scheduler, "scheduler backend")
 
-	n.roothash = tmroothash.New(n.ctx, n.parentNode, roothashApp.NewQueryFactory(state))
+	n.roothash = tmroothash.New(n.parentNode, roothashApp.NewQueryFactory(state))
 	n.serviceClients = append(n.serviceClients, n.roothash)
 	n.svcMgr.RegisterCleanupOnly(n.roothash, "roothash backend")
 

--- a/go/consensus/cometbft/full/full.go
+++ b/go/consensus/cometbft/full/full.go
@@ -526,11 +526,11 @@ func (t *fullService) WatchBlocks(ctx context.Context) (<-chan *consensusAPI.Blo
 
 // Implements consensusAPI.Backend.
 func (t *fullService) WatchCometBFTBlocks() (<-chan *cmttypes.Block, *pubsub.Subscription, error) {
-	typedCh := make(chan *cmttypes.Block)
+	ch := make(chan *cmttypes.Block)
 	sub := t.blockNotifier.Subscribe()
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 func (t *fullService) lazyInit() error { // nolint: gocyclo

--- a/go/consensus/cometbft/governance/governance.go
+++ b/go/consensus/cometbft/governance/governance.go
@@ -150,11 +150,11 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 }
 
 func (sc *ServiceClient) WatchEvents(context.Context) (<-chan *api.Event, pubsub.ClosableSubscription, error) {
-	typedCh := make(chan *api.Event)
+	ch := make(chan *api.Event)
 	sub := sc.eventNotifier.Subscribe()
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) (*api.ConsensusParameters, error) {

--- a/go/consensus/cometbft/governance/governance.go
+++ b/go/consensus/cometbft/governance/governance.go
@@ -33,6 +33,16 @@ type ServiceClient struct {
 	eventNotifier *pubsub.Broker
 }
 
+// New constructs a new CometBFT backed governance service client.
+func New(backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
+	return &ServiceClient{
+		logger:        logging.GetLogger("cometbft/staking"),
+		backend:       backend,
+		querier:       querier,
+		eventNotifier: pubsub.NewBroker(false),
+	}
+}
+
 func (sc *ServiceClient) ActiveProposals(ctx context.Context, height int64) ([]*api.Proposal, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
@@ -253,14 +263,4 @@ func EventsFromCometBFT(
 	}
 
 	return events, errs
-}
-
-// New constructs a new CometBFT backed governance backend instance.
-func New(backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
-	return &ServiceClient{
-		logger:        logging.GetLogger("cometbft/staking"),
-		backend:       backend,
-		querier:       querier,
-		eventNotifier: pubsub.NewBroker(false),
-	}
 }

--- a/go/consensus/cometbft/keymanager/keymanager.go
+++ b/go/consensus/cometbft/keymanager/keymanager.go
@@ -18,12 +18,20 @@ import (
 	secretsAPI "github.com/oasisprotocol/oasis-core/go/keymanager/secrets"
 )
 
-// ServiceClient is the registry service client.
+// ServiceClient is the key manager service client.
 type ServiceClient struct {
 	tmapi.BaseServiceClient
 
 	secretsClient *secrets.ServiceClient
 	churpClient   *churp.ServiceClient
+}
+
+// New constructs a new CometBFT backed key manager service client.
+func New(ctx context.Context, querier *app.QueryFactory) *ServiceClient {
+	return &ServiceClient{
+		secretsClient: secrets.New(ctx, querier),
+		churpClient:   churp.New(ctx, querier),
+	}
 }
 
 // StateToGenesis implements api.Backend.
@@ -65,13 +73,4 @@ func (sc *ServiceClient) DeliverEvent(_ context.Context, _ int64, _ cmttypes.Tx,
 		return err
 	}
 	return sc.churpClient.DeliverEvent(ev)
-}
-
-// New constructs a new CometBFT backed key manager management Backend
-// instance.
-func New(ctx context.Context, querier *app.QueryFactory) *ServiceClient {
-	return &ServiceClient{
-		secretsClient: secrets.New(ctx, querier),
-		churpClient:   churp.New(ctx, querier),
-	}
 }

--- a/go/consensus/cometbft/keymanager/keymanager.go
+++ b/go/consensus/cometbft/keymanager/keymanager.go
@@ -27,10 +27,10 @@ type ServiceClient struct {
 }
 
 // New constructs a new CometBFT backed key manager service client.
-func New(ctx context.Context, querier *app.QueryFactory) *ServiceClient {
+func New(querier *app.QueryFactory) *ServiceClient {
 	return &ServiceClient{
-		secretsClient: secrets.New(ctx, querier),
-		churpClient:   churp.New(ctx, querier),
+		secretsClient: secrets.New(querier),
+		churpClient:   churp.New(querier),
 	}
 }
 

--- a/go/consensus/cometbft/registry/registry.go
+++ b/go/consensus/cometbft/registry/registry.go
@@ -78,11 +78,11 @@ func (sc *ServiceClient) GetEntities(ctx context.Context, height int64) ([]*enti
 }
 
 func (sc *ServiceClient) WatchEntities(context.Context) (<-chan *api.EntityEvent, pubsub.ClosableSubscription, error) {
-	typedCh := make(chan *api.EntityEvent)
+	ch := make(chan *api.EntityEvent)
 	sub := sc.entityNotifier.Subscribe()
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 func (sc *ServiceClient) GetNode(ctx context.Context, query *api.IDQuery) (*node.Node, error) {
@@ -122,20 +122,20 @@ func (sc *ServiceClient) GetNodeByConsensusAddress(ctx context.Context, query *a
 }
 
 func (sc *ServiceClient) WatchNodes(context.Context) (<-chan *api.NodeEvent, pubsub.ClosableSubscription, error) {
-	typedCh := make(chan *api.NodeEvent)
+	ch := make(chan *api.NodeEvent)
 	sub := sc.nodeNotifier.Subscribe()
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 func (sc *ServiceClient) WatchNodeList(ctx context.Context) (<-chan *api.NodeList, pubsub.ClosableSubscription, error) {
 	hook := sc.nodeListNotifierHook(ctx)
-	typedCh := make(chan *api.NodeList)
+	ch := make(chan *api.NodeList)
 	sub := sc.nodeListNotifier.SubscribeEx(hook)
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 func (sc *ServiceClient) GetRuntime(ctx context.Context, query *api.GetRuntimeQuery) (*api.Runtime, error) {
@@ -149,11 +149,11 @@ func (sc *ServiceClient) GetRuntime(ctx context.Context, query *api.GetRuntimeQu
 
 func (sc *ServiceClient) WatchRuntimes(ctx context.Context) (<-chan *api.Runtime, pubsub.ClosableSubscription, error) {
 	hook := sc.runtimeNotifierHook(ctx)
-	typedCh := make(chan *api.Runtime)
+	ch := make(chan *api.Runtime)
 	sub := sc.runtimeNotifier.SubscribeEx(hook)
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 func (sc *ServiceClient) Cleanup() {
@@ -230,11 +230,11 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 
 // WatchEvents implements api.Backend.
 func (sc *ServiceClient) WatchEvents(_ context.Context) (<-chan *api.Event, pubsub.ClosableSubscription, error) {
-	typedCh := make(chan *api.Event)
+	ch := make(chan *api.Event)
 	sub := sc.eventNotifier.Subscribe()
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) (*api.ConsensusParameters, error) {

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -49,7 +49,6 @@ type ServiceClient struct {
 
 	mu sync.RWMutex
 
-	ctx    context.Context
 	logger *logging.Logger
 
 	backend tmapi.Backend
@@ -64,9 +63,8 @@ type ServiceClient struct {
 }
 
 // New constructs a new CometBFT-based roothash service client.
-func New(ctx context.Context, backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
+func New(backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
 	return &ServiceClient{
-		ctx:              ctx,
 		logger:           logging.GetLogger("cometbft/roothash"),
 		backend:          backend,
 		querier:          querier,

--- a/go/consensus/cometbft/scheduler/scheduler.go
+++ b/go/consensus/cometbft/scheduler/scheduler.go
@@ -29,6 +29,28 @@ type ServiceClient struct {
 	notifier *pubsub.Broker
 }
 
+// New constructs a new CometBFT-based scheduler service client.
+func New(querier *app.QueryFactory) *ServiceClient {
+	sc := &ServiceClient{
+		logger:  logging.GetLogger("cometbft/scheduler"),
+		querier: querier,
+	}
+	sc.notifier = pubsub.NewBrokerEx(func(ch channels.Channel) {
+		currentCommittees, err := sc.getCurrentCommittees()
+		if err != nil {
+			sc.logger.Error("couldn't get current committees. won't send them. good luck to the subscriber",
+				"err", err,
+			)
+			return
+		}
+		for _, c := range currentCommittees {
+			ch.In() <- c
+		}
+	})
+
+	return sc
+}
+
 func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
@@ -134,26 +156,4 @@ func (sc *ServiceClient) DeliverEvent(ctx context.Context, height int64, _ cmtty
 		}
 	}
 	return nil
-}
-
-// New constructs a new CometBFT-based scheduler backend instance.
-func New(querier *app.QueryFactory) *ServiceClient {
-	sc := &ServiceClient{
-		logger:  logging.GetLogger("cometbft/scheduler"),
-		querier: querier,
-	}
-	sc.notifier = pubsub.NewBrokerEx(func(ch channels.Channel) {
-		currentCommittees, err := sc.getCurrentCommittees()
-		if err != nil {
-			sc.logger.Error("couldn't get current committees. won't send them. good luck to the subscriber",
-				"err", err,
-			)
-			return
-		}
-		for _, c := range currentCommittees {
-			ch.In() <- c
-		}
-	})
-
-	return sc
 }

--- a/go/consensus/cometbft/scheduler/scheduler.go
+++ b/go/consensus/cometbft/scheduler/scheduler.go
@@ -101,11 +101,11 @@ func (sc *ServiceClient) GetCommittees(ctx context.Context, request *api.GetComm
 }
 
 func (sc *ServiceClient) WatchCommittees(_ context.Context) (<-chan *api.Committee, pubsub.ClosableSubscription, error) {
-	typedCh := make(chan *api.Committee)
+	ch := make(chan *api.Committee)
 	sub := sc.notifier.Subscribe()
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 func (sc *ServiceClient) getCurrentCommittees() ([]*api.Committee, error) {

--- a/go/consensus/cometbft/staking/staking.go
+++ b/go/consensus/cometbft/staking/staking.go
@@ -33,6 +33,16 @@ type ServiceClient struct {
 	eventNotifier *pubsub.Broker
 }
 
+// New constructs a new CometBFT backed staking service client.
+func New(backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
+	return &ServiceClient{
+		logger:        logging.GetLogger("cometbft/staking"),
+		backend:       backend,
+		querier:       querier,
+		eventNotifier: pubsub.NewBroker(false),
+	}
+}
+
 func (sc *ServiceClient) TokenSymbol(ctx context.Context, height int64) (string, error) {
 	params, err := sc.ConsensusParameters(ctx, height)
 	if err != nil {
@@ -430,14 +440,4 @@ func EventsFromCometBFT(
 	}
 
 	return events, errs
-}
-
-// New constructs a new CometBFT backed staking backend instance.
-func New(backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
-	return &ServiceClient{
-		logger:        logging.GetLogger("cometbft/staking"),
-		backend:       backend,
-		querier:       querier,
-		eventNotifier: pubsub.NewBroker(false),
-	}
 }

--- a/go/consensus/cometbft/staking/staking.go
+++ b/go/consensus/cometbft/staking/staking.go
@@ -297,11 +297,11 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 }
 
 func (sc *ServiceClient) WatchEvents(context.Context) (<-chan *api.Event, pubsub.ClosableSubscription, error) {
-	typedCh := make(chan *api.Event)
+	ch := make(chan *api.Event)
 	sub := sc.eventNotifier.Subscribe()
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) (*api.ConsensusParameters, error) {

--- a/go/consensus/cometbft/vault/vault.go
+++ b/go/consensus/cometbft/vault/vault.go
@@ -32,6 +32,16 @@ type ServiceClient struct {
 	eventNotifier *pubsub.Broker
 }
 
+// New constructs a new CometBFT backed vault service client.
+func New(backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
+	return &ServiceClient{
+		logger:        logging.GetLogger("cometbft/vault"),
+		backend:       backend,
+		querier:       querier,
+		eventNotifier: pubsub.NewBroker(false),
+	}
+}
+
 func (sc *ServiceClient) Vaults(ctx context.Context, height int64) ([]*vault.Vault, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
@@ -261,14 +271,4 @@ func EventsFromCometBFT(
 	}
 
 	return events, errs
-}
-
-// New constructs a new CometBFT backed vault backend instance.
-func New(backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
-	return &ServiceClient{
-		logger:        logging.GetLogger("cometbft/vault"),
-		backend:       backend,
-		querier:       querier,
-		eventNotifier: pubsub.NewBroker(false),
-	}
 }

--- a/go/consensus/cometbft/vault/vault.go
+++ b/go/consensus/cometbft/vault/vault.go
@@ -140,11 +140,11 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*vault.
 }
 
 func (sc *ServiceClient) WatchEvents(context.Context) (<-chan *vault.Event, pubsub.ClosableSubscription, error) {
-	typedCh := make(chan *vault.Event)
+	ch := make(chan *vault.Event)
 	sub := sc.eventNotifier.Subscribe()
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) (*vault.ConsensusParameters, error) {

--- a/go/p2p/rpc/peermgmt.go
+++ b/go/p2p/rpc/peermgmt.go
@@ -235,11 +235,11 @@ func (mgr *peerManager) RecordBadPeer(peerID core.PeerID) {
 }
 
 func (mgr *peerManager) WatchUpdates() (<-chan *PeerUpdate, pubsub.ClosableSubscription, error) {
-	typedCh := make(chan *PeerUpdate)
+	ch := make(chan *PeerUpdate)
 	sub := mgr.peerUpdatesNotifier.Subscribe()
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 func (mgr *peerManager) GetBestPeers(opts ...BestPeersOption) []core.PeerID {

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -170,19 +170,19 @@ func (h *runtimeHistory) LastStorageSyncedRound() (uint64, error) {
 }
 
 func (h *runtimeHistory) WatchBlocks() (<-chan *roothash.AnnotatedBlock, pubsub.ClosableSubscription, error) {
-	typedCh := make(chan *roothash.AnnotatedBlock)
+	ch := make(chan *roothash.AnnotatedBlock)
 	sub := h.syncedBlocksNotifier.Subscribe()
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 func (h *runtimeHistory) WatchCommittedBlocks() (<-chan *roothash.AnnotatedBlock, pubsub.ClosableSubscription, error) {
-	typedCh := make(chan *roothash.AnnotatedBlock)
+	ch := make(chan *roothash.AnnotatedBlock)
 	sub := h.committedBlocksNotifier.Subscribe()
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 func (h *runtimeHistory) WaitRoundSynced(ctx context.Context, round uint64) (uint64, error) {

--- a/go/runtime/host/mock/host.go
+++ b/go/runtime/host/mock/host.go
@@ -179,11 +179,11 @@ func (h *mockHost) UpdateCapabilityTEE() {
 
 // Implements host.Runtime.
 func (h *mockHost) WatchEvents() (<-chan *host.Event, pubsub.ClosableSubscription) {
-	typedCh := make(chan *host.Event)
+	ch := make(chan *host.Event)
 	sub := h.notifier.Subscribe()
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub
+	return ch, sub
 }
 
 // Implements host.Runtime.

--- a/go/runtime/host/multi/multi.go
+++ b/go/runtime/host/multi/multi.go
@@ -277,11 +277,11 @@ func (agg *Aggregate) UpdateCapabilityTEE() {
 
 // WatchEvents implements host.Runtime.
 func (agg *Aggregate) WatchEvents() (<-chan *host.Event, pubsub.ClosableSubscription) {
-	typedCh := make(chan *host.Event)
+	ch := make(chan *host.Event)
 	sub := agg.notifier.Subscribe()
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub
+	return ch, sub
 }
 
 // Start implements host.Runtime.

--- a/go/runtime/host/sandbox/host.go
+++ b/go/runtime/host/sandbox/host.go
@@ -159,11 +159,11 @@ func (h *sandboxHost) UpdateCapabilityTEE() {
 
 // Implements host.Runtime.
 func (h *sandboxHost) WatchEvents() (<-chan *host.Event, pubsub.ClosableSubscription) {
-	typedCh := make(chan *host.Event)
+	ch := make(chan *host.Event)
 	sub := h.notifier.Subscribe()
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub
+	return ch, sub
 }
 
 // Implements host.Runtime.

--- a/go/storage/mkvs/checkpoint/checkpointer.go
+++ b/go/storage/mkvs/checkpoint/checkpointer.go
@@ -119,11 +119,11 @@ func (c *checkpointer) ForceCheckpoint(version uint64) {
 
 // Implements Checkpointer.
 func (c *checkpointer) WatchCheckpoints() (<-chan uint64, pubsub.ClosableSubscription, error) {
-	typedCh := make(chan uint64)
+	ch := make(chan uint64)
 	sub := c.cpNotifier.Subscribe()
-	sub.Unwrap(typedCh)
+	sub.Unwrap(ch)
 
-	return typedCh, sub, nil
+	return ch, sub, nil
 }
 
 // Implements Checkpointer.


### PR DESCRIPTION
These changes achieve two things:
- Remove `ctx` from the constructors.
- Use the correct `ctx` when calling on subscribe hooks.