### PR TITLE
go/consensus/cometbft/light/client: Refactor light client

### DIFF
--- a/go/consensus/cometbft/light/client.go
+++ b/go/consensus/cometbft/light/client.go
@@ -74,6 +74,23 @@ func NewClient(ctx context.Context, chainContext string, p2p rpc.P2P, cfg Config
 	}, nil
 }
 
+// LastTrustedHeight returns the last trusted height.
+func (c *Client) LastTrustedHeight() (int64, error) {
+	height, err := c.lightClient.LastTrustedHeight()
+	if err != nil {
+		return 0, err
+	}
+	if height == -1 {
+		return 0, fmt.Errorf("no trusted headers")
+	}
+	return height, nil
+}
+
+// VerifyHeader verifies the given header.
+func (c *Client) VerifyHeader(ctx context.Context, header *cmttypes.Header) error {
+	return c.lightClient.VerifyHeader(ctx, header, time.Now())
+}
+
 // VerifyLightBlockAt returns a verified light block at the given height.
 func (c *Client) VerifyLightBlockAt(ctx context.Context, height int64) (*cmttypes.LightBlock, error) {
 	return c.lightClient.VerifyLightBlockAtHeight(ctx, height, time.Now())

--- a/go/consensus/cometbft/light/client.go
+++ b/go/consensus/cometbft/light/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	dbm "github.com/cometbft/cometbft-db"
@@ -31,6 +32,8 @@ type Config struct {
 // Client is a CometBFT consensus light client that talks with remote oasis-nodes that are using
 // the CometBFT consensus backend and verifies responses.
 type Client struct {
+	mu sync.Mutex
+
 	providers []*Provider
 
 	// lightClient is a wrapped CometBFT light client used for verifying headers.
@@ -88,11 +91,15 @@ func (c *Client) LastTrustedHeight() (int64, error) {
 
 // VerifyHeader verifies the given header.
 func (c *Client) VerifyHeader(ctx context.Context, header *cmttypes.Header) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.lightClient.VerifyHeader(ctx, header, time.Now())
 }
 
 // VerifyLightBlockAt returns a verified light block at the given height.
 func (c *Client) VerifyLightBlockAt(ctx context.Context, height int64) (*cmttypes.LightBlock, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.lightClient.VerifyLightBlockAtHeight(ctx, height, time.Now())
 }
 

--- a/go/consensus/cometbft/light/client.go
+++ b/go/consensus/cometbft/light/client.go
@@ -64,15 +64,8 @@ func tryProviders[R any](
 	return result, nil, err
 }
 
-// GetLightBlock queries peers for a specific light block.
-func (c *Client) GetLightBlock(ctx context.Context, height int64) (*consensus.LightBlock, rpc.PeerFeedback, error) {
-	return tryProviders(ctx, c.providers, func(p *Provider) (*consensus.LightBlock, rpc.PeerFeedback, error) {
-		return p.GetLightBlock(ctx, height)
-	})
-}
-
-// GetParameters queries peers for consensus parameters for a specific height.
-func (c *Client) GetParameters(ctx context.Context, height int64) (*consensus.Parameters, rpc.PeerFeedback, error) {
+// getParameters queries peers for consensus parameters for a specific height.
+func (c *Client) getParameters(ctx context.Context, height int64) (*consensus.Parameters, rpc.PeerFeedback, error) {
 	return tryProviders(ctx, c.providers, func(p *Provider) (*consensus.Parameters, rpc.PeerFeedback, error) {
 		return p.GetParameters(ctx, height)
 	})
@@ -85,7 +78,7 @@ func (c *Client) GetVerifiedLightBlock(ctx context.Context, height int64) (*cmtt
 
 // GetVerifiedParameters returns verified consensus parameters.
 func (c *Client) GetVerifiedParameters(ctx context.Context, height int64) (*cmtproto.ConsensusParams, error) {
-	p, pf, err := c.GetParameters(ctx, height)
+	p, pf, err := c.getParameters(ctx, height)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
CometBFT's light client is not safe for concurrent use by multiple goroutines, so we need to verify only one header/block at a time.