### PR TITLE
go/worker/storage: Fix runtime state pruner

### DIFF
--- a/.changelog/6446.bugfix.md
+++ b/.changelog/6446.bugfix.md
@@ -1,0 +1,5 @@
+go/worker/storage: Fix runtime state pruner
+
+Disabling pruning shouldn't prune any data including stale one
+(data marked as ready to be pruned) from the previous run when
+node had pruning enabled.

--- a/go/runtime/config/config.go
+++ b/go/runtime/config/config.go
@@ -377,6 +377,11 @@ type PruneConfig struct {
 	NumKept uint64 `yaml:"num_kept"`
 }
 
+// IsEnabled returns true when pruning is enabled.
+func (p PruneConfig) IsEnabled() bool {
+	return p.Strategy != "none"
+}
+
 // IndexerConfig is history indexer configuration.
 type IndexerConfig struct {
 	// BatchSize is max number of blocks committed in a batch during history reindex.

--- a/go/worker/storage/worker.go
+++ b/go/worker/storage/worker.go
@@ -109,7 +109,10 @@ func (w *Worker) registerRuntime(commonNode *committeeCommon.Node) error {
 			Disabled:          config.GlobalConfig.Storage.CheckpointSyncDisabled,
 			ChunkFetcherCount: config.GlobalConfig.Storage.FetcherCount,
 		},
-		config.GlobalConfig.Runtime.Prune.Interval,
+		committee.PruneConfig{
+			Enabled:  config.GlobalConfig.Runtime.Prune.IsEnabled(),
+			Interval: config.GlobalConfig.Runtime.Prune.Interval,
+		},
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Bug
Prior to this change it could happen that if you had pruning configured and then you disable it, the runtime state would still be pruned on the next restart.

This is because light history and runtime state pruning are decoupled, and state pruner simply removes all state rounds older than the last retained light history round. Since light history pruning is much faster, it could happen that even after restart and explicitly disabling pruning the pruner would still have some pending work to do.

## Context

This bug was introduced as part of https://github.com/oasisprotocol/oasis-core/pull/6355, which actually didn't solve the issue: https://github.com/oasisprotocol/oasis-core/pull/6446#issuecomment-3781697925.

~At that time https://github.com/oasisprotocol/oasis-core/pull/6355 was benched and it indeed solved the issue of sync getting effectively stopped due to slow pruning (in case of large state DB, https://github.com/oasisprotocol/oasis-core/issues/6334).  Exploring again if background pruning can still negatively impact syncing speed, as there were some such reports recently. Likely this is the case with "hot loops", although it seems to me that speed is also affected a lot by the age of the storage diffs (data availability).~

## Additional consideration
We should rate limit max number of versions that can be pruned in the given interval. This is already the case for the runtime light history. Consensus also suffers from this problem ~but is out of our hands~ and indeed configuring pruning there if done aggressively on large state can cause the node to halt a bit (negligible compared to runtimes) (currently mitigated with offline pruning). 

## Future Direction / Testing / Performance Regression

Like the previous 2 PRs about the storage worker, this is impossible to test unless this worker is refactored as [proposed](https://github.com/oasisprotocol/oasis-core/issues/6307#issuecomment-3591833009), so that we can test unhappy paths and or mock resources. This would also open possibility for automating performance regression tests, e.g. sanity sync(s) with pruning enabled prior to releasing a new release.

Imo, we should step it up when it comes to integration tests, else it is hard to guarantee correct code behavior.  At the same time this can quickly scope creep, as there is a lot of tech debt when it comes to making our workers testable and as with every refactor it increases the risk of introducing new bugs, unless done "perfectly" (takes resources :/).

 



