### PR TITLE
go/consensus/api: Remove services backend

### DIFF
--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -374,7 +374,7 @@ type P2PStatus struct {
 // Backend is an interface that a consensus backend must provide.
 type Backend interface {
 	service.BackgroundService
-	ServicesBackend
+	ClientBackend
 
 	// SupportedFeatures returns the features supported by this consensus backend.
 	SupportedFeatures() FeatureMask
@@ -394,19 +394,11 @@ type Backend interface {
 	// Pruner returns the state pruner.
 	Pruner() StatePruner
 
-	// RegisterP2PService registers the P2P service used for light client state sync.
-	RegisterP2PService(p2pAPI.Service) error
-}
-
-// ServicesBackend is an interface for consensus backends which indicate support for
-// communicating with consensus services.
-//
-// In case the feature is absent, these methods may return nil or ErrUnsupported.
-type ServicesBackend interface {
-	ClientBackend
-
 	// SubmissionManager returns the transaction submission manager.
 	SubmissionManager() SubmissionManager
+
+	// RegisterP2PService registers the P2P service used for light client state sync.
+	RegisterP2PService(p2pAPI.Service) error
 }
 
 // StatePruner is a state pruner implementation.

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -398,18 +398,12 @@ type Backend interface {
 	RegisterP2PService(p2pAPI.Service) error
 }
 
-// HaltHook is a function that gets called when consensus needs to halt for some reason.
-type HaltHook func(ctx context.Context, blockHeight int64, epoch beacon.EpochTime, err error)
-
 // ServicesBackend is an interface for consensus backends which indicate support for
 // communicating with consensus services.
 //
 // In case the feature is absent, these methods may return nil or ErrUnsupported.
 type ServicesBackend interface {
 	ClientBackend
-
-	// RegisterHaltHook registers a function to be called when the consensus needs to halt.
-	RegisterHaltHook(hook HaltHook)
 
 	// SubmissionManager returns the transaction submission manager.
 	SubmissionManager() SubmissionManager

--- a/go/consensus/cometbft/abci/mux.go
+++ b/go/consensus/cometbft/abci/mux.go
@@ -134,7 +134,7 @@ func (a *ApplicationServer) Register(app api.Application) error {
 
 // RegisterHaltHook registers a function to be called when the
 // consensus Halt epoch height is reached.
-func (a *ApplicationServer) RegisterHaltHook(hook consensus.HaltHook) {
+func (a *ApplicationServer) RegisterHaltHook(hook api.HaltHook) {
 	a.mux.registerHaltHook(hook)
 }
 
@@ -224,7 +224,7 @@ type abciMux struct {
 	appBlessed     api.Application
 
 	haltOnce  sync.Once
-	haltHooks []consensus.HaltHook
+	haltHooks []api.HaltHook
 
 	// invalidatedTxs maps transaction hashes (hash.Hash) to a subscriber
 	// waiting for that transaction to become invalid.
@@ -262,7 +262,7 @@ func (mux *abciMux) watchInvalidatedTx(txHash hash.Hash) (<-chan error, pubsub.C
 	return resultCh, sub, nil
 }
 
-func (mux *abciMux) registerHaltHook(hook consensus.HaltHook) {
+func (mux *abciMux) registerHaltHook(hook api.HaltHook) {
 	mux.Lock()
 	defer mux.Unlock()
 

--- a/go/consensus/cometbft/api/api.go
+++ b/go/consensus/cometbft/api/api.go
@@ -14,6 +14,7 @@ import (
 	cmtrpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	cmttypes "github.com/cometbft/cometbft/types"
 
+	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
@@ -213,6 +214,9 @@ type Backend interface {
 	// returned via the `EventDataNewBlock` query.
 	WatchCometBFTBlocks() (<-chan *cmttypes.Block, *pubsub.Subscription, error)
 }
+
+// HaltHook is a function that gets called when consensus needs to halt for some reason.
+type HaltHook func(ctx context.Context, height int64, epoch beacon.EpochTime, err error)
 
 // TransactionAuthHandler is the interface for ABCI applications that handle
 // authenticating transactions (checking nonces and fees).

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -506,15 +506,6 @@ func (n *commonNode) Pruner() consensusAPI.StatePruner {
 	return n.mux.Pruner()
 }
 
-// Implements consensusAPI.Backend.
-func (n *commonNode) RegisterHaltHook(hook consensusAPI.HaltHook) {
-	if !n.initialized() {
-		return
-	}
-
-	n.mux.RegisterHaltHook(hook)
-}
-
 func (n *commonNode) heightToCometBFTHeight(height int64) (int64, error) {
 	var tmHeight int64
 	if height == consensusAPI.HeightLatest {


### PR DESCRIPTION
Halt hooks are only used by full nodes and can be specific to the backend implementation. To simplify the service backend interface, halt hooks were moved to full node. They can be moved back later if needed.