### PR TITLE
go: Avoid global config and pass it explicitly instead

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -67,8 +67,12 @@ func (m NodeMode) HasLocalStorage() bool {
 	return false
 }
 
-// GlobalConfig holds the global configuration options.
-var GlobalConfig Config
+// GlobalConfigDeprecated holds the global configuration options.
+//
+// TODO: https://github.com/oasisprotocol/oasis-core/issues/6271
+//
+//	Avoid using global config. Instead you should pass it explicitly.
+var GlobalConfigDeprecated Config
 
 // Config is the top-level configuration structure.
 type Config struct {
@@ -175,18 +179,18 @@ func InitConfig(cfgFile string) error {
 
 	// Reset the global config and apply changes from the config file.
 	// Report error if any of the fields from the input file are unknown.
-	GlobalConfig = DefaultConfig()
+	GlobalConfigDeprecated = DefaultConfig()
 	dec := yaml.NewDecoder(bytes.NewReader(cfg))
 	dec.KnownFields(true)
-	err = dec.Decode(&GlobalConfig)
+	err = dec.Decode(&GlobalConfigDeprecated)
 	if err != nil && err != io.EOF {
 		return fmt.Errorf("failed to load config file '%s': %w", cfgFile, err)
 	}
 
 	// Validate config file.
-	return GlobalConfig.Validate()
+	return GlobalConfigDeprecated.Validate()
 }
 
 func init() {
-	GlobalConfig = DefaultConfig()
+	GlobalConfigDeprecated = DefaultConfig()
 }

--- a/go/config/p2p.go
+++ b/go/config/p2p.go
@@ -97,7 +97,7 @@ func (c *Config) hostConfig() (*p2p.HostConfig, error) {
 
 func (c *Config) gossipSubConfig() (*p2p.GossipSubConfig, error) {
 	var cfg p2p.GossipSubConfig
-	persistentPeers, err := api.AddrInfosFromConsensusAddrs(GlobalConfig.P2P.ConnectionManager.PersistentPeers)
+	persistentPeers, err := api.AddrInfosFromConsensusAddrs(GlobalConfigDeprecated.P2P.ConnectionManager.PersistentPeers)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert persistent peers' addresses: %w", err)
 	}

--- a/go/config/p2p.go
+++ b/go/config/p2p.go
@@ -1,0 +1,192 @@
+package config
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/libp2p/go-libp2p/core"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
+	"github.com/oasisprotocol/oasis-core/go/p2p"
+	"github.com/oasisprotocol/oasis-core/go/p2p/api"
+
+	"github.com/oasisprotocol/oasis-core/go/worker/common/configparser"
+)
+
+const (
+	// peersHighWatermarkDelta specifies how many peers after the maximum peer count is reached we
+	// ask the connection manager to start pruning peers.
+	peersHighWatermarkDelta = 30
+)
+
+// Load loads P2P configuration.
+func (c *Config) ToP2PConfig() (*p2p.Config, error) {
+	var cfg p2p.Config
+	rawAddresses, err := configparser.ParseAddressList(c.P2P.Registration.Addresses)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse address list: %w", err)
+	}
+	var addresses []multiaddr.Multiaddr
+	for _, addr := range rawAddresses {
+		var mAddr multiaddr.Multiaddr
+		mAddr, err = manet.FromNetAddr(addr.ToTCPAddr())
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert address to multiaddress: %w", err)
+		}
+		addresses = append(addresses, mAddr)
+	}
+
+	hostCfg, err := c.hostConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create host config: %w", err)
+	}
+
+	gossipSubCfg, err := c.gossipSubConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gossipsub config: %w", err)
+	}
+
+	bootstrapCfg, err := c.bootstrapDiscovery()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create bootstrap config: %w", err)
+	}
+
+	cfg.Addresses = addresses
+	cfg.HostConfig = *hostCfg
+	cfg.GossipSubConfig = *gossipSubCfg
+	cfg.BootstrapDiscoveryConfig = *bootstrapCfg
+
+	return &cfg, nil
+}
+
+func (c *Config) hostConfig() (*p2p.HostConfig, error) {
+	var cfg p2p.HostConfig
+
+	userAgent := fmt.Sprintf("oasis-core/%s", version.SoftwareVersion)
+
+	// Listen for connections on all interfaces.
+	listenAddr, err := multiaddr.NewMultiaddr(
+		fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", c.P2P.Port),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create multiaddress: %w", err)
+	}
+
+	cmCfg, err := c.connManagerConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create connection manager config: %w", err)
+	}
+
+	cgCfg, err := c.connGaterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create connection gater config: %w", err)
+	}
+
+	cfg.UserAgent = userAgent
+	cfg.Port = c.P2P.Port
+	cfg.ListenAddr = listenAddr
+	cfg.ConnManagerConfig = *cmCfg
+	cfg.ConnGaterConfig = *cgCfg
+	cfg.IsSeed = c.Mode == ModeSeed
+
+	return &cfg, nil
+}
+
+func (c *Config) gossipSubConfig() (*p2p.GossipSubConfig, error) {
+	var cfg p2p.GossipSubConfig
+	persistentPeers, err := api.AddrInfosFromConsensusAddrs(GlobalConfig.P2P.ConnectionManager.PersistentPeers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert persistent peers' addresses: %w", err)
+	}
+
+	cfg.PeerOutboundQueueSize = c.P2P.Gossipsub.PeerOutboundQueueSize
+	cfg.ValidateQueueSize = c.P2P.Gossipsub.ValidateQueueSize
+	cfg.ValidateThrottle = c.P2P.Gossipsub.ValidateThrottle
+	cfg.PersistentPeers = persistentPeers
+	cfg.ValidateConcurrency = c.P2P.Gossipsub.ValidateConcurrency
+
+	return &cfg, nil
+
+}
+
+func (c *Config) bootstrapDiscovery() (*p2p.BootstrapDiscoveryConfig, error) {
+	var cfg p2p.BootstrapDiscoveryConfig
+	seeds, err := api.AddrInfosFromConsensusAddrs(c.P2P.Seeds)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert seeds' addresses: %w", err)
+	}
+
+	cfg.Seeds = seeds
+	cfg.Enable = c.P2P.Discovery.Bootstrap.Enable
+	cfg.RetentionPeriod = c.P2P.Discovery.Bootstrap.RetentionPeriod
+
+	return &cfg, nil
+}
+
+func (c *Config) connManagerConfig() (*p2p.ConnManagerConfig, error) {
+	var cfg p2p.ConnManagerConfig
+	persistentPeersMap := make(map[core.PeerID]struct{})
+	for _, pp := range c.P2P.ConnectionManager.PersistentPeers {
+		var addr node.ConsensusAddress
+		if err := addr.UnmarshalText([]byte(pp)); err != nil {
+			return nil, fmt.Errorf("malformed address (expected pubkey@IP:port): %w", err)
+		}
+
+		pid, err := api.PublicKeyToPeerID(addr.ID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid public key (%s): %w", addr.ID, err)
+		}
+
+		persistentPeersMap[pid] = struct{}{}
+	}
+
+	persistentPeers := make([]peer.ID, 0)
+	for pid := range persistentPeersMap {
+		persistentPeers = append(persistentPeers, pid)
+	}
+
+	cfg.MinPeers = c.P2P.ConnectionManager.MaxNumPeers
+	cfg.MaxPeers = cfg.MinPeers + peersHighWatermarkDelta
+	cfg.GracePeriod = c.P2P.ConnectionManager.PeerGracePeriod
+	cfg.PersistentPeers = persistentPeers
+
+	return &cfg, nil
+}
+
+func (c *Config) connGaterConfig() (*p2p.ConnGaterConfig, error) {
+	var cfg p2p.ConnGaterConfig
+	blockedPeers := make([]net.IP, 0)
+	for _, blockedIP := range c.P2P.ConnectionGater.BlockedPeerIPs {
+		parsedIP := net.ParseIP(blockedIP)
+		if parsedIP == nil {
+			return nil, fmt.Errorf("malformed blocked IP: %s", blockedIP)
+		}
+		blockedPeers = append(blockedPeers, parsedIP)
+	}
+
+	cfg.BlockedPeers = blockedPeers
+
+	return &cfg, nil
+}
+
+func (c *Config) ToSeedConfig() (*p2p.SeedConfig, error) {
+	var cfg p2p.SeedConfig
+
+	hostCfg, err := c.hostConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create host config: %w", err)
+	}
+
+	bootstrapCfg, err := c.bootstrapDiscovery()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create bootstrap config: %w", err)
+	}
+
+	cfg.HostConfig = hostCfg
+	cfg.BootstrapDiscoveryConfig = bootstrapCfg
+
+	return &cfg, nil
+}

--- a/go/consensus/cometbft/cometbft.go
+++ b/go/consensus/cometbft/cometbft.go
@@ -37,7 +37,7 @@ func New(
 		return nil, err
 	}
 
-	switch config.GlobalConfig.Mode {
+	switch config.GlobalConfigDeprecated.Mode {
 	case config.ModeArchive:
 		node, err := createArchiveNode(ctx, dataDir, identity, genesis, doc, genesisDoc)
 		if err != nil {
@@ -147,7 +147,7 @@ func createStatelessServices(
 }
 
 func createProvider(identity *identity.Identity) (*consensusAPI.Client, error) {
-	addresses := config.GlobalConfig.Consensus.Providers
+	addresses := config.GlobalConfigDeprecated.Consensus.Providers
 	if len(addresses) == 0 {
 		return nil, fmt.Errorf("no providers configured")
 	}
@@ -161,7 +161,7 @@ func createLightClient(
 	doc *genesisAPI.Document,
 	p2p p2pAPI.Service,
 ) (*light.Client, error) {
-	hash, err := hex.DecodeString(config.GlobalConfig.Consensus.LightClient.Trust.Hash)
+	hash, err := hex.DecodeString(config.GlobalConfigDeprecated.Consensus.LightClient.Trust.Hash)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode trust hash: %w", err)
 	}
@@ -169,8 +169,8 @@ func createLightClient(
 	cfg := light.Config{
 		GenesisDocument: genesisDoc,
 		TrustOptions: cmtlight.TrustOptions{
-			Period: config.GlobalConfig.Consensus.LightClient.Trust.Period,
-			Height: int64(config.GlobalConfig.Consensus.LightClient.Trust.Height),
+			Period: config.GlobalConfigDeprecated.Consensus.LightClient.Trust.Period,
+			Height: int64(config.GlobalConfigDeprecated.Consensus.LightClient.Trust.Height),
 			Hash:   hash,
 		},
 	}
@@ -179,12 +179,12 @@ func createLightClient(
 }
 
 func createSubmissionManager(ctx context.Context, services consensusAPI.Services) (consensusAPI.SubmissionManager, error) {
-	pd, err := pricediscovery.New(ctx, services.Core(), config.GlobalConfig.Consensus.Submission.GasPrice)
+	pd, err := pricediscovery.New(ctx, services.Core(), config.GlobalConfigDeprecated.Consensus.Submission.GasPrice)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create price discovery: %w", err)
 	}
 
-	return consensusAPI.NewSubmissionManager(services, pd, config.GlobalConfig.Consensus.Submission.MaxFee), nil
+	return consensusAPI.NewSubmissionManager(services, pd, config.GlobalConfigDeprecated.Consensus.Submission.MaxFee), nil
 }
 
 func createCommonConfig(

--- a/go/consensus/cometbft/common/common.go
+++ b/go/consensus/cometbft/common/common.go
@@ -21,9 +21,9 @@ const (
 
 // GetExternalAddress returns the configured CometBFT external address.
 func GetExternalAddress() (*url.URL, error) {
-	addrURI := config.GlobalConfig.Consensus.ExternalAddress
+	addrURI := config.GlobalConfigDeprecated.Consensus.ExternalAddress
 	if addrURI == "" {
-		addrURI = config.GlobalConfig.Consensus.ListenAddress
+		addrURI = config.GlobalConfigDeprecated.Consensus.ListenAddress
 	}
 	if addrURI == "" {
 		return nil, fmt.Errorf("cometbft: no external address configured")

--- a/go/consensus/cometbft/full/archive.go
+++ b/go/consensus/cometbft/full/archive.go
@@ -171,7 +171,7 @@ func NewArchive(ctx context.Context, cfg ArchiveConfig) (consensusAPI.Service, e
 
 	appConfig := &abci.ApplicationConfig{
 		DataDir:        filepath.Join(srv.dataDir, tmcommon.StateDir),
-		StorageBackend: config.GlobalConfig.Storage.Backend,
+		StorageBackend: config.GlobalConfigDeprecated.Storage.Backend,
 		Pruning: abci.PruneConfig{
 			Strategy:      abci.PruneNone,
 			PruneInterval: time.Hour * 100, // Irrelevant as pruning is disabled.
@@ -191,7 +191,7 @@ func NewArchive(ctx context.Context, cfg ArchiveConfig) (consensusAPI.Service, e
 	}
 
 	// Setup needed CometBFT services.
-	logger := tmcommon.NewLogAdapter(!config.GlobalConfig.Consensus.LogDebug)
+	logger := tmcommon.NewLogAdapter(!config.GlobalConfigDeprecated.Consensus.LogDebug)
 	srv.abciClient = abcicli.NewLocalClient(new(cmtsync.Mutex), srv.mux.Mux())
 
 	dbProvider, err := db.GetProvider()

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -286,8 +286,8 @@ func (n *commonNode) initialize() error {
 	}
 
 	// Enable supplementary sanity checks when enabled.
-	if config.GlobalConfig.Consensus.SupplementarySanity.Enabled {
-		app := supplementarysanityApp.New(state, int64(config.GlobalConfig.Consensus.SupplementarySanity.Interval))
+	if config.GlobalConfigDeprecated.Consensus.SupplementarySanity.Enabled {
+		app := supplementarysanityApp.New(state, int64(config.GlobalConfigDeprecated.Consensus.SupplementarySanity.Interval))
 		if err := n.mux.Register(app); err != nil {
 			return fmt.Errorf("failed to register supplementary sanity check app: %w", err)
 		}

--- a/go/consensus/cometbft/full/full.go
+++ b/go/consensus/cometbft/full/full.go
@@ -548,28 +548,28 @@ func (t *fullService) lazyInit() error { // nolint: gocyclo
 
 	// Create CometBFT application mux.
 	var pruneCfg abci.PruneConfig
-	pruneStrat := config.GlobalConfig.Consensus.Prune.Strategy
+	pruneStrat := config.GlobalConfigDeprecated.Consensus.Prune.Strategy
 	if err = pruneCfg.Strategy.FromString(pruneStrat); err != nil {
 		return err
 	}
-	pruneCfg.NumKept = config.GlobalConfig.Consensus.Prune.NumKept
-	pruneCfg.PruneInterval = max(config.GlobalConfig.Consensus.Prune.Interval, time.Second)
+	pruneCfg.NumKept = config.GlobalConfigDeprecated.Consensus.Prune.NumKept
+	pruneCfg.PruneInterval = max(config.GlobalConfigDeprecated.Consensus.Prune.Interval, time.Second)
 
 	var threads uint16
-	if config.GlobalConfig.Storage.Checkpointer.ParallelChunker {
+	if config.GlobalConfigDeprecated.Storage.Checkpointer.ParallelChunker {
 		threads = chunkerThreads
 	}
 
 	appConfig := &abci.ApplicationConfig{
 		DataDir:                   filepath.Join(t.dataDir, tmcommon.StateDir),
-		StorageBackend:            config.GlobalConfig.Storage.Backend,
+		StorageBackend:            config.GlobalConfigDeprecated.Storage.Backend,
 		Pruning:                   pruneCfg,
-		HaltEpoch:                 beaconAPI.EpochTime(config.GlobalConfig.Consensus.HaltEpoch),
-		HaltHeight:                config.GlobalConfig.Consensus.HaltHeight,
-		MinGasPrice:               config.GlobalConfig.Consensus.MinGasPrice,
+		HaltEpoch:                 beaconAPI.EpochTime(config.GlobalConfigDeprecated.Consensus.HaltEpoch),
+		HaltHeight:                config.GlobalConfigDeprecated.Consensus.HaltHeight,
+		MinGasPrice:               config.GlobalConfigDeprecated.Consensus.MinGasPrice,
 		Identity:                  t.identity,
-		DisableCheckpointer:       config.GlobalConfig.Consensus.Checkpointer.Disabled,
-		CheckpointerCheckInterval: config.GlobalConfig.Consensus.Checkpointer.CheckInterval,
+		DisableCheckpointer:       config.GlobalConfigDeprecated.Consensus.Checkpointer.Disabled,
+		CheckpointerCheckInterval: config.GlobalConfigDeprecated.Consensus.Checkpointer.CheckInterval,
 		ChunkerThreads:            threads,
 		InitialHeight:             uint64(t.genesisHeight),
 		ChainContext:              t.chainContext,
@@ -588,19 +588,19 @@ func (t *fullService) lazyInit() error { // nolint: gocyclo
 	}
 
 	// Convert addresses and public keys to CometBFT form.
-	persistentPeers, err := tmcommon.ConsensusAddressesToCometBFT(config.GlobalConfig.Consensus.P2P.PersistentPeer)
+	persistentPeers, err := tmcommon.ConsensusAddressesToCometBFT(config.GlobalConfigDeprecated.Consensus.P2P.PersistentPeer)
 	if err != nil {
 		return fmt.Errorf("cometbft: failed to convert persistent peer addresses: %w", err)
 	}
-	seeds, err := tmcommon.ConsensusAddressesToCometBFT(config.GlobalConfig.P2P.Seeds)
+	seeds, err := tmcommon.ConsensusAddressesToCometBFT(config.GlobalConfigDeprecated.P2P.Seeds)
 	if err != nil {
 		return fmt.Errorf("cometbft: failed to convert seed addresses: %w", err)
 	}
-	sentryUpstreamAddrs, err := tmcommon.ConsensusAddressesToCometBFT(config.GlobalConfig.Consensus.SentryUpstreamAddresses)
+	sentryUpstreamAddrs, err := tmcommon.ConsensusAddressesToCometBFT(config.GlobalConfigDeprecated.Consensus.SentryUpstreamAddresses)
 	if err != nil {
 		return fmt.Errorf("cometbft: failed to convert sentry upstream addresses: %w", err)
 	}
-	unconditionalPeers, err := tmcommon.PublicKeysToCometBFT(config.GlobalConfig.Consensus.P2P.UnconditionalPeer)
+	unconditionalPeers, err := tmcommon.PublicKeysToCometBFT(config.GlobalConfigDeprecated.Consensus.P2P.UnconditionalPeer)
 	if err != nil {
 		return fmt.Errorf("cometbft: failed to convert unconditional peer public keys: %w", err)
 	}
@@ -613,24 +613,24 @@ func (t *fullService) lazyInit() error { // nolint: gocyclo
 	cometConfig.Consensus.SkipTimeoutCommit = t.skipTimeoutCommit
 	cometConfig.Consensus.CreateEmptyBlocks = true
 	cometConfig.Consensus.CreateEmptyBlocksInterval = t.emptyBlockInterval
-	cometConfig.Consensus.DebugUnsafeReplayRecoverCorruptedWAL = config.GlobalConfig.Consensus.Debug.UnsafeReplayRecoverCorruptedWAL && cmflags.DebugDontBlameOasis()
+	cometConfig.Consensus.DebugUnsafeReplayRecoverCorruptedWAL = config.GlobalConfigDeprecated.Consensus.Debug.UnsafeReplayRecoverCorruptedWAL && cmflags.DebugDontBlameOasis()
 	cometConfig.Mempool.Version = cmtconfig.MempoolV1
 	cometConfig.Instrumentation.Prometheus = true
 	cometConfig.Instrumentation.PrometheusListenAddr = ""
 	cometConfig.TxIndex.Indexer = "null"
-	cometConfig.P2P.ListenAddress = config.GlobalConfig.Consensus.ListenAddress
-	cometConfig.P2P.ExternalAddress = config.GlobalConfig.Consensus.ExternalAddress
-	cometConfig.P2P.PexReactor = !config.GlobalConfig.Consensus.P2P.DisablePeerExchange
-	cometConfig.P2P.MaxNumInboundPeers = config.GlobalConfig.Consensus.P2P.MaxNumInboundPeers
-	cometConfig.P2P.MaxNumOutboundPeers = config.GlobalConfig.Consensus.P2P.MaxNumOutboundPeers
-	cometConfig.P2P.SendRate = config.GlobalConfig.Consensus.P2P.SendRate
-	cometConfig.P2P.RecvRate = config.GlobalConfig.Consensus.P2P.RecvRate
+	cometConfig.P2P.ListenAddress = config.GlobalConfigDeprecated.Consensus.ListenAddress
+	cometConfig.P2P.ExternalAddress = config.GlobalConfigDeprecated.Consensus.ExternalAddress
+	cometConfig.P2P.PexReactor = !config.GlobalConfigDeprecated.Consensus.P2P.DisablePeerExchange
+	cometConfig.P2P.MaxNumInboundPeers = config.GlobalConfigDeprecated.Consensus.P2P.MaxNumInboundPeers
+	cometConfig.P2P.MaxNumOutboundPeers = config.GlobalConfigDeprecated.Consensus.P2P.MaxNumOutboundPeers
+	cometConfig.P2P.SendRate = config.GlobalConfigDeprecated.Consensus.P2P.SendRate
+	cometConfig.P2P.RecvRate = config.GlobalConfigDeprecated.Consensus.P2P.RecvRate
 	cometConfig.P2P.PersistentPeers = strings.Join(persistentPeers, ",")
-	cometConfig.P2P.PersistentPeersMaxDialPeriod = config.GlobalConfig.Consensus.P2P.PersistenPeersMaxDialPeriod
+	cometConfig.P2P.PersistentPeersMaxDialPeriod = config.GlobalConfigDeprecated.Consensus.P2P.PersistenPeersMaxDialPeriod
 	cometConfig.P2P.UnconditionalPeerIDs = strings.Join(unconditionalPeers, ",")
 	cometConfig.P2P.Seeds = strings.Join(seeds, ",")
-	cometConfig.P2P.AddrBookStrict = !(config.GlobalConfig.Consensus.Debug.P2PAddrBookLenient && cmflags.DebugDontBlameOasis())
-	cometConfig.P2P.AllowDuplicateIP = config.GlobalConfig.Consensus.Debug.P2PAllowDuplicateIP && cmflags.DebugDontBlameOasis()
+	cometConfig.P2P.AddrBookStrict = !(config.GlobalConfigDeprecated.Consensus.Debug.P2PAddrBookLenient && cmflags.DebugDontBlameOasis())
+	cometConfig.P2P.AllowDuplicateIP = config.GlobalConfigDeprecated.Consensus.Debug.P2PAllowDuplicateIP && cmflags.DebugDontBlameOasis()
 	cometConfig.RPC.ListenAddress = ""
 
 	if len(sentryUpstreamAddrs) > 0 {
@@ -722,19 +722,19 @@ func (t *fullService) lazyInit() error { // nolint: gocyclo
 
 		// Configure state sync if enabled.
 		var stateProvider cmtstatesync.StateProvider
-		if config.GlobalConfig.Consensus.StateSync.Enabled {
+		if config.GlobalConfigDeprecated.Consensus.StateSync.Enabled {
 			t.Logger.Info("state sync enabled")
 
 			// Enable state sync in the configuration.
 			cometConfig.StateSync.Enable = true
-			cometConfig.StateSync.TrustHash = config.GlobalConfig.Consensus.LightClient.Trust.Hash
+			cometConfig.StateSync.TrustHash = config.GlobalConfigDeprecated.Consensus.LightClient.Trust.Hash
 
 			// Create light client.
 			cfg := light.Config{
 				GenesisDocument: t.genesisDoc,
 				TrustOptions: cmtlight.TrustOptions{
-					Period: config.GlobalConfig.Consensus.LightClient.Trust.Period,
-					Height: int64(config.GlobalConfig.Consensus.LightClient.Trust.Height),
+					Period: config.GlobalConfigDeprecated.Consensus.LightClient.Trust.Period,
+					Height: int64(config.GlobalConfigDeprecated.Consensus.LightClient.Trust.Height),
 					Hash:   cometConfig.StateSync.TrustHashBytes(),
 				},
 			}
@@ -757,7 +757,7 @@ func (t *fullService) lazyInit() error { // nolint: gocyclo
 			cometbftGenesisProvider,
 			wrapDbProvider,
 			cmtnode.DefaultMetricsProvider(cometConfig.Instrumentation),
-			tmcommon.NewLogAdapter(!config.GlobalConfig.Consensus.LogDebug),
+			tmcommon.NewLogAdapter(!config.GlobalConfigDeprecated.Consensus.LogDebug),
 			cmtnode.StateProvider(stateProvider),
 		)
 		if err != nil {
@@ -918,7 +918,7 @@ func (t *fullService) upgradeHaltHook() api.HaltHook {
 			// when all the other services start shutting down.
 			//
 			// Randomize the period so that not all nodes shut down at the same time.
-			delay := random.GetRandomValueFromInterval(0.5, rand.Float64(), config.GlobalConfig.Consensus.UpgradeStopDelay)
+			delay := random.GetRandomValueFromInterval(0.5, rand.Float64(), config.GlobalConfigDeprecated.Consensus.UpgradeStopDelay)
 			time.Sleep(delay)
 
 			t.Logger.Info("stopping the node for upgrade")
@@ -993,12 +993,12 @@ func New(ctx context.Context, p2p p2pAPI.Service, cfg Config) (consensusAPI.Serv
 	t.Logger.Info("starting a full consensus node")
 
 	// Create price discovery mechanism and the submission manager.
-	pd, err := pricediscovery.New(ctx, t, config.GlobalConfig.Consensus.Submission.GasPrice)
+	pd, err := pricediscovery.New(ctx, t, config.GlobalConfigDeprecated.Consensus.Submission.GasPrice)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create price discovery: %w", err)
 	}
 	t.submissionMgr = consensusAPI.NewSubmissionManager(t, pd,
-		config.GlobalConfig.Consensus.Submission.MaxFee,
+		config.GlobalConfigDeprecated.Consensus.Submission.MaxFee,
 	)
 
 	if err := t.lazyInit(); err != nil {

--- a/go/consensus/cometbft/light/client.go
+++ b/go/consensus/cometbft/light/client.go
@@ -64,7 +64,7 @@ func NewClient(ctx context.Context, chainContext string, p2p rpc.P2P, cfg Config
 		witnesses,
 		cmtlightdb.New(dbm.NewMemDB(), ""),
 		cmtlight.MaxRetryAttempts(lcMaxRetryAttempts), // TODO: Make this configurable.
-		cmtlight.Logger(common.NewLogAdapter(!config.GlobalConfig.Consensus.LogDebug)),
+		cmtlight.Logger(common.NewLogAdapter(!config.GlobalConfigDeprecated.Consensus.LogDebug)),
 		cmtlight.DisableProviderRemoval(),
 	)
 	if err != nil {

--- a/go/consensus/cometbft/seed/seed.go
+++ b/go/consensus/cometbft/seed/seed.go
@@ -159,7 +159,7 @@ func New(dataDir string, identity *identity.Identity, doc *genesis.Document) (*S
 		return nil, fmt.Errorf("cometbft/seed: failed to initialize data dir: %w", err)
 	}
 
-	tmSeeds, err := tmcommon.ConsensusAddressesToCometBFT(config.GlobalConfig.P2P.Seeds)
+	tmSeeds, err := tmcommon.ConsensusAddressesToCometBFT(config.GlobalConfigDeprecated.P2P.Seeds)
 	if err != nil {
 		return nil, fmt.Errorf("cometbft/seed: failed to convert seed addresses: %w", err)
 	}
@@ -167,13 +167,13 @@ func New(dataDir string, identity *identity.Identity, doc *genesis.Document) (*S
 	p2pCfg := cmtconfig.DefaultP2PConfig()
 	p2pCfg.SeedMode = true
 	p2pCfg.Seeds = strings.Join(tmSeeds, ",")
-	p2pCfg.ExternalAddress = config.GlobalConfig.Consensus.ExternalAddress
-	p2pCfg.MaxNumInboundPeers = config.GlobalConfig.Consensus.P2P.MaxNumInboundPeers
-	p2pCfg.MaxNumOutboundPeers = config.GlobalConfig.Consensus.P2P.MaxNumOutboundPeers
-	p2pCfg.SendRate = config.GlobalConfig.Consensus.P2P.SendRate
-	p2pCfg.RecvRate = config.GlobalConfig.Consensus.P2P.RecvRate
-	p2pCfg.AddrBookStrict = !(config.GlobalConfig.Consensus.Debug.P2PAddrBookLenient && cmflags.DebugDontBlameOasis())
-	p2pCfg.AllowDuplicateIP = config.GlobalConfig.Consensus.Debug.P2PAllowDuplicateIP && cmflags.DebugDontBlameOasis()
+	p2pCfg.ExternalAddress = config.GlobalConfigDeprecated.Consensus.ExternalAddress
+	p2pCfg.MaxNumInboundPeers = config.GlobalConfigDeprecated.Consensus.P2P.MaxNumInboundPeers
+	p2pCfg.MaxNumOutboundPeers = config.GlobalConfigDeprecated.Consensus.P2P.MaxNumOutboundPeers
+	p2pCfg.SendRate = config.GlobalConfigDeprecated.Consensus.P2P.SendRate
+	p2pCfg.RecvRate = config.GlobalConfigDeprecated.Consensus.P2P.RecvRate
+	p2pCfg.AddrBookStrict = !(config.GlobalConfigDeprecated.Consensus.Debug.P2PAddrBookLenient && cmflags.DebugDontBlameOasis())
+	p2pCfg.AllowDuplicateIP = config.GlobalConfigDeprecated.Consensus.Debug.P2PAllowDuplicateIP && cmflags.DebugDontBlameOasis()
 
 	nodeKey := &cmtp2p.NodeKey{PrivKey: crypto.SignerToCometBFT(identity.P2PSigner)}
 
@@ -184,7 +184,7 @@ func New(dataDir string, identity *identity.Identity, doc *genesis.Document) (*S
 			version.CometBFTAppVersion,
 		),
 		DefaultNodeID: nodeKey.ID(),
-		ListenAddr:    config.GlobalConfig.Consensus.ListenAddress,
+		ListenAddr:    config.GlobalConfigDeprecated.Consensus.ListenAddress,
 		Network:       api.CometBFTChainID(srv.chainContext),
 		Version:       cmtversion.TMCoreSemVer,
 		Channels:      []byte{pex.PexChannel},
@@ -192,7 +192,7 @@ func New(dataDir string, identity *identity.Identity, doc *genesis.Document) (*S
 	}
 
 	// Carve out all of the services.
-	logger := tmcommon.NewLogAdapter(!config.GlobalConfig.Consensus.LogDebug)
+	logger := tmcommon.NewLogAdapter(!config.GlobalConfigDeprecated.Consensus.LogDebug)
 	if srv.addr, err = cmtp2p.NewNetAddressString(cmtp2p.IDAddressString(nodeInfo.DefaultNodeID, nodeInfo.ListenAddr)); err != nil {
 		return nil, fmt.Errorf("cometbft/seed: failed to create seed address: %w", err)
 	}
@@ -205,7 +205,7 @@ func New(dataDir string, identity *identity.Identity, doc *genesis.Document) (*S
 		return nil, fmt.Errorf("cometbft/seed: failed to start address book: %w", err)
 	}
 
-	if !(config.GlobalConfig.Consensus.Debug.DisableAddrBookFromGenesis && cmflags.DebugDontBlameOasis()) {
+	if !(config.GlobalConfigDeprecated.Consensus.Debug.DisableAddrBookFromGenesis && cmflags.DebugDontBlameOasis()) {
 		if err = populateAddrBookFromGenesis(srv.addrBook, doc, srv.addr); err != nil {
 			return nil, fmt.Errorf("cometbft/seed: failed to populate address book from genesis: %w", err)
 		}

--- a/go/genesis/file/file.go
+++ b/go/genesis/file/file.go
@@ -44,5 +44,5 @@ func (p *Provider) GetGenesisDocument() (*api.Document, error) {
 // DefaultProvider creates a new local file genesis provider for the genesis file path
 // specified in the genesis config.
 func DefaultProvider() *Provider {
-	return NewProvider(config.GlobalConfig.Genesis.File)
+	return NewProvider(config.GlobalConfigDeprecated.Genesis.File)
 }

--- a/go/ias/init.go
+++ b/go/ias/init.go
@@ -16,7 +16,7 @@ var logger = logging.GetLogger("ias")
 // New creates a new IAS endpoint.
 func New(identity *identity.Identity) ([]api.Endpoint, error) {
 	if cmdFlags.DebugDontBlameOasis() {
-		if config.GlobalConfig.IAS.DebugSkipVerify {
+		if config.GlobalConfigDeprecated.IAS.DebugSkipVerify {
 			logger.Warn("`ias.debug_skip_verify` set, AVR signature validation bypassed")
 			ias.SetSkipVerify()
 		}
@@ -24,6 +24,6 @@ func New(identity *identity.Identity) ([]api.Endpoint, error) {
 
 	return client.New(
 		identity,
-		config.GlobalConfig.IAS.ProxyAddresses,
+		config.GlobalConfigDeprecated.IAS.ProxyAddresses,
 	)
 }

--- a/go/oasis-node/cmd/common/flags/flags.go
+++ b/go/oasis-node/cmd/common/flags/flags.go
@@ -69,7 +69,7 @@ func DebugTestEntity() bool {
 
 // DebugAllowRoot returns true iff the root account enable flag is set.
 func DebugAllowRoot() bool {
-	return DebugDontBlameOasis() && config.GlobalConfig.Common.Debug.AllowRoot
+	return DebugDontBlameOasis() && config.GlobalConfigDeprecated.Common.Debug.AllowRoot
 }
 
 // GenesisFile returns the set genesis file.

--- a/go/oasis-node/cmd/common/metrics/metrics.go
+++ b/go/oasis-node/cmd/common/metrics/metrics.go
@@ -108,7 +108,7 @@ func (s *pullService) Cleanup() {
 }
 
 func newPullService() (service.BackgroundService, error) {
-	addr := config.GlobalConfig.Metrics.Address
+	addr := config.GlobalConfigDeprecated.Metrics.Address
 
 	svc := *service.NewBaseBackgroundService("metrics")
 
@@ -127,7 +127,7 @@ func newPullService() (service.BackgroundService, error) {
 		ln:                    ln,
 		s:                     &http.Server{Handler: promhttp.Handler(), ReadTimeout: 5 * time.Second},
 		errCh:                 make(chan error),
-		rsvc:                  newResourceService(config.GlobalConfig.Metrics.Interval),
+		rsvc:                  newResourceService(config.GlobalConfigDeprecated.Metrics.Interval),
 	}, nil
 }
 
@@ -225,11 +225,11 @@ func (s *pushService) initPusher(isReinit bool) {
 func newPushService() (service.BackgroundService, error) {
 	svc := &pushService{
 		BaseBackgroundService: *service.NewBaseBackgroundService("metrics"),
-		addr:                  config.GlobalConfig.Metrics.Address,
-		jobName:               config.GlobalConfig.Metrics.JobName,
-		labels:                config.GlobalConfig.Metrics.Labels,
-		interval:              config.GlobalConfig.Metrics.Interval,
-		rsvc:                  newResourceService(config.GlobalConfig.Metrics.Interval),
+		addr:                  config.GlobalConfigDeprecated.Metrics.Address,
+		jobName:               config.GlobalConfigDeprecated.Metrics.JobName,
+		labels:                config.GlobalConfigDeprecated.Metrics.Labels,
+		interval:              config.GlobalConfigDeprecated.Metrics.Interval,
+		rsvc:                  newResourceService(config.GlobalConfigDeprecated.Metrics.Interval),
 		stopCh:                make(chan struct{}),
 		quitCh:                make(chan struct{}),
 	}
@@ -248,7 +248,7 @@ func newPushService() (service.BackgroundService, error) {
 
 // New constructs a new metrics service.
 func New() (service.BackgroundService, error) {
-	mode := strings.ToLower(config.GlobalConfig.Metrics.Mode)
+	mode := strings.ToLower(config.GlobalConfigDeprecated.Metrics.Mode)
 	switch mode {
 	case MetricsModeNone:
 		return newStubService()
@@ -264,7 +264,7 @@ func New() (service.BackgroundService, error) {
 
 // Enabled returns if metrics are enabled.
 func Enabled() bool {
-	return config.GlobalConfig.Metrics.Mode != MetricsModeNone
+	return config.GlobalConfigDeprecated.Metrics.Mode != MetricsModeNone
 }
 
 // EscapeLabelCharacters replaces invalid prometheus label name characters with "_".
@@ -289,7 +289,7 @@ func GetDefaultPushLabels(ti *env.ScenarioInstanceInfo) map[string]string {
 			labels[EscapeLabelCharacters(f.Name)] = f.Value.String()
 		})
 		// Override any labels passed to oasis-test-runner via CLI.
-		for k, v := range config.GlobalConfig.Metrics.Labels {
+		for k, v := range config.GlobalConfigDeprecated.Metrics.Labels {
 			labels[k] = v
 		}
 

--- a/go/oasis-node/cmd/common/pprof/pprof.go
+++ b/go/oasis-node/cmd/common/pprof/pprof.go
@@ -109,7 +109,7 @@ func (p *pprofService) Cleanup() {
 
 // New constructs a new pprof service.
 func New() (service.BackgroundService, error) {
-	address := config.GlobalConfig.Pprof.BindAddress
+	address := config.GlobalConfigDeprecated.Pprof.BindAddress
 
 	return &pprofService{
 		BaseBackgroundService: *service.NewBaseBackgroundService("pprof"),

--- a/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
+++ b/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
@@ -104,7 +104,7 @@ func doDumpDB(cmd *cobra.Command, _ []string) {
 	ldb, _, stateRoot, err := abci.InitStateStorage(
 		&abci.ApplicationConfig{
 			DataDir:             filepath.Join(dataDir, cmtCommon.StateDir),
-			StorageBackend:      config.GlobalConfig.Storage.Backend,
+			StorageBackend:      config.GlobalConfigDeprecated.Storage.Backend,
 			MemoryOnlyStorage:   false,
 			ReadOnlyStorage:     viper.GetBool(cfgDumpReadOnlyDB),
 			DisableCheckpointer: true,

--- a/go/oasis-node/cmd/debug/storage/export.go
+++ b/go/oasis-node/cmd/debug/storage/export.go
@@ -158,9 +158,9 @@ func newDirectStorageBackend(dataDir string, namespace common.Namespace) (storag
 	// The right thing to do will be to use storage.New, but the backend config
 	// assumes that identity is valid, and we don't have one.
 	cfg := &storageAPI.Config{
-		Backend:      config.GlobalConfig.Storage.Backend,
+		Backend:      config.GlobalConfigDeprecated.Storage.Backend,
 		Namespace:    namespace,
-		MaxCacheSize: int64(config.ParseSizeInBytes(config.GlobalConfig.Storage.MaxCacheSize)),
+		MaxCacheSize: int64(config.ParseSizeInBytes(config.GlobalConfigDeprecated.Storage.MaxCacheSize)),
 	}
 	cfg.DB = filepath.Join(dataDir, storageDatabase.DefaultFileName(cfg.Backend))
 	return storageDatabase.New(cfg)

--- a/go/oasis-node/cmd/debug/txsource/txsource.go
+++ b/go/oasis-node/cmd/debug/txsource/txsource.go
@@ -48,9 +48,9 @@ var (
 func doRun(cmd *cobra.Command, _ []string) error {
 	cmd.SilenceUsage = true
 
-	config.GlobalConfig.Common.Log.Level = make(map[string]string)
-	config.GlobalConfig.Common.Log.Level["default"] = "debug"
-	config.GlobalConfig.Common.Log.Format = "json"
+	config.GlobalConfigDeprecated.Common.Log.Level = make(map[string]string)
+	config.GlobalConfigDeprecated.Common.Log.Level["default"] = "debug"
+	config.GlobalConfigDeprecated.Common.Log.Format = "json"
 
 	if err := common.Init(); err != nil {
 		common.EarlyLogAndExit(err)

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -384,7 +384,7 @@ func (n *Node) startRuntimeWorkers() error {
 //
 // Note: the reason for having the named err return value here is for the
 // deferred func below to propagate the error.
-func NewNode() (node *Node, err error) { // nolint: gocyclo
+func NewNode(cfg *config.Config) (node *Node, err error) { // nolint: gocyclo
 	logger := cmdCommon.Logger()
 
 	node = &Node{
@@ -490,7 +490,14 @@ func NewNode() (node *Node, err error) { // nolint: gocyclo
 	if isArchive {
 		node.P2P = p2p.NewNop()
 	} else {
-		node.P2P, err = p2p.New(node.Identity, node.chainContext, node.commonStore)
+		p2pCfg, err := cfg.ToP2PConfig()
+		if err != nil {
+			logger.Error("failed to create P2P config",
+				"err", err,
+			)
+			return nil, err
+		}
+		node.P2P, err = p2p.New(p2pCfg, node.Identity, node.chainContext, node.commonStore)
 		if err != nil {
 			return nil, err
 		}

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -414,7 +414,7 @@ func NewNode(cfg *config.Config) (node *Node, err error) { // nolint: gocyclo
 	// binary is from the logs.
 	logger.Info("Starting oasis-node",
 		"version", version.SoftwareVersion,
-		"mode", config.GlobalConfig.Mode,
+		"mode", config.GlobalConfigDeprecated.Mode,
 	)
 
 	if err = verifyElevatedPrivileges(logger); err != nil {
@@ -486,7 +486,7 @@ func NewNode(cfg *config.Config) (node *Node, err error) { // nolint: gocyclo
 		p2p.DebugForceAllowUnroutableAddresses()
 	}
 
-	isArchive := config.GlobalConfig.Mode == config.ModeArchive
+	isArchive := config.GlobalConfigDeprecated.Mode == config.ModeArchive
 	if isArchive {
 		node.P2P = p2p.NewNop()
 	} else {

--- a/go/oasis-node/cmd/node/node_control.go
+++ b/go/oasis-node/cmd/node/node_control.go
@@ -159,7 +159,7 @@ func (n *Node) GetStatus(ctx context.Context) (*control.Status, error) {
 
 	return &control.Status{
 		SoftwareVersion: version.SoftwareVersion,
-		Mode:            config.GlobalConfig.Mode,
+		Mode:            config.GlobalConfigDeprecated.Mode,
 		Debug:           ds,
 		Identity:        ident,
 		Consensus:       cs,
@@ -270,7 +270,7 @@ func (n *Node) getRuntimeStatus(ctx context.Context) (map[common.Namespace]contr
 		}
 
 		// Take storage into account for last retained round.
-		if config.GlobalConfig.Mode.HasLocalStorage() {
+		if config.GlobalConfigDeprecated.Mode.HasLocalStorage() {
 			lsb, ok := rt.Storage().(storage.LocalBackend)
 			switch ok {
 			case false:

--- a/go/oasis-node/cmd/node/run.go
+++ b/go/oasis-node/cmd/node/run.go
@@ -26,9 +26,9 @@ func Run(_ *cobra.Command, _ []string) {
 		err  error
 	)
 
-	cfg := &config.GlobalConfig
+	cfg := &config.GlobalConfigDeprecated
 
-	switch config.GlobalConfig.Mode {
+	switch config.GlobalConfigDeprecated.Mode {
 	case config.ModeSeed:
 		node, err = NewSeedNode(cfg)
 	default:

--- a/go/oasis-node/cmd/node/run.go
+++ b/go/oasis-node/cmd/node/run.go
@@ -26,11 +26,13 @@ func Run(_ *cobra.Command, _ []string) {
 		err  error
 	)
 
+	cfg := &config.GlobalConfig
+
 	switch config.GlobalConfig.Mode {
 	case config.ModeSeed:
-		node, err = NewSeedNode()
+		node, err = NewSeedNode(cfg)
 	default:
-		node, err = NewNode()
+		node, err = NewNode(cfg)
 	}
 
 	switch {

--- a/go/oasis-node/cmd/node/seed.go
+++ b/go/oasis-node/cmd/node/seed.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/oasisprotocol/oasis-core/go/common/grpc"
@@ -9,6 +8,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/persistent"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
+	"github.com/oasisprotocol/oasis-core/go/config"
 	cmtSeed "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/seed"
 	controlApi "github.com/oasisprotocol/oasis-core/go/control/api"
 	genesisFile "github.com/oasisprotocol/oasis-core/go/genesis/file"
@@ -55,7 +55,7 @@ func (n *SeedNode) Cleanup() {
 }
 
 // NewSeedNode initializes the seed node.
-func NewSeedNode() (node *SeedNode, err error) {
+func NewSeedNode(cfg *config.Config) (node *SeedNode, err error) {
 	logger := cmdCommon.Logger()
 
 	node = &SeedNode{
@@ -150,14 +150,17 @@ func NewSeedNode() (node *SeedNode, err error) {
 	}
 
 	// Initialize and start the libp2p seed.
-	var seedCfg p2p.SeedConfig
-	if err = seedCfg.Load(); err != nil {
-		return nil, fmt.Errorf("failed to load libp2p seed config: %w", err)
+	p2pCfg, err := cfg.ToSeedConfig()
+	if err != nil {
+		node.logger.Error("failed to create p2p seed node config",
+			"err", err,
+		)
+		return nil, err
 	}
-	seedCfg.Signer = node.identity.P2PSigner
-	seedCfg.CommonStore = node.commonStore
+	p2pCfg.Signer = node.identity.P2PSigner
+	p2pCfg.CommonStore = node.commonStore
 
-	node.libp2pSeed, err = p2p.NewSeedNode(&seedCfg)
+	node.libp2pSeed, err = p2p.NewSeedNode(p2pCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/go/oasis-node/cmd/node/seed_control.go
+++ b/go/oasis-node/cmd/node/seed_control.go
@@ -76,7 +76,7 @@ func (n *SeedNode) GetStatus(context.Context) (*control.Status, error) {
 
 	return &control.Status{
 		SoftwareVersion: version.SoftwareVersion,
-		Mode:            config.GlobalConfig.Mode,
+		Mode:            config.GlobalConfigDeprecated.Mode,
 		Identity:        identity,
 		Seed:            &seedStatus,
 	}, nil

--- a/go/oasis-node/cmd/storage/storage.go
+++ b/go/oasis-node/cmd/storage/storage.go
@@ -173,7 +173,7 @@ func doMigrate(_ *cobra.Command, args []string) error {
 			defer history.Close()
 
 			nodeCfg := &db.Config{
-				DB:        workerStorage.GetLocalBackendDBDir(runtimeDir, config.GlobalConfig.Storage.Backend),
+				DB:        workerStorage.GetLocalBackendDBDir(runtimeDir, config.GlobalConfigDeprecated.Storage.Backend),
 				Namespace: rt,
 			}
 
@@ -216,7 +216,7 @@ func doCheck(_ *cobra.Command, args []string) error {
 			runtimeDir := runtimeConfig.GetRuntimeStateDir(dataDir, rt)
 
 			nodeCfg := &db.Config{
-				DB:        workerStorage.GetLocalBackendDBDir(runtimeDir, config.GlobalConfig.Storage.Backend),
+				DB:        workerStorage.GetLocalBackendDBDir(runtimeDir, config.GlobalConfigDeprecated.Storage.Backend),
 				Namespace: rt,
 			}
 
@@ -262,7 +262,7 @@ func doRenameNs(_ *cobra.Command, args []string) error {
 	dstDir := runtimeConfig.GetRuntimeStateDir(dataDir, dstID)
 
 	nodeCfg := &db.Config{
-		DB:        workerStorage.GetLocalBackendDBDir(srcDir, config.GlobalConfig.Storage.Backend),
+		DB:        workerStorage.GetLocalBackendDBDir(srcDir, config.GlobalConfigDeprecated.Storage.Backend),
 		Namespace: srcID,
 	}
 

--- a/go/oasis-node/node_test.go
+++ b/go/oasis-node/node_test.go
@@ -134,19 +134,19 @@ func newTestNode(t *testing.T) *testNode {
 	initConfigOnce.Do(func() {
 		cmdCommon.InitConfig()
 
-		config.GlobalConfig.Common.Log.Level = make(map[string]string)
-		config.GlobalConfig.Common.Log.Level["default"] = "debug"
-		config.GlobalConfig.Common.Log.Format = "json"
+		config.GlobalConfigDeprecated.Common.Log.Level = make(map[string]string)
+		config.GlobalConfigDeprecated.Common.Log.Level["default"] = "debug"
+		config.GlobalConfigDeprecated.Common.Log.Format = "json"
 
-		config.GlobalConfig.Consensus.Validator = true
-		config.GlobalConfig.Common.Debug.AllowRoot = true
-		config.GlobalConfig.Mode = config.ModeCompute
-		config.GlobalConfig.Runtime.Provisioner = runtimeConfig.RuntimeProvisionerMock
-		config.GlobalConfig.Storage.Backend = "badger"
-		config.GlobalConfig.Storage.PublicRPCEnabled = true
-		config.GlobalConfig.Consensus.ListenAddress = "tcp://0.0.0.0:27565"
-		config.GlobalConfig.Consensus.SupplementarySanity.Enabled = true
-		config.GlobalConfig.Consensus.SupplementarySanity.Interval = 1
+		config.GlobalConfigDeprecated.Consensus.Validator = true
+		config.GlobalConfigDeprecated.Common.Debug.AllowRoot = true
+		config.GlobalConfigDeprecated.Mode = config.ModeCompute
+		config.GlobalConfigDeprecated.Runtime.Provisioner = runtimeConfig.RuntimeProvisionerMock
+		config.GlobalConfigDeprecated.Storage.Backend = "badger"
+		config.GlobalConfigDeprecated.Storage.PublicRPCEnabled = true
+		config.GlobalConfigDeprecated.Consensus.ListenAddress = "tcp://0.0.0.0:27565"
+		config.GlobalConfigDeprecated.Consensus.SupplementarySanity.Enabled = true
+		config.GlobalConfigDeprecated.Consensus.SupplementarySanity.Interval = 1
 	})
 
 	require := require.New(t)
@@ -159,10 +159,10 @@ func newTestNode(t *testing.T) *testNode {
 	entity, entitySigner, err := entity.Generate(dataDir, signerFactory, nil)
 	require.NoError(err, "create test entity")
 
-	config.GlobalConfig.Registration.Entity = filepath.Join(dataDir, "entity.json")
+	config.GlobalConfigDeprecated.Registration.Entity = filepath.Join(dataDir, "entity.json")
 
-	config.GlobalConfig.Common.DataDir = dataDir
-	config.GlobalConfig.Common.Log.File = filepath.Join(dataDir, "test-node.log")
+	config.GlobalConfigDeprecated.Common.DataDir = dataDir
+	config.GlobalConfigDeprecated.Common.Log.File = filepath.Join(dataDir, "test-node.log")
 	viper.Set(bundle.CfgDebugMockIDs, []string{
 		testRuntimeID.String(),
 	})
@@ -183,7 +183,7 @@ func newTestNode(t *testing.T) *testNode {
 	doc, err := tmTestGenesis.CreateTestNodeGenesisDocument(identity, entity, entitySigner)
 	require.NoError(err, "test entity genesis document")
 	require.NoError(doc.WriteFileJSON(genesisPath))
-	config.GlobalConfig.Genesis.File = genesisPath
+	config.GlobalConfigDeprecated.Genesis.File = genesisPath
 
 	n := &testNode{
 		runtimeID:    testRuntime.ID,

--- a/go/oasis-remote-signer/cmd/root.go
+++ b/go/oasis-remote-signer/cmd/root.go
@@ -70,8 +70,8 @@ func Execute() {
 }
 
 func ensureDataDir() (string, error) {
-	if config.GlobalConfig.Common.DataDir != "" {
-		return config.GlobalConfig.Common.DataDir, nil
+	if config.GlobalConfigDeprecated.Common.DataDir != "" {
+		return config.GlobalConfigDeprecated.Common.DataDir, nil
 	}
 
 	dataDir := viper.GetString(CfgDataDir)

--- a/go/p2p/host.go
+++ b/go/p2p/host.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p/core"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -16,9 +15,6 @@ import (
 	"github.com/multiformats/go-multiaddr"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
-	"github.com/oasisprotocol/oasis-core/go/common/node"
-	"github.com/oasisprotocol/oasis-core/go/common/version"
-	"github.com/oasisprotocol/oasis-core/go/config"
 	"github.com/oasisprotocol/oasis-core/go/p2p/api"
 )
 
@@ -32,6 +28,8 @@ type HostConfig struct {
 
 	ConnManagerConfig
 	ConnGaterConfig
+
+	IsSeed bool
 }
 
 // NewHost constructs a new libp2p host.
@@ -39,7 +37,7 @@ func NewHost(cfg *HostConfig) (host.Host, *conngater.BasicConnectionGater, error
 	id := api.SignerToPrivKey(cfg.Signer)
 
 	// Set up a resource manager so that we can reserve more resources.
-	rm, err := NewResourceManager()
+	rm, err := NewResourceManager(cfg.IsSeed)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -77,38 +75,6 @@ func (cfg *HostConfig) NewHost() (host.Host, *conngater.BasicConnectionGater, er
 	return NewHost(cfg)
 }
 
-// Load loads host configuration.
-func (cfg *HostConfig) Load() error {
-	userAgent := fmt.Sprintf("oasis-core/%s", version.SoftwareVersion)
-	port := config.GlobalConfig.P2P.Port
-
-	// Listen for connections on all interfaces.
-	listenAddr, err := multiaddr.NewMultiaddr(
-		fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", port),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create multiaddress: %w", err)
-	}
-
-	var cmCfg ConnManagerConfig
-	if err = cmCfg.Load(); err != nil {
-		return fmt.Errorf("failed to load connection manager config: %w", err)
-	}
-
-	var cgCfg ConnGaterConfig
-	if err = cgCfg.Load(); err != nil {
-		return fmt.Errorf("failed to load connection gater config: %w", err)
-	}
-
-	cfg.UserAgent = userAgent
-	cfg.Port = port
-	cfg.ListenAddr = listenAddr
-	cfg.ConnManagerConfig = cmCfg
-	cfg.ConnGaterConfig = cgCfg
-
-	return nil
-}
-
 // ConnManagerConfig describes a set of settings for a connection manager.
 type ConnManagerConfig struct {
 	MinPeers        int
@@ -133,36 +99,6 @@ func NewConnManager(cfg *ConnManagerConfig) (*connmgr.BasicConnMgr, error) {
 // NewConnManager constructs a new connection manager.
 func (cfg *ConnManagerConfig) NewConnManager() (*connmgr.BasicConnMgr, error) {
 	return NewConnManager(cfg)
-}
-
-// Load loads connection manager configuration.
-func (cfg *ConnManagerConfig) Load() error {
-	persistentPeersMap := make(map[core.PeerID]struct{})
-	for _, pp := range config.GlobalConfig.P2P.ConnectionManager.PersistentPeers {
-		var addr node.ConsensusAddress
-		if err := addr.UnmarshalText([]byte(pp)); err != nil {
-			return fmt.Errorf("malformed address (expected pubkey@IP:port): %w", err)
-		}
-
-		pid, err := api.PublicKeyToPeerID(addr.ID)
-		if err != nil {
-			return fmt.Errorf("invalid public key (%s): %w", addr.ID, err)
-		}
-
-		persistentPeersMap[pid] = struct{}{}
-	}
-
-	persistentPeers := make([]peer.ID, 0)
-	for pid := range persistentPeersMap {
-		persistentPeers = append(persistentPeers, pid)
-	}
-
-	cfg.MinPeers = config.GlobalConfig.P2P.ConnectionManager.MaxNumPeers
-	cfg.MaxPeers = cfg.MinPeers + peersHighWatermarkDelta
-	cfg.GracePeriod = config.GlobalConfig.P2P.ConnectionManager.PeerGracePeriod
-	cfg.PersistentPeers = persistentPeers
-
-	return nil
 }
 
 // ConnGaterConfig describes a set of settings for a connection gater.
@@ -191,26 +127,12 @@ func (cfg *ConnGaterConfig) NewConnGater() (*conngater.BasicConnectionGater, err
 	return NewConnGater(cfg)
 }
 
-// Load loads connection gater configuration.
-func (cfg *ConnGaterConfig) Load() error {
-	blockedPeers := make([]net.IP, 0)
-	for _, blockedIP := range config.GlobalConfig.P2P.ConnectionGater.BlockedPeerIPs {
-		parsedIP := net.ParseIP(blockedIP)
-		if parsedIP == nil {
-			return fmt.Errorf("malformed blocked IP: %s", blockedIP)
-		}
-		blockedPeers = append(blockedPeers, parsedIP)
-	}
-
-	cfg.BlockedPeers = blockedPeers
-
-	return nil
-}
-
 // NewResourceManager constructs a new resource manager.
-func NewResourceManager() (network.ResourceManager, error) {
+//
+// Seed specifies whether this is a seed node.
+func NewResourceManager(seed bool) (network.ResourceManager, error) {
 	// Use the default resource manager for non-seed nodes.
-	if config.GlobalConfig.Mode != config.ModeSeed {
+	if !seed {
 		return nil, nil
 	}
 

--- a/go/p2p/p2p.go
+++ b/go/p2p/p2p.go
@@ -25,14 +25,12 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/persistent"
-	"github.com/oasisprotocol/oasis-core/go/config"
 	"github.com/oasisprotocol/oasis-core/go/p2p/api"
 	"github.com/oasisprotocol/oasis-core/go/p2p/discovery/bootstrap"
 	"github.com/oasisprotocol/oasis-core/go/p2p/peermgmt"
 	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 	registryAPI "github.com/oasisprotocol/oasis-core/go/registry/api"
-	"github.com/oasisprotocol/oasis-core/go/worker/common/configparser"
 )
 
 const (
@@ -84,6 +82,8 @@ type p2p struct {
 	topics            map[string]*topicHandler
 
 	logger *logging.Logger
+
+	validateConcurrency int // TODO global limit
 }
 
 // Implements api.Service.
@@ -298,7 +298,7 @@ func (p *p2p) RegisterHandler(topic string, handler api.Handler) {
 	_ = p.pubsub.RegisterTopicValidator(
 		topic,
 		h.topicMessageValidator,
-		pubsub.WithValidatorConcurrency(config.GlobalConfig.P2P.Gossipsub.ValidateConcurrency),
+		pubsub.WithValidatorConcurrency(p.validateConcurrency),
 	)
 
 	p.logger.Debug("registered new topic handler",
@@ -359,12 +359,7 @@ func messageIdFn(pmsg *pb.Message) string { // nolint: revive
 }
 
 // New creates a new P2P node.
-func New(identity *identity.Identity, chainContext string, store *persistent.CommonStore) (api.Service, error) {
-	var cfg Config
-	if err := cfg.Load(); err != nil {
-		return nil, fmt.Errorf("p2p: failed to load peer config: %w", err)
-	}
-
+func New(cfg *Config, identity *identity.Identity, chainContext string, store *persistent.CommonStore) (api.Service, error) {
 	// Create the P2P host.
 	cfg.HostConfig.Signer = identity.P2PSigner
 	host, cg, err := NewHost(&cfg.HostConfig)
@@ -449,68 +444,16 @@ type Config struct {
 	BootstrapDiscoveryConfig
 }
 
-// Load loads P2P configuration.
-func (cfg *Config) Load() error {
-	rawAddresses, err := configparser.ParseAddressList(config.GlobalConfig.P2P.Registration.Addresses)
-	if err != nil {
-		return fmt.Errorf("failed to parse address list: %w", err)
-	}
-	var addresses []multiaddr.Multiaddr
-	for _, addr := range rawAddresses {
-		var mAddr multiaddr.Multiaddr
-		mAddr, err = manet.FromNetAddr(addr.ToTCPAddr())
-		if err != nil {
-			return fmt.Errorf("failed to convert address to multiaddress: %w", err)
-		}
-		addresses = append(addresses, mAddr)
-	}
-
-	var hostCfg HostConfig
-	if err := hostCfg.Load(); err != nil {
-		return fmt.Errorf("failed to load host config: %w", err)
-	}
-
-	var gossipSubCfg GossipSubConfig
-	if err := gossipSubCfg.Load(); err != nil {
-		return fmt.Errorf("failed to load gossipsub config: %w", err)
-	}
-
-	var bootstrapCfg BootstrapDiscoveryConfig
-	if err := bootstrapCfg.Load(); err != nil {
-		return fmt.Errorf("failed to load bootstrap config: %w", err)
-	}
-
-	cfg.Addresses = addresses
-	cfg.HostConfig = hostCfg
-	cfg.GossipSubConfig = gossipSubCfg
-	cfg.BootstrapDiscoveryConfig = bootstrapCfg
-
-	return nil
-}
-
 // GossipSubConfig describes a set of settings for a gossip pubsub.
 type GossipSubConfig struct {
 	// XXX: Main config has int64, but here just int -- investigate.
 	PeerOutboundQueueSize int
 	ValidateQueueSize     int
 	ValidateThrottle      int
+	// ValidateConcurrency controls the number of active validation goroutines of the topic.
+	ValidateConcurrency int
 
 	PersistentPeers []peer.AddrInfo
-}
-
-// Load loads gossipsub configuration.
-func (cfg *GossipSubConfig) Load() error {
-	persistentPeers, err := api.AddrInfosFromConsensusAddrs(config.GlobalConfig.P2P.ConnectionManager.PersistentPeers)
-	if err != nil {
-		return fmt.Errorf("failed to convert persistent peers' addresses: %w", err)
-	}
-
-	cfg.PeerOutboundQueueSize = config.GlobalConfig.P2P.Gossipsub.PeerOutboundQueueSize
-	cfg.ValidateQueueSize = config.GlobalConfig.P2P.Gossipsub.ValidateQueueSize
-	cfg.ValidateThrottle = config.GlobalConfig.P2P.Gossipsub.ValidateThrottle
-	cfg.PersistentPeers = persistentPeers
-
-	return nil
 }
 
 // BootstrapDiscoveryConfig describes a set of settings for a discovery.
@@ -518,18 +461,4 @@ type BootstrapDiscoveryConfig struct {
 	Enable          bool
 	Seeds           []peer.AddrInfo
 	RetentionPeriod time.Duration
-}
-
-// Load loads bootstrap discovery configuration.
-func (cfg *BootstrapDiscoveryConfig) Load() error {
-	seeds, err := api.AddrInfosFromConsensusAddrs(config.GlobalConfig.P2P.Seeds)
-	if err != nil {
-		return fmt.Errorf("failed to convert seeds' addresses: %w", err)
-	}
-
-	cfg.Seeds = seeds
-	cfg.Enable = config.GlobalConfig.P2P.Discovery.Bootstrap.Enable
-	cfg.RetentionPeriod = config.GlobalConfig.P2P.Discovery.Bootstrap.RetentionPeriod
-
-	return nil
 }

--- a/go/p2p/seed.go
+++ b/go/p2p/seed.go
@@ -2,7 +2,6 @@ package p2p
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"sync"
 
@@ -159,22 +158,4 @@ type SeedConfig struct {
 // NewSeed creates a new P2P seed node service.
 func (cfg *SeedConfig) NewSeed() (api.SeedService, error) {
 	return NewSeedNode(cfg)
-}
-
-// Load loads seed configuration.
-func (cfg *SeedConfig) Load() error {
-	var hostCfg HostConfig
-	if err := hostCfg.Load(); err != nil {
-		return fmt.Errorf("failed to load host config: %w", err)
-	}
-
-	var bootstrapCfg BootstrapDiscoveryConfig
-	if err := bootstrapCfg.Load(); err != nil {
-		return fmt.Errorf("failed to load bootstrap config: %w", err)
-	}
-
-	cfg.HostConfig = hostCfg
-	cfg.BootstrapDiscoveryConfig = bootstrapCfg
-
-	return nil
 }

--- a/go/runtime/bundle/manager.go
+++ b/go/runtime/bundle/manager.go
@@ -168,19 +168,19 @@ func NewManager(dataDir string, runtimeIDs []common.Namespace, store ManifestSto
 
 	// Define a limit on the maximum allowed bundle size.
 	bundleSize := int64(maxDefaultBundleSizeBytes)
-	if size := config.GlobalConfig.Runtime.MaxBundleSize; size != "" {
+	if size := config.GlobalConfigDeprecated.Runtime.MaxBundleSize; size != "" {
 		bundleSize = int64(config.ParseSizeInBytes(size))
 	}
 
 	// Validate global repository URLs.
-	globalBaseURLs, err := validateAndNormalizeURLs(config.GlobalConfig.Runtime.Registries)
+	globalBaseURLs, err := validateAndNormalizeURLs(config.GlobalConfigDeprecated.Runtime.Registries)
 	if err != nil {
 		return nil, err
 	}
 
 	// Validate each runtime's registry URLs.
 	runtimeBaseURLs := make(map[common.Namespace][]string)
-	for _, runtime := range config.GlobalConfig.Runtime.Runtimes {
+	for _, runtime := range config.GlobalConfigDeprecated.Runtime.Runtimes {
 		urls, err := validateAndNormalizeURLs(runtime.Registries)
 		if err != nil {
 			return nil, err
@@ -253,7 +253,7 @@ func (m *Manager) run(ctx context.Context) {
 	}
 
 	// Extract bundles from the configuration.
-	exploded, err := m.explodeBundles(config.GlobalConfig.Runtime.Paths)
+	exploded, err := m.explodeBundles(config.GlobalConfigDeprecated.Runtime.Paths)
 	if err != nil {
 		m.logger.Error("failed to explode bundles",
 			"err", err,

--- a/go/runtime/bundle/registry.go
+++ b/go/runtime/bundle/registry.go
@@ -98,18 +98,18 @@ func (r *Registry) AddManifest(manifest *ExplodedManifest) error {
 
 	for compID, comp := range components {
 		teeKind := comp.TEEKind()
-		if compCfg, ok := config.GlobalConfig.Runtime.GetComponent(manifest.ID, compID); ok {
+		if compCfg, ok := config.GlobalConfigDeprecated.Runtime.GetComponent(manifest.ID, compID); ok {
 			if kind, ok := compCfg.TEEKind(); ok {
 				teeKind = kind
 			}
 		} else {
 			// Support legacy configuration where the runtime environment determines
 			// whether the client node should run the runtime in an SGX environment.
-			isEnvAuto := config.GlobalConfig.Runtime.Environment == rtConfig.RuntimeEnvironmentAuto
-			hasSGXLoader := config.GlobalConfig.Runtime.SGX.Loader != ""
-			hasSGXLoader = hasSGXLoader || config.GlobalConfig.Runtime.SGXLoader != ""
-			insecureMock := config.GlobalConfig.Runtime.DebugMockTEE
-			if comp.ID().IsRONL() && config.GlobalConfig.Mode.IsClientOnly() && isEnvAuto && !hasSGXLoader && !insecureMock {
+			isEnvAuto := config.GlobalConfigDeprecated.Runtime.Environment == rtConfig.RuntimeEnvironmentAuto
+			hasSGXLoader := config.GlobalConfigDeprecated.Runtime.SGX.Loader != ""
+			hasSGXLoader = hasSGXLoader || config.GlobalConfigDeprecated.Runtime.SGXLoader != ""
+			insecureMock := config.GlobalConfigDeprecated.Runtime.DebugMockTEE
+			if comp.ID().IsRONL() && config.GlobalConfigDeprecated.Mode.IsClientOnly() && isEnvAuto && !hasSGXLoader && !insecureMock {
 				teeKind = component.TEEKindNone
 			}
 		}

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -126,7 +126,7 @@ func (h *runtimeHistory) Commit(blks []*roothash.AnnotatedBlock) error {
 }
 
 func (h *runtimeHistory) StorageSyncCheckpoint(round uint64) error {
-	if config.GlobalConfig.Mode == config.ModeArchive {
+	if config.GlobalConfigDeprecated.Mode == config.ModeArchive {
 		// If we are in archive mode, ignore storage sync checkpoints.
 		return nil
 	}

--- a/go/runtime/host/provisioner/provisioner.go
+++ b/go/runtime/host/provisioner/provisioner.go
@@ -92,23 +92,23 @@ func createProvisioner(
 	var err error
 	var insecureNoSandbox bool
 
-	attestInterval := config.GlobalConfig.Runtime.AttestInterval
-	sandboxBinary := config.GlobalConfig.Runtime.SandboxBinary
-	sgxLoader := config.GlobalConfig.Runtime.SGX.Loader
+	attestInterval := config.GlobalConfigDeprecated.Runtime.AttestInterval
+	sandboxBinary := config.GlobalConfigDeprecated.Runtime.SandboxBinary
+	sgxLoader := config.GlobalConfigDeprecated.Runtime.SGX.Loader
 	if sgxLoader == "" {
-		sgxLoader = config.GlobalConfig.Runtime.SGXLoader
+		sgxLoader = config.GlobalConfigDeprecated.Runtime.SGXLoader
 	}
-	insecureMock := config.GlobalConfig.Runtime.DebugMockTEE
+	insecureMock := config.GlobalConfigDeprecated.Runtime.DebugMockTEE
 
 	// Support legacy configuration where the runtime environment determines
 	// whether the TEE should be mocked.
-	if config.GlobalConfig.Runtime.Environment == rtConfig.RuntimeEnvironmentSGXMock {
+	if config.GlobalConfigDeprecated.Runtime.Environment == rtConfig.RuntimeEnvironmentSGXMock {
 		insecureMock = true
 	}
 
 	// Register provisioners based on the configured provisioner.
 	provisioners := make(map[component.TEEKind]runtimeHost.Provisioner)
-	switch p := config.GlobalConfig.Runtime.Provisioner; p {
+	switch p := config.GlobalConfigDeprecated.Runtime.Provisioner; p {
 	case rtConfig.RuntimeProvisionerMock:
 		// Mock provisioner, only supported when the runtime requires no TEE hardware.
 		if !cmdFlags.DebugDontBlameOasis() {
@@ -171,8 +171,8 @@ func createProvisioner(
 	// Configure TDX provisioner.
 	// TODO: Allow provisioner selection in the future, currently we only have QEMU.
 	cidPool, err := hostTdx.NewCidPool(
-		config.GlobalConfig.Runtime.TDX.CidStart,
-		config.GlobalConfig.Runtime.TDX.CidCount,
+		config.GlobalConfigDeprecated.Runtime.TDX.CidStart,
+		config.GlobalConfigDeprecated.Runtime.TDX.CidCount,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CID pool: %w", err)
@@ -194,7 +194,7 @@ func createProvisioner(
 
 	// Configure optional load balancing.
 	for tee, rp := range provisioners {
-		numInstances := int(config.GlobalConfig.Runtime.LoadBalancer.NumInstances)
+		numInstances := int(config.GlobalConfigDeprecated.Runtime.LoadBalancer.NumInstances)
 		provisioners[tee] = hostLoadBalance.NewProvisioner(rp, numInstances)
 	}
 

--- a/go/runtime/host/tdx/qemu.go
+++ b/go/runtime/host/tdx/qemu.go
@@ -285,7 +285,7 @@ func (p *qemuProvisioner) getSandboxConfig(cfg host.Config, _ sandbox.Connector,
 
 // createNetworkingConfig generates QEMU networking configuration for a component.
 func (p *qemuProvisioner) createNetworkingConfig(cfg host.Config) ([]string, error) {
-	compCfg, _ := config.GlobalConfig.Runtime.GetComponent(cfg.ID, cfg.Component.ID())
+	compCfg, _ := config.GlobalConfigDeprecated.Runtime.GetComponent(cfg.ID, cfg.Component.ID())
 	netdevOpts := []string{"user", "id=net0"}
 
 	// Inbound forwarding.

--- a/go/runtime/log/manager.go
+++ b/go/runtime/log/manager.go
@@ -51,7 +51,7 @@ func (m *Manager) Get(runtimeID common.Namespace, componentID component.ID) (*Lo
 	}
 	fn := filepath.Join(logDir, logFn)
 
-	log, err := NewLog(fn, config.GlobalConfig.Runtime.Log.MaxLogSize)
+	log, err := NewLog(fn, config.GlobalConfigDeprecated.Runtime.Log.MaxLogSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create log handle: %w", err)
 	}

--- a/go/runtime/registry/config.go
+++ b/go/runtime/registry/config.go
@@ -18,10 +18,10 @@ import (
 )
 
 func getLocalConfig(runtimeID common.Namespace, compID component.ID) map[string]any {
-	compCfg, ok := config.GlobalConfig.Runtime.GetComponent(runtimeID, compID)
+	compCfg, ok := config.GlobalConfigDeprecated.Runtime.GetComponent(runtimeID, compID)
 	// Support legacy RONL configuration defined at the top level.
 	if !ok && compID == component.ID_RONL {
-		return config.GlobalConfig.Runtime.GetLocalConfig(runtimeID)
+		return config.GlobalConfigDeprecated.Runtime.GetLocalConfig(runtimeID)
 	}
 	return compCfg.Config
 }
@@ -29,13 +29,13 @@ func getLocalConfig(runtimeID common.Namespace, compID component.ID) map[string]
 func getConfiguredRuntimeIDs() ([]common.Namespace, error) {
 	// Check if any runtimes are configured to be hosted.
 	runtimes := make(map[common.Namespace]struct{})
-	for _, cfg := range config.GlobalConfig.Runtime.Runtimes {
+	for _, cfg := range config.GlobalConfigDeprecated.Runtime.Runtimes {
 		runtimes[cfg.ID] = struct{}{}
 	}
 
 	// Support legacy configurations where runtimes are specified within
 	// configured bundles.
-	for _, path := range config.GlobalConfig.Runtime.Paths {
+	for _, path := range config.GlobalConfigDeprecated.Runtime.Paths {
 		if err := func() error {
 			bnd, err := bundle.Open(path)
 			if err != nil {
@@ -66,7 +66,7 @@ func getConfiguredRuntimeIDs() ([]common.Namespace, error) {
 	}
 
 	// Validate configured runtimes based on the runtime mode.
-	switch config.GlobalConfig.Mode {
+	switch config.GlobalConfigDeprecated.Mode {
 	case config.ModeValidator, config.ModeSeed:
 		// No runtimes should be configured.
 		if len(runtimes) > 0 && !cmdFlags.DebugDontBlameOasis() {
@@ -86,13 +86,13 @@ func getConfiguredRuntimeIDs() ([]common.Namespace, error) {
 
 func createHistoryFactory() (history.Factory, error) {
 	var pruneFactory history.PrunerFactory
-	strategy := config.GlobalConfig.Runtime.Prune.Strategy
+	strategy := config.GlobalConfigDeprecated.Runtime.Prune.Strategy
 	switch strings.ToLower(strategy) {
 	case history.PrunerStrategyNone:
 		pruneFactory = history.NewNonePrunerFactory()
 	case history.PrunerStrategyKeepLast:
-		numKept := config.GlobalConfig.Runtime.Prune.NumKept
-		pruneInterval := max(config.GlobalConfig.Runtime.Prune.Interval, time.Second)
+		numKept := config.GlobalConfigDeprecated.Runtime.Prune.NumKept
+		pruneInterval := max(config.GlobalConfigDeprecated.Runtime.Prune.Interval, time.Second)
 		pruneFactory = history.NewKeepLastPrunerFactory(numKept, pruneInterval)
 	default:
 		return nil, fmt.Errorf("runtime/registry: unknown history pruner strategy: %s", strategy)
@@ -100,7 +100,7 @@ func createHistoryFactory() (history.Factory, error) {
 
 	// Archive node won't commit any new blocks, so disable waiting for storage
 	// sync commits.
-	mode := config.GlobalConfig.Mode
+	mode := config.GlobalConfigDeprecated.Mode
 	hasLocalStorage := mode.HasLocalStorage() && !mode.IsArchive()
 
 	historyFactory := history.NewFactory(pruneFactory, hasLocalStorage)

--- a/go/runtime/registry/handler_rofl_mgmt.go
+++ b/go/runtime/registry/handler_rofl_mgmt.go
@@ -316,7 +316,7 @@ func (rh *roflHostHandler) handleLogGet(ctx context.Context, rq *rofl.LogGetRequ
 
 // ensureComponentPermissions ensures that the component has all of the specified permissions.
 func (rh *roflHostHandler) ensureComponentPermissions(perms ...runtimeConfig.ComponentPermission) error {
-	compCfg, ok := config.GlobalConfig.Runtime.GetComponent(rh.parent.runtime.ID(), rh.id)
+	compCfg, ok := config.GlobalConfigDeprecated.Runtime.GetComponent(rh.parent.runtime.ID(), rh.id)
 	if !ok {
 		return fmt.Errorf("forbidden")
 	}

--- a/go/runtime/registry/host.go
+++ b/go/runtime/registry/host.go
@@ -216,7 +216,7 @@ func (n *RuntimeHostNode) isComponentWanted(comp *bundle.ExplodedComponent) bool
 	}
 
 	// Node configuration overrides all other settings.
-	if compCfg, ok := config.GlobalConfig.Runtime.GetComponent(n.runtime.ID(), comp.ID()); ok {
+	if compCfg, ok := config.GlobalConfigDeprecated.Runtime.GetComponent(n.runtime.ID(), comp.ID()); ok {
 		return !compCfg.Disabled
 	}
 
@@ -226,7 +226,7 @@ func (n *RuntimeHostNode) isComponentWanted(comp *bundle.ExplodedComponent) bool
 	}
 
 	// On non-compute nodes, assume all components are disabled by default.
-	if config.GlobalConfig.Mode != config.ModeCompute {
+	if config.GlobalConfigDeprecated.Mode != config.ModeCompute {
 		return false
 	}
 

--- a/go/runtime/registry/registry.go
+++ b/go/runtime/registry/registry.go
@@ -561,7 +561,7 @@ func (r *runtimeRegistry) createRuntime(runtimeID common.Namespace, managed bool
 		r.consensus.Pruner().RegisterHandler(rt.history)
 
 		// Start indexing blocks.
-		indexer := history.NewBlockIndexer(r.consensus, rt.history, config.GlobalConfig.Runtime.Indexer.BatchSize)
+		indexer := history.NewBlockIndexer(r.consensus, rt.history, config.GlobalConfigDeprecated.Runtime.Indexer.BatchSize)
 		r.indexers[runtimeID] = indexer
 	}
 
@@ -687,7 +687,7 @@ func (r *runtimeRegistry) Cleanup() {
 // Init initializes the runtime registry by adding runtimes from the global
 // runtime configuration to the registry.
 func (r *runtimeRegistry) Init(runtimeIDs []common.Namespace) error {
-	managed := config.GlobalConfig.Mode != config.ModeKeyManager
+	managed := config.GlobalConfigDeprecated.Mode != config.ModeKeyManager
 
 	for _, runtimeID := range runtimeIDs {
 		if _, err := r.createRuntime(runtimeID, managed); err != nil {

--- a/go/worker/client/worker.go
+++ b/go/worker/client/worker.go
@@ -134,7 +134,7 @@ func (w *Worker) registerRuntime(commonNode *committeeCommon.Node) error {
 		rp  registration.RoleProvider
 	)
 
-	switch config.GlobalConfig.Mode {
+	switch config.GlobalConfigDeprecated.Mode {
 	case config.ModeClient, config.ModeStatelessClient:
 		// When a node is a client node and it has an entity configured,
 		// we register it with the observer role as this may be needed
@@ -159,7 +159,7 @@ func (w *Worker) registerRuntime(commonNode *committeeCommon.Node) error {
 	}
 
 	// If we are running in stateless client mode, register remote storage.
-	if config.GlobalConfig.Mode == config.ModeStatelessClient {
+	if config.GlobalConfigDeprecated.Mode == config.ModeStatelessClient {
 		commonNode.Runtime.RegisterStorage(NewStatelessStorage(commonNode.P2P, w.commonWorker.ChainContext, id))
 	}
 
@@ -180,7 +180,7 @@ func New(
 	registration *registration.Worker,
 ) (*Worker, error) {
 	var enabled bool
-	switch config.GlobalConfig.Mode {
+	switch config.GlobalConfigDeprecated.Mode {
 	case config.ModeValidator, config.ModeSeed, config.ModeKeyManager:
 		enabled = false
 	case config.ModeArchive:

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -437,9 +437,9 @@ func (n *Node) updateHostedRuntimeVersionLocked() {
 
 	// For compute nodes, determine if there is a next version and activate it early.
 	var nextVersion *version.Version
-	if config.GlobalConfig.Mode == config.ModeCompute {
+	if config.GlobalConfigDeprecated.Mode == config.ModeCompute {
 		nextDeploy := n.CurrentDescriptor.NextDeployment(epoch)
-		preWarmEpochs := beacon.EpochTime(config.GlobalConfig.Runtime.PreWarmEpochs)
+		preWarmEpochs := beacon.EpochTime(config.GlobalConfigDeprecated.Runtime.PreWarmEpochs)
 
 		if nextDeploy != nil && nextDeploy.ValidFrom-epoch <= preWarmEpochs {
 			nextVersion = new(version.Version)

--- a/go/worker/common/committee/p2p.go
+++ b/go/worker/common/committee/p2p.go
@@ -37,7 +37,7 @@ func (h *txMsgHandler) HandleMessage(ctx context.Context, _ signature.PublicKey,
 
 	tx := msg.([]byte) // Ensured by DecodeMessage.
 
-	switch config.GlobalConfig.Mode {
+	switch config.GlobalConfigDeprecated.Mode {
 	case config.ModeStatelessClient:
 		// Ignore transactions on stateless clients.
 	default:

--- a/go/worker/common/config.go
+++ b/go/worker/common/config.go
@@ -22,7 +22,7 @@ type Config struct { // nolint: maligned
 func NewConfig() (*Config, error) {
 	// Parse sentry configuration.
 	var sentryAddresses []node.TLSAddress
-	for _, v := range config.GlobalConfig.Runtime.SentryAddresses {
+	for _, v := range config.GlobalConfigDeprecated.Runtime.SentryAddresses {
 		var tlsAddr node.TLSAddress
 		if err := tlsAddr.UnmarshalText([]byte(v)); err != nil {
 			return nil, fmt.Errorf("worker: bad sentry address (%s): %w", v, err)
@@ -32,7 +32,7 @@ func NewConfig() (*Config, error) {
 
 	cfg := Config{
 		SentryAddresses: sentryAddresses,
-		TxPool:          config.GlobalConfig.Runtime.TxPool,
+		TxPool:          config.GlobalConfigDeprecated.Runtime.TxPool,
 		logger:          logging.GetLogger("worker/config"),
 	}
 

--- a/go/worker/common/worker.go
+++ b/go/worker/common/worker.go
@@ -193,7 +193,7 @@ func New(
 	provisioner host.Provisioner,
 ) (*Worker, error) {
 	var enabled bool
-	switch config.GlobalConfig.Mode {
+	switch config.GlobalConfigDeprecated.Mode {
 	case config.ModeValidator, config.ModeSeed:
 		enabled = false
 	case config.ModeArchive:

--- a/go/worker/compute/executor/worker.go
+++ b/go/worker/compute/executor/worker.go
@@ -173,7 +173,7 @@ func New(
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	var enabled bool
-	switch config.GlobalConfig.Mode {
+	switch config.GlobalConfigDeprecated.Mode {
 	case config.ModeCompute:
 		// When configured in compute mode, enable the executor worker.
 		enabled = true

--- a/go/worker/keymanager/churp.go
+++ b/go/worker/keymanager/churp.go
@@ -82,7 +82,7 @@ func newChurpWorker(kmWorker *Worker) (*churpWorker, error) {
 	// Read the configuration to determine in which schemes the worker
 	// should participate.
 	churps := make(map[uint8]*churp.Status)
-	for _, cfg := range config.GlobalConfig.Keymanager.Churp.Schemes {
+	for _, cfg := range config.GlobalConfigDeprecated.Keymanager.Churp.Schemes {
 		churps[cfg.ID] = nil
 	}
 

--- a/go/worker/keymanager/init.go
+++ b/go/worker/keymanager/init.go
@@ -27,7 +27,7 @@ func New(
 	provisioner host.Provisioner,
 ) (*Worker, error) {
 	var enabled bool
-	switch config.GlobalConfig.Mode {
+	switch config.GlobalConfigDeprecated.Mode {
 	case config.ModeKeyManager:
 		// When configured in keymanager mode, enable the keymanager worker.
 		enabled = true
@@ -58,7 +58,7 @@ func New(
 	initMetrics()
 
 	// Parse runtime ID.
-	if err := w.runtimeID.UnmarshalHex(config.GlobalConfig.Keymanager.RuntimeID); err != nil {
+	if err := w.runtimeID.UnmarshalHex(config.GlobalConfigDeprecated.Keymanager.RuntimeID); err != nil {
 		return nil, fmt.Errorf("worker/keymanager: failed to parse runtime ID: %w", err)
 	}
 	w.runtimeLabel = w.runtimeID.String()

--- a/go/worker/keymanager/secrets.go
+++ b/go/worker/keymanager/secrets.go
@@ -116,7 +116,7 @@ func newSecretsWorker(
 	}
 
 	privatePeers := make(map[core.PeerID]struct{})
-	for _, b64pk := range config.GlobalConfig.Keymanager.PrivatePeerPubKeys {
+	for _, b64pk := range config.GlobalConfigDeprecated.Keymanager.PrivatePeerPubKeys {
 		pkBytes, err := base64.StdEncoding.DecodeString(b64pk)
 		if err != nil {
 			return nil, fmt.Errorf("oasis/keymanager: `%s` is not a base64-encoded public key (%w)", b64pk, err)

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -1024,8 +1024,8 @@ func GetRegistrationSigner(identity *identity.Identity) (signature.PublicKey, si
 	}
 
 	// Determine the owning entity ID.
-	cfgEntityFn := config.GlobalConfig.Registration.Entity
-	cfgEntityID := config.GlobalConfig.Registration.EntityID
+	cfgEntityFn := config.GlobalConfigDeprecated.Registration.Entity
+	cfgEntityID := config.GlobalConfigDeprecated.Registration.EntityID
 
 	switch {
 	case cfgEntityFn != "":
@@ -1104,7 +1104,7 @@ func New(
 
 	w.storedDeregister = storedDeregister
 
-	if config.GlobalConfig.Consensus.Validator || config.GlobalConfig.Mode == config.ModeValidator {
+	if config.GlobalConfigDeprecated.Consensus.Validator || config.GlobalConfigDeprecated.Mode == config.ModeValidator {
 		rp, err := w.NewRoleProvider(node.RoleValidator)
 		if err != nil {
 			return nil, err

--- a/go/worker/sentry/worker.go
+++ b/go/worker/sentry/worker.go
@@ -14,7 +14,7 @@ import (
 
 // Enabled returns true if Sentry worker is enabled.
 func Enabled() bool {
-	return config.GlobalConfig.Sentry.Enabled
+	return config.GlobalConfigDeprecated.Sentry.Enabled
 }
 
 // Worker is a sentry node worker providing its address(es) to other nodes and
@@ -103,7 +103,7 @@ func New(sentry api.Backend, identity *identity.Identity) (*Worker, error) {
 
 	if w.enabled {
 		peerPubkeyAuth := auth.NewPeerPubkeyAuthenticator()
-		for _, pubkey := range config.GlobalConfig.Sentry.Control.AuthorizedPubkeys {
+		for _, pubkey := range config.GlobalConfigDeprecated.Sentry.Control.AuthorizedPubkeys {
 			var pk signature.PublicKey
 			if err := pk.UnmarshalText([]byte(pubkey)); err != nil {
 				return nil, fmt.Errorf("worker/sentry: failed unmarshalling upstream public key: %s: %w", pubkey, err)
@@ -112,7 +112,7 @@ func New(sentry api.Backend, identity *identity.Identity) (*Worker, error) {
 		}
 		grpcServer, err := grpc.NewServer(&grpc.ServerConfig{
 			Name:     "sentry",
-			Port:     config.GlobalConfig.Sentry.Control.Port,
+			Port:     config.GlobalConfigDeprecated.Sentry.Control.Port,
 			Identity: identity,
 			AuthFunc: peerPubkeyAuth.AuthFunc,
 		})

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -170,7 +170,7 @@ func NewNode(
 
 	// Create the fetcher pool.
 	fetchPool := workerpool.New("storage_fetch/" + commonNode.Runtime.ID().String())
-	fetchPool.Resize(config.GlobalConfig.Storage.FetcherCount)
+	fetchPool.Resize(config.GlobalConfigDeprecated.Storage.FetcherCount)
 
 	n := &Node{
 		commonNode: commonNode,
@@ -211,8 +211,8 @@ func NewNode(
 	// Create a new checkpointer. Always create a checkpointer, even if checkpointing is disabled
 	// in configuration so we can ensure that the genesis checkpoint is available.
 	checkInterval := checkpoint.CheckIntervalDisabled
-	if config.GlobalConfig.Storage.Checkpointer.Enabled {
-		checkInterval = config.GlobalConfig.Storage.Checkpointer.CheckInterval
+	if config.GlobalConfigDeprecated.Storage.Checkpointer.Enabled {
+		checkInterval = config.GlobalConfigDeprecated.Storage.Checkpointer.CheckInterval
 	}
 	checkpointerCfg := checkpoint.CheckpointerConfig{
 		Name:            "runtime",
@@ -234,7 +234,7 @@ func NewNode(
 			}
 
 			var threads uint16
-			if config.GlobalConfig.Storage.Checkpointer.ParallelChunker {
+			if config.GlobalConfigDeprecated.Storage.Checkpointer.ParallelChunker {
 				threads = chunkerThreads
 			}
 
@@ -294,7 +294,7 @@ func (n *Node) Name() string {
 // Start causes the worker to start responding to CometBFT new block events.
 func (n *Node) Start() error {
 	go n.worker()
-	if config.GlobalConfig.Storage.Checkpointer.Enabled {
+	if config.GlobalConfigDeprecated.Storage.Checkpointer.Enabled {
 		go n.consensusCheckpointSyncer()
 	}
 	return nil
@@ -1309,7 +1309,7 @@ mainLoop:
 			n.nudgeAvailability(cachedLastRound, latestBlockRound)
 
 			// Notify the checkpointer that there is a new finalized round.
-			if config.GlobalConfig.Storage.Checkpointer.Enabled {
+			if config.GlobalConfigDeprecated.Storage.Checkpointer.Enabled {
 				n.checkpointer.NotifyNewVersion(finalized.summary.Round)
 			}
 

--- a/go/worker/storage/init.go
+++ b/go/worker/storage/init.go
@@ -32,10 +32,10 @@ func NewLocalBackend(
 	namespace common.Namespace,
 ) (api.LocalBackend, error) {
 	cfg := &api.Config{
-		Backend:      strings.ToLower(config.GlobalConfig.Storage.Backend),
+		Backend:      strings.ToLower(config.GlobalConfigDeprecated.Storage.Backend),
 		DB:           dataDir,
 		Namespace:    namespace,
-		MaxCacheSize: int64(config.ParseSizeInBytes(config.GlobalConfig.Storage.MaxCacheSize)),
+		MaxCacheSize: int64(config.ParseSizeInBytes(config.GlobalConfigDeprecated.Storage.MaxCacheSize)),
 		NoFsync:      true, // Should be safe, storage will be re-applied on crashes.
 	}
 

--- a/go/worker/storage/worker.go
+++ b/go/worker/storage/worker.go
@@ -35,7 +35,7 @@ func New(
 	commonWorker *workerCommon.Worker,
 	registration *registration.Worker,
 ) (*Worker, error) {
-	enabled := config.GlobalConfig.Mode.HasLocalStorage() && len(commonWorker.GetRuntimes()) > 0
+	enabled := config.GlobalConfigDeprecated.Mode.HasLocalStorage() && len(commonWorker.GetRuntimes()) > 0
 
 	s := &Worker{
 		enabled:      enabled,
@@ -78,7 +78,7 @@ func (w *Worker) registerRuntime(commonNode *committeeCommon.Node) error {
 		return fmt.Errorf("failed to create role provider: %w", err)
 	}
 	var rpRPC registration.RoleProvider
-	if config.GlobalConfig.Storage.PublicRPCEnabled {
+	if config.GlobalConfigDeprecated.Storage.PublicRPCEnabled {
 		rpRPC, err = w.registration.NewRuntimeRoleProvider(node.RoleStorageRPC, id)
 		if err != nil {
 			return fmt.Errorf("failed to create rpc role provider: %w", err)
@@ -97,8 +97,8 @@ func (w *Worker) registerRuntime(commonNode *committeeCommon.Node) error {
 		w.commonWorker.GetConfig(),
 		localStorage,
 		&committee.CheckpointSyncConfig{
-			Disabled:          config.GlobalConfig.Storage.CheckpointSyncDisabled,
-			ChunkFetcherCount: config.GlobalConfig.Storage.FetcherCount,
+			Disabled:          config.GlobalConfigDeprecated.Storage.CheckpointSyncDisabled,
+			ChunkFetcherCount: config.GlobalConfigDeprecated.Storage.FetcherCount,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Closes #6271 

TODO: Factor out global config from `metrics` (not trivial) as currently we have cycle: config imports p2p, p2p imports metrics, metrics import config.