### PR TITLE
chore: fix the incorrect backticks in the comment

### DIFF
--- a/go/upgrade/migrations/consensus_242.go
+++ b/go/upgrade/migrations/consensus_242.go
@@ -11,7 +11,7 @@ import (
 // Consensus242 is the name of the upgrade that enables features introduced in Oasis Core 24.2.
 //
 // This upgrade includes:
-//   - The `MayQuery“ field in the CHURP SGX policy, which defines which enclave identities
+//   - The `MayQuery` field in the CHURP SGX policy, which defines which enclave identities
 //     are allowed to query runtime key shares.
 //   - An updated key manager policy update transaction that applies a new policy at the epoch
 //     boundary.


### PR DESCRIPTION
fix the incorrect backticks in the comment