### PR TITLE
ci: Fix goreleaser path

### DIFF
--- a/.github/workflows/ci-reproducibility.yml
+++ b/.github/workflows/ci-reproducibility.yml
@@ -90,7 +90,7 @@ jobs:
           sha256sum ${OASIS_NODE_MAKE_PATH} ${OASIS_NODE_GORELEASER_PATH} > ../oasis-node-SHA256SUMs
         env:
           OASIS_NODE_MAKE_PATH: go/oasis-node/oasis-node
-          OASIS_NODE_GORELEASER_PATH: dist/oasis-node_linux_amd64/oasis-node
+          OASIS_NODE_GORELEASER_PATH: dist/oasis-node_linux_amd64_v1/oasis-node
       - name: Upload checksums
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
```
*** Creating release for version 25.3...
  • building binaries
    • building                                       binary=dist/oasis-remote-signer_linux_amd64_v1/oasis-remote-signer
    • building                                       binary=dist/oasis-node_linux_amd64_v1/oasis-node
    • building                                       binary=dist/oasis-net-runner_linux_amd64_v1/oasis-net-runner
```