### PR TITLE
go/runtime/manager: Fix temporary bundle path

### DIFF
--- a/.changelog/6375.bugfix.md
+++ b/.changelog/6375.bugfix.md
@@ -1,0 +1,1 @@
+go/runtime/manager: Fix temporary bundle path

--- a/go/runtime/bundle/manager.go
+++ b/go/runtime/bundle/manager.go
@@ -350,7 +350,7 @@ func (m *Manager) AddTemporary(tmpPath string, opts ...AddOption) error {
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(m.tmpBundleDir, root.Name(), fi.Name())
+	path := filepath.Join(root.Name(), fi.Name())
 
 	return m.Add(path, opts...)
 }


### PR DESCRIPTION
`root.Name()` already returns the full path. 

This might have caused some issues on the testnet provider after node upgrade:

```
 net.oasis.error: module: unknown code: 1 message: failed to open bundle: runtime/bundle: failed to open bundle: open /node/data/runtimes/tmp/bundles/node/data/runtimes/tmp/bundles/d8f764ac129c15684291a35ce606b0dbf6aeebd6205dbf2e3a69d41994b57598/instance-00000000000003a9: no such file or directory
```


`root.Name()` test:
```go
package main

import (
	"fmt"
	"os"
)

func main() {
	_ = os.MkdirAll("/tmp/x/y", 0o755)

	root, err := os.OpenRoot("/tmp/x/y")
	if err != nil {
		panic(err)
	}
	defer root.Close()

	fmt.Println("root.Name() =", root.Name())
}

// outputs: root.Name() = /tmp/x/y
```