### PR TITLE
go/runtime/rofl/api: Fix attestation field name

### DIFF
--- a/.changelog/6267.bugfix.md
+++ b/.changelog/6267.bugfix.md
@@ -1,0 +1,1 @@
+go/runtime/rofl/api: Fix attestation field name

--- a/go/runtime/rofl/api/attestation.go
+++ b/go/runtime/rofl/api/attestation.go
@@ -25,7 +25,7 @@ type AttestLabelsRequest struct {
 // AttestLabelsResponse is the response from the AttestLabels method.
 type AttestLabelsResponse struct {
 	// Attestation is the CBOR-serialized label attestation.
-	Attestation []byte `json:"attstation"`
+	Attestation []byte `json:"attestation"`
 	// NodeID is the public key of the node attesting to the labels.
 	NodeID signature.PublicKey `json:"node_id"`
 	// Signature is the signature of the attested labels.


### PR DESCRIPTION
:facepalm: 