### PR TITLE
github/workflows/ci-lint: Limit setuptools to v81.0.0

### DIFF
--- a/.changelog/6455.internal.md
+++ b/.changelog/6455.internal.md
@@ -1,0 +1,1 @@
+github/workflows/ci-lint: Limit setuptools to v81.0.0

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -56,10 +56,11 @@ jobs:
       - name: Install gitlint
         run: |
           python -m pip install gitlint
-        # Needed for Towncrier fork to work with 3.12 and above
+        # Needed for Towncrier fork to work with 3.12 and above.
+        # As of version 82.0.0, pkg_resources is no longer available.
       - name: Install setuptools
         run: |
-          python -m pip install setuptools
+          python -m pip install "setuptools<=81.0.0"
       - name: Install towncrier
         run: |
           python -m pip install https://github.com/oasisprotocol/towncrier/archive/oasis-master.tar.gz


### PR DESCRIPTION
Package `pkg_resources` has been removed from Setuptools, used by `towncrier`. For details, see https://setuptools.pypa.io/en/stable/history.html. 

This is a temporary fix until we upgrade `towncrier`. 