### PR TITLE
buildkite: Require Sonatype OSS Index auth for nancy audit

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -12,6 +12,7 @@ docker_plugin_default_config: &docker_plugin_default_config
   volumes:
     - /var/lib/buildkite-agent/.coveralls:/root/.coveralls
     - /var/lib/buildkite-agent/.codecov:/root/.codecov
+    - /var/lib/buildkite-agent/.sonatype:/root/.sonatype
     # IAS Development API keys.
     - /var/lib/buildkite-agent/.oasis-ias:/root/.oasis-ias
     # Intel SGX Application Enclave Services Manager (AESM) daemon running on

--- a/.buildkite/go/nancy_audit.sh
+++ b/.buildkite/go/nancy_audit.sh
@@ -5,16 +5,40 @@
 # reported security vulnerabilities.
 #
 # Usage:
-# nancy_audit.sh
+# nancy_audit.sh [path_to_sonatype_oss_index_username] [path_to_sonatype_oss_index_token]
+#
+# path_to_sonatype_oss_index_username - Absolute or relative
+#     path to a file that contains the Sonatype OSS Index
+#     account username. Defaults to "~/.sonatype/oss_index_username".
+# path_to_sonatype_oss_index_token - Absolute or relative
+#     path to a file that contains the Sonatype OSS Index
+#     API token. Defaults to "~/.sonatype/oss_index_token".
 ############################################################
 
 # Helpful tips on writing build scripts:
 # https://buildkite.com/docs/pipelines/writing-build-scripts
 set -euxo pipefail
 
+###############
+# Optional args
+###############
+path_to_sonatype_oss_index_username=${1:-~/.sonatype/oss_index_username}
+path_to_sonatype_oss_index_token=${2:-~/.sonatype/oss_index_token}
+
+############
+# Local vars
+############
+set +x
+sonatype_oss_index_username=$(cat ${path_to_sonatype_oss_index_username})
+sonatype_oss_index_token=$(cat ${path_to_sonatype_oss_index_token})
+set -x
+
 ########################################
 # Check dependencies for vulnerabilities
 ########################################
 pushd go/oasis-node
-    go list -json -deps | nancy sleuth -x ../.nancy-ignore
+    go list -json -deps | nancy sleuth \
+        --username ${sonatype_oss_index_username} \
+        --token ${sonatype_oss_index_token} \
+        -x ../.nancy-ignore
 popd

--- a/.buildkite/go/nancy_audit.sh
+++ b/.buildkite/go/nancy_audit.sh
@@ -5,40 +5,29 @@
 # reported security vulnerabilities.
 #
 # Usage:
-# nancy_audit.sh [path_to_sonatype_oss_index_username] [path_to_sonatype_oss_index_token]
+# nancy_audit.sh
 #
-# path_to_sonatype_oss_index_username - Absolute or relative
-#     path to a file that contains the Sonatype OSS Index
-#     account username. Defaults to "~/.sonatype/oss_index_username".
-# path_to_sonatype_oss_index_token - Absolute or relative
-#     path to a file that contains the Sonatype OSS Index
-#     API token. Defaults to "~/.sonatype/oss_index_token".
+# Expects Sonatype OSS Index account username and API token in
+# "~/.sonatype/oss_index_username" and "~/.sonatype/oss_index_token".
 ############################################################
 
 # Helpful tips on writing build scripts:
 # https://buildkite.com/docs/pipelines/writing-build-scripts
 set -euxo pipefail
 
-###############
-# Optional args
-###############
-path_to_sonatype_oss_index_username=${1:-~/.sonatype/oss_index_username}
-path_to_sonatype_oss_index_token=${2:-~/.sonatype/oss_index_token}
-
-############
-# Local vars
-############
+#######################
+# Environment variables
+#######################
 set +x
-sonatype_oss_index_username=$(cat ${path_to_sonatype_oss_index_username})
-sonatype_oss_index_token=$(cat ${path_to_sonatype_oss_index_token})
+OSSI_USERNAME=$(cat ~/.sonatype/oss_index_username)
+OSSI_TOKEN=$(cat ~/.sonatype/oss_index_token)
+export OSSI_USERNAME
+export OSSI_TOKEN
 set -x
 
 ########################################
 # Check dependencies for vulnerabilities
 ########################################
 pushd go/oasis-node
-    go list -json -deps | nancy sleuth \
-        --username ${sonatype_oss_index_username} \
-        --token ${sonatype_oss_index_token} \
-        -x ../.nancy-ignore
+    go list -json -deps | nancy sleuth -x ../.nancy-ignore
 popd


### PR DESCRIPTION
Implementing authentication for our Nancy audit Buildkite step, as Sonatype OSS Index now requires authentication.