### PR TITLE
Changelog 21.0.2

### DIFF
--- a/.changelog/3819.feature.md
+++ b/.changelog/3819.feature.md
@@ -1,1 +1,0 @@
-go/staking: Improve pretty-print for `Escrow`/`ReclaimEscrow` transactions

--- a/.changelog/3820.bugfix.md
+++ b/.changelog/3820.bugfix.md
@@ -1,1 +1,0 @@
-go/worker/storage: Fix Finalize and Apply failure handling

--- a/.changelog/3820.internal.1.md
+++ b/.changelog/3820.internal.1.md
@@ -1,1 +1,0 @@
-go/worker/storage: Add independent heartbeat for syncing retries

--- a/.changelog/3820.internal.2.md
+++ b/.changelog/3820.internal.2.md
@@ -1,1 +1,0 @@
-go/storage/client: Implement node blacklisting

--- a/.changelog/3830.bugfix.md
+++ b/.changelog/3830.bugfix.md
@@ -1,4 +1,0 @@
-go/storage: Fix failure handling in checkpoint syncing
-
-In some cases, the database could be left in a corrupt state after a
-checkpoint chunk failed to be restored.

--- a/.changelog/6349.feature.md
+++ b/.changelog/6349.feature.md
@@ -1,6 +1,0 @@
-Add archive mode support
-
-Node started in archive mode only serves existing consensus and runtime
-states. The node has all unneeded consensus and P2P functionality disabled so
-it won't participate in the network. Archive mode can be set using the
-`consensus.tendermint.mode` setting.

--- a/.punch_version.py
+++ b/.punch_version.py
@@ -1,3 +1,3 @@
 year = '21'
 minor = 0
-micro = 1
+micro = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ The format is inspired by [Keep a Changelog].
 
 <!-- TOWNCRIER -->
 
+## 21.0.2 (2025-10-29)
+
+> ⚠️ **Note:** This release is intended only for archive nodes serving historical state.
+> Other functionality is not maintained or guaranteed to work.
+
+| Protocol          | Version   |
+|:------------------|:---------:|
+| Consensus         | 3.0.0     |
+| Runtime Host      | 2.0.0     |
+| Runtime Committee | 2.0.0     |
+
+### Features
+
+- Add archive mode support
+  ([#6349](https://github.com/oasisprotocol/oasis-core/issues/6349))
+
+  Node started in archive mode only serves existing consensus and runtime
+  states. The node has all unneeded consensus and P2P functionality disabled so
+  it won't participate in the network. Archive mode can be set using the
+  `consensus.tendermint.mode` setting.
+
 ## 21.0.1 (2021-03-22)
 
 | Protocol          | Version   |


### PR DESCRIPTION
Prepare a release for https://github.com/oasisprotocol/oasis-core/pull/6350

This is the last backport release we are missing for archive nodes.

Note that the release will be done manually, since the outdated CI jobs on the stable/21.0.x branches are most likely not working anymore.

Similar as it was done for https://github.com/oasisprotocol/oasis-core/releases/tag/v20.12.8 and https://github.com/oasisprotocol/oasis-core/releases/tag/v20.10.2

We will publish/make the release public at a later date, right before we release a new oasis-core version so that these release wont be at the top.