### PR TITLE
Split storage sync P2P protocol

### DIFF
--- a/.changelog/6262.feature.md
+++ b/.changelog/6262.feature.md
@@ -1,0 +1,12 @@
+go: Split storage sync p2p protocol
+
+Storage sync protocol was split into two independent protocols (checkpoint
+and diff sync).
+
+This change was made since there may be fewer nodes that expose checkpoints
+than storage diff. Previously, this could lead to issues with state sync
+when a node was connected with peers that supported storage sync protocol
+but had no checkpoints available.
+
+This was done in backwards compatible manner, so that both protocols are still
+advertised and used. Eventually, we plan to remove legacy protocol.

--- a/go/oasis-node/cmd/debug/byzantine/node.go
+++ b/go/oasis-node/cmd/debug/byzantine/node.go
@@ -22,7 +22,7 @@ import (
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
 	"github.com/oasisprotocol/oasis-core/go/worker/client"
-	storageP2P "github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/sync"
+	storageP2P "github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/synclegacy"
 )
 
 type byzantine struct {

--- a/go/p2p/p2p.go
+++ b/go/p2p/p2p.go
@@ -83,6 +83,8 @@ type p2p struct {
 	registerAddresses []multiaddr.Multiaddr
 	topics            map[string]*topicHandler
 
+	protocolRegistry *protocol.Registry
+
 	logger *logging.Logger
 }
 
@@ -281,7 +283,7 @@ func (p *p2p) Publish(_ context.Context, topic string, msg any) {
 
 // Implements api.Service.
 func (p *p2p) RegisterHandler(topic string, handler api.Handler) {
-	protocol.ValidateTopicID(topic)
+	p.protocolRegistry.ValidateTopicID(topic)
 
 	p.Lock()
 	defer p.Unlock()
@@ -337,7 +339,7 @@ func (p *p2p) PeerManager() api.PeerManager {
 
 // Implements api.Service.
 func (p *p2p) RegisterProtocolServer(srv rpc.Server) {
-	protocol.ValidateProtocolID(srv.Protocol())
+	p.protocolRegistry.ValidateProtocolID(srv.Protocol())
 
 	p.host.SetStreamHandler(srv.Protocol(), srv.HandleStream)
 
@@ -439,6 +441,7 @@ func New(identity *identity.Identity, chainContext string, store *persistent.Com
 		pubsub:            pubsub,
 		registerAddresses: cfg.Addresses,
 		topics:            make(map[string]*topicHandler),
+		protocolRegistry:  protocol.NewRegistry(),
 		logger:            logger,
 	}, nil
 }

--- a/go/p2p/protocol/protocol.go
+++ b/go/p2p/protocol/protocol.go
@@ -12,33 +12,32 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/p2p/api"
 )
 
-type protocolRegistry struct {
+// Registry is responsible for ensuring unique protocol ids.
+type Registry struct {
 	mu        sync.Mutex
 	protocols map[core.ProtocolID]struct{}
 }
 
-func newProtocolRegistry() *protocolRegistry {
-	return &protocolRegistry{
+func NewRegistry() *Registry {
+	return &Registry{
 		protocols: make(map[core.ProtocolID]struct{}),
 	}
 }
 
-var registry = newProtocolRegistry()
-
 // ValidateProtocolID panics if the protocol id is not unique.
-func ValidateProtocolID(p core.ProtocolID) {
-	registry.mu.Lock()
-	defer registry.mu.Unlock()
+func (r *Registry) ValidateProtocolID(p core.ProtocolID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
-	if _, ok := registry.protocols[p]; ok {
+	if _, ok := r.protocols[p]; ok {
 		panic(fmt.Sprintf("p2p/protocol: protocol or topic with name '%s' already exists", p))
 	}
-	registry.protocols[p] = struct{}{}
+	r.protocols[p] = struct{}{}
 }
 
 // ValidateTopicID panics if the topic id is not unique.
-func ValidateTopicID(topic string) {
-	ValidateProtocolID(core.ProtocolID(topic))
+func (r *Registry) ValidateTopicID(topic string) {
+	r.ValidateProtocolID(core.ProtocolID(topic))
 }
 
 // NewProtocolID generates a protocol identifier for a consensus P2P protocol.

--- a/go/p2p/protocol/protocol_test.go
+++ b/go/p2p/protocol/protocol_test.go
@@ -56,11 +56,10 @@ func TestProtocolID(t *testing.T) {
 		require.Equal(expected, NewTopicIDForRuntime(chainContext, runtimeID, kind, version))
 	})
 
-	registry = newProtocolRegistry()
-
 	t.Run("ValidateProtocolID", func(_ *testing.T) {
-		ValidateProtocolID("protocol-1")
-		ValidateProtocolID("protocol-2")
+		r := NewRegistry()
+		r.ValidateProtocolID("protocol-1")
+		r.ValidateProtocolID("protocol-2")
 	})
 
 	t.Run("ValidateProtocolID panics", func(t *testing.T) {
@@ -69,9 +68,8 @@ func TestProtocolID(t *testing.T) {
 				t.Errorf("validate protocol id should fail")
 			}
 		}()
-		ValidateProtocolID("protocol")
-		ValidateProtocolID("protocol")
+		r := NewRegistry()
+		r.ValidateProtocolID("protocol")
+		r.ValidateProtocolID("protocol")
 	})
-
-	registry = newProtocolRegistry()
 }

--- a/go/storage/mkvs/checkpoint/checkpoint.go
+++ b/go/storage/mkvs/checkpoint/checkpoint.go
@@ -48,7 +48,12 @@ type ChunkProvider interface {
 
 // GetCheckpointsRequest is a GetCheckpoints request.
 type GetCheckpointsRequest struct {
-	Version   uint16           `json:"version"`
+	// Version is version of the checkpoint request.
+	Version uint16 `json:"version"`
+	// Namespace is the namespace the checkpoints are for.
+	//
+	// Existing server implementation may ignore validation of this field.
+	// Best practice is to still pass it, but not rely on the actual validation.
 	Namespace common.Namespace `json:"namespace"`
 
 	// RootVersion specifies an optional root version to limit the request to. If specified, only

--- a/go/worker/storage/committee/checkpoint_sync_test.go
+++ b/go/worker/storage/committee/checkpoint_sync_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/node"
-	"github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/sync"
+	"github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/checkpointsync"
 )
 
 func TestSortCheckpoints(t *testing.T) {
-	cp1 := &sync.Checkpoint{
+	cp1 := &checkpointsync.Checkpoint{
 		Metadata: &checkpoint.Metadata{
 			Root: node.Root{
 				Version: 2,
@@ -20,7 +20,7 @@ func TestSortCheckpoints(t *testing.T) {
 		},
 		Peers: []rpc.PeerFeedback{rpc.NewNopPeerFeedback(), rpc.NewNopPeerFeedback()},
 	}
-	cp2 := &sync.Checkpoint{
+	cp2 := &checkpointsync.Checkpoint{
 		Metadata: &checkpoint.Metadata{
 			Root: node.Root{
 				Version: 2,
@@ -28,7 +28,7 @@ func TestSortCheckpoints(t *testing.T) {
 		},
 		Peers: []rpc.PeerFeedback{rpc.NewNopPeerFeedback()},
 	}
-	cp3 := &sync.Checkpoint{
+	cp3 := &checkpointsync.Checkpoint{
 		Metadata: &checkpoint.Metadata{
 			Root: node.Root{
 				Version: 1,
@@ -36,7 +36,7 @@ func TestSortCheckpoints(t *testing.T) {
 		},
 		Peers: []rpc.PeerFeedback{rpc.NewNopPeerFeedback(), rpc.NewNopPeerFeedback()},
 	}
-	cp4 := &sync.Checkpoint{
+	cp4 := &checkpointsync.Checkpoint{
 		Metadata: &checkpoint.Metadata{
 			Root: node.Root{
 				Version: 1,
@@ -45,9 +45,9 @@ func TestSortCheckpoints(t *testing.T) {
 		Peers: []rpc.PeerFeedback{rpc.NewNopPeerFeedback()},
 	}
 
-	s := []*sync.Checkpoint{cp2, cp3, cp4, cp1}
+	s := []*checkpointsync.Checkpoint{cp2, cp3, cp4, cp1}
 
 	sortCheckpoints(s)
 
-	assert.Equal(t, s, []*sync.Checkpoint{cp1, cp2, cp3, cp4})
+	assert.Equal(t, s, []*checkpointsync.Checkpoint{cp1, cp2, cp3, cp4})
 }

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -276,9 +276,7 @@ func NewNode(
 	})
 
 	// Advertise and serve legacy storage sync protocol.
-	// TODO #6270 will move advertisement part out of the protocol registration.
 	commonNode.P2P.RegisterProtocolServer(synclegacy.NewServer(commonNode.ChainContext, commonNode.Runtime.ID(), localStorage))
-	commonNode.P2P.RegisterProtocol(synclegacy.GetStorageSyncProtocolID(commonNode.ChainContext, commonNode.Runtime.ID()), 5, 10)
 
 	// Register diff sync protocol server.
 	commonNode.P2P.RegisterProtocolServer(diffsync.NewServer(commonNode.ChainContext, commonNode.Runtime.ID(), localStorage))
@@ -288,8 +286,6 @@ func NewNode(
 	}
 
 	// Create diff and checkpoint sync p2p protocol clients that have a fallback to the old legacy storage sync protocol.
-	// TODO: This automatically starts advertising the given protocol even if the server is not registered.
-	//       #6270 wil fix that by moving advertisement out of the client creation.
 	n.diffSync = diffsync.NewClient(commonNode.P2P, commonNode.ChainContext, commonNode.Runtime.ID())
 	n.checkpointSync = checkpointsync.NewClient(commonNode.P2P, commonNode.ChainContext, commonNode.Runtime.ID())
 

--- a/go/worker/storage/p2p/checkpointsync/client.go
+++ b/go/worker/storage/p2p/checkpointsync/client.go
@@ -33,6 +33,9 @@ type Client interface {
 		request *GetCheckpointChunkRequest,
 		cp *Checkpoint,
 	) (*GetCheckpointChunkResponse, rpc.PeerFeedback, error)
+
+	// IsReady is true when protocol client is aware of at least one remote peer.
+	IsReady() bool
 }
 
 // Checkpoint contains checkpoint metadata together with peer information.
@@ -112,6 +115,10 @@ func (c *client) GetCheckpointChunk(
 
 func (c *client) getBestPeers(opts ...rpc.BestPeersOption) []core.PeerID {
 	return append(c.mgr.GetBestPeers(opts...), c.fallbackMgr.GetBestPeers(opts...)...)
+}
+
+func (c *client) IsReady() bool {
+	return len(c.getBestPeers()) > 0
 }
 
 // NewClient creates a new checkpoint sync protocol client.

--- a/go/worker/storage/p2p/checkpointsync/client.go
+++ b/go/worker/storage/p2p/checkpointsync/client.go
@@ -120,9 +120,8 @@ func (c *client) getBestPeers(opts ...rpc.BestPeersOption) []core.PeerID {
 // upgrades of the network, this client has a fallback to the old legacy protocol.
 // The new protocol is prioritized.
 //
-// Warning: This client only registers the checkpoint sync protocol with the P2P
-// service. To enable advertisement of the legacy protocol, it must be registered
-// separately.
+// Finally, it ensures underlying p2p service starts tracking protocol peers
+// for both new and legacy protocol.
 func NewClient(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) Client {
 	pid := protocol.NewRuntimeProtocolID(chainContext, runtimeID, CheckpointSyncProtocolID, CheckpointSyncProtocolVersion)
 	fallbackPid := synclegacy.GetStorageSyncProtocolID(chainContext, runtimeID)
@@ -135,6 +134,7 @@ func NewClient(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) Cli
 	rc.RegisterListener(fallbackMgr)
 
 	p2p.RegisterProtocol(pid, minProtocolPeers, totalProtocolPeers)
+	p2p.RegisterProtocol(fallbackPid, minProtocolPeers, totalProtocolPeers)
 
 	return &client{
 		rc:          rc,

--- a/go/worker/storage/p2p/checkpointsync/client.go
+++ b/go/worker/storage/p2p/checkpointsync/client.go
@@ -10,7 +10,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
-	"github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/sync"
+	"github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/synclegacy"
 )
 
 const (
@@ -125,7 +125,7 @@ func (c *client) getBestPeers(opts ...rpc.BestPeersOption) []core.PeerID {
 // separately.
 func NewClient(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) Client {
 	pid := protocol.NewRuntimeProtocolID(chainContext, runtimeID, CheckpointSyncProtocolID, CheckpointSyncProtocolVersion)
-	fallbackPid := sync.GetStorageSyncProtocolID(chainContext, runtimeID)
+	fallbackPid := synclegacy.GetStorageSyncProtocolID(chainContext, runtimeID)
 	rc := rpc.NewClient(p2p.Host(), pid, fallbackPid)
 	mgr := rpc.NewPeerManager(p2p, pid)
 	rc.RegisterListener(mgr)

--- a/go/worker/storage/p2p/checkpointsync/protocol.go
+++ b/go/worker/storage/p2p/checkpointsync/protocol.go
@@ -1,5 +1,5 @@
 // Package checkpointsync defines wire protocol together with client/server
-// implementations for the checkpoints sync protocol, used for runtime state sync.
+// implementations for the checkpoint sync protocol, used for runtime state sync.
 package checkpointsync
 
 import (

--- a/go/worker/storage/p2p/checkpointsync/protocol.go
+++ b/go/worker/storage/p2p/checkpointsync/protocol.go
@@ -1,0 +1,74 @@
+// Package checkpointsync defines wire protocol together with client/server
+// implementations for the checkpoints sync protocol, used for runtime state sync.
+package checkpointsync
+
+import (
+	"time"
+
+	"github.com/libp2p/go-libp2p/core"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
+	"github.com/oasisprotocol/oasis-core/go/p2p/peermgmt"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
+	"github.com/oasisprotocol/oasis-core/go/storage/api"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
+)
+
+// CheckpointSyncProtocolID is a unique protocol identifier for the checkpoint sync protocol.
+const CheckpointSyncProtocolID = "checkpointsync"
+
+// CheckpointSyncProtocolVersion is the supported version of the checkpoint sync protocol.
+var CheckpointSyncProtocolVersion = version.Version{Major: 1, Minor: 0, Patch: 0}
+
+// Constants related to the GetCheckpoints method.
+const (
+	MethodGetCheckpoints = "GetCheckpoints"
+)
+
+// GetCheckpointsRequest is a GetCheckpoints request.
+type GetCheckpointsRequest struct {
+	Version uint16 `json:"version"`
+}
+
+// GetCheckpointsResponse is a response to a GetCheckpoints request.
+type GetCheckpointsResponse struct {
+	Checkpoints []*checkpoint.Metadata `json:"checkpoints,omitempty"`
+}
+
+// Constants related to the GetCheckpointChunk method.
+const (
+	MethodGetCheckpointChunk          = "GetCheckpointChunk"
+	MaxGetCheckpointChunkResponseTime = 60 * time.Second
+)
+
+// GetCheckpointChunkRequest is a GetCheckpointChunk request.
+type GetCheckpointChunkRequest struct {
+	Version uint16    `json:"version"`
+	Root    api.Root  `json:"root"`
+	Index   uint64    `json:"index"`
+	Digest  hash.Hash `json:"digest"`
+}
+
+// GetCheckpointChunkResponse is a response to a GetCheckpointChunk request.
+type GetCheckpointChunkResponse struct {
+	Chunk []byte `json:"chunk,omitempty"`
+}
+
+func init() {
+	peermgmt.RegisterNodeHandler(&peermgmt.NodeHandlerBundle{
+		ProtocolsFn: func(n *node.Node, chainContext string) []core.ProtocolID {
+			if !n.HasRoles(node.RoleComputeWorker | node.RoleStorageRPC) {
+				return []core.ProtocolID{}
+			}
+
+			protocols := make([]core.ProtocolID, len(n.Runtimes))
+			for i, rt := range n.Runtimes {
+				protocols[i] = protocol.NewRuntimeProtocolID(chainContext, rt.ID, CheckpointSyncProtocolID, CheckpointSyncProtocolVersion)
+			}
+
+			return protocols
+		},
+	})
+}

--- a/go/worker/storage/p2p/checkpointsync/protocol.go
+++ b/go/worker/storage/p2p/checkpointsync/protocol.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core"
 
+	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
@@ -21,6 +22,11 @@ const CheckpointSyncProtocolID = "checkpointsync"
 
 // CheckpointSyncProtocolVersion is the supported version of the checkpoint sync protocol.
 var CheckpointSyncProtocolVersion = version.Version{Major: 1, Minor: 0, Patch: 0}
+
+// ProtocolID returns the runtime checkpoint sync protocol ID.
+func ProtocolID(chainContext string, runtimeID common.Namespace) core.ProtocolID {
+	return protocol.NewRuntimeProtocolID(chainContext, runtimeID, CheckpointSyncProtocolID, CheckpointSyncProtocolVersion)
+}
 
 // Constants related to the GetCheckpoints method.
 const (
@@ -40,7 +46,7 @@ type GetCheckpointsResponse struct {
 // Constants related to the GetCheckpointChunk method.
 const (
 	MethodGetCheckpointChunk          = "GetCheckpointChunk"
-	MaxGetCheckpointChunkResponseTime = 60 * time.Second
+	MaxGetCheckpointChunkResponseTime = 1 * time.Minute
 )
 
 // GetCheckpointChunkRequest is a GetCheckpointChunk request.

--- a/go/worker/storage/p2p/checkpointsync/server.go
+++ b/go/worker/storage/p2p/checkpointsync/server.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
-	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 	"github.com/oasisprotocol/oasis-core/go/storage/api"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
@@ -70,5 +69,5 @@ func (s *service) handleGetCheckpointChunk(ctx context.Context, request *GetChec
 
 // NewServer creates a new checkpoints protocol server.
 func NewServer(chainContext string, runtimeID common.Namespace, backend api.Backend) rpc.Server {
-	return rpc.NewServer(protocol.NewRuntimeProtocolID(chainContext, runtimeID, CheckpointSyncProtocolID, CheckpointSyncProtocolVersion), &service{backend})
+	return rpc.NewServer(ProtocolID(chainContext, runtimeID), &service{backend})
 }

--- a/go/worker/storage/p2p/checkpointsync/server.go
+++ b/go/worker/storage/p2p/checkpointsync/server.go
@@ -1,0 +1,74 @@
+package checkpointsync
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
+	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+	"github.com/oasisprotocol/oasis-core/go/storage/api"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
+)
+
+type service struct {
+	backend api.Backend
+}
+
+func (s *service) HandleRequest(ctx context.Context, method string, body cbor.RawMessage) (any, error) {
+	switch method {
+	case MethodGetCheckpoints:
+		var rq GetCheckpointsRequest
+		if err := cbor.Unmarshal(body, &rq); err != nil {
+			return nil, rpc.ErrBadRequest
+		}
+
+		return s.handleGetCheckpoints(ctx, &rq)
+	case MethodGetCheckpointChunk:
+		var rq GetCheckpointChunkRequest
+		if err := cbor.Unmarshal(body, &rq); err != nil {
+			return nil, rpc.ErrBadRequest
+		}
+
+		return s.handleGetCheckpointChunk(ctx, &rq)
+	default:
+		return nil, rpc.ErrMethodNotSupported
+	}
+}
+
+func (s *service) handleGetCheckpoints(ctx context.Context, request *GetCheckpointsRequest) (*GetCheckpointsResponse, error) {
+	cps, err := s.backend.GetCheckpoints(ctx, &checkpoint.GetCheckpointsRequest{
+		Version: request.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetCheckpointsResponse{
+		Checkpoints: cps,
+	}, nil
+}
+
+func (s *service) handleGetCheckpointChunk(ctx context.Context, request *GetCheckpointChunkRequest) (*GetCheckpointChunkResponse, error) {
+	// TODO: Use stream resource manager to track buffer use.
+	var buf bytes.Buffer
+	err := s.backend.GetCheckpointChunk(ctx, &checkpoint.ChunkMetadata{
+		Version: request.Version,
+		Root:    request.Root,
+		Index:   request.Index,
+		Digest:  request.Digest,
+	}, &buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetCheckpointChunkResponse{
+		Chunk: buf.Bytes(),
+	}, nil
+}
+
+// NewServer creates a new checkpoints protocol server.
+func NewServer(chainContext string, runtimeID common.Namespace, backend api.Backend) rpc.Server {
+	return rpc.NewServer(protocol.NewRuntimeProtocolID(chainContext, runtimeID, CheckpointSyncProtocolID, CheckpointSyncProtocolVersion), &service{backend})
+}

--- a/go/worker/storage/p2p/diffsync/client.go
+++ b/go/worker/storage/p2p/diffsync/client.go
@@ -1,0 +1,73 @@
+package diffsync
+
+import (
+	"context"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
+	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+	"github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/sync"
+)
+
+const (
+	// minProtocolPeers is the minimum number of peers from the registry we want to have connected
+	// for diff sync protocol.
+	minProtocolPeers = 5
+
+	// totalProtocolPeers is the number of peers we want to have connected for diff sync protocol.
+	totalProtocolPeers = 10
+)
+
+// Client is a diff sync protocol client.
+type Client interface {
+	// GetDiff requests a write log of entries that must be applied to get from the first given root
+	// to the second one.
+	GetDiff(ctx context.Context, request *GetDiffRequest) (*GetDiffResponse, rpc.PeerFeedback, error)
+}
+
+type client struct {
+	rc          rpc.Client
+	mgr         rpc.PeerManager
+	fallbackMgr rpc.PeerManager
+}
+
+func (c *client) GetDiff(ctx context.Context, request *GetDiffRequest) (*GetDiffResponse, rpc.PeerFeedback, error) {
+	var rsp GetDiffResponse
+	peers := append(c.mgr.GetBestPeers(), c.fallbackMgr.GetBestPeers()...)
+	pf, err := c.rc.CallOne(ctx, peers, MethodGetDiff, request, &rsp,
+		rpc.WithMaxPeerResponseTime(MaxGetDiffResponseTime),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &rsp, pf, nil
+}
+
+// NewClient creates a new diff sync protocol client.
+//
+// Previously, it was part of the storage sync protocol. To enable seamless rolling
+// upgrades of the network, this client has a fallback to the old legacy protocol.
+// The new protocol is prioritized.
+//
+// Warning: This client only registers the diff sync protocol with the P2P
+// service. To enable advertisement of the legacy protocol, it must be registered
+// separately.
+func NewClient(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) Client {
+	pid := protocol.NewRuntimeProtocolID(chainContext, runtimeID, DiffSyncProtocolID, DiffSyncProtocolVersion)
+	fallbackPid := sync.GetStorageSyncProtocolID(chainContext, runtimeID)
+	rc := rpc.NewClient(p2p.Host(), pid, fallbackPid)
+	mgr := rpc.NewPeerManager(p2p, pid)
+	rc.RegisterListener(mgr)
+
+	// Fallback protocol requires a separate manager to manage peers that also support legacy protocol.
+	fallbackMgr := rpc.NewPeerManager(p2p, fallbackPid)
+	rc.RegisterListener(fallbackMgr)
+
+	p2p.RegisterProtocol(pid, minProtocolPeers, totalProtocolPeers)
+
+	return &client{
+		rc:          rc,
+		mgr:         mgr,
+		fallbackMgr: fallbackMgr,
+	}
+}

--- a/go/worker/storage/p2p/diffsync/client.go
+++ b/go/worker/storage/p2p/diffsync/client.go
@@ -49,9 +49,8 @@ func (c *client) GetDiff(ctx context.Context, request *GetDiffRequest) (*GetDiff
 // upgrades of the network, this client has a fallback to the old legacy protocol.
 // The new protocol is prioritized.
 //
-// Warning: This client only registers the diff sync protocol with the P2P
-// service. To enable advertisement of the legacy protocol, it must be registered
-// separately.
+// Finally, it ensures underlying p2p service starts tracking protocol peers
+// for both new and legacy protocol.
 func NewClient(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) Client {
 	pid := protocol.NewRuntimeProtocolID(chainContext, runtimeID, DiffSyncProtocolID, DiffSyncProtocolVersion)
 	fallbackPid := synclegacy.GetStorageSyncProtocolID(chainContext, runtimeID)
@@ -64,6 +63,7 @@ func NewClient(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) Cli
 	rc.RegisterListener(fallbackMgr)
 
 	p2p.RegisterProtocol(pid, minProtocolPeers, totalProtocolPeers)
+	p2p.RegisterProtocol(fallbackPid, minProtocolPeers, totalProtocolPeers)
 
 	return &client{
 		rc:          rc,

--- a/go/worker/storage/p2p/diffsync/client.go
+++ b/go/worker/storage/p2p/diffsync/client.go
@@ -6,7 +6,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
-	"github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/sync"
+	"github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/synclegacy"
 )
 
 const (
@@ -54,7 +54,7 @@ func (c *client) GetDiff(ctx context.Context, request *GetDiffRequest) (*GetDiff
 // separately.
 func NewClient(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) Client {
 	pid := protocol.NewRuntimeProtocolID(chainContext, runtimeID, DiffSyncProtocolID, DiffSyncProtocolVersion)
-	fallbackPid := sync.GetStorageSyncProtocolID(chainContext, runtimeID)
+	fallbackPid := synclegacy.GetStorageSyncProtocolID(chainContext, runtimeID)
 	rc := rpc.NewClient(p2p.Host(), pid, fallbackPid)
 	mgr := rpc.NewPeerManager(p2p, pid)
 	rc.RegisterListener(mgr)

--- a/go/worker/storage/p2p/diffsync/protocol.go
+++ b/go/worker/storage/p2p/diffsync/protocol.go
@@ -1,0 +1,55 @@
+// Package diffsync defines wire protocol together with client/server
+// implementations for the diff sync protocol, used for runtime block sync.
+package diffsync
+
+import (
+	"time"
+
+	"github.com/libp2p/go-libp2p/core"
+
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
+	"github.com/oasisprotocol/oasis-core/go/p2p/peermgmt"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
+	"github.com/oasisprotocol/oasis-core/go/storage/api"
+)
+
+// DiffSyncProtocolID is a unique protocol identifier for the diff sync protocol.
+const DiffSyncProtocolID = "diffsync"
+
+// DiffSyncProtocolVersion is the supported version of the diff sync protocol.
+var DiffSyncProtocolVersion = version.Version{Major: 1, Minor: 0, Patch: 0}
+
+// Constants related to the GetDiff method.
+const (
+	MethodGetDiff          = "GetDiff"
+	MaxGetDiffResponseTime = 15 * time.Second
+)
+
+// GetDiffRequest is a GetDiff request.
+type GetDiffRequest struct {
+	StartRoot api.Root `json:"start_root"`
+	EndRoot   api.Root `json:"end_root"`
+}
+
+// GetDiffResponse is a response to a GetDiff request.
+type GetDiffResponse struct {
+	WriteLog api.WriteLog `json:"write_log,omitempty"`
+}
+
+func init() {
+	peermgmt.RegisterNodeHandler(&peermgmt.NodeHandlerBundle{
+		ProtocolsFn: func(n *node.Node, chainContext string) []core.ProtocolID {
+			if !n.HasRoles(node.RoleComputeWorker | node.RoleStorageRPC) {
+				return []core.ProtocolID{}
+			}
+
+			protocols := make([]core.ProtocolID, len(n.Runtimes))
+			for i, rt := range n.Runtimes {
+				protocols[i] = protocol.NewRuntimeProtocolID(chainContext, rt.ID, DiffSyncProtocolID, DiffSyncProtocolVersion)
+			}
+
+			return protocols
+		},
+	})
+}

--- a/go/worker/storage/p2p/diffsync/protocol.go
+++ b/go/worker/storage/p2p/diffsync/protocol.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core"
 
+	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/p2p/peermgmt"
@@ -19,6 +20,11 @@ const DiffSyncProtocolID = "diffsync"
 
 // DiffSyncProtocolVersion is the supported version of the diff sync protocol.
 var DiffSyncProtocolVersion = version.Version{Major: 1, Minor: 0, Patch: 0}
+
+// ProtocolID returns the runtime diff sync protocol ID.
+func ProtocolID(chainContext string, runtimeID common.Namespace) core.ProtocolID {
+	return protocol.NewRuntimeProtocolID(chainContext, runtimeID, DiffSyncProtocolID, DiffSyncProtocolVersion)
+}
 
 // Constants related to the GetDiff method.
 const (

--- a/go/worker/storage/p2p/diffsync/server.go
+++ b/go/worker/storage/p2p/diffsync/server.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
-	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 	"github.com/oasisprotocol/oasis-core/go/storage/api"
 )
@@ -58,5 +57,5 @@ func (s *service) handleGetDiff(ctx context.Context, request *GetDiffRequest) (*
 
 // NewServer creates a new storage diff protocol server.
 func NewServer(chainContext string, runtimeID common.Namespace, backend api.Backend) rpc.Server {
-	return rpc.NewServer(protocol.NewRuntimeProtocolID(chainContext, runtimeID, DiffSyncProtocolID, DiffSyncProtocolVersion), &service{backend})
+	return rpc.NewServer(ProtocolID(chainContext, runtimeID), &service{backend})
 }

--- a/go/worker/storage/p2p/diffsync/server.go
+++ b/go/worker/storage/p2p/diffsync/server.go
@@ -1,0 +1,62 @@
+package diffsync
+
+import (
+	"context"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
+	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+	"github.com/oasisprotocol/oasis-core/go/storage/api"
+)
+
+type service struct {
+	backend api.Backend
+}
+
+func (s *service) HandleRequest(ctx context.Context, method string, body cbor.RawMessage) (any, error) {
+	switch method {
+	case MethodGetDiff:
+		var rq GetDiffRequest
+		if err := cbor.Unmarshal(body, &rq); err != nil {
+			return nil, rpc.ErrBadRequest
+		}
+
+		return s.handleGetDiff(ctx, &rq)
+	default:
+		return nil, rpc.ErrMethodNotSupported
+	}
+}
+
+func (s *service) handleGetDiff(ctx context.Context, request *GetDiffRequest) (*GetDiffResponse, error) {
+	it, err := s.backend.GetDiff(ctx, &api.GetDiffRequest{
+		StartRoot: request.StartRoot,
+		EndRoot:   request.EndRoot,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var rsp GetDiffResponse
+	for {
+		more, err := it.Next()
+		if err != nil {
+			return nil, err
+		}
+		if !more {
+			break
+		}
+
+		chunk, err := it.Value()
+		if err != nil {
+			return nil, err
+		}
+		rsp.WriteLog = append(rsp.WriteLog, chunk)
+	}
+	return &rsp, nil
+}
+
+// NewServer creates a new storage diff protocol server.
+func NewServer(chainContext string, runtimeID common.Namespace, backend api.Backend) rpc.Server {
+	return rpc.NewServer(protocol.NewRuntimeProtocolID(chainContext, runtimeID, DiffSyncProtocolID, DiffSyncProtocolVersion), &service{backend})
+}

--- a/go/worker/storage/p2p/sync_test/interoperable_test.go
+++ b/go/worker/storage/p2p/sync_test/interoperable_test.go
@@ -1,0 +1,395 @@
+package sync_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
+	"github.com/oasisprotocol/oasis-core/go/common/identity"
+	"github.com/oasisprotocol/oasis-core/go/common/persistent"
+	"github.com/oasisprotocol/oasis-core/go/config"
+	"github.com/oasisprotocol/oasis-core/go/p2p"
+	p2pApi "github.com/oasisprotocol/oasis-core/go/p2p/api"
+	"github.com/oasisprotocol/oasis-core/go/storage/api"
+	storageApi "github.com/oasisprotocol/oasis-core/go/storage/api"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/node"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/syncer"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/writelog"
+	"github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/checkpointsync"
+	"github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/diffsync"
+	"github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/sync"
+)
+
+var (
+	chainContext = "test_chain_context"
+	runtimeID    = common.NewTestNamespaceFromSeed([]byte("test namespace"), 0)
+)
+
+// TestStorageSync test interoperability of storage sync P2P protocols.
+//
+// For context storage sync protocol was split into two protocols that are
+// semantically equivalent to the respective subset of the legacy protocol.
+//
+// This test checks for backward and forward compatibility between legacy
+// and new clients, with respect to legacy and new protocol servers.
+func TestStorageSync(t *testing.T) {
+	require := require.New(t)
+
+	dataDir, err := os.MkdirTemp("", "oasis-worker-storage-p2p-sync_test")
+	require.NoError(err, "Failed to create a temporary directory")
+	defer os.RemoveAll(dataDir)
+
+	tests := []struct {
+		name       string
+		legacyHost bool
+		peerKind   peerKind
+		err        error
+	}{
+		{
+			name:       "Legacy host client with legacy peer",
+			legacyHost: true,
+			peerKind:   legacy,
+		},
+		{
+			name:       "Legacy host client with new peer (all protocols)",
+			legacyHost: true,
+			peerKind:   all,
+		},
+		{
+			name:       "New host client with legacy peer",
+			legacyHost: false,
+			peerKind:   legacy,
+		},
+		{
+			name:       "New host client with new peer (all protocols)",
+			legacyHost: false,
+			peerKind:   all,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			test(t, dataDir, tc.legacyHost, tc.peerKind)
+		})
+	}
+}
+
+func test(t *testing.T, dataDir string, legacyHost bool, peerKind peerKind) {
+	backend := &backendMock{}
+
+	peer1, clean1 := mustStartNewPeer(t, dataDir, 1, backend, none)
+	defer clean1()
+
+	peer2, clean2 := mustStartNewPeer(t, dataDir, 2, backend, peerKind)
+	defer clean2()
+
+	err := peer1.Host().Connect(context.Background(), peer.AddrInfo{
+		ID:    peer2.Host().ID(),
+		Addrs: peer2.Host().Addrs(),
+	})
+	require.NoError(t, err, "Connecting host to peer")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
+	defer cancel()
+
+	switch legacyHost {
+	case true:
+		testLegacyHostClient(ctx, t, peer1, backend)
+	default:
+		testNewClients(ctx, t, peer1, backend)
+	}
+}
+
+func testLegacyHostClient(ctx context.Context, t *testing.T, host p2pApi.Service, backend storageApi.Backend) {
+	require := require.New(t)
+
+	client := sync.NewClient(host, chainContext, runtimeID)
+	time.Sleep(2 * time.Second)
+
+	// Test diff part of the storagesync protocol.
+	rsp, _, err := client.GetDiff(ctx, &sync.GetDiffRequest{})
+	require.NoError(err, "Fetch storage diff from p2p")
+
+	err = assertEqualGetDiffResponse(ctx, backend, rsp.WriteLog)
+	require.NoError(err, "Assert expected storage diff response")
+
+	// Test checkpoints part of the storagesync protocol.
+	cps, err := client.GetCheckpoints(ctx, &sync.GetCheckpointsRequest{
+		Version: 1,
+	})
+	require.NoError(err, "Fetch checkpoints from p2p")
+	want, err := backend.GetCheckpoints(ctx, &checkpoint.GetCheckpointsRequest{
+		Version:   1,
+		Namespace: runtimeID,
+	})
+	require.NoError(err, "Fetch expected storage diff from backend")
+	getMeta := func(cp *sync.Checkpoint) *checkpoint.Metadata { return cp.Metadata }
+	err = assertEqualCheckpoints(cps, want, getMeta)
+	require.NoError(err, "Assert expected checkpoints response")
+}
+
+func testNewClients(ctx context.Context, t *testing.T, host p2pApi.Service, backend storageApi.Backend) {
+	require := require.New(t)
+
+	// Test diff sync protocol.
+	diffClient := diffsync.NewClient(host, chainContext, runtimeID)
+	time.Sleep(2 * time.Second)
+	rsp2, _, err := diffClient.GetDiff(ctx, &diffsync.GetDiffRequest{})
+	require.NoError(err, "Fetch storage diff from p2p")
+	err = assertEqualGetDiffResponse(ctx, backend, rsp2.WriteLog)
+	require.NoError(err, "Assert expected storage diff response")
+
+	// Test checkpoint sync protocol.
+	cpsClient := checkpointsync.NewClient(host, chainContext, runtimeID)
+	time.Sleep(2 * time.Second)
+	cps, err := cpsClient.GetCheckpoints(ctx, &checkpointsync.GetCheckpointsRequest{
+		Version: 1,
+	})
+	require.NoError(err, "Fetch checkpoints from p2p")
+	want, err := backend.GetCheckpoints(ctx, &checkpoint.GetCheckpointsRequest{
+		Version:   1,
+		Namespace: runtimeID,
+	})
+	require.NoError(err, "Fetch expected storage diff from backend")
+	getMeta := func(cp *checkpointsync.Checkpoint) *checkpoint.Metadata { return cp.Metadata }
+	err = assertEqualCheckpoints(cps, want, getMeta)
+	require.NoError(err, "Assert expected checkpoints response")
+}
+
+func assertEqualGetDiffResponse(ctx context.Context, backend storageApi.Backend, got storageApi.WriteLog) error {
+	diff, err := backend.GetDiff(ctx, &storageApi.GetDiffRequest{})
+	if err != nil {
+		return fmt.Errorf("fetching expected storage diff from backend: %w", err)
+	}
+
+	want := make(storageApi.WriteLog, 0)
+	for {
+		next, err := diff.Next()
+		if !next {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("writelog iterator next: %w", err)
+		}
+		val, err := diff.Value()
+		if err != nil {
+			return fmt.Errorf("writelog iterator value: %w", err)
+		}
+		want = append(want, val)
+	}
+
+	if !want.Equal(got) {
+		return fmt.Errorf("writelog not equal")
+	}
+	return nil
+}
+
+func assertEqualCheckpoints[C any](cps []C, want []*checkpoint.Metadata, getMeta func(C) *checkpoint.Metadata) error {
+	if len(cps) != len(want) {
+		return fmt.Errorf("slice size not equal: got %d, want %d", len(cps), len(want))
+	}
+	for i, cp1 := range cps {
+		if err := assertEqualCheckpointMeta(getMeta(cp1), want[i]); err != nil {
+			return fmt.Errorf("checkpoints at index %d not equal: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func assertEqualCheckpointMeta(this, other *checkpoint.Metadata) error {
+	if this.Version != other.Version {
+		return fmt.Errorf("version not equal")
+	}
+	if this.Root != other.Root {
+		return fmt.Errorf("root not equal")
+	}
+	if len(this.Chunks) != len(other.Chunks) {
+		return fmt.Errorf("not equal number of chunks")
+	}
+	for i, x := range this.Chunks {
+		if !x.Equal(&other.Chunks[i]) {
+			return fmt.Errorf("chunk %d not equal", i)
+		}
+	}
+	return nil
+}
+
+type peerKind int
+
+const (
+	legacy peerKind = iota
+	all
+	none
+)
+
+func mustStartNewPeer(t *testing.T, dataDir string, id int, backend storageApi.Backend, kind peerKind) (service p2pApi.Service, clean func()) {
+	var err error
+	var cleanups []func()
+	clean = func() {
+		for i := len(cleanups) - 1; i >= 0; i-- {
+			cleanups[i]()
+		}
+	}
+
+	defer func() {
+		if err != nil {
+			clean()
+		}
+	}()
+
+	require := require.New(t)
+
+	dataDir = path.Join(dataDir, strconv.Itoa(id))
+	err = os.Mkdir(dataDir, 0o700)
+	require.NoError(err, "Failed to create a temporary directory")
+	cleanups = append(cleanups, func() { os.RemoveAll(dataDir) })
+
+	identity, err := identity.LoadOrGenerate(dataDir, memory.NewFactory())
+	require.NoError(err, "Failed to generate a new identity")
+
+	store, err := persistent.NewCommonStore(dataDir)
+	require.NoError(err, "Failed to generate persistent common store")
+	cleanups = append(cleanups, func() { store.Close() })
+
+	port, err := getAvailablePort()
+	require.NoError(err)
+	// Avoid this pattern. Ideally p2p service should be refactored to not use
+	// global config.
+	config.GlobalConfig.P2P.Port = uint16(port)
+
+	p2p, err := p2p.New(identity, chainContext, store)
+	require.NoError(err, "Failed to generate persistent common store")
+	err = p2p.Start()
+	require.NoError(err, "Failed to start P2P service")
+	cleanups = append(cleanups, func() { p2p.Stop() })
+
+	switch kind {
+	case legacy:
+		serverLegacy := sync.NewServer(chainContext, runtimeID, backend)
+		p2p.RegisterProtocolServer(serverLegacy)
+	case all:
+		serverLegacy := sync.NewServer(chainContext, runtimeID, backend)
+		p2p.RegisterProtocolServer(serverLegacy)
+		diff := diffsync.NewServer(chainContext, runtimeID, backend)
+		p2p.RegisterProtocolServer(diff)
+		checkpoints := checkpointsync.NewServer(chainContext, runtimeID, backend)
+		p2p.RegisterProtocolServer(checkpoints)
+	case none:
+	default:
+		panic("peer kind not supported")
+	}
+
+	return p2p, clean
+}
+
+// getAvailablePort is only safe for testing, since we risk race between closing
+// and re-binding returned port.
+func getAvailablePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	addr := l.Addr().(*net.TCPAddr)
+	return addr.Port, nil
+}
+
+type backendMock struct{}
+
+func (bm *backendMock) SyncGet(context.Context, *syncer.GetRequest) (*syncer.ProofResponse, error) {
+	panic("not supported")
+}
+
+func (bm *backendMock) SyncGetPrefixes(context.Context, *syncer.GetPrefixesRequest) (*syncer.ProofResponse, error) {
+	panic("not supported")
+}
+
+func (bm *backendMock) SyncIterate(context.Context, *syncer.IterateRequest) (*syncer.ProofResponse, error) {
+	panic("not supported")
+}
+
+func hashFromBytes(data []byte) hash.Hash {
+	var hash hash.Hash
+	hash.FromBytes(data)
+	return hash
+}
+
+var (
+	cpVersion uint16
+	root      node.Root
+	hash1     hash.Hash = hashFromBytes([]byte("hash1"))
+	hash2     hash.Hash = hashFromBytes([]byte("hash2"))
+)
+
+func (bm *backendMock) GetCheckpoints(_ context.Context, request *checkpoint.GetCheckpointsRequest) ([]*checkpoint.Metadata, error) {
+	cpVersion = request.Version
+	root = node.Root{
+		// Existing bug: storagesync p2p server does not set namespace, nor does checkpoint.ChunkProvider validates it.
+		//               As a result empty namespace is always passed around, thus commenting Namespace field below.
+		// Namespace: request.Namespace
+		Version: 1,
+		Type:    api.RootTypeState,
+		Hash:    hashFromBytes([]byte("root has")),
+	}
+	cp := &checkpoint.Metadata{
+		Version: cpVersion,
+		Root:    root,
+		Chunks:  []hash.Hash{hash1, hash2},
+	}
+
+	return []*checkpoint.Metadata{cp}, nil
+}
+
+func (bm *backendMock) GetCheckpointChunk(_ context.Context, chunk *checkpoint.ChunkMetadata, w io.Writer) error {
+	if !chunk.Root.Equal(&root) || chunk.Version != cpVersion || chunk.Index > 1 {
+		return fmt.Errorf("invalid chunk metadata")
+	}
+
+	switch chunk.Index {
+	case 0:
+		if !chunk.Digest.Equal(&hash1) {
+			return fmt.Errorf("invalid chunk metada")
+		}
+		if _, err := w.Write([]byte("hash1")); err != nil {
+			return err
+		}
+	case 1:
+		if !chunk.Digest.Equal(&hash2) {
+			return fmt.Errorf("invalid chunk metada")
+		}
+		if _, err := w.Write([]byte("hash2")); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (bm *backendMock) GetDiff(_ context.Context, request *storageApi.GetDiffRequest) (storageApi.WriteLogIterator, error) {
+	items := writelog.WriteLog{
+		writelog.LogEntry{Key: []byte("startHash"), Value: []byte(request.StartRoot.Hash.String())},
+		writelog.LogEntry{Key: []byte("endHash"), Value: []byte(request.EndRoot.Hash.String())},
+	}
+	return writelog.NewStaticIterator(items), nil
+}
+
+func (bm *backendMock) Cleanup() {
+	panic("not supported")
+}
+
+func (bm *backendMock) Initialized() <-chan struct{} {
+	panic("not supported")
+}

--- a/go/worker/storage/p2p/sync_test/interoperable_test.go
+++ b/go/worker/storage/p2p/sync_test/interoperable_test.go
@@ -213,7 +213,7 @@ func assertEqualCheckpointMeta(this, other *checkpoint.Metadata) error {
 	if this.Version != other.Version {
 		return fmt.Errorf("version not equal")
 	}
-	if this.Root != other.Root {
+	if this.Root.Equal(&other.Root) {
 		return fmt.Errorf("root not equal")
 	}
 	if len(this.Chunks) != len(other.Chunks) {
@@ -337,12 +337,10 @@ var (
 func (bm *backendMock) GetCheckpoints(_ context.Context, request *checkpoint.GetCheckpointsRequest) ([]*checkpoint.Metadata, error) {
 	cpVersion = request.Version
 	root = node.Root{
-		// Existing bug: storagesync p2p server does not set namespace, nor does checkpoint.ChunkProvider validates it.
-		//               As a result empty namespace is always passed around, thus commenting Namespace field below.
-		// Namespace: request.Namespace
-		Version: 1,
-		Type:    api.RootTypeState,
-		Hash:    hashFromBytes([]byte("root has")),
+		Namespace: request.Namespace,
+		Version:   1,
+		Type:      api.RootTypeState,
+		Hash:      hashFromBytes([]byte("root has")),
 	}
 	cp := &checkpoint.Metadata{
 		Version: cpVersion,

--- a/go/worker/storage/p2p/synclegacy/client.go
+++ b/go/worker/storage/p2p/synclegacy/client.go
@@ -1,4 +1,4 @@
-package sync
+package synclegacy
 
 import (
 	"context"

--- a/go/worker/storage/p2p/synclegacy/client.go
+++ b/go/worker/storage/p2p/synclegacy/client.go
@@ -36,6 +36,9 @@ type Client interface {
 		request *GetCheckpointChunkRequest,
 		cp *Checkpoint,
 	) (*GetCheckpointChunkResponse, rpc.PeerFeedback, error)
+
+	// IsReady is true when protocol client is aware of at least one remote peer.
+	IsReady() bool
 }
 
 // Checkpoint contains checkpoint metadata together with peer information.
@@ -127,6 +130,10 @@ func (c *client) GetCheckpointChunk(
 // GetStorageSyncProtocolID returns unique storage sync protocol id for the specified chain context and runtime id.
 func GetStorageSyncProtocolID(chainContext string, runtimeID common.Namespace) core.ProtocolID {
 	return protocol.NewRuntimeProtocolID(chainContext, runtimeID, StorageSyncProtocolID, StorageSyncProtocolVersion)
+}
+
+func (c *client) IsReady() bool {
+	return len(c.mgrC.GetBestPeers()) > 0
 }
 
 // NewClient creates a new storage sync protocol client.

--- a/go/worker/storage/p2p/synclegacy/protocol.go
+++ b/go/worker/storage/p2p/synclegacy/protocol.go
@@ -1,4 +1,10 @@
-package sync
+// Package synclegacy defines wire protocol together with client/server
+// implementations for the legacy storage sync protocol, used for runtime block sync.
+//
+// The protocol was split into storage diff and checkpoints protocol.
+//
+// TODO: Remove it: https://github.com/oasisprotocol/oasis-core/issues/6261
+package synclegacy
 
 import (
 	"time"

--- a/go/worker/storage/p2p/synclegacy/server.go
+++ b/go/worker/storage/p2p/synclegacy/server.go
@@ -1,4 +1,4 @@
-package sync
+package synclegacy
 
 import (
 	"bytes"


### PR DESCRIPTION
Closes #5751, blocked by #6270.

Likely solves root cause of #5750.

**Open for discussion:**
1. E2e test to be more confident in integration part, even though existing integration test was helpful at catching bugs.
    * Cons: Additional config parameter, e2e test, and wrapping on the node side that delegates to appropriate client.
    * Alternatives: 
        * Adapt oasis tesnet runner to receive path to "legacy" binary (would also require to change CI).
        * Bootstrap a few nodes on the testnet and manually monitor p2p dashboard before release.
3. Extending rpc client (458f76f6274bbc22f7daab56a4b7882cc71dc216) with fallback protocol is likely the way to go.
    * Cons: Since existing storage sync has few methods, it might be simpler for the new clients to take the legacy client and fallback to it manually, avoiding the need for this change and additional [fallback manager](https://github.com/oasisprotocol/oasis-core/blob/f619b56b601b037ec7f0d7a60b499f8956714ae8/go/worker/storage/p2p/checkpoints/client.go#L116:L143).
4. Should new protocols alias legacy protocol definitions/methods given they are semantically equivalent?
    * Pros: Less duplication && less type fighting. 
    * Cons1: When removing the legacy protocol, things will have to be copied again (double work).
    * Cons2: In a way not aliasing protects against accidental changes in one manifesting in other.
 
 