### PR TITLE
go/runtime/localstorage: Fix nil dereference after close

### DIFF
--- a/.changelog/6231.bugfix.md
+++ b/.changelog/6231.bugfix.md
@@ -1,0 +1,1 @@
+go/runtime/localstorage: Fix nil dereference after close


### PR DESCRIPTION
Fixes #6232 