### PR TITLE
rust: Add RUSTSEC-2026-0104 to audit.toml

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,4 +4,5 @@ ignore = [
     "RUSTSEC-2026-0049", # Vulnerable crate is only used in simple-rofl test runtime.
     "RUSTSEC-2026-0098", # Vulnerable crate is only used in simple-rofl test runtime.
     "RUSTSEC-2026-0099", # Vulnerable crate is only used in simple-rofl test runtime.
+    "RUSTSEC-2026-0104", # Vulnerable crate is only used in simple-rofl test runtime.
 ]

--- a/.changelog/6513.internal.md
+++ b/.changelog/6513.internal.md
@@ -1,0 +1,1 @@
+rust: Add RUSTSEC-2026-0104 to audit.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2690,7 +2690,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -2755,9 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
```bash
    Scanning Cargo.lock for vulnerabilities (436 crate dependencies)
Crate:     rustls-webpki
Version:   0.102.8
Title:     Reachable panic in certificate revocation list parsing
Date:      2026-04-22
ID:        RUSTSEC-2026-0104
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0104
Solution:  Upgrade to >=0.103.13, <0.104.0-alpha.1 OR >=0.104.0-alpha.7
Dependency tree:
rustls-webpki 0.102.8
└── rustls-mbedcrypto-provider 0.1.1
    └── simple-rofl 0.0.0
Crate:     rustls-webpki
Version:   0.103.12
Title:     Reachable panic in certificate revocation list parsing
Date:      2026-04-22
ID:        RUSTSEC-2026-0104
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0104
Solution:  Upgrade to >=0.103.13, <0.104.0-alpha.1 OR >=0.104.0-alpha.7
Dependency tree:
rustls-webpki 0.103.12
└── rustls 0.23.36
    ├── simple-rofl 0.0.0
    ├── rustls-mbedtls-provider-utils 0.2.1
    │   ├── rustls-mbedpki-provider 0.2.1
    │   │   └── simple-rofl 0.0.0
    │   └── rustls-mbedcrypto-provider 0.1.1
    │       └── simple-rofl 0.0.0
    ├── rustls-mbedpki-provider 0.2.1
    └── rustls-mbedcrypto-provider 0.1.1

```