### PR TITLE
runtime/rhp: Bump maximum message size to 32 MiB

### DIFF
--- a/.changelog/6326.feature.md
+++ b/.changelog/6326.feature.md
@@ -1,0 +1,1 @@
+runtime/rhp: Bump maximum message size to 32 MiB

--- a/runtime/src/protocol.rs
+++ b/runtime/src/protocol.rs
@@ -73,7 +73,7 @@ impl Write for &Stream {
 }
 
 /// Maximum message size.
-const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024; // 16MiB
+const MAX_MESSAGE_SIZE: usize = 32 * 1024 * 1024; // 32MiB
 
 #[derive(Error, Debug)]
 pub enum ProtocolError {


### PR DESCRIPTION
Fixes: #6326