### PR TITLE
go/runtime/history: Always broadcast first synced round

### DIFF
--- a/.changelog/6476.bugfix.md
+++ b/.changelog/6476.bugfix.md
@@ -1,0 +1,1 @@
+go/runtime/history: Always broadcast first synced round

--- a/go/roothash/api/history.go
+++ b/go/roothash/api/history.go
@@ -36,7 +36,7 @@ type BlockHistory interface {
 	StorageSyncCheckpoint(round uint64) error
 
 	// LastStorageSyncedRound returns the last runtime round which was synced to storage.
-	LastStorageSyncedRound() (uint64, error)
+	LastStorageSyncedRound() (uint64, bool)
 
 	// WatchBlocks returns a channel watching block rounds as they are committed.
 	// If node has local storage this includes waiting for the round to be synced into storage.

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -138,6 +138,8 @@ func (h *runtimeHistory) StorageSyncCheckpoint(round uint64) error {
 	h.syncRoundLock.Lock()
 	defer h.syncRoundLock.Unlock()
 	switch {
+	case h.lastStorageSyncedRound == roothash.RoundInvalid:
+		// First sync, continue below.
 	case round < h.lastStorageSyncedRound:
 		return fmt.Errorf("runtime/history: storage sync checkpoint at lower round (current: %d wanted: %d)", h.lastStorageSyncedRound, round)
 	case round == h.lastStorageSyncedRound:
@@ -163,10 +165,13 @@ func (h *runtimeHistory) StorageSyncCheckpoint(round uint64) error {
 	return nil
 }
 
-func (h *runtimeHistory) LastStorageSyncedRound() (uint64, error) {
+func (h *runtimeHistory) LastStorageSyncedRound() (uint64, bool) {
 	h.syncRoundLock.RLock()
 	defer h.syncRoundLock.RUnlock()
-	return h.lastStorageSyncedRound, nil
+	if h.lastStorageSyncedRound == roothash.RoundInvalid {
+		return 0, false
+	}
+	return h.lastStorageSyncedRound, true
 }
 
 func (h *runtimeHistory) WatchBlocks() (<-chan *roothash.AnnotatedBlock, pubsub.ClosableSubscription, error) {
@@ -227,16 +232,26 @@ func (h *runtimeHistory) resolveRound(round uint64, includeStorage bool) (uint64
 		h.syncRoundLock.RLock()
 		defer h.syncRoundLock.RUnlock()
 		// Also take storage sync state into account.
-		if includeStorage && h.hasLocalStorage && h.lastStorageSyncedRound < meta.LastRound {
-			return h.lastStorageSyncedRound, nil
+		if includeStorage && h.hasLocalStorage {
+			if h.lastStorageSyncedRound == roothash.RoundInvalid {
+				return 0, roothash.ErrNotFound
+			}
+			if h.lastStorageSyncedRound < meta.LastRound {
+				return h.lastStorageSyncedRound, nil
+			}
 		}
 		return meta.LastRound, nil
 	default:
 		h.syncRoundLock.RLock()
 		defer h.syncRoundLock.RUnlock()
 		// Ensure round exists.
-		if includeStorage && h.hasLocalStorage && h.lastStorageSyncedRound < round {
-			return 0, roothash.ErrNotFound
+		if includeStorage && h.hasLocalStorage {
+			if h.lastStorageSyncedRound == roothash.RoundInvalid {
+				return 0, roothash.ErrNotFound
+			}
+			if h.lastStorageSyncedRound < round {
+				return 0, roothash.ErrNotFound
+			}
 		}
 		return round, nil
 	}
@@ -368,6 +383,7 @@ func New(runtimeID common.Namespace, dataDir string, prunerFactory PrunerFactory
 		ctx:                     ctx,
 		cancelCtx:               cancelCtx,
 		db:                      db,
+		lastStorageSyncedRound:  roothash.RoundInvalid,
 		hasLocalStorage:         hasLocalStorage,
 		syncedBlocksNotifier:    pubsub.NewBroker(true),
 		committedBlocksNotifier: pubsub.NewBroker(true),

--- a/go/runtime/history/history_test.go
+++ b/go/runtime/history/history_test.go
@@ -39,8 +39,8 @@ func TestHistory(t *testing.T) {
 	require.NoError(err, "LastConsensusHeight")
 	require.EqualValues(0, lastHeight)
 
-	lastRound, err := history.LastStorageSyncedRound()
-	require.NoError(err, "LastStorageSyncedRound")
+	lastRound, ok := history.LastStorageSyncedRound()
+	require.False(ok, "LastStorageSyncedRound")
 	require.EqualValues(0, lastRound)
 
 	_, err = history.GetBlock(ctx, 10)
@@ -95,8 +95,8 @@ func TestHistory(t *testing.T) {
 	err = history.StorageSyncCheckpoint(5)
 	require.Error(err, "StorageSyncCheckpoint should fail for lower height")
 
-	lastRound, err = history.LastStorageSyncedRound()
-	require.NoError(err, "LastStorageSyncedRound")
+	lastRound, ok = history.LastStorageSyncedRound()
+	require.True(ok, "LastStorageSyncedRound")
 	require.EqualValues(10, lastRound)
 
 	gotBlk, err := history.GetBlock(ctx, 10)


### PR DESCRIPTION
Fixes an issue where the runtime history using local storage did not broadcast the initial synced (zero) round.