### PR TITLE
go/worker/storage: Refactor state sync worker pt1

### DIFF
--- a/go/consensus/cometbft/abci/state.go
+++ b/go/consensus/cometbft/abci/state.go
@@ -782,10 +782,11 @@ func newApplicationState(ctx context.Context, upgrader upgrade.Backend, cfg *App
 				}, nil
 			},
 		}
-		s.checkpointer, err = checkpoint.NewCheckpointer(s.ctx, ndb, ldb.Checkpointer(), checkpointerCfg)
-		if err != nil {
-			return nil, fmt.Errorf("state: failed to create checkpointer: %w", err)
-		}
+		s.checkpointer = checkpoint.NewCheckpointer(ndb, ldb.Checkpointer(), checkpointerCfg)
+		go func() {
+			err := s.checkpointer.Serve(ctx)
+			s.logger.Error("checkpointer stopped", "err", err)
+		}()
 	}
 
 	go s.metricsWorker()

--- a/go/oasis-node/cmd/node/node_control.go
+++ b/go/oasis-node/cmd/node/node_control.go
@@ -312,8 +312,8 @@ func (n *Node) getRuntimeStatus(ctx context.Context) (map[common.Namespace]contr
 		}
 
 		// Fetch storage worker status.
-		if storageNode := n.StorageWorker.GetRuntime(rt.ID()); storageNode != nil {
-			status.Storage, err = storageNode.GetStatus(ctx)
+		if storageWorker := n.StorageWorker.GetRuntime(rt.ID()); storageWorker != nil {
+			status.Storage, err = storageWorker.GetStatus(ctx)
 			if err != nil {
 				logger.Error("failed to fetch storage worker status", "err", err)
 			}

--- a/go/oasis-test-runner/oasis/log.go
+++ b/go/oasis-test-runner/oasis/log.go
@@ -8,7 +8,7 @@ import (
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/commitment"
 	upgrade "github.com/oasisprotocol/oasis-core/go/upgrade/api"
-	workerStorage "github.com/oasisprotocol/oasis-core/go/worker/storage/committee"
+	storageWorker "github.com/oasisprotocol/oasis-core/go/worker/storage/committee"
 )
 
 // LogAssertEvent returns a handler which checks whether a specific log event was
@@ -116,7 +116,7 @@ func LogAssertRoothashRoothashReindexing() log.WatcherHandlerFactory {
 // LogAssertCheckpointSync returns a handler which checks whether initial storage sync from
 // a checkpoint was successful or not.
 func LogAssertCheckpointSync() log.WatcherHandlerFactory {
-	return LogAssertEvent(workerStorage.LogEventCheckpointSyncSuccess, "checkpoint sync did not succeed")
+	return LogAssertEvent(storageWorker.LogEventCheckpointSyncSuccess, "checkpoint sync did not succeed")
 }
 
 // LogAssertDiscrepancyMajorityFailure returns a handler which checks whether a discrepancy resolution

--- a/go/storage/mkvs/checkpoint/checkpointer.go
+++ b/go/storage/mkvs/checkpoint/checkpointer.go
@@ -72,7 +72,7 @@ type CreationParameters struct {
 	ChunkerThreads uint16
 }
 
-// Checkpointer is a checkpointer.
+// Checkpointer is responsible for creating the storage snapshots (checkpoints).
 type Checkpointer interface {
 	// NotifyNewVersion notifies the checkpointer that a new version has been finalized.
 	NotifyNewVersion(version uint64)
@@ -95,6 +95,9 @@ type Checkpointer interface {
 	// intervals; after unpausing, a checkpoint won't be created immediately, but the checkpointer
 	// will wait for the next regular event.
 	Pause(pause bool)
+
+	// Serve starts running the checkpointer.
+	Serve(ctx context.Context) error
 }
 
 type checkpointer struct {
@@ -285,7 +288,7 @@ func (c *checkpointer) maybeCheckpoint(ctx context.Context, version uint64, para
 	return nil
 }
 
-func (c *checkpointer) worker(ctx context.Context) {
+func (c *checkpointer) Serve(ctx context.Context) error {
 	c.logger.Debug("storage checkpointer started",
 		"check_interval", c.cfg.CheckInterval,
 	)
@@ -310,7 +313,7 @@ func (c *checkpointer) worker(ctx context.Context) {
 
 		select {
 		case <-ctx.Done():
-			return
+			return ctx.Err()
 		case <-time.After(interval):
 		case <-c.flushCh.Out():
 		case paused = <-c.pausedCh:
@@ -323,7 +326,7 @@ func (c *checkpointer) worker(ctx context.Context) {
 		)
 		select {
 		case <-ctx.Done():
-			return
+			return ctx.Err()
 		case v := <-c.notifyCh.Out():
 			version = v.(uint64)
 		case v := <-c.forceCh.Out():
@@ -387,13 +390,8 @@ func (c *checkpointer) worker(ctx context.Context) {
 
 // NewCheckpointer creates a new checkpointer that can be notified of new finalized versions and
 // will automatically generate the configured number of checkpoints.
-func NewCheckpointer(
-	ctx context.Context,
-	ndb db.NodeDB,
-	creator Creator,
-	cfg CheckpointerConfig,
-) (Checkpointer, error) {
-	c := &checkpointer{
+func NewCheckpointer(ndb db.NodeDB, creator Creator, cfg CheckpointerConfig) Checkpointer {
+	return &checkpointer{
 		cfg:        cfg,
 		ndb:        ndb,
 		creator:    creator,
@@ -405,6 +403,4 @@ func NewCheckpointer(
 		cpNotifier: pubsub.NewBroker(false),
 		logger:     logging.GetLogger("storage/mkvs/checkpoint/"+cfg.Name).With("namespace", cfg.Namespace),
 	}
-	go c.worker(ctx)
-	return c, nil
 }

--- a/go/storage/mkvs/checkpoint/checkpointer.go
+++ b/go/storage/mkvs/checkpoint/checkpointer.go
@@ -115,6 +115,23 @@ type checkpointer struct {
 	logger *logging.Logger
 }
 
+// NewCheckpointer creates a new checkpointer that can be notified of new finalized versions and
+// will automatically generate the configured number of checkpoints.
+func NewCheckpointer(ndb db.NodeDB, creator Creator, cfg CheckpointerConfig) Checkpointer {
+	return &checkpointer{
+		cfg:        cfg,
+		ndb:        ndb,
+		creator:    creator,
+		notifyCh:   channels.NewRingChannel(1),
+		forceCh:    channels.NewRingChannel(1),
+		flushCh:    channels.NewRingChannel(1),
+		statusCh:   make(chan struct{}),
+		pausedCh:   make(chan bool),
+		cpNotifier: pubsub.NewBroker(false),
+		logger:     logging.GetLogger("storage/mkvs/checkpoint/"+cfg.Name).With("namespace", cfg.Namespace),
+	}
+}
+
 // Implements Checkpointer.
 func (c *checkpointer) NotifyNewVersion(version uint64) {
 	c.notifyCh.In() <- version
@@ -141,6 +158,106 @@ func (c *checkpointer) Flush() {
 
 func (c *checkpointer) Pause(pause bool) {
 	c.pausedCh <- pause
+}
+
+func (c *checkpointer) Serve(ctx context.Context) error {
+	c.logger.Debug("storage checkpointer started",
+		"check_interval", c.cfg.CheckInterval,
+	)
+	defer func() {
+		c.logger.Debug("storage checkpointer terminating")
+	}()
+
+	paused := false
+
+	for {
+		var interval time.Duration
+		switch c.cfg.CheckInterval {
+		case CheckIntervalDisabled:
+			interval = CheckIntervalDisabled
+		default:
+			interval = random.GetRandomValueFromInterval(
+				checkpointIntervalRandomizationFactor,
+				rand.Float64(),
+				c.cfg.CheckInterval,
+			)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		case <-c.flushCh.Out():
+		case paused = <-c.pausedCh:
+			continue
+		}
+
+		var (
+			version uint64
+			force   bool
+		)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case v := <-c.notifyCh.Out():
+			version = v.(uint64)
+		case v := <-c.forceCh.Out():
+			version = v.(uint64)
+			force = true
+		}
+
+		// Fetch current checkpoint parameters.
+		params := c.cfg.Parameters
+		if params == nil && c.cfg.GetParameters != nil {
+			var err error
+			params, err = c.cfg.GetParameters(ctx)
+			if err != nil {
+				c.logger.Error("failed to get checkpoint parameters",
+					"err", err,
+					"version", version,
+				)
+				continue
+			}
+		}
+		if params == nil {
+			c.logger.Error("no checkpoint parameters")
+			continue
+		}
+
+		// Don't checkpoint if checkpoints are disabled.
+		switch {
+		case force:
+			// Always checkpoint when forced.
+		case paused:
+			continue
+		case params.Interval == 0:
+			continue
+		case c.cfg.CheckInterval == CheckIntervalDisabled:
+			continue
+		default:
+		}
+
+		var err error
+		switch force {
+		case false:
+			err = c.maybeCheckpoint(ctx, version, params)
+		case true:
+			err = c.checkpoint(ctx, version, params)
+		}
+		if err != nil {
+			c.logger.Error("failed to checkpoint",
+				"version", version,
+				"err", err,
+			)
+			continue
+		}
+
+		// Emit status update if someone is listening. This is only used in tests.
+		select {
+		case c.statusCh <- struct{}{}:
+		default:
+		}
+	}
 }
 
 func (c *checkpointer) checkpoint(ctx context.Context, version uint64, params *CreationParameters) (err error) {
@@ -286,121 +403,4 @@ func (c *checkpointer) maybeCheckpoint(ctx context.Context, version uint64, para
 	}
 
 	return nil
-}
-
-func (c *checkpointer) Serve(ctx context.Context) error {
-	c.logger.Debug("storage checkpointer started",
-		"check_interval", c.cfg.CheckInterval,
-	)
-	defer func() {
-		c.logger.Debug("storage checkpointer terminating")
-	}()
-
-	paused := false
-
-	for {
-		var interval time.Duration
-		switch c.cfg.CheckInterval {
-		case CheckIntervalDisabled:
-			interval = CheckIntervalDisabled
-		default:
-			interval = random.GetRandomValueFromInterval(
-				checkpointIntervalRandomizationFactor,
-				rand.Float64(),
-				c.cfg.CheckInterval,
-			)
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(interval):
-		case <-c.flushCh.Out():
-		case paused = <-c.pausedCh:
-			continue
-		}
-
-		var (
-			version uint64
-			force   bool
-		)
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case v := <-c.notifyCh.Out():
-			version = v.(uint64)
-		case v := <-c.forceCh.Out():
-			version = v.(uint64)
-			force = true
-		}
-
-		// Fetch current checkpoint parameters.
-		params := c.cfg.Parameters
-		if params == nil && c.cfg.GetParameters != nil {
-			var err error
-			params, err = c.cfg.GetParameters(ctx)
-			if err != nil {
-				c.logger.Error("failed to get checkpoint parameters",
-					"err", err,
-					"version", version,
-				)
-				continue
-			}
-		}
-		if params == nil {
-			c.logger.Error("no checkpoint parameters")
-			continue
-		}
-
-		// Don't checkpoint if checkpoints are disabled.
-		switch {
-		case force:
-			// Always checkpoint when forced.
-		case paused:
-			continue
-		case params.Interval == 0:
-			continue
-		case c.cfg.CheckInterval == CheckIntervalDisabled:
-			continue
-		default:
-		}
-
-		var err error
-		switch force {
-		case false:
-			err = c.maybeCheckpoint(ctx, version, params)
-		case true:
-			err = c.checkpoint(ctx, version, params)
-		}
-		if err != nil {
-			c.logger.Error("failed to checkpoint",
-				"version", version,
-				"err", err,
-			)
-			continue
-		}
-
-		// Emit status update if someone is listening. This is only used in tests.
-		select {
-		case c.statusCh <- struct{}{}:
-		default:
-		}
-	}
-}
-
-// NewCheckpointer creates a new checkpointer that can be notified of new finalized versions and
-// will automatically generate the configured number of checkpoints.
-func NewCheckpointer(ndb db.NodeDB, creator Creator, cfg CheckpointerConfig) Checkpointer {
-	return &checkpointer{
-		cfg:        cfg,
-		ndb:        ndb,
-		creator:    creator,
-		notifyCh:   channels.NewRingChannel(1),
-		forceCh:    channels.NewRingChannel(1),
-		flushCh:    channels.NewRingChannel(1),
-		statusCh:   make(chan struct{}),
-		pausedCh:   make(chan bool),
-		cpNotifier: pubsub.NewBroker(false),
-		logger:     logging.GetLogger("storage/mkvs/checkpoint/"+cfg.Name).With("namespace", cfg.Namespace),
-	}
 }

--- a/go/worker/storage/committee/checkpoint_sync.go
+++ b/go/worker/storage/committee/checkpoint_sync.go
@@ -22,7 +22,7 @@ const (
 	// cpListsTimeout is the timeout for fetching checkpoints from all nodes.
 	cpListsTimeout = 30 * time.Second
 	// cpRestoreTimeout is the timeout for restoring a checkpoint chunk from the remote peer.
-	cpRestoreTimeout = 60 * time.Second
+	cpRestoreTimeout = time.Minute
 
 	checkpointStatusDone = 0
 	checkpointStatusNext = 1

--- a/go/worker/storage/committee/checkpoint_sync.go
+++ b/go/worker/storage/committee/checkpoint_sync.go
@@ -21,7 +21,7 @@ import (
 const (
 	// cpListsTimeout is the timeout for fetching checkpoints from all nodes.
 	cpListsTimeout = 30 * time.Second
-	// cpRestoreTimeout is the timeout for restoring a checkpoint chunk from a node.
+	// cpRestoreTimeout is the timeout for restoring a checkpoint chunk from the remote peer.
 	cpRestoreTimeout = 60 * time.Second
 
 	checkpointStatusDone = 0
@@ -37,7 +37,7 @@ var ErrNoUsableCheckpoints = errors.New("storage: no checkpoint could be synced"
 
 // CheckpointSyncConfig is the checkpoint sync configuration.
 type CheckpointSyncConfig struct {
-	// Disabled specifies whether checkpoint sync should be disabled. In this case the node will
+	// Disabled specifies whether checkpoint sync should be disabled. In this case the storage worker will
 	// only sync by applying all diffs from genesis.
 	Disabled bool
 
@@ -81,7 +81,7 @@ func (h *chunkHeap) Pop() any {
 	return ret
 }
 
-func (n *Node) checkpointChunkFetcher(
+func (w *Worker) checkpointChunkFetcher(
 	ctx context.Context,
 	chunkDispatchCh chan *chunk,
 	chunkReturnCh chan *chunk,
@@ -103,9 +103,9 @@ func (n *Node) checkpointChunkFetcher(
 		defer cancel()
 
 		// Fetch chunk from peers.
-		rsp, pf, err := n.fetchChunk(chunkCtx, chunk)
+		rsp, pf, err := w.fetchChunk(chunkCtx, chunk)
 		if err != nil {
-			n.logger.Error("failed to fetch chunk from peers",
+			w.logger.Error("failed to fetch chunk from peers",
 				"err", err,
 				"chunk", chunk.Index,
 			)
@@ -114,7 +114,7 @@ func (n *Node) checkpointChunkFetcher(
 		}
 
 		// Restore fetched chunk.
-		done, err := n.localStorage.Checkpointer().RestoreChunk(chunkCtx, chunk.Index, bytes.NewBuffer(rsp))
+		done, err := w.localStorage.Checkpointer().RestoreChunk(chunkCtx, chunk.Index, bytes.NewBuffer(rsp))
 		cancel()
 
 		switch {
@@ -124,7 +124,7 @@ func (n *Node) checkpointChunkFetcher(
 			chunkReturnCh <- nil
 			return
 		case err != nil:
-			n.logger.Error("chunk restoration failed",
+			w.logger.Error("chunk restoration failed",
 				"chunk", chunk.Index,
 				"root", chunk.Root,
 				"err", err,
@@ -157,8 +157,8 @@ func (n *Node) checkpointChunkFetcher(
 // fetchChunk fetches chunk using checkpoint sync p2p protocol client.
 //
 // In case of no peers or error, it fallbacks to the legacy storage sync protocol.
-func (n *Node) fetchChunk(ctx context.Context, chunk *chunk) ([]byte, rpc.PeerFeedback, error) {
-	rsp1, pf, err := n.checkpointSync.GetCheckpointChunk(
+func (w *Worker) fetchChunk(ctx context.Context, chunk *chunk) ([]byte, rpc.PeerFeedback, error) {
+	rsp1, pf, err := w.checkpointSync.GetCheckpointChunk(
 		ctx,
 		&checkpointsync.GetCheckpointChunkRequest{
 			Version: chunk.Version,
@@ -175,7 +175,7 @@ func (n *Node) fetchChunk(ctx context.Context, chunk *chunk) ([]byte, rpc.PeerFe
 		return rsp1.Chunk, pf, nil
 	}
 
-	rsp2, pf, err := n.legacyStorageSync.GetCheckpointChunk(
+	rsp2, pf, err := w.legacyStorageSync.GetCheckpointChunk(
 		ctx,
 		&synclegacy.GetCheckpointChunkRequest{
 			Version: chunk.Version,
@@ -194,8 +194,8 @@ func (n *Node) fetchChunk(ctx context.Context, chunk *chunk) ([]byte, rpc.PeerFe
 	return rsp2.Chunk, pf, nil
 }
 
-func (n *Node) handleCheckpoint(check *checkpointsync.Checkpoint, maxParallelRequests uint) (cpStatus int, rerr error) {
-	if err := n.localStorage.Checkpointer().StartRestore(n.ctx, check.Metadata); err != nil {
+func (w *Worker) handleCheckpoint(check *checkpointsync.Checkpoint, maxParallelRequests uint) (cpStatus int, rerr error) {
+	if err := w.localStorage.Checkpointer().StartRestore(w.ctx, check.Metadata); err != nil {
 		// Any previous restores were already aborted by the driver up the call stack, so
 		// things should have been going smoothly here; bail.
 		return checkpointStatusBail, fmt.Errorf("can't start checkpoint restore: %w", err)
@@ -208,9 +208,9 @@ func (n *Node) handleCheckpoint(check *checkpointsync.Checkpoint, maxParallelReq
 		}
 		// Abort has to succeed even if we were interrupted by context cancellation.
 		ctx := context.Background()
-		if err := n.localStorage.Checkpointer().AbortRestore(ctx); err != nil {
+		if err := w.localStorage.Checkpointer().AbortRestore(ctx); err != nil {
 			cpStatus = checkpointStatusBail
-			n.logger.Error("error while aborting checkpoint restore on handler exit, aborting sync",
+			w.logger.Error("error while aborting checkpoint restore on handler exit, aborting sync",
 				"err", err,
 			)
 		}
@@ -222,7 +222,7 @@ func (n *Node) handleCheckpoint(check *checkpointsync.Checkpoint, maxParallelReq
 	chunkReturnCh := make(chan *chunk, maxParallelRequests)
 	errorCh := make(chan int, maxParallelRequests)
 
-	ctx, cancel := context.WithCancel(n.ctx)
+	ctx, cancel := context.WithCancel(w.ctx)
 
 	// Spawn the worker group to fetch and restore checkpoint chunks.
 	var workerGroup sync.WaitGroup
@@ -231,7 +231,7 @@ func (n *Node) handleCheckpoint(check *checkpointsync.Checkpoint, maxParallelReq
 		workerGroup.Add(1)
 		go func() {
 			defer workerGroup.Done()
-			n.checkpointChunkFetcher(ctx, chunkDispatchCh, chunkReturnCh, errorCh)
+			w.checkpointChunkFetcher(ctx, chunkDispatchCh, chunkReturnCh, errorCh)
 		}()
 	}
 	go func() {
@@ -264,7 +264,7 @@ func (n *Node) handleCheckpoint(check *checkpointsync.Checkpoint, maxParallelReq
 			checkpoint: check,
 		})
 	}
-	n.logger.Debug("checkpoint chunks prepared for dispatch",
+	w.logger.Debug("checkpoint chunks prepared for dispatch",
 		"chunks", len(check.Chunks),
 		"checkpoint_root", check.Root,
 	)
@@ -283,8 +283,8 @@ func (n *Node) handleCheckpoint(check *checkpointsync.Checkpoint, maxParallelReq
 		}
 
 		select {
-		case <-n.ctx.Done():
-			return checkpointStatusBail, n.ctx.Err()
+		case <-w.ctx.Done():
+			return checkpointStatusBail, w.ctx.Err()
 
 		case returned := <-chunkReturnCh:
 			if returned == nil {
@@ -313,13 +313,13 @@ func (n *Node) handleCheckpoint(check *checkpointsync.Checkpoint, maxParallelReq
 	}
 }
 
-func (n *Node) getCheckpointList() ([]*checkpointsync.Checkpoint, error) {
-	ctx, cancel := context.WithTimeout(n.ctx, cpListsTimeout)
+func (w *Worker) getCheckpointList() ([]*checkpointsync.Checkpoint, error) {
+	ctx, cancel := context.WithTimeout(w.ctx, cpListsTimeout)
 	defer cancel()
 
-	list, err := n.fetchCheckpoints(ctx)
+	list, err := w.fetchCheckpoints(ctx)
 	if err != nil {
-		n.logger.Error("failed to retrieve any checkpoints",
+		w.logger.Error("failed to retrieve any checkpoints",
 			"err", err,
 		)
 		return nil, err
@@ -334,15 +334,15 @@ func (n *Node) getCheckpointList() ([]*checkpointsync.Checkpoint, error) {
 // fetchCheckpoints fetches checkpoints using checkpoint sync p2p protocol client.
 //
 // In case of no peers, error or no checkpoints, it fallbacks to the legacy storage sync protocol.
-func (n *Node) fetchCheckpoints(ctx context.Context) ([]*checkpointsync.Checkpoint, error) {
-	list1, err := n.checkpointSync.GetCheckpoints(ctx, &checkpointsync.GetCheckpointsRequest{
+func (w *Worker) fetchCheckpoints(ctx context.Context) ([]*checkpointsync.Checkpoint, error) {
+	list1, err := w.checkpointSync.GetCheckpoints(ctx, &checkpointsync.GetCheckpointsRequest{
 		Version: 1,
 	})
 	if err == nil && len(list1) > 0 { // if NO error and at least one checkpoint
 		return list1, nil
 	}
 
-	list2, err := n.legacyStorageSync.GetCheckpoints(ctx, &synclegacy.GetCheckpointsRequest{
+	list2, err := w.legacyStorageSync.GetCheckpoints(ctx, &synclegacy.GetCheckpointsRequest{
 		Version: 1,
 	})
 	if err != nil {
@@ -369,8 +369,8 @@ func sortCheckpoints(s []*checkpointsync.Checkpoint) {
 	})
 }
 
-func (n *Node) checkCheckpointUsable(cp *checkpointsync.Checkpoint, remainingMask outstandingMask, genesisRound uint64) bool {
-	namespace := n.commonNode.Runtime.ID()
+func (w *Worker) checkCheckpointUsable(cp *checkpointsync.Checkpoint, remainingMask outstandingMask, genesisRound uint64) bool {
+	namespace := w.commonNode.Runtime.ID()
 	if !namespace.Equal(&cp.Root.Namespace) {
 		// Not for the right runtime.
 		return false
@@ -380,12 +380,12 @@ func (n *Node) checkCheckpointUsable(cp *checkpointsync.Checkpoint, remainingMas
 		return false
 	}
 
-	blk, err := n.commonNode.Runtime.History().GetCommittedBlock(n.ctx, cp.Root.Version)
+	blk, err := w.commonNode.Runtime.History().GetCommittedBlock(w.ctx, cp.Root.Version)
 	if err != nil {
-		n.logger.Error("can't get block information for checkpoint, skipping", "err", err, "root", cp.Root)
+		w.logger.Error("can't get block information for checkpoint, skipping", "err", err, "root", cp.Root)
 		return false
 	}
-	_, lastIORoot, lastStateRoot := n.GetLastSynced()
+	_, lastIORoot, lastStateRoot := w.GetLastSynced()
 	lastVersions := map[storageApi.RootType]uint64{
 		storageApi.RootTypeIO:    lastIORoot.Version,
 		storageApi.RootTypeState: lastStateRoot.Version,
@@ -401,18 +401,18 @@ func (n *Node) checkCheckpointUsable(cp *checkpointsync.Checkpoint, remainingMas
 			}
 		}
 	}
-	n.logger.Info("checkpoint for unknown root skipped", "root", cp.Root)
+	w.logger.Info("checkpoint for unknown root skipped", "root", cp.Root)
 	return false
 }
 
-func (n *Node) syncCheckpoints(genesisRound uint64, wantOnlyGenesis bool) (*blockSummary, error) {
+func (w *Worker) syncCheckpoints(genesisRound uint64, wantOnlyGenesis bool) (*blockSummary, error) {
 	// Store roots and round info for checkpoints that finished syncing.
 	// Round and namespace info will get overwritten as rounds are skipped
 	// for errors, driven by remainingRoots.
 	var syncState blockSummary
 
 	// Fetch checkpoints from peers.
-	cps, err := n.getCheckpointList()
+	cps, err := w.getCheckpointList()
 	if err != nil {
 		return nil, fmt.Errorf("can't get checkpoint list from peers: %w", err)
 	}
@@ -440,8 +440,8 @@ func (n *Node) syncCheckpoints(genesisRound uint64, wantOnlyGenesis bool) (*bloc
 		if !multipartRunning {
 			return
 		}
-		if err := n.localStorage.NodeDB().AbortMultipartInsert(); err != nil {
-			n.logger.Error("error aborting multipart restore on exit from syncer",
+		if err := w.localStorage.NodeDB().AbortMultipartInsert(); err != nil {
+			w.logger.Error("error aborting multipart restore on exit from syncer",
 				"err", err,
 			)
 		}
@@ -449,7 +449,7 @@ func (n *Node) syncCheckpoints(genesisRound uint64, wantOnlyGenesis bool) (*bloc
 
 	for _, check := range cps {
 
-		if check.Root.Version < genesisRound || !n.checkCheckpointUsable(check, remainingRoots, genesisRound) {
+		if check.Root.Version < genesisRound || !w.checkCheckpointUsable(check, remainingRoots, genesisRound) {
 			continue
 		}
 
@@ -458,10 +458,10 @@ func (n *Node) syncCheckpoints(genesisRound uint64, wantOnlyGenesis bool) (*bloc
 			// previous retries. Aborting multipart works with no multipart in
 			// progress too.
 			multipartRunning = false
-			if err := n.localStorage.NodeDB().AbortMultipartInsert(); err != nil {
+			if err := w.localStorage.NodeDB().AbortMultipartInsert(); err != nil {
 				return nil, fmt.Errorf("error aborting previous multipart restore: %w", err)
 			}
-			if err := n.localStorage.NodeDB().StartMultipartInsert(check.Root.Version); err != nil {
+			if err := w.localStorage.NodeDB().StartMultipartInsert(check.Root.Version); err != nil {
 				return nil, fmt.Errorf("error starting multipart insert for round %d: %w", check.Root.Version, err)
 			}
 			multipartRunning = true
@@ -486,18 +486,18 @@ func (n *Node) syncCheckpoints(genesisRound uint64, wantOnlyGenesis bool) (*bloc
 			}
 		}
 
-		status, err := n.handleCheckpoint(check, n.checkpointSyncCfg.ChunkFetcherCount)
+		status, err := w.handleCheckpoint(check, w.checkpointSyncCfg.ChunkFetcherCount)
 		switch status {
 		case checkpointStatusDone:
-			n.logger.Info("successfully restored from checkpoint", "root", check.Root, "mask", mask)
+			w.logger.Info("successfully restored from checkpoint", "root", check.Root, "mask", mask)
 
 			syncState.Namespace = check.Root.Namespace
 			syncState.Round = check.Root.Version
 			syncState.Roots = append(syncState.Roots, check.Root)
 			remainingRoots.remove(check.Root.Type)
 			if remainingRoots.isEmpty() {
-				if err = n.localStorage.NodeDB().Finalize(syncState.Roots); err != nil {
-					n.logger.Error("can't finalize version after all checkpoints restored",
+				if err = w.localStorage.NodeDB().Finalize(syncState.Roots); err != nil {
+					w.logger.Error("can't finalize version after all checkpoints restored",
 						"err", err,
 						"version", prevVersion,
 						"roots", syncState.Roots,
@@ -510,10 +510,10 @@ func (n *Node) syncCheckpoints(genesisRound uint64, wantOnlyGenesis bool) (*bloc
 			}
 			continue
 		case checkpointStatusNext:
-			n.logger.Info("error trying to restore from checkpoint, trying next most recent", "root", check.Root, "err", err)
+			w.logger.Info("error trying to restore from checkpoint, trying next most recent", "root", check.Root, "err", err)
 			continue
 		case checkpointStatusBail:
-			n.logger.Error("error trying to restore from checkpoint, unrecoverable", "root", check.Root, "err", err)
+			w.logger.Error("error trying to restore from checkpoint, unrecoverable", "root", check.Root, "err", err)
 			return nil, fmt.Errorf("error restoring from checkpoints: %w", err)
 		}
 	}

--- a/go/worker/storage/committee/metrics.go
+++ b/go/worker/storage/committee/metrics.go
@@ -49,9 +49,9 @@ var (
 	prometheusOnce sync.Once
 )
 
-func (n *Node) getMetricLabels() prometheus.Labels {
+func (w *Worker) getMetricLabels() prometheus.Labels {
 	return prometheus.Labels{
-		"runtime": n.commonNode.Runtime.ID().String(),
+		"runtime": w.commonNode.Runtime.ID().String(),
 	}
 }
 

--- a/go/worker/storage/committee/prune.go
+++ b/go/worker/storage/committee/prune.go
@@ -1,0 +1,48 @@
+package committee
+
+import (
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	mkvsDB "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
+)
+
+type pruneHandler struct {
+	logger *logging.Logger
+	worker *Worker
+}
+
+func (p *pruneHandler) Prune(rounds []uint64) error {
+	// Make sure we never prune past what was synced.
+	lastSycnedRound, _, _ := p.worker.GetLastSynced()
+
+	for _, round := range rounds {
+		if round >= lastSycnedRound {
+			return fmt.Errorf("worker/storage: tried to prune past last synced round (last synced: %d)",
+				lastSycnedRound,
+			)
+		}
+
+		// Old suggestion: Make sure we don't prune rounds that need to be checkpointed but haven't been yet.
+
+		p.logger.Debug("pruning storage for round", "round", round)
+
+		// Prune given block.
+		err := p.worker.localStorage.NodeDB().Prune(round)
+		switch err {
+		case nil:
+		case mkvsDB.ErrNotEarliest:
+			p.logger.Debug("skipping non-earliest round",
+				"round", round,
+			)
+			continue
+		default:
+			p.logger.Error("failed to prune block",
+				"err", err,
+			)
+			return err
+		}
+	}
+
+	return nil
+}

--- a/go/worker/storage/committee/worker.go
+++ b/go/worker/storage/committee/worker.go
@@ -150,8 +150,6 @@ type Worker struct {
 
 	undefinedRound uint64
 
-	fetchPool *workerpool.Pool
-
 	workerCommonCfg workerCommon.Config
 
 	checkpointer         checkpoint.Checkpointer
@@ -187,10 +185,6 @@ func New(
 ) (*Worker, error) {
 	initMetrics()
 
-	// Create the fetcher pool.
-	fetchPool := workerpool.New("storage_fetch/" + commonNode.Runtime.ID().String())
-	fetchPool.Resize(config.GlobalConfig.Storage.FetcherCount)
-
 	w := &Worker{
 		commonNode: commonNode,
 
@@ -202,8 +196,6 @@ func New(
 		workerCommonCfg: workerCommonCfg,
 
 		localStorage: localStorage,
-
-		fetchPool: fetchPool,
 
 		checkpointSyncCfg: checkpointSyncCfg,
 
@@ -233,10 +225,6 @@ func New(
 		return nil, fmt.Errorf("failed to create checkpointer: %w", err)
 	}
 	w.checkpointer = checkpointer
-	go func() {
-		err := w.checkpointer.Serve(w.ctx)
-		w.logger.Error("checkpointer stopped", "err", err)
-	}()
 
 	// Register prune handler.
 	commonNode.Runtime.History().Pruner().RegisterHandler(&pruneHandler{
@@ -321,20 +309,11 @@ func (w *Worker) newCheckpointer(commonNode *committee.Node, localStorage storag
 // Start causes the worker to start responding to CometBFT new block events.
 func (w *Worker) Start() error {
 	go w.worker()
-	if config.GlobalConfig.Storage.Checkpointer.Enabled {
-		go w.consensusCheckpointSyncer()
-	}
 	return nil
 }
 
 // Stop causes the worker to stop watching and shut down.
 func (w *Worker) Stop() {
-	w.statusLock.Lock()
-	w.status = api.StatusStopping
-	w.statusLock.Unlock()
-
-	w.fetchPool.Stop()
-
 	w.ctxCancel()
 }
 
@@ -819,13 +798,31 @@ func (w *Worker) worker() { // nolint: gocyclo
 	}
 
 	w.logger.Info("starting")
-
 	w.statusLock.Lock()
 	w.status = api.StatusStarting
 	w.statusLock.Unlock()
 
 	var wg sync.WaitGroup
 	defer wg.Wait()
+
+	ctx, cancel := context.WithCancel(w.ctx)
+	defer cancel()
+
+	wg.Go(func() {
+		<-ctx.Done()
+		w.statusLock.Lock()
+		w.status = api.StatusStopping
+		w.statusLock.Unlock()
+	})
+	defer w.logger.Info("stopped")
+
+	wg.Go(func() {
+		err := w.checkpointer.Serve(ctx)
+		w.logger.Error("checkpointer stopped", "err", err)
+	})
+	if config.GlobalConfig.Storage.Checkpointer.Enabled {
+		go w.consensusCheckpointSyncer()
+	}
 
 	// Determine genesis block.
 	genesisBlock, err := w.commonNode.Consensus.RootHash().GetGenesisBlock(w.ctx, &roothashApi.RuntimeRequest{
@@ -1079,6 +1076,7 @@ func (w *Worker) worker() { // nolint: gocyclo
 		}
 	}
 	close(w.initCh)
+	w.logger.Info("initialized")
 
 	// Notify the checkpointer of the genesis round so it can be checkpointed.
 	w.checkpointer.ForceCheckpoint(genesisBlock.Header.Round)
@@ -1092,6 +1090,11 @@ func (w *Worker) worker() { // nolint: gocyclo
 
 	syncingRounds := make(map[uint64]*inFlight)
 	summaryCache := make(map[uint64]*blockSummary)
+
+	fetchPool := workerpool.New("storage_fetch/" + w.commonNode.Runtime.ID().String())
+	fetchPool.Resize(config.GlobalConfig.Storage.FetcherCount)
+	defer fetchPool.Stop()
+
 	triggerRoundFetches := func() {
 		for i := lastFullyAppliedRound + 1; i <= latestBlockRound; i++ {
 			syncing, ok := syncingRounds[i]
@@ -1142,7 +1145,7 @@ func (w *Worker) worker() { // nolint: gocyclo
 				if !syncing.outstanding.contains(rootType) && syncing.awaitingRetry.contains(rootType) {
 					syncing.scheduleDiff(rootType)
 					wg.Add(1)
-					w.fetchPool.Submit(func() {
+					fetchPool.Submit(func() {
 						defer wg.Done()
 						w.fetchDiff(this.Round, prevRoots[i], this.Roots[i])
 					})

--- a/go/worker/storage/committee/worker.go
+++ b/go/worker/storage/committee/worker.go
@@ -949,8 +949,6 @@ func (w *Worker) Serve(ctx context.Context) error { // nolint: gocyclo
 		"last_synced", cachedLastRound,
 	)
 
-	lastFullyAppliedRound := cachedLastRound
-
 	// Try to perform initial sync from state and io checkpoints if either:
 	//
 	// - Checkpoint sync has been forced because there is insufficient information available to use
@@ -1013,7 +1011,6 @@ func (w *Worker) Serve(ctx context.Context) error { // nolint: gocyclo
 			if err != nil {
 				return fmt.Errorf("failed to flush synced state %w", err)
 			}
-			lastFullyAppliedRound = cachedLastRound
 			w.logger.Info("checkpoint sync succeeded",
 				logging.LogEvent, LogEventCheckpointSyncSuccess,
 			)
@@ -1028,6 +1025,7 @@ func (w *Worker) Serve(ctx context.Context) error { // nolint: gocyclo
 
 	// Don't register availability immediately, we want to know first how far behind consensus we are.
 	latestBlockRound := w.undefinedRound
+	lastFullyAppliedRound := cachedLastRound
 
 	heartbeat := heartbeat{}
 	heartbeat.reset()

--- a/go/worker/storage/committee/worker.go
+++ b/go/worker/storage/committee/worker.go
@@ -29,7 +29,6 @@ import (
 	storageApi "github.com/oasisprotocol/oasis-core/go/storage/api"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/checkpoint"
 	dbApi "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
-	mkvsDB "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
 	workerCommon "github.com/oasisprotocol/oasis-core/go/worker/common"
 	"github.com/oasisprotocol/oasis-core/go/worker/common/committee"
 	"github.com/oasisprotocol/oasis-core/go/worker/registration"
@@ -1360,44 +1359,4 @@ mainLoop:
 	// blockCh will be garbage-collected without being closed. It can potentially still contain
 	// some new blocks, but only as many as were already in-flight at the point when the main
 	// context was canceled.
-}
-
-type pruneHandler struct {
-	logger *logging.Logger
-	worker *Worker
-}
-
-func (p *pruneHandler) Prune(rounds []uint64) error {
-	// Make sure we never prune past what was synced.
-	lastSycnedRound, _, _ := p.worker.GetLastSynced()
-
-	for _, round := range rounds {
-		if round >= lastSycnedRound {
-			return fmt.Errorf("worker/storage: tried to prune past last synced round (last synced: %d)",
-				lastSycnedRound,
-			)
-		}
-
-		// TODO: Make sure we don't prune rounds that need to be checkpointed but haven't been yet.
-
-		p.logger.Debug("pruning storage for round", "round", round)
-
-		// Prune given block.
-		err := p.worker.localStorage.NodeDB().Prune(round)
-		switch err {
-		case nil:
-		case mkvsDB.ErrNotEarliest:
-			p.logger.Debug("skipping non-earliest round",
-				"round", round,
-			)
-			continue
-		default:
-			p.logger.Error("failed to prune block",
-				"err", err,
-			)
-			return err
-		}
-	}
-
-	return nil
 }

--- a/go/worker/storage/committee/worker.go
+++ b/go/worker/storage/committee/worker.go
@@ -824,6 +824,9 @@ func (w *Worker) worker() { // nolint: gocyclo
 	w.status = api.StatusStarting
 	w.statusLock.Unlock()
 
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
 	// Determine genesis block.
 	genesisBlock, err := w.commonNode.Consensus.RootHash().GetGenesisBlock(w.ctx, &roothashApi.RuntimeRequest{
 		RuntimeID: w.commonNode.Runtime.ID(),
@@ -1087,7 +1090,6 @@ func (w *Worker) worker() { // nolint: gocyclo
 	heartbeat := heartbeat{}
 	heartbeat.reset()
 
-	var wg sync.WaitGroup
 	syncingRounds := make(map[uint64]*inFlight)
 	summaryCache := make(map[uint64]*blockSummary)
 	triggerRoundFetches := func() {
@@ -1360,7 +1362,6 @@ mainLoop:
 		}
 	}
 
-	wg.Wait()
 	// blockCh will be garbage-collected without being closed. It can potentially still contain
 	// some new blocks, but only as many as were already in-flight at the point when the main
 	// context was canceled.

--- a/go/worker/storage/committee/worker.go
+++ b/go/worker/storage/committee/worker.go
@@ -225,11 +225,15 @@ func New(
 	w.ctx, w.ctxCancel = context.WithCancel(context.Background())
 
 	// Create a checkpointer (even if checkpointing is disabled) to ensure the genesis checkpoint is available.
-	checkpointer, err := w.newCheckpointer(w.ctx, commonNode, localStorage)
+	checkpointer, err := w.newCheckpointer(commonNode, localStorage)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create checkpointer: %w", err)
 	}
 	w.checkpointer = checkpointer
+	go func() {
+		err := w.checkpointer.Serve(w.ctx)
+		w.logger.Error("checkpointer stopped", "err", err)
+	}()
 
 	// Register prune handler.
 	commonNode.Runtime.History().Pruner().RegisterHandler(&pruneHandler{
@@ -255,7 +259,7 @@ func New(
 	return w, nil
 }
 
-func (w *Worker) newCheckpointer(ctx context.Context, commonNode *committee.Node, localStorage storageApi.LocalBackend) (checkpoint.Checkpointer, error) {
+func (w *Worker) newCheckpointer(commonNode *committee.Node, localStorage storageApi.LocalBackend) (checkpoint.Checkpointer, error) {
 	checkInterval := checkpoint.CheckIntervalDisabled
 	if config.GlobalConfig.Storage.Checkpointer.Enabled {
 		checkInterval = config.GlobalConfig.Storage.Checkpointer.CheckInterval
@@ -303,11 +307,10 @@ func (w *Worker) newCheckpointer(ctx context.Context, commonNode *committee.Node
 	}
 
 	return checkpoint.NewCheckpointer(
-		ctx,
 		localStorage.NodeDB(),
 		localStorage.Checkpointer(),
 		checkpointerCfg,
-	)
+	), nil
 }
 
 // Service interface.

--- a/go/worker/storage/committee/worker.go
+++ b/go/worker/storage/committee/worker.go
@@ -880,12 +880,6 @@ func (w *Worker) worker() { // nolint: gocyclo
 		}
 	}
 
-	// Notify the checkpointer of the genesis round so it can be checkpointed.
-	if w.checkpointer != nil {
-		w.checkpointer.ForceCheckpoint(genesisBlock.Header.Round)
-		w.checkpointer.Flush()
-	}
-
 	// Check if we are able to fetch the first block that we would be syncing if we used iterative
 	// syncing. In case we cannot (likely because we synced the consensus layer via state sync), we
 	// must wait for a later checkpoint to become available.
@@ -1075,6 +1069,10 @@ func (w *Worker) worker() { // nolint: gocyclo
 		}
 	}
 	close(w.initCh)
+
+	// Notify the checkpointer of the genesis round so it can be checkpointed.
+	w.checkpointer.ForceCheckpoint(genesisBlock.Header.Round)
+	w.checkpointer.Flush()
 
 	// Don't register availability immediately, we want to know first how far behind consensus we are.
 	latestBlockRound := w.undefinedRound

--- a/go/worker/storage/service_internal.go
+++ b/go/worker/storage/service_internal.go
@@ -9,12 +9,12 @@ import (
 var _ api.StorageWorker = (*Worker)(nil)
 
 func (w *Worker) GetLastSyncedRound(_ context.Context, request *api.GetLastSyncedRoundRequest) (*api.GetLastSyncedRoundResponse, error) {
-	node := w.runtimes[request.RuntimeID]
-	if node == nil {
+	worker := w.runtimes[request.RuntimeID]
+	if worker == nil {
 		return nil, api.ErrRuntimeNotFound
 	}
 
-	round, ioRoot, stateRoot := node.GetLastSynced()
+	round, ioRoot, stateRoot := worker.GetLastSynced()
 	return &api.GetLastSyncedRoundResponse{
 		Round:     round,
 		IORoot:    ioRoot,


### PR DESCRIPTION
**What was done:**

1. **Pass context explicitly.**
2. Fix:
    * Panicking.
    * Deadlocking on the clean-up.
    * Triggering genesis checkpoint to early.
3. Minor refactors.


**Follow-up**:

I propose factoring out _checkpointer_ and _availability nudger_ (https://github.com/oasisprotocol/oasis-core/pull/6308) into separate workers. Could be one PR for each.
This will make _diff sync part_ easier to reason about and thus optimize.
