### PR TITLE
registry/api: Use nil instead of empty slices

### DIFF
--- a/.changelog/6413.bugfix.md
+++ b/.changelog/6413.bugfix.md
@@ -1,0 +1,1 @@
+registry/api: Use nil instead of empty slices

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -1523,7 +1523,7 @@ func StakeClaimForRuntime(id common.Namespace) staking.StakeClaim {
 // The passed list of runtimes must be unique runtime descriptors for all runtimes that the node is
 // registered for.
 func StakeThresholdsForNode(n *node.Node, rts []*Runtime) []staking.StakeThreshold {
-	thresholds := make([]staking.StakeThreshold, 0)
+	var thresholds []staking.StakeThreshold
 
 	// Validator nodes are global.
 	if n.HasRoles(node.RoleValidator) {

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -890,7 +890,7 @@ func GlobalStakeThreshold(kind ThresholdKind) StakeThreshold {
 
 // GlobalStakeThresholds creates a new list of global StakeThresholds.
 func GlobalStakeThresholds(kinds ...ThresholdKind) []StakeThreshold {
-	sts := make([]StakeThreshold, 0, len(kinds))
+	var sts []StakeThreshold
 	for _, k := range kinds {
 		sts = append(sts, GlobalStakeThreshold(k))
 	}

--- a/go/staking/api/api_test.go
+++ b/go/staking/api/api_test.go
@@ -201,6 +201,25 @@ func TestStakeThreshold(t *testing.T) {
 	}
 }
 
+func TestGlobalStakeThresholds(t *testing.T) {
+	t.Run("No kinds", func(t *testing.T) {
+		// The returned slice must be nil (not empty) to ensure consistent
+		// CBOR encoding in the consensus state.
+		thresholds := GlobalStakeThresholds()
+		require.Nil(t, thresholds)
+	})
+
+	t.Run("One kind", func(t *testing.T) {
+		thresholds := GlobalStakeThresholds(KindEntity)
+		require.Len(t, thresholds, 1)
+	})
+
+	t.Run("Multiple kinds", func(t *testing.T) {
+		thresholds := GlobalStakeThresholds(KindEntity, KindNodeCompute, KindNodeKeyManager)
+		require.Len(t, thresholds, 3)
+	})
+}
+
 func TestStakeAccumulator(t *testing.T) {
 	require := require.New(t)
 

--- a/go/storage/mkvs/db/api/api.go
+++ b/go/storage/mkvs/db/api/api.go
@@ -120,7 +120,7 @@ func PolicyForRoot(root node.Root) *RootPolicy {
 
 // RootTypesWithPolicy returns all root types where the given policy predicate evaluates to true.
 func RootTypesWithPolicy(policyFn func(*RootPolicy) bool) []node.RootType {
-	types := make([]node.RootType, 0)
+	var types []node.RootType
 	for rootType, policy := range rootPolicies {
 		if policyFn(policy) {
 			types = append(types, rootType)

--- a/go/storage/mkvs/db/badger/badger.go
+++ b/go/storage/mkvs/db/badger/badger.go
@@ -505,7 +505,7 @@ func (d *badgerNodeDB) GetRootsForVersion(version uint64) ([]node.Root, error) {
 		return nil, err
 	}
 
-	roots := make([]node.Root, 0, len(rootsMeta.Roots))
+	var roots []node.Root
 	for rootHash := range rootsMeta.Roots {
 		roots = append(roots, node.Root{
 			Namespace: d.namespace,

--- a/go/storage/mkvs/db/pathbadger/pathbadger.go
+++ b/go/storage/mkvs/db/pathbadger/pathbadger.go
@@ -191,7 +191,7 @@ func (d *badgerNodeDB) GetRootsForVersion(version uint64) ([]node.Root, error) {
 	it := tx.NewIterator(badger.IteratorOptions{Prefix: prefix})
 	defer it.Close()
 
-	roots := make([]node.Root, 0)
+	var roots []node.Root
 	for it.Rewind(); it.Valid(); it.Next() {
 		var (
 			v        uint64


### PR DESCRIPTION
Reverting slice changes from:
- https://github.com/oasisprotocol/oasis-core/pull/6383