### PR TITLE
go/worker/storage/config: Default to parallel chunking algorithm

### DIFF
--- a/.changelog/6219.internal.md
+++ b/.changelog/6219.internal.md
@@ -1,0 +1,1 @@
+go/worker/storage/config: Default to parallel checkpoint creation

--- a/go/worker/storage/config/config.go
+++ b/go/worker/storage/config/config.go
@@ -55,7 +55,7 @@ func DefaultConfig() Config {
 		Checkpointer: CheckpointerConfig{
 			Enabled:         false,
 			CheckInterval:   1 * time.Minute,
-			ParallelChunker: false,
+			ParallelChunker: true,
 		},
 	}
 }


### PR DESCRIPTION
Closes #6219 

I run new chunking algorithm for a few days in the cloud, increasing checkpoint creation frequence 10x, and did a state sync from this node a few times.

This was done by having local and remote node both use new `checkpointsync` p2p protocol. Since this were the only two peers on the new protocol they automatically discovered each other.