### PR TITLE
go/staking/api: Format known addresses in staking tx PrettyPrint

### DIFF
--- a/.changelog/6453.feature.md
+++ b/.changelog/6453.feature.md
@@ -1,0 +1,1 @@
+go/staking/api: Format known addresses in staking transaction PrettyPrint

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -426,7 +426,7 @@ type Transfer struct {
 // PrettyPrint writes a pretty-printed representation of Transfer to the given
 // writer.
 func (t Transfer) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
-	fmt.Fprintf(w, "%sTo:     %s\n", prefix, t.To)
+	fmt.Fprintf(w, "%sTo:     %s\n", prefix, FormatAddress(ctx, t.To))
 
 	fmt.Fprintf(w, "%sAmount: ", prefix)
 	token.PrettyPrintAmount(ctx, t.Amount, w)
@@ -477,7 +477,7 @@ type Escrow struct {
 // PrettyPrint writes a pretty-printed representation of Escrow to the given
 // writer.
 func (e Escrow) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
-	fmt.Fprintf(w, "%sTo:     %s\n", prefix, e.Account)
+	fmt.Fprintf(w, "%sTo:     %s\n", prefix, FormatAddress(ctx, e.Account))
 
 	fmt.Fprintf(w, "%sAmount: ", prefix)
 	token.PrettyPrintAmount(ctx, e.Amount, w)
@@ -503,8 +503,8 @@ type ReclaimEscrow struct {
 
 // PrettyPrint writes a pretty-printed representation of ReclaimEscrow to the
 // given writer.
-func (re ReclaimEscrow) PrettyPrint(_ context.Context, prefix string, w io.Writer) {
-	fmt.Fprintf(w, "%sFrom:   %s\n", prefix, re.Account)
+func (re ReclaimEscrow) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
+	fmt.Fprintf(w, "%sFrom:   %s\n", prefix, FormatAddress(ctx, re.Account))
 
 	fmt.Fprintf(w, "%sShares: %s\n", prefix, re.Shares)
 }
@@ -552,7 +552,7 @@ type Allow struct {
 
 // PrettyPrint writes a pretty-printed representation of Allow to the given writer.
 func (aw Allow) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
-	fmt.Fprintf(w, "%sBeneficiary:   %s\n", prefix, aw.Beneficiary)
+	fmt.Fprintf(w, "%sBeneficiary:   %s\n", prefix, FormatAddress(ctx, aw.Beneficiary))
 
 	sign := "+"
 	if aw.Negative {
@@ -582,7 +582,7 @@ type Withdraw struct {
 
 // PrettyPrint writes a pretty-printed representation of Withdraw to the given writer.
 func (wt Withdraw) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
-	fmt.Fprintf(w, "%sFrom:   %s\n", prefix, wt.From)
+	fmt.Fprintf(w, "%sFrom:   %s\n", prefix, FormatAddress(ctx, wt.From))
 
 	fmt.Fprintf(w, "%sAmount: ", prefix)
 	token.PrettyPrintAmount(ctx, wt.Amount, w)

--- a/go/staking/api/prettyprint.go
+++ b/go/staking/api/prettyprint.go
@@ -9,6 +9,43 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 )
 
+type contextKey string
+
+// ContextKeyAccountNames is the key to retrieve native (Bech32) account names from context.
+var ContextKeyAccountNames = contextKey("staking/account-names")
+
+// AccountNames maps native (Bech32) addresses to user-defined account names for pretty printing.
+type AccountNames map[string]string
+
+// FormatAddress is like FormatAddressWith but reads names from ctx.
+func FormatAddress(ctx context.Context, addr Address) string {
+	var names AccountNames
+	if v, ok := ctx.Value(ContextKeyAccountNames).(AccountNames); ok {
+		names = v
+	}
+
+	return FormatAddressWith(names, addr)
+}
+
+// FormatAddressWith formats a staking address for display.
+//
+// Output cases:
+//   - Named address:   "name (oasis1...)"
+//   - Unknown address: "oasis1..."
+func FormatAddressWith(names AccountNames, addr Address) string {
+	native := addr.String()
+	if names == nil {
+		return native
+	}
+
+	name := names[native]
+	if name == "" {
+		return native
+	}
+
+	return fmt.Sprintf("%s (%s)", name, native)
+}
+
 // PrettyPrintCommissionRatePercentage returns the string representing the
 // commission rate (bound) in percentage for the given commission rate (bound)
 // numerator.


### PR DESCRIPTION
related to https://github.com/oasisprotocol/cli/pull/683