### PR TITLE
go/consensus/api: Remove GetSignerNonce

### DIFF
--- a/.changelog/6208.internal.md
+++ b/.changelog/6208.internal.md
@@ -1,0 +1,4 @@
+go/consensus/api: Remove GetSignerNonce
+
+The `GetSignerNonce` method was removed as it is no longer used.
+Nonce information is now available through the staking backend.

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -157,12 +157,6 @@ type Backend interface {
 	// SubmitEvidence submits evidence of misbehavior.
 	SubmitEvidence(ctx context.Context, evidence *Evidence) error
 
-	// GetSignerNonce returns the nonce that should be used by the given
-	// signer for transmitting the next transaction.
-	//
-	// Deprecated: Use staking backend instead.
-	GetSignerNonce(ctx context.Context, req *GetSignerNonceRequest) (uint64, error)
-
 	// GetTransactions returns a list of all transactions contained within a
 	// consensus block at a specific height.
 	//
@@ -443,12 +437,6 @@ type StatePruneHandler interface {
 type EstimateGasRequest struct {
 	Signer      signature.PublicKey      `json:"signer"`
 	Transaction *transaction.Transaction `json:"transaction"`
-}
-
-// GetSignerNonceRequest is a GetSignerNonce request.
-type GetSignerNonceRequest struct {
-	AccountAddress staking.Address `json:"account_address"`
-	Height         int64           `json:"height"`
 }
 
 // TransactionsWithResults is GetTransactionsWithResults response.

--- a/go/consensus/api/grpc.go
+++ b/go/consensus/api/grpc.go
@@ -37,8 +37,6 @@ var (
 	methodEstimateGas = serviceName.NewMethod("EstimateGas", &EstimateGasRequest{})
 	// methodMinGasPrice is the MinGasPrice method.
 	methodMinGasPrice = serviceName.NewMethod("MinGasPrice", nil)
-	// methodGetSignerNonce is a GetSignerNonce method.
-	methodGetSignerNonce = serviceName.NewMethod("GetSignerNonce", &GetSignerNonceRequest{})
 	// methodGetBlock is the GetBlock method.
 	methodGetBlock = serviceName.NewMethod("GetBlock", int64(0))
 	// methodGetBlockResults is the GetBlockResults method.
@@ -107,10 +105,6 @@ var (
 			{
 				MethodName: methodMinGasPrice.ShortName(),
 				Handler:    handlerMinGasPrice,
-			},
-			{
-				MethodName: methodGetSignerNonce.ShortName(),
-				Handler:    handlerGetSignerNonce,
 			},
 			{
 				MethodName: methodGetBlock.ShortName(),
@@ -327,29 +321,6 @@ func handlerMinGasPrice(
 		return srv.(Services).Core().MinGasPrice(ctx)
 	}
 	return interceptor(ctx, nil, info, handler)
-}
-
-func handlerGetSignerNonce(
-	srv any,
-	ctx context.Context,
-	dec func(any) error,
-	interceptor grpc.UnaryServerInterceptor,
-) (any, error) {
-	rq := new(GetSignerNonceRequest)
-	if err := dec(rq); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(Services).Core().GetSignerNonce(ctx, rq)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: methodGetSignerNonce.FullName(),
-	}
-	handler := func(ctx context.Context, req any) (any, error) {
-		return srv.(Services).Core().GetSignerNonce(ctx, req.(*GetSignerNonceRequest))
-	}
-	return interceptor(ctx, rq, info, handler)
 }
 
 func handlerGetBlock(
@@ -821,14 +792,6 @@ func (c *Client) MinGasPrice(ctx context.Context) (*quantity.Quantity, error) {
 		return nil, err
 	}
 	return &rsp, nil
-}
-
-func (c *Client) GetSignerNonce(ctx context.Context, req *GetSignerNonceRequest) (uint64, error) {
-	var nonce uint64
-	if err := c.conn.Invoke(ctx, methodGetSignerNonce.FullName(), req, &nonce); err != nil {
-		return nonce, err
-	}
-	return nonce, nil
 }
 
 func (c *Client) GetBlock(ctx context.Context, height int64) (*Block, error) {

--- a/go/consensus/cometbft/full/archive.go
+++ b/go/consensus/cometbft/full/archive.go
@@ -143,11 +143,6 @@ func (srv *archiveService) EstimateGas(context.Context, *consensusAPI.EstimateGa
 }
 
 // Implements consensusAPI.Backend.
-func (srv *archiveService) GetSignerNonce(context.Context, *consensusAPI.GetSignerNonceRequest) (uint64, error) {
-	return 0, consensusAPI.ErrUnsupported
-}
-
-// Implements consensusAPI.Backend.
 func (srv *archiveService) WatchBlocks(ctx context.Context) (<-chan *consensusAPI.Block, pubsub.ClosableSubscription, error) {
 	ctx, sub := pubsub.NewContextSubscription(ctx)
 	ch := make(chan *consensusAPI.Block)

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -520,19 +520,6 @@ func (n *commonNode) heightToCometBFTHeight(height int64) (int64, error) {
 	return height, nil
 }
 
-// Implements consensusAPI.Backend.
-func (n *commonNode) GetSignerNonce(ctx context.Context, req *consensusAPI.GetSignerNonceRequest) (uint64, error) {
-	acct, err := n.Staking().Account(ctx, &stakingAPI.OwnerQuery{
-		Height: req.Height,
-		Owner:  req.AccountAddress,
-	})
-	if err != nil {
-		return 0, err
-	}
-
-	return acct.General.Nonce, nil
-}
-
 // GetCometBFTBlock returns the CometBFT block at the specified height.
 func (n *commonNode) GetCometBFTBlock(ctx context.Context, height int64) (*cmttypes.Block, error) {
 	if err := n.ensureStarted(ctx); err != nil {

--- a/go/consensus/tests/tester.go
+++ b/go/consensus/tests/tester.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api"
 	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
@@ -130,15 +129,6 @@ func ConsensusImplementationTests(t *testing.T, consensus api.Backend) {
 		Transaction: transaction.NewTransaction(0, nil, staking.MethodTransfer, &staking.Transfer{}),
 	})
 	require.NoError(err, "EstimateGas")
-
-	nonce, err := consensus.GetSignerNonce(ctx, &api.GetSignerNonceRequest{ //nolint:staticcheck
-		AccountAddress: staking.NewAddress(
-			signature.NewPublicKey("badfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
-		),
-		Height: api.HeightLatest,
-	})
-	require.NoError(err, "GetSignerNonce")
-	require.Equal(uint64(0), nonce, "Nonce should be zero")
 
 	// Light client API.
 	shdr, err := consensus.GetLightBlock(ctx, blk.Height)

--- a/go/oasis-test-runner/scenario/e2e/runtime/archive_api.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/archive_api.go
@@ -168,12 +168,6 @@ func (sc *archiveAPI) testArchiveAPI(ctx context.Context, archiveCtrl *oasis.Con
 		return fmt.Errorf("archive node GetUnconfirmedTransactions should work: %w", err)
 	}
 
-	sc.Logger.Info("testing GetSignerNonce")
-	_, err = archiveCtrl.Consensus.GetSignerNonce(ctx, &consensusAPI.GetSignerNonceRequest{}) //nolint:staticcheck
-	if err != consensusAPI.ErrUnsupported {
-		return fmt.Errorf("archive node GetSignerNonce should fail with unsupported")
-	}
-
 	sc.Logger.Info("testing GetLightBlock")
 	_, err = archiveCtrl.Consensus.GetLightBlock(ctx, consensusAPI.HeightLatest)
 	if err != nil {


### PR DESCRIPTION
The `GetSignerNonce` method was removed as it is no longer used. Nonce information is now available through the staking backend.

Merge after Oasis Core 25.4 is released and deployed on Mainnet.