### PR TITLE
go/oasis-node/cmd/common: Fix isNodeRunning function

### DIFF
--- a/.changelog/6520.bugfix.md
+++ b/.changelog/6520.bugfix.md
@@ -1,0 +1,4 @@
+go/oasis-node/cmd/common: Fix is node running helper
+
+Now the helper tries to dial the node socket to check
+whether the node is running.

--- a/go/oasis-node/cmd/common/common.go
+++ b/go/oasis-node/cmd/common/common.go
@@ -6,9 +6,12 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
@@ -77,11 +80,14 @@ func InternalSocketPath() string {
 func IsNodeRunning() (bool, error) {
 	path := InternalSocketPath()
 
-	if _, err := os.Stat(path); err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return false, nil
-		}
-		return false, fmt.Errorf("stat %s: %w", path, err)
+	conn, err := net.DialTimeout("unix", path, time.Second)
+	switch {
+	case err == nil:
+		_ = conn.Close()
+	case errors.Is(err, fs.ErrNotExist) || errors.Is(err, syscall.ECONNREFUSED):
+		return false, nil
+	default:
+		return false, fmt.Errorf("failed to dial internal socket %s: %w", path, err)
 	}
 
 	return true, nil


### PR DESCRIPTION
## What
Storage commands gated by this check are sometimes blocked due to the stale internal socket. This has now also surfaced in the e2e test I was writing about offline pruning/compaction.

## How to test locally
A non-graceful shutdown of the node tends to keep stale `internal.sock`.

## Observation
Seem that `internal.sock`  is sometimes not cleaned even with graceful shutdown. Meaning a possible bug during shutdown/cleanup (out of scope).
