### PR TITLE
rust: Bump rustls-webpki to 0.103.12

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,4 +2,5 @@
 ignore = [
     "RUSTSEC-2023-0071", # Does not affect our current use of the library.
     "RUSTSEC-2026-0049", # Vulnerable crate is only used in simple-rofl test runtime.
+    "RUSTSEC-2026-0098", # Vulnerable crate is only used in simple-rofl test runtime.
 ]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,4 +3,5 @@ ignore = [
     "RUSTSEC-2023-0071", # Does not affect our current use of the library.
     "RUSTSEC-2026-0049", # Vulnerable crate is only used in simple-rofl test runtime.
     "RUSTSEC-2026-0098", # Vulnerable crate is only used in simple-rofl test runtime.
+    "RUSTSEC-2026-0099", # Vulnerable crate is only used in simple-rofl test runtime.
 ]

--- a/.changelog/6501.internal.md
+++ b/.changelog/6501.internal.md
@@ -1,0 +1,1 @@
+rust: Bump rustls-webpki to 0.103.12

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2690,7 +2690,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -2755,9 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
```
Crate:     rustls-webpki
Version:   0.102.8
Title:     Name constraints for URI names were incorrectly accepted
Date:      2026-04-14
ID:        RUSTSEC-2026-0098
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0098
Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6

Dependency tree:
rustls-webpki 0.102.8
└── rustls-mbedcrypto-provider 0.1.1
    └── simple-rofl 0.0.0
```

```
Crate:     rustls-webpki
Version:   0.102.8
Title:     Name constraints were accepted for certificates asserting a wildcard name
Date:      2026-04-14
ID:        RUSTSEC-2026-0099
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0099
Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6
```

```
Crate:     rustls-webpki
Version:   0.103.10
Title:     Name constraints for URI names were incorrectly accepted
Date:      2026-04-14
ID:        RUSTSEC-2026-0098
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0098
Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6

Dependency tree:
rustls-webpki 0.103.10
└── rustls 0.23.36
    ├── simple-rofl 0.0.0
    ├── rustls-mbedtls-provider-utils 0.2.1
    │   ├── rustls-mbedpki-provider 0.2.1
    │   │   └── simple-rofl 0.0.0
    │   └── rustls-mbedcrypto-provider 0.1.1
    │       └── simple-rofl 0.0.0
    ├── rustls-mbedpki-provider 0.2.1
    └── rustls-mbedcrypto-provider 0.1.1
```

```
Crate:     rustls-webpki
Version:   0.103.10
Title:     Name constraints were accepted for certificates asserting a wildcard name
Date:      2026-04-14
ID:        RUSTSEC-2026-0099
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0099
Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6