### PR TITLE
runtime/protocol: Propagate write failures

### DIFF
--- a/.changelog/6327.bugfix.md
+++ b/.changelog/6327.bugfix.md
@@ -1,0 +1,1 @@
+runtime/protocol: Propagate write failures


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/oasis-core/issues/6327

Example client side response with the update:
```go
	addrss, err := rt.Accounts.Addresses(context.Background(), uint64(height), types.NativeDenomination)
	if err != nil {
		println("Failed to fetch addresses:", err.Error())
	}
	// prints: Failed to fetch addresses: Failed to write response: message too large
```

while before the query would just appear to be stuck on the client.