### PR TITLE
go/consensus/api: Add method GetBlockResults

### DIFF
--- a/.changelog/6180.feature.md
+++ b/.changelog/6180.feature.md
@@ -1,0 +1,4 @@
+go/consensus/api: Add method GetBlockResults
+
+A new method has been added to the consensus backend that returns block
+results for a specified height.

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -135,6 +135,9 @@ type Backend interface {
 	// GetBlock returns a consensus block at a specific height.
 	GetBlock(ctx context.Context, height int64) (*Block, error)
 
+	// GetBlockResults returns the consensus block results at a specific height.
+	GetBlockResults(ctx context.Context, height int64) (*BlockResults, error)
+
 	// GetLightBlock returns a light version of the consensus layer block that can be used for light
 	// client verification.
 	GetLightBlock(ctx context.Context, height int64) (*LightBlock, error)
@@ -241,6 +244,17 @@ type Block struct {
 	// Size is the size of the block in bytes.
 	Size uint64 `json:"size,omitempty"`
 	// Meta contains the consensus backend specific block metadata.
+	Meta cbor.RawMessage `json:"meta"`
+}
+
+// BlockResults are consensus block results.
+//
+// While some common fields are provided, most of the structure is dependent on
+// the actual backend implementation.
+type BlockResults struct {
+	// Height contains the block height.
+	Height int64 `json:"height"`
+	// Meta contains the consensus backend specific block results metadata.
 	Meta cbor.RawMessage `json:"meta"`
 }
 

--- a/go/consensus/cometbft/api/api.go
+++ b/go/consensus/cometbft/api/api.go
@@ -12,7 +12,6 @@ import (
 	cmtp2p "github.com/cometbft/cometbft/p2p"
 	cmtcrypto "github.com/cometbft/cometbft/proto/tendermint/crypto"
 	cmtcoretypes "github.com/cometbft/cometbft/rpc/core/types"
-	cmtrpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	cmttypes "github.com/cometbft/cometbft/types"
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
@@ -240,7 +239,7 @@ type Backend interface {
 
 	// GetCometBFTBlockResults returns the ABCI results from processing a block
 	// at a specific height.
-	GetCometBFTBlockResults(ctx context.Context, height int64) (*cmtrpctypes.ResultBlockResults, error)
+	GetCometBFTBlockResults(ctx context.Context, height int64) (*cmtcoretypes.ResultBlockResults, error)
 
 	// WatchCometBFTBlocks returns a stream of CometBFT blocks as they are
 	// returned via the `EventDataNewBlock` query.
@@ -329,8 +328,8 @@ type ServiceClient interface {
 	// ServiceDescriptor returns the consensus service descriptor.
 	ServiceDescriptor() ServiceDescriptor
 
-	// DeliverBlock delivers a new block.
-	DeliverBlock(ctx context.Context, blk *cmttypes.Block) error
+	// DeliverHeight delivers a new block height.
+	DeliverHeight(ctx context.Context, height int64) error
 
 	// DeliverEvent delivers an event emitted by the consensus service.
 	DeliverEvent(ctx context.Context, height int64, tx cmttypes.Tx, ev *types.Event) error
@@ -340,8 +339,8 @@ type ServiceClient interface {
 // all the delivery methods. Implementations should override them as needed.
 type BaseServiceClient struct{}
 
-// DeliverBlock implements ServiceClient.
-func (bsc *BaseServiceClient) DeliverBlock(context.Context, *cmttypes.Block) error {
+// DeliverHeight implements ServiceClient.
+func (bsc *BaseServiceClient) DeliverHeight(context.Context, int64) error {
 	return nil
 }
 

--- a/go/consensus/cometbft/api/api.go
+++ b/go/consensus/cometbft/api/api.go
@@ -20,7 +20,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
-	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/events"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
@@ -228,22 +227,6 @@ func NewBlockResults(results *cmtcoretypes.ResultBlockResults) *consensus.BlockR
 		Height: results.Height,
 		Meta:   cbor.Marshal(meta),
 	}
-}
-
-// Backend is a CometBFT consensus backend.
-type Backend interface {
-	consensus.Backend
-
-	// GetCometBFTBlock returns the CometBFT block at the specified height.
-	GetCometBFTBlock(ctx context.Context, height int64) (*cmttypes.Block, error)
-
-	// GetCometBFTBlockResults returns the ABCI results from processing a block
-	// at a specific height.
-	GetCometBFTBlockResults(ctx context.Context, height int64) (*cmtcoretypes.ResultBlockResults, error)
-
-	// WatchCometBFTBlocks returns a stream of CometBFT blocks as they are
-	// returned via the `EventDataNewBlock` query.
-	WatchCometBFTBlocks() (<-chan *cmttypes.Block, *pubsub.Subscription, error)
 }
 
 // HaltHook is a function that gets called when consensus needs to halt for some reason.

--- a/go/consensus/cometbft/beacon/beacon.go
+++ b/go/consensus/cometbft/beacon/beacon.go
@@ -246,12 +246,12 @@ func (sc *ServiceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
 	return tmapi.NewStaticServiceDescriptor("beacon", app.EventType, []cmtpubsub.Query{app.QueryApp})
 }
 
-func (sc *ServiceClient) DeliverBlock(ctx context.Context, blk *cmttypes.Block) error {
+func (sc *ServiceClient) DeliverHeight(ctx context.Context, height int64) error {
 	if sc.initialNotify {
 		return nil
 	}
 
-	q, err := sc.querier.QueryAt(ctx, blk.Height)
+	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {
 		return fmt.Errorf("epochtime: failed to query state: %w", err)
 	}

--- a/go/consensus/cometbft/beacon/beacon.go
+++ b/go/consensus/cometbft/beacon/beacon.go
@@ -18,6 +18,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/events"
 	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/beacon"
@@ -33,7 +34,7 @@ type ServiceClient struct {
 
 	logger *logging.Logger
 
-	consensus tmapi.Backend
+	consensus consensus.Backend
 	querier   *app.QueryFactory
 
 	epochNotifier     *pubsub.Broker
@@ -53,7 +54,7 @@ type ServiceClient struct {
 }
 
 // New constructs a new CometBFT backed beacon service client.
-func New(baseEpoch beaconAPI.EpochTime, baseBlock int64, consensus tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
+func New(baseEpoch beaconAPI.EpochTime, baseBlock int64, consensus consensus.Backend, querier *app.QueryFactory) *ServiceClient {
 	return &ServiceClient{
 		logger:            logging.GetLogger("cometbft/beacon"),
 		consensus:         consensus,

--- a/go/consensus/cometbft/full/archive.go
+++ b/go/consensus/cometbft/full/archive.go
@@ -29,7 +29,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/consensus/cometbft/db"
 )
 
-var _ api.Backend = (*archiveService)(nil)
+var _ consensusAPI.Backend = (*archiveService)(nil)
 
 // ArchiveConfig contains configuration parameters for the archive node.
 type ArchiveConfig struct {

--- a/go/consensus/cometbft/full/archive.go
+++ b/go/consensus/cometbft/full/archive.go
@@ -256,16 +256,16 @@ func (srv *archiveService) serviceClientWorker(ctx context.Context, svc api.Serv
 	logger := srv.Logger.With("service", sd.Name())
 	logger.Info("starting command dispatcher")
 
-	latestBlock, err := srv.GetCometBFTBlock(ctx, consensusAPI.HeightLatest)
+	height, err := srv.GetLatestHeight(ctx)
 	if err != nil {
-		logger.Error("failed to fetch latest block",
+		logger.Error("failed to fetch latest height",
 			"err", err,
 		)
 		return
 	}
 
-	if err := svc.DeliverBlock(ctx, latestBlock); err != nil {
-		logger.Error("failed to deliver block to service client",
+	if err := svc.DeliverHeight(ctx, height); err != nil {
+		logger.Error("failed to deliver block height to service client",
 			"err", err,
 		)
 	}

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -573,12 +573,12 @@ func (n *commonNode) GetCometBFTBlockResults(ctx context.Context, height int64) 
 	if err != nil {
 		return nil, err
 	}
-	result, err := cmtcore.BlockResults(n.rpcCtx, &tmHeight)
+	results, err := cmtcore.BlockResults(n.rpcCtx, &tmHeight)
 	if err != nil {
 		return nil, fmt.Errorf("cometbft: block results query failed: %w", err)
 	}
 
-	return result, nil
+	return results, nil
 }
 
 // Implements consensusAPI.Backend.
@@ -592,6 +592,16 @@ func (n *commonNode) GetBlock(ctx context.Context, height int64) (*consensusAPI.
 	}
 
 	return api.NewBlock(blk), nil
+}
+
+// Implements consensusAPI.Backend.
+func (n *commonNode) GetBlockResults(ctx context.Context, height int64) (*consensusAPI.BlockResults, error) {
+	results, err := n.GetCometBFTBlockResults(ctx, height)
+	if err != nil {
+		return nil, err
+	}
+
+	return api.NewBlockResults(results), nil
 }
 
 // Implements consensusAPI.Backend.

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -147,7 +147,7 @@ type commonNode struct {
 	state     uint32
 	startedCh chan struct{}
 
-	parentNode api.Backend
+	parentNode consensusAPI.Backend
 }
 
 func (n *commonNode) initialized() bool {
@@ -540,7 +540,7 @@ func (n *commonNode) GetSignerNonce(ctx context.Context, req *consensusAPI.GetSi
 	return acct.General.Nonce, nil
 }
 
-// Implements consensusAPI.Backend.
+// GetCometBFTBlock returns the CometBFT block at the specified height.
 func (n *commonNode) GetCometBFTBlock(ctx context.Context, height int64) (*cmttypes.Block, error) {
 	if err := n.ensureStarted(ctx); err != nil {
 		return nil, err
@@ -563,7 +563,8 @@ func (n *commonNode) GetCometBFTBlock(ctx context.Context, height int64) (*cmtty
 	return result.Block, nil
 }
 
-// Implements consensusAPI.Backend.
+// GetCometBFTBlockResults returns the ABCI results from processing a block
+// at a specific height.
 func (n *commonNode) GetCometBFTBlockResults(ctx context.Context, height int64) (*cmtcoretypes.ResultBlockResults, error) {
 	if err := n.ensureStarted(ctx); err != nil {
 		return nil, err

--- a/go/consensus/cometbft/full/full.go
+++ b/go/consensus/cometbft/full/full.go
@@ -73,7 +73,7 @@ const (
 )
 
 var (
-	_ api.Backend = (*fullService)(nil)
+	_ consensusAPI.Backend = (*fullService)(nil)
 
 	labelCometBFT = prometheus.Labels{"backend": "cometbft"}
 )
@@ -531,7 +531,8 @@ func (t *fullService) WatchBlocks(ctx context.Context) (<-chan *consensusAPI.Blo
 	return mapCh, sub, nil
 }
 
-// Implements consensusAPI.Backend.
+// WatchCometBFTBlocks returns a stream of CometBFT blocks as they are
+// returned via the `EventDataNewBlock` query.
 func (t *fullService) WatchCometBFTBlocks() (<-chan *cmttypes.Block, *pubsub.Subscription, error) {
 	ch := make(chan *cmttypes.Block)
 	sub := t.blockNotifier.Subscribe()

--- a/go/consensus/cometbft/full/services.go
+++ b/go/consensus/cometbft/full/services.go
@@ -51,9 +51,12 @@ func (t *fullService) serviceClientWorker(ctx context.Context, svc api.ServiceCl
 					t.Logger.Error("event processing failed", "err", err)
 				}
 			}()
-		case blk := <-blkCh:
-			if err := svc.DeliverBlock(ctx, blk); err != nil {
-				logger.Error("failed to deliver block to service client", "err", err)
+		case blk, ok := <-blkCh:
+			if !ok {
+				return
+			}
+			if err := svc.DeliverHeight(ctx, blk.Height); err != nil {
+				logger.Error("failed to deliver block height to service client", "err", err)
 			}
 		case ev := <-evCh:
 			if err := svc.DeliverEvent(ctx, ev.height, ev.tx, &ev.ev); err != nil {

--- a/go/consensus/cometbft/full/services.go
+++ b/go/consensus/cometbft/full/services.go
@@ -23,7 +23,7 @@ func (t *fullService) serviceClientWorker(ctx context.Context, svc api.ServiceCl
 	logger := t.Logger.With("service", svd.Name())
 	logger.Info("starting event dispatcher")
 
-	blkCh, blkSub, err := t.WatchCometBFTBlocks()
+	blkCh, blkSub, err := t.WatchBlocks(ctx)
 	if err != nil {
 		logger.Error("failed to subscribe to cometbft blocks, not starting",
 			"err", err,

--- a/go/consensus/cometbft/governance/events.go
+++ b/go/consensus/cometbft/governance/events.go
@@ -1,0 +1,90 @@
+package governance
+
+import (
+	"errors"
+	"fmt"
+
+	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
+	cmttypes "github.com/cometbft/cometbft/types"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	eventsAPI "github.com/oasisprotocol/oasis-core/go/consensus/api/events"
+	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/governance"
+	"github.com/oasisprotocol/oasis-core/go/governance/api"
+)
+
+// EventsFromCometBFT extracts governance events from CometBFT events.
+func EventsFromCometBFT(
+	tx cmttypes.Tx,
+	height int64,
+	tmEvents []cmtabcitypes.Event,
+) ([]*api.Event, error) {
+	var txHash hash.Hash
+	switch tx {
+	case nil:
+		txHash.Empty()
+	default:
+		txHash = hash.NewFromBytes(tx)
+	}
+
+	var events []*api.Event
+	var errs error
+	for _, tmEv := range tmEvents {
+		// Ignore events that don't relate to the governance app.
+		if tmEv.GetType() != app.EventType {
+			continue
+		}
+
+		for _, pair := range tmEv.GetAttributes() {
+			key := pair.GetKey()
+			val := pair.GetValue()
+
+			switch {
+			case eventsAPI.IsAttributeKind(key, &api.ProposalSubmittedEvent{}):
+				// Proposal submitted event.
+				var e api.ProposalSubmittedEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("governance: corrupt ProposalSubmitted event: %w", err))
+					continue
+				}
+
+				evt := &api.Event{Height: height, TxHash: txHash, ProposalSubmitted: &e}
+				events = append(events, evt)
+			case eventsAPI.IsAttributeKind(key, &api.ProposalExecutedEvent{}):
+				//  Proposal executed event.
+				var e api.ProposalExecutedEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("governance: corrupt ProposalExecuted event: %w", err))
+					continue
+				}
+
+				evt := &api.Event{Height: height, TxHash: txHash, ProposalExecuted: &e}
+				events = append(events, evt)
+			case eventsAPI.IsAttributeKind(key, &api.ProposalFinalizedEvent{}):
+				// Proposal finalized event.
+				var e api.ProposalFinalizedEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("governance: corrupt ProposalFinalized event: %w", err))
+					continue
+				}
+
+				evt := &api.Event{Height: height, TxHash: txHash, ProposalFinalized: &e}
+				events = append(events, evt)
+			case eventsAPI.IsAttributeKind(key, &api.VoteEvent{}):
+				// Vote event.
+				var e api.VoteEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("governance: corrupt Vote event: %w", err))
+					continue
+				}
+
+				evt := &api.Event{Height: height, TxHash: txHash, Vote: &e}
+				events = append(events, evt)
+			default:
+				errs = errors.Join(errs, fmt.Errorf("governance: unknown event type: key: %s, val: %s", key, val))
+			}
+		}
+	}
+
+	return events, errs
+}

--- a/go/consensus/cometbft/governance/governance.go
+++ b/go/consensus/cometbft/governance/governance.go
@@ -8,12 +8,12 @@ import (
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
 	cmtpubsub "github.com/cometbft/cometbft/libs/pubsub"
-	cmtrpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	cmttypes "github.com/cometbft/cometbft/types"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	eventsAPI "github.com/oasisprotocol/oasis-core/go/consensus/api/events"
 	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/governance"
@@ -27,14 +27,14 @@ type ServiceClient struct {
 
 	logger *logging.Logger
 
-	consensus tmapi.Backend
+	consensus consensus.Backend
 	querier   *app.QueryFactory
 
 	eventNotifier *pubsub.Broker
 }
 
 // New constructs a new CometBFT backed governance service client.
-func New(consensus tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
+func New(consensus consensus.Backend, querier *app.QueryFactory) *ServiceClient {
 	return &ServiceClient{
 		logger:        logging.GetLogger("cometbft/staking"),
 		consensus:     consensus,
@@ -99,13 +99,16 @@ func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*api
 
 func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
-	var results *cmtrpctypes.ResultBlockResults
-	results, err := sc.consensus.GetCometBFTBlockResults(ctx, height)
+	results, err := sc.consensus.GetBlockResults(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft block results",
 			"err", err,
 			"height", height,
 		)
+		return nil, err
+	}
+	meta, err := tmapi.NewBlockResultsMeta(results)
+	if err != nil {
 		return nil, err
 	}
 
@@ -121,14 +124,14 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 
 	var events []*api.Event
 	// Decode events from block results (at the beginning of the block).
-	blockEvs, err := EventsFromCometBFT(nil, results.Height, results.BeginBlockEvents)
+	blockEvs, err := EventsFromCometBFT(nil, results.Height, meta.BeginBlockEvents)
 	if err != nil {
 		return nil, err
 	}
 	events = append(events, blockEvs...)
 
 	// Decode events from transaction results.
-	for txIdx, txResult := range results.TxsResults {
+	for txIdx, txResult := range meta.TxsResults {
 		// The order of transactions in txns and results.TxsResults is
 		// supposed to match, so the same index in both slices refers to the
 		// same transaction.
@@ -140,7 +143,7 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 	}
 
 	// Decode events from block results (at the end of the block).
-	blockEvs, err = EventsFromCometBFT(nil, results.Height, results.EndBlockEvents)
+	blockEvs, err = EventsFromCometBFT(nil, results.Height, meta.EndBlockEvents)
 	if err != nil {
 		return nil, err
 	}

--- a/go/consensus/cometbft/governance/governance.go
+++ b/go/consensus/cometbft/governance/governance.go
@@ -3,18 +3,15 @@ package governance
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
 	cmtpubsub "github.com/cometbft/cometbft/libs/pubsub"
 	cmttypes "github.com/cometbft/cometbft/types"
 
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
-	eventsAPI "github.com/oasisprotocol/oasis-core/go/consensus/api/events"
 	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/governance"
 	"github.com/oasisprotocol/oasis-core/go/governance/api"
@@ -190,80 +187,4 @@ func (sc *ServiceClient) DeliverEvent(_ context.Context, height int64, tx cmttyp
 	}
 
 	return nil
-}
-
-// EventsFromCometBFT extracts governance events from CometBFT events.
-func EventsFromCometBFT(
-	tx cmttypes.Tx,
-	height int64,
-	tmEvents []cmtabcitypes.Event,
-) ([]*api.Event, error) {
-	var txHash hash.Hash
-	switch tx {
-	case nil:
-		txHash.Empty()
-	default:
-		txHash = hash.NewFromBytes(tx)
-	}
-
-	var events []*api.Event
-	var errs error
-	for _, tmEv := range tmEvents {
-		// Ignore events that don't relate to the governance app.
-		if tmEv.GetType() != app.EventType {
-			continue
-		}
-
-		for _, pair := range tmEv.GetAttributes() {
-			key := pair.GetKey()
-			val := pair.GetValue()
-
-			switch {
-			case eventsAPI.IsAttributeKind(key, &api.ProposalSubmittedEvent{}):
-				// Proposal submitted event.
-				var e api.ProposalSubmittedEvent
-				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("governance: corrupt ProposalSubmitted event: %w", err))
-					continue
-				}
-
-				evt := &api.Event{Height: height, TxHash: txHash, ProposalSubmitted: &e}
-				events = append(events, evt)
-			case eventsAPI.IsAttributeKind(key, &api.ProposalExecutedEvent{}):
-				//  Proposal executed event.
-				var e api.ProposalExecutedEvent
-				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("governance: corrupt ProposalExecuted event: %w", err))
-					continue
-				}
-
-				evt := &api.Event{Height: height, TxHash: txHash, ProposalExecuted: &e}
-				events = append(events, evt)
-			case eventsAPI.IsAttributeKind(key, &api.ProposalFinalizedEvent{}):
-				// Proposal finalized event.
-				var e api.ProposalFinalizedEvent
-				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("governance: corrupt ProposalFinalized event: %w", err))
-					continue
-				}
-
-				evt := &api.Event{Height: height, TxHash: txHash, ProposalFinalized: &e}
-				events = append(events, evt)
-			case eventsAPI.IsAttributeKind(key, &api.VoteEvent{}):
-				// Vote event.
-				var e api.VoteEvent
-				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("governance: corrupt Vote event: %w", err))
-					continue
-				}
-
-				evt := &api.Event{Height: height, TxHash: txHash, Vote: &e}
-				events = append(events, evt)
-			default:
-				errs = errors.Join(errs, fmt.Errorf("governance: unknown event type: key: %s, val: %s", key, val))
-			}
-		}
-	}
-
-	return events, errs
 }

--- a/go/consensus/cometbft/governance/governance.go
+++ b/go/consensus/cometbft/governance/governance.go
@@ -166,9 +166,6 @@ func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) 
 	return q.ConsensusParameters(ctx)
 }
 
-func (sc *ServiceClient) Cleanup() {
-}
-
 // ServiceDescriptor implements api.ServiceClient.
 func (sc *ServiceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
 	return tmapi.NewStaticServiceDescriptor(api.ModuleName, app.EventType, []cmtpubsub.Query{app.QueryApp})

--- a/go/consensus/cometbft/governance/governance.go
+++ b/go/consensus/cometbft/governance/governance.go
@@ -96,39 +96,35 @@ func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*api
 
 func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
-	results, err := sc.consensus.GetBlockResults(ctx, height)
+	results, err := tmapi.GetBlockResults(ctx, height, sc.consensus)
 	if err != nil {
-		sc.logger.Error("failed to get cometbft block results",
+		sc.logger.Error("failed to get block results",
 			"err", err,
 			"height", height,
 		)
 		return nil, err
 	}
-	meta, err := tmapi.NewBlockResultsMeta(results)
-	if err != nil {
-		return nil, err
-	}
 
 	// Get transactions at given height.
-	txns, err := sc.consensus.GetTransactions(ctx, height)
+	txns, err := sc.consensus.GetTransactions(ctx, results.Height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft transactions",
 			"err", err,
-			"height", height,
+			"height", results.Height,
 		)
 		return nil, err
 	}
 
 	var events []*api.Event
 	// Decode events from block results (at the beginning of the block).
-	blockEvs, err := EventsFromCometBFT(nil, results.Height, meta.BeginBlockEvents)
+	blockEvs, err := EventsFromCometBFT(nil, results.Height, results.Meta.BeginBlockEvents)
 	if err != nil {
 		return nil, err
 	}
 	events = append(events, blockEvs...)
 
 	// Decode events from transaction results.
-	for txIdx, txResult := range meta.TxsResults {
+	for txIdx, txResult := range results.Meta.TxsResults {
 		// The order of transactions in txns and results.TxsResults is
 		// supposed to match, so the same index in both slices refers to the
 		// same transaction.
@@ -140,7 +136,7 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 	}
 
 	// Decode events from block results (at the end of the block).
-	blockEvs, err = EventsFromCometBFT(nil, results.Height, meta.EndBlockEvents)
+	blockEvs, err = EventsFromCometBFT(nil, results.Height, results.Meta.EndBlockEvents)
 	if err != nil {
 		return nil, err
 	}

--- a/go/consensus/cometbft/registry/events.go
+++ b/go/consensus/cometbft/registry/events.go
@@ -1,0 +1,95 @@
+package registry
+
+import (
+	"errors"
+	"fmt"
+
+	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
+	cmttypes "github.com/cometbft/cometbft/types"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	eventsAPI "github.com/oasisprotocol/oasis-core/go/consensus/api/events"
+	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/registry"
+	"github.com/oasisprotocol/oasis-core/go/registry/api"
+)
+
+// EventsFromCometBFT extracts registry events from CometBFT events.
+func EventsFromCometBFT(
+	tx cmttypes.Tx,
+	height int64,
+	tmEvents []cmtabcitypes.Event,
+) ([]*api.Event, []*NodeListEpochInternalEvent, error) {
+	var txHash hash.Hash
+	switch tx {
+	case nil:
+		txHash.Empty()
+	default:
+		txHash = hash.NewFromBytes(tx)
+	}
+
+	var events []*api.Event
+	var nodeListEvents []*NodeListEpochInternalEvent
+	var errs error
+	for _, tmEv := range tmEvents {
+		// Ignore events that don't relate to the registry app.
+		if tmEv.GetType() != app.EventType {
+			continue
+		}
+
+		for _, pair := range tmEv.GetAttributes() {
+			key := pair.GetKey()
+			val := pair.GetValue()
+
+			switch {
+			case eventsAPI.IsAttributeKind(key, &api.NodeListEpochEvent{}):
+				// Node list epoch event (value is ignored).
+				nodeListEvents = append(nodeListEvents, &NodeListEpochInternalEvent{Height: height})
+			case eventsAPI.IsAttributeKind(key, &api.RuntimeStartedEvent{}):
+				// Runtime started event.
+				var e api.RuntimeStartedEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("registry: corrupt RuntimeStarted event: %w", err))
+					continue
+				}
+
+				events = append(events, &api.Event{Height: height, TxHash: txHash, RuntimeStartedEvent: &e})
+			case eventsAPI.IsAttributeKind(key, &api.RuntimeSuspendedEvent{}):
+				// Runtime suspended event.
+				var e api.RuntimeSuspendedEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("registry: corrupt RuntimeSuspended event: %w", err))
+					continue
+				}
+
+				events = append(events, &api.Event{Height: height, TxHash: txHash, RuntimeSuspendedEvent: &e})
+			case eventsAPI.IsAttributeKind(key, &api.EntityEvent{}):
+				// Entity event.
+				var e api.EntityEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("registry: corrupt Entity event: %w", err))
+					continue
+				}
+
+				events = append(events, &api.Event{Height: height, TxHash: txHash, EntityEvent: &e})
+			case eventsAPI.IsAttributeKind(key, &api.NodeEvent{}):
+				// Node event.
+				var e api.NodeEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("registry: corrupt Node event: %w", err))
+					continue
+				}
+
+				events = append(events, &api.Event{Height: height, TxHash: txHash, NodeEvent: &e})
+			case eventsAPI.IsAttributeKind(key, &api.NodeUnfrozenEvent{}):
+				// Node unfrozen event.
+				var e api.NodeUnfrozenEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("registry: corrupt NodeUnfrozen event: %w", err))
+					continue
+				}
+				events = append(events, &api.Event{Height: height, TxHash: txHash, NodeUnfrozenEvent: &e})
+			}
+		}
+	}
+	return events, nodeListEvents, errs
+}

--- a/go/consensus/cometbft/registry/registry.go
+++ b/go/consensus/cometbft/registry/registry.go
@@ -152,9 +152,6 @@ func (sc *ServiceClient) WatchRuntimes(ctx context.Context) (<-chan *api.Runtime
 	return ch, sub, nil
 }
 
-func (sc *ServiceClient) Cleanup() {
-}
-
 func (sc *ServiceClient) GetRuntimes(ctx context.Context, query *api.GetRuntimesQuery) ([]*api.Runtime, error) {
 	q, err := sc.querier.QueryAt(ctx, query.Height)
 	if err != nil {

--- a/go/consensus/cometbft/registry/registry.go
+++ b/go/consensus/cometbft/registry/registry.go
@@ -171,39 +171,35 @@ func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*api
 
 func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
-	results, err := sc.consensus.GetBlockResults(ctx, height)
+	results, err := tmapi.GetBlockResults(ctx, height, sc.consensus)
 	if err != nil {
-		sc.logger.Error("failed to get cometbft block results",
+		sc.logger.Error("failed to get block results",
 			"err", err,
 			"height", height,
 		)
 		return nil, err
 	}
-	meta, err := tmapi.NewBlockResultsMeta(results)
-	if err != nil {
-		return nil, err
-	}
 
 	// Get transactions at given height.
-	txns, err := sc.consensus.GetTransactions(ctx, height)
+	txns, err := sc.consensus.GetTransactions(ctx, results.Height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft transactions",
 			"err", err,
-			"height", height,
+			"height", results.Height,
 		)
 		return nil, err
 	}
 
 	var events []*api.Event
 	// Decode events from block results (at the beginning of the block).
-	blockEvs, _, err := EventsFromCometBFT(nil, results.Height, meta.BeginBlockEvents)
+	blockEvs, _, err := EventsFromCometBFT(nil, results.Height, results.Meta.BeginBlockEvents)
 	if err != nil {
 		return nil, err
 	}
 	events = append(events, blockEvs...)
 
 	// Decode events from transaction results.
-	for txIdx, txResult := range meta.TxsResults {
+	for txIdx, txResult := range results.Meta.TxsResults {
 		// The order of transactions in txns and results.TxsResults is
 		// supposed to match, so the same index in both slices refers to the
 		// same transaction.
@@ -215,7 +211,7 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 	}
 
 	// Decode events from block results (at the end of the block).
-	blockEvs, _, err = EventsFromCometBFT(nil, results.Height, meta.EndBlockEvents)
+	blockEvs, _, err = EventsFromCometBFT(nil, results.Height, results.Meta.EndBlockEvents)
 	if err != nil {
 		return nil, err
 	}

--- a/go/consensus/cometbft/roothash/events.go
+++ b/go/consensus/cometbft/roothash/events.go
@@ -1,0 +1,113 @@
+package roothash
+
+import (
+	"errors"
+	"fmt"
+
+	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
+	cmttypes "github.com/cometbft/cometbft/types"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	eventsAPI "github.com/oasisprotocol/oasis-core/go/consensus/api/events"
+	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/roothash"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
+)
+
+// EventsFromCometBFT extracts roothash events from CometBFT events.
+func EventsFromCometBFT(
+	tx cmttypes.Tx,
+	height int64,
+	tmEvents []cmtabcitypes.Event,
+) ([]*roothash.Event, error) {
+	var txHash hash.Hash
+	switch tx {
+	case nil:
+		txHash.Empty()
+	default:
+		txHash = hash.NewFromBytes(tx)
+	}
+
+	var events []*roothash.Event
+	var errs error
+EventLoop:
+	for _, tmEv := range tmEvents {
+		// Ignore events that don't relate to the roothash app.
+		if tmEv.GetType() != app.EventType {
+			continue
+		}
+
+		var (
+			runtimeID *common.Namespace
+			ev        *roothash.Event
+		)
+		for _, pair := range tmEv.GetAttributes() {
+			key := pair.GetKey()
+			val := pair.GetValue()
+
+			switch {
+			case eventsAPI.IsAttributeKind(key, &roothash.FinalizedEvent{}):
+				// Finalized event.
+				var e roothash.FinalizedEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("roothash: corrupt Finalized event: %w", err))
+					continue EventLoop
+				}
+
+				ev = &roothash.Event{Finalized: &e}
+			case eventsAPI.IsAttributeKind(key, &roothash.ExecutionDiscrepancyDetectedEvent{}):
+				// An execution discrepancy has been detected.
+				var e roothash.ExecutionDiscrepancyDetectedEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("roothash: corrupt ExecutionDiscrepancyDetected event: %w", err))
+					continue EventLoop
+				}
+
+				ev = &roothash.Event{ExecutionDiscrepancyDetected: &e}
+			case eventsAPI.IsAttributeKind(key, &roothash.ExecutorCommittedEvent{}):
+				// An executor commit has been processed.
+				var e roothash.ExecutorCommittedEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("roothash: corrupt ExecutorCommitted event: %w", err))
+					continue EventLoop
+				}
+
+				ev = &roothash.Event{ExecutorCommitted: &e}
+			case eventsAPI.IsAttributeKind(key, &roothash.InMsgProcessedEvent{}):
+				// Incoming message processed event.
+				var e roothash.InMsgProcessedEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("roothash: corrupt InMsgProcessed event: %w", err))
+					continue EventLoop
+				}
+
+				ev = &roothash.Event{InMsgProcessed: &e}
+			case eventsAPI.IsAttributeKind(key, &roothash.RuntimeIDAttribute{}):
+				if runtimeID != nil {
+					errs = errors.Join(errs, fmt.Errorf("roothash: duplicate runtime ID attribute"))
+					continue EventLoop
+				}
+				rtAttribute := roothash.RuntimeIDAttribute{}
+				if err := eventsAPI.DecodeValue(val, &rtAttribute); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("roothash: corrupt runtime ID: %w", err))
+					continue EventLoop
+				}
+				runtimeID = &rtAttribute.ID
+			default:
+				errs = errors.Join(errs, fmt.Errorf("roothash: unknown event type: key: %s, val: %s", key, val))
+			}
+		}
+
+		if runtimeID == nil {
+			errs = errors.Join(errs, fmt.Errorf("roothash: missing runtime ID attribute"))
+			continue
+		}
+		if ev != nil {
+			ev.RuntimeID = *runtimeID
+			ev.Height = height
+			ev.TxHash = txHash
+			events = append(events, ev)
+		}
+	}
+	return events, errs
+}

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -315,10 +315,6 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 	return events, nil
 }
 
-// Cleanup implements api.Backend.
-func (sc *ServiceClient) Cleanup() {
-}
-
 func (sc *ServiceClient) getRuntimeNotifiers(id common.Namespace) *runtimeBrokers {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -258,39 +258,35 @@ func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) 
 // GetEvents implements api.Backend.
 func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
-	results, err := sc.consensus.GetBlockResults(ctx, height)
+	results, err := tmapi.GetBlockResults(ctx, height, sc.consensus)
 	if err != nil {
-		sc.logger.Error("failed to get cometbft block results",
+		sc.logger.Error("failed to get block results",
 			"err", err,
 			"height", height,
 		)
 		return nil, err
 	}
-	meta, err := tmapi.NewBlockResultsMeta(results)
-	if err != nil {
-		return nil, err
-	}
 
 	// Get transactions at given height.
-	txns, err := sc.consensus.GetTransactions(ctx, height)
+	txns, err := sc.consensus.GetTransactions(ctx, results.Height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft transactions",
 			"err", err,
-			"height", height,
+			"height", results.Height,
 		)
 		return nil, err
 	}
 
 	var events []*api.Event
 	// Decode events from block results (at the beginning of the block).
-	blockEvs, err := EventsFromCometBFT(nil, results.Height, meta.BeginBlockEvents)
+	blockEvs, err := EventsFromCometBFT(nil, results.Height, results.Meta.BeginBlockEvents)
 	if err != nil {
 		return nil, err
 	}
 	events = append(events, blockEvs...)
 
 	// Decode events from transaction results.
-	for txIdx, txResult := range meta.TxsResults {
+	for txIdx, txResult := range results.Meta.TxsResults {
 		// The order of transactions in txns and results.TxsResults is
 		// supposed to match, so the same index in both slices refers to the
 		// same transaction.
@@ -306,7 +302,7 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 	}
 
 	// Decode events from block results (at the end of the block).
-	blockEvs, err = EventsFromCometBFT(nil, results.Height, meta.EndBlockEvents)
+	blockEvs, err = EventsFromCometBFT(nil, results.Height, results.Meta.EndBlockEvents)
 	if err != nil {
 		return nil, err
 	}

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -341,8 +341,8 @@ func (sc *ServiceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
 	return tmapi.NewServiceDescriptor(api.ModuleName, app.EventType, sc.queryCh)
 }
 
-// DeliverBlock implements api.ServiceClient.
-func (sc *ServiceClient) DeliverBlock(ctx context.Context, blk *cmttypes.Block) error {
+// DeliverHeight implements roothash.ServiceClient.
+func (sc *ServiceClient) DeliverHeight(ctx context.Context, height int64) error {
 	sc.mu.RLock()
 	trs := slices.Collect(maps.Values(sc.trackedRuntimes))
 	sc.mu.RUnlock()
@@ -356,13 +356,13 @@ func (sc *ServiceClient) DeliverBlock(ctx context.Context, blk *cmttypes.Block) 
 		}
 		rs, err := sc.GetRuntimeState(ctx, &api.RuntimeRequest{
 			RuntimeID: tr.runtimeID,
-			Height:    blk.Height,
+			Height:    height,
 		})
 		if err != nil {
 			sc.logger.Warn("failed to get runtime state",
 				"err", err,
 				"runtime_id", tr.runtimeID,
-				"height", blk.Height,
+				"height", height,
 			)
 			return fmt.Errorf("roothash: failed to get runtime state: %w", err)
 		}

--- a/go/consensus/cometbft/scheduler/scheduler.go
+++ b/go/consensus/cometbft/scheduler/scheduler.go
@@ -67,9 +67,6 @@ func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) 
 	return q.ConsensusParameters(ctx)
 }
 
-func (sc *ServiceClient) Cleanup() {
-}
-
 func (sc *ServiceClient) GetValidators(ctx context.Context, height int64) ([]*api.Validator, error) {
 	q, err := sc.querier.QueryAt(ctx, height)
 	if err != nil {

--- a/go/consensus/cometbft/staking/events.go
+++ b/go/consensus/cometbft/staking/events.go
@@ -1,0 +1,120 @@
+package staking
+
+import (
+	"errors"
+	"fmt"
+
+	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
+	cmttypes "github.com/cometbft/cometbft/types"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	eventsAPI "github.com/oasisprotocol/oasis-core/go/consensus/api/events"
+	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/staking"
+	"github.com/oasisprotocol/oasis-core/go/staking/api"
+)
+
+// EventsFromCometBFT extracts staking events from CometBFT events.
+func EventsFromCometBFT(
+	tx cmttypes.Tx,
+	height int64,
+	tmEvents []cmtabcitypes.Event,
+) ([]*api.Event, error) {
+	var txHash hash.Hash
+	switch tx {
+	case nil:
+		txHash.Empty()
+	default:
+		txHash = hash.NewFromBytes(tx)
+	}
+
+	var events []*api.Event
+	var errs error
+	for _, tmEv := range tmEvents {
+		// Ignore events that don't relate to the staking app.
+		if tmEv.GetType() != app.EventType {
+			continue
+		}
+
+		for _, pair := range tmEv.GetAttributes() {
+			key := pair.GetKey()
+			val := pair.GetValue()
+
+			switch {
+			case eventsAPI.IsAttributeKind(key, &api.TakeEscrowEvent{}):
+				// Take escrow event.
+				var e api.TakeEscrowEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("staking: corrupt TakeEscrow event: %w", err))
+					continue
+				}
+
+				evt := &api.Event{Height: height, TxHash: txHash, Escrow: &api.EscrowEvent{Take: &e}}
+				events = append(events, evt)
+			case eventsAPI.IsAttributeKind(key, &api.TransferEvent{}):
+				// Transfer event.
+				var e api.TransferEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("staking: corrupt Transfer event: %w", err))
+					continue
+				}
+
+				evt := &api.Event{Height: height, TxHash: txHash, Transfer: &e}
+				events = append(events, evt)
+			case eventsAPI.IsAttributeKind(key, &api.ReclaimEscrowEvent{}):
+				// Reclaim escrow event.
+				var e api.ReclaimEscrowEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("staking: corrupt ReclaimEscrow event: %w", err))
+					continue
+				}
+
+				evt := &api.Event{Height: height, TxHash: txHash, Escrow: &api.EscrowEvent{Reclaim: &e}}
+				events = append(events, evt)
+			case eventsAPI.IsAttributeKind(key, &api.AddEscrowEvent{}):
+				// Add escrow event.
+				var e api.AddEscrowEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("staking: corrupt AddEscrow event: %w", err))
+					continue
+				}
+
+				evt := &api.Event{Height: height, TxHash: txHash, Escrow: &api.EscrowEvent{Add: &e}}
+				events = append(events, evt)
+			case eventsAPI.IsAttributeKind(key, &api.DebondingStartEscrowEvent{}):
+				// Debonding start escrow event.
+				var e api.DebondingStartEscrowEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("staking: corrupt DebondingStart escrow event: %w", err))
+					continue
+				}
+
+				evt := &api.Event{Height: height, TxHash: txHash, Escrow: &api.EscrowEvent{DebondingStart: &e}}
+				events = append(events, evt)
+			case eventsAPI.IsAttributeKind(key, &api.BurnEvent{}):
+				// Burn event.
+				var e api.BurnEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("staking: corrupt Burn event: %w", err))
+					continue
+				}
+
+				evt := &api.Event{Height: height, TxHash: txHash, Burn: &e}
+				events = append(events, evt)
+			case eventsAPI.IsAttributeKind(key, &api.AllowanceChangeEvent{}):
+				// Allowance change event.
+				var e api.AllowanceChangeEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("staking: corrupt AllowanceChange event: %w", err))
+					continue
+				}
+
+				evt := &api.Event{Height: height, TxHash: txHash, AllowanceChange: &e}
+				events = append(events, evt)
+			default:
+				errs = errors.Join(errs, fmt.Errorf("staking: unknown event type: key: %s, val: %s", key, val))
+			}
+		}
+	}
+
+	return events, errs
+}

--- a/go/consensus/cometbft/staking/staking.go
+++ b/go/consensus/cometbft/staking/staking.go
@@ -3,19 +3,16 @@ package staking
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
 	cmtpubsub "github.com/cometbft/cometbft/libs/pubsub"
 	cmttypes "github.com/cometbft/cometbft/types"
 
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
-	eventsAPI "github.com/oasisprotocol/oasis-core/go/consensus/api/events"
 	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/staking"
 	"github.com/oasisprotocol/oasis-core/go/staking/api"
@@ -337,110 +334,4 @@ func (sc *ServiceClient) DeliverEvent(_ context.Context, height int64, tx cmttyp
 	}
 
 	return nil
-}
-
-// EventsFromCometBFT extracts staking events from CometBFT events.
-func EventsFromCometBFT(
-	tx cmttypes.Tx,
-	height int64,
-	tmEvents []cmtabcitypes.Event,
-) ([]*api.Event, error) {
-	var txHash hash.Hash
-	switch tx {
-	case nil:
-		txHash.Empty()
-	default:
-		txHash = hash.NewFromBytes(tx)
-	}
-
-	var events []*api.Event
-	var errs error
-	for _, tmEv := range tmEvents {
-		// Ignore events that don't relate to the staking app.
-		if tmEv.GetType() != app.EventType {
-			continue
-		}
-
-		for _, pair := range tmEv.GetAttributes() {
-			key := pair.GetKey()
-			val := pair.GetValue()
-
-			switch {
-			case eventsAPI.IsAttributeKind(key, &api.TakeEscrowEvent{}):
-				// Take escrow event.
-				var e api.TakeEscrowEvent
-				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("staking: corrupt TakeEscrow event: %w", err))
-					continue
-				}
-
-				evt := &api.Event{Height: height, TxHash: txHash, Escrow: &api.EscrowEvent{Take: &e}}
-				events = append(events, evt)
-			case eventsAPI.IsAttributeKind(key, &api.TransferEvent{}):
-				// Transfer event.
-				var e api.TransferEvent
-				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("staking: corrupt Transfer event: %w", err))
-					continue
-				}
-
-				evt := &api.Event{Height: height, TxHash: txHash, Transfer: &e}
-				events = append(events, evt)
-			case eventsAPI.IsAttributeKind(key, &api.ReclaimEscrowEvent{}):
-				// Reclaim escrow event.
-				var e api.ReclaimEscrowEvent
-				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("staking: corrupt ReclaimEscrow event: %w", err))
-					continue
-				}
-
-				evt := &api.Event{Height: height, TxHash: txHash, Escrow: &api.EscrowEvent{Reclaim: &e}}
-				events = append(events, evt)
-			case eventsAPI.IsAttributeKind(key, &api.AddEscrowEvent{}):
-				// Add escrow event.
-				var e api.AddEscrowEvent
-				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("staking: corrupt AddEscrow event: %w", err))
-					continue
-				}
-
-				evt := &api.Event{Height: height, TxHash: txHash, Escrow: &api.EscrowEvent{Add: &e}}
-				events = append(events, evt)
-			case eventsAPI.IsAttributeKind(key, &api.DebondingStartEscrowEvent{}):
-				// Debonding start escrow event.
-				var e api.DebondingStartEscrowEvent
-				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("staking: corrupt DebondingStart escrow event: %w", err))
-					continue
-				}
-
-				evt := &api.Event{Height: height, TxHash: txHash, Escrow: &api.EscrowEvent{DebondingStart: &e}}
-				events = append(events, evt)
-			case eventsAPI.IsAttributeKind(key, &api.BurnEvent{}):
-				// Burn event.
-				var e api.BurnEvent
-				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("staking: corrupt Burn event: %w", err))
-					continue
-				}
-
-				evt := &api.Event{Height: height, TxHash: txHash, Burn: &e}
-				events = append(events, evt)
-			case eventsAPI.IsAttributeKind(key, &api.AllowanceChangeEvent{}):
-				// Allowance change event.
-				var e api.AllowanceChangeEvent
-				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("staking: corrupt AllowanceChange event: %w", err))
-					continue
-				}
-
-				evt := &api.Event{Height: height, TxHash: txHash, AllowanceChange: &e}
-				events = append(events, evt)
-			default:
-				errs = errors.Join(errs, fmt.Errorf("staking: unknown event type: key: %s, val: %s", key, val))
-			}
-		}
-	}
-
-	return events, errs
 }

--- a/go/consensus/cometbft/staking/staking.go
+++ b/go/consensus/cometbft/staking/staking.go
@@ -313,9 +313,6 @@ func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) 
 	return q.ConsensusParameters(ctx)
 }
 
-func (sc *ServiceClient) Cleanup() {
-}
-
 // ServiceDescriptor implements api.ServiceClient.
 func (sc *ServiceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
 	return tmapi.NewStaticServiceDescriptor(api.ModuleName, app.EventType, []cmtpubsub.Query{app.QueryApp})

--- a/go/consensus/cometbft/staking/staking.go
+++ b/go/consensus/cometbft/staking/staking.go
@@ -8,13 +8,13 @@ import (
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
 	cmtpubsub "github.com/cometbft/cometbft/libs/pubsub"
-	cmtrpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	cmttypes "github.com/cometbft/cometbft/types"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	eventsAPI "github.com/oasisprotocol/oasis-core/go/consensus/api/events"
 	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/staking"
@@ -27,14 +27,14 @@ type ServiceClient struct {
 
 	logger *logging.Logger
 
-	consensus tmapi.Backend
+	consensus consensus.Backend
 	querier   *app.QueryFactory
 
 	eventNotifier *pubsub.Broker
 }
 
 // New constructs a new CometBFT backed staking service client.
-func New(consensus tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
+func New(consensus consensus.Backend, querier *app.QueryFactory) *ServiceClient {
 	return &ServiceClient{
 		logger:        logging.GetLogger("cometbft/staking"),
 		consensus:     consensus,
@@ -246,13 +246,16 @@ func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*api
 
 func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Event, error) {
 	// Get block results at given height.
-	var results *cmtrpctypes.ResultBlockResults
-	results, err := sc.consensus.GetCometBFTBlockResults(ctx, height)
+	results, err := sc.consensus.GetBlockResults(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft block results",
 			"err", err,
 			"height", height,
 		)
+		return nil, err
+	}
+	meta, err := tmapi.NewBlockResultsMeta(results)
+	if err != nil {
 		return nil, err
 	}
 
@@ -268,14 +271,14 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 
 	var events []*api.Event
 	// Decode events from block results (at the beginning of the block).
-	blockEvs, err := EventsFromCometBFT(nil, results.Height, results.BeginBlockEvents)
+	blockEvs, err := EventsFromCometBFT(nil, results.Height, meta.BeginBlockEvents)
 	if err != nil {
 		return nil, err
 	}
 	events = append(events, blockEvs...)
 
 	// Decode events from transaction results.
-	for txIdx, txResult := range results.TxsResults {
+	for txIdx, txResult := range meta.TxsResults {
 		// The order of transactions in txns and results.TxsResults is
 		// supposed to match, so the same index in both slices refers to the
 		// same transaction.
@@ -287,7 +290,7 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 	}
 
 	// Decode events from block results (at the end of the block).
-	blockEvs, err = EventsFromCometBFT(nil, results.Height, results.EndBlockEvents)
+	blockEvs, err = EventsFromCometBFT(nil, results.Height, meta.EndBlockEvents)
 	if err != nil {
 		return nil, err
 	}

--- a/go/consensus/cometbft/vault/events.go
+++ b/go/consensus/cometbft/vault/events.go
@@ -1,0 +1,108 @@
+package vault
+
+import (
+	"errors"
+	"fmt"
+
+	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
+	cmttypes "github.com/cometbft/cometbft/types"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	eventsAPI "github.com/oasisprotocol/oasis-core/go/consensus/api/events"
+	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/vault"
+	vault "github.com/oasisprotocol/oasis-core/go/vault/api"
+)
+
+// EventsFromCometBFT extracts vault events from CometBFT events.
+func EventsFromCometBFT(
+	tx cmttypes.Tx,
+	height int64,
+	tmEvents []cmtabcitypes.Event,
+) ([]*vault.Event, error) {
+	var txHash hash.Hash
+	switch tx {
+	case nil:
+		txHash.Empty()
+	default:
+		txHash = hash.NewFromBytes(tx)
+	}
+
+	var events []*vault.Event
+	var errs error
+	for _, tmEv := range tmEvents {
+		// Ignore events that don't relate to the vault app.
+		if tmEv.GetType() != app.EventType {
+			continue
+		}
+
+		for _, pair := range tmEv.GetAttributes() {
+			key := pair.GetKey()
+			val := pair.GetValue()
+
+			evt := &vault.Event{Height: height, TxHash: txHash}
+			switch {
+			case eventsAPI.IsAttributeKind(key, &vault.ActionSubmittedEvent{}):
+				// Action submitted event.
+				var e vault.ActionSubmittedEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("vault: corrupt ActionSubmitted event: %w", err))
+					continue
+				}
+
+				evt.ActionSubmitted = &e
+			case eventsAPI.IsAttributeKind(key, &vault.ActionCanceledEvent{}):
+				// Action canceled event.
+				var e vault.ActionCanceledEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("vault: corrupt ActionCanceled event: %w", err))
+					continue
+				}
+
+				evt.ActionCanceled = &e
+			case eventsAPI.IsAttributeKind(key, &vault.ActionExecutedEvent{}):
+				// Action executed event.
+				var e vault.ActionExecutedEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("vault: corrupt ActionExecuted event: %w", err))
+					continue
+				}
+
+				evt.ActionExecuted = &e
+			case eventsAPI.IsAttributeKind(key, &vault.StateChangedEvent{}):
+				// State changed event.
+				var e vault.StateChangedEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("vault: corrupt StateChanged event: %w", err))
+					continue
+				}
+
+				evt.StateChanged = &e
+			case eventsAPI.IsAttributeKind(key, &vault.PolicyUpdatedEvent{}):
+				// Policy updated event.
+				var e vault.PolicyUpdatedEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("vault: corrupt PolicyUpdated event: %w", err))
+					continue
+				}
+
+				evt.PolicyUpdated = &e
+			case eventsAPI.IsAttributeKind(key, &vault.AuthorityUpdatedEvent{}):
+				// Action submitted event.
+				var e vault.AuthorityUpdatedEvent
+				if err := eventsAPI.DecodeValue(val, &e); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("vault: corrupt AuthorityUpdated event: %w", err))
+					continue
+				}
+
+				evt.AuthorityUpdated = &e
+			default:
+				errs = errors.Join(errs, fmt.Errorf("vault: unknown event type: key: %s, val: %s", key, val))
+				continue
+			}
+
+			events = append(events, evt)
+		}
+	}
+
+	return events, errs
+}

--- a/go/consensus/cometbft/vault/vault.go
+++ b/go/consensus/cometbft/vault/vault.go
@@ -3,18 +3,15 @@ package vault
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
 	cmtpubsub "github.com/cometbft/cometbft/libs/pubsub"
 	cmttypes "github.com/cometbft/cometbft/types"
 
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
-	eventsAPI "github.com/oasisprotocol/oasis-core/go/consensus/api/events"
 	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/vault"
 	vault "github.com/oasisprotocol/oasis-core/go/vault/api"
@@ -180,98 +177,4 @@ func (sc *ServiceClient) DeliverEvent(_ context.Context, height int64, tx cmttyp
 	}
 
 	return nil
-}
-
-// EventsFromCometBFT extracts vault events from CometBFT events.
-func EventsFromCometBFT(
-	tx cmttypes.Tx,
-	height int64,
-	tmEvents []cmtabcitypes.Event,
-) ([]*vault.Event, error) {
-	var txHash hash.Hash
-	switch tx {
-	case nil:
-		txHash.Empty()
-	default:
-		txHash = hash.NewFromBytes(tx)
-	}
-
-	var events []*vault.Event
-	var errs error
-	for _, tmEv := range tmEvents {
-		// Ignore events that don't relate to the vault app.
-		if tmEv.GetType() != app.EventType {
-			continue
-		}
-
-		for _, pair := range tmEv.GetAttributes() {
-			key := pair.GetKey()
-			val := pair.GetValue()
-
-			evt := &vault.Event{Height: height, TxHash: txHash}
-			switch {
-			case eventsAPI.IsAttributeKind(key, &vault.ActionSubmittedEvent{}):
-				// Action submitted event.
-				var e vault.ActionSubmittedEvent
-				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("vault: corrupt ActionSubmitted event: %w", err))
-					continue
-				}
-
-				evt.ActionSubmitted = &e
-			case eventsAPI.IsAttributeKind(key, &vault.ActionCanceledEvent{}):
-				// Action canceled event.
-				var e vault.ActionCanceledEvent
-				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("vault: corrupt ActionCanceled event: %w", err))
-					continue
-				}
-
-				evt.ActionCanceled = &e
-			case eventsAPI.IsAttributeKind(key, &vault.ActionExecutedEvent{}):
-				// Action executed event.
-				var e vault.ActionExecutedEvent
-				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("vault: corrupt ActionExecuted event: %w", err))
-					continue
-				}
-
-				evt.ActionExecuted = &e
-			case eventsAPI.IsAttributeKind(key, &vault.StateChangedEvent{}):
-				// State changed event.
-				var e vault.StateChangedEvent
-				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("vault: corrupt StateChanged event: %w", err))
-					continue
-				}
-
-				evt.StateChanged = &e
-			case eventsAPI.IsAttributeKind(key, &vault.PolicyUpdatedEvent{}):
-				// Policy updated event.
-				var e vault.PolicyUpdatedEvent
-				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("vault: corrupt PolicyUpdated event: %w", err))
-					continue
-				}
-
-				evt.PolicyUpdated = &e
-			case eventsAPI.IsAttributeKind(key, &vault.AuthorityUpdatedEvent{}):
-				// Action submitted event.
-				var e vault.AuthorityUpdatedEvent
-				if err := eventsAPI.DecodeValue(val, &e); err != nil {
-					errs = errors.Join(errs, fmt.Errorf("vault: corrupt AuthorityUpdated event: %w", err))
-					continue
-				}
-
-				evt.AuthorityUpdated = &e
-			default:
-				errs = errors.Join(errs, fmt.Errorf("vault: unknown event type: key: %s, val: %s", key, val))
-				continue
-			}
-
-			events = append(events, evt)
-		}
-	}
-
-	return events, errs
 }

--- a/go/consensus/cometbft/vault/vault.go
+++ b/go/consensus/cometbft/vault/vault.go
@@ -86,39 +86,35 @@ func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*vau
 
 func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*vault.Event, error) {
 	// Get block results at given height.
-	results, err := sc.consensus.GetBlockResults(ctx, height)
+	results, err := tmapi.GetBlockResults(ctx, height, sc.consensus)
 	if err != nil {
-		sc.logger.Error("failed to get cometbft block results",
+		sc.logger.Error("failed to get block results",
 			"err", err,
 			"height", height,
 		)
 		return nil, err
 	}
-	meta, err := tmapi.NewBlockResultsMeta(results)
-	if err != nil {
-		return nil, err
-	}
 
 	// Get transactions at given height.
-	txns, err := sc.consensus.GetTransactions(ctx, height)
+	txns, err := sc.consensus.GetTransactions(ctx, results.Height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft transactions",
 			"err", err,
-			"height", height,
+			"height", results.Height,
 		)
 		return nil, err
 	}
 
 	var events []*vault.Event
 	// Decode events from block results (at the beginning of the block).
-	blockEvs, err := EventsFromCometBFT(nil, results.Height, meta.BeginBlockEvents)
+	blockEvs, err := EventsFromCometBFT(nil, results.Height, results.Meta.BeginBlockEvents)
 	if err != nil {
 		return nil, err
 	}
 	events = append(events, blockEvs...)
 
 	// Decode events from transaction results.
-	for txIdx, txResult := range meta.TxsResults {
+	for txIdx, txResult := range results.Meta.TxsResults {
 		// The order of transactions in txns and results.TxsResults is
 		// supposed to match, so the same index in both slices refers to the
 		// same transaction.
@@ -130,7 +126,7 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*vault.
 	}
 
 	// Decode events from block results (at the end of the block).
-	blockEvs, err = EventsFromCometBFT(nil, results.Height, meta.EndBlockEvents)
+	blockEvs, err = EventsFromCometBFT(nil, results.Height, results.Meta.EndBlockEvents)
 	if err != nil {
 		return nil, err
 	}

--- a/go/consensus/cometbft/vault/vault.go
+++ b/go/consensus/cometbft/vault/vault.go
@@ -8,12 +8,12 @@ import (
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
 	cmtpubsub "github.com/cometbft/cometbft/libs/pubsub"
-	cmtrpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	cmttypes "github.com/cometbft/cometbft/types"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	eventsAPI "github.com/oasisprotocol/oasis-core/go/consensus/api/events"
 	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/vault"
@@ -26,14 +26,14 @@ type ServiceClient struct {
 
 	logger *logging.Logger
 
-	consensus tmapi.Backend
+	consensus consensus.Backend
 	querier   *app.QueryFactory
 
 	eventNotifier *pubsub.Broker
 }
 
 // New constructs a new CometBFT backed vault service client.
-func New(consensus tmapi.Backend, querier *app.QueryFactory) *ServiceClient {
+func New(consensus consensus.Backend, querier *app.QueryFactory) *ServiceClient {
 	return &ServiceClient{
 		logger:        logging.GetLogger("cometbft/vault"),
 		consensus:     consensus,
@@ -89,13 +89,16 @@ func (sc *ServiceClient) StateToGenesis(ctx context.Context, height int64) (*vau
 
 func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*vault.Event, error) {
 	// Get block results at given height.
-	var results *cmtrpctypes.ResultBlockResults
-	results, err := sc.consensus.GetCometBFTBlockResults(ctx, height)
+	results, err := sc.consensus.GetBlockResults(ctx, height)
 	if err != nil {
 		sc.logger.Error("failed to get cometbft block results",
 			"err", err,
 			"height", height,
 		)
+		return nil, err
+	}
+	meta, err := tmapi.NewBlockResultsMeta(results)
+	if err != nil {
 		return nil, err
 	}
 
@@ -111,14 +114,14 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*vault.
 
 	var events []*vault.Event
 	// Decode events from block results (at the beginning of the block).
-	blockEvs, err := EventsFromCometBFT(nil, results.Height, results.BeginBlockEvents)
+	blockEvs, err := EventsFromCometBFT(nil, results.Height, meta.BeginBlockEvents)
 	if err != nil {
 		return nil, err
 	}
 	events = append(events, blockEvs...)
 
 	// Decode events from transaction results.
-	for txIdx, txResult := range results.TxsResults {
+	for txIdx, txResult := range meta.TxsResults {
 		// The order of transactions in txns and results.TxsResults is
 		// supposed to match, so the same index in both slices refers to the
 		// same transaction.
@@ -130,7 +133,7 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*vault.
 	}
 
 	// Decode events from block results (at the end of the block).
-	blockEvs, err = EventsFromCometBFT(nil, results.Height, results.EndBlockEvents)
+	blockEvs, err = EventsFromCometBFT(nil, results.Height, meta.EndBlockEvents)
 	if err != nil {
 		return nil, err
 	}

--- a/go/consensus/cometbft/vault/vault.go
+++ b/go/consensus/cometbft/vault/vault.go
@@ -156,9 +156,6 @@ func (sc *ServiceClient) ConsensusParameters(ctx context.Context, height int64) 
 	return q.ConsensusParameters(ctx)
 }
 
-func (sc *ServiceClient) Cleanup() {
-}
-
 // ServiceDescriptor implements api.ServiceClient.
 func (sc *ServiceClient) ServiceDescriptor() tmapi.ServiceDescriptor {
 	return tmapi.NewStaticServiceDescriptor(vault.ModuleName, app.EventType, []cmtpubsub.Query{app.QueryApp})

--- a/go/consensus/tests/tester.go
+++ b/go/consensus/tests/tester.go
@@ -46,6 +46,11 @@ func ConsensusImplementationTests(t *testing.T, consensus api.Backend) {
 	require.Greater(blk.Height, int64(0), "block height should be greater than zero")
 	require.Greater(blk.Size, uint64(0), "block size should be greater than zero")
 
+	results, err := consensus.GetBlockResults(ctx, api.HeightLatest)
+	require.NoError(err, "GetBlockResults")
+	require.NotNil(blk, "returned block results should not be nil")
+	require.Greater(results.Height, int64(0), "block results height should be greater than zero")
+
 	status, err := consensus.GetStatus(ctx)
 	require.NoError(err, "GetStatus")
 	require.NotNil(status, "returned status should not be nil")

--- a/go/governance/api/api.go
+++ b/go/governance/api/api.go
@@ -381,9 +381,6 @@ type Backend interface {
 
 	// WatchEvents returns a channel that produces a stream of Events.
 	WatchEvents(ctx context.Context) (<-chan *Event, pubsub.ClosableSubscription, error)
-
-	// Cleanup cleans up the backend.
-	Cleanup()
 }
 
 // ProposalQuery is a proposal query.

--- a/go/oasis-node/cmd/debug/txsource/workload/queries.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/queries.go
@@ -230,6 +230,14 @@ func (q *queries) doConsensusQueries(ctx context.Context, rng *rand.Rand, height
 		}
 	}
 
+	blockResults, err := q.consensus.GetBlockResults(ctx, height)
+	if err != nil {
+		return fmt.Errorf("GetBlockResults at height %d: %w", height, err)
+	}
+	if blockResults.Height != height {
+		return fmt.Errorf("blockResults.Height: %d == %d violated", blockResults.Height, height)
+	}
+
 	txs, err := q.consensus.GetTransactions(ctx, height)
 	if err != nil {
 		return fmt.Errorf("GetTransactions at height %d: %w", height, err)

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -224,9 +224,6 @@ type Backend interface {
 
 	// ConsensusParameters returns the registry consensus parameters.
 	ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error)
-
-	// Cleanup cleans up the registry backend.
-	Cleanup()
 }
 
 // IDQuery is a registry query by ID.

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -164,9 +164,6 @@ type Backend interface {
 
 	// GetEvents returns the events at specified block height.
 	GetEvents(ctx context.Context, height int64) ([]*Event, error)
-
-	// Cleanup cleans up the roothash backend.
-	Cleanup()
 }
 
 // RuntimeRequest is a generic roothash get request for a specific runtime.

--- a/go/scheduler/api/api.go
+++ b/go/scheduler/api/api.go
@@ -368,9 +368,6 @@ type Backend interface {
 
 	// ConsensusParameters returns the scheduler consensus parameters.
 	ConsensusParameters(ctx context.Context, height int64) (*ConsensusParameters, error)
-
-	// Cleanup cleans up the scheduler backend.
-	Cleanup()
 }
 
 // GetCommitteesRequest is a GetCommittees request.

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -184,9 +184,6 @@ type Backend interface {
 
 	// WatchEvents returns a channel that produces a stream of Events.
 	WatchEvents(ctx context.Context) (<-chan *Event, pubsub.ClosableSubscription, error)
-
-	// Cleanup cleans up the backend.
-	Cleanup()
 }
 
 // ThresholdQuery is a threshold query.

--- a/go/vault/api/api.go
+++ b/go/vault/api/api.go
@@ -57,9 +57,6 @@ type Backend interface {
 
 	// WatchEvents returns a channel that produces a stream of Events.
 	WatchEvents(ctx context.Context) (<-chan *Event, pubsub.ClosableSubscription, error)
-
-	// Cleanup cleans up the backend.
-	Cleanup()
 }
 
 // VaultQuery is a query for data about a given vault.


### PR DESCRIPTION
Method `GetBlockResults` is needed by the light client node to serve events.

If performance degrades due to unmarshalling block results metadata in every `GetEvents` call, we can retain the backend interface and use `GetCometBFTBlockResults` if implemented, falling back to `GetBlockResults` otherwise.