### PR TITLE
Release oasis storage prune and compact subcomands

### DIFF
--- a/.changelog/6519.feature.0.md
+++ b/.changelog/6519.feature.0.md
@@ -1,0 +1,5 @@
+go/oasis-node/cmd/storage: Release offline pruning command
+
+Command `storage prune-experimental` has been released as
+`storage prune` and now in addition to consensus databases
+also prunes runtime databases.

--- a/.changelog/6519.feature.1.md
+++ b/.changelog/6519.feature.1.md
@@ -1,0 +1,5 @@
+go/oasis-node/cmd/storage: Release offline compaction command
+
+Command `storage compact-experimental` has been released as
+`storage compact` and now in addition to consensus databases
+also compacts runtime databases.

--- a/docs/oasis-node/cli.md
+++ b/docs/oasis-node/cli.md
@@ -365,19 +365,19 @@ may stay constant or not be reclaimed for a very long time.
 This command gives operators manual control to release disk space during
 maintenance periods.
 
-### prune-experimental
+### prune
 
 Run (when the node is not running):
 
 ```sh
-oasis-node storage prune-experimental --config /path/to/config/file
+oasis-node storage prune --config /path/to/config/file
 ```
 
-to trigger manual pruning of consensus database instances:
+to trigger manual pruning of all configured database instances:
 
 ```sh
-{"caller":"storage.go:433","level":"info","module":"cmd/storage", \
-"msg":"Starting consensus databases pruning. This may take a while...", \
+{"caller":"prune.go:47","level":"info","module":"cmd/storage", \
+"msg":"Starting databases pruning. This may take a while...", \
 "ts":"2025-10-23T11:02:11.129822974Z"}
 ```
 

--- a/docs/oasis-node/cli.md
+++ b/docs/oasis-node/cli.md
@@ -334,15 +334,15 @@ oasis1qqncl383h8458mr9cytatygctzwsx02n4c5f8ed7
 
 ## storage
 
-### compact-experimental
+### compact
 
 Run (when the node is not running):
 
 ```sh
-oasis-node storage compact-experimental --config /path/to/config/file
+oasis-node storage compact --config /path/to/config/file
 ```
 
-to trigger manual compaction of consensus database instances:
+to trigger manual compaction of all configured database instances:
 
 ```sh
 {"caller":"storage.go:310","level":"info","module":"cmd/storage", \
@@ -385,8 +385,8 @@ Operators should run this whenever they change pruning configuration, e.g. when
 enabling it for the first time, or later changing it to retain less data. This
 way they guarantee the node is healthy when it starts.
 
-Following successful pruning, to release disk space, they are encouraged to run
-[the compaction command](#compact-experimental).
+After the pruning operators should run [the compaction command](#compact)
+to release disk space.
 
 ### inspect
 

--- a/go/oasis-node/cmd/storage/compact.go
+++ b/go/oasis-node/cmd/storage/compact.go
@@ -78,6 +78,7 @@ func compactCometDB(path string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open BadgerDB: %w", err)
 	}
+	defer db.Close()
 
 	if err := flattenBadgerDB(db, logger); err != nil {
 		return fmt.Errorf("failed to compact %s: %w", path, err)
@@ -100,7 +101,7 @@ func findCometDBs(dataDir string) ([]string, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to walk dir %s: %w", dataDir, err)
+		return nil, fmt.Errorf("failed to walk dir %s: %w", dir, err)
 	}
 
 	if len(dbDirs) == 0 {

--- a/go/oasis-node/cmd/storage/compact.go
+++ b/go/oasis-node/cmd/storage/compact.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	badgerDB "github.com/dgraph-io/badger/v4"
 	"github.com/spf13/cobra"
 
-	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/common"
 	cmtDBProvider "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/db/badger"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasisprotocol/oasis-core/go/runtime/registry"
@@ -44,41 +43,16 @@ WARNING: Ensure you have at least as much of a free disk as your largest databas
 
 			logger.Info("Starting database compactions. This may take a while...")
 
-			// Compact CometBFT managed databases: block store, evidence and state (NOT application state).
-			if err := compactCometDBs(dataDir); err != nil {
-				return fmt.Errorf("failed to compact CometBFT managed databases: %w", err)
+			if err := compactConsensusDBs(dataDir); err != nil {
+				return fmt.Errorf("failed to compact consensus databases: %w", err)
 			}
 
-			// Compact consensus NodeDB (application state).
-			if err := compactConsensusNodeDB(dataDir); err != nil {
-				return fmt.Errorf("failed to compact consensus NodeDB: %w", err)
-			}
-
-			// Compact Runtime Databases (history and state DB).
 			runtimes, err := registry.GetConfiguredRuntimeIDs()
 			if err != nil {
 				return fmt.Errorf("failed to get configured runtimes: %w", err)
 			}
 			for _, rt := range runtimes {
-				if err := func() error {
-					history, err := openRuntimeLightHistory(dataDir, rt)
-					if err != nil {
-						return fmt.Errorf("failed to open runtime history: %w", err)
-					}
-					defer history.Close()
-					if err := history.Compact(); err != nil {
-						return fmt.Errorf("failed to compact runtime history: %w", err)
-					}
-					ndb, err := openRuntimeStateDB(dataDir, rt)
-					if err != nil {
-						return fmt.Errorf("failed to open runtime state DB: %w", err)
-					}
-					defer ndb.Close()
-					if err := ndb.Compact(); err != nil {
-						return fmt.Errorf("failed to compact runtime state DB: %w", err)
-					}
-					return nil
-				}(); err != nil {
+				if err := compactRuntimeDBs(dataDir, rt); err != nil {
 					return fmt.Errorf("failed to compact runtime dbs (runtime ID: %s): %w", rt, err)
 				}
 			}
@@ -90,35 +64,27 @@ WARNING: Ensure you have at least as much of a free disk as your largest databas
 	return cmd
 }
 
+func compactConsensusDBs(dataDir string) error {
+	// Compact CometBFT managed databases: block store, evidence and state (NOT application state).
+	if err := compactCometDBs(dataDir); err != nil {
+		return fmt.Errorf("failed to compact CometBFT managed databases: %w", err)
+	}
+
+	// Compact consensus NodeDB (application state).
+	ndb, close, err := openConsensusNodeDB(dataDir)
+	if err != nil {
+		return fmt.Errorf("failed to open consensus NodeDB: %w", err)
+	}
+	defer close()
+
+	if err := ndb.Compact(); err != nil {
+		return fmt.Errorf("failed to compact consensus node DB: %w", err)
+	}
+
+	return nil
+}
+
 func compactCometDBs(dataDir string) error {
-	paths, err := findCometDBs(dataDir)
-	if err != nil {
-		return fmt.Errorf("failed to find database instances: %w", err)
-	}
-	for _, path := range paths {
-		if err := compactCometDB(path); err != nil {
-			return fmt.Errorf("failed to compact %s: %w", path, err)
-		}
-	}
-	return nil
-}
-
-func compactCometDB(path string) error {
-	logger := logger.With("path", path)
-	db, err := cmtDBProvider.OpenBadger(path, logger)
-	if err != nil {
-		return fmt.Errorf("failed to open BadgerDB: %w", err)
-	}
-	defer db.Close()
-
-	if err := flattenBadgerDB(db, logger); err != nil {
-		return fmt.Errorf("failed to compact %s: %w", path, err)
-	}
-
-	return nil
-}
-
-func findCometDBs(dataDir string) ([]string, error) {
 	dir := fmt.Sprintf("%s/consensus/data", dataDir)
 
 	var dbDirs []string
@@ -132,17 +98,29 @@ func findCometDBs(dataDir string) ([]string, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to walk dir %s: %w", dir, err)
+		return fmt.Errorf("failed to walk dir %s: %w", dir, err)
 	}
 
 	if len(dbDirs) == 0 {
-		return nil, fmt.Errorf("zero database instances found")
+		return fmt.Errorf("zero database instances found")
 	}
 
-	return dbDirs, nil
+	for _, dbDir := range dbDirs {
+		if err := compactCometDB(dbDir); err != nil {
+			return fmt.Errorf("failed to compact %s: %w", dbDir, err)
+		}
+	}
+	return nil
 }
 
-func flattenBadgerDB(db *badgerDB.DB, logger *logging.Logger) error {
+func compactCometDB(path string) error {
+	logger := logger.With("path", path)
+	db, err := cmtDBProvider.OpenBadger(path, logger)
+	if err != nil {
+		return fmt.Errorf("failed to open BadgerDB: %w", err)
+	}
+	defer db.Close()
+
 	logger.Info("compacting")
 
 	if err := db.Flatten(1); err != nil {
@@ -154,12 +132,22 @@ func flattenBadgerDB(db *badgerDB.DB, logger *logging.Logger) error {
 	return nil
 }
 
-func compactConsensusNodeDB(dataDir string) error {
-	ndb, close, err := openConsensusNodeDB(dataDir)
+func compactRuntimeDBs(dataDir string, rt common.Namespace) error {
+	history, err := openRuntimeLightHistory(dataDir, rt)
 	if err != nil {
-		return fmt.Errorf("failed to open consensus NodeDB: %w", err)
+		return fmt.Errorf("failed to open runtime history: %w", err)
 	}
-	defer close()
-
-	return ndb.Compact()
+	defer history.Close()
+	if err := history.Compact(); err != nil {
+		return fmt.Errorf("failed to compact runtime history: %w", err)
+	}
+	ndb, err := openRuntimeStateDB(dataDir, rt)
+	if err != nil {
+		return fmt.Errorf("failed to open runtime state DB: %w", err)
+	}
+	defer ndb.Close()
+	if err := ndb.Compact(); err != nil {
+		return fmt.Errorf("failed to compact runtime state DB: %w", err)
+	}
+	return nil
 }

--- a/go/oasis-node/cmd/storage/compact.go
+++ b/go/oasis-node/cmd/storage/compact.go
@@ -12,14 +12,15 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	cmtDBProvider "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/db/badger"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
+	"github.com/oasisprotocol/oasis-core/go/runtime/registry"
 )
 
 func newCompactCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "compact-experimental",
+		Use:   "compact",
 		Args:  cobra.NoArgs,
-		Short: "EXPERIMENTAL: trigger compaction for all consensus databases",
-		Long: `EXPERIMENTAL: Optimize the storage for all consensus databases by manually compacting the underlying storage engines.
+		Short: "trigger compaction for all databases",
+		Long: `Optimize the storage for all databases by manually compacting the underlying storage engines.
 
 WARNING: Ensure you have at least as much of a free disk as your largest database.
 `,
@@ -48,8 +49,38 @@ WARNING: Ensure you have at least as much of a free disk as your largest databas
 				return fmt.Errorf("failed to compact CometBFT managed databases: %w", err)
 			}
 
+			// Compact consensus NodeDB (application state).
 			if err := compactConsensusNodeDB(dataDir); err != nil {
 				return fmt.Errorf("failed to compact consensus NodeDB: %w", err)
+			}
+
+			// Compact Runtime Databases (history and state DB).
+			runtimes, err := registry.GetConfiguredRuntimeIDs()
+			if err != nil {
+				return fmt.Errorf("failed to get configured runtimes: %w", err)
+			}
+			for _, rt := range runtimes {
+				if err := func() error {
+					history, err := openRuntimeLightHistory(dataDir, rt)
+					if err != nil {
+						return fmt.Errorf("failed to open runtime history: %w", err)
+					}
+					defer history.Close()
+					if err := history.Compact(); err != nil {
+						return fmt.Errorf("failed to compact runtime history: %w", err)
+					}
+					ndb, err := openRuntimeStateDB(dataDir, rt)
+					if err != nil {
+						return fmt.Errorf("failed to open runtime state DB: %w", err)
+					}
+					defer ndb.Close()
+					if err := ndb.Compact(); err != nil {
+						return fmt.Errorf("failed to compact runtime state DB: %w", err)
+					}
+					return nil
+				}(); err != nil {
+					return fmt.Errorf("failed to compact runtime dbs (runtime ID: %s): %w", rt, err)
+				}
 			}
 
 			return nil

--- a/go/oasis-node/cmd/storage/compact.go
+++ b/go/oasis-node/cmd/storage/compact.go
@@ -14,45 +14,49 @@ import (
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 )
 
-var storageCompactCmd = &cobra.Command{
-	Use:   "compact-experimental",
-	Args:  cobra.NoArgs,
-	Short: "EXPERIMENTAL: trigger compaction for all consensus databases",
-	Long: `EXPERIMENTAL: Optimize the storage for all consensus databases by manually compacting the underlying storage engines.
+func newCompactCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "compact-experimental",
+		Args:  cobra.NoArgs,
+		Short: "EXPERIMENTAL: trigger compaction for all consensus databases",
+		Long: `EXPERIMENTAL: Optimize the storage for all consensus databases by manually compacting the underlying storage engines.
 
 WARNING: Ensure you have at least as much of a free disk as your largest database.
 `,
-	RunE: doDBCompactions,
-}
+		PreRunE: func(_ *cobra.Command, args []string) error {
+			if err := cmdCommon.Init(); err != nil {
+				cmdCommon.EarlyLogAndExit(err)
+			}
 
-func doDBCompactions(_ *cobra.Command, args []string) error {
-	if err := cmdCommon.Init(); err != nil {
-		cmdCommon.EarlyLogAndExit(err)
+			running, err := cmdCommon.IsNodeRunning()
+			if err != nil {
+				return fmt.Errorf("failed to ensure the node is not running: %w", err)
+			}
+
+			if running {
+				return fmt.Errorf("compaction can only be done when the node is not running")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dataDir := cmdCommon.DataDir()
+
+			logger.Info("Starting database compactions. This may take a while...")
+
+			// Compact CometBFT managed databases: block store, evidence and state (NOT application state).
+			if err := compactCometDBs(dataDir); err != nil {
+				return fmt.Errorf("failed to compact CometBFT managed databases: %w", err)
+			}
+
+			if err := compactConsensusNodeDB(dataDir); err != nil {
+				return fmt.Errorf("failed to compact consensus NodeDB: %w", err)
+			}
+
+			return nil
+		},
 	}
 
-	running, err := cmdCommon.IsNodeRunning()
-	if err != nil {
-		return fmt.Errorf("failed to ensure the node is not running: %w", err)
-	}
-
-	if running {
-		return fmt.Errorf("compaction can only be done when the node is not running")
-	}
-
-	dataDir := cmdCommon.DataDir()
-
-	logger.Info("Starting database compactions. This may take a while...")
-
-	// Compact CometBFT managed databases: block store, evidence and state (NOT application state).
-	if err := compactCometDBs(dataDir); err != nil {
-		return fmt.Errorf("failed to compact CometBFT managed databases: %w", err)
-	}
-
-	if err := compactConsensusNodeDB(dataDir); err != nil {
-		return fmt.Errorf("failed to compact consensus NodeDB: %w", err)
-	}
-
-	return nil
+	return cmd
 }
 
 func compactCometDBs(dataDir string) error {

--- a/go/oasis-node/cmd/storage/compact.go
+++ b/go/oasis-node/cmd/storage/compact.go
@@ -1,0 +1,129 @@
+package storage
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	badgerDB "github.com/dgraph-io/badger/v4"
+	"github.com/spf13/cobra"
+
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	cmtDBProvider "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/db/badger"
+	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
+)
+
+var storageCompactCmd = &cobra.Command{
+	Use:   "compact-experimental",
+	Args:  cobra.NoArgs,
+	Short: "EXPERIMENTAL: trigger compaction for all consensus databases",
+	Long: `EXPERIMENTAL: Optimize the storage for all consensus databases by manually compacting the underlying storage engines.
+
+WARNING: Ensure you have at least as much of a free disk as your largest database.
+`,
+	RunE: doDBCompactions,
+}
+
+func doDBCompactions(_ *cobra.Command, args []string) error {
+	if err := cmdCommon.Init(); err != nil {
+		cmdCommon.EarlyLogAndExit(err)
+	}
+
+	running, err := cmdCommon.IsNodeRunning()
+	if err != nil {
+		return fmt.Errorf("failed to ensure the node is not running: %w", err)
+	}
+
+	if running {
+		return fmt.Errorf("compaction can only be done when the node is not running")
+	}
+
+	dataDir := cmdCommon.DataDir()
+
+	logger.Info("Starting database compactions. This may take a while...")
+
+	// Compact CometBFT managed databases: block store, evidence and state (NOT application state).
+	if err := compactCometDBs(dataDir); err != nil {
+		return fmt.Errorf("failed to compact CometBFT managed databases: %w", err)
+	}
+
+	if err := compactConsensusNodeDB(dataDir); err != nil {
+		return fmt.Errorf("failed to compact consensus NodeDB: %w", err)
+	}
+
+	return nil
+}
+
+func compactCometDBs(dataDir string) error {
+	paths, err := findCometDBs(dataDir)
+	if err != nil {
+		return fmt.Errorf("failed to find database instances: %w", err)
+	}
+	for _, path := range paths {
+		if err := compactCometDB(path); err != nil {
+			return fmt.Errorf("failed to compact %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func compactCometDB(path string) error {
+	logger := logger.With("path", path)
+	db, err := cmtDBProvider.OpenBadger(path, logger)
+	if err != nil {
+		return fmt.Errorf("failed to open BadgerDB: %w", err)
+	}
+
+	if err := flattenBadgerDB(db, logger); err != nil {
+		return fmt.Errorf("failed to compact %s: %w", path, err)
+	}
+
+	return nil
+}
+
+func findCometDBs(dataDir string) ([]string, error) {
+	dir := fmt.Sprintf("%s/consensus/data", dataDir)
+
+	var dbDirs []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() && strings.HasSuffix(d.Name(), ".db") {
+			dbDirs = append(dbDirs, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk dir %s: %w", dataDir, err)
+	}
+
+	if len(dbDirs) == 0 {
+		return nil, fmt.Errorf("zero database instances found")
+	}
+
+	return dbDirs, nil
+}
+
+func flattenBadgerDB(db *badgerDB.DB, logger *logging.Logger) error {
+	logger.Info("compacting")
+
+	if err := db.Flatten(1); err != nil {
+		return fmt.Errorf("failed to flatten db: %w", err)
+	}
+
+	logger.Info("compaction completed")
+
+	return nil
+}
+
+func compactConsensusNodeDB(dataDir string) error {
+	ndb, close, err := openConsensusNodeDB(dataDir)
+	if err != nil {
+		return fmt.Errorf("failed to open consensus NodeDB: %w", err)
+	}
+	defer close()
+
+	return ndb.Compact()
+}

--- a/go/oasis-node/cmd/storage/prune.go
+++ b/go/oasis-node/cmd/storage/prune.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/cometbft/cometbft/state"
+	"github.com/cometbft/cometbft/store"
 	"github.com/spf13/cobra"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
@@ -14,8 +16,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	db "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
 )
-
-var pruneDiskSyncInterval uint64 = 10_000
 
 func newPruneCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -101,14 +101,33 @@ func pruneConsensusDBs(ctx context.Context, dataDir string, numKept uint64, runt
 	}
 	logger.Info("pruning of consensus node DB successful", "pruned", pruned)
 
-	if err := pruneCometDBs(dataDir, int64(retainHeight)); err != nil {
+	if err := pruneCometDBs(ctx, dataDir, int64(retainHeight)); err != nil {
 		return fmt.Errorf("failed to prune CometBFT managed databases: %w", err)
 	}
 
 	return nil
 }
 
-func pruneBefore(ctx context.Context, ndb db.NodeDB, version uint64) (uint64, error) {
+type pruneOption func(*pruneOptions)
+
+type pruneOptions struct {
+	diskSyncInterval uint64
+}
+
+func withPruneDiskSyncInterval(interval uint64) pruneOption {
+	return func(opts *pruneOptions) {
+		opts.diskSyncInterval = interval
+	}
+}
+
+func pruneBefore(ctx context.Context, ndb db.NodeDB, version uint64, options ...pruneOption) (uint64, error) {
+	opts := pruneOptions{
+		diskSyncInterval: 10_000,
+	}
+	for _, option := range options {
+		option(&opts)
+	}
+
 	earliest := ndb.GetEarliestVersion()
 
 	if version <= earliest {
@@ -127,7 +146,7 @@ func pruneBefore(ctx context.Context, ndb db.NodeDB, version uint64) (uint64, er
 		}
 		pruned++
 
-		if pruneDiskSyncInterval != 0 && h%pruneDiskSyncInterval == 0 { // periodically sync to disk
+		if opts.diskSyncInterval != 0 && h%opts.diskSyncInterval == 0 { // periodically sync to disk
 			if err := ndb.Sync(); err != nil {
 				return 0, fmt.Errorf("failed to sync NodeDB: %w", err)
 			}
@@ -177,34 +196,12 @@ func minReindexedHeight(dataDir string, runtimes []common.Namespace) (int64, err
 	return minH, nil
 }
 
-func pruneCometDBs(dataDir string, retainHeight int64) error {
+func pruneCometDBs(ctx context.Context, dataDir string, retainHeight int64) error {
 	blockstore, err := openConsensusBlockstore(dataDir)
 	if err != nil {
 		return fmt.Errorf("failed to open consensus blockstore: %w", err)
 	}
 	defer blockstore.Close()
-
-	// Mimic the upstream pruning logic from CometBFT
-	// (see https://github.com/oasisprotocol/cometbft/blob/653c9a0c95ac0f91a0c8c11efb9aa21c98407af6/state/execution.go#L655):
-	// 1. Get the base from the blockstore
-	// 2. Prune blockstore
-	// 3. Prune statestore
-	//
-	// This ordering is problematic: if the blockstore pruning succeeds (updating the base) but
-	// state DB pruning fails or is interrupted, a subsequent pruning run will skip already
-	// pruned blocks while leaving part of the state DB unpruned.
-	base := blockstore.Base()
-	if retainHeight <= base {
-		logger.Info("blockstore and state db already pruned")
-		return nil
-	}
-
-	logger.Info("pruning consensus blockstore", "base", base, "retain_height", retainHeight)
-	n, err := blockstore.PruneBlocks(retainHeight)
-	if err != nil {
-		return fmt.Errorf("failed to prune blocks (retain height: %d): %w", retainHeight, err)
-	}
-	logger.Info("blockstore pruning finished", "pruned", n)
 
 	state, err := openConsensusStatestore(dataDir)
 	if err != nil {
@@ -212,11 +209,57 @@ func pruneCometDBs(dataDir string, retainHeight int64) error {
 	}
 	defer state.Close()
 
-	logger.Info("pruning consensus states", "base", base, "retain_height", retainHeight)
-	if err := state.PruneStates(base, retainHeight); err != nil {
-		return fmt.Errorf("failed to prune state db (start: %d, end: %d): %w", base, retainHeight, err)
+	logger.Info("pruning block and state store", "retain_height", retainHeight)
+
+	const cometPruneBatchSize int64 = 10_000
+	var totalPruned uint64
+	for pruneUntil := blockstore.Base(); pruneUntil < retainHeight; {
+		if err = ctx.Err(); err != nil {
+			return err
+		}
+
+		pruneUntil = min(pruneUntil+cometPruneBatchSize, retainHeight)
+
+		pruned, err := pruneBlocks(blockstore, state, pruneUntil)
+		if err != nil {
+			return fmt.Errorf("failed to prune block and state store: %w", err)
+		}
+		totalPruned += pruned
 	}
-	logger.Info("state db pruning finished")
+
+	logger.Info("successfully pruned block and state store", "pruned", totalPruned)
 
 	return nil
+}
+
+// pruneBlocks mimics the upstream pruning logic from CometBFT
+// (see https://github.com/oasisprotocol/cometbft/blob/653c9a0c95ac0f91a0c8c11efb9aa21c98407af6/state/execution.go#L655):
+// 1. Get the base from the blockstore
+// 2. Prune blockstore
+// 3. Prune statestore
+//
+// This ordering is problematic: if the blockstore pruning succeeds (updating the base) but
+// state DB pruning fails or is interrupted, a subsequent pruning run will skip already
+// pruned blocks while leaving part of the state DB unpruned.
+//
+// Best way to mitigate the size of stale state (if it happens, very unlikely) is to prune in small batches.
+func pruneBlocks(blockstore *store.BlockStore, statestore state.Store, retainHeight int64) (uint64, error) {
+	base := blockstore.Base()
+	if retainHeight <= base {
+		logger.Info("blockstore and state db already pruned")
+		return 0, nil
+	}
+
+	logger.Debug("pruning consensus blockstore", "base", base, "retain_height", retainHeight)
+	pruned, err := blockstore.PruneBlocks(retainHeight)
+	if err != nil {
+		return 0, fmt.Errorf("failed to prune blocks (retain height: %d): %w", retainHeight, err)
+	}
+
+	logger.Debug("pruning consensus states", "base", base, "retain_height", retainHeight)
+	if err := statestore.PruneStates(base, retainHeight); err != nil {
+		return 0, fmt.Errorf("failed to prune state db (start: %d, end: %d): %w", base, retainHeight, err)
+	}
+
+	return pruned, nil
 }

--- a/go/oasis-node/cmd/storage/prune.go
+++ b/go/oasis-node/cmd/storage/prune.go
@@ -14,48 +14,51 @@ import (
 	db "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
 )
 
-var pruneCmd = &cobra.Command{
-	Use:   "prune-experimental",
-	Args:  cobra.NoArgs,
-	Short: "EXPERIMENTAL: trigger pruning for all consensus databases",
-	RunE:  doPrune,
-}
+func newPruneCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "prune-experimental",
+		Args:  cobra.NoArgs,
+		Short: "EXPERIMENTAL: trigger pruning for all consensus databases",
+		PreRunE: func(_ *cobra.Command, args []string) error {
+			if err := cmdCommon.Init(); err != nil {
+				cmdCommon.EarlyLogAndExit(err)
+			}
 
-func doPrune(_ *cobra.Command, args []string) error {
-	if err := cmdCommon.Init(); err != nil {
-		cmdCommon.EarlyLogAndExit(err)
+			running, err := cmdCommon.IsNodeRunning()
+			if err != nil {
+				return fmt.Errorf("failed to ensure the node is not running: %w", err)
+			}
+			if running {
+				return fmt.Errorf("pruning can only be done when the node is not running")
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if config.GlobalConfig.Consensus.Prune.Strategy == cmtConfig.PruneStrategyNone {
+				logger.Info("skipping consensus pruning since disabled in the config")
+				return nil
+			}
+
+			runtimes, err := registry.GetConfiguredRuntimeIDs()
+			if err != nil {
+				return fmt.Errorf("failed to get configured runtimes: %w", err)
+			}
+
+			logger.Info("Starting consensus databases pruning. This may take a while...")
+
+			if err := pruneConsensusDBs(
+				cmdCommon.DataDir(),
+				config.GlobalConfig.Consensus.Prune.NumKept,
+				runtimes,
+			); err != nil {
+				return fmt.Errorf("failed to prune consensus databases: %w", err)
+			}
+
+			return nil
+		},
 	}
-
-	running, err := cmdCommon.IsNodeRunning()
-	if err != nil {
-		return fmt.Errorf("failed to ensure the node is not running: %w", err)
-	}
-
-	if running {
-		return fmt.Errorf("pruning can only be done when the node is not running")
-	}
-
-	if config.GlobalConfig.Consensus.Prune.Strategy == cmtConfig.PruneStrategyNone {
-		logger.Info("skipping consensus pruning since disabled in the config")
-		return nil
-	}
-
-	runtimes, err := registry.GetConfiguredRuntimeIDs()
-	if err != nil {
-		return fmt.Errorf("failed to get configured runtimes: %w", err)
-	}
-
-	logger.Info("Starting consensus databases pruning. This may take a while...")
-
-	if err := pruneConsensusDBs(
-		cmdCommon.DataDir(),
-		config.GlobalConfig.Consensus.Prune.NumKept,
-		runtimes,
-	); err != nil {
-		return fmt.Errorf("failed to prune consensus databases: %w", err)
-	}
-
-	return nil
+	return cmd
 }
 
 func pruneConsensusDBs(dataDir string, numKept uint64, runtimes []common.Namespace) error {

--- a/go/oasis-node/cmd/storage/prune.go
+++ b/go/oasis-node/cmd/storage/prune.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 
@@ -13,15 +14,17 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/config"
 	cmtConfig "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/config"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
+	"github.com/oasisprotocol/oasis-core/go/runtime/history"
 	"github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	db "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
 )
 
 func newPruneCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "prune-experimental",
+		Use:   "prune",
 		Args:  cobra.NoArgs,
-		Short: "EXPERIMENTAL: trigger pruning for all consensus databases",
+		Short: "trigger pruning of all databases",
 		PreRunE: func(_ *cobra.Command, args []string) error {
 			if err := cmdCommon.Init(); err != nil {
 				cmdCommon.EarlyLogAndExit(err)
@@ -38,26 +41,48 @@ func newPruneCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if config.GlobalConfig.Consensus.Prune.Strategy == cmtConfig.PruneStrategyNone {
-				logger.Info("skipping consensus pruning since disabled in the config")
-				return nil
-			}
-
 			runtimes, err := registry.GetConfiguredRuntimeIDs()
 			if err != nil {
 				return fmt.Errorf("failed to get configured runtimes: %w", err)
 			}
 
-			logger.Info("Starting consensus databases pruning. This may take a while...")
+			logger.Info("Starting databases pruning. This may take a while...")
 
-			if err := pruneConsensusDBs(
-				cmd.Context(),
-				cmdCommon.DataDir(),
+			dataDir := cmdCommon.DataDir()
+			ctx := cmd.Context()
+
+			// Consensus pruning
+			if config.GlobalConfig.Consensus.Prune.Strategy == cmtConfig.PruneStrategyNone {
+				logger.Info("skipping consensus pruning since disabled in the config")
+			} else if err := pruneConsensusDBs(
+				ctx,
+				dataDir,
 				config.GlobalConfig.Consensus.Prune.NumKept,
 				runtimes,
 			); err != nil {
 				return fmt.Errorf("failed to prune consensus databases: %w", err)
 			}
+
+			// Runtime pruning
+			if len(runtimes) == 0 {
+				return nil
+			}
+			if !config.GlobalConfig.Runtime.Prune.IsEnabled() {
+				logger.Info("skipping runtime pruning since disabled in the config")
+				return nil
+			}
+			for _, rt := range runtimes {
+				if err := pruneRuntimeDBs(
+					ctx,
+					dataDir,
+					rt,
+					config.GlobalConfig.Runtime.Prune.NumKept,
+				); err != nil {
+					return fmt.Errorf("failed to prune runtime databases (runtime ID: %s): %w", rt, err)
+				}
+			}
+
+			logger.Info("pruning of all databases successful")
 
 			return nil
 		},
@@ -74,12 +99,12 @@ func pruneConsensusDBs(ctx context.Context, dataDir string, numKept uint64, runt
 
 	latest, ok := ndb.GetLatestVersion()
 	if !ok {
-		logger.Info("skipping pruning as state db is empty")
+		logger.Info("skipping consensus pruning as state db is empty")
 		return nil
 	}
 
 	if latest < numKept {
-		logger.Info("skipping pruning as the latest version is smaller than the number of versions to keep")
+		logger.Info("skipping consensus pruning as the latest version is smaller than the number of versions to keep")
 		return nil
 	}
 
@@ -95,16 +120,18 @@ func pruneConsensusDBs(ctx context.Context, dataDir string, numKept uint64, runt
 		uint64(minReindexed),
 	)
 
+	logger.Info("pruning consensus state DB", "retain_height", retainHeight)
 	pruned, err := pruneBefore(ctx, ndb, retainHeight)
 	if err != nil {
-		return fmt.Errorf("failed to prune application state: %w", err)
+		return fmt.Errorf("failed to prune consensus state DB: %w", err)
 	}
-	logger.Info("pruning of consensus node DB successful", "pruned", pruned)
+	logger.Info("pruning of consensus state DB successful", "pruned", pruned)
 
 	if err := pruneCometDBs(ctx, dataDir, int64(retainHeight)); err != nil {
 		return fmt.Errorf("failed to prune CometBFT managed databases: %w", err)
 	}
 
+	logger.Info("pruning of consensus databases successful")
 	return nil
 }
 
@@ -262,4 +289,101 @@ func pruneBlocks(blockstore *store.BlockStore, statestore state.Store, retainHei
 	}
 
 	return pruned, nil
+}
+
+func pruneRuntimeDBs(ctx context.Context, dataDir string, runtimeID common.Namespace, numKept uint64) error {
+	logger := logger.With("runtime_id", runtimeID)
+
+	ndb, err := openRuntimeStateDB(dataDir, runtimeID)
+	if err != nil {
+		return fmt.Errorf("failed to open runtime state DB: %w", err)
+	}
+	defer ndb.Close()
+	latest, ok := ndb.GetLatestVersion()
+	if !ok {
+		logger.Info("skipping runtime pruning as state DB is empty")
+		return nil
+	}
+
+	if latest < numKept {
+		logger.Info("skipping runtime pruning as the latest version is smaller than the number of versions to keep")
+		return nil
+	}
+
+	// By calculating retain round from the runtime state DB latest round,
+	// we ensure light history is never pruned past the latest synced runtime
+	// round.
+	retainRound := latest - numKept
+
+	// Prune light history before state DB, since node expects this order
+	// of pruning.
+	logger.Info("pruning runtime history", "retain_round", retainRound)
+	history, err := openRuntimeLightHistory(dataDir, runtimeID)
+	if err != nil {
+		return fmt.Errorf("failed to open runtime light history: %w", err)
+	}
+	defer history.Close()
+	pruned, err := pruneRuntimeHistory(ctx, history, retainRound)
+	if err != nil {
+		return fmt.Errorf("failed to prune runtime history before round %d: %w", retainRound, err)
+	}
+	logger.Info("pruning of runtime history successful", "pruned", pruned)
+
+	logger.Info("pruning runtime state DB", "retain_round", retainRound)
+	pruned, err = pruneBefore(ctx, ndb, retainRound)
+	if err != nil {
+		return fmt.Errorf("failed to prune nodeDB before round %d: %w", retainRound, err)
+	}
+	logger.Info("pruning of runtime state DB successful", "pruned", pruned)
+
+	return nil
+}
+
+type pruneRuntimeHistoryOption func(*pruneRuntimeHistoryOptions)
+
+type pruneRuntimeHistoryOptions struct {
+	batchSize uint64
+}
+
+func withPruneRuntimeHistoryBatchSize(batchSize uint64) pruneRuntimeHistoryOption {
+	return func(opts *pruneRuntimeHistoryOptions) {
+		opts.batchSize = batchSize
+	}
+}
+
+func pruneRuntimeHistory(ctx context.Context, history history.History, retainRound uint64, options ...pruneRuntimeHistoryOption) (uint64, error) {
+	opts := pruneRuntimeHistoryOptions{
+		batchSize: 10_000,
+	}
+	for _, option := range options {
+		option(&opts)
+	}
+
+	earliest, err := history.GetEarliestBlock(ctx)
+	switch {
+	case err == nil:
+	case errors.Is(err, roothash.ErrNotFound): // empty
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("failed to get earliest runtime block: %w", err)
+	}
+
+	var totalPruned uint64
+	for pruneUntil := earliest.Header.Round; pruneUntil < retainRound; {
+		logger.Debug("pruning runtime history", "prune_until", pruneUntil)
+		if err = ctx.Err(); err != nil {
+			return 0, err
+		}
+
+		pruneUntil = min(pruneUntil+opts.batchSize, retainRound)
+
+		pruned, err := history.PruneBefore(pruneUntil)
+		if err != nil {
+			return 0, fmt.Errorf("failed to prune runtime history before round %d: %w", pruneUntil, err)
+		}
+		totalPruned += pruned
+		logger.Debug("pruned runtime history", "pruned", pruned)
+	}
+
+	return totalPruned, nil
 }

--- a/go/oasis-node/cmd/storage/prune.go
+++ b/go/oasis-node/cmd/storage/prune.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"math"
 
@@ -13,6 +14,8 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	db "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
 )
+
+var pruneDiskSyncInterval uint64 = 10_000
 
 func newPruneCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -48,6 +51,7 @@ func newPruneCmd() *cobra.Command {
 			logger.Info("Starting consensus databases pruning. This may take a while...")
 
 			if err := pruneConsensusDBs(
+				cmd.Context(),
 				cmdCommon.DataDir(),
 				config.GlobalConfig.Consensus.Prune.NumKept,
 				runtimes,
@@ -61,7 +65,7 @@ func newPruneCmd() *cobra.Command {
 	return cmd
 }
 
-func pruneConsensusDBs(dataDir string, numKept uint64, runtimes []common.Namespace) error {
+func pruneConsensusDBs(ctx context.Context, dataDir string, numKept uint64, runtimes []common.Namespace) error {
 	ndb, close, err := openConsensusNodeDB(dataDir)
 	if err != nil {
 		return fmt.Errorf("failed to open NodeDB: %w", err)
@@ -91,9 +95,11 @@ func pruneConsensusDBs(dataDir string, numKept uint64, runtimes []common.Namespa
 		uint64(minReindexed),
 	)
 
-	if err := pruneConsensusNodeDB(ndb, retainHeight); err != nil {
+	pruned, err := pruneBefore(ctx, ndb, retainHeight)
+	if err != nil {
 		return fmt.Errorf("failed to prune application state: %w", err)
 	}
+	logger.Info("pruning of consensus node DB successful", "pruned", pruned)
 
 	if err := pruneCometDBs(dataDir, int64(retainHeight)); err != nil {
 		return fmt.Errorf("failed to prune CometBFT managed databases: %w", err)
@@ -102,33 +108,38 @@ func pruneConsensusDBs(dataDir string, numKept uint64, runtimes []common.Namespa
 	return nil
 }
 
-func pruneConsensusNodeDB(ndb db.NodeDB, retainHeight uint64) error {
-	startHeight := ndb.GetEarliestVersion()
+func pruneBefore(ctx context.Context, ndb db.NodeDB, version uint64) (uint64, error) {
+	earliest := ndb.GetEarliestVersion()
 
-	if retainHeight <= startHeight {
-		logger.Info("consensus state already pruned", "retain_height", retainHeight, "start_height", startHeight)
-		return nil
+	if version <= earliest {
+		logger.Info("db state already pruned", "earliest", earliest, "version", version)
+		return 0, nil
 	}
 
-	logger.Info("pruning consensus state", "start_height", startHeight, "retain_height", retainHeight)
-	for h := startHeight; h < retainHeight; h++ {
-		if err := ndb.Prune(h); err != nil {
-			return fmt.Errorf("failed to prune version %d: %w", h, err)
+	logger.Info("pruning node DB", "earliest", earliest, "version", version)
+	var pruned uint64
+	for h := earliest; h < version; h++ {
+		if err := ctx.Err(); err != nil {
+			return 0, err
 		}
+		if err := ndb.Prune(h); err != nil {
+			return 0, fmt.Errorf("failed to prune version %d: %w", h, err)
+		}
+		pruned++
 
-		if h%10_000 == 0 { // periodically sync to disk
+		if pruneDiskSyncInterval != 0 && h%pruneDiskSyncInterval == 0 { // periodically sync to disk
 			if err := ndb.Sync(); err != nil {
-				return fmt.Errorf("failed to sync NodeDB: %w", err)
+				return 0, fmt.Errorf("failed to sync NodeDB: %w", err)
 			}
 			logger.Debug("forcing NodeDB disk sync during pruning", "version", h)
 		}
 	}
 
 	if err := ndb.Sync(); err != nil {
-		return fmt.Errorf("failed to sync NodeDB: %w", err)
+		return 0, fmt.Errorf("failed to sync NodeDB: %w", err)
 	}
 
-	return nil
+	return pruned, nil
 }
 
 // minReindexedHeight returns the smallest consensus height reindexed by any

--- a/go/oasis-node/cmd/storage/prune.go
+++ b/go/oasis-node/cmd/storage/prune.go
@@ -1,0 +1,208 @@
+package storage
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/spf13/cobra"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/config"
+	cmtConfig "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/config"
+	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
+	"github.com/oasisprotocol/oasis-core/go/runtime/registry"
+	db "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
+)
+
+var pruneCmd = &cobra.Command{
+	Use:   "prune-experimental",
+	Args:  cobra.NoArgs,
+	Short: "EXPERIMENTAL: trigger pruning for all consensus databases",
+	RunE:  doPrune,
+}
+
+func doPrune(_ *cobra.Command, args []string) error {
+	if err := cmdCommon.Init(); err != nil {
+		cmdCommon.EarlyLogAndExit(err)
+	}
+
+	running, err := cmdCommon.IsNodeRunning()
+	if err != nil {
+		return fmt.Errorf("failed to ensure the node is not running: %w", err)
+	}
+
+	if running {
+		return fmt.Errorf("pruning can only be done when the node is not running")
+	}
+
+	if config.GlobalConfig.Consensus.Prune.Strategy == cmtConfig.PruneStrategyNone {
+		logger.Info("skipping consensus pruning since disabled in the config")
+		return nil
+	}
+
+	runtimes, err := registry.GetConfiguredRuntimeIDs()
+	if err != nil {
+		return fmt.Errorf("failed to get configured runtimes: %w", err)
+	}
+
+	logger.Info("Starting consensus databases pruning. This may take a while...")
+
+	if err := pruneConsensusDBs(
+		cmdCommon.DataDir(),
+		config.GlobalConfig.Consensus.Prune.NumKept,
+		runtimes,
+	); err != nil {
+		return fmt.Errorf("failed to prune consensus databases: %w", err)
+	}
+
+	return nil
+}
+
+func pruneConsensusDBs(dataDir string, numKept uint64, runtimes []common.Namespace) error {
+	ndb, close, err := openConsensusNodeDB(dataDir)
+	if err != nil {
+		return fmt.Errorf("failed to open NodeDB: %w", err)
+	}
+	defer close()
+
+	latest, ok := ndb.GetLatestVersion()
+	if !ok {
+		logger.Info("skipping pruning as state db is empty")
+		return nil
+	}
+
+	if latest < numKept {
+		logger.Info("skipping pruning as the latest version is smaller than the number of versions to keep")
+		return nil
+	}
+
+	// In case of configured runtimes, do not prune past the earliest reindexed
+	// consensus height, so that light history can be populated correctly.
+	minReindexed, err := minReindexedHeight(dataDir, runtimes)
+	if err != nil {
+		return fmt.Errorf("failed to fetch earliest reindexed consensus height: %w", err)
+	}
+
+	retainHeight := min(
+		latest-numKept, // underflow not possible due to if above.
+		uint64(minReindexed),
+	)
+
+	if err := pruneConsensusNodeDB(ndb, retainHeight); err != nil {
+		return fmt.Errorf("failed to prune application state: %w", err)
+	}
+
+	if err := pruneCometDBs(dataDir, int64(retainHeight)); err != nil {
+		return fmt.Errorf("failed to prune CometBFT managed databases: %w", err)
+	}
+
+	return nil
+}
+
+func pruneConsensusNodeDB(ndb db.NodeDB, retainHeight uint64) error {
+	startHeight := ndb.GetEarliestVersion()
+
+	if retainHeight <= startHeight {
+		logger.Info("consensus state already pruned", "retain_height", retainHeight, "start_height", startHeight)
+		return nil
+	}
+
+	logger.Info("pruning consensus state", "start_height", startHeight, "retain_height", retainHeight)
+	for h := startHeight; h < retainHeight; h++ {
+		if err := ndb.Prune(h); err != nil {
+			return fmt.Errorf("failed to prune version %d: %w", h, err)
+		}
+
+		if h%10_000 == 0 { // periodically sync to disk
+			if err := ndb.Sync(); err != nil {
+				return fmt.Errorf("failed to sync NodeDB: %w", err)
+			}
+			logger.Debug("forcing NodeDB disk sync during pruning", "version", h)
+		}
+	}
+
+	if err := ndb.Sync(); err != nil {
+		return fmt.Errorf("failed to sync NodeDB: %w", err)
+	}
+
+	return nil
+}
+
+// minReindexedHeight returns the smallest consensus height reindexed by any
+// of the configured runtimes.
+//
+// In case of no configured runtimes it returns max int64.
+func minReindexedHeight(dataDir string, runtimes []common.Namespace) (int64, error) {
+	fetchLastReindexedHeight := func(runtimeID common.Namespace) (int64, error) {
+		history, err := openRuntimeLightHistory(dataDir, runtimeID)
+		if err != nil {
+			return 0, fmt.Errorf("failed to open runtime light history: %w", err)
+		}
+		defer history.Close()
+
+		h, err := history.LastConsensusHeight()
+		if err != nil {
+			return 0, fmt.Errorf("failed to get last consensus height: %w", err)
+		}
+
+		return h, nil
+	}
+
+	var minH int64 = math.MaxInt64
+	for _, rt := range runtimes {
+		h, err := fetchLastReindexedHeight(rt)
+		if err != nil {
+			return 0, fmt.Errorf("failed to fetch last reindexed height for %s: %w", rt, err)
+		}
+
+		if h < minH {
+			minH = h
+		}
+	}
+
+	return minH, nil
+}
+
+func pruneCometDBs(dataDir string, retainHeight int64) error {
+	blockstore, err := openConsensusBlockstore(dataDir)
+	if err != nil {
+		return fmt.Errorf("failed to open consensus blockstore: %w", err)
+	}
+	defer blockstore.Close()
+
+	// Mimic the upstream pruning logic from CometBFT
+	// (see https://github.com/oasisprotocol/cometbft/blob/653c9a0c95ac0f91a0c8c11efb9aa21c98407af6/state/execution.go#L655):
+	// 1. Get the base from the blockstore
+	// 2. Prune blockstore
+	// 3. Prune statestore
+	//
+	// This ordering is problematic: if the blockstore pruning succeeds (updating the base) but
+	// state DB pruning fails or is interrupted, a subsequent pruning run will skip already
+	// pruned blocks while leaving part of the state DB unpruned.
+	base := blockstore.Base()
+	if retainHeight <= base {
+		logger.Info("blockstore and state db already pruned")
+		return nil
+	}
+
+	logger.Info("pruning consensus blockstore", "base", base, "retain_height", retainHeight)
+	n, err := blockstore.PruneBlocks(retainHeight)
+	if err != nil {
+		return fmt.Errorf("failed to prune blocks (retain height: %d): %w", retainHeight, err)
+	}
+	logger.Info("blockstore pruning finished", "pruned", n)
+
+	state, err := openConsensusStatestore(dataDir)
+	if err != nil {
+		return fmt.Errorf("failed to open consensus state store: %w", err)
+	}
+	defer state.Close()
+
+	logger.Info("pruning consensus states", "base", base, "retain_height", retainHeight)
+	if err := state.PruneStates(base, retainHeight); err != nil {
+		return fmt.Errorf("failed to prune state db (start: %d, end: %d): %w", base, retainHeight, err)
+	}
+	logger.Info("state db pruning finished")
+
+	return nil
+}

--- a/go/oasis-node/cmd/storage/prune_test.go
+++ b/go/oasis-node/cmd/storage/prune_test.go
@@ -1,0 +1,118 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs"
+	dbAPI "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/pathbadger"
+	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/node"
+)
+
+func TestPruneNodeDB(t *testing.T) {
+	ctx := context.Background()
+	ns := common.NewTestNamespaceFromSeed([]byte("storage prune test ns"), 0)
+
+	ndb, err := newTestNodeDB(t, ns)
+	require.NoError(t, err)
+	defer ndb.Close()
+
+	lastRoot := newEmptyRoot(node.RootTypeState)
+	addVersion := func(version uint64) node.Root {
+		root := commitTestRoot(ctx, t, ndb, ns, lastRoot, version, node.RootTypeState, map[string]string{
+			"key": "value " + strconv.FormatUint(version, 10),
+		})
+		require.NoError(t, ndb.Finalize([]node.Root{root}))
+		lastRoot = root
+		return root
+	}
+
+	for version := uint64(1); version <= 20; version++ {
+		addVersion(version)
+	}
+
+	t.Run("prune", func(t *testing.T) {
+		pruned, err := pruneBefore(ctx, ndb, 2)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), pruned)
+		require.Equal(t, uint64(2), ndb.GetEarliestVersion())
+	})
+
+	t.Run("prune with retain version before earliest is no-op", func(t *testing.T) {
+		pruned, err := pruneBefore(ctx, ndb, 1)
+		require.NoError(t, err)
+		require.EqualValues(t, 0, pruned)
+		require.Equal(t, uint64(2), ndb.GetEarliestVersion())
+	})
+
+	t.Run("prune with periodic disk sync", func(t *testing.T) {
+		// Force disk sync.
+		oldSyncInterval := pruneDiskSyncInterval
+		pruneDiskSyncInterval = 2
+
+		defer func() {
+			pruneDiskSyncInterval = oldSyncInterval
+		}()
+
+		wantEarliest := uint64(17)
+		wantPruned := wantEarliest - ndb.GetEarliestVersion()
+		pruned, err := pruneBefore(ctx, ndb, wantEarliest)
+		require.NoError(t, err)
+		require.Equal(t, wantPruned, pruned)
+		require.Equal(t, wantEarliest, ndb.GetEarliestVersion())
+	})
+}
+
+func newTestNodeDB(t *testing.T, ns common.Namespace) (dbAPI.NodeDB, error) {
+	t.Helper()
+
+	return pathbadger.New(&dbAPI.Config{
+		DB:        filepath.Join(t.TempDir()),
+		Namespace: ns,
+		NoFsync:   true,
+	})
+}
+
+func commitTestRoot(
+	ctx context.Context,
+	t *testing.T,
+	ndb dbAPI.NodeDB,
+	ns common.Namespace,
+	oldRoot node.Root,
+	version uint64,
+	rootType node.RootType,
+	data map[string]string,
+) node.Root {
+	t.Helper()
+
+	tree := mkvs.NewWithRoot(nil, ndb, oldRoot)
+	defer tree.Close()
+
+	for k, v := range data {
+		err := tree.Insert(ctx, []byte(k), []byte(v))
+		require.NoError(t, err)
+	}
+
+	_, rootHash, err := tree.Commit(ctx, ns, version)
+	require.NoError(t, err)
+
+	return node.Root{
+		Namespace: ns,
+		Version:   version,
+		Type:      rootType,
+		Hash:      rootHash,
+	}
+}
+
+func newEmptyRoot(rootType node.RootType) node.Root {
+	var root node.Root
+	root.Empty()
+	root.Type = rootType
+	return root
+}

--- a/go/oasis-node/cmd/storage/prune_test.go
+++ b/go/oasis-node/cmd/storage/prune_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
+	"github.com/oasisprotocol/oasis-core/go/runtime/history"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs"
 	dbAPI "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/pathbadger"
@@ -58,6 +61,45 @@ func TestPruneNodeDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, wantPruned, pruned)
 		require.Equal(t, wantEarliest, ndb.GetEarliestVersion())
+	})
+}
+
+func TestPruneRuntimeHistory(t *testing.T) {
+	ctx := t.Context()
+	runtimeID := common.NewTestNamespaceFromSeed([]byte("runtime history prune test ns"), 0)
+
+	h, err := history.New(runtimeID, t.TempDir(), history.NewNonePrunerFactory(), false)
+	require.NoError(t, err, "New")
+	defer h.Close()
+
+	t.Run("empty", func(t *testing.T) {
+		pruned, err := pruneRuntimeHistory(ctx, h, 10)
+		require.NoError(t, err)
+		require.EqualValues(t, 0, pruned)
+	})
+
+	// Commit blocks for rounds 0-19.
+	blks := make([]*roothash.AnnotatedBlock, 20)
+	for i := range blks {
+		blk := &roothash.AnnotatedBlock{
+			Height: int64(100 + i), // Height is different than round.
+			Block:  block.NewGenesisBlock(runtimeID, 0),
+		}
+		blk.Block.Header.Round = uint64(i)
+		blks[i] = blk
+	}
+	require.NoError(t, h.Commit(blks), "Commit")
+
+	t.Run("prune", func(t *testing.T) {
+		pruned, err := pruneRuntimeHistory(ctx, h, 1)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, pruned)
+	})
+
+	t.Run("prune in batch", func(t *testing.T) {
+		pruned, err := pruneRuntimeHistory(ctx, h, 17, withPruneRuntimeHistoryBatchSize(2))
+		require.NoError(t, err)
+		require.EqualValues(t, 16, pruned)
 	})
 }
 

--- a/go/oasis-node/cmd/storage/prune_test.go
+++ b/go/oasis-node/cmd/storage/prune_test.go
@@ -52,17 +52,9 @@ func TestPruneNodeDB(t *testing.T) {
 	})
 
 	t.Run("prune with periodic disk sync", func(t *testing.T) {
-		// Force disk sync.
-		oldSyncInterval := pruneDiskSyncInterval
-		pruneDiskSyncInterval = 2
-
-		defer func() {
-			pruneDiskSyncInterval = oldSyncInterval
-		}()
-
 		wantEarliest := uint64(17)
 		wantPruned := wantEarliest - ndb.GetEarliestVersion()
-		pruned, err := pruneBefore(ctx, ndb, wantEarliest)
+		pruned, err := pruneBefore(ctx, ndb, wantEarliest, withPruneDiskSyncInterval(2))
 		require.NoError(t, err)
 		require.Equal(t, wantPruned, pruned)
 		require.Equal(t, wantEarliest, ndb.GetEarliestVersion())

--- a/go/oasis-node/cmd/storage/storage.go
+++ b/go/oasis-node/cmd/storage/storage.go
@@ -286,7 +286,7 @@ func Register(parentCmd *cobra.Command) {
 	storageCmd.AddCommand(storageMigrateCmd)
 	storageCmd.AddCommand(storageCheckCmd)
 	storageCmd.AddCommand(storageRenameNsCmd)
-	storageCmd.AddCommand(storageCompactCmd)
+	storageCmd.AddCommand(newCompactCmd())
 	storageCmd.AddCommand(newPruneCmd())
 	storageCmd.AddCommand(newInspectCmd())
 	parentCmd.AddCommand(storageCmd)

--- a/go/oasis-node/cmd/storage/storage.go
+++ b/go/oasis-node/cmd/storage/storage.go
@@ -5,20 +5,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
-	badgerDB "github.com/dgraph-io/badger/v4"
 	"github.com/spf13/cobra"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/config"
-	cmtDBProvider "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/db/badger"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/runtime/bundle"
@@ -55,17 +51,6 @@ var (
 		Args:  cobra.ExactArgs(2),
 		Short: "change the namespace of a runtime database",
 		RunE:  doRenameNs,
-	}
-
-	storageCompactCmd = &cobra.Command{
-		Use:   "compact-experimental",
-		Args:  cobra.NoArgs,
-		Short: "EXPERIMENTAL: trigger compaction for all consensus databases",
-		Long: `EXPERIMENTAL: Optimize the storage for all consensus databases by manually compacting the underlying storage engines.
-
-WARNING: Ensure you have at least as much of a free disk as your largest database.
-`,
-		RunE: doDBCompactions,
 	}
 
 	logger = logging.GetLogger("cmd/storage")
@@ -292,109 +277,6 @@ func doRenameNs(_ *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-func doDBCompactions(_ *cobra.Command, args []string) error {
-	if err := cmdCommon.Init(); err != nil {
-		cmdCommon.EarlyLogAndExit(err)
-	}
-
-	running, err := cmdCommon.IsNodeRunning()
-	if err != nil {
-		return fmt.Errorf("failed to ensure the node is not running: %w", err)
-	}
-
-	if running {
-		return fmt.Errorf("compaction can only be done when the node is not running")
-	}
-
-	dataDir := cmdCommon.DataDir()
-
-	logger.Info("Starting database compactions. This may take a while...")
-
-	// Compact CometBFT managed databases: block store, evidence and state (NOT application state).
-	if err := compactCometDBs(dataDir); err != nil {
-		return fmt.Errorf("failed to compact CometBFT managed databases: %w", err)
-	}
-
-	if err := compactConsensusNodeDB(dataDir); err != nil {
-		return fmt.Errorf("failed to compact consensus NodeDB: %w", err)
-	}
-
-	return nil
-}
-
-func compactCometDBs(dataDir string) error {
-	paths, err := findCometDBs(dataDir)
-	if err != nil {
-		return fmt.Errorf("failed to find database instances: %w", err)
-	}
-	for _, path := range paths {
-		if err := compactCometDB(path); err != nil {
-			return fmt.Errorf("failed to compact %s: %w", path, err)
-		}
-	}
-	return nil
-}
-
-func compactCometDB(path string) error {
-	logger := logger.With("path", path)
-	db, err := cmtDBProvider.OpenBadger(path, logger)
-	if err != nil {
-		return fmt.Errorf("failed to open BadgerDB: %w", err)
-	}
-
-	if err := flattenBadgerDB(db, logger); err != nil {
-		return fmt.Errorf("failed to compact %s: %w", path, err)
-	}
-
-	return nil
-}
-
-func findCometDBs(dataDir string) ([]string, error) {
-	dir := fmt.Sprintf("%s/consensus/data", dataDir)
-
-	var dbDirs []string
-	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() && strings.HasSuffix(d.Name(), ".db") {
-			dbDirs = append(dbDirs, path)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to walk dir %s: %w", dataDir, err)
-	}
-
-	if len(dbDirs) == 0 {
-		return nil, fmt.Errorf("zero database instances found")
-	}
-
-	return dbDirs, nil
-}
-
-func flattenBadgerDB(db *badgerDB.DB, logger *logging.Logger) error {
-	logger.Info("compacting")
-
-	if err := db.Flatten(1); err != nil {
-		return fmt.Errorf("failed to flatten db: %w", err)
-	}
-
-	logger.Info("compaction completed")
-
-	return nil
-}
-
-func compactConsensusNodeDB(dataDir string) error {
-	ndb, close, err := openConsensusNodeDB(dataDir)
-	if err != nil {
-		return fmt.Errorf("failed to open consensus NodeDB: %w", err)
-	}
-	defer close()
-
-	return ndb.Compact()
 }
 
 // Register registers the client sub-command and all of its children.

--- a/go/oasis-node/cmd/storage/storage.go
+++ b/go/oasis-node/cmd/storage/storage.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,14 +18,12 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/config"
-	cmtConfig "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/config"
 	cmtDBProvider "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/db/badger"
 	cmdCommon "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/runtime/bundle"
 	runtimeConfig "github.com/oasisprotocol/oasis-core/go/runtime/config"
 	"github.com/oasisprotocol/oasis-core/go/runtime/history"
-	"github.com/oasisprotocol/oasis-core/go/runtime/registry"
 	db "github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/api"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/db/badger"
 	"github.com/oasisprotocol/oasis-core/go/storage/mkvs/node"
@@ -69,13 +66,6 @@ var (
 WARNING: Ensure you have at least as much of a free disk as your largest database.
 `,
 		RunE: doDBCompactions,
-	}
-
-	pruneCmd = &cobra.Command{
-		Use:   "prune-experimental",
-		Args:  cobra.NoArgs,
-		Short: "EXPERIMENTAL: trigger pruning for all consensus databases",
-		RunE:  doPrune,
 	}
 
 	logger = logging.GetLogger("cmd/storage")
@@ -405,192 +395,6 @@ func compactConsensusNodeDB(dataDir string) error {
 	defer close()
 
 	return ndb.Compact()
-}
-
-func doPrune(_ *cobra.Command, args []string) error {
-	if err := cmdCommon.Init(); err != nil {
-		cmdCommon.EarlyLogAndExit(err)
-	}
-
-	running, err := cmdCommon.IsNodeRunning()
-	if err != nil {
-		return fmt.Errorf("failed to ensure the node is not running: %w", err)
-	}
-
-	if running {
-		return fmt.Errorf("pruning can only be done when the node is not running")
-	}
-
-	if config.GlobalConfig.Consensus.Prune.Strategy == cmtConfig.PruneStrategyNone {
-		logger.Info("skipping consensus pruning since disabled in the config")
-		return nil
-	}
-
-	runtimes, err := registry.GetConfiguredRuntimeIDs()
-	if err != nil {
-		return fmt.Errorf("failed to get configured runtimes: %w", err)
-	}
-
-	logger.Info("Starting consensus databases pruning. This may take a while...")
-
-	if err := pruneConsensusDBs(
-		cmdCommon.DataDir(),
-		config.GlobalConfig.Consensus.Prune.NumKept,
-		runtimes,
-	); err != nil {
-		return fmt.Errorf("failed to prune consensus databases: %w", err)
-	}
-
-	return nil
-}
-
-func pruneConsensusDBs(dataDir string, numKept uint64, runtimes []common.Namespace) error {
-	ndb, close, err := openConsensusNodeDB(dataDir)
-	if err != nil {
-		return fmt.Errorf("failed to open NodeDB: %w", err)
-	}
-	defer close()
-
-	latest, ok := ndb.GetLatestVersion()
-	if !ok {
-		logger.Info("skipping pruning as state db is empty")
-		return nil
-	}
-
-	if latest < numKept {
-		logger.Info("skipping pruning as the latest version is smaller than the number of versions to keep")
-		return nil
-	}
-
-	// In case of configured runtimes, do not prune past the earliest reindexed
-	// consensus height, so that light history can be populated correctly.
-	minReindexed, err := minReindexedHeight(dataDir, runtimes)
-	if err != nil {
-		return fmt.Errorf("failed to fetch earliest reindexed consensus height: %w", err)
-	}
-
-	retainHeight := min(
-		latest-numKept, // underflow not possible due to if above.
-		uint64(minReindexed),
-	)
-
-	if err := pruneConsensusNodeDB(ndb, retainHeight); err != nil {
-		return fmt.Errorf("failed to prune application state: %w", err)
-	}
-
-	if err := pruneCometDBs(dataDir, int64(retainHeight)); err != nil {
-		return fmt.Errorf("failed to prune CometBFT managed databases: %w", err)
-	}
-
-	return nil
-}
-
-func pruneConsensusNodeDB(ndb db.NodeDB, retainHeight uint64) error {
-	startHeight := ndb.GetEarliestVersion()
-
-	if retainHeight <= startHeight {
-		logger.Info("consensus state already pruned", "retain_height", retainHeight, "start_height", startHeight)
-		return nil
-	}
-
-	logger.Info("pruning consensus state", "start_height", startHeight, "retain_height", retainHeight)
-	for h := startHeight; h < retainHeight; h++ {
-		if err := ndb.Prune(h); err != nil {
-			return fmt.Errorf("failed to prune version %d: %w", h, err)
-		}
-
-		if h%10_000 == 0 { // periodically sync to disk
-			if err := ndb.Sync(); err != nil {
-				return fmt.Errorf("failed to sync NodeDB: %w", err)
-			}
-			logger.Debug("forcing NodeDB disk sync during pruning", "version", h)
-		}
-	}
-
-	if err := ndb.Sync(); err != nil {
-		return fmt.Errorf("failed to sync NodeDB: %w", err)
-	}
-
-	return nil
-}
-
-// minReindexedHeight returns the smallest consensus height reindexed by any
-// of the configured runtimes.
-//
-// In case of no configured runtimes it returns max int64.
-func minReindexedHeight(dataDir string, runtimes []common.Namespace) (int64, error) {
-	fetchLastReindexedHeight := func(runtimeID common.Namespace) (int64, error) {
-		history, err := openRuntimeLightHistory(dataDir, runtimeID)
-		if err != nil {
-			return 0, fmt.Errorf("failed to open runtime light history: %w", err)
-		}
-		defer history.Close()
-
-		h, err := history.LastConsensusHeight()
-		if err != nil {
-			return 0, fmt.Errorf("failed to get last consensus height: %w", err)
-		}
-
-		return h, nil
-	}
-
-	var minH int64 = math.MaxInt64
-	for _, rt := range runtimes {
-		h, err := fetchLastReindexedHeight(rt)
-		if err != nil {
-			return 0, fmt.Errorf("failed to fetch last reindexed height for %s: %w", rt, err)
-		}
-
-		if h < minH {
-			minH = h
-		}
-	}
-
-	return minH, nil
-}
-
-func pruneCometDBs(dataDir string, retainHeight int64) error {
-	blockstore, err := openConsensusBlockstore(dataDir)
-	if err != nil {
-		return fmt.Errorf("failed to open consensus blockstore: %w", err)
-	}
-	defer blockstore.Close()
-
-	// Mimic the upstream pruning logic from CometBFT
-	// (see https://github.com/oasisprotocol/cometbft/blob/653c9a0c95ac0f91a0c8c11efb9aa21c98407af6/state/execution.go#L655):
-	// 1. Get the base from the blockstore
-	// 2. Prune blockstore
-	// 3. Prune statestore
-	//
-	// This ordering is problematic: if the blockstore pruning succeeds (updating the base) but
-	// state DB pruning fails or is interrupted, a subsequent pruning run will skip already
-	// pruned blocks while leaving part of the state DB unpruned.
-	base := blockstore.Base()
-	if retainHeight <= base {
-		logger.Info("blockstore and state db already pruned")
-		return nil
-	}
-
-	logger.Info("pruning consensus blockstore", "base", base, "retain_height", retainHeight)
-	n, err := blockstore.PruneBlocks(retainHeight)
-	if err != nil {
-		return fmt.Errorf("failed to prune blocks (retain height: %d): %w", retainHeight, err)
-	}
-	logger.Info("blockstore pruning finished", "pruned", n)
-
-	state, err := openConsensusStatestore(dataDir)
-	if err != nil {
-		return fmt.Errorf("failed to open consensus state store: %w", err)
-	}
-	defer state.Close()
-
-	logger.Info("pruning consensus states", "base", base, "retain_height", retainHeight)
-	if err := state.PruneStates(base, retainHeight); err != nil {
-		return fmt.Errorf("failed to prune state db (start: %d, end: %d): %w", base, retainHeight, err)
-	}
-	logger.Info("state db pruning finished")
-
-	return nil
 }
 
 // Register registers the client sub-command and all of its children.

--- a/go/oasis-node/cmd/storage/storage.go
+++ b/go/oasis-node/cmd/storage/storage.go
@@ -405,7 +405,7 @@ func Register(parentCmd *cobra.Command) {
 	storageCmd.AddCommand(storageCheckCmd)
 	storageCmd.AddCommand(storageRenameNsCmd)
 	storageCmd.AddCommand(storageCompactCmd)
-	storageCmd.AddCommand(pruneCmd)
+	storageCmd.AddCommand(newPruneCmd())
 	storageCmd.AddCommand(newInspectCmd())
 	parentCmd.AddCommand(storageCmd)
 }

--- a/go/oasis-test-runner/oasis/controller.go
+++ b/go/oasis-test-runner/oasis/controller.go
@@ -1,10 +1,14 @@
 package oasis
 
 import (
+	"context"
+	"fmt"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
+	"github.com/oasisprotocol/oasis-core/go/common"
 	cmnGrpc "github.com/oasisprotocol/oasis-core/go/common/grpc"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	control "github.com/oasisprotocol/oasis-core/go/control/api"
@@ -44,6 +48,52 @@ type Controller struct {
 // Close closes the gRPC connection with the node the controller is controlling.
 func (c *Controller) Close() {
 	c.conn.Close()
+}
+
+// WaitHeight waits until the controller observes at least specified consensus height.
+func (c *Controller) WaitHeight(ctx context.Context, height int64) error {
+	blkCh, sub, err := c.Consensus.WatchBlocks(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to watch consensus blocks: %w", err)
+	}
+	defer sub.Close()
+
+	for {
+		select {
+		case blk, ok := <-blkCh:
+			if !ok {
+				return fmt.Errorf("consensus block channel closed")
+			}
+			if blk.Height >= height {
+				return nil
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// WaitRound waits until the controller observes at least specified runtime round.
+func (c *Controller) WaitRound(ctx context.Context, runtimeID common.Namespace, round uint64) error {
+	blkCh, sub, err := c.RuntimeClient.WatchBlocks(ctx, runtimeID)
+	if err != nil {
+		return fmt.Errorf("failed to watch runtime blocks: %w", err)
+	}
+	defer sub.Close()
+
+	for {
+		select {
+		case annBlk, ok := <-blkCh:
+			if !ok {
+				return fmt.Errorf("runtime block channel closed")
+			}
+			if annBlk.Block.Header.Round >= round {
+				return nil
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 }
 
 // NewController creates a new node controller given the path to

--- a/go/oasis-test-runner/scenario/e2e/runtime/offline_pruning.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/offline_pruning.go
@@ -1,0 +1,214 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/oasisprotocol/oasis-core/go/config"
+	"github.com/oasisprotocol/oasis-core/go/consensus/cometbft/abci"
+	cmdStorage "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/storage"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis"
+	oasisCli "github.com/oasisprotocol/oasis-core/go/oasis-test-runner/oasis/cli"
+	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
+)
+
+// OfflinePruning is the offline pruning e2e scenario.
+var OfflinePruning scenario.Scenario = newOfflinePruningImpl()
+
+const (
+	storageSubCommand = "storage"
+	configFlag        = "--config"
+)
+
+type offlinePruningImpl struct {
+	Scenario
+}
+
+func newOfflinePruningImpl() scenario.Scenario {
+	return &offlinePruningImpl{
+		Scenario: *NewScenario(
+			"offline-pruning",
+			NewTestClient().WithScenario(SimpleScenario),
+		),
+	}
+}
+
+func (sc *offlinePruningImpl) Clone() scenario.Scenario {
+	return &offlinePruningImpl{
+		Scenario: *sc.Scenario.Clone().(*Scenario),
+	}
+}
+
+func (sc *offlinePruningImpl) Fixture() (*oasis.NetworkFixture, error) {
+	f, err := sc.Scenario.Fixture()
+	if err != nil {
+		return nil, err
+	}
+
+	client := oasis.ClientFixture{
+		RuntimeProvisioner: f.Clients[0].RuntimeProvisioner,
+		Runtimes:           []int{1},
+	}
+	f.Clients = append(f.Clients, client)
+
+	return f, nil
+}
+
+func (sc *offlinePruningImpl) Run(ctx context.Context, childEnv *env.Env) error {
+	// Start the network and run the test client to populate state.
+	if err := sc.StartNetworkAndTestClient(ctx, childEnv); err != nil {
+		return err
+	}
+	if err := sc.WaitTestClient(); err != nil {
+		return err
+	}
+
+	// Ensure client on which offline pruning and compaction will be done has successfully
+	// synced at least twice the number of versions the pruner will keep.
+	const offlinePruningNumKept uint64 = 5
+	minSyncedHeight := offlinePruningNumKept * 2
+	minSyncedRound := offlinePruningNumKept * 2
+	client := sc.Net.Clients()[1]
+	clientCtrl, err := oasis.NewController(client.SocketPath())
+	if err != nil {
+		return fmt.Errorf("failed to create controller for client node: %w", err)
+	}
+	defer clientCtrl.Close()
+	if err := clientCtrl.WaitHeight(ctx, int64(minSyncedHeight)); err != nil {
+		return err
+	}
+	if err := clientCtrl.WaitRound(ctx, KeyValueRuntimeID, minSyncedRound); err != nil {
+		return err
+	}
+
+	if err := client.StopGracefully(); err != nil {
+		return fmt.Errorf("failed to stop client node: %w", err)
+	}
+
+	beforePrune, err := sc.fetchStorageInspectStatus(childEnv, client.Node)
+	if err != nil {
+		return err
+	}
+
+	if err := sc.setPruningConfig(client.Node, offlinePruningNumKept); err != nil {
+		return err
+	}
+	if err := sc.runOfflinePruning(childEnv, client.Node); err != nil {
+		return err
+	}
+	if err := sc.runOfflineCompaction(childEnv, client.Node); err != nil {
+		return err
+	}
+
+	afterPrune, err := sc.fetchStorageInspectStatus(childEnv, client.Node)
+	if err != nil {
+		return err
+	}
+
+	ensurePruned := func(want, got uint64) error {
+		if want != got {
+			return fmt.Errorf("want last retained version %d, got %d", want, got)
+		}
+		return nil
+	}
+
+	// The test assumes that the client's runtime history indexer is not behind more than
+	// the number of versions the pruner will keep, as otherwise consensus state pruning
+	// might be blocked by min reindexed height.
+
+	if err := ensurePruned( // Consensus state
+		beforePrune.Consensus.StateDB.LatestVersion-offlinePruningNumKept,
+		afterPrune.Consensus.StateDB.LastRetainedVersion,
+	); err != nil {
+		return fmt.Errorf("consensus state not pruned as expected: %w", err)
+	}
+
+	if err := ensurePruned( // Consensus block history
+		beforePrune.Consensus.BlockHistory.LatestVersion-offlinePruningNumKept,
+		afterPrune.Consensus.BlockHistory.LastRetainedVersion,
+	); err != nil {
+		return fmt.Errorf("consensus block history not pruned as expected: %w", err)
+	}
+
+	if err := client.Start(); err != nil {
+		return fmt.Errorf("failed to start client node: %w", err)
+	}
+	if err := client.WaitReady(ctx); err != nil {
+		return fmt.Errorf("client node failed to become ready: %w", err)
+	}
+
+	return nil
+}
+
+func (sc *offlinePruningImpl) fetchStorageInspectStatus(childEnv *env.Env, node *oasis.Node) (*cmdStorage.Status, error) {
+	args := []string{
+		storageSubCommand,
+		"inspect",
+		configFlag, node.ConfigFile(),
+		"--output", "json",
+	}
+	resp, err := oasisCli.RunSubCommandWithOutput(childEnv, sc.Logger, "storage-inspect", sc.Net.Config().NodeBinary, args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect storage status: %w", err)
+	}
+
+	var status cmdStorage.Status
+	if err = json.Unmarshal(resp.Bytes(), &status); err != nil {
+		return nil, fmt.Errorf("failed to parse storage status: %w", err)
+	}
+
+	return &status, nil
+}
+
+func (sc *offlinePruningImpl) setPruningConfig(node *oasis.Node, numKept uint64) error {
+	cfgBytes, err := os.ReadFile(node.ConfigFile())
+	if err != nil {
+		return fmt.Errorf("failed to read node config: %w", err)
+	}
+
+	var cfg config.Config
+	if err = yaml.Unmarshal(cfgBytes, &cfg); err != nil {
+		return fmt.Errorf("failed to unmarshal node config: %w", err)
+	}
+	cfg.Consensus.Prune.Strategy = abci.PruneKeepN.String()
+	cfg.Consensus.Prune.NumKept = numKept
+
+	cfgBytes, err = yaml.Marshal(&cfg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal node config: %w", err)
+	}
+	if err = os.WriteFile(node.ConfigFile(), cfgBytes, 0o600); err != nil {
+		return fmt.Errorf("failed to write node config: %w", err)
+	}
+
+	return nil
+}
+
+func (sc *offlinePruningImpl) runOfflinePruning(childEnv *env.Env, node *oasis.Node) error {
+	args := []string{
+		storageSubCommand,
+		"prune-experimental",
+		configFlag, node.ConfigFile(),
+	}
+	if err := oasisCli.RunSubCommand(childEnv, sc.Logger, "offline-pruning", sc.Net.Config().NodeBinary, args); err != nil {
+		return fmt.Errorf("failed to run offline pruning: %w", err)
+	}
+	return nil
+}
+
+func (sc *offlinePruningImpl) runOfflineCompaction(childEnv *env.Env, node *oasis.Node) error {
+	args := []string{
+		storageSubCommand,
+		"compact-experimental",
+		configFlag, node.ConfigFile(),
+	}
+	if err := oasisCli.RunSubCommand(childEnv, sc.Logger, "offline-compaction", sc.Net.Config().NodeBinary, args); err != nil {
+		return fmt.Errorf("failed to run offline compaction: %w", err)
+	}
+	return nil
+}

--- a/go/oasis-test-runner/scenario/e2e/runtime/offline_pruning.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/offline_pruning.go
@@ -135,6 +135,23 @@ func (sc *offlinePruningImpl) Run(ctx context.Context, childEnv *env.Env) error 
 		return fmt.Errorf("consensus block history not pruned as expected: %w", err)
 	}
 
+	beforeRuntimePrune := beforePrune.Runtimes[KeyValueRuntimeID]
+	afterRuntimePrune := afterPrune.Runtimes[KeyValueRuntimeID]
+
+	if err := ensurePruned( // Runtime state
+		beforeRuntimePrune.StateDB.LatestVersion-offlinePruningNumKept,
+		afterRuntimePrune.StateDB.LastRetainedVersion,
+	); err != nil {
+		return fmt.Errorf("runtime state not pruned as expected: %w", err)
+	}
+
+	if err := ensurePruned( // Runtime light history
+		beforeRuntimePrune.LightHistory.LatestVersion-offlinePruningNumKept,
+		afterRuntimePrune.LightHistory.LastRetainedVersion,
+	); err != nil {
+		return fmt.Errorf("runtime light history not pruned as expected: %w", err)
+	}
+
 	if err := client.Start(); err != nil {
 		return fmt.Errorf("failed to start client node: %w", err)
 	}
@@ -177,6 +194,8 @@ func (sc *offlinePruningImpl) setPruningConfig(node *oasis.Node, numKept uint64)
 	}
 	cfg.Consensus.Prune.Strategy = abci.PruneKeepN.String()
 	cfg.Consensus.Prune.NumKept = numKept
+	cfg.Runtime.Prune.Strategy = "keep_last"
+	cfg.Runtime.Prune.NumKept = numKept
 
 	cfgBytes, err = yaml.Marshal(&cfg)
 	if err != nil {
@@ -192,7 +211,7 @@ func (sc *offlinePruningImpl) setPruningConfig(node *oasis.Node, numKept uint64)
 func (sc *offlinePruningImpl) runOfflinePruning(childEnv *env.Env, node *oasis.Node) error {
 	args := []string{
 		storageSubCommand,
-		"prune-experimental",
+		"prune",
 		configFlag, node.ConfigFile(),
 	}
 	if err := oasisCli.RunSubCommand(childEnv, sc.Logger, "offline-pruning", sc.Net.Config().NodeBinary, args); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/runtime/offline_pruning.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/offline_pruning.go
@@ -223,7 +223,7 @@ func (sc *offlinePruningImpl) runOfflinePruning(childEnv *env.Env, node *oasis.N
 func (sc *offlinePruningImpl) runOfflineCompaction(childEnv *env.Env, node *oasis.Node) error {
 	args := []string{
 		storageSubCommand,
-		"compact-experimental",
+		"compact",
 		configFlag, node.ConfigFile(),
 	}
 	if err := oasisCli.RunSubCommand(childEnv, sc.Logger, "offline-compaction", sc.Net.Config().NodeBinary, args); err != nil {

--- a/go/oasis-test-runner/scenario/e2e/runtime/scenario.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime/scenario.go
@@ -405,6 +405,8 @@ func RegisterScenarios() error {
 		ROFL,
 		// Stateless client tests.
 		StatelessClient,
+		// Offline pruning test.
+		OfflinePruning,
 	} {
 		if err := cmd.Register(s); err != nil {
 			return err

--- a/go/runtime/history/db.go
+++ b/go/runtime/history/db.go
@@ -304,6 +304,10 @@ func (d *DB) getLastBlock() (*roothash.AnnotatedBlock, error) {
 	return &blk, nil
 }
 
+func (d *DB) flatten() error {
+	return d.db.Flatten(1)
+}
+
 func (d *DB) close() {
 	d.gc.Stop()
 	d.db.Close()

--- a/go/runtime/history/db.go
+++ b/go/runtime/history/db.go
@@ -243,6 +243,40 @@ func (d *DB) getEarliestBlock() (*roothash.AnnotatedBlock, error) {
 	return &blk, nil
 }
 
+func (d *DB) pruneBefore(round uint64) (uint64, error) {
+	var pruned uint64
+	if err := d.db.Update(func(tx *badger.Txn) error {
+		it := tx.NewIterator(badger.IteratorOptions{
+			Prefix: blockKeyFmt.Encode(),
+		})
+		defer it.Close()
+
+		for it.Rewind(); it.Valid(); it.Next() {
+			item := it.Item()
+
+			var r uint64
+			if !blockKeyFmt.Decode(item.Key(), &r) {
+				panic("bad iterator: unable to decode key") // cannot happen.
+			}
+
+			if r >= round {
+				break
+			}
+
+			if err := tx.Delete(item.KeyCopy(nil)); err != nil {
+				return err
+			}
+
+			pruned++
+		}
+
+		return nil
+	}); err != nil {
+		return 0, err
+	}
+	return pruned, nil
+}
+
 func (d *DB) getLastBlock() (*roothash.AnnotatedBlock, error) {
 	var blk roothash.AnnotatedBlock
 	txErr := d.db.View(func(tx *badger.Txn) error {

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -38,6 +38,9 @@ type History interface {
 	// PruneBefore prunes runtime history before the given round.
 	PruneBefore(round uint64) (uint64, error)
 
+	// Compact triggers compaction of the History underlying storage engine.
+	Compact() error
+
 	// Close closes the history keeper.
 	Close()
 }
@@ -323,6 +326,18 @@ func (h *runtimeHistory) CanPruneConsensus(height int64) error {
 	if height > lastHeight {
 		return fmt.Errorf("height %d not yet indexed for %s", height, h.RuntimeID())
 	}
+
+	return nil
+}
+
+func (h *runtimeHistory) Compact() error {
+	h.logger.Info("compacting")
+
+	if err := h.db.flatten(); err != nil {
+		return fmt.Errorf("failed to flatten db: %w", err)
+	}
+
+	h.logger.Info("compaction completed")
 
 	return nil
 }

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -35,6 +35,9 @@ type History interface {
 	// Pruner returns the history pruner.
 	Pruner() Pruner
 
+	// PruneBefore prunes runtime history before the given round.
+	PruneBefore(round uint64) (uint64, error)
+
 	// Close closes the history keeper.
 	Close()
 }
@@ -300,6 +303,10 @@ func (h *runtimeHistory) GetEarliestBlock(ctx context.Context) (*block.Block, er
 		return nil, err
 	}
 	return annBlk.Block, nil
+}
+
+func (h *runtimeHistory) PruneBefore(round uint64) (uint64, error) {
+	return h.db.pruneBefore(round)
 }
 
 // CanPruneConsenus returns no error when the specified consensus height has been already reindexed.

--- a/go/runtime/history/history_test.go
+++ b/go/runtime/history/history_test.go
@@ -421,6 +421,45 @@ func TestPruneBefore(t *testing.T) {
 	})
 }
 
+func TestCompact(t *testing.T) {
+	ctx := t.Context()
+
+	runtimeID := common.NewTestNamespaceFromSeed([]byte("compact test namespace"), 0)
+	h, err := New(runtimeID, t.TempDir(), NewNonePrunerFactory(), false)
+	require.NoError(t, err, "New")
+	defer h.Close()
+
+	t.Run("compact empty", func(t *testing.T) {
+		require.NoError(t, h.Compact())
+	})
+
+	blks := createBlocks(runtimeID)
+	t.Run("compact without pruning", func(t *testing.T) {
+		require.NoError(t, h.Commit(blks), "Commit")
+		require.NoError(t, h.Compact())
+
+		for _, blk := range blks {
+			got, err := h.GetBlock(ctx, blk.Block.Header.Round)
+			require.NoError(t, err, "GetBlock(%d)", blk.Block.Header.Round)
+			require.Equal(t, blk.Block, got)
+		}
+	})
+
+	t.Run("compact after prune", func(t *testing.T) {
+		firstRound := blks[0].Block.Header.Round
+		_, err := h.PruneBefore(firstRound + 1)
+		require.NoError(t, err)
+		require.NoError(t, h.Compact())
+
+		_, err = h.GetBlock(ctx, blks[0].Block.Header.Round)
+		require.ErrorIs(t, err, roothash.ErrNotFound)
+
+		got, err := h.GetBlock(ctx, blks[1].Block.Header.Round)
+		require.NoError(t, err, "GetBlock(%d)", blks[1].Block.Header.Round)
+		require.Equal(t, blks[1].Block, got)
+	})
+}
+
 type testPruneHandler struct {
 	done         bool
 	doneCh       chan struct{}

--- a/go/runtime/history/history_test.go
+++ b/go/runtime/history/history_test.go
@@ -364,6 +364,63 @@ func TestWatchBlocksWithoutHistory(t *testing.T) {
 	})
 }
 
+func TestPruneBefore(t *testing.T) {
+	ctx := t.Context()
+
+	runtimeID := common.NewTestNamespaceFromSeed([]byte("prune test namespace"), 0)
+
+	h, err := New(runtimeID, t.TempDir(), NewNonePrunerFactory(), false)
+	require.NoError(t, err, "New")
+	defer h.Close()
+
+	// Commit blocks for rounds 10-20.
+	blks := make([]*roothash.AnnotatedBlock, 11)
+	for i := range blks {
+		blk := &roothash.AnnotatedBlock{
+			Height: int64(100 + i), // height is different than round.
+			Block:  block.NewGenesisBlock(runtimeID, 0),
+		}
+		blk.Block.Header.Round = uint64(10 + i)
+		blks[i] = blk
+	}
+	require.NoError(t, h.Commit(blks), "Commit")
+
+	t.Run("prune before earliest: no-op", func(t *testing.T) {
+		pruned, err := h.PruneBefore(10)
+		require.NoError(t, err)
+		require.EqualValues(t, 0, pruned, "no blocks should be pruned")
+
+		earliest, err := h.GetEarliestBlock(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 10, earliest.Header.Round, "earliest round should still be 10")
+	})
+
+	t.Run("prune some versions", func(t *testing.T) {
+		pruned, err := h.PruneBefore(12)
+		require.NoError(t, err)
+		require.EqualValues(t, 2, pruned, "rounds 10-11 should be pruned")
+
+		earliest, err := h.GetEarliestBlock(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 12, earliest.Header.Round, "earliest round should now be 12")
+	})
+
+	t.Run("prune everything", func(t *testing.T) {
+		pruned, err := h.PruneBefore(21)
+		require.NoError(t, err)
+		require.EqualValues(t, 9, pruned, "rounds 12-20 should all be pruned")
+
+		_, err = h.GetEarliestBlock(ctx)
+		require.ErrorIs(t, err, roothash.ErrNotFound, "history should be empty")
+	})
+
+	t.Run("prune on empty: no-op", func(t *testing.T) {
+		pruned, err := h.PruneBefore(2)
+		require.NoError(t, err)
+		require.EqualValues(t, 0, pruned, "nothing to prune on empty history")
+	})
+}
+
 type testPruneHandler struct {
 	done         bool
 	doneCh       chan struct{}


### PR DESCRIPTION
Closes #6519.

Relatively trivial to review. LOC is big because I extracted commands to separate files and added missing tests (separate commits).

## Motivation
1. Offline pruning/compaction was introduced because late pruning 1. may not reclaim disk space, 2. may cause node to fall behind even once registered as ready (pending compaction load).
2. We could also use it to create https://github.com/oasisprotocol/oasis-core/issues/6423, serving as alternative to https://github.com/oasisprotocol/oasis-core/pull/6454.

## How to test locally

For testing I used latest Sapphire  [snapshot](https://snapshots.oasis.io/#node/mainnet/20250722-20260403/) (cca 7 months of data, `keep_n = 100_000`). It took 10min to prune and 6min to compact. For consensus I used [snapshot-old](https://snapshots.oasis.io/#node/mainnet/20250722-20251105/) (cca 3 months of data, `keep_n = 100_000`), due to limited disk space on my machine. Pruning took 2min and compaction 3min.

Node started syncing normally after prune/compact commands.



## Possible follow-up
For https://github.com/oasisprotocol/oasis-core/pull/6454, we may want to add additional flag to the pruning command, e.g. `retain_height`, that ignores pruning config and calculates corresponding rounds at this height of every runtime, implementing `keep_from` [proposal](https://github.com/oasisprotocol/oasis-core/issues/6423#issue-3689723722).
