### PR TITLE
go/consensus/cometbft/abci/prune: Lazy read earliest version

### DIFF
--- a/go/consensus/cometbft/abci/prune_test.go
+++ b/go/consensus/cometbft/abci/prune_test.go
@@ -45,26 +45,20 @@ func TestPruneKeepN(t *testing.T) {
 		require.NoError(err, "Finalize")
 	}
 
-	earliestVersion := ndb.GetEarliestVersion()
-	require.EqualValues(1, earliestVersion, "earliest version should be correct")
-	latestVersion, exists := ndb.GetLatestVersion()
-	require.EqualValues(11, latestVersion, "latest version should be correct")
-	require.True(exists, "latest version should exist")
-
 	pruner, err := newStatePruner(&PruneConfig{
 		Strategy: PruneKeepN,
 		NumKept:  2,
 	}, ndb)
 	require.NoError(err, "newStatePruner failed")
 
-	earliestVersion = ndb.GetEarliestVersion()
+	earliestVersion := ndb.GetEarliestVersion()
 	require.EqualValues(1, earliestVersion, "earliest version should be correct")
-	latestVersion, exists = ndb.GetLatestVersion()
+	latestVersion, exists := ndb.GetLatestVersion()
 	require.EqualValues(11, latestVersion, "latest version should be correct")
 	require.True(exists, "latest version should exist")
 
 	lastRetainedVersion := pruner.GetLastRetainedVersion()
-	require.EqualValues(1, lastRetainedVersion, "last retained version should be correct")
+	require.Zero(lastRetainedVersion, "last retained version should not be set")
 
 	err = pruner.Prune(11)
 	require.NoError(err, "Prune")


### PR DESCRIPTION
Tested on a client with an empty data dir. 

Before (prune starts with 0):
```json
{"caller":"prune.go:174","latest_version":26455298,"level":"debug","log_event":"cometbft/abci/prune","module":"abci-mux/pruner","msg":"Prune: Delete","pruned_version":0,"ts":"2025-05-06T10:38:45.508387156Z"}
```

After (prune starts with 26456114) :
```json
{"caller":"prune.go:170","latest_version":26456114,"level":"debug","log_event":"cometbft/abci/prune","module":"abci-mux/pruner","msg":"Prune: Delete","pruned_version":26451681,"ts":"2025-05-06T10:34:34.592106051Z"}
```

