### PR TITLE
go/consensus/api: Refactor consensus interfaces

### DIFF
--- a/go/beacon/tests/tester.go
+++ b/go/beacon/tests/tester.go
@@ -12,7 +12,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/beacon/api"
 	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
-	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	consensusAPI "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 )
 
@@ -23,28 +23,28 @@ var TestSigner = memorySigner.NewTestSigner("oasis-core epochtime mock key seed"
 
 // BeaconImplementationTests exercises the basic functionality of a
 // beacon backend.
-func BeaconImplementationTests(t *testing.T, backend consensus.Backend) {
+func BeaconImplementationTests(t *testing.T, consensus consensusAPI.Service) {
 	require := require.New(t)
 
-	timeSource := backend.Beacon()
+	timeSource := consensus.Beacon()
 
-	beacon, err := timeSource.GetBeacon(context.Background(), consensus.HeightLatest)
+	beacon, err := timeSource.GetBeacon(context.Background(), consensusAPI.HeightLatest)
 	require.NoError(err, "GetBeacon")
 	require.Len(beacon, api.BeaconSize, "GetBeacon - length")
 
-	_ = MustAdvanceEpoch(t, backend)
+	_ = MustAdvanceEpoch(t, consensus)
 
-	newBeacon, err := timeSource.GetBeacon(context.Background(), consensus.HeightLatest)
+	newBeacon, err := timeSource.GetBeacon(context.Background(), consensusAPI.HeightLatest)
 	require.NoError(err, "GetBeacon")
 	require.Len(newBeacon, api.BeaconSize, "GetBeacon - length")
 	require.NotEqual(beacon, newBeacon, "After epoch transition, new beacon should be generated.")
 
-	latestEpoch, err := timeSource.GetEpoch(context.Background(), consensus.HeightLatest)
+	latestEpoch, err := timeSource.GetEpoch(context.Background(), consensusAPI.HeightLatest)
 	require.NoError(err, "GetEpoch")
 
 	// Querying epoch for a non-existing height should fail.
 	_, err = timeSource.GetEpoch(context.Background(), 100000000000)
-	require.ErrorIs(err, consensus.ErrVersionNotFound, "GetEpoch should fail for non-existing height")
+	require.ErrorIs(err, consensusAPI.ErrVersionNotFound, "GetEpoch should fail for non-existing height")
 
 	var lastHeight int64
 	for epoch := api.EpochTime(0); epoch <= latestEpoch; epoch++ {
@@ -57,16 +57,16 @@ func BeaconImplementationTests(t *testing.T, backend consensus.Backend) {
 
 // EpochtimeSetableImplementationTest exercises the basic functionality of
 // a setable (mock) epochtime backend.
-func EpochtimeSetableImplementationTest(t *testing.T, backend consensus.Backend) {
+func EpochtimeSetableImplementationTest(t *testing.T, consensus consensusAPI.Service) {
 	require := require.New(t)
 
-	timeSource := backend.Beacon()
+	timeSource := consensus.Beacon()
 
-	parameters, err := timeSource.ConsensusParameters(context.Background(), consensus.HeightLatest)
+	parameters, err := timeSource.ConsensusParameters(context.Background(), consensusAPI.HeightLatest)
 	require.NoError(err, "ConsensusParameters")
 	require.True(parameters.DebugMockBackend, "expected debug backend")
 
-	epoch, err := timeSource.GetEpoch(context.Background(), consensus.HeightLatest)
+	epoch, err := timeSource.GetEpoch(context.Background(), consensusAPI.HeightLatest)
 	require.NoError(err, "GetEpoch")
 
 	var e api.EpochTime
@@ -92,7 +92,7 @@ func EpochtimeSetableImplementationTest(t *testing.T, backend consensus.Backend)
 	}
 
 	epoch++
-	err = SetEpoch(context.Background(), epoch, backend)
+	err = SetEpoch(context.Background(), epoch, consensus)
 	require.NoError(err, "SetEpoch")
 
 	select {
@@ -109,28 +109,28 @@ func EpochtimeSetableImplementationTest(t *testing.T, backend consensus.Backend)
 		t.Fatalf("failed to receive latest epoch after transition")
 	}
 
-	e, err = timeSource.GetEpoch(context.Background(), consensus.HeightLatest)
+	e, err = timeSource.GetEpoch(context.Background(), consensusAPI.HeightLatest)
 	require.NoError(err, "GetEpoch after set")
 	require.Equal(epoch, e, "GetEpoch after set, epoch")
 }
 
 // MustAdvanceEpoch advances the epoch and returns the new epoch.
-func MustAdvanceEpoch(t *testing.T, backend consensus.Backend) api.EpochTime {
+func MustAdvanceEpoch(t *testing.T, consensus consensusAPI.Service) api.EpochTime {
 	require := require.New(t)
 
-	timeSource := backend.Beacon()
+	timeSource := consensus.Beacon()
 
 	ctx, cancel := context.WithTimeout(context.Background(), recvTimeout)
 	defer cancel()
 
-	epoch, err := timeSource.GetEpoch(ctx, consensus.HeightLatest)
+	epoch, err := timeSource.GetEpoch(ctx, consensusAPI.HeightLatest)
 	require.NoError(err, "GetEpoch")
 
 	// While using a timeout here would be nice, the correct timeout value
 	// depends on the block interval and all the various internal timekeeping
 	// periods so it's not easy to set one.
 	epoch++
-	err = SetEpoch(context.Background(), epoch, backend)
+	err = SetEpoch(context.Background(), epoch, consensus)
 	require.NoError(err, "SetEpoch")
 
 	return epoch
@@ -141,16 +141,16 @@ func MustAdvanceEpoch(t *testing.T, backend consensus.Backend) api.EpochTime {
 // Between each epoch increment the method ensures that the consensus validator is re-registered
 // so that epochs are not advanced too fast, which could cause a consensus error due to no
 // validators being registered for the epoch.
-func MustAdvanceEpochMulti(t *testing.T, backend consensus.Backend, increment uint64) api.EpochTime {
+func MustAdvanceEpochMulti(t *testing.T, consensus consensusAPI.Service, increment uint64) api.EpochTime {
 	require := require.New(t)
 
-	timeSource := backend.Beacon()
-	registry := backend.Registry()
+	timeSource := consensus.Beacon()
+	registry := consensus.Registry()
 
 	ctx, cancel := context.WithTimeout(context.Background(), recvTimeout)
 	defer cancel()
 
-	epoch, err := timeSource.GetEpoch(ctx, consensus.HeightLatest)
+	epoch, err := timeSource.GetEpoch(ctx, consensusAPI.HeightLatest)
 	require.NoError(err, "GetEpoch")
 
 	// While using a timeout here would be nice, the correct timeout value
@@ -167,7 +167,7 @@ func MustAdvanceEpochMulti(t *testing.T, backend consensus.Backend, increment ui
 		// While using a timeout here would be nice, the correct timeout value
 		// depends on the block interval and all the various internal timekeeping
 		// periods so it's not easy to set one.
-		err = SetEpoch(context.Background(), epoch, backend)
+		err = SetEpoch(context.Background(), epoch, consensus)
 		require.NoError(err, "SetEpoch")
 
 		// Ensure validator re-registers before transitioning to next epoch.
@@ -194,15 +194,15 @@ func MustAdvanceEpochMulti(t *testing.T, backend consensus.Backend, increment ui
 }
 
 // SetEpoch sets the current epoch.
-func SetEpoch(ctx context.Context, epoch api.EpochTime, backend consensus.Backend) error {
-	ch, sub, err := backend.Beacon().WatchEpochs(ctx)
+func SetEpoch(ctx context.Context, epoch api.EpochTime, consensus consensusAPI.Service) error {
+	ch, sub, err := consensus.Beacon().WatchEpochs(ctx)
 	if err != nil {
 		return fmt.Errorf("watch epochs failed: %w", err)
 	}
 	defer sub.Close()
 
 	tx := transaction.NewTransaction(0, nil, api.MethodSetEpoch, epoch)
-	if err := consensus.SignAndSubmitTx(ctx, backend, TestSigner, tx); err != nil {
+	if err := consensusAPI.SignAndSubmitTx(ctx, consensus, TestSigner, tx); err != nil {
 		return fmt.Errorf("set epoch failed: %w", err)
 	}
 

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -197,10 +197,11 @@ type Backend interface {
 
 // Services are consensus services.
 type Services interface {
-	Backend
-
 	// Beacon returns the beacon backend.
 	Beacon() beacon.Backend
+
+	// Core returns the consensus core backend.
+	Core() Backend
 
 	// Governance returns the governance backend.
 	Governance() governance.Backend

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -109,8 +109,8 @@ func (m FeatureMask) Has(f FeatureMask) bool {
 	return m&f != 0
 }
 
-// ClientBackend is a consensus interface used by clients that connect to the local full node.
-type ClientBackend interface {
+// Backend is a consensus interface used by clients that connect to the local full node.
+type Backend interface {
 	// SubmitTx submits a signed consensus transaction and waits for the transaction to be included
 	// in a block. Use SubmitTxNoWait if you only need to broadcast the transaction.
 	SubmitTx(ctx context.Context, tx *transaction.SignedTransaction) error
@@ -371,10 +371,10 @@ type P2PStatus struct {
 	Peers []string `json:"peers"`
 }
 
-// Backend is an interface that a consensus backend must provide.
-type Backend interface {
+// Service is an interface that a consensus backend service must provide.
+type Service interface {
 	service.BackgroundService
-	ClientBackend
+	Backend
 
 	// SupportedFeatures returns the features supported by this consensus backend.
 	SupportedFeatures() FeatureMask

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -193,30 +193,35 @@ type Backend interface {
 
 	// GetNextBlockState returns the state of the next block being voted on by validators.
 	GetNextBlockState(ctx context.Context) (*NextBlockState, error)
+}
+
+// Services are consensus services.
+type Services interface {
+	Backend
 
 	// Beacon returns the beacon backend.
 	Beacon() beacon.Backend
 
-	// Registry returns the registry backend.
-	Registry() registry.Backend
-
-	// Staking returns the staking backend.
-	Staking() staking.Backend
-
-	// Scheduler returns the scheduler backend.
-	Scheduler() scheduler.Backend
-
 	// Governance returns the governance backend.
 	Governance() governance.Backend
+
+	// KeyManager returns the keymanager backend.
+	KeyManager() keymanager.Backend
+
+	// Registry returns the registry backend.
+	Registry() registry.Backend
 
 	// RootHash returns the roothash backend.
 	RootHash() roothash.Backend
 
+	// Scheduler returns the scheduler backend.
+	Scheduler() scheduler.Backend
+
+	// Staking returns the staking backend.
+	Staking() staking.Backend
+
 	// Vault returns the vault backend.
 	Vault() vault.Backend
-
-	// KeyManager returns the keymanager backend.
-	KeyManager() keymanager.Backend
 }
 
 // Block is a consensus block.
@@ -374,7 +379,7 @@ type P2PStatus struct {
 // Service is an interface that a consensus backend service must provide.
 type Service interface {
 	service.BackgroundService
-	Backend
+	Services
 
 	// SupportedFeatures returns the features supported by this consensus backend.
 	SupportedFeatures() FeatureMask

--- a/go/consensus/api/grpc.go
+++ b/go/consensus/api/grpc.go
@@ -80,7 +80,7 @@ var (
 	// serviceDesc is the gRPC service descriptor.
 	serviceDesc = grpc.ServiceDesc{
 		ServiceName: string(serviceName),
-		HandlerType: (*ClientBackend)(nil),
+		HandlerType: (*Backend)(nil),
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: methodSubmitTx.ShortName(),
@@ -200,14 +200,14 @@ func handlerSubmitTx(
 		return nil, err
 	}
 	if interceptor == nil {
-		return nil, srv.(ClientBackend).SubmitTx(ctx, rq)
+		return nil, srv.(Backend).SubmitTx(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodSubmitTx.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return nil, srv.(ClientBackend).SubmitTx(ctx, req.(*transaction.SignedTransaction))
+		return nil, srv.(Backend).SubmitTx(ctx, req.(*transaction.SignedTransaction))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -223,14 +223,14 @@ func handlerSubmitTxNoWait(
 		return nil, err
 	}
 	if interceptor == nil {
-		return nil, srv.(ClientBackend).SubmitTxNoWait(ctx, rq)
+		return nil, srv.(Backend).SubmitTxNoWait(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodSubmitTxNoWait.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return nil, srv.(ClientBackend).SubmitTxNoWait(ctx, req.(*transaction.SignedTransaction))
+		return nil, srv.(Backend).SubmitTxNoWait(ctx, req.(*transaction.SignedTransaction))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -246,14 +246,14 @@ func handlerSubmitTxWithProof(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ClientBackend).SubmitTxWithProof(ctx, rq)
+		return srv.(Backend).SubmitTxWithProof(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodSubmitTxWithProof.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(ClientBackend).SubmitTxWithProof(ctx, req.(*transaction.SignedTransaction))
+		return srv.(Backend).SubmitTxWithProof(ctx, req.(*transaction.SignedTransaction))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -269,14 +269,14 @@ func handlerStateToGenesis(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ClientBackend).StateToGenesis(ctx, height)
+		return srv.(Backend).StateToGenesis(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodStateToGenesis.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(ClientBackend).StateToGenesis(ctx, req.(int64))
+		return srv.(Backend).StateToGenesis(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -292,14 +292,14 @@ func handlerEstimateGas(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ClientBackend).EstimateGas(ctx, rq)
+		return srv.(Backend).EstimateGas(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodEstimateGas.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(ClientBackend).EstimateGas(ctx, req.(*EstimateGasRequest))
+		return srv.(Backend).EstimateGas(ctx, req.(*EstimateGasRequest))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -311,14 +311,14 @@ func handlerMinGasPrice(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(ClientBackend).MinGasPrice(ctx)
+		return srv.(Backend).MinGasPrice(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodMinGasPrice.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(ClientBackend).MinGasPrice(ctx)
+		return srv.(Backend).MinGasPrice(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -334,14 +334,14 @@ func handlerGetSignerNonce(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ClientBackend).GetSignerNonce(ctx, rq)
+		return srv.(Backend).GetSignerNonce(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetSignerNonce.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(ClientBackend).GetSignerNonce(ctx, req.(*GetSignerNonceRequest))
+		return srv.(Backend).GetSignerNonce(ctx, req.(*GetSignerNonceRequest))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -357,14 +357,14 @@ func handlerGetBlock(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ClientBackend).GetBlock(ctx, height)
+		return srv.(Backend).GetBlock(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetBlock.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(ClientBackend).GetBlock(ctx, req.(int64))
+		return srv.(Backend).GetBlock(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -380,14 +380,14 @@ func handlerGetLightBlock(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ClientBackend).GetLightBlock(ctx, height)
+		return srv.(Backend).GetLightBlock(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetLightBlock.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(ClientBackend).GetLightBlock(ctx, req.(int64))
+		return srv.(Backend).GetLightBlock(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -399,14 +399,14 @@ func handlerGetLatestHeight(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(ClientBackend).GetLatestHeight(ctx)
+		return srv.(Backend).GetLatestHeight(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetLatestHeight.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(ClientBackend).GetLatestHeight(ctx)
+		return srv.(Backend).GetLatestHeight(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -418,14 +418,14 @@ func handlerGetLastRetainedHeight(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(ClientBackend).GetLastRetainedHeight(ctx)
+		return srv.(Backend).GetLastRetainedHeight(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetLastRetainedHeight.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(ClientBackend).GetLastRetainedHeight(ctx)
+		return srv.(Backend).GetLastRetainedHeight(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -441,14 +441,14 @@ func handlerGetTransactions(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ClientBackend).GetTransactions(ctx, height)
+		return srv.(Backend).GetTransactions(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetTransactions.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(ClientBackend).GetTransactions(ctx, req.(int64))
+		return srv.(Backend).GetTransactions(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -464,14 +464,14 @@ func handlerGetTransactionsWithResults(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ClientBackend).GetTransactionsWithResults(ctx, height)
+		return srv.(Backend).GetTransactionsWithResults(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetTransactionsWithResults.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(ClientBackend).GetTransactionsWithResults(ctx, req.(int64))
+		return srv.(Backend).GetTransactionsWithResults(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -487,14 +487,14 @@ func handlerGetTransactionsWithProofs(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ClientBackend).GetTransactionsWithProofs(ctx, height)
+		return srv.(Backend).GetTransactionsWithProofs(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetTransactionsWithProofs.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(ClientBackend).GetTransactionsWithProofs(ctx, req.(int64))
+		return srv.(Backend).GetTransactionsWithProofs(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -506,14 +506,14 @@ func handlerGetUnconfirmedTransactions(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(ClientBackend).GetUnconfirmedTransactions(ctx)
+		return srv.(Backend).GetUnconfirmedTransactions(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetUnconfirmedTransactions.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(ClientBackend).GetUnconfirmedTransactions(ctx)
+		return srv.(Backend).GetUnconfirmedTransactions(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -529,14 +529,14 @@ func handlerStateSyncGet(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ClientBackend).State().SyncGet(ctx, rq)
+		return srv.(Backend).State().SyncGet(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodStateSyncGet.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(ClientBackend).State().SyncGet(ctx, req.(*syncer.GetRequest))
+		return srv.(Backend).State().SyncGet(ctx, req.(*syncer.GetRequest))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -552,14 +552,14 @@ func handlerStateSyncGetPrefixes(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ClientBackend).State().SyncGetPrefixes(ctx, rq)
+		return srv.(Backend).State().SyncGetPrefixes(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodStateSyncGetPrefixes.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(ClientBackend).State().SyncGetPrefixes(ctx, req.(*syncer.GetPrefixesRequest))
+		return srv.(Backend).State().SyncGetPrefixes(ctx, req.(*syncer.GetPrefixesRequest))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -575,14 +575,14 @@ func handlerStateSyncIterate(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ClientBackend).State().SyncIterate(ctx, rq)
+		return srv.(Backend).State().SyncIterate(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodStateSyncIterate.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(ClientBackend).State().SyncIterate(ctx, req.(*syncer.IterateRequest))
+		return srv.(Backend).State().SyncIterate(ctx, req.(*syncer.IterateRequest))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -594,14 +594,14 @@ func handlerGetGenesisDocument(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(ClientBackend).GetGenesisDocument(ctx)
+		return srv.(Backend).GetGenesisDocument(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetGenesisDocument.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(ClientBackend).GetGenesisDocument(ctx)
+		return srv.(Backend).GetGenesisDocument(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -613,14 +613,14 @@ func handlerGetChainContext(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(ClientBackend).GetChainContext(ctx)
+		return srv.(Backend).GetChainContext(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetChainContext.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(ClientBackend).GetChainContext(ctx)
+		return srv.(Backend).GetChainContext(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -632,14 +632,14 @@ func handlerGetStatus(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(ClientBackend).GetStatus(ctx)
+		return srv.(Backend).GetStatus(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetStatus.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(ClientBackend).GetStatus(ctx)
+		return srv.(Backend).GetStatus(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -651,14 +651,14 @@ func handlerGetNextBlockState(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(ClientBackend).GetNextBlockState(ctx)
+		return srv.(Backend).GetNextBlockState(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetNextBlockState.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(ClientBackend).GetNextBlockState(ctx)
+		return srv.(Backend).GetNextBlockState(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -674,14 +674,14 @@ func handlerGetParameters(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ClientBackend).GetParameters(ctx, height)
+		return srv.(Backend).GetParameters(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetParameters.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(ClientBackend).GetParameters(ctx, req.(int64))
+		return srv.(Backend).GetParameters(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -697,14 +697,14 @@ func handlerSubmitEvidence(
 		return nil, err
 	}
 	if interceptor == nil {
-		return nil, srv.(ClientBackend).SubmitEvidence(ctx, rq)
+		return nil, srv.(Backend).SubmitEvidence(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodSubmitEvidence.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return nil, srv.(ClientBackend).SubmitEvidence(ctx, req.(*Evidence))
+		return nil, srv.(Backend).SubmitEvidence(ctx, req.(*Evidence))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -715,7 +715,7 @@ func handlerWatchBlocks(srv any, stream grpc.ServerStream) error {
 	}
 
 	ctx := stream.Context()
-	ch, sub, err := srv.(ClientBackend).WatchBlocks(ctx)
+	ch, sub, err := srv.(Backend).WatchBlocks(ctx)
 	if err != nil {
 		return err
 	}
@@ -738,7 +738,7 @@ func handlerWatchBlocks(srv any, stream grpc.ServerStream) error {
 }
 
 // RegisterService registers a new client backend service with the given gRPC server.
-func RegisterService(server *grpc.Server, service ClientBackend) {
+func RegisterService(server *grpc.Server, service Backend) {
 	server.RegisterService(&serviceDesc, service)
 }
 

--- a/go/consensus/api/grpc.go
+++ b/go/consensus/api/grpc.go
@@ -80,7 +80,7 @@ var (
 	// serviceDesc is the gRPC service descriptor.
 	serviceDesc = grpc.ServiceDesc{
 		ServiceName: string(serviceName),
-		HandlerType: (*Backend)(nil),
+		HandlerType: (*Services)(nil),
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: methodSubmitTx.ShortName(),
@@ -200,14 +200,14 @@ func handlerSubmitTx(
 		return nil, err
 	}
 	if interceptor == nil {
-		return nil, srv.(Backend).SubmitTx(ctx, rq)
+		return nil, srv.(Services).SubmitTx(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodSubmitTx.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return nil, srv.(Backend).SubmitTx(ctx, req.(*transaction.SignedTransaction))
+		return nil, srv.(Services).SubmitTx(ctx, req.(*transaction.SignedTransaction))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -223,14 +223,14 @@ func handlerSubmitTxNoWait(
 		return nil, err
 	}
 	if interceptor == nil {
-		return nil, srv.(Backend).SubmitTxNoWait(ctx, rq)
+		return nil, srv.(Services).SubmitTxNoWait(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodSubmitTxNoWait.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return nil, srv.(Backend).SubmitTxNoWait(ctx, req.(*transaction.SignedTransaction))
+		return nil, srv.(Services).SubmitTxNoWait(ctx, req.(*transaction.SignedTransaction))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -246,14 +246,14 @@ func handlerSubmitTxWithProof(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Backend).SubmitTxWithProof(ctx, rq)
+		return srv.(Services).SubmitTxWithProof(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodSubmitTxWithProof.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Backend).SubmitTxWithProof(ctx, req.(*transaction.SignedTransaction))
+		return srv.(Services).SubmitTxWithProof(ctx, req.(*transaction.SignedTransaction))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -269,14 +269,14 @@ func handlerStateToGenesis(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Backend).StateToGenesis(ctx, height)
+		return srv.(Services).StateToGenesis(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodStateToGenesis.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Backend).StateToGenesis(ctx, req.(int64))
+		return srv.(Services).StateToGenesis(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -292,14 +292,14 @@ func handlerEstimateGas(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Backend).EstimateGas(ctx, rq)
+		return srv.(Services).EstimateGas(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodEstimateGas.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Backend).EstimateGas(ctx, req.(*EstimateGasRequest))
+		return srv.(Services).EstimateGas(ctx, req.(*EstimateGasRequest))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -311,14 +311,14 @@ func handlerMinGasPrice(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(Backend).MinGasPrice(ctx)
+		return srv.(Services).MinGasPrice(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodMinGasPrice.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(Backend).MinGasPrice(ctx)
+		return srv.(Services).MinGasPrice(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -334,14 +334,14 @@ func handlerGetSignerNonce(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Backend).GetSignerNonce(ctx, rq)
+		return srv.(Services).GetSignerNonce(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetSignerNonce.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Backend).GetSignerNonce(ctx, req.(*GetSignerNonceRequest))
+		return srv.(Services).GetSignerNonce(ctx, req.(*GetSignerNonceRequest))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -357,14 +357,14 @@ func handlerGetBlock(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Backend).GetBlock(ctx, height)
+		return srv.(Services).GetBlock(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetBlock.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Backend).GetBlock(ctx, req.(int64))
+		return srv.(Services).GetBlock(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -380,14 +380,14 @@ func handlerGetLightBlock(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Backend).GetLightBlock(ctx, height)
+		return srv.(Services).GetLightBlock(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetLightBlock.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Backend).GetLightBlock(ctx, req.(int64))
+		return srv.(Services).GetLightBlock(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -399,14 +399,14 @@ func handlerGetLatestHeight(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(Backend).GetLatestHeight(ctx)
+		return srv.(Services).GetLatestHeight(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetLatestHeight.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(Backend).GetLatestHeight(ctx)
+		return srv.(Services).GetLatestHeight(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -418,14 +418,14 @@ func handlerGetLastRetainedHeight(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(Backend).GetLastRetainedHeight(ctx)
+		return srv.(Services).GetLastRetainedHeight(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetLastRetainedHeight.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(Backend).GetLastRetainedHeight(ctx)
+		return srv.(Services).GetLastRetainedHeight(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -441,14 +441,14 @@ func handlerGetTransactions(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Backend).GetTransactions(ctx, height)
+		return srv.(Services).GetTransactions(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetTransactions.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Backend).GetTransactions(ctx, req.(int64))
+		return srv.(Services).GetTransactions(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -464,14 +464,14 @@ func handlerGetTransactionsWithResults(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Backend).GetTransactionsWithResults(ctx, height)
+		return srv.(Services).GetTransactionsWithResults(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetTransactionsWithResults.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Backend).GetTransactionsWithResults(ctx, req.(int64))
+		return srv.(Services).GetTransactionsWithResults(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -487,14 +487,14 @@ func handlerGetTransactionsWithProofs(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Backend).GetTransactionsWithProofs(ctx, height)
+		return srv.(Services).GetTransactionsWithProofs(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetTransactionsWithProofs.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Backend).GetTransactionsWithProofs(ctx, req.(int64))
+		return srv.(Services).GetTransactionsWithProofs(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -506,14 +506,14 @@ func handlerGetUnconfirmedTransactions(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(Backend).GetUnconfirmedTransactions(ctx)
+		return srv.(Services).GetUnconfirmedTransactions(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetUnconfirmedTransactions.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(Backend).GetUnconfirmedTransactions(ctx)
+		return srv.(Services).GetUnconfirmedTransactions(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -529,14 +529,14 @@ func handlerStateSyncGet(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Backend).State().SyncGet(ctx, rq)
+		return srv.(Services).State().SyncGet(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodStateSyncGet.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Backend).State().SyncGet(ctx, req.(*syncer.GetRequest))
+		return srv.(Services).State().SyncGet(ctx, req.(*syncer.GetRequest))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -552,14 +552,14 @@ func handlerStateSyncGetPrefixes(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Backend).State().SyncGetPrefixes(ctx, rq)
+		return srv.(Services).State().SyncGetPrefixes(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodStateSyncGetPrefixes.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Backend).State().SyncGetPrefixes(ctx, req.(*syncer.GetPrefixesRequest))
+		return srv.(Services).State().SyncGetPrefixes(ctx, req.(*syncer.GetPrefixesRequest))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -575,14 +575,14 @@ func handlerStateSyncIterate(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Backend).State().SyncIterate(ctx, rq)
+		return srv.(Services).State().SyncIterate(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodStateSyncIterate.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Backend).State().SyncIterate(ctx, req.(*syncer.IterateRequest))
+		return srv.(Services).State().SyncIterate(ctx, req.(*syncer.IterateRequest))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -594,14 +594,14 @@ func handlerGetGenesisDocument(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(Backend).GetGenesisDocument(ctx)
+		return srv.(Services).GetGenesisDocument(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetGenesisDocument.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(Backend).GetGenesisDocument(ctx)
+		return srv.(Services).GetGenesisDocument(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -613,14 +613,14 @@ func handlerGetChainContext(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(Backend).GetChainContext(ctx)
+		return srv.(Services).GetChainContext(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetChainContext.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(Backend).GetChainContext(ctx)
+		return srv.(Services).GetChainContext(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -632,14 +632,14 @@ func handlerGetStatus(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(Backend).GetStatus(ctx)
+		return srv.(Services).GetStatus(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetStatus.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(Backend).GetStatus(ctx)
+		return srv.(Services).GetStatus(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -651,14 +651,14 @@ func handlerGetNextBlockState(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(Backend).GetNextBlockState(ctx)
+		return srv.(Services).GetNextBlockState(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetNextBlockState.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(Backend).GetNextBlockState(ctx)
+		return srv.(Services).GetNextBlockState(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -674,14 +674,14 @@ func handlerGetParameters(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Backend).GetParameters(ctx, height)
+		return srv.(Services).GetParameters(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetParameters.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Backend).GetParameters(ctx, req.(int64))
+		return srv.(Services).GetParameters(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -697,14 +697,14 @@ func handlerSubmitEvidence(
 		return nil, err
 	}
 	if interceptor == nil {
-		return nil, srv.(Backend).SubmitEvidence(ctx, rq)
+		return nil, srv.(Services).SubmitEvidence(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodSubmitEvidence.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return nil, srv.(Backend).SubmitEvidence(ctx, req.(*Evidence))
+		return nil, srv.(Services).SubmitEvidence(ctx, req.(*Evidence))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -715,7 +715,7 @@ func handlerWatchBlocks(srv any, stream grpc.ServerStream) error {
 	}
 
 	ctx := stream.Context()
-	ch, sub, err := srv.(Backend).WatchBlocks(ctx)
+	ch, sub, err := srv.(Services).WatchBlocks(ctx)
 	if err != nil {
 		return err
 	}
@@ -738,7 +738,7 @@ func handlerWatchBlocks(srv any, stream grpc.ServerStream) error {
 }
 
 // RegisterService registers a new client backend service with the given gRPC server.
-func RegisterService(server *grpc.Server, service Backend) {
+func RegisterService(server *grpc.Server, service Services) {
 	server.RegisterService(&serviceDesc, service)
 }
 

--- a/go/consensus/api/grpc.go
+++ b/go/consensus/api/grpc.go
@@ -200,14 +200,14 @@ func handlerSubmitTx(
 		return nil, err
 	}
 	if interceptor == nil {
-		return nil, srv.(Services).SubmitTx(ctx, rq)
+		return nil, srv.(Services).Core().SubmitTx(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodSubmitTx.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return nil, srv.(Services).SubmitTx(ctx, req.(*transaction.SignedTransaction))
+		return nil, srv.(Services).Core().SubmitTx(ctx, req.(*transaction.SignedTransaction))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -223,14 +223,14 @@ func handlerSubmitTxNoWait(
 		return nil, err
 	}
 	if interceptor == nil {
-		return nil, srv.(Services).SubmitTxNoWait(ctx, rq)
+		return nil, srv.(Services).Core().SubmitTxNoWait(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodSubmitTxNoWait.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return nil, srv.(Services).SubmitTxNoWait(ctx, req.(*transaction.SignedTransaction))
+		return nil, srv.(Services).Core().SubmitTxNoWait(ctx, req.(*transaction.SignedTransaction))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -246,14 +246,14 @@ func handlerSubmitTxWithProof(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Services).SubmitTxWithProof(ctx, rq)
+		return srv.(Services).Core().SubmitTxWithProof(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodSubmitTxWithProof.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Services).SubmitTxWithProof(ctx, req.(*transaction.SignedTransaction))
+		return srv.(Services).Core().SubmitTxWithProof(ctx, req.(*transaction.SignedTransaction))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -269,14 +269,14 @@ func handlerStateToGenesis(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Services).StateToGenesis(ctx, height)
+		return srv.(Services).Core().StateToGenesis(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodStateToGenesis.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Services).StateToGenesis(ctx, req.(int64))
+		return srv.(Services).Core().StateToGenesis(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -292,14 +292,14 @@ func handlerEstimateGas(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Services).EstimateGas(ctx, rq)
+		return srv.(Services).Core().EstimateGas(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodEstimateGas.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Services).EstimateGas(ctx, req.(*EstimateGasRequest))
+		return srv.(Services).Core().EstimateGas(ctx, req.(*EstimateGasRequest))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -311,14 +311,14 @@ func handlerMinGasPrice(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(Services).MinGasPrice(ctx)
+		return srv.(Services).Core().MinGasPrice(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodMinGasPrice.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(Services).MinGasPrice(ctx)
+		return srv.(Services).Core().MinGasPrice(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -334,14 +334,14 @@ func handlerGetSignerNonce(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Services).GetSignerNonce(ctx, rq)
+		return srv.(Services).Core().GetSignerNonce(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetSignerNonce.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Services).GetSignerNonce(ctx, req.(*GetSignerNonceRequest))
+		return srv.(Services).Core().GetSignerNonce(ctx, req.(*GetSignerNonceRequest))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -357,14 +357,14 @@ func handlerGetBlock(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Services).GetBlock(ctx, height)
+		return srv.(Services).Core().GetBlock(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetBlock.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Services).GetBlock(ctx, req.(int64))
+		return srv.(Services).Core().GetBlock(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -380,14 +380,14 @@ func handlerGetLightBlock(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Services).GetLightBlock(ctx, height)
+		return srv.(Services).Core().GetLightBlock(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetLightBlock.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Services).GetLightBlock(ctx, req.(int64))
+		return srv.(Services).Core().GetLightBlock(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -399,14 +399,14 @@ func handlerGetLatestHeight(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(Services).GetLatestHeight(ctx)
+		return srv.(Services).Core().GetLatestHeight(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetLatestHeight.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(Services).GetLatestHeight(ctx)
+		return srv.(Services).Core().GetLatestHeight(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -418,14 +418,14 @@ func handlerGetLastRetainedHeight(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(Services).GetLastRetainedHeight(ctx)
+		return srv.(Services).Core().GetLastRetainedHeight(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetLastRetainedHeight.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(Services).GetLastRetainedHeight(ctx)
+		return srv.(Services).Core().GetLastRetainedHeight(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -441,14 +441,14 @@ func handlerGetTransactions(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Services).GetTransactions(ctx, height)
+		return srv.(Services).Core().GetTransactions(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetTransactions.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Services).GetTransactions(ctx, req.(int64))
+		return srv.(Services).Core().GetTransactions(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -464,14 +464,14 @@ func handlerGetTransactionsWithResults(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Services).GetTransactionsWithResults(ctx, height)
+		return srv.(Services).Core().GetTransactionsWithResults(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetTransactionsWithResults.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Services).GetTransactionsWithResults(ctx, req.(int64))
+		return srv.(Services).Core().GetTransactionsWithResults(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -487,14 +487,14 @@ func handlerGetTransactionsWithProofs(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Services).GetTransactionsWithProofs(ctx, height)
+		return srv.(Services).Core().GetTransactionsWithProofs(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetTransactionsWithProofs.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Services).GetTransactionsWithProofs(ctx, req.(int64))
+		return srv.(Services).Core().GetTransactionsWithProofs(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -506,14 +506,14 @@ func handlerGetUnconfirmedTransactions(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(Services).GetUnconfirmedTransactions(ctx)
+		return srv.(Services).Core().GetUnconfirmedTransactions(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetUnconfirmedTransactions.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(Services).GetUnconfirmedTransactions(ctx)
+		return srv.(Services).Core().GetUnconfirmedTransactions(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -529,14 +529,14 @@ func handlerStateSyncGet(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Services).State().SyncGet(ctx, rq)
+		return srv.(Services).Core().State().SyncGet(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodStateSyncGet.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Services).State().SyncGet(ctx, req.(*syncer.GetRequest))
+		return srv.(Services).Core().State().SyncGet(ctx, req.(*syncer.GetRequest))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -552,14 +552,14 @@ func handlerStateSyncGetPrefixes(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Services).State().SyncGetPrefixes(ctx, rq)
+		return srv.(Services).Core().State().SyncGetPrefixes(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodStateSyncGetPrefixes.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Services).State().SyncGetPrefixes(ctx, req.(*syncer.GetPrefixesRequest))
+		return srv.(Services).Core().State().SyncGetPrefixes(ctx, req.(*syncer.GetPrefixesRequest))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -575,14 +575,14 @@ func handlerStateSyncIterate(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Services).State().SyncIterate(ctx, rq)
+		return srv.(Services).Core().State().SyncIterate(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodStateSyncIterate.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Services).State().SyncIterate(ctx, req.(*syncer.IterateRequest))
+		return srv.(Services).Core().State().SyncIterate(ctx, req.(*syncer.IterateRequest))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -594,14 +594,14 @@ func handlerGetGenesisDocument(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(Services).GetGenesisDocument(ctx)
+		return srv.(Services).Core().GetGenesisDocument(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetGenesisDocument.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(Services).GetGenesisDocument(ctx)
+		return srv.(Services).Core().GetGenesisDocument(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -613,14 +613,14 @@ func handlerGetChainContext(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(Services).GetChainContext(ctx)
+		return srv.(Services).Core().GetChainContext(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetChainContext.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(Services).GetChainContext(ctx)
+		return srv.(Services).Core().GetChainContext(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -632,14 +632,14 @@ func handlerGetStatus(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(Services).GetStatus(ctx)
+		return srv.(Services).Core().GetStatus(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetStatus.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(Services).GetStatus(ctx)
+		return srv.(Services).Core().GetStatus(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -651,14 +651,14 @@ func handlerGetNextBlockState(
 	interceptor grpc.UnaryServerInterceptor,
 ) (any, error) {
 	if interceptor == nil {
-		return srv.(Services).GetNextBlockState(ctx)
+		return srv.(Services).Core().GetNextBlockState(ctx)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetNextBlockState.FullName(),
 	}
 	handler := func(ctx context.Context, _ any) (any, error) {
-		return srv.(Services).GetNextBlockState(ctx)
+		return srv.(Services).Core().GetNextBlockState(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
 }
@@ -674,14 +674,14 @@ func handlerGetParameters(
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(Services).GetParameters(ctx, height)
+		return srv.(Services).Core().GetParameters(ctx, height)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodGetParameters.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Services).GetParameters(ctx, req.(int64))
+		return srv.(Services).Core().GetParameters(ctx, req.(int64))
 	}
 	return interceptor(ctx, height, info, handler)
 }
@@ -697,14 +697,14 @@ func handlerSubmitEvidence(
 		return nil, err
 	}
 	if interceptor == nil {
-		return nil, srv.(Services).SubmitEvidence(ctx, rq)
+		return nil, srv.(Services).Core().SubmitEvidence(ctx, rq)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: methodSubmitEvidence.FullName(),
 	}
 	handler := func(ctx context.Context, req any) (any, error) {
-		return nil, srv.(Services).SubmitEvidence(ctx, req.(*Evidence))
+		return nil, srv.(Services).Core().SubmitEvidence(ctx, req.(*Evidence))
 	}
 	return interceptor(ctx, rq, info, handler)
 }
@@ -715,7 +715,7 @@ func handlerWatchBlocks(srv any, stream grpc.ServerStream) error {
 	}
 
 	ctx := stream.Context()
-	ch, sub, err := srv.(Services).WatchBlocks(ctx)
+	ch, sub, err := srv.(Services).Core().WatchBlocks(ctx)
 	if err != nil {
 		return err
 	}
@@ -980,34 +980,50 @@ func (c *Client) WatchBlocks(ctx context.Context) (<-chan *Block, pubsub.Closabl
 	return ch, sub, nil
 }
 
-func (c *Client) Beacon() beacon.Backend {
+// ServicesClient is a gRPC consensus services client.
+type ServicesClient struct {
+	conn *grpc.ClientConn
+}
+
+// NewServicesClient creates a new gRPC consensus services client.
+func NewServicesClient(c *grpc.ClientConn) *ServicesClient {
+	return &ServicesClient{
+		conn: c,
+	}
+}
+
+func (c *ServicesClient) Beacon() beacon.Backend {
 	return beacon.NewClient(c.conn)
 }
 
-func (c *Client) Registry() registry.Backend {
-	return registry.NewClient(c.conn)
+func (c *ServicesClient) Core() Backend {
+	return NewClient(c.conn)
 }
 
-func (c *Client) Staking() staking.Backend {
-	return staking.NewClient(c.conn)
-}
-
-func (c *Client) Scheduler() scheduler.Backend {
-	return scheduler.NewClient(c.conn)
-}
-
-func (c *Client) Governance() governance.Backend {
+func (c *ServicesClient) Governance() governance.Backend {
 	return governance.NewClient(c.conn)
 }
 
-func (c *Client) RootHash() roothash.Backend {
+func (c *ServicesClient) KeyManager() keymanager.Backend {
+	return keymanager.NewClient(c.conn)
+}
+
+func (c *ServicesClient) Registry() registry.Backend {
+	return registry.NewClient(c.conn)
+}
+
+func (c *ServicesClient) RootHash() roothash.Backend {
 	return roothash.NewClient(c.conn)
 }
 
-func (c *Client) Vault() vault.Backend {
-	return vault.NewClient(c.conn)
+func (c *ServicesClient) Scheduler() scheduler.Backend {
+	return scheduler.NewClient(c.conn)
 }
 
-func (c *Client) KeyManager() keymanager.Backend {
-	return keymanager.NewClient(c.conn)
+func (c *ServicesClient) Staking() staking.Backend {
+	return staking.NewClient(c.conn)
+}
+
+func (c *ServicesClient) Vault() vault.Backend {
+	return vault.NewClient(c.conn)
 }

--- a/go/consensus/api/submission.go
+++ b/go/consensus/api/submission.go
@@ -51,7 +51,7 @@ type SubmissionManager interface {
 }
 
 type submissionManager struct {
-	backend        ClientBackend
+	backend        Backend
 	priceDiscovery PriceDiscovery
 	maxFee         quantity.Quantity
 
@@ -236,7 +236,7 @@ func (m *submissionManager) SignAndSubmitTxWithProof(ctx context.Context, signer
 }
 
 // NewSubmissionManager creates a new transaction submission manager.
-func NewSubmissionManager(backend ClientBackend, priceDiscovery PriceDiscovery, maxFee uint64) SubmissionManager {
+func NewSubmissionManager(backend Backend, priceDiscovery PriceDiscovery, maxFee uint64) SubmissionManager {
 	sm := &submissionManager{
 		backend:        backend,
 		priceDiscovery: priceDiscovery,
@@ -256,8 +256,8 @@ func NewSubmissionManager(backend ClientBackend, priceDiscovery PriceDiscovery, 
 //
 // If the fee is set to nil, it will be automatically filled in based on gas
 // estimation and current gas price discovery.
-func SignAndSubmitTx(ctx context.Context, backend Backend, signer signature.Signer, tx *transaction.Transaction) error {
-	return backend.SubmissionManager().SignAndSubmitTx(ctx, signer, tx)
+func SignAndSubmitTx(ctx context.Context, consensus Service, signer signature.Signer, tx *transaction.Transaction) error {
+	return consensus.SubmissionManager().SignAndSubmitTx(ctx, signer, tx)
 }
 
 // SignAndSubmitTxWithProof is a helper function that signs and submits
@@ -268,8 +268,8 @@ func SignAndSubmitTx(ctx context.Context, backend Backend, signer signature.Sign
 //
 // If the fee is set to nil, it will be automatically filled in based on gas
 // estimation and current gas price discovery.
-func SignAndSubmitTxWithProof(ctx context.Context, backend Backend, signer signature.Signer, tx *transaction.Transaction) (*transaction.SignedTransaction, *transaction.Proof, error) {
-	return backend.SubmissionManager().SignAndSubmitTxWithProof(ctx, signer, tx)
+func SignAndSubmitTxWithProof(ctx context.Context, consensus Service, signer signature.Signer, tx *transaction.Transaction) (*transaction.SignedTransaction, *transaction.Proof, error) {
+	return consensus.SubmissionManager().SignAndSubmitTxWithProof(ctx, signer, tx)
 }
 
 type noOpPriceDiscovery struct{}

--- a/go/consensus/cometbft/api/api.go
+++ b/go/consensus/cometbft/api/api.go
@@ -201,7 +201,7 @@ func NewBlock(blk *cmttypes.Block) *consensus.Block {
 
 // Backend is a CometBFT consensus backend.
 type Backend interface {
-	consensus.ClientBackend
+	consensus.Backend
 
 	// GetCometBFTBlock returns the CometBFT block at the specified height.
 	GetCometBFTBlock(ctx context.Context, height int64) (*cmttypes.Block, error)

--- a/go/consensus/cometbft/api/api.go
+++ b/go/consensus/cometbft/api/api.go
@@ -201,7 +201,7 @@ func NewBlock(blk *cmttypes.Block) *consensus.Block {
 
 // Backend is a CometBFT consensus backend.
 type Backend interface {
-	consensus.Backend
+	consensus.ClientBackend
 
 	// GetCometBFTBlock returns the CometBFT block at the specified height.
 	GetCometBFTBlock(ctx context.Context, height int64) (*cmttypes.Block, error)

--- a/go/consensus/cometbft/beacon/beacon.go
+++ b/go/consensus/cometbft/beacon/beacon.go
@@ -33,8 +33,8 @@ type ServiceClient struct {
 
 	logger *logging.Logger
 
-	backend tmapi.Backend
-	querier *app.QueryFactory
+	consensus tmapi.Backend
+	querier   *app.QueryFactory
 
 	epochNotifier     *pubsub.Broker
 	epochLastNotified beaconAPI.EpochTime
@@ -53,10 +53,10 @@ type ServiceClient struct {
 }
 
 // New constructs a new CometBFT backed beacon service client.
-func New(baseEpoch beaconAPI.EpochTime, baseBlock int64, backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
+func New(baseEpoch beaconAPI.EpochTime, baseBlock int64, consensus tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
 	return &ServiceClient{
 		logger:            logging.GetLogger("cometbft/beacon"),
-		backend:           backend,
+		consensus:         consensus,
 		querier:           querier,
 		epochNotifier:     pubsub.NewBroker(false),
 		epochLastNotified: beaconAPI.EpochInvalid,
@@ -124,12 +124,12 @@ func (sc *ServiceClient) GetEpochBlock(ctx context.Context, epoch beaconAPI.Epoc
 		return cachedHeight.(int64), nil
 	}
 
-	lowHeight, err := sc.backend.GetLastRetainedHeight(ctx)
+	lowHeight, err := sc.consensus.GetLastRetainedHeight(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to query last retained version: %w", err)
 	}
 
-	hiHeight, err := sc.backend.GetLatestHeight(ctx)
+	hiHeight, err := sc.consensus.GetLatestHeight(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/go/consensus/cometbft/cometbft.go
+++ b/go/consensus/cometbft/cometbft.go
@@ -22,7 +22,7 @@ func New(
 	upgrader upgradeAPI.Backend,
 	genesis genesisAPI.Provider,
 	doc *genesisAPI.Document,
-) (consensusAPI.Backend, error) {
+) (consensusAPI.Service, error) {
 	genesisDoc, err := api.GetCometBFTGenesisDocument(doc)
 	if err != nil {
 		return nil, err

--- a/go/consensus/cometbft/full/archive.go
+++ b/go/consensus/cometbft/full/archive.go
@@ -132,6 +132,7 @@ func (srv *archiveService) GetStatus(ctx context.Context) (*consensusAPI.Status,
 		return nil, err
 	}
 	status.Status = consensusAPI.StatusStateReady
+	status.Features = srv.SupportedFeatures()
 
 	return status, nil
 }

--- a/go/consensus/cometbft/full/archive.go
+++ b/go/consensus/cometbft/full/archive.go
@@ -159,7 +159,7 @@ func (srv *archiveService) WatchBlocks(ctx context.Context) (<-chan *consensusAP
 }
 
 // NewArchive creates a new archive-only consensus service.
-func NewArchive(ctx context.Context, cfg ArchiveConfig) (consensusAPI.Backend, error) {
+func NewArchive(ctx context.Context, cfg ArchiveConfig) (consensusAPI.Service, error) {
 	commonNode := newCommonNode(ctx, cfg.CommonConfig)
 
 	srv := &archiveService{

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -819,16 +819,11 @@ func (n *commonNode) GetParameters(ctx context.Context, height int64) (*consensu
 	}, nil
 }
 
-func (n *commonNode) SupportedFeatures() consensusAPI.FeatureMask {
-	return n.parentNode.SupportedFeatures()
-}
-
 // Implements consensusAPI.Backend.
 func (n *commonNode) GetStatus(ctx context.Context) (*consensusAPI.Status, error) {
 	status := &consensusAPI.Status{
 		Version:       version.ConsensusProtocol,
 		Backend:       api.BackendName,
-		Features:      n.SupportedFeatures(),
 		ChainContext:  n.chainContext,
 		GenesisHeight: n.genesisHeight,
 	}

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -449,6 +449,11 @@ func (n *commonNode) Beacon() beaconAPI.Backend {
 }
 
 // Implements consensusAPI.Backend.
+func (n *commonNode) Core() consensusAPI.Backend {
+	return n.parentNode
+}
+
+// Implements consensusAPI.Backend.
 func (n *commonNode) KeyManager() keymanagerAPI.Backend {
 	return n.keymanager
 }

--- a/go/consensus/cometbft/full/full.go
+++ b/go/consensus/cometbft/full/full.go
@@ -414,6 +414,7 @@ func (t *fullService) GetStatus(ctx context.Context) (*consensusAPI.Status, erro
 		return nil, err
 	}
 	status.Status = consensusAPI.StatusStateSyncing
+	status.Features = t.SupportedFeatures()
 
 	status.P2P = &consensusAPI.P2PStatus{}
 	status.P2P.PubKey = t.identity.P2PSigner.Public()

--- a/go/consensus/cometbft/full/full.go
+++ b/go/consensus/cometbft/full/full.go
@@ -971,7 +971,7 @@ func (t *fullService) dumpGenesis(ctx context.Context, height int64) error {
 }
 
 // New creates a new CometBFT consensus backend.
-func New(ctx context.Context, cfg Config) (consensusAPI.Backend, error) {
+func New(ctx context.Context, cfg Config) (consensusAPI.Service, error) {
 	commonNode := newCommonNode(ctx, cfg.CommonConfig)
 
 	t := &fullService{

--- a/go/consensus/cometbft/governance/governance.go
+++ b/go/consensus/cometbft/governance/governance.go
@@ -27,17 +27,17 @@ type ServiceClient struct {
 
 	logger *logging.Logger
 
-	backend tmapi.Backend
-	querier *app.QueryFactory
+	consensus tmapi.Backend
+	querier   *app.QueryFactory
 
 	eventNotifier *pubsub.Broker
 }
 
 // New constructs a new CometBFT backed governance service client.
-func New(backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
+func New(consensus tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
 	return &ServiceClient{
 		logger:        logging.GetLogger("cometbft/staking"),
-		backend:       backend,
+		consensus:     consensus,
 		querier:       querier,
 		eventNotifier: pubsub.NewBroker(false),
 	}
@@ -100,7 +100,7 @@ func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*api
 func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
 	var results *cmtrpctypes.ResultBlockResults
-	results, err := sc.backend.GetCometBFTBlockResults(ctx, height)
+	results, err := sc.consensus.GetCometBFTBlockResults(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft block results",
 			"err", err,
@@ -110,7 +110,7 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 	}
 
 	// Get transactions at given height.
-	txns, err := sc.backend.GetTransactions(ctx, height)
+	txns, err := sc.consensus.GetTransactions(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft transactions",
 			"err", err,

--- a/go/consensus/cometbft/registry/registry.go
+++ b/go/consensus/cometbft/registry/registry.go
@@ -30,8 +30,8 @@ type ServiceClient struct {
 
 	logger *logging.Logger
 
-	backend tmapi.Backend
-	querier *app.QueryFactory
+	consensus tmapi.Backend
+	querier   *app.QueryFactory
 
 	entityNotifier   *pubsub.Broker
 	nodeNotifier     *pubsub.Broker
@@ -41,10 +41,10 @@ type ServiceClient struct {
 }
 
 // New constructs a new CometBFT backed registry service client.
-func New(backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
+func New(consensus tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
 	return &ServiceClient{
 		logger:           logging.GetLogger("cometbft/registry"),
-		backend:          backend,
+		consensus:        consensus,
 		querier:          querier,
 		entityNotifier:   pubsub.NewBroker(false),
 		nodeNotifier:     pubsub.NewBroker(false),
@@ -179,7 +179,7 @@ func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*api
 func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
 	var results *cmtrpctypes.ResultBlockResults
-	results, err := sc.backend.GetCometBFTBlockResults(ctx, height)
+	results, err := sc.consensus.GetCometBFTBlockResults(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft block results",
 			"err", err,
@@ -189,7 +189,7 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 	}
 
 	// Get transactions at given height.
-	txns, err := sc.backend.GetTransactions(ctx, height)
+	txns, err := sc.consensus.GetTransactions(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft transactions",
 			"err", err,

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -51,8 +51,8 @@ type ServiceClient struct {
 
 	logger *logging.Logger
 
-	backend tmapi.Backend
-	querier *app.QueryFactory
+	consensus tmapi.Backend
+	querier   *app.QueryFactory
 
 	allBlockNotifier *pubsub.Broker
 	runtimeNotifiers map[common.Namespace]*runtimeBrokers
@@ -63,10 +63,10 @@ type ServiceClient struct {
 }
 
 // New constructs a new CometBFT-based roothash service client.
-func New(backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
+func New(consensus tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
 	return &ServiceClient{
 		logger:           logging.GetLogger("cometbft/roothash"),
-		backend:          backend,
+		consensus:        consensus,
 		querier:          querier,
 		allBlockNotifier: pubsub.NewBroker(false),
 		runtimeNotifiers: make(map[common.Namespace]*runtimeBrokers),
@@ -262,7 +262,7 @@ func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) 
 func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
 	var results *cmtrpctypes.ResultBlockResults
-	results, err := sc.backend.GetCometBFTBlockResults(ctx, height)
+	results, err := sc.consensus.GetCometBFTBlockResults(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft block results",
 			"err", err,
@@ -272,7 +272,7 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 	}
 
 	// Get transactions at given height.
-	txns, err := sc.backend.GetTransactions(ctx, height)
+	txns, err := sc.consensus.GetTransactions(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft transactions",
 			"err", err,

--- a/go/consensus/cometbft/staking/staking.go
+++ b/go/consensus/cometbft/staking/staking.go
@@ -27,17 +27,17 @@ type ServiceClient struct {
 
 	logger *logging.Logger
 
-	backend tmapi.Backend
-	querier *app.QueryFactory
+	consensus tmapi.Backend
+	querier   *app.QueryFactory
 
 	eventNotifier *pubsub.Broker
 }
 
 // New constructs a new CometBFT backed staking service client.
-func New(backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
+func New(consensus tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
 	return &ServiceClient{
 		logger:        logging.GetLogger("cometbft/staking"),
-		backend:       backend,
+		consensus:     consensus,
 		querier:       querier,
 		eventNotifier: pubsub.NewBroker(false),
 	}
@@ -54,7 +54,7 @@ func (sc *ServiceClient) TokenSymbol(ctx context.Context, height int64) (string,
 	}
 
 	// Fallback to genesis document.
-	genesis, err := sc.backend.GetGenesisDocument(ctx)
+	genesis, err := sc.consensus.GetGenesisDocument(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -73,7 +73,7 @@ func (sc *ServiceClient) TokenValueExponent(ctx context.Context, height int64) (
 	}
 
 	// Fallback to genesis document.
-	genesis, err := sc.backend.GetGenesisDocument(ctx)
+	genesis, err := sc.consensus.GetGenesisDocument(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -247,7 +247,7 @@ func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*api
 func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
 	var results *cmtrpctypes.ResultBlockResults
-	results, err := sc.backend.GetCometBFTBlockResults(ctx, height)
+	results, err := sc.consensus.GetCometBFTBlockResults(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft block results",
 			"err", err,
@@ -257,7 +257,7 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 	}
 
 	// Get transactions at given height.
-	txns, err := sc.backend.GetTransactions(ctx, height)
+	txns, err := sc.consensus.GetTransactions(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft transactions",
 			"err", err,

--- a/go/consensus/cometbft/vault/vault.go
+++ b/go/consensus/cometbft/vault/vault.go
@@ -26,17 +26,17 @@ type ServiceClient struct {
 
 	logger *logging.Logger
 
-	backend tmapi.Backend
-	querier *app.QueryFactory
+	consensus tmapi.Backend
+	querier   *app.QueryFactory
 
 	eventNotifier *pubsub.Broker
 }
 
 // New constructs a new CometBFT backed vault service client.
-func New(backend tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
+func New(consensus tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
 	return &ServiceClient{
 		logger:        logging.GetLogger("cometbft/vault"),
-		backend:       backend,
+		consensus:     consensus,
 		querier:       querier,
 		eventNotifier: pubsub.NewBroker(false),
 	}
@@ -90,7 +90,7 @@ func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*vau
 func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*vault.Event, error) {
 	// Get block results at given height.
 	var results *cmtrpctypes.ResultBlockResults
-	results, err := sc.backend.GetCometBFTBlockResults(ctx, height)
+	results, err := sc.consensus.GetCometBFTBlockResults(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft block results",
 			"err", err,
@@ -100,7 +100,7 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*vault.
 	}
 
 	// Get transactions at given height.
-	txns, err := sc.backend.GetTransactions(ctx, height)
+	txns, err := sc.consensus.GetTransactions(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft transactions",
 			"err", err,

--- a/go/consensus/p2p/light/server.go
+++ b/go/consensus/p2p/light/server.go
@@ -19,7 +19,7 @@ const (
 )
 
 type service struct {
-	consensus consensus.Service
+	consensus consensus.Backend
 
 	logger *logging.Logger
 }
@@ -57,7 +57,7 @@ func (s *service) handleGetLightBlock(ctx context.Context, height int64) (*conse
 func NewServer(
 	p2p rpc.P2P,
 	chainContext string,
-	consensus consensus.Service,
+	consensus consensus.Backend,
 ) rpc.Server {
 	p2p.RegisterProtocol(ProtocolID(chainContext), minProtocolPeers, totalProtocolPeers)
 

--- a/go/consensus/p2p/light/server.go
+++ b/go/consensus/p2p/light/server.go
@@ -19,7 +19,7 @@ const (
 )
 
 type service struct {
-	consensus consensus.Backend
+	consensus consensus.Service
 
 	logger *logging.Logger
 }
@@ -57,7 +57,7 @@ func (s *service) handleGetLightBlock(ctx context.Context, height int64) (*conse
 func NewServer(
 	p2p rpc.P2P,
 	chainContext string,
-	consensus consensus.Backend,
+	consensus consensus.Service,
 ) rpc.Server {
 	p2p.RegisterProtocol(ProtocolID(chainContext), minProtocolPeers, totalProtocolPeers)
 

--- a/go/consensus/pricediscovery/pricediscovery.go
+++ b/go/consensus/pricediscovery/pricediscovery.go
@@ -35,7 +35,7 @@ type priceDiscovery struct {
 	// tracks the current index of the blockPrices rolling array.
 	blockPricesCurrentIdx int
 
-	client consensus.Backend
+	consensus consensus.Backend
 
 	logger *logging.Logger
 }
@@ -50,7 +50,7 @@ func (pd *priceDiscovery) GasPrice() (*quantity.Quantity, error) {
 
 // refreshMinGasPrice refreshes minimum gas price reported by the consensus layer.
 func (pd *priceDiscovery) refreshMinGasPrice(ctx context.Context) {
-	mgp, err := pd.client.MinGasPrice(ctx)
+	mgp, err := pd.consensus.MinGasPrice(ctx)
 	if err != nil {
 		pd.logger.Warn("failed to fetch minimum gas price",
 			"err", err,
@@ -120,13 +120,13 @@ func (pd *priceDiscovery) worker(ctx context.Context, ch <-chan *consensus.Block
 }
 
 // New creates a new dynamic price discovery implementation.
-func New(ctx context.Context, client consensus.Backend, fallbackGasPrice uint64) (consensus.PriceDiscovery, error) {
+func New(ctx context.Context, consensus consensus.Backend, fallbackGasPrice uint64) (consensus.PriceDiscovery, error) {
 	pd := &priceDiscovery{
 		finalGasPrice:    quantity.NewFromUint64(fallbackGasPrice),
 		fallbackGasPrice: quantity.NewFromUint64(fallbackGasPrice),
 		minGasPrice:      quantity.NewQuantity(),
 		computedGasPrice: quantity.NewQuantity(),
-		client:           client,
+		consensus:        consensus,
 		logger:           logging.GetLogger("consensus/pricediscovery"),
 	}
 
@@ -136,7 +136,7 @@ func New(ctx context.Context, client consensus.Backend, fallbackGasPrice uint64)
 	}
 
 	// Subscribe to consensus layer blocks and start watching.
-	ch, sub, err := pd.client.WatchBlocks(ctx)
+	ch, sub, err := pd.consensus.WatchBlocks(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to subscribe to block updates: %w", err)
 	}

--- a/go/consensus/pricediscovery/pricediscovery.go
+++ b/go/consensus/pricediscovery/pricediscovery.go
@@ -35,7 +35,7 @@ type priceDiscovery struct {
 	// tracks the current index of the blockPrices rolling array.
 	blockPricesCurrentIdx int
 
-	client consensus.ClientBackend
+	client consensus.Backend
 
 	logger *logging.Logger
 }
@@ -120,7 +120,7 @@ func (pd *priceDiscovery) worker(ctx context.Context, ch <-chan *consensus.Block
 }
 
 // New creates a new dynamic price discovery implementation.
-func New(ctx context.Context, client consensus.ClientBackend, fallbackGasPrice uint64) (consensus.PriceDiscovery, error) {
+func New(ctx context.Context, client consensus.Backend, fallbackGasPrice uint64) (consensus.PriceDiscovery, error) {
 	pd := &priceDiscovery{
 		finalGasPrice:    quantity.NewFromUint64(fallbackGasPrice),
 		fallbackGasPrice: quantity.NewFromUint64(fallbackGasPrice),

--- a/go/consensus/tests/tester.go
+++ b/go/consensus/tests/tester.go
@@ -26,7 +26,7 @@ const (
 
 // ConsensusImplementationTests exercises the basic functionality of a
 // consensus backend.
-func ConsensusImplementationTests(t *testing.T, backend consensus.ClientBackend) {
+func ConsensusImplementationTests(t *testing.T, backend consensus.Backend) {
 	require := require.New(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), recvTimeout)

--- a/go/consensus/tests/tester.go
+++ b/go/consensus/tests/tester.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
-	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	consensusAPI "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs"
@@ -26,34 +26,34 @@ const (
 
 // ConsensusImplementationTests exercises the basic functionality of a
 // consensus backend.
-func ConsensusImplementationTests(t *testing.T, backend consensus.Backend) {
+func ConsensusImplementationTests(t *testing.T, consensus consensusAPI.Backend) {
 	require := require.New(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), recvTimeout)
 	defer cancel()
 
-	genDoc, err := backend.GetGenesisDocument(ctx)
+	genDoc, err := consensus.GetGenesisDocument(ctx)
 	require.NoError(err, "GetGenesisDocument")
 	require.NotNil(genDoc, "returned genesis document should not be nil")
 
-	chainCtx, err := backend.GetChainContext(ctx)
+	chainCtx, err := consensus.GetChainContext(ctx)
 	require.NoError(err, "GetChainContext")
 	require.EqualValues(genDoc.ChainContext(), chainCtx, "returned chain context should be correct")
 
-	blk, err := backend.GetBlock(ctx, consensus.HeightLatest)
+	blk, err := consensus.GetBlock(ctx, consensusAPI.HeightLatest)
 	require.NoError(err, "GetBlock")
 	require.NotNil(blk, "returned block should not be nil")
 	require.Greater(blk.Height, int64(0), "block height should be greater than zero")
 	require.Greater(blk.Size, uint64(0), "block size should be greater than zero")
 
-	status, err := backend.GetStatus(ctx)
+	status, err := consensus.GetStatus(ctx)
 	require.NoError(err, "GetStatus")
 	require.NotNil(status, "returned status should not be nil")
 	require.EqualValues(1, status.GenesisHeight, "genesis height must be 1")
 	// We run this test without pruning. All we check is that we retain everything as configured.
 	require.EqualValues(1, status.LastRetainedHeight, "last retained height must be 1")
 
-	blk, err = backend.GetBlock(ctx, status.LatestHeight)
+	blk, err = consensus.GetBlock(ctx, status.LatestHeight)
 	require.NoError(err, "GetBlock")
 
 	require.EqualValues(blk.Height, status.LatestHeight, "latest block heights should match")
@@ -61,11 +61,11 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.Backend) {
 	require.EqualValues(blk.StateRoot, status.LatestStateRoot, "latest state roots should match")
 	require.EqualValues(blk.Size, status.LatestBlockSize, "latest block sizes should match")
 
-	txs, err := backend.GetTransactions(ctx, status.LatestHeight)
+	txs, err := consensus.GetTransactions(ctx, status.LatestHeight)
 	require.NoError(err, "GetTransactions")
 	require.NotEmpty(txs, "number of transactions should be greater than zero")
 
-	txsWithResults, err := backend.GetTransactionsWithResults(ctx, status.LatestHeight)
+	txsWithResults, err := consensus.GetTransactionsWithResults(ctx, status.LatestHeight)
 	require.NoError(err, "GetTransactionsWithResults")
 	require.Len(
 		txsWithResults.Transactions,
@@ -85,7 +85,7 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.Backend) {
 		}
 	}
 
-	txsWithProofs, err := backend.GetTransactionsWithProofs(ctx, status.LatestHeight)
+	txsWithProofs, err := consensus.GetTransactionsWithProofs(ctx, status.LatestHeight)
 	require.NoError(err, "GetTransactionsWithProofs")
 	require.Len(
 		txsWithProofs.Transactions,
@@ -98,10 +98,10 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.Backend) {
 		"GetTransactionsWithProofs.Proofs length mismatch",
 	)
 
-	_, err = backend.GetUnconfirmedTransactions(ctx)
+	_, err = consensus.GetUnconfirmedTransactions(ctx)
 	require.NoError(err, "GetUnconfirmedTransactions")
 
-	blockCh, blockSub, err := backend.WatchBlocks(ctx)
+	blockCh, blockSub, err := consensus.WatchBlocks(ctx)
 	require.NoError(err, "WatchBlocks")
 	defer blockSub.Close()
 
@@ -117,68 +117,68 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.Backend) {
 		}
 	}
 
-	_, err = backend.EstimateGas(ctx, &consensus.EstimateGasRequest{})
-	require.ErrorIs(err, consensus.ErrInvalidArgument, "EstimateGas with nil transaction should fail")
+	_, err = consensus.EstimateGas(ctx, &consensusAPI.EstimateGasRequest{})
+	require.ErrorIs(err, consensusAPI.ErrInvalidArgument, "EstimateGas with nil transaction should fail")
 
-	_, err = backend.EstimateGas(ctx, &consensus.EstimateGasRequest{
+	_, err = consensus.EstimateGas(ctx, &consensusAPI.EstimateGasRequest{
 		Signer:      memorySigner.NewTestSigner("estimate gas signer").Public(),
 		Transaction: transaction.NewTransaction(0, nil, staking.MethodTransfer, &staking.Transfer{}),
 	})
 	require.NoError(err, "EstimateGas")
 
-	nonce, err := backend.GetSignerNonce(ctx, &consensus.GetSignerNonceRequest{
+	nonce, err := consensus.GetSignerNonce(ctx, &consensusAPI.GetSignerNonceRequest{
 		AccountAddress: staking.NewAddress(
 			signature.NewPublicKey("badfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
 		),
-		Height: consensus.HeightLatest,
+		Height: consensusAPI.HeightLatest,
 	})
 	require.NoError(err, "GetSignerNonce")
 	require.Equal(uint64(0), nonce, "Nonce should be zero")
 
 	// Light client API.
-	shdr, err := backend.GetLightBlock(ctx, blk.Height)
+	shdr, err := consensus.GetLightBlock(ctx, blk.Height)
 	require.NoError(err, "GetLightBlock")
 	require.Equal(shdr.Height, blk.Height, "returned light block height should be correct")
 	require.NotNil(shdr.Meta, "returned light block should contain metadata")
 
 	// Late block queries.
-	lshdr, err := backend.GetLightBlock(ctx, consensus.HeightLatest)
+	lshdr, err := consensus.GetLightBlock(ctx, consensusAPI.HeightLatest)
 	require.NoError(err, "GetLightBlock(HeightLatest)")
 	require.True(lshdr.Height >= shdr.Height, "returned latest light block height should be greater or equal")
 	require.NotNil(shdr.Meta, "returned latest light block should contain metadata")
 
-	params, err := backend.GetParameters(ctx, blk.Height)
+	params, err := consensus.GetParameters(ctx, blk.Height)
 	require.NoError(err, "GetParameters")
 	require.Equal(params.Height, blk.Height, "returned parameters height should be correct")
 	require.NotNil(params.Meta, "returned parameters should contain metadata")
 	require.NotEqual(0, params.Parameters.StateCheckpointInterval, "returned parameters should contain parameters")
 
-	lparams, err := backend.GetParameters(ctx, blk.Height)
+	lparams, err := consensus.GetParameters(ctx, blk.Height)
 	require.NoError(err, "GetParameters(HeightLatest)")
 	require.NotEqual(0, lparams.Parameters.StateCheckpointInterval, "returned parameters should contain parameters")
 
-	err = backend.SubmitTxNoWait(ctx, &transaction.SignedTransaction{})
+	err = consensus.SubmitTxNoWait(ctx, &transaction.SignedTransaction{})
 	require.Error(err, "SubmitTxNoWait should fail with invalid transaction")
 
 	testTx := transaction.NewTransaction(0, &transaction.Fee{Gas: 10_000}, staking.MethodTransfer, &staking.Transfer{})
-	testSigner := memorySigner.NewTestSigner(fmt.Sprintf("consensus tests tx signer: %T", backend))
+	testSigner := memorySigner.NewTestSigner(fmt.Sprintf("consensus tests tx signer: %T", consensus))
 	testSigTx, err := transaction.Sign(testSigner, testTx)
 	require.NoError(err, "transaction.Sign")
-	err = backend.SubmitTxNoWait(ctx, testSigTx)
+	err = consensus.SubmitTxNoWait(ctx, testSigTx)
 	require.NoError(err, "SubmitTxNoWait")
 
-	err = backend.SubmitEvidence(ctx, &consensus.Evidence{})
+	err = consensus.SubmitEvidence(ctx, &consensusAPI.Evidence{})
 	require.Error(err, "SubmitEvidence should fail with invalid evidence")
 
 	// Trigger some duplicate transaction errors.
-	err = backend.SubmitTxNoWait(ctx, testSigTx)
+	err = consensus.SubmitTxNoWait(ctx, testSigTx)
 	require.Error(err, "SubmitTxNoWait(duplicate)")
-	require.True(errors.Is(err, consensus.ErrDuplicateTx), "SubmitTxNoWait should return ErrDuplicateTx on duplicate tx")
+	require.True(errors.Is(err, consensusAPI.ErrDuplicateTx), "SubmitTxNoWait should return ErrDuplicateTx on duplicate tx")
 
 	// We should be able to do remote state queries. Of course the state format is backend-specific
 	// so we simply perform some usual storage operations like fetching random keys and iterating
 	// through everything.
-	state := mkvs.NewWithRoot(backend.State(), nil, blk.StateRoot)
+	state := mkvs.NewWithRoot(consensus.State(), nil, blk.StateRoot)
 	defer state.Close()
 
 	it := state.NewIterator(ctx)
@@ -192,7 +192,7 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.Backend) {
 	require.NotEmpty(keys, "there should be some keys in consensus state")
 
 	// Start with a clean tree to avoid hitting the cache.
-	state = mkvs.NewWithRoot(backend.State(), nil, blk.StateRoot)
+	state = mkvs.NewWithRoot(consensus.State(), nil, blk.StateRoot)
 	defer state.Close()
 
 	for _, key := range keys {
@@ -201,7 +201,7 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.Backend) {
 	}
 
 	// Start with a clean tree to avoid hitting the cache.
-	state = mkvs.NewWithRoot(backend.State(), nil, blk.StateRoot)
+	state = mkvs.NewWithRoot(consensus.State(), nil, blk.StateRoot)
 	defer state.Close()
 
 	err = state.PrefetchPrefixes(ctx, keys[:1], 10)

--- a/go/governance/tests/tester.go
+++ b/go/governance/tests/tester.go
@@ -44,7 +44,7 @@ type governanceTestsState struct {
 func GovernanceImplementationTests(
 	t *testing.T,
 	backend api.Backend,
-	consensus consensusAPI.Backend,
+	consensus consensusAPI.Service,
 	entity *entity.Entity,
 	entitySigner signature.Signer,
 ) {
@@ -89,7 +89,7 @@ func GovernanceImplementationTests(
 	// an upgrade proposal is closed.
 	for _, tc := range []struct {
 		n  string
-		fn func(*testing.T, api.Backend, consensusAPI.Backend, *governanceTestsState)
+		fn func(*testing.T, api.Backend, consensusAPI.Service, *governanceTestsState)
 	}{
 		{"TestBadProposals", testBadProposals},
 		{"TestUpgradeProposalSubmit", testUpgradeProposalSubmit},
@@ -104,7 +104,7 @@ func GovernanceImplementationTests(
 
 func assertAccountBalance(
 	t *testing.T,
-	consensus consensusAPI.Backend,
+	consensus consensusAPI.Service,
 	addr staking.Address,
 	height int64,
 	expectedBalance *quantity.Quantity,
@@ -116,7 +116,7 @@ func assertAccountBalance(
 	require.EqualValues(expectedBalance, &acc.General.Balance, "account should have expected balance")
 }
 
-func testBadProposals(t *testing.T, _ api.Backend, consensus consensusAPI.Backend, _ *governanceTestsState) {
+func testBadProposals(t *testing.T, _ api.Backend, consensus consensusAPI.Service, _ *governanceTestsState) {
 	require := require.New(t)
 	ctx := context.Background()
 
@@ -143,7 +143,7 @@ func testBadProposals(t *testing.T, _ api.Backend, consensus consensusAPI.Backen
 	require.Equal(api.ErrInvalidArgument, err, "SubmitProposalTx")
 }
 
-func testBadVotes(t *testing.T, _ api.Backend, consensus consensusAPI.Backend, testState *governanceTestsState) {
+func testBadVotes(t *testing.T, _ api.Backend, consensus consensusAPI.Service, testState *governanceTestsState) {
 	require := require.New(t)
 	ctx := context.Background()
 
@@ -162,7 +162,7 @@ func testBadVotes(t *testing.T, _ api.Backend, consensus consensusAPI.Backend, t
 	require.Equal(api.ErrNotEligible, err, "CastVoteTx")
 }
 
-func testUpgradeProposalSubmit(t *testing.T, backend api.Backend, consensus consensusAPI.Backend, testState *governanceTestsState) {
+func testUpgradeProposalSubmit(t *testing.T, backend api.Backend, consensus consensusAPI.Service, testState *governanceTestsState) {
 	require := require.New(t)
 	ctx := context.Background()
 
@@ -187,7 +187,7 @@ func testUpgradeProposalSubmit(t *testing.T, backend api.Backend, consensus cons
 	submitProposal(t, content, backend, consensus, testState)
 }
 
-func testUpgradeProposalVoteAndClose(t *testing.T, backend api.Backend, consensus consensusAPI.Backend, testState *governanceTestsState) {
+func testUpgradeProposalVoteAndClose(t *testing.T, backend api.Backend, consensus consensusAPI.Service, testState *governanceTestsState) {
 	require := require.New(t)
 	ctx := context.Background()
 
@@ -200,7 +200,7 @@ func testUpgradeProposalVoteAndClose(t *testing.T, backend api.Backend, consensu
 	require.Equal(1, len(pendingUpgrade), "There should be one pending upgrade")
 }
 
-func testCancelUpgradeProposal(t *testing.T, backend api.Backend, consensus consensusAPI.Backend, testState *governanceTestsState) {
+func testCancelUpgradeProposal(t *testing.T, backend api.Backend, consensus consensusAPI.Service, testState *governanceTestsState) {
 	require := require.New(t)
 	ctx := context.Background()
 
@@ -224,7 +224,7 @@ func testCancelUpgradeProposal(t *testing.T, backend api.Backend, consensus cons
 	require.True(len(proposals) > 1, "At least two proposals should exist")
 }
 
-func testChangeParametersProposal(t *testing.T, backend api.Backend, consensus consensusAPI.Backend, testState *governanceTestsState) {
+func testChangeParametersProposal(t *testing.T, backend api.Backend, consensus consensusAPI.Service, testState *governanceTestsState) {
 	require := require.New(t)
 	ctx := context.Background()
 
@@ -259,7 +259,7 @@ func testChangeParametersProposal(t *testing.T, backend api.Backend, consensus c
 	require.True(len(proposals) > 2, "At least three proposals should exist")
 }
 
-func submitProposal(t *testing.T, content *api.ProposalContent, backend api.Backend, consensus consensusAPI.Backend, testState *governanceTestsState) {
+func submitProposal(t *testing.T, content *api.ProposalContent, backend api.Backend, consensus consensusAPI.Service, testState *governanceTestsState) {
 	require := require.New(t)
 	ctx := context.Background()
 
@@ -329,7 +329,7 @@ WaitForSubmittedProposal:
 	testState.proposal = proposal
 }
 
-func voteAndCloseProposal(t *testing.T, backend api.Backend, consensus consensusAPI.Backend, testState *governanceTestsState) {
+func voteAndCloseProposal(t *testing.T, backend api.Backend, consensus consensusAPI.Service, testState *governanceTestsState) {
 	require := require.New(t)
 	ctx := context.Background()
 

--- a/go/oasis-node/cmd/common/metrics/metrics.go
+++ b/go/oasis-node/cmd/common/metrics/metrics.go
@@ -2,7 +2,6 @@
 package metrics
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -60,7 +59,6 @@ type pullService struct {
 	ln net.Listener
 	s  *http.Server
 
-	ctx   context.Context
 	errCh chan error
 
 	rsvc *resourceService
@@ -109,7 +107,7 @@ func (s *pullService) Cleanup() {
 	}
 }
 
-func newPullService(ctx context.Context) (service.BackgroundService, error) {
+func newPullService() (service.BackgroundService, error) {
 	addr := config.GlobalConfig.Metrics.Address
 
 	svc := *service.NewBaseBackgroundService("metrics")
@@ -126,7 +124,6 @@ func newPullService(ctx context.Context) (service.BackgroundService, error) {
 
 	return &pullService{
 		BaseBackgroundService: svc,
-		ctx:                   ctx,
 		ln:                    ln,
 		s:                     &http.Server{Handler: promhttp.Handler(), ReadTimeout: 5 * time.Second},
 		errCh:                 make(chan error),
@@ -250,13 +247,13 @@ func newPushService() (service.BackgroundService, error) {
 }
 
 // New constructs a new metrics service.
-func New(ctx context.Context) (service.BackgroundService, error) {
+func New() (service.BackgroundService, error) {
 	mode := strings.ToLower(config.GlobalConfig.Metrics.Mode)
 	switch mode {
 	case MetricsModeNone:
 		return newStubService()
 	case MetricsModePull:
-		return newPullService(ctx)
+		return newPullService()
 	default:
 		if mode == MetricsModePush && flags.DebugDontBlameOasis() {
 			return newPushService()

--- a/go/oasis-node/cmd/consensus/consensus.go
+++ b/go/oasis-node/cmd/consensus/consensus.go
@@ -66,7 +66,7 @@ var (
 	logger = logging.GetLogger("cmd/consensus")
 )
 
-func doConnect(cmd *cobra.Command) (*grpc.ClientConn, consensus.ClientBackend) {
+func doConnect(cmd *cobra.Command) (*grpc.ClientConn, consensus.Backend) {
 	conn, err := cmdGrpc.NewClient(cmd)
 	if err != nil {
 		logger.Error("failed to establish connection with node",

--- a/go/oasis-node/cmd/consensus/consensus.go
+++ b/go/oasis-node/cmd/consensus/consensus.go
@@ -75,7 +75,7 @@ func doConnect(cmd *cobra.Command) (*grpc.ClientConn, consensus.Services) {
 		os.Exit(1)
 	}
 
-	client := consensus.NewClient(conn)
+	client := consensus.NewServicesClient(conn)
 	return conn, client
 }
 
@@ -129,7 +129,7 @@ func doSubmitTx(cmd *cobra.Command, _ []string) {
 
 	tx := loadTx()
 
-	if err := client.SubmitTx(context.Background(), tx); err != nil {
+	if err := client.Core().SubmitTx(context.Background(), tx); err != nil {
 		logger.Error("failed to submit transaction",
 			"err", err,
 		)
@@ -171,7 +171,7 @@ func doEstimateGas(cmd *cobra.Command, _ []string) {
 		)
 		os.Exit(1)
 	}
-	gas, err := client.EstimateGas(context.Background(), &req)
+	gas, err := client.Core().EstimateGas(context.Background(), &req)
 	if err != nil {
 		logger.Error("failed to estimate gas",
 			"err", err,
@@ -190,7 +190,7 @@ func doNextBlockState(cmd *cobra.Command, _ []string) {
 	defer conn.Close()
 
 	// Use background context to block until the result comes in.
-	state, err := client.GetNextBlockState(context.Background())
+	state, err := client.Core().GetNextBlockState(context.Background())
 	if err != nil {
 		logger.Error("failed to query next block state",
 			"err", err,

--- a/go/oasis-node/cmd/consensus/consensus.go
+++ b/go/oasis-node/cmd/consensus/consensus.go
@@ -66,7 +66,7 @@ var (
 	logger = logging.GetLogger("cmd/consensus")
 )
 
-func doConnect(cmd *cobra.Command) (*grpc.ClientConn, consensus.Backend) {
+func doConnect(cmd *cobra.Command) (*grpc.ClientConn, consensus.Services) {
 	conn, err := cmdGrpc.NewClient(cmd)
 	if err != nil {
 		logger.Error("failed to establish connection with node",

--- a/go/oasis-node/cmd/debug/byzantine/beacon_vrf.go
+++ b/go/oasis-node/cmd/debug/byzantine/beacon_vrf.go
@@ -247,7 +247,7 @@ func waitTillHeightAtLeast(
 	b *byzantine,
 	height int64,
 ) (int64, error) {
-	ch, sub, err := b.cometbft.service.WatchBlocks(ctx)
+	ch, sub, err := b.cometbft.service.Core().WatchBlocks(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to watch blocks: %w", err)
 	}

--- a/go/oasis-node/cmd/debug/byzantine/cometbft.go
+++ b/go/oasis-node/cmd/debug/byzantine/cometbft.go
@@ -38,7 +38,7 @@ func (ht *honestCometBFT) start(id *identity.Identity, dataDir string) error {
 
 	// Wait for height=1 to pass, during which mux apps perform deferred initialization.
 	blockOne := make(chan struct{})
-	blocksCh, blocksSub, err := ht.service.WatchBlocks(context.Background())
+	blocksCh, blocksSub, err := ht.service.Core().WatchBlocks(context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to watch blocks: %w", err)
 	}

--- a/go/oasis-node/cmd/debug/byzantine/cometbft.go
+++ b/go/oasis-node/cmd/debug/byzantine/cometbft.go
@@ -12,7 +12,7 @@ import (
 )
 
 type honestCometBFT struct {
-	service consensus.Backend
+	service consensus.Service
 
 	genesis    genesis.Provider
 	genesisDoc *genesis.Document

--- a/go/oasis-node/cmd/debug/byzantine/executor.go
+++ b/go/oasis-node/cmd/debug/byzantine/executor.go
@@ -347,7 +347,7 @@ func (cbc *computeBatchContext) createCommitment(
 	return nil
 }
 
-func (cbc *computeBatchContext) publishToChain(svc consensus.Backend, id *identity.Identity) error {
+func (cbc *computeBatchContext) publishToChain(svc consensus.Service, id *identity.Identity) error {
 	if err := roothashExecutorCommit(svc, id, cbc.runtimeID, []commitment.ExecutorCommitment{*cbc.commit}); err != nil {
 		return fmt.Errorf("roothash merge commitment: %w", err)
 	}

--- a/go/oasis-node/cmd/debug/byzantine/node.go
+++ b/go/oasis-node/cmd/debug/byzantine/node.go
@@ -229,7 +229,7 @@ func initializeAndRegisterByzantineNode(
 	return b, nil
 }
 
-func waitForEpoch(svc consensus.Backend, epoch beacon.EpochTime) error {
+func waitForEpoch(svc consensus.Service, epoch beacon.EpochTime) error {
 	ch, sub, err := svc.Beacon().WatchEpochs(context.Background())
 	if err != nil {
 		return err

--- a/go/oasis-node/cmd/debug/byzantine/registry.go
+++ b/go/oasis-node/cmd/debug/byzantine/registry.go
@@ -14,7 +14,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/worker/registration"
 )
 
-func registryRegisterNode(svc consensus.Backend, id *identity.Identity, p2pAddresses []node.Address, runtimeID common.Namespace, capabilities *node.Capabilities, roles node.RolesMask) error {
+func registryRegisterNode(svc consensus.Service, id *identity.Identity, p2pAddresses []node.Address, runtimeID common.Namespace, capabilities *node.Capabilities, roles node.RolesMask) error {
 	entityID, registrationSigner, err := registration.GetRegistrationSigner(id)
 	if err != nil {
 		return fmt.Errorf("registration GetRegistrationSigner: %w", err)

--- a/go/oasis-node/cmd/debug/byzantine/roothash.go
+++ b/go/oasis-node/cmd/debug/byzantine/roothash.go
@@ -11,12 +11,12 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
 )
 
-func roothashExecutorCommit(svc consensus.Backend, id *identity.Identity, runtimeID common.Namespace, commits []commitment.ExecutorCommitment) error {
+func roothashExecutorCommit(svc consensus.Service, id *identity.Identity, runtimeID common.Namespace, commits []commitment.ExecutorCommitment) error {
 	tx := roothash.NewExecutorCommitTx(0, nil, runtimeID, commits)
 	return consensus.SignAndSubmitTx(context.Background(), svc, id.NodeSigner, tx)
 }
 
-func getRoothashLatestBlock(ctx context.Context, sbc consensus.Backend, runtimeID common.Namespace) (*block.Block, error) {
+func getRoothashLatestBlock(ctx context.Context, sbc consensus.Service, runtimeID common.Namespace) (*block.Block, error) {
 	return sbc.RootHash().GetLatestBlock(ctx, &roothash.RuntimeRequest{
 		RuntimeID: runtimeID,
 		Height:    consensus.HeightLatest,

--- a/go/oasis-node/cmd/debug/byzantine/scheduler.go
+++ b/go/oasis-node/cmd/debug/byzantine/scheduler.go
@@ -11,7 +11,7 @@ import (
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 )
 
-func schedulerNextElectionHeight(svc consensus.Backend, epoch beacon.EpochTime) (int64, beacon.EpochTime, error) {
+func schedulerNextElectionHeight(svc consensus.Service, epoch beacon.EpochTime) (int64, beacon.EpochTime, error) {
 	ch, sub, err := svc.Scheduler().WatchCommittees(context.Background())
 	if err != nil {
 		return -1, beacon.EpochInvalid, fmt.Errorf("failed to watch committees: %w", err)

--- a/go/oasis-node/cmd/debug/txsource/workload/commission.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/commission.go
@@ -345,7 +345,7 @@ func (c *commission) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	conn *grpc.ClientConn,
-	cnsc consensus.Backend,
+	cnsc consensus.Services,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 	_ []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/commission.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/commission.go
@@ -345,7 +345,7 @@ func (c *commission) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	conn *grpc.ClientConn,
-	cnsc consensus.ClientBackend,
+	cnsc consensus.Backend,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 	_ []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/delegation.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/delegation.go
@@ -185,7 +185,7 @@ func (d *delegation) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	conn *grpc.ClientConn,
-	cnsc consensus.ClientBackend,
+	cnsc consensus.Backend,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 	_ []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/delegation.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/delegation.go
@@ -185,7 +185,7 @@ func (d *delegation) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	conn *grpc.ClientConn,
-	cnsc consensus.Backend,
+	cnsc consensus.Services,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 	_ []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/governance.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/governance.go
@@ -64,7 +64,7 @@ type governanceWorkload struct {
 	currentEpoch beacon.EpochTime
 	parameters   *governance.ConsensusParameters
 
-	consensus consensus.Backend
+	consensus consensus.Services
 
 	proposerAccounts []*struct {
 		signer  signature.Signer
@@ -578,7 +578,7 @@ func (g *governanceWorkload) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	_ *grpc.ClientConn,
-	cnsc consensus.Backend,
+	cnsc consensus.Services,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 	validatorEntities []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/governance.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/governance.go
@@ -64,8 +64,7 @@ type governanceWorkload struct {
 	currentEpoch beacon.EpochTime
 	parameters   *governance.ConsensusParameters
 
-	consensus  consensus.ClientBackend
-	governance governance.Backend
+	consensus consensus.ClientBackend
 
 	proposerAccounts []*struct {
 		signer  signature.Signer
@@ -135,7 +134,7 @@ func (g *governanceWorkload) submitProposalContent(pc *governance.ProposalConten
 	// Find submitted proposal.
 	// In case there are multiple proposals with identical content, select the
 	// one with higher ID - since that is the more recently submitted proposal.
-	aps, err := g.governance.ActiveProposals(g.ctx, consensus.HeightLatest)
+	aps, err := g.consensus.Governance().ActiveProposals(g.ctx, consensus.HeightLatest)
 	if err != nil {
 		return 0, fmt.Errorf("failed to query active proposals: %w", err)
 	}
@@ -178,7 +177,7 @@ func (g *governanceWorkload) doUpgradeProposal() error {
 	// there is a pending upgrade already scheduled minUpgradeEpoch before/after the
 	// proposed upgrade epoch.
 	var shouldFail bool
-	pendingUpgrades, err := g.governance.PendingUpgrades(g.ctx, consensus.HeightLatest)
+	pendingUpgrades, err := g.consensus.Governance().PendingUpgrades(g.ctx, consensus.HeightLatest)
 	if err != nil {
 		return fmt.Errorf("governance.PendingUpgrades: %w", err)
 	}
@@ -208,7 +207,7 @@ func (g *governanceWorkload) doUpgradeProposal() error {
 
 func (g *governanceWorkload) submitCancelUpgradeProposal(descriptor *upgrade.Descriptor, shouldFail bool) (uint64, error) {
 	// Find proposal matching the pending upgrade.
-	ps, err := g.governance.Proposals(g.ctx, consensus.HeightLatest)
+	ps, err := g.consensus.Governance().Proposals(g.ctx, consensus.HeightLatest)
 	if err != nil {
 		return 0, fmt.Errorf("querying proposals: %w", err)
 	}
@@ -236,7 +235,7 @@ func (g *governanceWorkload) submitCancelUpgradeProposal(descriptor *upgrade.Des
 }
 
 func (g *governanceWorkload) doCancelUpgradeProposal() error {
-	pendingUpgrades, err := g.governance.PendingUpgrades(g.ctx, consensus.HeightLatest)
+	pendingUpgrades, err := g.consensus.Governance().PendingUpgrades(g.ctx, consensus.HeightLatest)
 	if err != nil {
 		return fmt.Errorf("governance.PendingUpgrades: %w", err)
 	}
@@ -509,7 +508,7 @@ func (g *governanceWorkload) submitVote(voter signature.Signer, proposalID uint6
 }
 
 func (g *governanceWorkload) doGovernanceVote() error {
-	activeProposals, err := g.governance.ActiveProposals(g.ctx, consensus.HeightLatest)
+	activeProposals, err := g.consensus.Governance().ActiveProposals(g.ctx, consensus.HeightLatest)
 	if err != nil {
 		return fmt.Errorf("governance.ActiveProposals(): %w", err)
 	}
@@ -597,7 +596,6 @@ func (g *governanceWorkload) Run(
 	}
 
 	g.consensus = cnsc
-	g.governance = cnsc.Governance()
 
 	g.validatorEntities = validatorEntities
 	if len(g.validatorEntities) == 0 {
@@ -682,7 +680,7 @@ func (g *governanceWorkload) Run(
 			// XXX: this makes sure that any pending upgrades that are about to be executed are
 			// canceled. When txsource suite supports handling upgrades mid-run, remove this part.
 			var upgrades []*upgrade.Descriptor
-			upgrades, err = g.governance.PendingUpgrades(g.ctx, consensus.HeightLatest)
+			upgrades, err = g.consensus.Governance().PendingUpgrades(g.ctx, consensus.HeightLatest)
 			if err != nil {
 				return fmt.Errorf("querying pending upgrades: %w", err)
 			}

--- a/go/oasis-node/cmd/debug/txsource/workload/governance.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/governance.go
@@ -64,7 +64,7 @@ type governanceWorkload struct {
 	currentEpoch beacon.EpochTime
 	parameters   *governance.ConsensusParameters
 
-	consensus consensus.ClientBackend
+	consensus consensus.Backend
 
 	proposerAccounts []*struct {
 		signer  signature.Signer
@@ -578,7 +578,7 @@ func (g *governanceWorkload) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	_ *grpc.ClientConn,
-	cnsc consensus.ClientBackend,
+	cnsc consensus.Backend,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 	validatorEntities []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/oversized.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/oversized.go
@@ -42,7 +42,7 @@ func (o *oversized) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	_ *grpc.ClientConn,
-	cnsc consensus.Backend,
+	cnsc consensus.Services,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 	_ []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/oversized.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/oversized.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
-	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	consensusAPI "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	consensusGenesis "github.com/oasisprotocol/oasis-core/go/consensus/genesis"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
@@ -42,13 +42,13 @@ func (o *oversized) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	_ *grpc.ClientConn,
-	cnsc consensus.Services,
-	sm consensus.SubmissionManager,
+	consensus consensusAPI.Services,
+	sm consensusAPI.SubmissionManager,
 	fundingAccount signature.Signer,
 	_ []signature.Signer,
 ) error {
 	// Initialize base workload.
-	o.BaseWorkload.Init(cnsc, sm, fundingAccount)
+	o.BaseWorkload.Init(consensus, sm, fundingAccount)
 
 	txSignerFactory := memorySigner.NewFactory()
 	txSigner, err := txSignerFactory.Generate(signature.SignerEntity, rng)
@@ -59,7 +59,7 @@ func (o *oversized) Run(
 
 	ctx := context.Background()
 
-	params, err := cnsc.GetParameters(ctx, consensus.HeightLatest)
+	params, err := consensus.Core().GetParameters(ctx, consensusAPI.HeightLatest)
 	if err != nil {
 		return fmt.Errorf("failed to query consensus parameters: %w", err)
 	}
@@ -114,13 +114,13 @@ func (o *oversized) Run(
 
 		// Wait for a maximum of 5 seconds.
 		submitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		err = cnsc.SubmitTx(submitCtx, signedTx)
+		err = consensus.Core().SubmitTx(submitCtx, signedTx)
 		cancel()
 		switch err {
 		case nil:
 			// This should never happen.
 			return fmt.Errorf("successfully submitted an oversized transaction")
-		case consensus.ErrOversizedTx:
+		case consensusAPI.ErrOversizedTx:
 			// Submitting an oversized transaction is an error, so we expect this to fail.
 			o.Logger.Info("transaction rejected due to ErrOversizedTx")
 		default:

--- a/go/oasis-node/cmd/debug/txsource/workload/oversized.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/oversized.go
@@ -42,7 +42,7 @@ func (o *oversized) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	_ *grpc.ClientConn,
-	cnsc consensus.ClientBackend,
+	cnsc consensus.Backend,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 	_ []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/parallel.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/parallel.go
@@ -49,7 +49,7 @@ func (p *parallel) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	_ *grpc.ClientConn,
-	cnsc consensus.Backend,
+	cnsc consensus.Services,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 	_ []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/parallel.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/parallel.go
@@ -49,7 +49,7 @@ func (p *parallel) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	_ *grpc.ClientConn,
-	cnsc consensus.ClientBackend,
+	cnsc consensus.Backend,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 	_ []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/queries.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/queries.go
@@ -84,7 +84,7 @@ type queries struct {
 	control    control.NodeController
 	beacon     beacon.Backend
 	staking    staking.Backend
-	consensus  consensus.ClientBackend
+	consensus  consensus.Backend
 	registry   registry.Backend
 	scheduler  scheduler.Backend
 	governance governance.Backend
@@ -874,7 +874,7 @@ func (q *queries) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	conn *grpc.ClientConn,
-	cnsc consensus.ClientBackend,
+	cnsc consensus.Backend,
 	_ consensus.SubmissionManager,
 	_ signature.Signer,
 	_ []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/queries.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/queries.go
@@ -874,7 +874,7 @@ func (q *queries) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	conn *grpc.ClientConn,
-	cnsc consensus.Backend,
+	cnsc consensus.Services,
 	_ consensus.SubmissionManager,
 	_ signature.Signer,
 	_ []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/queries.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/queries.go
@@ -23,7 +23,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
-	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	consensusAPI "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction/results"
 	tmcrypto "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/crypto"
 	control "github.com/oasisprotocol/oasis-core/go/control/api"
@@ -81,15 +81,16 @@ type queries struct {
 	stakingParams   *staking.ConsensusParameters
 	schedulerParams *scheduler.ConsensusParameters
 
-	control    control.NodeController
 	beacon     beacon.Backend
-	staking    staking.Backend
-	consensus  consensus.Backend
-	registry   registry.Backend
-	scheduler  scheduler.Backend
+	consensus  consensusAPI.Backend
 	governance governance.Backend
+	registry   registry.Backend
 	roothash   roothash.Backend
-	runtime    runtimeClient.RuntimeClient
+	scheduler  scheduler.Backend
+	staking    staking.Backend
+
+	control control.NodeController
+	runtime runtimeClient.RuntimeClient
 
 	runtimeGenesisRound uint64
 
@@ -874,8 +875,8 @@ func (q *queries) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	conn *grpc.ClientConn,
-	cnsc consensus.Services,
-	_ consensus.SubmissionManager,
+	consensus consensusAPI.Services,
+	_ consensusAPI.SubmissionManager,
 	_ signature.Signer,
 	_ []signature.Signer,
 ) error {
@@ -885,7 +886,7 @@ func (q *queries) Run(
 	q.logger = logging.GetLogger("cmd/txsource/workload/queries")
 
 	q.control = control.NewNodeControllerClient(conn)
-	q.consensus = cnsc
+	q.consensus = consensus.Core()
 	q.beacon = beacon.NewClient(conn)
 	q.registry = registry.NewClient(conn)
 	q.runtime = runtimeClient.NewClient(conn)
@@ -894,15 +895,15 @@ func (q *queries) Run(
 	q.staking = staking.NewClient(conn)
 	q.roothash = roothash.NewClient(conn)
 
-	q.stakingParams, err = q.staking.ConsensusParameters(ctx, consensus.HeightLatest)
+	q.stakingParams, err = q.staking.ConsensusParameters(ctx, consensusAPI.HeightLatest)
 	if err != nil {
 		return fmt.Errorf("failed to query staking consensus parameters: %w", err)
 	}
-	q.schedulerParams, err = q.scheduler.ConsensusParameters(ctx, consensus.HeightLatest)
+	q.schedulerParams, err = q.scheduler.ConsensusParameters(ctx, consensusAPI.HeightLatest)
 	if err != nil {
 		return fmt.Errorf("failed to query scheduler consensus parameters: %w", err)
 	}
-	q.epochtimeParams, err = q.beacon.ConsensusParameters(ctx, consensus.HeightLatest)
+	q.epochtimeParams, err = q.beacon.ConsensusParameters(ctx, consensusAPI.HeightLatest)
 	if err != nil {
 		return fmt.Errorf("failed to query epochtime consensus parameters: %w", err)
 	}

--- a/go/oasis-node/cmd/debug/txsource/workload/registration.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/registration.go
@@ -165,7 +165,7 @@ func (r *registration) Run( // nolint: gocyclo
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	conn *grpc.ClientConn,
-	cnsc consensus.Backend,
+	cnsc consensus.Services,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 	_ []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/registration.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/registration.go
@@ -165,7 +165,7 @@ func (r *registration) Run( // nolint: gocyclo
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	conn *grpc.ClientConn,
-	cnsc consensus.ClientBackend,
+	cnsc consensus.Backend,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 	_ []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/registration.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/registration.go
@@ -19,7 +19,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
-	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	consensusAPI "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
@@ -165,13 +165,13 @@ func (r *registration) Run( // nolint: gocyclo
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	conn *grpc.ClientConn,
-	cnsc consensus.Services,
-	sm consensus.SubmissionManager,
+	consensus consensusAPI.Services,
+	sm consensusAPI.SubmissionManager,
 	fundingAccount signature.Signer,
 	_ []signature.Signer,
 ) error {
 	// Initialize base workload.
-	r.BaseWorkload.Init(cnsc, sm, fundingAccount)
+	r.BaseWorkload.Init(consensus, sm, fundingAccount)
 
 	beacon := beacon.NewClient(conn)
 	ctx := context.Background()
@@ -220,9 +220,9 @@ func (r *registration) Run( // nolint: gocyclo
 	// XXX: currently entities are only registered at start. Could also
 	// periodically register new entities.
 	for i := range entityAccs {
-		entityAccs[i].reckonedNonce, err = cnsc.GetSignerNonce(ctx, &consensus.GetSignerNonceRequest{
+		entityAccs[i].reckonedNonce, err = consensus.Core().GetSignerNonce(ctx, &consensusAPI.GetSignerNonceRequest{
 			AccountAddress: entityAccs[i].address,
-			Height:         consensus.HeightLatest,
+			Height:         consensusAPI.HeightLatest,
 		})
 		if err != nil {
 			return fmt.Errorf("GetSignerNonce error: %w", err)
@@ -247,9 +247,9 @@ func (r *registration) Run( // nolint: gocyclo
 
 			var nodeAccNonce uint64
 			nodeAccAddress := staking.NewAddress(ident.NodeSigner.Public())
-			nodeAccNonce, err = cnsc.GetSignerNonce(ctx, &consensus.GetSignerNonceRequest{
+			nodeAccNonce, err = consensus.Core().GetSignerNonce(ctx, &consensusAPI.GetSignerNonceRequest{
 				AccountAddress: nodeAccAddress,
-				Height:         consensus.HeightLatest,
+				Height:         consensusAPI.HeightLatest,
 			})
 			if err != nil {
 				return fmt.Errorf("GetSignerNonce error for accout %s: %w", nodeAccAddress, err)
@@ -288,7 +288,7 @@ func (r *registration) Run( // nolint: gocyclo
 		// XXX: currently only a single runtime is used throughout the test, could use more.
 		if i == 0 {
 			// Current epoch.
-			epoch, err := beacon.GetEpoch(ctx, consensus.HeightLatest)
+			epoch, err := beacon.GetEpoch(ctx, consensusAPI.HeightLatest)
 			if err != nil {
 				return fmt.Errorf("failed to get current epoch: %w", err)
 			}
@@ -325,7 +325,7 @@ func (r *registration) Run( // nolint: gocyclo
 		selectedNode := selectedAcc.nodeIdentities[rng.Intn(registryNumNodesPerEntity)]
 
 		// Current epoch.
-		epoch, err := beacon.GetEpoch(loopCtx, consensus.HeightLatest)
+		epoch, err := beacon.GetEpoch(loopCtx, consensusAPI.HeightLatest)
 		if err != nil {
 			return fmt.Errorf("failed to get current epoch: %w", err)
 		}

--- a/go/oasis-node/cmd/debug/txsource/workload/runtime.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/runtime.go
@@ -790,7 +790,7 @@ func (r *runtime) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	conn *grpc.ClientConn,
-	cnsc consensus.Backend,
+	cnsc consensus.Services,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 	_ []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/runtime.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/runtime.go
@@ -790,7 +790,7 @@ func (r *runtime) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	conn *grpc.ClientConn,
-	cnsc consensus.ClientBackend,
+	cnsc consensus.Backend,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 	_ []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/runtime.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/runtime.go
@@ -496,7 +496,7 @@ func (r *runtime) escrowIsZero(ctx context.Context, address staking.Address) (bo
 // at every iteration of the test.
 func (r *runtime) assertBalanceInvariants(ctx context.Context) error {
 	// Use a consistent height for querying balances.
-	height, err := r.Consensus().GetLatestHeight(ctx)
+	height, err := r.Consensus().Core().GetLatestHeight(ctx)
 	if err != nil {
 		return err
 	}

--- a/go/oasis-node/cmd/debug/txsource/workload/transfer.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/transfer.go
@@ -41,7 +41,7 @@ type transferAccount struct {
 type transfer struct {
 	BaseWorkload
 
-	consensus consensus.Backend
+	consensus consensus.Services
 
 	accounts       []transferAccount
 	fundingAccount signature.Signer
@@ -248,7 +248,7 @@ func (t *transfer) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	conn *grpc.ClientConn,
-	cnsc consensus.Backend,
+	cnsc consensus.Services,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 	_ []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/transfer.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/transfer.go
@@ -41,7 +41,7 @@ type transferAccount struct {
 type transfer struct {
 	BaseWorkload
 
-	consensus consensus.ClientBackend
+	consensus consensus.Backend
 
 	accounts       []transferAccount
 	fundingAccount signature.Signer
@@ -248,7 +248,7 @@ func (t *transfer) Run(
 	gracefulExit context.Context,
 	rng *rand.Rand,
 	conn *grpc.ClientConn,
-	cnsc consensus.ClientBackend,
+	cnsc consensus.Backend,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 	_ []signature.Signer,

--- a/go/oasis-node/cmd/debug/txsource/workload/workload.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/workload.go
@@ -82,7 +82,7 @@ func (bw *BaseWorkload) Init(
 	bw.fundingAccount = fundingAccount
 }
 
-// Consensus returns the consensus client backend.
+// Consensus returns the consensus services.
 func (bw *BaseWorkload) Consensus() consensus.Services {
 	return bw.cc
 }

--- a/go/oasis-node/cmd/debug/txsource/workload/workload.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/workload.go
@@ -53,7 +53,7 @@ type Workload interface {
 		gracefulExit context.Context,
 		rng *rand.Rand,
 		conn *grpc.ClientConn,
-		cnsc consensus.ClientBackend,
+		cnsc consensus.Backend,
 		sm consensus.SubmissionManager,
 		fundingAccount signature.Signer,
 		validatorEntities []signature.Signer,
@@ -65,7 +65,7 @@ type BaseWorkload struct {
 	// Logger is the logger for the workload.
 	Logger *logging.Logger
 
-	cc consensus.ClientBackend
+	cc consensus.Backend
 	sm consensus.SubmissionManager
 
 	fundingAccount signature.Signer
@@ -73,7 +73,7 @@ type BaseWorkload struct {
 
 // Init initializes the base workload.
 func (bw *BaseWorkload) Init(
-	cc consensus.ClientBackend,
+	cc consensus.Backend,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 ) {
@@ -83,7 +83,7 @@ func (bw *BaseWorkload) Init(
 }
 
 // Consensus returns the consensus client backend.
-func (bw *BaseWorkload) Consensus() consensus.ClientBackend {
+func (bw *BaseWorkload) Consensus() consensus.Backend {
 	return bw.cc
 }
 
@@ -181,7 +181,7 @@ func NewBaseWorkload(name string) BaseWorkload {
 // FundAccountFromTestEntity funds an account from test entity.
 func FundAccountFromTestEntity(
 	ctx context.Context,
-	cc consensus.ClientBackend,
+	cc consensus.Backend,
 	sm consensus.SubmissionManager,
 	to signature.Signer,
 ) error {

--- a/go/oasis-node/cmd/debug/txsource/workload/workload.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/workload.go
@@ -53,7 +53,7 @@ type Workload interface {
 		gracefulExit context.Context,
 		rng *rand.Rand,
 		conn *grpc.ClientConn,
-		cnsc consensus.Backend,
+		cnsc consensus.Services,
 		sm consensus.SubmissionManager,
 		fundingAccount signature.Signer,
 		validatorEntities []signature.Signer,
@@ -65,7 +65,7 @@ type BaseWorkload struct {
 	// Logger is the logger for the workload.
 	Logger *logging.Logger
 
-	cc consensus.Backend
+	cc consensus.Services
 	sm consensus.SubmissionManager
 
 	fundingAccount signature.Signer
@@ -73,7 +73,7 @@ type BaseWorkload struct {
 
 // Init initializes the base workload.
 func (bw *BaseWorkload) Init(
-	cc consensus.Backend,
+	cc consensus.Services,
 	sm consensus.SubmissionManager,
 	fundingAccount signature.Signer,
 ) {
@@ -83,7 +83,7 @@ func (bw *BaseWorkload) Init(
 }
 
 // Consensus returns the consensus client backend.
-func (bw *BaseWorkload) Consensus() consensus.Backend {
+func (bw *BaseWorkload) Consensus() consensus.Services {
 	return bw.cc
 }
 
@@ -181,7 +181,7 @@ func NewBaseWorkload(name string) BaseWorkload {
 // FundAccountFromTestEntity funds an account from test entity.
 func FundAccountFromTestEntity(
 	ctx context.Context,
-	cc consensus.Backend,
+	cc consensus.Services,
 	sm consensus.SubmissionManager,
 	to signature.Signer,
 ) error {

--- a/go/oasis-node/cmd/ias/proxy.go
+++ b/go/oasis-node/cmd/ias/proxy.go
@@ -153,7 +153,7 @@ func doProxy(cmd *cobra.Command, _ []string) {
 	env.svcMgr.Register(env.grpcSrv)
 
 	// Initialize the metrics server.
-	metrics, err := metrics.New(env.svcMgr.Ctx)
+	metrics, err := metrics.New()
 	if err != nil {
 		logger.Error("failed to initialize metrics server",
 			"err", err,

--- a/go/oasis-node/cmd/node/init.go
+++ b/go/oasis-node/cmd/node/init.go
@@ -83,7 +83,7 @@ func loadOrGenerateIdentity(dataDir string, logger *logging.Logger) (*identity.I
 // startMetricServer initializes and starts the metrics reporting server.
 func startMetricServer(svcMgr *background.ServiceManager, logger *logging.Logger) (service.BackgroundService, error) {
 	// Initialize the metrics server.
-	metrics, err := metrics.New(svcMgr.Ctx)
+	metrics, err := metrics.New()
 	if err != nil {
 		logger.Error("failed to initialize metrics server",
 			"err", err,

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -550,7 +550,7 @@ func NewNode() (node *Node, err error) { // nolint: gocyclo
 	}
 
 	// Register consensus light client P2P protocol server.
-	node.P2P.RegisterProtocolServer(consensusLightP2P.NewServer(node.P2P, node.chainContext, node.Consensus))
+	node.P2P.RegisterProtocolServer(consensusLightP2P.NewServer(node.P2P, node.chainContext, node.Consensus.Core()))
 
 	// If the consensus backend supports communicating with consensus services, we can also start
 	// all services required for runtime operation.

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -64,7 +64,7 @@ type Node struct {
 
 	commonStore *persistent.CommonStore
 
-	Consensus    consensusAPI.Backend
+	Consensus    consensusAPI.Service
 	LightService consensusAPI.LightService
 
 	dataDir      string

--- a/go/oasis-node/cmd/node/node_control.go
+++ b/go/oasis-node/cmd/node/node_control.go
@@ -186,7 +186,7 @@ func (n *Node) getIdentityStatus() control.IdentityStatus {
 }
 
 func (n *Node) getConsensusStatus(ctx context.Context) (*consensus.Status, error) {
-	return n.Consensus.GetStatus(ctx)
+	return n.Consensus.Core().GetStatus(ctx)
 }
 
 func (n *Node) getLightClientStatus() (*consensus.LightClientStatus, error) {

--- a/go/oasis-node/node_test.go
+++ b/go/oasis-node/node_test.go
@@ -304,7 +304,7 @@ func testRegisterEntityRuntime(t *testing.T, node *testNode) {
 }
 
 func testConsensus(t *testing.T, node *testNode) {
-	consensusTests.ConsensusImplementationTests(t, node.Consensus)
+	consensusTests.ConsensusImplementationTests(t, node.Consensus.Core())
 }
 
 func testConsensusClient(t *testing.T, node *testNode) {

--- a/go/oasis-test-runner/oasis/controller.go
+++ b/go/oasis-test-runner/oasis/controller.go
@@ -26,7 +26,7 @@ type Controller struct {
 	control.NodeController
 
 	Beacon        beacon.Backend
-	Consensus     consensus.ClientBackend
+	Consensus     consensus.Backend
 	Staking       staking.Backend
 	Governance    governance.Backend
 	Registry      registry.Backend

--- a/go/oasis-test-runner/oasis/controller.go
+++ b/go/oasis-test-runner/oasis/controller.go
@@ -26,7 +26,7 @@ type Controller struct {
 	control.NodeController
 
 	Beacon        beacon.Backend
-	Consensus     consensus.Backend
+	Consensus     consensus.Services
 	Staking       staking.Backend
 	Governance    governance.Backend
 	Registry      registry.Backend

--- a/go/oasis-test-runner/oasis/controller.go
+++ b/go/oasis-test-runner/oasis/controller.go
@@ -26,7 +26,7 @@ type Controller struct {
 	control.NodeController
 
 	Beacon        beacon.Backend
-	Consensus     consensus.Services
+	Consensus     consensus.Backend
 	Staking       staking.Backend
 	Governance    governance.Backend
 	Registry      registry.Backend

--- a/go/oasis-test-runner/scenario/e2e/runtime/keymanager_rotation_failure.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/keymanager_rotation_failure.go
@@ -169,7 +169,7 @@ func (sc *kmRotationFailureImpl) extendKeymanagerRegistrations(ctx context.Conte
 	if err != nil {
 		return err
 	}
-	params, err := sc.Net.ClientController().Consensus.Registry().ConsensusParameters(ctx, consensus.HeightLatest)
+	params, err := sc.Net.ClientController().Registry.ConsensusParameters(ctx, consensus.HeightLatest)
 	if err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/validator_equivocation.go
+++ b/go/oasis-test-runner/scenario/e2e/validator_equivocation.go
@@ -226,7 +226,7 @@ WaitLoop:
 	}
 
 	// Make sure the node is frozen.
-	nodeStatus, err := ctrl.Consensus.Registry().GetNodeStatus(ctx, &registry.IDQuery{ID: identity.NodeSigner.Public(), Height: consensusAPI.HeightLatest})
+	nodeStatus, err := ctrl.Registry.GetNodeStatus(ctx, &registry.IDQuery{ID: identity.NodeSigner.Public(), Height: consensusAPI.HeightLatest})
 	if err != nil {
 		return fmt.Errorf("GetNodeStatus: %w", err)
 	}

--- a/go/p2p/p2p.go
+++ b/go/p2p/p2p.go
@@ -395,7 +395,7 @@ func New(identity *identity.Identity, consensus consensus.Service, store *persis
 		return nil, fmt.Errorf("p2p: failed to initialize libp2p gossipsub: %w", err)
 	}
 
-	chainContext, err := consensus.GetChainContext(ctx)
+	chainContext, err := consensus.Core().GetChainContext(ctx)
 	if err != nil {
 		ctxCancel()
 		_ = host.Close()

--- a/go/p2p/p2p.go
+++ b/go/p2p/p2p.go
@@ -360,7 +360,7 @@ func messageIdFn(pmsg *pb.Message) string { // nolint: revive
 }
 
 // New creates a new P2P node.
-func New(identity *identity.Identity, consensus consensus.Backend, store *persistent.CommonStore) (api.Service, error) {
+func New(identity *identity.Identity, consensus consensus.Service, store *persistent.CommonStore) (api.Service, error) {
 	var cfg Config
 	if err := cfg.Load(); err != nil {
 		return nil, fmt.Errorf("p2p: failed to load peer config: %w", err)

--- a/go/p2p/peermgmt/peermgr.go
+++ b/go/p2p/peermgmt/peermgr.go
@@ -82,7 +82,7 @@ func NewPeerManager(
 	h host.Host,
 	g connmgr.ConnectionGater,
 	ps *pubsub.PubSub,
-	consensus consensus.Backend,
+	consensus consensus.Service,
 	chainContext string,
 	cs *persistent.CommonStore,
 	opts ...PeerManagerOption,

--- a/go/p2p/peermgmt/registry.go
+++ b/go/p2p/peermgmt/registry.go
@@ -19,7 +19,7 @@ import (
 type peerRegistry struct {
 	logger *logging.Logger
 
-	consensus    consensus.Backend
+	consensus    consensus.Service
 	chainContext string
 
 	mu            sync.Mutex
@@ -33,12 +33,12 @@ type peerRegistry struct {
 	startOne cmSync.One
 }
 
-func newPeerRegistry(c consensus.Backend, chainContext string) *peerRegistry {
+func newPeerRegistry(consensus consensus.Service, chainContext string) *peerRegistry {
 	l := logging.GetLogger("p2p/peer-manager/registry")
 
 	return &peerRegistry{
 		logger:        l,
-		consensus:     c,
+		consensus:     consensus,
 		chainContext:  chainContext,
 		peers:         make(map[core.PeerID]peer.AddrInfo),
 		protocolPeers: make(map[core.ProtocolID]map[core.PeerID]struct{}),

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -60,7 +60,7 @@ type finalizedEvent struct {
 
 // RootHashImplementationTests exercises the basic functionality of a
 // roothash backend.
-func RootHashImplementationTests(t *testing.T, backend api.Backend, consensus consensusAPI.Backend, identity *identity.Identity) {
+func RootHashImplementationTests(t *testing.T, backend api.Backend, consensus consensusAPI.Service, identity *identity.Identity) {
 	seedBase := []byte(fmt.Sprintf("RootHashImplementationTests: %T", backend))
 
 	require := require.New(t)
@@ -181,7 +181,7 @@ func testGenesisBlock(t *testing.T, backend api.Backend, state *runtimeState) {
 	require.EqualValues(genesisBlock, blk, "retrieved block is genesis block")
 }
 
-func testEpochTransitionBlock(t *testing.T, backend api.Backend, consensus consensusAPI.Backend, states []*runtimeState) {
+func testEpochTransitionBlock(t *testing.T, backend api.Backend, consensus consensusAPI.Service, states []*runtimeState) {
 	require := require.New(t)
 
 	// Before an epoch transition there should just be a genesis block.
@@ -227,7 +227,7 @@ func testEpochTransitionBlock(t *testing.T, backend api.Backend, consensus conse
 	}
 }
 
-func (s *runtimeState) refreshCommittees(t *testing.T, consensus consensusAPI.Backend) {
+func (s *runtimeState) refreshCommittees(t *testing.T, consensus consensusAPI.Service) {
 	nodes := make(map[signature.PublicKey]*registryTests.TestNode)
 	for _, node := range s.rt.TestNodes() {
 		nodes[node.Node.ID] = node
@@ -239,7 +239,7 @@ func (s *runtimeState) refreshCommittees(t *testing.T, consensus consensusAPI.Ba
 	s.executorCommittee = mustGetCommittee(t, s.rt, epoch, consensus.Scheduler(), nodes)
 }
 
-func (s *runtimeState) testEpochTransitionBlock(t *testing.T, consensus consensusAPI.Backend, ch <-chan *api.AnnotatedBlock) {
+func (s *runtimeState) testEpochTransitionBlock(t *testing.T, consensus consensusAPI.Service, ch <-chan *api.AnnotatedBlock) {
 	require := require.New(t)
 
 	s.refreshCommittees(t, consensus)
@@ -266,13 +266,13 @@ func (s *runtimeState) testEpochTransitionBlock(t *testing.T, consensus consensu
 	}
 }
 
-func testSuccessfulRound(t *testing.T, backend api.Backend, consensus consensusAPI.Backend, states []*runtimeState) {
+func testSuccessfulRound(t *testing.T, backend api.Backend, consensus consensusAPI.Service, states []*runtimeState) {
 	for _, state := range states {
 		state.testSuccessfulRound(t, backend, consensus)
 	}
 }
 
-func (s *runtimeState) generateExecutorCommitments(t *testing.T, consensus consensusAPI.Backend, child *block.Block, rank uint64) (
+func (s *runtimeState) generateExecutorCommitments(t *testing.T, consensus consensusAPI.Service, child *block.Block, rank uint64) (
 	*block.Block,
 	[]commitment.ExecutorCommitment,
 	[]*registryTests.TestNode,
@@ -470,7 +470,7 @@ func (s *runtimeState) livenessStatisticsDiff(t *testing.T, ctx context.Context,
 	return after
 }
 
-func (s *runtimeState) testSuccessfulRound(t *testing.T, backend api.Backend, consensus consensusAPI.Backend) {
+func (s *runtimeState) testSuccessfulRound(t *testing.T, backend api.Backend, consensus consensusAPI.Service) {
 	require := require.New(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*recvTimeout)
@@ -534,7 +534,7 @@ func (s *runtimeState) testSuccessfulRound(t *testing.T, backend api.Backend, co
 	require.EqualValues(missedProposals, livenessStatistics.MissedProposals, "there should be no failed proposals")
 }
 
-func testRoundTimeout(t *testing.T, backend api.Backend, consensus consensusAPI.Backend, states []*runtimeState) {
+func testRoundTimeout(t *testing.T, backend api.Backend, consensus consensusAPI.Service, states []*runtimeState) {
 	for _, state := range states {
 		for _, rank := range []uint64{0, 1, 2} {
 			state.testRoundTimeout(t, backend, consensus, rank)
@@ -542,7 +542,7 @@ func testRoundTimeout(t *testing.T, backend api.Backend, consensus consensusAPI.
 	}
 }
 
-func (s *runtimeState) testRoundTimeout(t *testing.T, backend api.Backend, consensus consensusAPI.Backend, rank uint64) {
+func (s *runtimeState) testRoundTimeout(t *testing.T, backend api.Backend, consensus consensusAPI.Service, rank uint64) {
 	require := require.New(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*recvTimeout)
@@ -745,13 +745,13 @@ func (s *runtimeState) testRoundTimeout(t *testing.T, backend api.Backend, conse
 	})
 }
 
-func testRoundTimeoutWithEpochTransition(t *testing.T, backend api.Backend, consensus consensusAPI.Backend, states []*runtimeState) {
+func testRoundTimeoutWithEpochTransition(t *testing.T, backend api.Backend, consensus consensusAPI.Service, states []*runtimeState) {
 	for _, state := range states {
 		state.testRoundTimeoutWithEpochTransition(t, backend, consensus)
 	}
 }
 
-func (s *runtimeState) testRoundTimeoutWithEpochTransition(t *testing.T, backend api.Backend, consensus consensusAPI.Backend) {
+func (s *runtimeState) testRoundTimeoutWithEpochTransition(t *testing.T, backend api.Backend, consensus consensusAPI.Service) {
 	require := require.New(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*recvTimeout)
@@ -903,7 +903,7 @@ func MustTransitionEpoch(
 	}
 }
 
-func testSubmitEquivocationEvidence(t *testing.T, backend api.Backend, consensus consensusAPI.Backend, _ *identity.Identity, states []*runtimeState) {
+func testSubmitEquivocationEvidence(t *testing.T, backend api.Backend, consensus consensusAPI.Service, _ *identity.Identity, states []*runtimeState) {
 	require := require.New(t)
 
 	ctx := context.Background()

--- a/go/runtime/history/indexer.go
+++ b/go/runtime/history/indexer.go
@@ -294,7 +294,7 @@ func (bi *BlockIndexer) reindexTo(ctx context.Context, height int64) error {
 	}
 	startHeight := lastHeight + 1 // +1 since we want the last non-seen height.
 
-	lastRetainedHeight, err := bi.consensus.GetLastRetainedHeight(ctx)
+	lastRetainedHeight, err := bi.consensus.Core().GetLastRetainedHeight(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get last retained height: %w", err)
 	}

--- a/go/runtime/history/indexer.go
+++ b/go/runtime/history/indexer.go
@@ -59,7 +59,7 @@ type BlockIndexer struct {
 	mu       sync.RWMutex
 	startOne cmSync.One
 
-	consensus consensus.Backend
+	consensus consensus.Service
 	history   History
 	batchSize uint16
 
@@ -74,7 +74,7 @@ type BlockIndexer struct {
 }
 
 // NewBlockIndexer creates a new block indexer.
-func NewBlockIndexer(consensus consensus.Backend, history History, batchSize uint16) *BlockIndexer {
+func NewBlockIndexer(consensus consensus.Service, history History, batchSize uint16) *BlockIndexer {
 	logger := logging.GetLogger("runtime/history/indexer").With("runtime_id", history.RuntimeID())
 
 	return &BlockIndexer{

--- a/go/runtime/host/provisioner/provisioner.go
+++ b/go/runtime/host/provisioner/provisioner.go
@@ -33,7 +33,7 @@ func New(
 	dataDir string,
 	commonStore *persistent.CommonStore,
 	identity *identity.Identity,
-	consensus consensus.Backend,
+	consensus consensus.Service,
 ) (runtimeHost.Provisioner, error) {
 	// Initialize the IAS proxy client.
 	ias, err := ias.New(identity)
@@ -57,7 +57,7 @@ func New(
 	return createProvisioner(dataDir, commonStore, identity, consensus, hostInfo, ias, qs)
 }
 
-func createHostInfo(consensus consensus.Backend) (*hostProtocol.HostInfo, error) {
+func createHostInfo(consensus consensus.Service) (*hostProtocol.HostInfo, error) {
 	cs, err := consensus.GetStatus(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get consensus layer status: %w", err)
@@ -92,7 +92,7 @@ func createProvisioner(
 	dataDir string,
 	commonStore *persistent.CommonStore,
 	identity *identity.Identity,
-	consensus consensus.Backend,
+	consensus consensus.Service,
 	hostInfo *hostProtocol.HostInfo,
 	ias []iasAPI.Endpoint,
 	qs pcs.QuoteService,

--- a/go/runtime/host/provisioner/provisioner.go
+++ b/go/runtime/host/provisioner/provisioner.go
@@ -58,12 +58,12 @@ func New(
 }
 
 func createHostInfo(consensus consensus.Service) (*hostProtocol.HostInfo, error) {
-	cs, err := consensus.GetStatus(context.Background())
+	cs, err := consensus.Core().GetStatus(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get consensus layer status: %w", err)
 	}
 
-	chainCtx, err := consensus.GetChainContext(context.Background())
+	chainCtx, err := consensus.Core().GetChainContext(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain context: %w", err)
 	}

--- a/go/runtime/host/sgx/common/common.go
+++ b/go/runtime/host/sgx/common/common.go
@@ -28,13 +28,13 @@ import (
 func GetQuotePolicy(
 	ctx context.Context,
 	cfg *host.Config,
-	cb consensus.Backend,
+	cs consensus.Service,
 	fallbackPolicy *sgxQuote.Policy,
 ) (*sgxQuote.Policy, error) {
 	switch cfg.Component.Kind {
 	case component.RONL:
 		// Load RONL policy from the consensus layer.
-		rt, err := cb.Registry().GetRuntime(ctx, &registry.GetRuntimeQuery{
+		rt, err := cs.Registry().GetRuntime(ctx, &registry.GetRuntimeQuery{
 			Height:           consensus.HeightLatest,
 			ID:               cfg.ID,
 			IncludeSuspended: true,

--- a/go/runtime/host/sgx/provisioner.go
+++ b/go/runtime/host/sgx/provisioner.go
@@ -63,7 +63,7 @@ type Config struct {
 	// PCS is the Intel Provisioning Certification Service quote service.
 	PCS pcs.QuoteService
 	// Consensus is the consensus layer backend.
-	Consensus consensus.Backend
+	Consensus consensus.Service
 	// Identity is the node identity.
 	Identity *identity.Identity
 
@@ -93,7 +93,7 @@ type sgxProvisioner struct {
 	ias       []ias.Endpoint
 	pcs       pcs.QuoteService
 	aesm      *aesm.Client
-	consensus consensus.Backend
+	consensus consensus.Service
 	identity  *identity.Identity
 	store     *persistent.CommonStore
 

--- a/go/runtime/host/tdx/qemu.go
+++ b/go/runtime/host/tdx/qemu.go
@@ -57,7 +57,7 @@ type QemuConfig struct {
 	// PCS is the Intel Provisioning Certification Service quote service.
 	PCS pcs.QuoteService
 	// Consensus is the consensus layer backend.
-	Consensus consensus.Backend
+	Consensus consensus.Service
 	// Identity is the node identity.
 	Identity *identity.Identity
 
@@ -80,7 +80,7 @@ type qemuProvisioner struct {
 
 	sandbox   host.Provisioner
 	pcs       pcs.QuoteService
-	consensus consensus.Backend
+	consensus consensus.Service
 	identity  *identity.Identity
 	cidPool   *CidPool
 

--- a/go/runtime/nodes/runtime.go
+++ b/go/runtime/nodes/runtime.go
@@ -34,7 +34,7 @@ func TagsForRoleMask(nodeRoles node.RolesMask) (tags []string) {
 type runtimeNodesWatcher struct { // nolint: maligned
 	sync.RWMutex
 
-	consensus consensus.Backend
+	consensus consensus.Service
 
 	runtimeID common.Namespace
 
@@ -195,7 +195,7 @@ func (rw *runtimeNodesWatcher) watchRuntimeNodeUpdates(ctx context.Context) {
 // Aditionally, watched nodes are tagged by node roles.
 func NewRuntimeNodeLookup(
 	ctx context.Context,
-	consensus consensus.Backend,
+	consensus consensus.Service,
 	runtimeID common.Namespace,
 ) (NodeDescriptorLookup, error) {
 	rw := &runtimeNodesWatcher{

--- a/go/runtime/nodes/versioned.go
+++ b/go/runtime/nodes/versioned.go
@@ -53,7 +53,7 @@ type VersionedNodeDescriptorWatcher interface {
 type versionedNodeDescriptorWatcher struct {
 	sync.RWMutex
 
-	consensus consensus.Backend
+	consensus consensus.Service
 
 	frozen        bool
 	version       int64
@@ -270,7 +270,7 @@ func (nw *versionedNodeDescriptorWatcher) Versioned() bool {
 //
 // This watcher will only track nodes that will be explicitly marked to watch
 // via WatchNode/WatchNodeWithTags methods.
-func NewVersionedNodeDescriptorWatcher(ctx context.Context, consensus consensus.Backend) (VersionedNodeDescriptorWatcher, error) {
+func NewVersionedNodeDescriptorWatcher(ctx context.Context, consensus consensus.Service) (VersionedNodeDescriptorWatcher, error) {
 	nw := &versionedNodeDescriptorWatcher{
 		consensus: consensus,
 		logger:    logging.GetLogger("runtime/committee/nodedescriptorwatcher"),

--- a/go/runtime/registry/handler.go
+++ b/go/runtime/registry/handler.go
@@ -46,7 +46,7 @@ type RuntimeHostHandlerEnvironment interface {
 type runtimeHostHandler struct {
 	env       RuntimeHostHandlerEnvironment
 	runtime   Runtime
-	consensus consensus.Backend
+	consensus consensus.Service
 }
 
 // NewRuntimeHostHandler returns a protocol handler that provides the required host methods for the
@@ -56,7 +56,7 @@ type runtimeHostHandler struct {
 func NewRuntimeHostHandler(
 	env RuntimeHostHandlerEnvironment,
 	runtime Runtime,
-	consensus consensus.Backend,
+	consensus consensus.Service,
 ) host.RuntimeHandler {
 	return &runtimeHostHandler{
 		env:       env,

--- a/go/runtime/registry/handler.go
+++ b/go/runtime/registry/handler.go
@@ -210,7 +210,7 @@ func (h *runtimeHostHandler) handleHostStorageSync(
 		}
 	case protocol.HostStorageEndpointConsensus:
 		// Consensus state storage.
-		rs = h.consensus.State()
+		rs = h.consensus.Core().State()
 	default:
 		return nil, fmt.Errorf("endpoint not supported")
 	}
@@ -257,7 +257,7 @@ func (h *runtimeHostHandler) handleHostFetchConsensusBlock(
 	ctx context.Context,
 	rq *protocol.HostFetchConsensusBlockRequest,
 ) (*protocol.HostFetchConsensusBlockResponse, error) {
-	blk, err := h.consensus.GetLightBlock(ctx, int64(rq.Height))
+	blk, err := h.consensus.Core().GetLightBlock(ctx, int64(rq.Height))
 	if err != nil {
 		lc, err := h.env.GetLightProvider()
 		if err != nil {
@@ -322,7 +322,7 @@ func (h *runtimeHostHandler) handleHostFetchConsensusEvents(
 func (h *runtimeHostHandler) handleHostFetchGenesisHeight(
 	ctx context.Context,
 ) (*protocol.HostFetchGenesisHeightResponse, error) {
-	doc, err := h.consensus.GetGenesisDocument(ctx)
+	doc, err := h.consensus.Core().GetGenesisDocument(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +350,7 @@ func (h *runtimeHostHandler) handleHostFetchBlockMetadataTx(
 	ctx context.Context,
 	rq *protocol.HostFetchBlockMetadataTxRequest,
 ) (*protocol.HostFetchBlockMetadataTxResponse, error) {
-	tps, err := h.consensus.GetTransactionsWithProofs(ctx, int64(rq.Height))
+	tps, err := h.consensus.Core().GetTransactionsWithProofs(ctx, int64(rq.Height))
 	if err != nil {
 		return nil, err
 	}

--- a/go/runtime/registry/notifier.go
+++ b/go/runtime/registry/notifier.go
@@ -73,7 +73,7 @@ type runtimeHostNotifier struct {
 
 	runtime   Runtime
 	host      *composite.Host
-	consensus consensus.Backend
+	consensus consensus.Service
 
 	notifyCh chan *componentNotifyFuncWithQueue
 
@@ -81,7 +81,7 @@ type runtimeHostNotifier struct {
 }
 
 // NewRuntimeHostNotifier returns a protocol notifier that handles key manager policy updates.
-func NewRuntimeHostNotifier(runtime Runtime, host *composite.Host, consensus consensus.Backend) protocol.Notifier {
+func NewRuntimeHostNotifier(runtime Runtime, host *composite.Host, consensus consensus.Service) protocol.Notifier {
 	logger := logging.GetLogger("runtime/registry/notifier").With("runtime_id", runtime.ID())
 
 	return &runtimeHostNotifier{

--- a/go/runtime/registry/notifier.go
+++ b/go/runtime/registry/notifier.go
@@ -453,7 +453,7 @@ func (n *runtimeHostNotifier) updateKeyManagerQuotePolicy(policy *quote.Policy) 
 }
 
 func (n *runtimeHostNotifier) watchConsensusLightBlocks(ctx context.Context) {
-	rawCh, sub, err := n.consensus.WatchBlocks(ctx)
+	rawCh, sub, err := n.consensus.Core().WatchBlocks(ctx)
 	if err != nil {
 		n.logger.Error("failed to subscribe to consensus block updates",
 			"err", err,

--- a/go/runtime/registry/registry.go
+++ b/go/runtime/registry/registry.go
@@ -125,7 +125,7 @@ type runtime struct { // nolint: maligned
 	activeDescriptorHash hash.Hash
 	managed              bool
 
-	consensus    consensus.Backend
+	consensus    consensus.Service
 	storage      storageAPI.Backend
 	localStorage localstorage.LocalStorage
 
@@ -146,7 +146,7 @@ func newRuntime(
 	runtimeID common.Namespace,
 	managed bool,
 	dataDir string,
-	consensus consensus.Backend,
+	consensus consensus.Service,
 	bundleRegistry *bundle.Registry,
 	bundleManager *bundle.Manager,
 ) (*runtime, error) {
@@ -474,7 +474,7 @@ type runtimeRegistry struct {
 
 	dataDir string
 
-	consensus consensus.Backend
+	consensus consensus.Service
 	client    runtimeClient.RuntimeClient
 
 	runtimes map[common.Namespace]*runtime
@@ -695,7 +695,7 @@ func (r *runtimeRegistry) Init(runtimeIDs []common.Namespace) error {
 // New creates a new runtime registry.
 func New(
 	dataDir string,
-	consensus consensus.Backend,
+	consensus consensus.Service,
 ) (Registry, error) {
 	// Get configured runtime IDs.
 	runtimeIDs, err := getConfiguredRuntimeIDs()

--- a/go/scheduler/tests/tester.go
+++ b/go/scheduler/tests/tester.go
@@ -23,7 +23,7 @@ const recvTimeout = 5 * time.Second
 
 // SchedulerImplementationTests exercises the basic functionality of a
 // scheduler backend.
-func SchedulerImplementationTests(t *testing.T, name string, identity *identity.Identity, backend api.Backend, consensus consensusAPI.Service) {
+func SchedulerImplementationTests(t *testing.T, name string, identity *identity.Identity, scheduler api.Backend, consensus consensusAPI.Service) {
 	ctx := context.Background()
 	seed := []byte("SchedulerImplementationTests/" + name)
 
@@ -36,10 +36,10 @@ func SchedulerImplementationTests(t *testing.T, name string, identity *identity.
 	nodes := rt.Populate(t, consensus.Registry(), consensus, seed)
 
 	// Query genesis parameters.
-	_, err = backend.ConsensusParameters(ctx, consensusAPI.HeightLatest)
+	_, err = scheduler.ConsensusParameters(ctx, consensusAPI.HeightLatest)
 	require.NoError(err, "ConsensusParameters")
 
-	ch, sub, err := backend.WatchCommittees(ctx)
+	ch, sub, err := scheduler.WatchCommittees(ctx)
 	require.NoError(err, "WatchCommittees")
 	defer sub.Close()
 
@@ -77,7 +77,7 @@ func SchedulerImplementationTests(t *testing.T, name string, identity *identity.
 		}
 
 		var committees []*api.Committee
-		committees, err = backend.GetCommittees(context.Background(), &api.GetCommitteesRequest{
+		committees, err = scheduler.GetCommittees(context.Background(), &api.GetCommitteesRequest{
 			RuntimeID: rt.Runtime.ID,
 			Height:    consensusAPI.HeightLatest,
 		})
@@ -119,7 +119,7 @@ func SchedulerImplementationTests(t *testing.T, name string, identity *identity.
 	// Cleanup the registry.
 	rt.Cleanup(t, consensus.Registry(), consensus)
 
-	validators, err := backend.GetValidators(context.Background(), consensusAPI.HeightLatest)
+	validators, err := scheduler.GetValidators(context.Background(), consensusAPI.HeightLatest)
 	require.NoError(err, "GetValidators")
 
 	require.Len(validators, 1, "should be only one validator")

--- a/go/scheduler/tests/tester.go
+++ b/go/scheduler/tests/tester.go
@@ -23,7 +23,7 @@ const recvTimeout = 5 * time.Second
 
 // SchedulerImplementationTests exercises the basic functionality of a
 // scheduler backend.
-func SchedulerImplementationTests(t *testing.T, name string, identity *identity.Identity, backend api.Backend, consensus consensusAPI.Backend) {
+func SchedulerImplementationTests(t *testing.T, name string, identity *identity.Identity, backend api.Backend, consensus consensusAPI.Service) {
 	ctx := context.Background()
 	seed := []byte("SchedulerImplementationTests/" + name)
 

--- a/go/sentry/sentry.go
+++ b/go/sentry/sentry.go
@@ -19,7 +19,7 @@ type backend struct {
 
 	logger *logging.Logger
 
-	consensus consensus.Backend
+	consensus consensus.Service
 	identity  *identity.Identity
 }
 
@@ -40,16 +40,16 @@ func (b *backend) GetAddresses(context.Context) (*api.SentryAddresses, error) {
 
 // New constructs a new sentry backend instance.
 func New(
-	consensusBackend consensus.Backend,
+	consensus consensus.Service,
 	identity *identity.Identity,
 ) (api.Backend, error) {
-	if consensusBackend == nil {
+	if consensus == nil {
 		return nil, fmt.Errorf("sentry: consensus backend is nil")
 	}
 
 	b := &backend{
 		logger:    logging.GetLogger("sentry"),
-		consensus: consensusBackend,
+		consensus: consensus,
 		identity:  identity,
 	}
 

--- a/go/staking/tests/tester.go
+++ b/go/staking/tests/tester.go
@@ -138,13 +138,13 @@ var (
 func StakingImplementationTests(
 	t *testing.T,
 	backend api.Backend,
-	consensus consensusAPI.Backend,
+	consensus consensusAPI.Service,
 	identity *identity.Identity,
 	entity *entity.Entity,
 ) {
 	for _, tc := range []struct {
 		n  string
-		fn func(*testing.T, *stakingTestsState, api.Backend, consensusAPI.Backend)
+		fn func(*testing.T, *stakingTestsState, api.Backend, consensusAPI.Service)
 	}{
 		{"Thresholds", testThresholds},
 		{"CommonPool", testCommonPool},
@@ -171,10 +171,10 @@ func StakingImplementationTests(
 
 // StakingClientImplementationTests exercises the basic functionality of a
 // staking client backend.
-func StakingClientImplementationTests(t *testing.T, backend api.Backend, consensus consensusAPI.Backend) {
+func StakingClientImplementationTests(t *testing.T, backend api.Backend, consensus consensusAPI.Service) {
 	for _, tc := range []struct {
 		n  string
-		fn func(*testing.T, *stakingTestsState, api.Backend, consensusAPI.Backend)
+		fn func(*testing.T, *stakingTestsState, api.Backend, consensusAPI.Service)
 	}{
 		{"Thresholds", testThresholds},
 		{"LastBlockFees", testLastBlockFees},
@@ -191,7 +191,7 @@ func StakingClientImplementationTests(t *testing.T, backend api.Backend, consens
 	}
 }
 
-func testThresholds(t *testing.T, _ *stakingTestsState, backend api.Backend, _ consensusAPI.Backend) {
+func testThresholds(t *testing.T, _ *stakingTestsState, backend api.Backend, _ consensusAPI.Service) {
 	require := require.New(t)
 
 	for _, kind := range []api.ThresholdKind{
@@ -209,7 +209,7 @@ func testThresholds(t *testing.T, _ *stakingTestsState, backend api.Backend, _ c
 	}
 }
 
-func testCommonPool(t *testing.T, _ *stakingTestsState, backend api.Backend, _ consensusAPI.Backend) {
+func testCommonPool(t *testing.T, _ *stakingTestsState, backend api.Backend, _ consensusAPI.Service) {
 	require := require.New(t)
 
 	commonPool, err := backend.CommonPool(context.Background(), consensusAPI.HeightLatest)
@@ -220,7 +220,7 @@ func testCommonPool(t *testing.T, _ *stakingTestsState, backend api.Backend, _ c
 	require.EqualValues(commonPool, &commonPoolAcc.General.Balance, "CommonPool Account - initial value should match")
 }
 
-func testLastBlockFees(t *testing.T, _ *stakingTestsState, backend api.Backend, _ consensusAPI.Backend) {
+func testLastBlockFees(t *testing.T, _ *stakingTestsState, backend api.Backend, _ consensusAPI.Service) {
 	require := require.New(t)
 
 	lastBlockFees, err := backend.LastBlockFees(context.Background(), consensusAPI.HeightLatest)
@@ -232,7 +232,7 @@ func testLastBlockFees(t *testing.T, _ *stakingTestsState, backend api.Backend, 
 	require.True(lastBlockFeesAcc.General.Balance.IsZero(), "LastBlockFees Account - initial value")
 }
 
-func testGovernanceDeposits(t *testing.T, _ *stakingTestsState, backend api.Backend, _ consensusAPI.Backend) {
+func testGovernanceDeposits(t *testing.T, _ *stakingTestsState, backend api.Backend, _ consensusAPI.Service) {
 	require := require.New(t)
 
 	governanceDeposits, err := backend.GovernanceDeposits(context.Background(), consensusAPI.HeightLatest)
@@ -244,7 +244,7 @@ func testGovernanceDeposits(t *testing.T, _ *stakingTestsState, backend api.Back
 	require.True(governanceDepositsAcc.General.Balance.IsZero(), "GovernaceDeposits Account - initial value")
 }
 
-func testDelegations(t *testing.T, state *stakingTestsState, backend api.Backend, _ consensusAPI.Backend) {
+func testDelegations(t *testing.T, state *stakingTestsState, backend api.Backend, _ consensusAPI.Service) {
 	require := require.New(t)
 
 	accts := state.accounts
@@ -452,11 +452,11 @@ func testDelegations(t *testing.T, state *stakingTestsState, backend api.Backend
 	}
 }
 
-func testTransfer(t *testing.T, state *stakingTestsState, backend api.Backend, consensus consensusAPI.Backend) {
+func testTransfer(t *testing.T, state *stakingTestsState, backend api.Backend, consensus consensusAPI.Service) {
 	testTransferHelper(t, state, backend, consensus, state.accounts.getAccount(1), state.accounts.getAccount(2))
 }
 
-func testSelfTransfer(t *testing.T, state *stakingTestsState, backend api.Backend, consensus consensusAPI.Backend) {
+func testSelfTransfer(t *testing.T, state *stakingTestsState, backend api.Backend, consensus consensusAPI.Service) {
 	testTransferHelper(t, state, backend, consensus, state.accounts.getAccount(1), state.accounts.getAccount(1))
 }
 
@@ -464,7 +464,7 @@ func testTransferHelper(
 	t *testing.T,
 	_ *stakingTestsState,
 	backend api.Backend,
-	consensus consensusAPI.Backend,
+	consensus consensusAPI.Service,
 	srcAccData, destAccData accountData,
 ) {
 	require := require.New(t)
@@ -563,7 +563,7 @@ TransferWaitLoop:
 	require.Error(err, "Transfer - more than available balance")
 }
 
-func testBurn(t *testing.T, state *stakingTestsState, backend api.Backend, consensus consensusAPI.Backend) {
+func testBurn(t *testing.T, state *stakingTestsState, backend api.Backend, consensus consensusAPI.Service) {
 	require := require.New(t)
 
 	accData := state.accounts.getAccount(1)
@@ -695,11 +695,11 @@ func testBurn(t *testing.T, state *stakingTestsState, backend api.Backend, conse
 	)
 }
 
-func testEscrow(t *testing.T, state *stakingTestsState, backend api.Backend, consensus consensusAPI.Backend) {
+func testEscrow(t *testing.T, state *stakingTestsState, backend api.Backend, consensus consensusAPI.Service) {
 	testEscrowHelper(t, state, backend, consensus, state.accounts.getAccount(1), state.accounts.getAccount(2))
 }
 
-func testSelfEscrow(t *testing.T, state *stakingTestsState, backend api.Backend, consensus consensusAPI.Backend) {
+func testSelfEscrow(t *testing.T, state *stakingTestsState, backend api.Backend, consensus consensusAPI.Service) {
 	testEscrowHelper(t, state, backend, consensus, state.accounts.getAccount(1), state.accounts.getAccount(1))
 }
 
@@ -707,7 +707,7 @@ func testEscrowHelper( // nolint: gocyclo
 	t *testing.T,
 	_ *stakingTestsState,
 	backend api.Backend,
-	consensus consensusAPI.Backend,
+	consensus consensusAPI.Service,
 	srcAccData, destAccData accountData,
 ) {
 	require := require.New(t)
@@ -1028,7 +1028,7 @@ func testEscrowHelper( // nolint: gocyclo
 	require.Error(err, "AddEscrow")
 }
 
-func testAllowance(t *testing.T, state *stakingTestsState, backend api.Backend, consensus consensusAPI.Backend) {
+func testAllowance(t *testing.T, state *stakingTestsState, backend api.Backend, consensus consensusAPI.Service) {
 	testAllowanceHelper(t, state, backend, consensus, state.accounts.getAccount(1), state.accounts.getAccount(2))
 }
 
@@ -1036,7 +1036,7 @@ func testAllowanceHelper(
 	t *testing.T,
 	_ *stakingTestsState,
 	backend api.Backend,
-	consensus consensusAPI.Backend,
+	consensus consensusAPI.Service,
 	srcAccData, destAccData accountData,
 ) {
 	require := require.New(t)
@@ -1178,7 +1178,7 @@ func testSlashConsensusEquivocation(
 	t *testing.T,
 	state *stakingTestsState,
 	backend api.Backend,
-	consensus consensusAPI.Backend,
+	consensus consensusAPI.Service,
 	ident *identity.Identity,
 	ent *entity.Entity,
 ) {

--- a/go/vault/tests/tester.go
+++ b/go/vault/tests/tester.go
@@ -31,7 +31,7 @@ type vaultTestState struct {
 // VaultImplementationTests exercises the basic functionality of a vault backend.
 func VaultImplementationTests(
 	t *testing.T,
-	backend api.Backend,
+	vault api.Backend,
 	consensus consensusAPI.Service,
 ) {
 	require := require.New(t)
@@ -39,7 +39,7 @@ func VaultImplementationTests(
 	testState := &vaultTestState{}
 
 	// Query state.
-	_, err := backend.StateToGenesis(ctx, consensusAPI.HeightLatest)
+	_, err := vault.StateToGenesis(ctx, consensusAPI.HeightLatest)
 	require.NoError(err, "StateToGenesis")
 
 	// Run multiple sub-tests.

--- a/go/vault/tests/tester.go
+++ b/go/vault/tests/tester.go
@@ -32,7 +32,7 @@ type vaultTestState struct {
 func VaultImplementationTests(
 	t *testing.T,
 	backend api.Backend,
-	consensus consensusAPI.Backend,
+	consensus consensusAPI.Service,
 ) {
 	require := require.New(t)
 	ctx := context.Background()
@@ -45,7 +45,7 @@ func VaultImplementationTests(
 	// Run multiple sub-tests.
 	for _, tc := range []struct {
 		n  string
-		fn func(*testing.T, consensusAPI.Backend, *vaultTestState)
+		fn func(*testing.T, consensusAPI.Service, *vaultTestState)
 	}{
 		{"TestVaultCreate", testVaultCreate},
 		{"TestVaultAuthorizeAction", testVaultAuthorizeAction},
@@ -56,7 +56,7 @@ func VaultImplementationTests(
 	}
 }
 
-func testVaultCreate(t *testing.T, consensus consensusAPI.Backend, testState *vaultTestState) {
+func testVaultCreate(t *testing.T, consensus consensusAPI.Service, testState *vaultTestState) {
 	require := require.New(t)
 	ctx := context.Background()
 
@@ -99,7 +99,7 @@ func testVaultCreate(t *testing.T, consensus consensusAPI.Backend, testState *va
 	require.NoError(err, "TransferTx to vault")
 }
 
-func testVaultAuthorizeAction(t *testing.T, consensus consensusAPI.Backend, testState *vaultTestState) {
+func testVaultAuthorizeAction(t *testing.T, consensus consensusAPI.Service, testState *vaultTestState) {
 	require := require.New(t)
 	ctx := context.Background()
 
@@ -126,7 +126,7 @@ func testVaultAuthorizeAction(t *testing.T, consensus consensusAPI.Backend, test
 	require.NoError(err, "AuthorizeActionTx")
 }
 
-func testVaultWithdraw(t *testing.T, consensus consensusAPI.Backend, testState *vaultTestState) {
+func testVaultWithdraw(t *testing.T, consensus consensusAPI.Service, testState *vaultTestState) {
 	require := require.New(t)
 	ctx := context.Background()
 
@@ -149,7 +149,7 @@ func testVaultWithdraw(t *testing.T, consensus consensusAPI.Backend, testState *
 	require.ErrorIs(err, staking.ErrForbidden, "Withdraw")
 }
 
-func testVaultExecuteMessage(t *testing.T, consensus consensusAPI.Backend, testState *vaultTestState) {
+func testVaultExecuteMessage(t *testing.T, consensus consensusAPI.Service, testState *vaultTestState) {
 	require := require.New(t)
 	ctx := context.Background()
 

--- a/go/worker/beacon/tx_retry.go
+++ b/go/worker/beacon/tx_retry.go
@@ -18,7 +18,7 @@ type txRetry struct {
 
 	logger *logging.Logger
 
-	consensus consensus.Backend
+	consensus consensus.Service
 	identity  *identity.Identity
 
 	cancelFn context.CancelFunc
@@ -89,7 +89,7 @@ func (rtr *txRetry) SubmitTx(
 
 func newTxRetry(
 	logger *logging.Logger,
-	consensus consensus.Backend,
+	consensus consensus.Service,
 	identity *identity.Identity,
 ) *txRetry {
 	return &txRetry{

--- a/go/worker/beacon/worker.go
+++ b/go/worker/beacon/worker.go
@@ -20,7 +20,7 @@ type Worker struct {
 	ctx context.Context
 
 	identity  *identity.Identity
-	consensus consensus.Backend
+	consensus consensus.Service
 
 	allQuitCh chan struct{}
 	allQuitWg sync.WaitGroup
@@ -59,7 +59,7 @@ func (w *Worker) Name() string {
 // New creates a new worker instance.
 func New(
 	identity *identity.Identity,
-	consensus consensus.Backend,
+	consensus consensus.Service,
 	registrationWorker *registration.Worker,
 ) (*Worker, error) {
 	var (

--- a/go/worker/beacon/worker_vrf.go
+++ b/go/worker/beacon/worker_vrf.go
@@ -76,7 +76,7 @@ func (w *vrfWorker) worker() {
 	defer eventSub.Close()
 
 	// Subscribe to block height events.
-	blockCh, blockSub, err := w.parent.consensus.WatchBlocks(w.parent.ctx)
+	blockCh, blockSub, err := w.parent.consensus.Core().WatchBlocks(w.parent.ctx)
 	if err != nil {
 		w.logger.Error("failed to subscribe to block events",
 			"err", err,
@@ -110,7 +110,7 @@ func (w *vrfWorker) worker() {
 		}
 
 		// Re-query the current block height.
-		blk, err := w.parent.consensus.GetBlock(w.parent.ctx, consensus.HeightLatest)
+		blk, err := w.parent.consensus.Core().GetBlock(w.parent.ctx, consensus.HeightLatest)
 		if err != nil {
 			w.logger.Error("failed to query latest block",
 				"err", err,

--- a/go/worker/client/committee/node.go
+++ b/go/worker/client/committee/node.go
@@ -191,7 +191,7 @@ func (n *Node) Query(ctx context.Context, round uint64, method string, args []by
 		return nil, fmt.Errorf("client: failed to fetch annotated block from history: %w", err)
 	}
 
-	lb, err := n.commonNode.Consensus.GetLightBlock(ctx, annBlk.Height)
+	lb, err := n.commonNode.Consensus.Core().GetLightBlock(ctx, annBlk.Height)
 	if err != nil {
 		return nil, fmt.Errorf("client: failed to get light block at height %d: %w", annBlk.Height, err)
 	}

--- a/go/worker/common/committee/group.go
+++ b/go/worker/common/committee/group.go
@@ -152,7 +152,7 @@ type Group struct {
 	runtimeID common.Namespace
 	identity  *identity.Identity
 
-	consensus consensus.Backend
+	consensus consensus.Service
 
 	activeEpoch *epoch
 	// nodes is a node descriptor watcher for all nodes that are part of any of our committees.
@@ -309,7 +309,7 @@ func NewGroup(
 	ctx context.Context,
 	runtimeID common.Namespace,
 	identity *identity.Identity,
-	consensus consensus.Backend,
+	consensus consensus.Service,
 ) (*Group, error) {
 	nw, err := nodes.NewVersionedNodeDescriptorWatcher(ctx, consensus)
 	if err != nil {

--- a/go/worker/common/committee/keymanager.go
+++ b/go/worker/common/committee/keymanager.go
@@ -43,7 +43,7 @@ type KeyManagerClientWrapper struct {
 
 	id           *common.Namespace
 	p2p          p2p.Service
-	consensus    consensus.Backend
+	consensus    consensus.Service
 	chainContext string
 	cli          keymanagerP2P.Client
 	nt           *nodeTracker
@@ -271,7 +271,7 @@ func (km *KeyManagerClientWrapper) getKeyManagerClient() (keymanagerP2P.Client, 
 }
 
 // NewKeyManagerClientWrapper creates a new key manager client wrapper.
-func NewKeyManagerClientWrapper(p2p p2p.Service, consensus consensus.Backend, chainContext string, logger *logging.Logger) *KeyManagerClientWrapper {
+func NewKeyManagerClientWrapper(p2p p2p.Service, consensus consensus.Service, chainContext string, logger *logging.Logger) *KeyManagerClientWrapper {
 	return &KeyManagerClientWrapper{
 		p2p:           p2p,
 		consensus:     consensus,
@@ -285,7 +285,7 @@ type nodeTracker struct {
 	sync.Mutex
 
 	p2p          p2p.Service
-	consensus    consensus.Backend
+	consensus    consensus.Service
 	keymanagerID common.Namespace
 
 	nodes map[signature.PublicKey]core.PeerID
@@ -424,7 +424,7 @@ func (nt *nodeTracker) trackKeymanagerNodes(ctx context.Context) {
 
 // newKeyManagerNodeTracker creates a new tracker that is responsible for keeping the list
 // of key manager nodes and their peer identities up-to-date.
-func newKeyManagerNodeTracker(p2p p2p.Service, consensus consensus.Backend, keymanagerID common.Namespace) *nodeTracker {
+func newKeyManagerNodeTracker(p2p p2p.Service, consensus consensus.Service, keymanagerID common.Namespace) *nodeTracker {
 	return &nodeTracker{
 		p2p:          p2p,
 		consensus:    consensus,

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -154,7 +154,7 @@ type Node struct {
 	Identity         *identity.Identity
 	KeyManager       keymanager.Backend
 	KeyManagerClient *KeyManagerClientWrapper
-	Consensus        consensus.Backend
+	Consensus        consensus.Service
 	LightProvider    consensus.LightProvider
 	Group            *Group
 	P2P              p2pAPI.Service
@@ -872,7 +872,7 @@ func NewNode(
 	rtRegistry runtimeRegistry.Registry,
 	identity *identity.Identity,
 	keymanager keymanager.Backend,
-	consensus consensus.Backend,
+	consensus consensus.Service,
 	lightProvider consensus.LightProvider,
 	p2pHost p2pAPI.Service,
 	txPoolCfg tpConfig.Config,

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -470,7 +470,7 @@ func (n *Node) handleNewBlockLocked(blk *block.Block, height int64) {
 	firstBlockReceived := n.CurrentBlock == nil
 
 	// Fetch light consensus block.
-	consensusBlk, err := n.Consensus.GetLightBlock(n.ctx, height)
+	consensusBlk, err := n.Consensus.Core().GetLightBlock(n.ctx, height)
 	if err != nil {
 		n.logger.Error("failed to query light block",
 			"err", err,
@@ -916,7 +916,7 @@ func NewNode(
 	n.KeyManagerClient = NewKeyManagerClientWrapper(p2pHost, consensus, chainContext, n.logger)
 
 	// Prepare the runtime host handler.
-	handler := runtimeRegistry.NewRuntimeHostHandler(&nodeEnvironment{n}, n.Runtime, n.Consensus)
+	handler := runtimeRegistry.NewRuntimeHostHandler(&nodeEnvironment{n}, n.Runtime, consensus)
 
 	// Prepare the runtime host node helpers.
 	rhn, err := runtimeRegistry.NewRuntimeHostNode(runtime, provisioner, handler)

--- a/go/worker/common/worker.go
+++ b/go/worker/common/worker.go
@@ -25,7 +25,7 @@ type Worker struct {
 	DataDir         string
 	ChainContext    string
 	Identity        *identity.Identity
-	Consensus       consensus.Backend
+	Consensus       consensus.Service
 	LightProvider   consensus.LightProvider
 	P2P             p2p.Service
 	KeyManager      keymanagerApi.Backend
@@ -185,7 +185,7 @@ func New(
 	dataDir string,
 	chainContext string,
 	identity *identity.Identity,
-	consensus consensus.Backend,
+	consensus consensus.Service,
 	lightProvider consensus.LightProvider,
 	p2p p2p.Service,
 	keyManager keymanagerApi.Backend,

--- a/go/worker/compute/executor/committee/trust.go
+++ b/go/worker/compute/executor/committee/trust.go
@@ -20,7 +20,7 @@ func (n *Node) startRuntimeTrustSyncLocked(rt host.RichRuntime) {
 	ctx, n.runtimeTrustSyncCncl = context.WithCancel(n.ctx)
 
 	syncOp := func() error {
-		height, err := n.commonNode.Consensus.GetLatestHeight(ctx)
+		height, err := n.commonNode.Consensus.Core().GetLatestHeight(ctx)
 		if err != nil {
 			n.logger.Warn("failed to retrieve latest consensus block height for runtime light client sync",
 				"err", err,

--- a/go/worker/compute/executor/tests/tester.go
+++ b/go/worker/compute/executor/tests/tester.go
@@ -36,7 +36,7 @@ func WorkerImplementationTests(
 	runtimeID common.Namespace,
 	commonNode *commonCommittee.Node,
 	rtNode *committee.Node,
-	backend consensus.Backend,
+	consensus consensus.Service,
 	storage storage.Backend,
 ) {
 	// Wait for worker to start and register.
@@ -48,19 +48,19 @@ func WorkerImplementationTests(
 
 	// Run the various test cases. (Ordering matters.)
 	t.Run("InitialEpochTransition", func(t *testing.T) {
-		testInitialEpochTransition(t, stateCh, backend)
+		testInitialEpochTransition(t, stateCh, consensus)
 	})
 
 	t.Run("QueueTx", func(t *testing.T) {
-		testQueueTx(t, runtimeID, stateCh, commonNode, rtNode, backend.RootHash(), storage)
+		testQueueTx(t, runtimeID, stateCh, commonNode, rtNode, consensus.RootHash(), storage)
 	})
 
 	// TODO: Add more tests.
 }
 
-func testInitialEpochTransition(t *testing.T, stateCh <-chan committee.NodeState, backend consensus.Backend) {
+func testInitialEpochTransition(t *testing.T, stateCh <-chan committee.NodeState, consensus consensus.Service) {
 	// Perform an epoch transition, so that the node gets elected leader.
-	beaconTests.MustAdvanceEpoch(t, backend)
+	beaconTests.MustAdvanceEpoch(t, consensus)
 
 	// Node should transition to WaitingForBatch state.
 	waitForNodeTransition(t, stateCh, committee.WaitingForBatch)

--- a/go/worker/keymanager/churp.go
+++ b/go/worker/keymanager/churp.go
@@ -228,7 +228,7 @@ func (w *churpWorker) work(ctx context.Context, _ host.Runtime) {
 		"node_id", w.kmWorker.nodeID,
 	)
 
-	stCh, stSub, err := w.kmWorker.backend.Churp().WatchStatuses(ctx)
+	stCh, stSub, err := w.kmWorker.keymanager.Churp().WatchStatuses(ctx)
 	if err != nil {
 		w.logger.Error("failed to watch statuses",
 			"err", err,
@@ -246,7 +246,7 @@ func (w *churpWorker) work(ctx context.Context, _ host.Runtime) {
 	}
 	defer epoSub.Close()
 
-	blkCh, blkSub, err := w.kmWorker.commonWorker.Consensus.WatchBlocks(ctx)
+	blkCh, blkSub, err := w.kmWorker.commonWorker.Consensus.Core().WatchBlocks(ctx)
 	if err != nil {
 		w.logger.Error("failed to watch blocks",
 			"err", err,

--- a/go/worker/keymanager/init.go
+++ b/go/worker/keymanager/init.go
@@ -22,7 +22,7 @@ import (
 func New(
 	commonWorker *workerCommon.Worker,
 	r *registration.Worker,
-	backend api.Backend,
+	keymanager api.Backend,
 	provisioner host.Provisioner,
 ) (*Worker, error) {
 	var enabled bool
@@ -46,7 +46,7 @@ func New(
 		peerMap:      NewPeerMap(),
 		accessList:   NewAccessList(),
 		commonWorker: commonWorker,
-		backend:      backend,
+		keymanager:   keymanager,
 		enabled:      enabled,
 	}
 
@@ -94,7 +94,7 @@ func New(
 	w.kmRuntimeWatcher = newKmRuntimeWatcher(w.runtimeID, commonWorker.Consensus, w.accessList)
 
 	// Prepare sub-workers.
-	w.secretsWorker, err = newSecretsWorker(w.runtimeID, commonWorker, w, r, backend)
+	w.secretsWorker, err = newSecretsWorker(w.runtimeID, commonWorker, w, r, keymanager)
 	if err != nil {
 		return nil, fmt.Errorf("worker/keymanager: failed to create secrets worker: %w", err)
 	}

--- a/go/worker/keymanager/watcher.go
+++ b/go/worker/keymanager/watcher.go
@@ -23,7 +23,7 @@ import (
 // key manager runtime, ensuring it remains up-to-date.
 type kmNodeWatcher struct {
 	runtimeID common.Namespace
-	consensus consensus.Backend
+	consensus consensus.Service
 
 	peerMap    *PeerMap
 	accessList *AccessList
@@ -32,7 +32,7 @@ type kmNodeWatcher struct {
 	logger *logging.Logger
 }
 
-func newKmNodeWatcher(runtimeID common.Namespace, consensus consensus.Backend, peerMap *PeerMap, accessList *AccessList, peerTagger p2p.PeerTagger) *kmNodeWatcher {
+func newKmNodeWatcher(runtimeID common.Namespace, consensus consensus.Service, peerMap *PeerMap, accessList *AccessList, peerTagger p2p.PeerTagger) *kmNodeWatcher {
 	logger := logging.GetLogger("worker/keymanager/watcher/km")
 
 	return &kmNodeWatcher{
@@ -147,7 +147,7 @@ type kmRuntimeWatcher struct {
 	mu sync.RWMutex
 
 	runtimeID common.Namespace
-	consensus consensus.Backend
+	consensus consensus.Service
 
 	accessList *AccessList
 
@@ -156,7 +156,7 @@ type kmRuntimeWatcher struct {
 	logger *logging.Logger
 }
 
-func newKmRuntimeWatcher(runtimeID common.Namespace, consensus consensus.Backend, accessList *AccessList) *kmRuntimeWatcher {
+func newKmRuntimeWatcher(runtimeID common.Namespace, consensus consensus.Service, accessList *AccessList) *kmRuntimeWatcher {
 	logger := logging.GetLogger("worker/keymanager/watcher/rts")
 
 	return &kmRuntimeWatcher{
@@ -251,14 +251,14 @@ func (w *kmRuntimeWatcher) Runtimes() []common.Namespace {
 // the access list for the specified runtime, ensuring it remains up-to-date.
 type rtNodeWatcher struct {
 	runtimeID common.Namespace
-	consensus consensus.Backend
+	consensus consensus.Service
 
 	accessList *AccessList
 
 	logger *logging.Logger
 }
 
-func newRtNodeWatcher(runtimeID common.Namespace, consensus consensus.Backend, accessList *AccessList) *rtNodeWatcher {
+func newRtNodeWatcher(runtimeID common.Namespace, consensus consensus.Service, accessList *AccessList) *rtNodeWatcher {
 	logger := logging.GetLogger("worker/keymanager/watcher/rt").With("runtime_id", runtimeID)
 
 	return &rtNodeWatcher{

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -76,7 +76,7 @@ type Worker struct { // nolint: maligned
 
 	commonWorker     *workerCommon.Worker
 	roleProvider     registration.RoleProvider
-	backend          api.Backend
+	keymanager       api.Backend
 	notifier         protocol.Notifier
 	keyManagerClient *commonCommittee.KeyManagerClientWrapper
 

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -265,7 +265,7 @@ func (w *Worker) registrationLoop() { // nolint: gocyclo
 			blockSub pubsub.ClosableSubscription
 			err      error
 		)
-		blockCh, blockSub, err = w.consensus.WatchBlocks(w.ctx)
+		blockCh, blockSub, err = w.consensus.Core().WatchBlocks(w.ctx)
 		switch err {
 		case nil:
 			defer blockSub.Close()

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -204,7 +204,7 @@ type Worker struct { // nolint: maligned
 	stopRegCh    chan struct{} // closed internally to trigger clean registration lapse
 
 	logger    *logging.Logger
-	consensus consensus.Backend
+	consensus consensus.Service
 
 	roleProviders []*roleProvider
 	registerCh    chan struct{}
@@ -1058,7 +1058,7 @@ func New(
 	beacon beacon.Backend,
 	registry registry.Backend,
 	identity *identity.Identity,
-	consensus consensus.Backend,
+	consensus consensus.Service,
 	p2p p2p.Service,
 	workerCommonCfg *workerCommon.Config,
 	store *persistent.CommonStore,

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -726,7 +726,7 @@ func (w *Worker) GetRegistrationStatus(ctx context.Context) (*control.Registrati
 	*status = w.status
 	w.RUnlock()
 
-	if status == nil || status.Descriptor == nil {
+	if status.Descriptor == nil {
 		return status, nil
 	}
 

--- a/go/worker/sentry/worker.go
+++ b/go/worker/sentry/worker.go
@@ -22,7 +22,7 @@ func Enabled() bool {
 type Worker struct {
 	enabled bool
 
-	backend api.Backend
+	sentry api.Backend
 
 	grpcServer *grpc.Server
 
@@ -93,10 +93,10 @@ func (w *Worker) Cleanup() {
 }
 
 // New creates a new sentry worker.
-func New(backend api.Backend, identity *identity.Identity) (*Worker, error) {
+func New(sentry api.Backend, identity *identity.Identity) (*Worker, error) {
 	w := &Worker{
 		enabled: Enabled(),
-		backend: backend,
+		sentry:  sentry,
 		quitCh:  make(chan struct{}),
 		logger:  logging.GetLogger("worker/sentry"),
 	}
@@ -121,7 +121,7 @@ func New(backend api.Backend, identity *identity.Identity) (*Worker, error) {
 		}
 		w.grpcServer = grpcServer
 		// Initialize and register the sentry gRPC service.
-		api.RegisterService(w.grpcServer.Server(), backend)
+		api.RegisterService(w.grpcServer.Server(), sentry)
 	}
 
 	return w, nil

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -602,7 +602,7 @@ func (n *Node) consensusCheckpointSyncer() {
 	}
 
 	// Determine the maximum number of consensus checkpoints to keep.
-	consensusParams, err := n.commonNode.Consensus.GetParameters(n.ctx, consensus.HeightLatest)
+	consensusParams, err := n.commonNode.Consensus.Core().GetParameters(n.ctx, consensus.HeightLatest)
 	if err != nil {
 		n.logger.Error("failed to fetch consensus parameters",
 			"err", err,
@@ -652,7 +652,7 @@ func (n *Node) consensusCheckpointSyncer() {
 			)
 
 			if blkCh == nil {
-				blkCh, blkSub, err = n.commonNode.Consensus.WatchBlocks(n.ctx)
+				blkCh, blkSub, err = n.commonNode.Consensus.Core().WatchBlocks(n.ctx)
 				if err != nil {
 					n.logger.Error("failed to watch blocks",
 						"err", err,


### PR DESCRIPTION
I think it makes sense to remove consensus services from consensus backend, so that you can create the latter and get former for free, as services are currently implemented on top of the consensus backend.

The new interface that captures all backends would look like this:
```go
// Services are consensus services.
type Services interface {
	// Beacon returns the beacon backend.
	Beacon() beacon.Backend

	// Core returns the consensus core backend.
	Core() Backend

	// Governance returns the governance backend.
	Governance() governance.Backend

	// KeyManager returns the keymanager backend.
	KeyManager() keymanager.Backend

	// Registry returns the registry backend.
	Registry() registry.Backend

	// RootHash returns the roothash backend.
	RootHash() roothash.Backend

	// Scheduler returns the scheduler backend.
	Scheduler() scheduler.Backend

	// Staking returns the staking backend.
	Staking() staking.Backend

	// Vault returns the vault backend.
	Vault() vault.Backend
}

func TestSampleUsage() {
	var consensus consensus.Services // or consensus.Service
	staking := backend.Staking()
}
```
