### PR TITLE
go/common/version: Bump runtime host protocol version to v6.0.0

### DIFF
--- a/.changelog/6417.internal.md
+++ b/.changelog/6417.internal.md
@@ -1,0 +1,5 @@
+go/common/version: Bump runtime host protocol version to v6.0.0
+
+When fetching a light block from consensus, the runtime host protocol
+must support validator set retrieval, which was already introduced
+in version v25.8.

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -148,7 +148,7 @@ var (
 	// the runtime.
 	//
 	// NOTE: This version must be synced with runtime/src/common/version.rs.
-	RuntimeHostProtocol = Version{Major: 5, Minor: 1, Patch: 0}
+	RuntimeHostProtocol = Version{Major: 6, Minor: 0, Patch: 0}
 
 	// RuntimeCommitteeProtocol versions the P2P protocol used by the runtime
 	// committee members.

--- a/runtime/src/common/version.rs
+++ b/runtime/src/common/version.rs
@@ -63,8 +63,8 @@ impl From<u64> for Version {
 // and the runtime. This version MUST be compatible with the one supported by
 // the worker host.
 pub const PROTOCOL_VERSION: Version = Version {
-    major: 5,
-    minor: 1,
+    major: 6,
+    minor: 0,
     patch: 0,
 };
 


### PR DESCRIPTION
When fetching a light block from consensus, the runtime host protocol must support validator set retrieval, which was already introduced in version v25.8.