### PR TITLE
go/p2p: Add observer nodes to the target set of registered nodes

### DIFF
--- a/.changelog/6342.feature.md
+++ b/.changelog/6342.feature.md
@@ -1,0 +1,1 @@
+go/p2p: Add observer nodes to the target set of registered nodes to track

--- a/go/worker/storage/p2p/checkpointsync/protocol.go
+++ b/go/worker/storage/p2p/checkpointsync/protocol.go
@@ -65,7 +65,7 @@ type GetCheckpointChunkResponse struct {
 func init() {
 	peermgmt.RegisterNodeHandler(&peermgmt.NodeHandlerBundle{
 		ProtocolsFn: func(n *node.Node, chainContext string) []core.ProtocolID {
-			if !n.HasRoles(node.RoleComputeWorker | node.RoleStorageRPC) {
+			if !n.HasRoles(node.RoleComputeWorker | node.RoleObserver | node.RoleStorageRPC) {
 				return []core.ProtocolID{}
 			}
 

--- a/go/worker/storage/p2p/diffsync/protocol.go
+++ b/go/worker/storage/p2p/diffsync/protocol.go
@@ -46,7 +46,7 @@ type GetDiffResponse struct {
 func init() {
 	peermgmt.RegisterNodeHandler(&peermgmt.NodeHandlerBundle{
 		ProtocolsFn: func(n *node.Node, chainContext string) []core.ProtocolID {
-			if !n.HasRoles(node.RoleComputeWorker | node.RoleStorageRPC) {
+			if !n.HasRoles(node.RoleComputeWorker | node.RoleObserver | node.RoleStorageRPC) {
 				return []core.ProtocolID{}
 			}
 

--- a/go/worker/storage/p2p/synclegacy/protocol.go
+++ b/go/worker/storage/p2p/synclegacy/protocol.go
@@ -86,7 +86,7 @@ type GetCheckpointChunkResponse struct {
 func init() {
 	peermgmt.RegisterNodeHandler(&peermgmt.NodeHandlerBundle{
 		ProtocolsFn: func(n *node.Node, chainContext string) []core.ProtocolID {
-			if !n.HasRoles(node.RoleComputeWorker | node.RoleStorageRPC) {
+			if !n.HasRoles(node.RoleComputeWorker | node.RoleObserver | node.RoleStorageRPC) {
 				return []core.ProtocolID{}
 			}
 


### PR DESCRIPTION
Closes #6342.

Not sure this will have much impact as these nodes were likely found via discovery (seed nodes, or possibly via libp2p if already connected with a given peer due to other protocol)...