### PR TITLE
go: Remove tx hash from events

### DIFF
--- a/go/consensus/cometbft/api/api.go
+++ b/go/consensus/cometbft/api/api.go
@@ -361,7 +361,7 @@ type ServiceClient interface {
 	DeliverHeight(ctx context.Context, height int64) error
 
 	// DeliverEvent delivers an event emitted by the consensus service.
-	DeliverEvent(ctx context.Context, height int64, tx cmttypes.Tx, ev *types.Event) error
+	DeliverEvent(ctx context.Context, height int64, ev *types.Event) error
 }
 
 // BaseServiceClient is a default ServiceClient implementation that provides noop implementations of
@@ -374,7 +374,7 @@ func (bsc *BaseServiceClient) DeliverHeight(context.Context, int64) error {
 }
 
 // DeliverEvent implements ServiceClient.
-func (bsc *BaseServiceClient) DeliverEvent(context.Context, int64, cmttypes.Tx, *types.Event) error {
+func (bsc *BaseServiceClient) DeliverEvent(context.Context, int64, *types.Event) error {
 	return nil
 }
 

--- a/go/consensus/cometbft/beacon/beacon.go
+++ b/go/consensus/cometbft/beacon/beacon.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
-	cmttypes "github.com/cometbft/cometbft/types"
 	"github.com/eapache/channels"
 
 	"github.com/oasisprotocol/oasis-core/go/beacon/api"
@@ -288,7 +287,7 @@ func (sc *ServiceClient) DeliverHeight(ctx context.Context, height int64) error 
 	return nil
 }
 
-func (sc *ServiceClient) DeliverEvent(_ context.Context, height int64, _ cmttypes.Tx, ev *cmtabcitypes.Event) error {
+func (sc *ServiceClient) DeliverEvent(_ context.Context, height int64, ev *cmtabcitypes.Event) error {
 	for _, pair := range ev.GetAttributes() {
 		key := pair.GetKey()
 		val := pair.GetValue()

--- a/go/consensus/cometbft/full/common.go
+++ b/go/consensus/cometbft/full/common.go
@@ -699,7 +699,7 @@ func (n *commonNode) GetTransactionsWithResults(ctx context.Context, height int6
 		return nil, err
 	}
 
-	txResults, err := TransactionResultsFromCometBFT(height, txs, blockResults.TxsResults)
+	txResults, err := TransactionResultsFromCometBFT(height, blockResults.TxsResults)
 	if err != nil {
 		return nil, err
 	}
@@ -914,10 +914,10 @@ func newCommonNode(ctx context.Context, cfg CommonConfig) *commonNode {
 
 // TransactionResultsFromCometBFT converts CometBFT transactions and responses
 // into transaction results.
-func TransactionResultsFromCometBFT(height int64, txs [][]byte, responses []*cmtabcitypes.ResponseDeliverTx) ([]*results.Result, error) {
-	txResults := make([]*results.Result, 0, len(txs))
+func TransactionResultsFromCometBFT(height int64, responses []*cmtabcitypes.ResponseDeliverTx) ([]*results.Result, error) {
+	txResults := make([]*results.Result, 0, len(responses))
 
-	for idx, rs := range responses {
+	for _, rs := range responses {
 		// Transaction result.
 		result := &results.Result{
 			Error: results.Error{
@@ -929,7 +929,7 @@ func TransactionResultsFromCometBFT(height int64, txs [][]byte, responses []*cmt
 		}
 
 		// Transaction staking events.
-		stakingEvents, err := tmstaking.EventsFromCometBFT(txs[idx], height, rs.Events)
+		stakingEvents, err := tmstaking.EventsFromCometBFT(height, rs.Events)
 		if err != nil {
 			return nil, err
 		}
@@ -938,7 +938,7 @@ func TransactionResultsFromCometBFT(height int64, txs [][]byte, responses []*cmt
 		}
 
 		// Transaction registry events.
-		registryEvents, _, err := tmregistry.EventsFromCometBFT(txs[idx], height, rs.Events)
+		registryEvents, _, err := tmregistry.EventsFromCometBFT(height, rs.Events)
 		if err != nil {
 			return nil, err
 		}
@@ -947,7 +947,7 @@ func TransactionResultsFromCometBFT(height int64, txs [][]byte, responses []*cmt
 		}
 
 		// Transaction roothash events.
-		roothashEvents, err := tmroothash.EventsFromCometBFT(txs[idx], height, rs.Events)
+		roothashEvents, err := tmroothash.EventsFromCometBFT(height, rs.Events)
 		if err != nil {
 			return nil, err
 		}
@@ -956,7 +956,7 @@ func TransactionResultsFromCometBFT(height int64, txs [][]byte, responses []*cmt
 		}
 
 		// Transaction governance events.
-		governanceEvents, err := tmgovernance.EventsFromCometBFT(txs[idx], height, rs.Events)
+		governanceEvents, err := tmgovernance.EventsFromCometBFT(height, rs.Events)
 		if err != nil {
 			return nil, err
 		}

--- a/go/consensus/cometbft/governance/events.go
+++ b/go/consensus/cometbft/governance/events.go
@@ -5,28 +5,14 @@ import (
 	"fmt"
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
-	cmttypes "github.com/cometbft/cometbft/types"
 
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	eventsAPI "github.com/oasisprotocol/oasis-core/go/consensus/api/events"
 	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/governance"
 	"github.com/oasisprotocol/oasis-core/go/governance/api"
 )
 
 // EventsFromCometBFT extracts governance events from CometBFT events.
-func EventsFromCometBFT(
-	tx cmttypes.Tx,
-	height int64,
-	tmEvents []cmtabcitypes.Event,
-) ([]*api.Event, error) {
-	var txHash hash.Hash
-	switch tx {
-	case nil:
-		txHash.Empty()
-	default:
-		txHash = hash.NewFromBytes(tx)
-	}
-
+func EventsFromCometBFT(height int64, tmEvents []cmtabcitypes.Event) ([]*api.Event, error) {
 	var events []*api.Event
 	var errs error
 	for _, tmEv := range tmEvents {
@@ -48,7 +34,7 @@ func EventsFromCometBFT(
 					continue
 				}
 
-				evt := &api.Event{Height: height, TxHash: txHash, ProposalSubmitted: &e}
+				evt := &api.Event{Height: height, ProposalSubmitted: &e}
 				events = append(events, evt)
 			case eventsAPI.IsAttributeKind(key, &api.ProposalExecutedEvent{}):
 				//  Proposal executed event.
@@ -58,7 +44,7 @@ func EventsFromCometBFT(
 					continue
 				}
 
-				evt := &api.Event{Height: height, TxHash: txHash, ProposalExecuted: &e}
+				evt := &api.Event{Height: height, ProposalExecuted: &e}
 				events = append(events, evt)
 			case eventsAPI.IsAttributeKind(key, &api.ProposalFinalizedEvent{}):
 				// Proposal finalized event.
@@ -68,7 +54,7 @@ func EventsFromCometBFT(
 					continue
 				}
 
-				evt := &api.Event{Height: height, TxHash: txHash, ProposalFinalized: &e}
+				evt := &api.Event{Height: height, ProposalFinalized: &e}
 				events = append(events, evt)
 			case eventsAPI.IsAttributeKind(key, &api.VoteEvent{}):
 				// Vote event.
@@ -78,7 +64,7 @@ func EventsFromCometBFT(
 					continue
 				}
 
-				evt := &api.Event{Height: height, TxHash: txHash, Vote: &e}
+				evt := &api.Event{Height: height, Vote: &e}
 				events = append(events, evt)
 			default:
 				errs = errors.Join(errs, fmt.Errorf("governance: unknown event type: key: %s, val: %s", key, val))

--- a/go/consensus/cometbft/governance/governance.go
+++ b/go/consensus/cometbft/governance/governance.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
-	cmttypes "github.com/cometbft/cometbft/types"
 
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
@@ -109,30 +108,17 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 		return nil, err
 	}
 
-	// Get transactions at given height.
-	txns, err := sc.consensus.GetTransactions(ctx, results.Height)
-	if err != nil {
-		sc.logger.Error("failed to get cometbft transactions",
-			"err", err,
-			"height", results.Height,
-		)
-		return nil, err
-	}
-
 	var events []*api.Event
 	// Decode events from block results (at the beginning of the block).
-	blockEvs, err := EventsFromCometBFT(nil, results.Height, results.Meta.BeginBlockEvents)
+	blockEvs, err := EventsFromCometBFT(results.Height, results.Meta.BeginBlockEvents)
 	if err != nil {
 		return nil, err
 	}
 	events = append(events, blockEvs...)
 
 	// Decode events from transaction results.
-	for txIdx, txResult := range results.Meta.TxsResults {
-		// The order of transactions in txns and results.TxsResults is
-		// supposed to match, so the same index in both slices refers to the
-		// same transaction.
-		evs, txErr := EventsFromCometBFT(txns[txIdx], results.Height, txResult.Events)
+	for _, txResult := range results.Meta.TxsResults {
+		evs, txErr := EventsFromCometBFT(results.Height, txResult.Events)
 		if txErr != nil {
 			return nil, txErr
 		}
@@ -140,7 +126,7 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*api.Ev
 	}
 
 	// Decode events from block results (at the end of the block).
-	blockEvs, err = EventsFromCometBFT(nil, results.Height, results.Meta.EndBlockEvents)
+	blockEvs, err = EventsFromCometBFT(results.Height, results.Meta.EndBlockEvents)
 	if err != nil {
 		return nil, err
 	}
@@ -172,8 +158,8 @@ func (sc *ServiceClient) ServiceDescriptor() *tmapi.ServiceDescriptor {
 }
 
 // DeliverEvent implements api.ServiceClient.
-func (sc *ServiceClient) DeliverEvent(_ context.Context, height int64, tx cmttypes.Tx, ev *cmtabcitypes.Event) error {
-	events, err := EventsFromCometBFT(tx, height, []cmtabcitypes.Event{*ev})
+func (sc *ServiceClient) DeliverEvent(_ context.Context, height int64, ev *cmtabcitypes.Event) error {
+	events, err := EventsFromCometBFT(height, []cmtabcitypes.Event{*ev})
 	if err != nil {
 		return fmt.Errorf("governance: failed to process cometbft events: %w", err)
 	}

--- a/go/consensus/cometbft/keymanager/keymanager.go
+++ b/go/consensus/cometbft/keymanager/keymanager.go
@@ -6,7 +6,6 @@ import (
 	"context"
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
-	cmttypes "github.com/cometbft/cometbft/types"
 
 	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/keymanager"
@@ -73,7 +72,7 @@ func (sc *ServiceClient) ServiceDescriptor() *tmapi.ServiceDescriptor {
 }
 
 // DeliverEvent implements api.ServiceClient.
-func (sc *ServiceClient) DeliverEvent(_ context.Context, _ int64, _ cmttypes.Tx, ev *cmtabcitypes.Event) error {
+func (sc *ServiceClient) DeliverEvent(_ context.Context, _ int64, ev *cmtabcitypes.Event) error {
 	if err := sc.secretsClient.DeliverEvent(ev); err != nil {
 		return err
 	}

--- a/go/consensus/cometbft/registry/events.go
+++ b/go/consensus/cometbft/registry/events.go
@@ -5,28 +5,14 @@ import (
 	"fmt"
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
-	cmttypes "github.com/cometbft/cometbft/types"
 
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	eventsAPI "github.com/oasisprotocol/oasis-core/go/consensus/api/events"
 	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/registry"
 	"github.com/oasisprotocol/oasis-core/go/registry/api"
 )
 
 // EventsFromCometBFT extracts registry events from CometBFT events.
-func EventsFromCometBFT(
-	tx cmttypes.Tx,
-	height int64,
-	tmEvents []cmtabcitypes.Event,
-) ([]*api.Event, []*NodeListEpochInternalEvent, error) {
-	var txHash hash.Hash
-	switch tx {
-	case nil:
-		txHash.Empty()
-	default:
-		txHash = hash.NewFromBytes(tx)
-	}
-
+func EventsFromCometBFT(height int64, tmEvents []cmtabcitypes.Event) ([]*api.Event, []*NodeListEpochInternalEvent, error) {
 	var events []*api.Event
 	var nodeListEvents []*NodeListEpochInternalEvent
 	var errs error
@@ -52,7 +38,7 @@ func EventsFromCometBFT(
 					continue
 				}
 
-				events = append(events, &api.Event{Height: height, TxHash: txHash, RuntimeStartedEvent: &e})
+				events = append(events, &api.Event{Height: height, RuntimeStartedEvent: &e})
 			case eventsAPI.IsAttributeKind(key, &api.RuntimeSuspendedEvent{}):
 				// Runtime suspended event.
 				var e api.RuntimeSuspendedEvent
@@ -61,7 +47,7 @@ func EventsFromCometBFT(
 					continue
 				}
 
-				events = append(events, &api.Event{Height: height, TxHash: txHash, RuntimeSuspendedEvent: &e})
+				events = append(events, &api.Event{Height: height, RuntimeSuspendedEvent: &e})
 			case eventsAPI.IsAttributeKind(key, &api.EntityEvent{}):
 				// Entity event.
 				var e api.EntityEvent
@@ -70,7 +56,7 @@ func EventsFromCometBFT(
 					continue
 				}
 
-				events = append(events, &api.Event{Height: height, TxHash: txHash, EntityEvent: &e})
+				events = append(events, &api.Event{Height: height, EntityEvent: &e})
 			case eventsAPI.IsAttributeKind(key, &api.NodeEvent{}):
 				// Node event.
 				var e api.NodeEvent
@@ -79,7 +65,7 @@ func EventsFromCometBFT(
 					continue
 				}
 
-				events = append(events, &api.Event{Height: height, TxHash: txHash, NodeEvent: &e})
+				events = append(events, &api.Event{Height: height, NodeEvent: &e})
 			case eventsAPI.IsAttributeKind(key, &api.NodeUnfrozenEvent{}):
 				// Node unfrozen event.
 				var e api.NodeUnfrozenEvent
@@ -87,7 +73,7 @@ func EventsFromCometBFT(
 					errs = errors.Join(errs, fmt.Errorf("registry: corrupt NodeUnfrozen event: %w", err))
 					continue
 				}
-				events = append(events, &api.Event{Height: height, TxHash: txHash, NodeUnfrozenEvent: &e})
+				events = append(events, &api.Event{Height: height, NodeUnfrozenEvent: &e})
 			}
 		}
 	}

--- a/go/consensus/cometbft/roothash/events.go
+++ b/go/consensus/cometbft/roothash/events.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
-	cmttypes "github.com/cometbft/cometbft/types"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	eventsAPI "github.com/oasisprotocol/oasis-core/go/consensus/api/events"
 	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/roothash"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
@@ -16,18 +14,9 @@ import (
 
 // EventsFromCometBFT extracts roothash events from CometBFT events.
 func EventsFromCometBFT(
-	tx cmttypes.Tx,
 	height int64,
 	tmEvents []cmtabcitypes.Event,
 ) ([]*roothash.Event, error) {
-	var txHash hash.Hash
-	switch tx {
-	case nil:
-		txHash.Empty()
-	default:
-		txHash = hash.NewFromBytes(tx)
-	}
-
 	var events []*roothash.Event
 	var errs error
 EventLoop:
@@ -105,7 +94,6 @@ EventLoop:
 		if ev != nil {
 			ev.RuntimeID = *runtimeID
 			ev.Height = height
-			ev.TxHash = txHash
 			events = append(events, ev)
 		}
 	}

--- a/go/consensus/cometbft/roothash/roothash.go
+++ b/go/consensus/cometbft/roothash/roothash.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
-	cmttypes "github.com/cometbft/cometbft/types"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crash"
@@ -270,34 +269,17 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*rootha
 		return nil, err
 	}
 
-	// Get transactions at given height.
-	txns, err := sc.consensus.GetTransactions(ctx, results.Height)
-	if err != nil {
-		sc.logger.Error("failed to get cometbft transactions",
-			"err", err,
-			"height", results.Height,
-		)
-		return nil, err
-	}
-
 	var events []*roothash.Event
 	// Decode events from block results (at the beginning of the block).
-	blockEvs, err := EventsFromCometBFT(nil, results.Height, results.Meta.BeginBlockEvents)
+	blockEvs, err := EventsFromCometBFT(results.Height, results.Meta.BeginBlockEvents)
 	if err != nil {
 		return nil, err
 	}
 	events = append(events, blockEvs...)
 
 	// Decode events from transaction results.
-	for txIdx, txResult := range results.Meta.TxsResults {
-		// The order of transactions in txns and results.TxsResults is
-		// supposed to match, so the same index in both slices refers to the
-		// same transaction.
-		var tx cmttypes.Tx
-		if txns != nil {
-			tx = txns[txIdx]
-		}
-		evs, txErr := EventsFromCometBFT(tx, results.Height, txResult.Events)
+	for _, txResult := range results.Meta.TxsResults {
+		evs, txErr := EventsFromCometBFT(results.Height, txResult.Events)
 		if txErr != nil {
 			return nil, txErr
 		}
@@ -305,7 +287,7 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*rootha
 	}
 
 	// Decode events from block results (at the end of the block).
-	blockEvs, err = EventsFromCometBFT(nil, results.Height, results.Meta.EndBlockEvents)
+	blockEvs, err = EventsFromCometBFT(results.Height, results.Meta.EndBlockEvents)
 	if err != nil {
 		return nil, err
 	}
@@ -378,8 +360,8 @@ func (sc *ServiceClient) DeliverHeight(ctx context.Context, height int64) error 
 }
 
 // DeliverEvent implements roothash.ServiceClient.
-func (sc *ServiceClient) DeliverEvent(ctx context.Context, height int64, tx cmttypes.Tx, ev *cmtabcitypes.Event) error {
-	events, err := EventsFromCometBFT(tx, height, []cmtabcitypes.Event{*ev})
+func (sc *ServiceClient) DeliverEvent(ctx context.Context, height int64, ev *cmtabcitypes.Event) error {
+	events, err := EventsFromCometBFT(height, []cmtabcitypes.Event{*ev})
 	if err != nil {
 		return fmt.Errorf("roothash: failed to process cometbft events: %w", err)
 	}

--- a/go/consensus/cometbft/scheduler/scheduler.go
+++ b/go/consensus/cometbft/scheduler/scheduler.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
-	cmttypes "github.com/cometbft/cometbft/types"
 	"github.com/eapache/channels"
 
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
@@ -124,7 +123,7 @@ func (sc *ServiceClient) ServiceDescriptor() *tmapi.ServiceDescriptor {
 }
 
 // DeliverEvent implements api.ServiceClient.
-func (sc *ServiceClient) DeliverEvent(ctx context.Context, height int64, _ cmttypes.Tx, ev *cmtabcitypes.Event) error {
+func (sc *ServiceClient) DeliverEvent(ctx context.Context, height int64, ev *cmtabcitypes.Event) error {
 	for _, pair := range ev.GetAttributes() {
 		if events.IsAttributeKind(pair.GetKey(), &api.ElectedEvent{}) {
 			var e api.ElectedEvent

--- a/go/consensus/cometbft/staking/events.go
+++ b/go/consensus/cometbft/staking/events.go
@@ -5,28 +5,14 @@ import (
 	"fmt"
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
-	cmttypes "github.com/cometbft/cometbft/types"
 
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	eventsAPI "github.com/oasisprotocol/oasis-core/go/consensus/api/events"
 	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/staking"
 	"github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
 // EventsFromCometBFT extracts staking events from CometBFT events.
-func EventsFromCometBFT(
-	tx cmttypes.Tx,
-	height int64,
-	tmEvents []cmtabcitypes.Event,
-) ([]*api.Event, error) {
-	var txHash hash.Hash
-	switch tx {
-	case nil:
-		txHash.Empty()
-	default:
-		txHash = hash.NewFromBytes(tx)
-	}
-
+func EventsFromCometBFT(height int64, tmEvents []cmtabcitypes.Event) ([]*api.Event, error) {
 	var events []*api.Event
 	var errs error
 	for _, tmEv := range tmEvents {
@@ -48,7 +34,7 @@ func EventsFromCometBFT(
 					continue
 				}
 
-				evt := &api.Event{Height: height, TxHash: txHash, Escrow: &api.EscrowEvent{Take: &e}}
+				evt := &api.Event{Height: height, Escrow: &api.EscrowEvent{Take: &e}}
 				events = append(events, evt)
 			case eventsAPI.IsAttributeKind(key, &api.TransferEvent{}):
 				// Transfer event.
@@ -58,7 +44,7 @@ func EventsFromCometBFT(
 					continue
 				}
 
-				evt := &api.Event{Height: height, TxHash: txHash, Transfer: &e}
+				evt := &api.Event{Height: height, Transfer: &e}
 				events = append(events, evt)
 			case eventsAPI.IsAttributeKind(key, &api.ReclaimEscrowEvent{}):
 				// Reclaim escrow event.
@@ -68,7 +54,7 @@ func EventsFromCometBFT(
 					continue
 				}
 
-				evt := &api.Event{Height: height, TxHash: txHash, Escrow: &api.EscrowEvent{Reclaim: &e}}
+				evt := &api.Event{Height: height, Escrow: &api.EscrowEvent{Reclaim: &e}}
 				events = append(events, evt)
 			case eventsAPI.IsAttributeKind(key, &api.AddEscrowEvent{}):
 				// Add escrow event.
@@ -78,7 +64,7 @@ func EventsFromCometBFT(
 					continue
 				}
 
-				evt := &api.Event{Height: height, TxHash: txHash, Escrow: &api.EscrowEvent{Add: &e}}
+				evt := &api.Event{Height: height, Escrow: &api.EscrowEvent{Add: &e}}
 				events = append(events, evt)
 			case eventsAPI.IsAttributeKind(key, &api.DebondingStartEscrowEvent{}):
 				// Debonding start escrow event.
@@ -88,7 +74,7 @@ func EventsFromCometBFT(
 					continue
 				}
 
-				evt := &api.Event{Height: height, TxHash: txHash, Escrow: &api.EscrowEvent{DebondingStart: &e}}
+				evt := &api.Event{Height: height, Escrow: &api.EscrowEvent{DebondingStart: &e}}
 				events = append(events, evt)
 			case eventsAPI.IsAttributeKind(key, &api.BurnEvent{}):
 				// Burn event.
@@ -98,7 +84,7 @@ func EventsFromCometBFT(
 					continue
 				}
 
-				evt := &api.Event{Height: height, TxHash: txHash, Burn: &e}
+				evt := &api.Event{Height: height, Burn: &e}
 				events = append(events, evt)
 			case eventsAPI.IsAttributeKind(key, &api.AllowanceChangeEvent{}):
 				// Allowance change event.
@@ -108,7 +94,7 @@ func EventsFromCometBFT(
 					continue
 				}
 
-				evt := &api.Event{Height: height, TxHash: txHash, AllowanceChange: &e}
+				evt := &api.Event{Height: height, AllowanceChange: &e}
 				events = append(events, evt)
 			default:
 				errs = errors.Join(errs, fmt.Errorf("staking: unknown event type: key: %s, val: %s", key, val))

--- a/go/consensus/cometbft/stateless/core.go
+++ b/go/consensus/cometbft/stateless/core.go
@@ -344,7 +344,7 @@ func (c *Core) GetTransactionsWithResults(ctx context.Context, height int64) (*c
 		return nil, err
 	}
 
-	txResults, err := full.TransactionResultsFromCometBFT(lb.Height, txs, meta.TxsResults)
+	txResults, err := full.TransactionResultsFromCometBFT(lb.Height, meta.TxsResults)
 	if err != nil {
 		return nil, err
 	}

--- a/go/consensus/cometbft/vault/events.go
+++ b/go/consensus/cometbft/vault/events.go
@@ -5,28 +5,14 @@ import (
 	"fmt"
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
-	cmttypes "github.com/cometbft/cometbft/types"
 
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	eventsAPI "github.com/oasisprotocol/oasis-core/go/consensus/api/events"
 	app "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/vault"
 	vault "github.com/oasisprotocol/oasis-core/go/vault/api"
 )
 
 // EventsFromCometBFT extracts vault events from CometBFT events.
-func EventsFromCometBFT(
-	tx cmttypes.Tx,
-	height int64,
-	tmEvents []cmtabcitypes.Event,
-) ([]*vault.Event, error) {
-	var txHash hash.Hash
-	switch tx {
-	case nil:
-		txHash.Empty()
-	default:
-		txHash = hash.NewFromBytes(tx)
-	}
-
+func EventsFromCometBFT(height int64, tmEvents []cmtabcitypes.Event) ([]*vault.Event, error) {
 	var events []*vault.Event
 	var errs error
 	for _, tmEv := range tmEvents {
@@ -39,7 +25,7 @@ func EventsFromCometBFT(
 			key := pair.GetKey()
 			val := pair.GetValue()
 
-			evt := &vault.Event{Height: height, TxHash: txHash}
+			evt := &vault.Event{Height: height}
 			switch {
 			case eventsAPI.IsAttributeKind(key, &vault.ActionSubmittedEvent{}):
 				// Action submitted event.

--- a/go/consensus/cometbft/vault/vault.go
+++ b/go/consensus/cometbft/vault/vault.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	cmtabcitypes "github.com/cometbft/cometbft/abci/types"
-	cmttypes "github.com/cometbft/cometbft/types"
 
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
@@ -99,30 +98,17 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*vault.
 		return nil, err
 	}
 
-	// Get transactions at given height.
-	txns, err := sc.consensus.GetTransactions(ctx, results.Height)
-	if err != nil {
-		sc.logger.Error("failed to get cometbft transactions",
-			"err", err,
-			"height", results.Height,
-		)
-		return nil, err
-	}
-
 	var events []*vault.Event
 	// Decode events from block results (at the beginning of the block).
-	blockEvs, err := EventsFromCometBFT(nil, results.Height, results.Meta.BeginBlockEvents)
+	blockEvs, err := EventsFromCometBFT(results.Height, results.Meta.BeginBlockEvents)
 	if err != nil {
 		return nil, err
 	}
 	events = append(events, blockEvs...)
 
 	// Decode events from transaction results.
-	for txIdx, txResult := range results.Meta.TxsResults {
-		// The order of transactions in txns and results.TxsResults is
-		// supposed to match, so the same index in both slices refers to the
-		// same transaction.
-		evs, txErr := EventsFromCometBFT(txns[txIdx], results.Height, txResult.Events)
+	for _, txResult := range results.Meta.TxsResults {
+		evs, txErr := EventsFromCometBFT(results.Height, txResult.Events)
 		if txErr != nil {
 			return nil, txErr
 		}
@@ -130,7 +116,7 @@ func (sc *ServiceClient) GetEvents(ctx context.Context, height int64) ([]*vault.
 	}
 
 	// Decode events from block results (at the end of the block).
-	blockEvs, err = EventsFromCometBFT(nil, results.Height, results.Meta.EndBlockEvents)
+	blockEvs, err = EventsFromCometBFT(results.Height, results.Meta.EndBlockEvents)
 	if err != nil {
 		return nil, err
 	}
@@ -162,8 +148,8 @@ func (sc *ServiceClient) ServiceDescriptor() *tmapi.ServiceDescriptor {
 }
 
 // DeliverEvent implements api.ServiceClient.
-func (sc *ServiceClient) DeliverEvent(_ context.Context, height int64, tx cmttypes.Tx, ev *cmtabcitypes.Event) error {
-	events, err := EventsFromCometBFT(tx, height, []cmtabcitypes.Event{*ev})
+func (sc *ServiceClient) DeliverEvent(_ context.Context, height int64, ev *cmtabcitypes.Event) error {
+	events, err := EventsFromCometBFT(height, []cmtabcitypes.Event{*ev})
 	if err != nil {
 		return fmt.Errorf("vault: failed to process cometbft events: %w", err)
 	}

--- a/go/governance/api/api.go
+++ b/go/governance/api/api.go
@@ -10,7 +10,6 @@ import (
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
 	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
@@ -500,8 +499,7 @@ func (c *ConsensusParameterChanges) Apply(params *ConsensusParameters) error {
 
 // Event signifies a governance event, returned via GetEvents.
 type Event struct {
-	Height int64     `json:"height,omitempty"`
-	TxHash hash.Hash `json:"tx_hash,omitempty"`
+	Height int64 `json:"height,omitempty"`
 
 	ProposalSubmitted *ProposalSubmittedEvent `json:"proposal_submitted,omitempty"`
 	ProposalExecuted  *ProposalExecutedEvent  `json:"proposal_executed,omitempty"`

--- a/go/oasis-node/cmd/debug/txsource/workload/queries.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/queries.go
@@ -106,9 +106,6 @@ func (q *queries) sanityCheckTransactionEvents(ctx context.Context, height int64
 	}
 	expectedRegistryEvents := make(map[hash.Hash]int)
 	for _, event := range registryEvents {
-		if event.TxHash.IsEmpty() {
-			continue
-		}
 		h := hash.NewFromBytes(cbor.Marshal(event)[:])
 		expectedRegistryEvents[h] = expectedRegistryEvents[h] + 1
 	}
@@ -119,9 +116,6 @@ func (q *queries) sanityCheckTransactionEvents(ctx context.Context, height int64
 	}
 	expectedStakingEvents := make(map[hash.Hash]int)
 	for _, event := range stakingEvents {
-		if event.TxHash.IsEmpty() {
-			continue
-		}
 		h := hash.NewFromBytes(cbor.Marshal(event)[:])
 		expectedStakingEvents[h] = expectedStakingEvents[h] + 1
 	}
@@ -132,9 +126,6 @@ func (q *queries) sanityCheckTransactionEvents(ctx context.Context, height int64
 	}
 	expectedGovernanceEvents := make(map[hash.Hash]int)
 	for _, event := range governanceEvents {
-		if event.TxHash.IsEmpty() {
-			continue
-		}
 		h := hash.NewFromBytes(cbor.Marshal(event)[:])
 		expectedGovernanceEvents[h] = expectedGovernanceEvents[h] + 1
 	}

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -11,7 +11,6 @@ import (
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/entity"
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
@@ -371,8 +370,7 @@ func (e *NodeListEpochEvent) DecodeValue(string) error {
 
 // Event is a registry event returned via GetEvents.
 type Event struct {
-	Height int64     `json:"height,omitempty"`
-	TxHash hash.Hash `json:"tx_hash,omitempty"`
+	Height int64 `json:"height,omitempty"`
 
 	RuntimeStartedEvent   *RuntimeStartedEvent   `json:"runtime_started,omitempty"`
 	RuntimeSuspendedEvent *RuntimeSuspendedEvent `json:"runtime_suspended,omitempty"`

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -221,7 +221,6 @@ func testRegistryEntityNodes( // nolint: gocyclo
 				for _, evt := range evts {
 					if evt.EntityEvent != nil {
 						if evt.EntityEvent.Entity.ID.Equal(ev.Entity.ID) && evt.EntityEvent.IsRegistration {
-							require.False(evt.TxHash.IsEmpty(), "Event transaction hash should not be empty")
 							require.Greater(evt.Height, int64(0), "Event height should be greater than zero")
 							receivedEvt = evt
 							break
@@ -309,7 +308,6 @@ func testRegistryEntityNodes( // nolint: gocyclo
 					for _, evt := range evts {
 						if evt.NodeEvent != nil {
 							if evt.NodeEvent.Node.ID.Equal(tn.Node.ID) && evt.NodeEvent.IsRegistration {
-								require.False(evt.TxHash.IsEmpty(), "Event transaction hash should not be empty")
 								require.Greater(evt.Height, int64(0), "Event height should be greater than zero")
 								receivedEvt = evt
 								break
@@ -490,7 +488,6 @@ func testRegistryEntityNodes( // nolint: gocyclo
 				for _, evt := range evts {
 					if evt.NodeEvent != nil {
 						if evt.NodeEvent.Node.ID.Equal(ev.Node.ID) && !evt.NodeEvent.IsRegistration {
-							require.True(evt.TxHash.IsEmpty(), "Node expiration event hash should be empty")
 							require.Greater(evt.Height, int64(0), "Event height should be greater than zero")
 							receivedEvt = evt
 							break
@@ -575,7 +572,6 @@ func testRegistryEntityNodes( // nolint: gocyclo
 			for _, evt := range evts {
 				if evt.EntityEvent != nil {
 					if evt.EntityEvent.Entity.ID.Equal(ev.Entity.ID) && !evt.EntityEvent.IsRegistration {
-						require.False(evt.TxHash.IsEmpty(), "Event transaction hash should not be empty")
 						require.Greater(evt.Height, int64(0), "Event height should be greater than zero")
 						receivedEvt = evt
 						break
@@ -622,7 +618,6 @@ func testRegistryEntityNodes( // nolint: gocyclo
 				for _, evt := range evts {
 					if evt.EntityEvent != nil {
 						if evt.EntityEvent.Entity.ID.Equal(ev.Entity.ID) && !evt.EntityEvent.IsRegistration {
-							require.False(evt.TxHash.IsEmpty(), "Event transaction hash should not be empty")
 							require.Greater(evt.Height, int64(0), "Event height should be greater than zero")
 							receivedEvt = evt
 							break
@@ -1589,7 +1584,6 @@ func (rt *TestRuntime) MustRegister(t *testing.T, registry api.Backend, consensu
 				for _, evt := range evts {
 					if evt.RuntimeStartedEvent != nil {
 						if evt.RuntimeStartedEvent.Runtime.ID.Equal(&v.ID) {
-							require.False(evt.TxHash.IsEmpty(), "Event transaction hash should not be empty")
 							require.Greater(evt.Height, int64(0), "Event height should be greater than zero")
 							receivedEvt = evt
 							break
@@ -1682,7 +1676,6 @@ func BulkPopulate(t *testing.T, registry api.Backend, consensus consensusAPI.Ser
 		for _, evt := range evts {
 			if evt.EntityEvent != nil {
 				if evt.EntityEvent.Entity.ID.Equal(ev.Entity.ID) && evt.EntityEvent.IsRegistration {
-					require.False(evt.TxHash.IsEmpty(), "Event transaction hash should not be empty")
 					require.Greater(evt.Height, int64(0), "Event height should be greater than zero")
 					gotIt = true
 					break
@@ -1717,7 +1710,6 @@ func BulkPopulate(t *testing.T, registry api.Backend, consensus consensusAPI.Ser
 			for _, evt := range evts {
 				if evt.NodeEvent != nil {
 					if evt.NodeEvent.Node.ID.Equal(ev.Node.ID) && evt.NodeEvent.IsRegistration {
-						require.False(evt.TxHash.IsEmpty(), "Event transaction hash should not be empty")
 						require.Greater(evt.Height, int64(0), "Event height should be greater than zero")
 						gotIt = true
 						break

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -522,8 +522,7 @@ func (me *MessageEvent) IsSuccess() bool {
 
 // Event is a roothash event.
 type Event struct {
-	Height int64     `json:"height,omitempty"`
-	TxHash hash.Hash `json:"tx_hash,omitempty"`
+	Height int64 `json:"height,omitempty"`
 
 	RuntimeID common.Namespace `json:"runtime_id"`
 

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -7,7 +7,6 @@ import (
 	"io"
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
 	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
@@ -265,8 +264,7 @@ type EscrowEvent struct {
 
 // Event signifies a staking event, returned via GetEvents.
 type Event struct {
-	Height int64     `json:"height,omitempty"`
-	TxHash hash.Hash `json:"tx_hash,omitempty"`
+	Height int64 `json:"height,omitempty"`
 
 	Transfer        *TransferEvent        `json:"transfer,omitempty"`
 	Burn            *BurnEvent            `json:"burn,omitempty"`

--- a/go/staking/api/api_test.go
+++ b/go/staking/api/api_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 )
@@ -606,50 +605,44 @@ func TestEventsSerialization(t *testing.T) {
 	addr1 := NewAddress(pk1)
 	pk2 := signature.NewPublicKey("bbbfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 	addr2 := NewAddress(pk2)
-	var txHash hash.Hash
-	txHash.Empty()
 
 	// NOTE: These cases should be synced with tests in runtime/src/consensus/staking.rs.
 	for _, tc := range []struct {
 		ev             Event
 		expectedBase64 string
 	}{
-		{Event{}, "oWd0eF9oYXNoWCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="},
-		{Event{Height: 42}, "omZoZWlnaHQYKmd0eF9oYXNoWCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="},
-		{Event{Height: 42, TxHash: txHash}, "omZoZWlnaHQYKmd0eF9oYXNoWCDGcrjR71btKKuHw2IsURQGm90617j5c3SY0MAezvCWeg=="},
+		{Event{}, "oA=="},
+		{Event{Height: 42}, "oWZoZWlnaHQYKg=="},
 
 		// Transfer.
 		{
 			Event{
 				Height: 42,
-				TxHash: txHash,
 				Transfer: &TransferEvent{
 					From:   addr1,
 					To:     addr2,
 					Amount: mustInitQuantity(t, 100),
 				},
 			},
-			"o2ZoZWlnaHQYKmd0eF9oYXNoWCDGcrjR71btKKuHw2IsURQGm90617j5c3SY0MAezvCWemh0cmFuc2ZlcqNidG9VALkSOXiV5kcMUfq+zJ3cg/cK7YahZGZyb21VACByFDSJP2FsCYFI4s+fmePigm4TZmFtb3VudEFk",
+			"omZoZWlnaHQYKmh0cmFuc2ZlcqNidG9VALkSOXiV5kcMUfq+zJ3cg/cK7YahZGZyb21VACByFDSJP2FsCYFI4s+fmePigm4TZmFtb3VudEFk",
 		},
 
 		// Burn.
 		{
 			Event{
 				Height: 42,
-				TxHash: txHash,
 				Burn: &BurnEvent{
 					Owner:  addr1,
 					Amount: mustInitQuantity(t, 100),
 				},
 			},
-			"o2RidXJuomVvd25lclUAIHIUNIk/YWwJgUjiz5+Z4+KCbhNmYW1vdW50QWRmaGVpZ2h0GCpndHhfaGFzaFggxnK40e9W7Sirh8NiLFEUBpvdOte4+XN0mNDAHs7wlno=",
+			"omRidXJuomVvd25lclUAIHIUNIk/YWwJgUjiz5+Z4+KCbhNmYW1vdW50QWRmaGVpZ2h0GCo=",
 		},
 
 		// Escrow.
 		{
 			Event{
 				Height: 42,
-				TxHash: txHash,
 				Escrow: &EscrowEvent{
 					Add: &AddEscrowEvent{
 						Owner:     addr1,
@@ -659,12 +652,11 @@ func TestEventsSerialization(t *testing.T) {
 					},
 				},
 			},
-			"o2Zlc2Nyb3ehY2FkZKRlb3duZXJVACByFDSJP2FsCYFI4s+fmePigm4TZmFtb3VudEFkZmVzY3Jvd1UAuRI5eJXmRwxR+r7MndyD9wrthqFqbmV3X3NoYXJlc0EyZmhlaWdodBgqZ3R4X2hhc2hYIMZyuNHvVu0oq4fDYixRFAab3TrXuPlzdJjQwB7O8JZ6",
+			"omZlc2Nyb3ehY2FkZKRlb3duZXJVACByFDSJP2FsCYFI4s+fmePigm4TZmFtb3VudEFkZmVzY3Jvd1UAuRI5eJXmRwxR+r7MndyD9wrthqFqbmV3X3NoYXJlc0EyZmhlaWdodBgq",
 		},
 		{
 			Event{
 				Height: 42,
-				TxHash: txHash,
 				Escrow: &EscrowEvent{
 					Take: &TakeEscrowEvent{
 						Owner:           addr1,
@@ -673,12 +665,11 @@ func TestEventsSerialization(t *testing.T) {
 					},
 				},
 			},
-			"o2Zlc2Nyb3ehZHRha2WjZW93bmVyVQAgchQ0iT9hbAmBSOLPn5nj4oJuE2ZhbW91bnRBZHBkZWJvbmRpbmdfYW1vdW50QRRmaGVpZ2h0GCpndHhfaGFzaFggxnK40e9W7Sirh8NiLFEUBpvdOte4+XN0mNDAHs7wlno=",
+			"omZlc2Nyb3ehZHRha2WjZW93bmVyVQAgchQ0iT9hbAmBSOLPn5nj4oJuE2ZhbW91bnRBZHBkZWJvbmRpbmdfYW1vdW50QRRmaGVpZ2h0GCo=",
 		},
 		{
 			Event{
 				Height: 42,
-				TxHash: txHash,
 				Escrow: &EscrowEvent{
 					DebondingStart: &DebondingStartEscrowEvent{
 						Owner:           addr1,
@@ -690,12 +681,11 @@ func TestEventsSerialization(t *testing.T) {
 					},
 				},
 			},
-			"o2Zlc2Nyb3ehb2RlYm9uZGluZ19zdGFydKZlb3duZXJVACByFDSJP2FsCYFI4s+fmePigm4TZmFtb3VudEFkZmVzY3Jvd1UAuRI5eJXmRwxR+r7MndyD9wrthqFtYWN0aXZlX3NoYXJlc0Eyb2RlYm9uZF9lbmRfdGltZRgqcGRlYm9uZGluZ19zaGFyZXNBGWZoZWlnaHQYKmd0eF9oYXNoWCDGcrjR71btKKuHw2IsURQGm90617j5c3SY0MAezvCWeg==",
+			"omZlc2Nyb3ehb2RlYm9uZGluZ19zdGFydKZlb3duZXJVACByFDSJP2FsCYFI4s+fmePigm4TZmFtb3VudEFkZmVzY3Jvd1UAuRI5eJXmRwxR+r7MndyD9wrthqFtYWN0aXZlX3NoYXJlc0Eyb2RlYm9uZF9lbmRfdGltZRgqcGRlYm9uZGluZ19zaGFyZXNBGWZoZWlnaHQYKg==",
 		},
 		{
 			Event{
 				Height: 42,
-				TxHash: txHash,
 				Escrow: &EscrowEvent{
 					Reclaim: &ReclaimEscrowEvent{
 						Owner:  addr1,
@@ -705,14 +695,13 @@ func TestEventsSerialization(t *testing.T) {
 					},
 				},
 			},
-			"o2Zlc2Nyb3ehZ3JlY2xhaW2kZW93bmVyVQAgchQ0iT9hbAmBSOLPn5nj4oJuE2ZhbW91bnRBZGZlc2Nyb3dVALkSOXiV5kcMUfq+zJ3cg/cK7YahZnNoYXJlc0EZZmhlaWdodBgqZ3R4X2hhc2hYIMZyuNHvVu0oq4fDYixRFAab3TrXuPlzdJjQwB7O8JZ6",
+			"omZlc2Nyb3ehZ3JlY2xhaW2kZW93bmVyVQAgchQ0iT9hbAmBSOLPn5nj4oJuE2ZhbW91bnRBZGZlc2Nyb3dVALkSOXiV5kcMUfq+zJ3cg/cK7YahZnNoYXJlc0EZZmhlaWdodBgq",
 		},
 
 		// Allowance change.
 		{
 			Event{
 				Height: 42,
-				TxHash: txHash,
 				AllowanceChange: &AllowanceChangeEvent{
 					Owner:        addr1,
 					Beneficiary:  addr2,
@@ -721,12 +710,11 @@ func TestEventsSerialization(t *testing.T) {
 					AmountChange: mustInitQuantity(t, 50),
 				},
 			},
-			"o2ZoZWlnaHQYKmd0eF9oYXNoWCDGcrjR71btKKuHw2IsURQGm90617j5c3SY0MAezvCWenBhbGxvd2FuY2VfY2hhbmdlpGVvd25lclUAIHIUNIk/YWwJgUjiz5+Z4+KCbhNpYWxsb3dhbmNlQWRrYmVuZWZpY2lhcnlVALkSOXiV5kcMUfq+zJ3cg/cK7YahbWFtb3VudF9jaGFuZ2VBMg==",
+			"omZoZWlnaHQYKnBhbGxvd2FuY2VfY2hhbmdlpGVvd25lclUAIHIUNIk/YWwJgUjiz5+Z4+KCbhNpYWxsb3dhbmNlQWRrYmVuZWZpY2lhcnlVALkSOXiV5kcMUfq+zJ3cg/cK7YahbWFtb3VudF9jaGFuZ2VBMg==",
 		},
 		{
 			Event{
 				Height: 42,
-				TxHash: txHash,
 				AllowanceChange: &AllowanceChangeEvent{
 					Owner:        addr1,
 					Beneficiary:  addr2,
@@ -735,7 +723,7 @@ func TestEventsSerialization(t *testing.T) {
 					AmountChange: mustInitQuantity(t, 50),
 				},
 			},
-			"o2ZoZWlnaHQYKmd0eF9oYXNoWCDGcrjR71btKKuHw2IsURQGm90617j5c3SY0MAezvCWenBhbGxvd2FuY2VfY2hhbmdlpWVvd25lclUAIHIUNIk/YWwJgUjiz5+Z4+KCbhNobmVnYXRpdmX1aWFsbG93YW5jZUFka2JlbmVmaWNpYXJ5VQC5Ejl4leZHDFH6vsyd3IP3Cu2GoW1hbW91bnRfY2hhbmdlQTI=",
+			"omZoZWlnaHQYKnBhbGxvd2FuY2VfY2hhbmdlpWVvd25lclUAIHIUNIk/YWwJgUjiz5+Z4+KCbhNobmVnYXRpdmX1aWFsbG93YW5jZUFka2JlbmVmaWNpYXJ5VQC5Ejl4leZHDFH6vsyd3IP3Cu2GoW1hbW91bnRfY2hhbmdlQTI=",
 		},
 	} {
 		enc := cbor.Marshal(tc.ev)

--- a/go/staking/tests/tester.go
+++ b/go/staking/tests/tester.go
@@ -520,7 +520,6 @@ TransferWaitLoop:
 					if evt.Transfer != nil {
 						if evt.Transfer.From.Equal(te.From) && evt.Transfer.To.Equal(te.To) && evt.Transfer.Amount.Cmp(&te.Amount) == 0 {
 							gotTransfer = true
-							require.True(!evt.TxHash.IsEmpty(), "GetEvents should return valid txn hash")
 							break
 						}
 					}
@@ -633,7 +632,6 @@ func testBurn(t *testing.T, state *stakingTestsState, staking api.Backend, conse
 						if evt.Transfer != nil {
 							if evt.Transfer.From.Equal(te.From) && evt.Transfer.To.Equal(te.To) && evt.Transfer.Amount.Cmp(&te.Amount) == 0 {
 								gotIt = true
-								require.True(!evt.TxHash.IsEmpty(), "GetEvents should return valid txn hash")
 								break
 							}
 						}
@@ -1092,7 +1090,6 @@ AllowWaitLoop:
 				ac2 := ev2.AllowanceChange
 				if ac2.Owner.Equal(ac.Owner) && ac2.Beneficiary.Equal(ac.Beneficiary) {
 					require.EqualValues(ac, ac2, "GetEvents should return the same event")
-					require.True(!ev2.TxHash.IsEmpty(), "GetEvents should return valid txn hash")
 					break AllowWaitLoop
 				}
 			}

--- a/go/vault/api/events.go
+++ b/go/vault/api/events.go
@@ -1,14 +1,12 @@
 package api
 
 import (
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
 // Event signifies a vault event.
 type Event struct {
-	Height int64     `json:"height,omitempty"`
-	TxHash hash.Hash `json:"tx_hash,omitempty"`
+	Height int64 `json:"height,omitempty"`
 
 	ActionSubmitted  *ActionSubmittedEvent  `json:"action_submitted,omitempty"`
 	ActionCanceled   *ActionCanceledEvent   `json:"action_canceled,omitempty"`


### PR DESCRIPTION
Since no one is using the transaction hash of an event, we could simplify the code and make it faster by removing it. Does that make sense?

Hm, ... I think that nexus needs this :thinking: 