### PR TITLE
go/worker/storage/committee: Refactor diff sync

### DIFF
--- a/go/worker/storage/committee/diffsync/fetcher.go
+++ b/go/worker/storage/committee/diffsync/fetcher.go
@@ -1,0 +1,394 @@
+package diffsync
+
+import (
+	"container/heap"
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
+	"github.com/oasisprotocol/oasis-core/go/runtime/history"
+	storageApi "github.com/oasisprotocol/oasis-core/go/storage/api"
+	"github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/diffsync"
+	"github.com/oasisprotocol/oasis-core/go/worker/storage/p2p/synclegacy"
+)
+
+type P2PFetcher struct {
+	logger            *logging.Logger
+	history           history.History
+	diffSync          diffsync.Client
+	legacyStorageSync synclegacy.Client
+	undefinedRound    uint64
+	lastFullyApplied  uint64
+	nextCh            chan Diff
+	acceptCh          chan struct{}
+	rejectCh          chan struct{}
+	rejectTaskCh      chan fetchTask
+	diffCh            chan diffRes
+	fetcherCount      uint
+}
+
+func NewP2PFetcher(
+	history history.History,
+	diffSync diffsync.Client,
+	legacyStorageSync synclegacy.Client,
+	lastFullyApplied,
+	undefinedRound uint64,
+	fetcherCount uint,
+) *P2PFetcher {
+	return &P2PFetcher{
+		logger:            logging.GetLogger("worker/storage/committee/fetcher").With("runtime_id", history.RuntimeID()),
+		history:           history,
+		diffSync:          diffSync,
+		legacyStorageSync: legacyStorageSync,
+		undefinedRound:    undefinedRound,
+		lastFullyApplied:  lastFullyApplied,
+		nextCh:            make(chan Diff),
+		diffCh:            make(chan diffRes),
+		rejectCh:          make(chan struct{}, 1),
+		acceptCh:          make(chan struct{}, 1),
+		rejectTaskCh:      make(chan fetchTask), // TODO consider adding more.
+		fetcherCount:      fetcherCount,
+	}
+}
+
+// Next returns whean a next storage diff is ready to be applied.
+//
+// Invariants:
+//   - A call to Next is blocking.
+//   - It is not safe to call next before either Acceept and or Reject.
+//   - The order of storage and IO diffs for a single round is not guaranteed.
+func (f *P2PFetcher) Next(ctx context.Context) (Diff, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return Diff{}, ctx.Err()
+		case diff, ok := <-f.nextCh:
+			if !ok {
+				return Diff{}, fmt.Errorf("fetcher closed")
+			}
+			return diff, nil
+		}
+	}
+}
+
+// Accept accepts a storage diff obtained via call to Next.
+func (f *P2PFetcher) Accept() {
+	select {
+	case f.acceptCh <- struct{}{}:
+	default:
+	}
+}
+
+// Reject rejects a storage diff obtained via call to Next.
+func (f *P2PFetcher) Reject() {
+	select {
+	case f.rejectCh <- struct{}{}:
+	default:
+	}
+}
+
+func (f *P2PFetcher) Serve(ctx context.Context) error {
+	var (
+		lastDiff      diffRes
+		acceptedCount int
+		pendingAck    bool
+	)
+	pendingApply := &minRoundQueue{}
+
+	lastFullyApplied := f.lastFullyApplied
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	producer, taskCh := newTaskProducer(f.history, f.logger, lastFullyApplied, f.undefinedRound, f.fetcherCount)
+	wg.Go(func() {
+		if err := producer.serve(ctx); err != nil {
+			f.logger.Error("producer failed", "err", err)
+		}
+	})
+
+	for i := uint(0); i < f.fetcherCount; i++ {
+		wg.Go(func() {
+			for task := range taskCh {
+				res, _ := f.fetchWithRetry(ctx, task) // TODO handle the error or omit it.
+				select {
+				case f.diffCh <- res:
+				case <-ctx.Done():
+				}
+			}
+		})
+	}
+
+	wg.Go(func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case task := <-f.rejectTaskCh:
+				res, _ := f.fetchWithRetry(ctx, task) // TODO handle the error or omit it.
+				select {
+				case f.diffCh <- res:
+				case <-ctx.Done():
+				}
+			}
+		}
+	})
+
+	trySendingNextForApply := func() {
+		if pendingAck {
+			return
+		}
+		hasNext := pendingApply.Len() > 0 && lastFullyApplied+1 == (*pendingApply)[0].round
+		if !hasNext {
+			return
+		}
+		pendingAck = true
+		lastDiff = heap.Pop(pendingApply).(diffRes)
+		wg.Go(func() {
+			select {
+			case <-ctx.Done():
+				return
+			case f.nextCh <- Diff{
+				round:    lastDiff.round,
+				prevRoot: lastDiff.prevRoot,
+				thisRoot: lastDiff.thisRoot,
+				writeLog: lastDiff.writeLog}:
+			}
+		})
+	}
+
+	for {
+		select { // For optimal performance no case should be blocking.
+		case <-ctx.Done():
+			return ctx.Err()
+		case diff := <-f.diffCh:
+			heap.Push(pendingApply, diff)
+			trySendingNextForApply()
+		case <-f.rejectCh:
+			lastDiff.pf.RecordBadPeer()
+			pendingAck = false
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case f.rejectTaskCh <- lastDiff.fetchTask:
+			}
+		case <-f.acceptCh:
+			lastDiff.pf.RecordSuccess()
+			acceptedCount++
+			if acceptedCount == 2 {
+				lastFullyApplied++
+				acceptedCount = 0
+			}
+			pendingAck = false
+			trySendingNextForApply()
+		}
+	}
+}
+
+// TODO add backoff.
+func (f *P2PFetcher) fetchWithRetry(ctx context.Context, task fetchTask) (diffRes, error) {
+	result := diffRes{
+		fetchTask: task,
+		pf:        rpc.NewNopPeerFeedback(),
+	}
+
+	if task.thisRoot.Hash.Equal(&task.prevRoot.Hash) {
+		result.writeLog = storageApi.WriteLog{}
+		return result, nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		default:
+		}
+
+		wl, pf, err := f.getDiff(ctx, task.prevRoot, task.thisRoot)
+		if err != nil {
+			f.logger.Error("failed to fetch storage diff", "err", err)
+			continue
+		}
+		result.pf = pf
+		result.writeLog = wl
+		return result, err
+	}
+}
+
+// getDiff fetches writelog using diff sync p2p protocol client.
+//
+// In case of no peers or error, it fallbacks to the legacy storage sync protocol.
+func (f *P2PFetcher) getDiff(ctx context.Context, prevRoot, thisRoot storageApi.Root) (storageApi.WriteLog, rpc.PeerFeedback, error) {
+	f.logger.Debug("calling GetDiff",
+		"old_root", prevRoot,
+		"new_root", thisRoot,
+	)
+
+	// diffResponseTimeout is the maximum time for fetching storage diff from the peer.
+	const diffResponseTimeout = 15 * time.Second
+
+	ctx, cancel := context.WithTimeout(ctx, diffResponseTimeout)
+	defer cancel()
+	rsp1, pf, err := f.diffSync.GetDiff(ctx, &diffsync.GetDiffRequest{StartRoot: prevRoot, EndRoot: thisRoot})
+	if err == nil { // if NO error
+		return rsp1.WriteLog, pf, nil
+	}
+
+	ctx, cancel = context.WithTimeout(ctx, diffResponseTimeout)
+	defer cancel()
+	rsp2, pf, err := f.legacyStorageSync.GetDiff(ctx, &synclegacy.GetDiffRequest{StartRoot: prevRoot, EndRoot: thisRoot})
+	if err != nil {
+		return nil, nil, err
+	}
+	return rsp2.WriteLog, pf, nil
+}
+
+type fetchTask struct {
+	round    uint64
+	prevRoot storageApi.Root
+	thisRoot storageApi.Root
+}
+
+type taskProducer struct {
+	history        history.History
+	logger         *logging.Logger
+	undefinedRound uint64
+	lastEnqueued   uint64
+	prevStateRoot  storageApi.Root
+	tasks          chan fetchTask
+}
+
+func newTaskProducer(
+	history history.History,
+	logger *logging.Logger,
+	lastFullyApplied uint64,
+	undefinedRound uint64,
+	queueSize uint,
+) (*taskProducer, <-chan fetchTask) {
+	producer := &taskProducer{
+		history:        history,
+		logger:         logger,
+		undefinedRound: undefinedRound,
+		lastEnqueued:   lastFullyApplied,
+		tasks:          make(chan fetchTask, queueSize),
+	}
+	return producer, producer.tasks
+}
+
+func (p *taskProducer) serve(ctx context.Context) error {
+	blkCh, sub, err := p.history.WatchCommittedBlocks()
+	if err != nil {
+		return fmt.Errorf("subscribing to commited blocks: %w", err)
+	}
+	if err := p.initState(ctx); err != nil {
+		sub.Close()
+		return err
+	}
+
+	defer close(p.tasks)
+	defer sub.Close()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case next, ok := <-blkCh:
+			if !ok {
+				return nil
+			}
+			p.logger.Debug("producer received new block", "blk", next.Block)
+			if err := p.fillUntil(ctx, next.Block); err != nil {
+				p.logger.Warn("failed to fill fetch task gap: %w", err)
+			}
+		}
+	}
+}
+
+func (p *taskProducer) initState(ctx context.Context) error {
+	if p.lastEnqueued == p.undefinedRound {
+		p.prevStateRoot = storageApi.Root{
+			Namespace: p.history.RuntimeID(),
+			Version:   p.lastEnqueued + 1,
+			Type:      storageApi.RootTypeState,
+		}
+		p.prevStateRoot.Empty()
+		return nil
+	}
+
+	blk, err := p.history.GetCommittedBlock(ctx, p.lastEnqueued)
+	if err != nil {
+		return fmt.Errorf("get history block (round: %d): %w", p.lastEnqueued, err)
+	}
+	p.prevStateRoot = blk.Header.StorageRootState()
+	return nil
+}
+
+func (p *taskProducer) enqueue(ctx context.Context, blk *block.Block) {
+	emit := func(task fetchTask) {
+		select {
+		case <-ctx.Done():
+			return
+		case p.tasks <- task:
+			p.logger.Debug("enqueued new fetch task", "task", task)
+		}
+	}
+
+	thisIORoot := blk.Header.StorageRootIO()
+	prevIORoot := thisIORoot
+	prevIORoot.Hash.Empty()
+	emit(fetchTask{blk.Header.Round, prevIORoot, thisIORoot})
+
+	thisStateRoot := blk.Header.StorageRootState()
+	emit(fetchTask{blk.Header.Round, p.prevStateRoot, thisStateRoot})
+	p.prevStateRoot = thisStateRoot
+
+	p.lastEnqueued = blk.Header.Round
+}
+
+func (p *taskProducer) fillUntil(ctx context.Context, blk *block.Block) error {
+	for r := p.lastEnqueued + 1; r < blk.Header.Round; r++ {
+		blk, err := p.history.GetCommittedBlock(ctx, r)
+		if err != nil {
+			return fmt.Errorf("failed to get light block (round: %d): %w", r, err)
+		}
+		p.enqueue(ctx, blk)
+	}
+	p.enqueue(ctx, blk)
+	return nil
+}
+
+// minRoundQueue is a round-based min priority queue.
+type minRoundQueue []diffRes
+
+// Sorting interface.
+func (q minRoundQueue) Len() int           { return len(q) }
+func (q minRoundQueue) Less(i, j int) bool { return q[i].round < q[j].round }
+func (q minRoundQueue) Swap(i, j int)      { q[i], q[j] = q[j], q[i] }
+
+// Push appends x as the last element in the heap's array.
+func (q *minRoundQueue) Push(x any) {
+	*q = append(*q, x.(diffRes))
+}
+
+// Pop removes and returns the last element in the heap's array.
+func (q *minRoundQueue) Pop() any {
+	old := *q
+	n := len(old)
+	x := old[n-1]
+	*q = old[0 : n-1]
+	return x
+}
+
+// diffRes has all the context needed for a single GetDiff operation.
+type diffRes struct {
+	fetchTask
+	pf       rpc.PeerFeedback
+	writeLog storageApi.WriteLog
+}

--- a/go/worker/storage/committee/diffsync/worker.go
+++ b/go/worker/storage/committee/diffsync/worker.go
@@ -1,0 +1,174 @@
+package diffsync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	storageApi "github.com/oasisprotocol/oasis-core/go/storage/api"
+	dbApi "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/runtime/history"
+)
+
+type Fetcher interface {
+	Next(ctx context.Context) (Diff, error)
+	Accept()
+	Reject()
+}
+
+// Diff has a writelog, so that applying it to the state with prevRoot
+// produces a new state that corresponds to thisRoot.
+type Diff struct {
+	round    uint64
+	prevRoot storageApi.Root
+	thisRoot storageApi.Root
+	writeLog storageApi.WriteLog
+}
+
+type Finalized struct {
+	Round uint64
+	Roots []storageApi.Root
+}
+
+type Worker struct {
+	logger       *logging.Logger
+	fetcher      Fetcher
+	localStorage storageApi.LocalBackend
+	updates      chan Finalized
+}
+
+// New creates a new diff sync worker.
+//
+// Fetcher implements fetching storage diffs, that are then applied ot the localStorage.
+func New(history history.History, localStorage storageApi.LocalBackend, fetcher Fetcher) *Worker {
+	return &Worker{
+		logger:       logging.GetLogger("worker/storage/committee/diffsync").With("runtime_id", history.RuntimeID()),
+		localStorage: localStorage,
+		fetcher:      fetcher,
+		updates:      make(chan Finalized, 1),
+	}
+}
+
+func (w *Worker) Updates() <-chan Finalized {
+	return w.updates
+}
+
+// Serve fetches, applies and finalizes storage diffs.
+func (w *Worker) Serve(ctx context.Context) error {
+	defer close(w.updates)
+
+	w.logger.Info("starting")
+	defer w.logger.Info("stopping")
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	appliedCh := make(chan []storageApi.Root, dbApi.MaxPendingVersions)
+	defer close(appliedCh)
+
+	// Apply.
+	g.Go(func() error {
+		var applied []storageApi.Root
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+
+			diff, err := w.fetcher.Next(ctx)
+			if err != nil {
+				w.logger.Error("fetcher failed to fetch next diff", "err", err)
+				continue
+			}
+
+			// If thisRoot already exists then localStorage.Apply ignores request.
+			// Consider writting a test for this assumption, so that if Apply changes
+			// we catch semantic change.
+			if err = w.localStorage.Apply(ctx, &storageApi.ApplyRequest{
+				Namespace: diff.thisRoot.Namespace,
+				RootType:  diff.thisRoot.Type,
+				SrcRound:  diff.prevRoot.Version,
+				SrcRoot:   diff.prevRoot.Hash,
+				DstRound:  diff.thisRoot.Version,
+				DstRoot:   diff.thisRoot.Hash,
+				WriteLog:  diff.writeLog,
+			}); err != nil {
+				w.logger.Error("failed to apply storage diff", "err", err)
+				w.fetcher.Reject()
+				continue
+				// TODO error handling has now changed.
+			}
+
+			w.logger.Debug("applied", "root", diff.thisRoot)
+			w.fetcher.Accept()
+			applied = append(applied, diff.thisRoot)
+
+			// The worker expected that two storage roots are always finalized.
+			// Maybe it should not.
+			if len(applied) < 2 {
+				continue
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case appliedCh <- applied:
+				applied = nil
+			}
+		}
+	})
+
+	// Finalize.
+	g.Go(func() error {
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case roots := <-appliedCh:
+				finalized, err := w.finalize(roots)
+				if err != nil {
+					return fmt.Errorf("failed to finalize: %w", err)
+				}
+				w.notify(finalized)
+			}
+		}
+	})
+
+	return g.Wait()
+}
+
+func (w *Worker) finalize(roots []storageApi.Root) (Finalized, error) {
+	err := w.localStorage.NodeDB().Finalize(roots)
+
+	var round uint64
+	for _, root := range roots {
+		round = root.Version
+	}
+
+	switch {
+	case err == nil:
+		w.logger.Debug("finalized", "round", round)
+	case errors.Is(err, storageApi.ErrAlreadyFinalized):
+		// This can happen if we are restoring after a roothash migration or if
+		// we crashed before updating the sync state.
+		w.logger.Warn("already finalized", "round", round)
+	default:
+		return Finalized{}, fmt.Errorf("failed to finalize (round: %d): %w", round, err)
+	}
+	return Finalized{round, roots}, nil
+}
+
+func (w *Worker) notify(f Finalized) {
+	select {
+	case w.updates <- f:
+	default:
+		select {
+		case <-w.updates:
+		default:
+		}
+		w.updates <- f
+	}
+}


### PR DESCRIPTION
Improve worker performance and make it more readable, idiomatic, testable and benchmarkable. **The idea of this PR is to first assess whether refactor is worth it.**

Looking at `25.6` and `25.9` logs, the queuing of the tasks was not optimal. In practice even after this change we are still blocked by data availability when syncing older storage diffs (e.g. genesis sync) and or pruning at the same time**. So in practice performance hasn't changed (benchmarked already), except for maybe when syncing recent state (cca `50%` faster but need to reproduce to confirm).


Things I like:
Got rid of two redundant structures; syncing rounds and summary cache together with corresponding locking. Given this is IO-bound task, and the work is primarily about concurrency (not parallelism) I believe moving from mutexes to channels is desirable.

Things I dislike: I will probably get rid of the new `diffsync` nested package, also overall it still feels to complex. Writing another fetcher, that will read from another local DB for the purpose of benchmarking will probably clarify design.


** As [pointed out ](https://github.com/oasisprotocol/oasis-core/issues/6334#issuecomment-3347954991), and benchmarked again, runtime state pruning is incredibly slow even with only few versions locally. As `ndb.Finalize` and `ndb.Prune` are completely sequential due to metadata lock and with pruning [critical section](https://github.com/oasisprotocol/oasis-core/blob/1d84224a7a860b2298846f838d7c9e4b1d17504c/go/storage/mkvs/db/pathbadger/pathbadger.go#L530:L635) easily lasting `0.1-0.5s` this means syncing interleaved with pruning is bounded with `1-5` rounds/s assuming all other operations would be negligible. As this is not the case, and there is likely big write amplification/compaction load on the DB in practice we are closer to `1-2` rounds/s.