### PR TITLE
go: Bump default block cache size of NodeDB badger instances to 256 MiB

### DIFF
--- a/.changelog/6339.feature.md
+++ b/.changelog/6339.feature.md
@@ -1,0 +1,4 @@
+go/NodeDB: Bump default BadgerDB block cache size to 256 MiB
+
+Previously default value for NodeDB instances was 64 MiB. By bumping it
+we speed-up pruning of runtime state quite significantly.

--- a/go/consensus/cometbft/abci/state.go
+++ b/go/consensus/cometbft/abci/state.go
@@ -655,7 +655,7 @@ func InitStateStorage(cfg *ApplicationConfig) (storage.LocalBackend, storage.Nod
 	db, err := storageDB.New(&storage.Config{
 		Backend:          cfg.StorageBackend,
 		DB:               filepath.Join(baseDir, storageDB.DefaultFileName(cfg.StorageBackend)),
-		MaxCacheSize:     64 * 1024 * 1024, // TODO: Make this configurable.
+		MaxCacheSize:     256 * 1024 * 1024, // TODO: Make this configurable.
 		DiscardWriteLogs: true,
 		NoFsync:          true, // This is safe as CometBFT will replay on crash.
 		MemoryOnly:       cfg.MemoryOnlyStorage,

--- a/go/storage/mkvs/db/badger/helpers.go
+++ b/go/storage/mkvs/db/badger/helpers.go
@@ -33,7 +33,7 @@ func commonConfigToBadgerOptions(cfg *api.Config, db *badgerNodeDB) badger.Optio
 	opts = opts.WithSyncWrites(!cfg.NoFsync)
 	opts = opts.WithCompression(options.Snappy)
 	if cfg.MaxCacheSize == 0 {
-		opts = opts.WithBlockCacheSize(64 * 1024 * 1024)
+		opts = opts.WithBlockCacheSize(256 * 1024 * 1024)
 	} else {
 		opts = opts.WithBlockCacheSize(cfg.MaxCacheSize)
 	}

--- a/go/storage/mkvs/db/pathbadger/config.go
+++ b/go/storage/mkvs/db/pathbadger/config.go
@@ -16,7 +16,7 @@ func commonConfigToBadgerOptions(cfg *api.Config, logger *logging.Logger) badger
 	opts = opts.WithSyncWrites(!cfg.NoFsync)
 	opts = opts.WithCompression(options.Snappy)
 	if cfg.MaxCacheSize == 0 {
-		opts = opts.WithBlockCacheSize(64 * 1024 * 1024)
+		opts = opts.WithBlockCacheSize(256 * 1024 * 1024)
 	} else {
 		opts = opts.WithBlockCacheSize(cfg.MaxCacheSize)
 	}

--- a/go/worker/storage/config/config.go
+++ b/go/worker/storage/config/config.go
@@ -48,7 +48,7 @@ func (c *Config) Validate() error {
 func DefaultConfig() Config {
 	return Config{
 		Backend:                "auto",
-		MaxCacheSize:           "64mb",
+		MaxCacheSize:           "256mb",
 		FetcherCount:           4,
 		PublicRPCEnabled:       false,
 		CheckpointSyncDisabled: false,


### PR DESCRIPTION
As from the experiments, increasing block cache size significantly increases the pruning speed of the runtime state ([see](https://github.com/oasisprotocol/oasis-core/issues/6334#issuecomment-3347762369)).

Looking at the badgerDB [documentation](https://github.com/hypermodeinc/badger/blob/64b2f3736e24c16219b0e74f826d46c7187d6f46/options.go#L685), it is recommended to use cache if using compression. The current default value is `256 MB`, thus bumping to it from existing `64 MB`.

Finally, given that we are highly data intensive application we may set it to even more, e.g. `1 GB`.

Might be also a good idea to bump cometbft managed databases (i.e. blockstore, state, evidence) albeit feels wasteful for the evidence, and currently there is no granularity. Given we don't have performance bottlenecks there for now we could keep it as is.

Will add a changelog once we align on the final size and scope of the changes. 