### PR TITLE
go/consensus/cometbft/stateless: Fix transactions with proofs methods

### DIFF
--- a/.changelog/6527.bugfix.md
+++ b/.changelog/6527.bugfix.md
@@ -1,0 +1,3 @@
+go/consensus/cometbft/stateless: Fix transaction with proofs methods
+
+Methods SubmitTxWithProof and GetTransactionsWithProofs were fixed.

--- a/go/consensus/cometbft/stateless/core.go
+++ b/go/consensus/cometbft/stateless/core.go
@@ -3,7 +3,6 @@ package stateless
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"fmt"
 	"sync"
 	"time"
@@ -341,12 +340,7 @@ func (c *Core) GetTransactionsWithProofs(ctx context.Context, height int64) (*co
 		return nil, err
 	}
 
-	_, proofs := merkle.Proofs(txs)
-
-	return &consensusAPI.TransactionsWithProofs{
-		Transactions: txs,
-		Proofs:       proofs,
-	}, nil
+	return transactionsWithProofs(txs), nil
 }
 
 // GetTransactionsWithResults implements api.Backend.
@@ -434,7 +428,11 @@ func (c *Core) SubmitTxWithProof(ctx context.Context, tx *transaction.SignedTran
 		return nil, err
 	}
 
-	if err = c.verifyProof(ctx, proof, tx); err != nil {
+	lb, err := c.lightBlock(ctx, proof.Height)
+	if err != nil {
+		return nil, err
+	}
+	if err = verifyTransactionProof(proof, tx, lb); err != nil {
 		return nil, err
 	}
 
@@ -688,17 +686,19 @@ func verifyTransactions(txs [][]byte, lb *cmttypes.LightBlock) error {
 	return nil
 }
 
-func (c *Core) verifyProof(ctx context.Context, proof *transaction.Proof, tx *transaction.SignedTransaction) error {
-	stateRoot, err := c.stateRoot(ctx, proof.Height)
-	if err != nil {
-		return err
-	}
+func transactionsWithProofs(txs [][]byte) *consensusAPI.TransactionsWithProofs {
+	_, proofs := merkle.ProofsForTransactions(txs)
 
-	hash := sha256.Sum256(cbor.Marshal(tx))
-	if err := merkle.Verify(proof.RawProof, stateRoot[:], hash[:]); err != nil {
+	return &consensusAPI.TransactionsWithProofs{
+		Transactions: txs,
+		Proofs:       proofs,
+	}
+}
+
+func verifyTransactionProof(proof *transaction.Proof, tx *transaction.SignedTransaction, lb *cmttypes.LightBlock) error {
+	if err := merkle.VerifyTransaction(proof.RawProof, lb.DataHash, cbor.Marshal(tx)); err != nil {
 		return fmt.Errorf("failed to verify proof: %w", err)
 	}
-
 	return nil
 }
 

--- a/go/consensus/cometbft/stateless/core_test.go
+++ b/go/consensus/cometbft/stateless/core_test.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	"github.com/oasisprotocol/oasis-core/go/consensus/cometbft/light"
 )
 
@@ -159,6 +161,33 @@ func TestVerification(t *testing.T) {
 			require.Error(t, err, "transaction verification should fail")
 		})
 	})
+}
+
+func TestVerifyTransactionProof(t *testing.T) {
+	clb, err := testLightBlock()
+	require.NoError(t, err, "light block generation should succeed")
+
+	lb, err := light.DecodeLightBlock(clb)
+	require.NoError(t, err, "light block decoding should succeed")
+
+	txs, err := testTransactions()
+	require.NoError(t, err, "transaction generation should succeed")
+
+	txsWithProofs := transactionsWithProofs(txs)
+	require.Len(t, txsWithProofs.Proofs, len(txsWithProofs.Transactions), "proof count should match transaction count")
+
+	for i, txBytes := range txsWithProofs.Transactions {
+		require.Equal(t, txs[i], txBytes, "transaction should match original")
+
+		var tx transaction.SignedTransaction
+		require.NoError(t, cbor.Unmarshal(txBytes, &tx), "transaction decoding should succeed")
+
+		proof := &transaction.Proof{
+			Height:   lb.Height,
+			RawProof: txsWithProofs.Proofs[i],
+		}
+		require.NoError(t, verifyTransactionProof(proof, &tx, lb), "transaction proof verification should pass")
+	}
 }
 
 func testLightBlock() (*consensus.LightBlock, error) {


### PR DESCRIPTION
## Problem
Using stateless client node, I tried to run raw sgx rofl that starts with old trust root on the testnet (experiment for other PR) and encountered the following issue:

```bash
{"err":"freshness verification: failed to fetch freshness proof: StringTracer: rpc error: server error: module: unknown code: 1 message: failed to verify proof: invalid root hash: wanted 0590BB91C1924979E27341B49DA78862F5C42B221ABFB408181E5F528C4EFB45 got 9D2C1CD41442C44EE79968A6460896D08DE357A5F9F3C28C59D5512E8201EC1E","level":"error","module":"runtime/consensus/cometbft/verifier","msg":"Consensus verifier terminated, aborting","ts":"2026-05-18T21:28:00.853486221Z"}
```


Rofl was simple, i.e. I only logged every new runtime block received.Repeating experiment using normal client node, I encountered no issues for rofl and ronl consensus verifier inside the enclave.

## Solution
Use `merkle.ProofsForTransactions` instead of `merkle.Proofs` and for verifying compare against light block data hash not state root.

## Consideration

Maybe e2e stateless client test should be extended to deploy simple rofl, since this was the main motivation for this role. 


