### PR TITLE
go/storage/mkvs/db/pathbadger: Fix pruning performance

### DIFF
--- a/.changelog/6334.bugfix.md
+++ b/.changelog/6334.bugfix.md
@@ -1,0 +1,1 @@
+go/storage/mkvs/db/pathbadger: Fix pruning performance

--- a/go/storage/mkvs/db/pathbadger/pathbadger.go
+++ b/go/storage/mkvs/db/pathbadger/pathbadger.go
@@ -555,11 +555,11 @@ func (d *badgerNodeDB) Prune(version uint64) error {
 
 	// Delete data for all root types that cannot have children.
 	for _, rootType := range api.RootTypesWithPolicy(func(p *api.RootPolicy) bool { return p.NoChildRoots }) {
-		// Delete all finalized nodes.
+		// Delete all finalized nodes for this version.
 		wtx := d.db.NewTransactionAt(versionToTs(version), false)
 		defer wtx.Discard()
 
-		prefix := finalizedNodeKeyFmt.Encode(byte(rootType))
+		prefix := finalizedNodeKeyFmt.Encode(byte(rootType), encodeVersionKey(version))
 		it := wtx.NewIterator(badger.IteratorOptions{Prefix: prefix})
 		defer it.Close()
 


### PR DESCRIPTION
Closes https://github.com/oasisprotocol/oasis-core/issues/6334.

# Benchmarks
On the baremetal instance:
* 20x speed-up with 100k versions locally.
* With more versions performance gain increases:
    * E.g. `3.2M` versions (see Sapphire [snapshot](https://snapshots.oasis.io/#node/mainnet/20250722-20260403/)) were pruned in around `7min`. Using the old code it takes `20s` to prune just one version!

_Sanity_: Runtime state pruning is now as efficient as consensus state pruning even though runtime state is 1000x bigger than the consensus state (looking at the checkpoint size). This still makes sense given that IO state is minimal compared to the EVM state, and that EVM state pruning is only about dropping writelogs and increasing the discard timestamp. The work was already partly done during commit operation by marking the nodes as ready to be removed and we still have a pending compaction (disk not reclaimed automatically).


# Considerations:
- For `NoChildRoots: true` (IO roots), at version `N` we should  eagerly delete all nodes in `N-1` so that we have better locality and thus less compaction overhead (we are unknowingly using this trick for the state root already).
    - Given that IO state is minimal probably not critical, but we would have to bench compaction after the pruning to see the difference. 

# Implications/follow-up
* All pruning issues we had are fixed.
    * This includes combination of syncing and pruning being incredibly slow with prune operation dominating the syncing time. 
* For the follow-up I will include runtime state pruning and compaction to `storage prune/compact` commands.
    * The workaround for the snapshot creation with exact start version using `storage checkpoint create/import` will most likely be no longer needed  


