### PR TITLE
go/worker/storage/committee: Fix teardown

### DIFF
--- a/.changelog/6444.bugfix.md
+++ b/.changelog/6444.bugfix.md
@@ -1,0 +1,1 @@
+go/worker/storage/committee: Fix worker teardown


### PR DESCRIPTION
https://github.com/oasisprotocol/internal-ops/issues/1317#issuecomment-3765815368 showed that in case of corrupted storage, our worker teardown might get stuck.

## How to test

Start your node with paratime configured and return a dummy error [here](https://github.com/oasisprotocol/oasis-core/blob/4aca0773e2257c619233f3dfc649faf73168b39a/go/worker/storage/committee/worker.go#L1280).

Prior to this change indexer would continue, whilst storage worker would get stuck at teardown.

It would be nice to have a test for this, but we would need to completely refactor storage worker first. Mainly all the state DB, p2p and other stuff should be passed as parameters, so that errors can be mocked in the "integration" tests.