### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/go/common/crypto/drbg/hmac_drbg.go
+++ b/go/common/crypto/drbg/hmac_drbg.go
@@ -43,10 +43,7 @@ type Drbg struct {
 func (r *Drbg) Read(p []byte) (n int, err error) {
 	toRead, off := len(p), 0
 	for toRead > 0 {
-		readSz := toRead
-		if readSz > maxBytesPerRequest {
-			readSz = maxBytesPerRequest
-		}
+		readSz := min(toRead, maxBytesPerRequest)
 
 		b, err := r.generate(readSz, nil)
 		if err != nil {


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.