### PR TITLE
go/worker/storage/committee: Fix prune handler

### DIFF
--- a/.changelog/6445.bugfix.md
+++ b/.changelog/6445.bugfix.md
@@ -1,0 +1,4 @@
+go/worker/storage/committee: Fix prune handler
+
+Prune handler had an edge case when State DB was empty,
+which could cause runtime light history to be pruned prematurely.

--- a/go/worker/storage/committee/prune.go
+++ b/go/worker/storage/committee/prune.go
@@ -20,6 +20,9 @@ type pruneHandler struct {
 // Implements runtime.history.PruneHandler.
 func (p *pruneHandler) CanPruneRuntime(rounds []uint64) error {
 	lastSycnedRound, _, _ := p.worker.GetLastSynced()
+	if lastSycnedRound == defaultUndefinedRound {
+		return fmt.Errorf("worker/storage: tried to prune past last synced round (empty state db)")
+	}
 
 	for _, round := range rounds {
 		if round >= lastSycnedRound {


### PR DESCRIPTION
We had this bug ever since, just nobody noticed.

If you set runtime with pruning and genesis sync, first thing will be the runtime light history created by indexing consensus data. Light history is needed to fetch corresponding runtime state. To prevent too early pruning of light history, prune handlers don't allow to prune it past last synced round.

Unfortunately, if the runtime state DB is empty, `worker.GetLastSynced()` returns `defaultUndefinedRound` that equals to max `uint64`, effectively allowing to prune anything. This removes early light history, and the node is then later (once consensus is synced) stuck at checkpoint sync, as there is no corresponding light block to verify the genesis checkpoint against.

Also noticed pruning with default parameters is set to 64 rounds every 2 minutes. With https://github.com/oasisprotocol/oasis-core/pull/6355 merged, we might want to bump the defaults...