### PR TITLE
go/storagek/mkvs: Simplify Iterator's doNext function

### DIFF
--- a/go/storage/mkvs/iterator.go
+++ b/go/storage/mkvs/iterator.go
@@ -269,13 +269,11 @@ func (it *treeIterator) doNext(ptr *node.Pointer, bitDepth node.Depth, path, key
 
 		// Check if the key is longer than the current path but lexicographically smaller. In this
 		// case everything in this subtree will be larger so we need to take the first value.
-		var takeFirst bool
-		if bitLength > 0 && key.BitLength() >= bitLength && key.Compare(newPath) < 0 {
-			takeFirst = true
-		}
+		takeFirst := bitLength > 0 && key.BitLength() >= bitLength && key.Compare(newPath) < 0
+		keyNotLonger := key.BitLength() <= bitLength
 
 		// Does lookup key end here? Look into LeafNode.
-		if (state == visitBefore && (key.BitLength() <= bitLength || takeFirst)) || state == visitAt {
+		if (state == visitBefore && (keyNotLonger || takeFirst)) || state == visitAt {
 			if state == visitBefore {
 				err := it.doNext(n.LeafNode, bitLength, path, key, visitBefore)
 				if err != nil {
@@ -288,7 +286,7 @@ func (it *treeIterator) doNext(ptr *node.Pointer, bitDepth node.Depth, path, key
 				}
 			}
 			// Key has not been found, continue with search for next key.
-			if key.BitLength() <= bitLength {
+			if keyNotLonger {
 				key = key.AppendBit(bitLength, false)
 			}
 		}

--- a/go/storage/mkvs/iterator.go
+++ b/go/storage/mkvs/iterator.go
@@ -275,7 +275,7 @@ func (it *treeIterator) doNext(ptr *node.Pointer, bitDepth node.Depth, path, key
 		// Does lookup key end here? Look into LeafNode.
 		if (state == visitBefore && (keyNotLonger || takeFirst)) || state == visitAt {
 			if state == visitBefore {
-				err := it.doNext(n.LeafNode, bitLength, path, key, visitBefore)
+				err := it.doNext(n.LeafNode, bitLength, newPath, key, visitBefore)
 				if err != nil {
 					return err
 				}
@@ -298,7 +298,7 @@ func (it *treeIterator) doNext(ptr *node.Pointer, bitDepth node.Depth, path, key
 		// Continue recursively based on a bit value.
 		if (state == visitAt && (!key.GetBit(bitLength) || takeFirst)) || state == visitAtLeft {
 			if state == visitAt {
-				err := it.doNext(n.Left, bitLength, newPath.AppendBit(bitLength, false), key, visitBefore)
+				err := it.doNext(n.Left, bitLength, newPath, key, visitBefore)
 				if err != nil {
 					return err
 				}
@@ -314,7 +314,7 @@ func (it *treeIterator) doNext(ptr *node.Pointer, bitDepth node.Depth, path, key
 		}
 
 		if state == visitAt || state == visitAtLeft {
-			err := it.doNext(n.Right, bitLength, newPath.AppendBit(bitLength, true), key, visitBefore)
+			err := it.doNext(n.Right, bitLength, newPath, key, visitBefore)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Whilst working on #6165 (still WIP) I found iterator code quite hard to follow/debug. I tried to simplify it a bit but am still not 100% convinced by the changes ([see comment](https://github.com/oasisprotocol/oasis-core/pull/6176#discussion_r2072365166)).
