### PR TITLE
go/common/version: Trim pre-release suffixes

### DIFF
--- a/.changelog/6447.internal.md
+++ b/.changelog/6447.internal.md
@@ -1,0 +1,5 @@
+go/common/version: Trim pre-release suffixes
+
+Updated version.FromString to trim 'rc', 'alpha', and 'beta' suffixes without
+hyphens when parsing version strings. Added test cases to ensure correct
+parsing of versions with pre-release suffixes.

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -83,6 +83,10 @@ func FromString(s string) (Version, error) {
 	s = strings.Split(s, "-")[0]
 	// Trim potential git commit.
 	s = strings.Split(s, "+")[0]
+	// Trim potential pre-release suffixes without hyphen.
+	s = strings.Split(s, "rc")[0]
+	s = strings.Split(s, "alpha")[0]
+	s = strings.Split(s, "beta")[0]
 	// Take at most four components: major.minor.patch.remainder.
 	split := strings.SplitN(s, ".", 4)
 

--- a/go/common/version/version_test.go
+++ b/go/common/version/version_test.go
@@ -82,6 +82,10 @@ func TestFromString(t *testing.T) {
 		{"1.0", Version{1, 0, 0}},
 		{"1", Version{1, 0, 0}},
 		{"1.2.3.4", Version{1, 2, 3}},
+		{"1.26rc3", Version{1, 26, 0}},
+		{"1.26-rc3", Version{1, 26, 0}},
+		{"1.26beta3", Version{1, 26, 0}},
+		{"1.26-beta3", Version{1, 26, 0}},
 	} {
 		version, err := FromString(v.semver)
 		require.NoError(err)


### PR DESCRIPTION
Updated version.FromString to trim 'rc', 'alpha', and 'beta' suffixes without hyphens when parsing version strings. Added test cases to ensure correct parsing of versions with pre-release suffixes.

Ref:
* Found in https://github.com/Homebrew/homebrew-core/pull/258912 with oasis test failure: `panic: version: failed to parse SemVer '1.26rc1': strconv.ParseUint: parsing "26rc1": invalid syntax`
* Sadly, the Go https://github.com/golang/go/issues/32450 was declined.

after this is merged and released it would need an update in https://github.com/oasisprotocol/cli

Thanks/Hvala!