### PR TITLE
Split storage sync P2P protocol (manual fallback)

### DIFF
--- a/.changelog/5751.feature.md
+++ b/.changelog/5751.feature.md
@@ -1,0 +1,12 @@
+go: Split storage sync p2p protocol
+
+Storage sync protocol was split into two independent protocols (checkpoint
+and diff sync).
+
+This change was made since there may be fewer nodes that expose checkpoints
+than storage diff. Previously, this could lead to issues with state sync
+when a node was connected with peers that supported storage sync protocol
+but had no checkpoints available.
+
+This was done in backwards compatible manner, so that both protocols are still
+advertised and used. Eventually, we plan to remove legacy protocol.

--- a/go/oasis-node/cmd/debug/byzantine/node.go
+++ b/go/oasis-node/cmd/debug/byzantine/node.go
@@ -22,7 +22,7 @@ import (
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 	storage "github.com/oasisprotocol/oasis-core/go/storage/api"
 	"github.com/oasisprotocol/oasis-core/go/worker/client"
-	storageP2P "github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/sync"
+	"github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/synclegacy"
 )
 
 type byzantine struct {
@@ -154,7 +154,7 @@ func initializeAndRegisterByzantineNode(
 	if err != nil {
 		return nil, fmt.Errorf("initializing storage node failed: %w", err)
 	}
-	b.p2p.service.RegisterProtocolServer(storageP2P.NewServer(b.chainContext, b.runtimeID, storage))
+	b.p2p.service.RegisterProtocolServer(synclegacy.NewServer(b.chainContext, b.runtimeID, storage))
 	b.storage = storage
 
 	// Wait for activation epoch.

--- a/go/p2p/rpc/client.go
+++ b/go/p2p/rpc/client.go
@@ -364,6 +364,10 @@ func (c *client) CallMulti(
 ) ([]any, []PeerFeedback, error) {
 	c.logger.Debug("call multiple", "method", method)
 
+	if len(peers) == 0 {
+		return nil, nil, fmt.Errorf("no peers given to service the request")
+	}
+
 	co := NewCallMultiOptions(opts...)
 
 	// Prepare the request.

--- a/go/worker/common/p2p/txsync/client.go
+++ b/go/worker/common/p2p/txsync/client.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
-	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 )
 
@@ -82,7 +81,7 @@ func (c *client) GetTxs(ctx context.Context, request *GetTxsRequest) (*GetTxsRes
 
 // NewClient creates a new transaction sync protocol client.
 func NewClient(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) Client {
-	pid := protocol.NewRuntimeProtocolID(chainContext, runtimeID, TxSyncProtocolID, TxSyncProtocolVersion)
+	pid := ProtocolID(chainContext, runtimeID)
 	mgr := rpc.NewPeerManager(p2p, pid)
 	rc := rpc.NewClient(p2p.Host(), pid)
 	rc.RegisterListener(mgr)

--- a/go/worker/common/p2p/txsync/protocol.go
+++ b/go/worker/common/p2p/txsync/protocol.go
@@ -47,7 +47,7 @@ func init() {
 
 			protocols := make([]core.ProtocolID, len(n.Runtimes))
 			for i, rt := range n.Runtimes {
-				protocols[i] = protocol.NewRuntimeProtocolID(chainContext, rt.ID, TxSyncProtocolID, TxSyncProtocolVersion)
+				protocols[i] = ProtocolID(chainContext, rt.ID)
 			}
 
 			return protocols

--- a/go/worker/keymanager/p2p/client.go
+++ b/go/worker/keymanager/p2p/client.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	p2p "github.com/oasisprotocol/oasis-core/go/p2p/api"
-	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 )
 
@@ -46,7 +45,7 @@ func (c *client) CallEnclave(ctx context.Context, request *CallEnclaveRequest, p
 
 // NewClient creates a new keymanager protocol client.
 func NewClient(p2p p2p.Service, chainContext string, keymanagerID common.Namespace) Client {
-	pid := protocol.NewRuntimeProtocolID(chainContext, keymanagerID, KeyManagerProtocolID, KeyManagerProtocolVersion)
+	pid := ProtocolID(chainContext, keymanagerID)
 	mgr := rpc.NewPeerManager(p2p, pid)
 	rc := rpc.NewClient(p2p.Host(), pid)
 	rc.RegisterListener(mgr)

--- a/go/worker/keymanager/p2p/protocol.go
+++ b/go/worker/keymanager/p2p/protocol.go
@@ -50,7 +50,7 @@ func init() {
 
 			protocols := make([]core.ProtocolID, len(n.Runtimes))
 			for i, rt := range n.Runtimes {
-				protocols[i] = protocol.NewRuntimeProtocolID(chainContext, rt.ID, KeyManagerProtocolID, KeyManagerProtocolVersion)
+				protocols[i] = ProtocolID(chainContext, rt.ID)
 			}
 
 			return protocols

--- a/go/worker/storage/committee/checkpoint_sync_test.go
+++ b/go/worker/storage/committee/checkpoint_sync_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/node"
-	"github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/sync"
+	"github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/checkpointsync"
 )
 
 func TestSortCheckpoints(t *testing.T) {
-	cp1 := &sync.Checkpoint{
+	cp1 := &checkpointsync.Checkpoint{
 		Metadata: &checkpoint.Metadata{
 			Root: node.Root{
 				Version: 2,
@@ -20,7 +20,7 @@ func TestSortCheckpoints(t *testing.T) {
 		},
 		Peers: []rpc.PeerFeedback{rpc.NewNopPeerFeedback(), rpc.NewNopPeerFeedback()},
 	}
-	cp2 := &sync.Checkpoint{
+	cp2 := &checkpointsync.Checkpoint{
 		Metadata: &checkpoint.Metadata{
 			Root: node.Root{
 				Version: 2,
@@ -28,7 +28,7 @@ func TestSortCheckpoints(t *testing.T) {
 		},
 		Peers: []rpc.PeerFeedback{rpc.NewNopPeerFeedback()},
 	}
-	cp3 := &sync.Checkpoint{
+	cp3 := &checkpointsync.Checkpoint{
 		Metadata: &checkpoint.Metadata{
 			Root: node.Root{
 				Version: 1,
@@ -36,7 +36,7 @@ func TestSortCheckpoints(t *testing.T) {
 		},
 		Peers: []rpc.PeerFeedback{rpc.NewNopPeerFeedback(), rpc.NewNopPeerFeedback()},
 	}
-	cp4 := &sync.Checkpoint{
+	cp4 := &checkpointsync.Checkpoint{
 		Metadata: &checkpoint.Metadata{
 			Root: node.Root{
 				Version: 1,
@@ -45,9 +45,9 @@ func TestSortCheckpoints(t *testing.T) {
 		Peers: []rpc.PeerFeedback{rpc.NewNopPeerFeedback()},
 	}
 
-	s := []*sync.Checkpoint{cp2, cp3, cp4, cp1}
+	s := []*checkpointsync.Checkpoint{cp2, cp3, cp4, cp1}
 
 	sortCheckpoints(s)
 
-	assert.Equal(t, s, []*sync.Checkpoint{cp1, cp2, cp3, cp4})
+	assert.Equal(t, s, []*checkpointsync.Checkpoint{cp1, cp2, cp3, cp4})
 }

--- a/go/worker/storage/p2p/checkpointsync/client.go
+++ b/go/worker/storage/p2p/checkpointsync/client.go
@@ -1,0 +1,125 @@
+package checkpointsync
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p/core"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
+	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
+)
+
+const (
+	// minProtocolPeers is the minimum number of peers from the registry we want to have connected
+	// for checkpoint sync protocol.
+	minProtocolPeers = 5
+
+	// totalProtocolPeers is the number of peers we want to have connected for checkpoint sync protocol.
+	totalProtocolPeers = 10
+)
+
+// Client is a checkpoint sync protocol client.
+type Client interface {
+	// GetCheckpoints returns a list of checkpoint metadata for all known checkpoints.
+	GetCheckpoints(ctx context.Context, request *GetCheckpointsRequest) ([]*Checkpoint, error)
+
+	// GetCheckpointChunk requests a specific checkpoint chunk.
+	GetCheckpointChunk(
+		ctx context.Context,
+		request *GetCheckpointChunkRequest,
+		cp *Checkpoint,
+	) (*GetCheckpointChunkResponse, rpc.PeerFeedback, error)
+}
+
+// Checkpoint contains checkpoint metadata together with peer information.
+type Checkpoint struct {
+	*checkpoint.Metadata
+
+	// Peers are the feedback structures of all the peers that have advertised this checkpoint.
+	Peers []rpc.PeerFeedback
+}
+
+type client struct {
+	rc  rpc.Client
+	mgr rpc.PeerManager
+}
+
+func (c *client) GetCheckpoints(ctx context.Context, request *GetCheckpointsRequest) ([]*Checkpoint, error) {
+	var rsp GetCheckpointsResponse
+	rsps, pfs, err := c.rc.CallMulti(ctx, c.mgr.GetBestPeers(), MethodGetCheckpoints, request, rsp)
+	if err != nil {
+		return nil, err
+	}
+
+	// Combine deduplicated results into a single result.
+	var checkpoints []*Checkpoint
+	cps := make(map[hash.Hash]*Checkpoint)
+	for i, peerRsp := range rsps {
+		peerCps := peerRsp.(*GetCheckpointsResponse).Checkpoints
+
+		for _, cpMeta := range peerCps {
+			h := cpMeta.EncodedHash()
+			cp := cps[h]
+			if cp == nil {
+				cp = &Checkpoint{
+					Metadata: cpMeta,
+				}
+				cps[h] = cp
+				checkpoints = append(checkpoints, cp)
+			}
+			cp.Peers = append(cp.Peers, pfs[i])
+		}
+
+		// Record success for a peer if it returned at least one checkpoint.
+		if len(peerCps) > 0 {
+			pfs[i].RecordSuccess()
+		}
+	}
+	return checkpoints, nil
+}
+
+func (c *client) GetCheckpointChunk(
+	ctx context.Context,
+	request *GetCheckpointChunkRequest,
+	cp *Checkpoint,
+) (*GetCheckpointChunkResponse, rpc.PeerFeedback, error) {
+	var opts []rpc.BestPeersOption
+	// When a checkpoint is passed, we limit requests to only those peers that actually advertised
+	// having the checkpoint in question to avoid needless requests.
+	if cp != nil {
+		peers := make([]core.PeerID, 0, len(cp.Peers))
+		for _, pf := range cp.Peers {
+			peers = append(peers, pf.PeerID())
+		}
+		opts = append(opts, rpc.WithLimitPeers(peers))
+	}
+
+	var rsp GetCheckpointChunkResponse
+	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(opts...), MethodGetCheckpointChunk, request, &rsp,
+		rpc.WithMaxPeerResponseTime(MaxGetCheckpointChunkResponseTime),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &rsp, pf, nil
+}
+
+// NewClient creates a new checkpoint sync protocol client.
+//
+// Moreover, it ensures underlying p2p service starts tracking protocol peers.
+func NewClient(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) Client {
+	pid := protocol.NewRuntimeProtocolID(chainContext, runtimeID, CheckpointSyncProtocolID, CheckpointSyncProtocolVersion)
+	rc := rpc.NewClient(p2p.Host(), pid)
+	mgr := rpc.NewPeerManager(p2p, pid)
+	rc.RegisterListener(mgr)
+
+	p2p.RegisterProtocol(pid, minProtocolPeers, totalProtocolPeers)
+
+	return &client{
+		rc:  rc,
+		mgr: mgr,
+	}
+}

--- a/go/worker/storage/p2p/checkpointsync/client.go
+++ b/go/worker/storage/p2p/checkpointsync/client.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
-	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
 )
@@ -111,7 +110,7 @@ func (c *client) GetCheckpointChunk(
 //
 // Moreover, it ensures underlying p2p service starts tracking protocol peers.
 func NewClient(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) Client {
-	pid := protocol.NewRuntimeProtocolID(chainContext, runtimeID, CheckpointSyncProtocolID, CheckpointSyncProtocolVersion)
+	pid := ProtocolID(chainContext, runtimeID)
 	rc := rpc.NewClient(p2p.Host(), pid)
 	mgr := rpc.NewPeerManager(p2p, pid)
 	rc.RegisterListener(mgr)

--- a/go/worker/storage/p2p/checkpointsync/protocol.go
+++ b/go/worker/storage/p2p/checkpointsync/protocol.go
@@ -1,0 +1,80 @@
+// Package checkpointsync defines wire protocol together with client/server
+// implementations for the checkpoint sync protocol, used for runtime state sync.
+package checkpointsync
+
+import (
+	"time"
+
+	"github.com/libp2p/go-libp2p/core"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
+	"github.com/oasisprotocol/oasis-core/go/p2p/peermgmt"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
+	"github.com/oasisprotocol/oasis-core/go/storage/api"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
+)
+
+// CheckpointSyncProtocolID is a unique protocol identifier for the checkpoint sync protocol.
+const CheckpointSyncProtocolID = "checkpointsync"
+
+// CheckpointSyncProtocolVersion is the supported version of the checkpoint sync protocol.
+var CheckpointSyncProtocolVersion = version.Version{Major: 1, Minor: 0, Patch: 0}
+
+// ProtocolID returns the runtime checkpoint sync protocol ID.
+func ProtocolID(chainContext string, runtimeID common.Namespace) core.ProtocolID {
+	return protocol.NewRuntimeProtocolID(chainContext, runtimeID, CheckpointSyncProtocolID, CheckpointSyncProtocolVersion)
+}
+
+// Constants related to the GetCheckpoints method.
+const (
+	MethodGetCheckpoints = "GetCheckpoints"
+)
+
+// GetCheckpointsRequest is a GetCheckpoints request.
+type GetCheckpointsRequest struct {
+	Version uint16 `json:"version"`
+}
+
+// GetCheckpointsResponse is a response to a GetCheckpoints request.
+type GetCheckpointsResponse struct {
+	Checkpoints []*checkpoint.Metadata `json:"checkpoints,omitempty"`
+}
+
+// Constants related to the GetCheckpointChunk method.
+const (
+	MethodGetCheckpointChunk          = "GetCheckpointChunk"
+	MaxGetCheckpointChunkResponseTime = time.Minute
+)
+
+// GetCheckpointChunkRequest is a GetCheckpointChunk request.
+type GetCheckpointChunkRequest struct {
+	Version uint16    `json:"version"`
+	Root    api.Root  `json:"root"`
+	Index   uint64    `json:"index"`
+	Digest  hash.Hash `json:"digest"`
+}
+
+// GetCheckpointChunkResponse is a response to a GetCheckpointChunk request.
+type GetCheckpointChunkResponse struct {
+	Chunk []byte `json:"chunk,omitempty"`
+}
+
+func init() {
+	peermgmt.RegisterNodeHandler(&peermgmt.NodeHandlerBundle{
+		ProtocolsFn: func(n *node.Node, chainContext string) []core.ProtocolID {
+			if !n.HasRoles(node.RoleComputeWorker | node.RoleStorageRPC) {
+				return []core.ProtocolID{}
+			}
+
+			protocols := make([]core.ProtocolID, len(n.Runtimes))
+			for i, rt := range n.Runtimes {
+				protocols[i] = protocol.NewRuntimeProtocolID(chainContext, rt.ID, CheckpointSyncProtocolID, CheckpointSyncProtocolVersion)
+			}
+
+			return protocols
+		},
+	})
+}

--- a/go/worker/storage/p2p/checkpointsync/protocol.go
+++ b/go/worker/storage/p2p/checkpointsync/protocol.go
@@ -71,7 +71,7 @@ func init() {
 
 			protocols := make([]core.ProtocolID, len(n.Runtimes))
 			for i, rt := range n.Runtimes {
-				protocols[i] = protocol.NewRuntimeProtocolID(chainContext, rt.ID, CheckpointSyncProtocolID, CheckpointSyncProtocolVersion)
+				protocols[i] = ProtocolID(chainContext, rt.ID)
 			}
 
 			return protocols

--- a/go/worker/storage/p2p/checkpointsync/server.go
+++ b/go/worker/storage/p2p/checkpointsync/server.go
@@ -1,0 +1,73 @@
+package checkpointsync
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+	"github.com/oasisprotocol/oasis-core/go/storage/api"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
+)
+
+type service struct {
+	backend api.Backend
+}
+
+func (s *service) HandleRequest(ctx context.Context, method string, body cbor.RawMessage) (any, error) {
+	switch method {
+	case MethodGetCheckpoints:
+		var rq GetCheckpointsRequest
+		if err := cbor.Unmarshal(body, &rq); err != nil {
+			return nil, rpc.ErrBadRequest
+		}
+
+		return s.handleGetCheckpoints(ctx, &rq)
+	case MethodGetCheckpointChunk:
+		var rq GetCheckpointChunkRequest
+		if err := cbor.Unmarshal(body, &rq); err != nil {
+			return nil, rpc.ErrBadRequest
+		}
+
+		return s.handleGetCheckpointChunk(ctx, &rq)
+	default:
+		return nil, rpc.ErrMethodNotSupported
+	}
+}
+
+func (s *service) handleGetCheckpoints(ctx context.Context, request *GetCheckpointsRequest) (*GetCheckpointsResponse, error) {
+	cps, err := s.backend.GetCheckpoints(ctx, &checkpoint.GetCheckpointsRequest{
+		Version: request.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetCheckpointsResponse{
+		Checkpoints: cps,
+	}, nil
+}
+
+func (s *service) handleGetCheckpointChunk(ctx context.Context, request *GetCheckpointChunkRequest) (*GetCheckpointChunkResponse, error) {
+	// Consider using stream resource manager to track buffer use.
+	var buf bytes.Buffer
+	err := s.backend.GetCheckpointChunk(ctx, &checkpoint.ChunkMetadata{
+		Version: request.Version,
+		Root:    request.Root,
+		Index:   request.Index,
+		Digest:  request.Digest,
+	}, &buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetCheckpointChunkResponse{
+		Chunk: buf.Bytes(),
+	}, nil
+}
+
+// NewServer creates a new checkpoint sync protocol server.
+func NewServer(chainContext string, runtimeID common.Namespace, backend api.Backend) rpc.Server {
+	return rpc.NewServer(ProtocolID(chainContext, runtimeID), &service{backend})
+}

--- a/go/worker/storage/p2p/diffsync/client.go
+++ b/go/worker/storage/p2p/diffsync/client.go
@@ -1,0 +1,58 @@
+package diffsync
+
+import (
+	"context"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
+	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+)
+
+const (
+	// minProtocolPeers is the minimum number of peers from the registry we want to have connected
+	// for diff sync protocol.
+	minProtocolPeers = 5
+
+	// totalProtocolPeers is the number of peers we want to have connected for diff sync protocol.
+	totalProtocolPeers = 10
+)
+
+// Client is a diff sync protocol client.
+type Client interface {
+	// GetDiff requests a write log of entries that must be applied to get from the first given root
+	// to the second one.
+	GetDiff(ctx context.Context, request *GetDiffRequest) (*GetDiffResponse, rpc.PeerFeedback, error)
+}
+
+type client struct {
+	rc  rpc.Client
+	mgr rpc.PeerManager
+}
+
+func (c *client) GetDiff(ctx context.Context, request *GetDiffRequest) (*GetDiffResponse, rpc.PeerFeedback, error) {
+	var rsp GetDiffResponse
+	pf, err := c.rc.CallOne(ctx, c.mgr.GetBestPeers(), MethodGetDiff, request, &rsp,
+		rpc.WithMaxPeerResponseTime(MaxGetDiffResponseTime),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &rsp, pf, nil
+}
+
+// NewClient creates a new diff sync protocol client.
+//
+// Moreover, it ensures underlying p2p service starts tracking protocol peers.
+func NewClient(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) Client {
+	pid := protocol.NewRuntimeProtocolID(chainContext, runtimeID, DiffSyncProtocolID, DiffSyncProtocolVersion)
+	rc := rpc.NewClient(p2p.Host(), pid)
+	mgr := rpc.NewPeerManager(p2p, pid)
+	rc.RegisterListener(mgr)
+
+	p2p.RegisterProtocol(pid, minProtocolPeers, totalProtocolPeers)
+
+	return &client{
+		rc:  rc,
+		mgr: mgr,
+	}
+}

--- a/go/worker/storage/p2p/diffsync/client.go
+++ b/go/worker/storage/p2p/diffsync/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
-	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 )
 
@@ -44,7 +43,7 @@ func (c *client) GetDiff(ctx context.Context, request *GetDiffRequest) (*GetDiff
 //
 // Moreover, it ensures underlying p2p service starts tracking protocol peers.
 func NewClient(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) Client {
-	pid := protocol.NewRuntimeProtocolID(chainContext, runtimeID, DiffSyncProtocolID, DiffSyncProtocolVersion)
+	pid := ProtocolID(chainContext, runtimeID)
 	rc := rpc.NewClient(p2p.Host(), pid)
 	mgr := rpc.NewPeerManager(p2p, pid)
 	rc.RegisterListener(mgr)

--- a/go/worker/storage/p2p/diffsync/protocol.go
+++ b/go/worker/storage/p2p/diffsync/protocol.go
@@ -52,7 +52,7 @@ func init() {
 
 			protocols := make([]core.ProtocolID, len(n.Runtimes))
 			for i, rt := range n.Runtimes {
-				protocols[i] = protocol.NewRuntimeProtocolID(chainContext, rt.ID, DiffSyncProtocolID, DiffSyncProtocolVersion)
+				protocols[i] = ProtocolID(chainContext, rt.ID)
 			}
 
 			return protocols

--- a/go/worker/storage/p2p/diffsync/protocol.go
+++ b/go/worker/storage/p2p/diffsync/protocol.go
@@ -1,0 +1,61 @@
+// Package diffsync defines wire protocol together with client/server
+// implementations for the diff sync protocol, used for runtime block sync.
+package diffsync
+
+import (
+	"time"
+
+	"github.com/libp2p/go-libp2p/core"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
+	"github.com/oasisprotocol/oasis-core/go/p2p/peermgmt"
+	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
+	"github.com/oasisprotocol/oasis-core/go/storage/api"
+)
+
+// DiffSyncProtocolID is a unique protocol identifier for the diff sync protocol.
+const DiffSyncProtocolID = "diffsync"
+
+// DiffSyncProtocolVersion is the supported version of the diff sync protocol.
+var DiffSyncProtocolVersion = version.Version{Major: 1, Minor: 0, Patch: 0}
+
+// ProtocolID returns the runtime diff sync protocol ID.
+func ProtocolID(chainContext string, runtimeID common.Namespace) core.ProtocolID {
+	return protocol.NewRuntimeProtocolID(chainContext, runtimeID, DiffSyncProtocolID, DiffSyncProtocolVersion)
+}
+
+// Constants related to the GetDiff method.
+const (
+	MethodGetDiff          = "GetDiff"
+	MaxGetDiffResponseTime = 15 * time.Second
+)
+
+// GetDiffRequest is a GetDiff request.
+type GetDiffRequest struct {
+	StartRoot api.Root `json:"start_root"`
+	EndRoot   api.Root `json:"end_root"`
+}
+
+// GetDiffResponse is a response to a GetDiff request.
+type GetDiffResponse struct {
+	WriteLog api.WriteLog `json:"write_log,omitempty"`
+}
+
+func init() {
+	peermgmt.RegisterNodeHandler(&peermgmt.NodeHandlerBundle{
+		ProtocolsFn: func(n *node.Node, chainContext string) []core.ProtocolID {
+			if !n.HasRoles(node.RoleComputeWorker | node.RoleStorageRPC) {
+				return []core.ProtocolID{}
+			}
+
+			protocols := make([]core.ProtocolID, len(n.Runtimes))
+			for i, rt := range n.Runtimes {
+				protocols[i] = protocol.NewRuntimeProtocolID(chainContext, rt.ID, DiffSyncProtocolID, DiffSyncProtocolVersion)
+			}
+
+			return protocols
+		},
+	})
+}

--- a/go/worker/storage/p2p/diffsync/server.go
+++ b/go/worker/storage/p2p/diffsync/server.go
@@ -1,0 +1,61 @@
+package diffsync
+
+import (
+	"context"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+	"github.com/oasisprotocol/oasis-core/go/storage/api"
+)
+
+type service struct {
+	backend api.Backend
+}
+
+func (s *service) HandleRequest(ctx context.Context, method string, body cbor.RawMessage) (any, error) {
+	switch method {
+	case MethodGetDiff:
+		var rq GetDiffRequest
+		if err := cbor.Unmarshal(body, &rq); err != nil {
+			return nil, rpc.ErrBadRequest
+		}
+
+		return s.handleGetDiff(ctx, &rq)
+	default:
+		return nil, rpc.ErrMethodNotSupported
+	}
+}
+
+func (s *service) handleGetDiff(ctx context.Context, request *GetDiffRequest) (*GetDiffResponse, error) {
+	it, err := s.backend.GetDiff(ctx, &api.GetDiffRequest{
+		StartRoot: request.StartRoot,
+		EndRoot:   request.EndRoot,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var rsp GetDiffResponse
+	for {
+		more, err := it.Next()
+		if err != nil {
+			return nil, err
+		}
+		if !more {
+			break
+		}
+
+		chunk, err := it.Value()
+		if err != nil {
+			return nil, err
+		}
+		rsp.WriteLog = append(rsp.WriteLog, chunk)
+	}
+	return &rsp, nil
+}
+
+// NewServer creates a new diff sync protocol server.
+func NewServer(chainContext string, runtimeID common.Namespace, backend api.Backend) rpc.Server {
+	return rpc.NewServer(ProtocolID(chainContext, runtimeID), &service{backend})
+}

--- a/go/worker/storage/p2p/pub/client.go
+++ b/go/worker/storage/p2p/pub/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
-	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 )
 
@@ -64,7 +63,7 @@ func (c *client) Iterate(ctx context.Context, request *IterateRequest) (*ProofRe
 
 // NewClient creates a new storage pub protocol client.
 func NewClient(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) Client {
-	pid := protocol.NewRuntimeProtocolID(chainContext, runtimeID, StoragePubProtocolID, StoragePubProtocolVersion)
+	pid := ProtocolID(chainContext, runtimeID)
 	mgr := rpc.NewPeerManager(p2p, pid)
 	rc := rpc.NewClient(p2p.Host(), pid)
 	rc.RegisterListener(mgr)

--- a/go/worker/storage/p2p/pub/protocol.go
+++ b/go/worker/storage/p2p/pub/protocol.go
@@ -58,7 +58,7 @@ func init() {
 
 			protocols := make([]core.ProtocolID, len(n.Runtimes))
 			for i, rt := range n.Runtimes {
-				protocols[i] = protocol.NewRuntimeProtocolID(chainContext, rt.ID, StoragePubProtocolID, StoragePubProtocolVersion)
+				protocols[i] = ProtocolID(chainContext, rt.ID)
 			}
 
 			return protocols

--- a/go/worker/storage/p2p/synclegacy/client.go
+++ b/go/worker/storage/p2p/synclegacy/client.go
@@ -1,4 +1,4 @@
-package sync
+package synclegacy
 
 import (
 	"context"

--- a/go/worker/storage/p2p/synclegacy/client.go
+++ b/go/worker/storage/p2p/synclegacy/client.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
-	"github.com/oasisprotocol/oasis-core/go/p2p/protocol"
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
 )
@@ -129,7 +128,7 @@ func NewClient(p2p rpc.P2P, chainContext string, runtimeID common.Namespace) Cli
 	// Use two separate clients and managers for the same protocol. This is to make sure that peers
 	// are scored differently between the two use cases (syncing diffs vs. syncing checkpoints). We
 	// could consider separating this into two protocols in the future.
-	pid := protocol.NewRuntimeProtocolID(chainContext, runtimeID, StorageSyncProtocolID, StorageSyncProtocolVersion)
+	pid := ProtocolID(chainContext, runtimeID)
 
 	rcC := rpc.NewClient(p2p.Host(), pid)
 	mgrC := rpc.NewPeerManager(p2p, pid)

--- a/go/worker/storage/p2p/synclegacy/protocol.go
+++ b/go/worker/storage/p2p/synclegacy/protocol.go
@@ -92,7 +92,7 @@ func init() {
 
 			protocols := make([]core.ProtocolID, len(n.Runtimes))
 			for i, rt := range n.Runtimes {
-				protocols[i] = protocol.NewRuntimeProtocolID(chainContext, rt.ID, StorageSyncProtocolID, StorageSyncProtocolVersion)
+				protocols[i] = ProtocolID(chainContext, rt.ID)
 			}
 
 			return protocols

--- a/go/worker/storage/p2p/synclegacy/protocol.go
+++ b/go/worker/storage/p2p/synclegacy/protocol.go
@@ -1,4 +1,10 @@
-package sync
+// Package synclegacy defines wire protocol together with client/server
+// implementations for the legacy storage sync protocol, used for runtime block sync.
+//
+// The protocol was split into storage diff and checkpoints protocol.
+//
+// TODO: Remove it: https://github.com/oasisprotocol/oasis-core/issues/6261
+package synclegacy
 
 import (
 	"time"

--- a/go/worker/storage/p2p/synclegacy/server.go
+++ b/go/worker/storage/p2p/synclegacy/server.go
@@ -1,4 +1,4 @@
-package sync
+package synclegacy
 
 import (
 	"bytes"


### PR DESCRIPTION
As discussed in #6262 it might be simpler to manually handle fallback to the legacy protocol.

Closes #5751.

Regarding the style, I would prefer to keep it consistent with other p2p packages even if not optimal: https://github.com/oasisprotocol/oasis-core/pull/6262#discussion_r2220496029