### PR TITLE
go/consensus/cometbft/api: Remove message execution from context

### DIFF
--- a/go/consensus/cometbft/abci/messages.go
+++ b/go/consensus/cometbft/abci/messages.go
@@ -25,13 +25,13 @@ func (md *messageDispatcher) Subscribe(kind any, ms api.MessageSubscriber) {
 }
 
 // Implements api.MessageDispatcher.
-func (md *messageDispatcher) Publish(ctx *api.Context, kind, msg any) (any, error) {
+func (md *messageDispatcher) Publish(ctx *api.Context, msg api.Message) (any, error) {
 	var (
 		result         any
 		errs           error
 		numSubscribers int
 	)
-	for _, ms := range md.subscriptions[kind] {
+	for _, ms := range md.subscriptions[msg.Kind] {
 		// Check whether the subscriber can be toggled.
 		if togMs, ok := ms.(api.TogglableMessageSubscriber); ok {
 			enabled, err := togMs.Enabled(ctx)
@@ -47,7 +47,7 @@ func (md *messageDispatcher) Publish(ctx *api.Context, kind, msg any) (any, erro
 		numSubscribers++
 
 		// Deliver the message.
-		if resp, err := ms.ExecuteMessage(ctx, kind, msg); err != nil {
+		if resp, err := ms.ExecuteMessage(ctx, msg); err != nil {
 			errs = errors.Join(errs, err)
 		} else {
 			switch {

--- a/go/consensus/cometbft/abci/messages_test.go
+++ b/go/consensus/cometbft/abci/messages_test.go
@@ -33,8 +33,8 @@ type testSubscriber struct {
 }
 
 // Implements api.MessageSubscriber.
-func (s *testSubscriber) ExecuteMessage(_ *api.Context, _, msg any) (any, error) {
-	switch m := msg.(type) {
+func (s *testSubscriber) ExecuteMessage(_ *api.Context, msg api.Message) (any, error) {
+	switch m := msg.Data.(type) {
 	case *testMessage:
 		s.msgs = append(s.msgs, m.foo)
 		if s.fail {
@@ -66,7 +66,10 @@ func TestMessageDispatcher(t *testing.T) {
 	md := newMessageDispatcher()
 
 	// Publish without subscribers should work.
-	res, err := md.Publish(ctx, testMessageA, &testMessage{foo: 42})
+	res, err := md.Publish(ctx, api.Message{
+		Kind: testMessageA,
+		Data: &testMessage{foo: 42},
+	})
 	require.Error(err, "Publish")
 	require.Equal(api.ErrNoSubscribers, err)
 	require.Nil(res, "Publish results should be empty")
@@ -74,7 +77,10 @@ func TestMessageDispatcher(t *testing.T) {
 	// With a disabled subscriber should behave same as with no subscribers.
 	var ms testSubscriber
 	md.Subscribe(testMessageA, &ms)
-	res, err = md.Publish(ctx, testMessageA, &testMessage{foo: 42})
+	res, err = md.Publish(ctx, api.Message{
+		Kind: testMessageA,
+		Data: &testMessage{foo: 42},
+	})
 	require.Error(err, "Publish")
 	require.Equal(api.ErrNoSubscribers, err)
 	require.Nil(res, "Publish results should be empty")
@@ -82,24 +88,36 @@ func TestMessageDispatcher(t *testing.T) {
 
 	// With an enabled subscriber.
 	ms.enabled = true
-	res, err = md.Publish(ctx, testMessageA, &testMessage{foo: 42})
+	res, err = md.Publish(ctx, api.Message{
+		Kind: testMessageA,
+		Data: &testMessage{foo: 42},
+	})
 	require.NoError(err, "Publish")
 	require.EqualValues(int32(42), res, "correct publish message result")
 	require.EqualValues([]int32{42}, ms.msgs, "correct messages should be delivered")
 
-	res, err = md.Publish(ctx, testMessageA, &testMessage{foo: 43})
+	res, err = md.Publish(ctx, api.Message{
+		Kind: testMessageA,
+		Data: &testMessage{foo: 43},
+	})
 	require.NoError(err, "Publish")
 	require.EqualValues(int32(43), res, "correct publish message result")
 	require.EqualValues([]int32{42, 43}, ms.msgs, "correct messages should be delivered")
 
-	res, err = md.Publish(ctx, testMessageB, &testMessage{foo: 44})
+	res, err = md.Publish(ctx, api.Message{
+		Kind: testMessageB,
+		Data: &testMessage{foo: 44},
+	})
 	require.Error(err, "Publish")
 	require.Equal(api.ErrNoSubscribers, err)
 	require.Nil(res, "publish message results should be empty")
 	require.EqualValues([]int32{42, 43}, ms.msgs, "correct messages should be delivered")
 
 	// Returning an error.
-	res, err = md.Publish(ctx, testMessageA, &errorMessage{})
+	res, err = md.Publish(ctx, api.Message{
+		Kind: testMessageA,
+		Data: &errorMessage{},
+	})
 	require.Error(err, "Publish")
 	require.Nil(nil, res, "publish message results should be empty")
 	require.True(errors.Is(err, errTest), "returned error should be the correct one")
@@ -110,7 +128,10 @@ func TestMessageDispatcher(t *testing.T) {
 		noResult: true,
 	}
 	md.Subscribe(testMessageA, &ms2)
-	res, err = md.Publish(ctx, testMessageA, &testMessage{foo: 44})
+	res, err = md.Publish(ctx, api.Message{
+		Kind: testMessageA,
+		Data: &testMessage{foo: 44},
+	})
 	require.NoError(err, "Publish")
 	require.EqualValues(int32(44), res, "correct publish message result")
 	require.EqualValues([]int32{42, 43, 44}, ms.msgs, "correct messages should be delivered")
@@ -119,6 +140,9 @@ func TestMessageDispatcher(t *testing.T) {
 	// Multiple subscribers returning results.
 	ms2.noResult = false
 	require.Panics(func() {
-		_, _ = md.Publish(ctx, testMessageA, &testMessage{foo: 44})
+		_, _ = md.Publish(ctx, api.Message{
+			Kind: testMessageA,
+			Data: &testMessage{foo: 44},
+		})
 	}, "multiple subscribers returning results should panic")
 }

--- a/go/consensus/cometbft/abci/mux.go
+++ b/go/consensus/cometbft/abci/mux.go
@@ -945,7 +945,9 @@ func (mux *abciMux) finishInitialization() error {
 		ctx := mux.state.NewContext(api.ContextEndBlock)
 		defer ctx.Close()
 
-		if _, err := mux.md.Publish(ctx, api.MessageStateSyncCompleted, nil); err != nil {
+		if _, err := mux.md.Publish(ctx, api.Message{
+			Kind: api.MessageStateSyncCompleted,
+		}); err != nil {
 			mux.logger.Error("failed to dispatch state sync completed message",
 				"err", err,
 			)

--- a/go/consensus/cometbft/abci/snapshots.go
+++ b/go/consensus/cometbft/abci/snapshots.go
@@ -270,7 +270,9 @@ func (mux *abciMux) ApplySnapshotChunk(req types.RequestApplySnapshotChunk) type
 		ctx := mux.state.NewContext(api.ContextEndBlock)
 		defer ctx.Close()
 
-		if _, err = mux.md.Publish(ctx, api.MessageStateSyncCompleted, nil); err != nil {
+		if _, err = mux.md.Publish(ctx, api.Message{
+			Kind: api.MessageStateSyncCompleted,
+		}); err != nil {
 			mux.logger.Error("failed to dispatch state sync completed message",
 				"err", err,
 			)

--- a/go/consensus/cometbft/abci/subcall.go
+++ b/go/consensus/cometbft/abci/subcall.go
@@ -11,11 +11,11 @@ import (
 const maxSubcallDepth = 8
 
 // ExecuteMessage implements api.MessageSubscriber.
-func (mux *abciMux) ExecuteMessage(ctx *api.Context, kind, msg any) (any, error) {
-	switch kind {
+func (mux *abciMux) ExecuteMessage(ctx *api.Context, msg api.Message) (any, error) {
+	switch msg.Kind {
 	case api.MessageExecuteSubcall:
 		// Subcall execution request.
-		info, ok := msg.(*api.SubcallInfo)
+		info, ok := msg.Data.(*api.SubcallInfo)
 		if !ok {
 			return nil, fmt.Errorf("invalid subcall info")
 		}

--- a/go/consensus/cometbft/api/app.go
+++ b/go/consensus/cometbft/api/app.go
@@ -12,10 +12,20 @@ import (
 // ErrNoSubscribers is the error returned when publishing a message that noone is subscribed to.
 var ErrNoSubscribers = errors.New("no subscribers to given message kind")
 
+// Message is a message sent between applications.
+type Message struct {
+	// Sender identifies the application that sent the message.
+	Sender string
+	// Kind specifies the receiver-defined message type.
+	Kind any
+	// Data contains the receiver-defined message data.
+	Data any
+}
+
 // MessageSubscriber is a message subscriber interface.
 type MessageSubscriber interface {
 	// ExecuteMessage executes a given message.
-	ExecuteMessage(ctx *Context, kind, msg any) (any, error)
+	ExecuteMessage(ctx *Context, msg Message) (any, error)
 }
 
 // TogglableMessageSubscriber is a message subscriber that can be disabled.
@@ -29,13 +39,12 @@ type MessageDispatcher interface {
 	// Subscribe subscribes a given message subscriber to messages of a specific kind.
 	Subscribe(kind any, ms MessageSubscriber)
 
-	// Publish publishes a message of a given kind by dispatching to all subscribers.
-	// Subscribers can return a result, but at most one subscriber should return a
-	// non-nil result to any published message. Panics in case more than one subscriber
-	// returns a non-nil result.
+	// Publish publishes a message to all subscribers./ Subscribers can return a result,
+	// but at most one subscriber should return a non-nil result to any published message.
+	// Panics in case more than one subscriber returns a non-nil result.
 	//
 	// In case there are no subscribers ErrNoSubscribers is returned.
-	Publish(ctx *Context, kind, msg any) (any, error)
+	Publish(ctx *Context, msg Message) (any, error)
 }
 
 // NoopMessageDispatcher is a no-op message dispatcher that performs no dispatch.
@@ -46,7 +55,7 @@ func (nd *NoopMessageDispatcher) Subscribe(any, MessageSubscriber) {
 }
 
 // Publish implements MessageDispatcher.
-func (nd *NoopMessageDispatcher) Publish(*Context, any, any) (any, error) {
+func (nd *NoopMessageDispatcher) Publish(*Context, Message) (any, error) {
 	return nil, nil
 }
 

--- a/go/consensus/cometbft/api/context.go
+++ b/go/consensus/cometbft/api/context.go
@@ -65,8 +65,7 @@ type Context struct {
 	mode        ContextMode
 	currentTime time.Time
 
-	isMessageExecution bool
-	isTransaction      bool
+	isTransaction bool
 
 	data           any
 	events         []types.Event
@@ -217,22 +216,21 @@ func (c *Context) CallDepth() int {
 
 // NewChild creates a new child context that shares state with the current context.
 //
-// If you want isolated state and events use NewTransaction instad.
+// If you want isolated state and events use NewTransaction instead.
 func (c *Context) NewChild() *Context {
 	cc := &Context{
-		parent:             c,
-		mode:               c.mode,
-		currentTime:        c.currentTime,
-		isMessageExecution: c.isMessageExecution,
-		gasAccountant:      c.gasAccountant,
-		txSigner:           c.txSigner,
-		callerAddress:      c.callerAddress,
-		appState:           c.appState,
-		state:              c.state,
-		lastHeight:         c.lastHeight,
-		blockCtx:           c.blockCtx,
-		initialHeight:      c.initialHeight,
-		logger:             c.logger,
+		parent:        c,
+		mode:          c.mode,
+		currentTime:   c.currentTime,
+		gasAccountant: c.gasAccountant,
+		txSigner:      c.txSigner,
+		callerAddress: c.callerAddress,
+		appState:      c.appState,
+		state:         c.state,
+		lastHeight:    c.lastHeight,
+		blockCtx:      c.blockCtx,
+		initialHeight: c.initialHeight,
+		logger:        c.logger,
 	}
 	cc.Context = context.WithValue(c.Context, contextKey{}, cc)
 	return cc
@@ -295,13 +293,6 @@ func (c *Context) WithSimulation() *Context {
 	return child
 }
 
-// WithMessageExecution creates a child context and sets the message execution flag.
-func (c *Context) WithMessageExecution() *Context {
-	child := c.NewChild()
-	child.isMessageExecution = true
-	return child
-}
-
 // IsInitChain returns true if this ia an init chain context.
 func (c *Context) IsInitChain() bool {
 	return c.mode == ContextInitChain
@@ -315,11 +306,6 @@ func (c *Context) IsCheckOnly() bool {
 // IsSimulation returns true if this is a simulation-only context.
 func (c *Context) IsSimulation() bool {
 	return c.mode == ContextSimulateTx
-}
-
-// IsMessageExecution returns true if this is a message execution context.
-func (c *Context) IsMessageExecution() bool {
-	return c.isMessageExecution
 }
 
 // EmitData emits data to be serialized as transaction output.

--- a/go/consensus/cometbft/api/context_test.go
+++ b/go/consensus/cometbft/api/context_test.go
@@ -84,11 +84,6 @@ func TestChildContext(t *testing.T) {
 	child.EmitEvent(NewEventBuilder("test").TypedAttribute(&FooEvent{Bar: []byte("bar")}))
 	child.Close()
 	require.Empty(ctx.GetEvents(), "events should not propagate in simulation mode")
-
-	child = ctx.WithMessageExecution()
-	require.True(child.IsMessageExecution(), "child should have message execution enabled")
-	require.False(ctx.IsMessageExecution(), "parent should not have message execution enabled")
-	child.Close()
 }
 
 func TestTransactionContext(t *testing.T) {

--- a/go/consensus/cometbft/apps/governance/governance.go
+++ b/go/consensus/cometbft/apps/governance/governance.go
@@ -112,10 +112,10 @@ func (app *Application) ExecuteTx(ctx *api.Context, tx *transaction.Transaction)
 }
 
 // ExecuteMessage implements api.MessageSubscriber.
-func (app *Application) ExecuteMessage(ctx *api.Context, kind, msg any) (any, error) {
-	switch kind {
+func (app *Application) ExecuteMessage(ctx *api.Context, msg api.Message) (any, error) {
+	switch msg.Kind {
 	case roothashApi.RuntimeMessageGovernance:
-		m := msg.(*message.GovernanceMessage)
+		m := msg.Data.(*message.GovernanceMessage)
 		switch {
 		case m.CastVote != nil:
 			state := governanceState.NewMutableState(ctx.State())
@@ -130,11 +130,11 @@ func (app *Application) ExecuteMessage(ctx *api.Context, kind, msg any) (any, er
 		return app.completeStateSync(ctx)
 	case governanceApi.MessageValidateParameterChanges:
 		// A change parameters proposal is about to be submitted. Validate changes.
-		return app.changeParameters(ctx, msg, false)
+		return app.changeParameters(ctx, msg.Data, false)
 	case governanceApi.MessageChangeParameters:
 		// A change parameters proposal has just been accepted and closed. Validate and apply
 		// changes.
-		return app.changeParameters(ctx, msg, true)
+		return app.changeParameters(ctx, msg.Data, true)
 	default:
 		return nil, governance.ErrInvalidArgument
 	}
@@ -303,7 +303,11 @@ func (app *Application) executeProposal(ctx *api.Context, state *governanceState
 		}
 
 		// Notify other interested applications about the change parameters proposal.
-		res, err := app.md.Publish(ctx, governanceApi.MessageChangeParameters, proposal.Content.ChangeParameters)
+		res, err := app.md.Publish(ctx, api.Message{
+			Sender: governance.ModuleName,
+			Kind:   governanceApi.MessageChangeParameters,
+			Data:   proposal.Content.ChangeParameters,
+		})
 		if err != nil {
 			ctx.Logger().Debug("failed to dispatch change parameters proposal message",
 				"err", err,

--- a/go/consensus/cometbft/apps/governance/governance.go
+++ b/go/consensus/cometbft/apps/governance/governance.go
@@ -19,8 +19,9 @@ import (
 	stakingapp "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/staking"
 	stakingState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/staking/state"
 	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/message"
-	stakingAPI "github.com/oasisprotocol/oasis-core/go/staking/api"
+	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 	upgrade "github.com/oasisprotocol/oasis-core/go/upgrade/api"
 )
 
@@ -105,7 +106,7 @@ func (app *Application) ExecuteTx(ctx *api.Context, tx *transaction.Transaction)
 			)
 			return governance.ErrInvalidArgument
 		}
-		return app.castVote(ctx, state, &proposalVote)
+		return app.castVote(ctx, state, &proposalVote, false)
 	default:
 		return governance.ErrInvalidArgument
 	}
@@ -119,7 +120,7 @@ func (app *Application) ExecuteMessage(ctx *api.Context, msg api.Message) (any, 
 		switch {
 		case m.CastVote != nil:
 			state := governanceState.NewMutableState(ctx.State())
-			return nil, app.castVote(ctx, state, m.CastVote)
+			return nil, app.castVote(ctx, state, m.CastVote, msg.Sender == roothash.ModuleName)
 		case m.SubmitProposal != nil:
 			state := governanceState.NewMutableState(ctx.State())
 			return app.submitProposal(ctx, state, m.SubmitProposal)
@@ -338,17 +339,17 @@ func validatorsEscrow(
 	ctx context.Context,
 	stakingState *stakingState.ImmutableState,
 	schedulerState *schedulerState.ImmutableState,
-) (*quantity.Quantity, map[stakingAPI.Address]*stakingAPI.SharePool, error) {
+) (*quantity.Quantity, map[staking.Address]*staking.SharePool, error) {
 	currentValidators, err := schedulerState.CurrentValidators(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to query current validators: %w", err)
 	}
 
 	totalVotingStake := quantity.NewQuantity()
-	validatorEntitiesEscrow := make(map[stakingAPI.Address]*stakingAPI.SharePool)
+	validatorEntitiesEscrow := make(map[staking.Address]*staking.SharePool)
 
 	for _, validator := range currentValidators {
-		entityAddr := stakingAPI.NewAddress(validator.EntityID)
+		entityAddr := staking.NewAddress(validator.EntityID)
 
 		// If there are multiple nodes in the validator set belonging to the same entity,
 		// only count the entity escrow once.
@@ -356,7 +357,7 @@ func validatorsEscrow(
 			continue
 		}
 
-		var account *stakingAPI.Account
+		var account *staking.Account
 		account, err = stakingState.Account(ctx, entityAddr)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to query validator account: %w", err)
@@ -378,7 +379,7 @@ func (app *Application) closeProposal(
 	state *governanceState.MutableState,
 	stakingState *stakingState.ImmutableState,
 	totalVotingStake quantity.Quantity,
-	validatorEntitiesPool map[stakingAPI.Address]*stakingAPI.SharePool,
+	validatorEntitiesPool map[staking.Address]*staking.SharePool,
 	proposal *governance.Proposal,
 ) error {
 	params, err := state.ConsensusParameters(ctx)
@@ -397,8 +398,8 @@ func (app *Application) closeProposal(
 		"validator_entities_pool", validatorEntitiesPool,
 		"votes", votes,
 	)
-	validatorVotes := make(map[stakingAPI.Address]*governance.Vote)
-	validatorVoteShares := make(map[stakingAPI.Address]map[governance.Vote]quantity.Quantity)
+	validatorVotes := make(map[staking.Address]*governance.Vote)
+	validatorVoteShares := make(map[staking.Address]map[governance.Vote]quantity.Quantity)
 	for validator := range validatorEntitiesPool {
 		validatorVoteShares[validator] = make(map[governance.Vote]quantity.Quantity)
 	}

--- a/go/consensus/cometbft/apps/governance/transactions.go
+++ b/go/consensus/cometbft/apps/governance/transactions.go
@@ -223,6 +223,7 @@ func (app *Application) castVote(
 	ctx *api.Context,
 	state *governanceState.MutableState,
 	proposalVote *governance.ProposalVote,
+	runtimeMsg bool,
 ) error {
 	if ctx.IsCheckOnly() {
 		return nil
@@ -250,7 +251,7 @@ func (app *Application) castVote(
 
 	// Query signer entity descriptor.
 	var submitterNodes []signature.PublicKey
-	switch ctx.IsMessageExecution() {
+	switch runtimeMsg {
 	case true:
 		// Runtime messages are not real consensus transactions as they
 		// don't have a transaction signer.

--- a/go/consensus/cometbft/apps/governance/transactions.go
+++ b/go/consensus/cometbft/apps/governance/transactions.go
@@ -143,7 +143,11 @@ func (app *Application) submitProposal(
 	case proposalContent.ChangeParameters != nil:
 		// Notify other interested applications to validate the parameter changes.
 		var res any
-		res, err = app.md.Publish(ctx, governanceApi.MessageValidateParameterChanges, proposalContent.ChangeParameters)
+		res, err = app.md.Publish(ctx, api.Message{
+			Sender: governance.ModuleName,
+			Kind:   governanceApi.MessageValidateParameterChanges,
+			Data:   proposalContent.ChangeParameters,
+		})
 		if err != nil {
 			ctx.Logger().Debug("governance: failed to dispatch validate parameter changes message",
 				"err", err,

--- a/go/consensus/cometbft/apps/governance/transactions_test.go
+++ b/go/consensus/cometbft/apps/governance/transactions_test.go
@@ -483,7 +483,7 @@ func TestCastVote(t *testing.T) {
 		defer txCtx.Close()
 		txCtx.SetTxSigner(tc.txSigner)
 
-		err = app.castVote(txCtx, state, tc.vote)
+		err = app.castVote(txCtx, state, tc.vote, false)
 		require.Equal(tc.err, err, tc.msg)
 
 		tc.check()

--- a/go/consensus/cometbft/apps/registry/registry.go
+++ b/go/consensus/cometbft/apps/registry/registry.go
@@ -84,10 +84,10 @@ func (app *Application) BeginBlock(ctx *api.Context) error {
 }
 
 // ExecuteMessage implements api.MessageSubscriber.
-func (app *Application) ExecuteMessage(ctx *api.Context, kind, msg any) (any, error) {
-	switch kind {
+func (app *Application) ExecuteMessage(ctx *api.Context, msg api.Message) (any, error) {
+	switch msg.Kind {
 	case roothashApi.RuntimeMessageRegistry:
-		m := msg.(*message.RegistryMessage)
+		m := msg.Data.(*message.RegistryMessage)
 		switch {
 		case m.UpdateRuntime != nil:
 			state := registryState.NewMutableState(ctx.State())
@@ -97,11 +97,11 @@ func (app *Application) ExecuteMessage(ctx *api.Context, kind, msg any) (any, er
 		}
 	case governanceApi.MessageValidateParameterChanges:
 		// A change parameters proposal is about to be submitted. Validate changes.
-		return app.changeParameters(ctx, msg, false)
+		return app.changeParameters(ctx, msg.Data, false)
 	case governanceApi.MessageChangeParameters:
 		// A change parameters proposal has just been accepted and closed. Validate and apply
 		// changes.
-		return app.changeParameters(ctx, msg, true)
+		return app.changeParameters(ctx, msg.Data, true)
 	default:
 		return nil, registry.ErrInvalidArgument
 	}

--- a/go/consensus/cometbft/apps/registry/transactions.go
+++ b/go/consensus/cometbft/apps/registry/transactions.go
@@ -462,7 +462,11 @@ func (app *Application) registerNode( // nolint: gocyclo
 			)
 
 			// Notify other interested applications about the resumed runtime.
-			if _, err = app.md.Publish(ctx, registryApi.MessageRuntimeResumed, rt); err != nil {
+			if _, err = app.md.Publish(ctx, api.Message{
+				Sender: registry.ModuleName,
+				Kind:   registryApi.MessageRuntimeResumed,
+				Data:   rt,
+			}); err != nil {
 				ctx.Logger().Error("RegisterNode: failed to dispatch runtime resumption message",
 					"err", err,
 				)
@@ -756,7 +760,11 @@ func (app *Application) registerRuntime( // nolint: gocyclo
 
 	// Notify other interested applications about the new runtime.
 	if existingRt == nil {
-		if _, err = app.md.Publish(ctx, registryApi.MessageNewRuntimeRegistered, rt); err != nil {
+		if _, err = app.md.Publish(ctx, api.Message{
+			Sender: registry.ModuleName,
+			Kind:   registryApi.MessageNewRuntimeRegistered,
+			Data:   rt,
+		}); err != nil {
 			ctx.Logger().Error("RegisterRuntime: failed to dispatch message",
 				"err", err,
 			)
@@ -764,7 +772,11 @@ func (app *Application) registerRuntime( // nolint: gocyclo
 		}
 	}
 
-	if _, err = app.md.Publish(ctx, registryApi.MessageRuntimeUpdated, rt); err != nil {
+	if _, err = app.md.Publish(ctx, api.Message{
+		Sender: registry.ModuleName,
+		Kind:   registryApi.MessageRuntimeUpdated,
+		Data:   rt,
+	}); err != nil {
 		ctx.Logger().Error("RegisterRuntime: failed to dispatch message",
 			"err", err,
 		)

--- a/go/consensus/cometbft/apps/roothash/messages.go
+++ b/go/consensus/cometbft/apps/roothash/messages.go
@@ -109,8 +109,6 @@ func (app *Application) processRuntimeMessages(
 	rtState *roothash.RuntimeState,
 	msgs []message.Message,
 ) []*roothash.MessageEvent {
-	ctx = ctx.WithMessageExecution()
-	defer ctx.Close()
 	ctx = ctx.WithCallerAddress(staking.NewRuntimeAddress(rtState.Runtime.ID))
 	defer ctx.Close()
 

--- a/go/consensus/cometbft/apps/roothash/messages.go
+++ b/go/consensus/cometbft/apps/roothash/messages.go
@@ -8,6 +8,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
+	"github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	tmapi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	registryState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/registry/state"
 	roothashApi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/roothash/api"
@@ -135,11 +136,23 @@ func (app *Application) processRuntimeMessages(
 		var err error
 		switch {
 		case msg.Staking != nil:
-			result, err = app.md.Publish(ctx, roothashApi.RuntimeMessageStaking, msg.Staking)
+			result, err = app.md.Publish(ctx, api.Message{
+				Sender: roothash.ModuleName,
+				Kind:   roothashApi.RuntimeMessageStaking,
+				Data:   msg.Staking,
+			})
 		case msg.Registry != nil:
-			result, err = app.md.Publish(ctx, roothashApi.RuntimeMessageRegistry, msg.Registry)
+			result, err = app.md.Publish(ctx, api.Message{
+				Sender: roothash.ModuleName,
+				Kind:   roothashApi.RuntimeMessageRegistry,
+				Data:   msg.Registry,
+			})
 		case msg.Governance != nil:
-			result, err = app.md.Publish(ctx, roothashApi.RuntimeMessageGovernance, msg.Governance)
+			result, err = app.md.Publish(ctx, api.Message{
+				Sender: roothash.ModuleName,
+				Kind:   roothashApi.RuntimeMessageGovernance,
+				Data:   msg.Governance,
+			})
 		default:
 			// Unsupported message.
 			err = roothash.ErrInvalidArgument

--- a/go/consensus/cometbft/apps/roothash/roothash.go
+++ b/go/consensus/cometbft/apps/roothash/roothash.go
@@ -252,15 +252,15 @@ func (app *Application) onRuntimeCommitteeChanged(
 }
 
 // ExecuteMessage implements api.MessageSubscriber.
-func (app *Application) ExecuteMessage(ctx *api.Context, kind, msg any) (any, error) {
-	switch kind {
+func (app *Application) ExecuteMessage(ctx *api.Context, msg api.Message) (any, error) {
+	switch msg.Kind {
 	case registryApi.MessageNewRuntimeRegistered:
 		// A new runtime has been registered.
 		if ctx.IsInitChain() {
 			// Ignore messages emitted during InitChain as we handle these separately.
 			return nil, nil
 		}
-		rt := msg.(*registry.Runtime)
+		rt := msg.Data.(*registry.Runtime)
 
 		ctx.Logger().Debug("ExecuteMessage: new runtime",
 			"runtime", rt.ID,
@@ -273,7 +273,7 @@ func (app *Application) ExecuteMessage(ctx *api.Context, kind, msg any) (any, er
 			// Ignore messages emitted during InitChain as we handle these separately.
 			return nil, nil
 		}
-		return nil, app.verifyRuntimeUpdate(ctx, msg.(*registry.Runtime))
+		return nil, app.verifyRuntimeUpdate(ctx, msg.Data.(*registry.Runtime))
 	case registryApi.MessageRuntimeResumed:
 		// A previously suspended runtime has been resumed.
 		return nil, nil
@@ -283,14 +283,14 @@ func (app *Application) ExecuteMessage(ctx *api.Context, kind, msg any) (any, er
 	case schedulerApi.MessageBeforeSchedule:
 		// Scheduler is about to perform scheduling. Process liveness statistics to make sure they
 		// get taken into account for the next election.
-		return app.doBeforeSchedule(ctx, msg)
+		return app.doBeforeSchedule(ctx, msg.Data)
 	case governanceApi.MessageValidateParameterChanges:
 		// A change parameters proposal is about to be submitted. Validate changes.
-		return app.changeParameters(ctx, msg, false)
+		return app.changeParameters(ctx, msg.Data, false)
 	case governanceApi.MessageChangeParameters:
 		// A change parameters proposal has just been accepted and closed. Validate and apply
 		// changes.
-		return app.changeParameters(ctx, msg, true)
+		return app.changeParameters(ctx, msg.Data, true)
 	default:
 		return nil, roothash.ErrInvalidArgument
 	}

--- a/go/consensus/cometbft/apps/roothash/transactions_test.go
+++ b/go/consensus/cometbft/apps/roothash/transactions_test.go
@@ -39,7 +39,7 @@ func (nd *testMsgDispatcher) Subscribe(any, abciAPI.MessageSubscriber) {
 }
 
 // Implements MessageDispatcher.
-func (nd *testMsgDispatcher) Publish(ctx *abciAPI.Context, kind, msg any) (any, error) {
+func (nd *testMsgDispatcher) Publish(ctx *abciAPI.Context, msg abciAPI.Message) (any, error) {
 	// Either we need to be in simulation mode or the gas accountant must be a no-op one.
 	if !ctx.IsSimulation() && ctx.Gas() != abciAPI.NewNopGasAccountant() {
 		panic("gas estimation should always use simulation mode")
@@ -55,9 +55,9 @@ func (nd *testMsgDispatcher) Publish(ctx *abciAPI.Context, kind, msg any) (any, 
 		governance.GasOpSubmitProposal: 2000,
 	}
 
-	switch kind {
+	switch msg.Kind {
 	case roothashApi.RuntimeMessageStaking:
-		m := msg.(*message.StakingMessage)
+		m := msg.Data.(*message.StakingMessage)
 		switch {
 		case m.Transfer != nil:
 			if err := ctx.Gas().UseGas(1, staking.GasOpTransfer, gasCosts); err != nil {
@@ -83,7 +83,7 @@ func (nd *testMsgDispatcher) Publish(ctx *abciAPI.Context, kind, msg any) (any, 
 			return nil, staking.ErrInvalidArgument
 		}
 	case roothashApi.RuntimeMessageRegistry:
-		m := msg.(*message.RegistryMessage)
+		m := msg.Data.(*message.RegistryMessage)
 		switch {
 		case m.UpdateRuntime != nil:
 			if err := ctx.Gas().UseGas(1, registry.GasOpRegisterRuntime, gasCosts); err != nil {
@@ -94,7 +94,7 @@ func (nd *testMsgDispatcher) Publish(ctx *abciAPI.Context, kind, msg any) (any, 
 			return nil, registry.ErrInvalidArgument
 		}
 	case roothashApi.RuntimeMessageGovernance:
-		m := msg.(*message.GovernanceMessage)
+		m := msg.Data.(*message.GovernanceMessage)
 		switch {
 		case m.CastVote != nil:
 			if err := ctx.Gas().UseGas(1, governance.GasOpCastVote, gasCosts); err != nil {

--- a/go/consensus/cometbft/apps/scheduler/scheduler.go
+++ b/go/consensus/cometbft/apps/scheduler/scheduler.go
@@ -158,7 +158,11 @@ func (app *Application) shouldElect(ctx *api.Context) (*electionDecision, error)
 // and optionally distributes staking rewards.
 func (app *Application) elect(ctx *api.Context, epoch beacon.EpochTime, reward bool) error {
 	// Notify applications that we are going to schedule committees.
-	_, err := app.md.Publish(ctx, schedulerApi.MessageBeforeSchedule, epoch)
+	_, err := app.md.Publish(ctx, api.Message{
+		Sender: scheduler.ModuleName,
+		Kind:   schedulerApi.MessageBeforeSchedule,
+		Data:   epoch,
+	})
 	if err != nil {
 		return fmt.Errorf("cometbft/scheduler: before schedule notification failed: %w", err)
 	}
@@ -294,15 +298,15 @@ func (app *Application) elect(ctx *api.Context, epoch beacon.EpochTime, reward b
 }
 
 // ExecuteMessage implements api.MessageSubscriber.
-func (app *Application) ExecuteMessage(ctx *api.Context, kind, msg any) (any, error) {
-	switch kind {
+func (app *Application) ExecuteMessage(ctx *api.Context, msg api.Message) (any, error) {
+	switch msg.Kind {
 	case governanceApi.MessageValidateParameterChanges:
 		// A change parameters proposal is about to be submitted. Validate changes.
-		return app.changeParameters(ctx, msg, false)
+		return app.changeParameters(ctx, msg.Data, false)
 	case governanceApi.MessageChangeParameters:
 		// A change parameters proposal has just been accepted and closed. Validate and apply
 		// changes.
-		return app.changeParameters(ctx, msg, true)
+		return app.changeParameters(ctx, msg.Data, true)
 	default:
 		return nil, fmt.Errorf("cometbft/scheduler: unexpected message")
 	}

--- a/go/consensus/cometbft/apps/staking/staking.go
+++ b/go/consensus/cometbft/apps/staking/staking.go
@@ -15,6 +15,7 @@ import (
 	registryState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/registry/state"
 	roothashApi "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/roothash/api"
 	stakingState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/staking/state"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/message"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
@@ -145,9 +146,9 @@ func (app *Application) ExecuteMessage(ctx *api.Context, msg api.Message) (any, 
 		case m.Withdraw != nil:
 			return app.withdraw(ctx, state, m.Withdraw)
 		case m.AddEscrow != nil:
-			return app.addEscrow(ctx, state, m.AddEscrow)
+			return app.addEscrow(ctx, state, m.AddEscrow, msg.Sender == roothash.ModuleName)
 		case m.ReclaimEscrow != nil:
-			return app.reclaimEscrow(ctx, state, m.ReclaimEscrow)
+			return app.reclaimEscrow(ctx, state, m.ReclaimEscrow, msg.Sender == roothash.ModuleName)
 		default:
 			return nil, staking.ErrInvalidArgument
 		}
@@ -191,7 +192,7 @@ func (app *Application) ExecuteTx(ctx *api.Context, tx *transaction.Transaction)
 			return staking.ErrInvalidArgument
 		}
 
-		_, err := app.addEscrow(ctx, state, &escrow)
+		_, err := app.addEscrow(ctx, state, &escrow, false)
 		return err
 	case staking.MethodReclaimEscrow:
 		var reclaim staking.ReclaimEscrow
@@ -199,7 +200,7 @@ func (app *Application) ExecuteTx(ctx *api.Context, tx *transaction.Transaction)
 			return staking.ErrInvalidArgument
 		}
 
-		_, err := app.reclaimEscrow(ctx, state, &reclaim)
+		_, err := app.reclaimEscrow(ctx, state, &reclaim, false)
 		return err
 	case staking.MethodAmendCommissionSchedule:
 		var amend staking.AmendCommissionSchedule

--- a/go/consensus/cometbft/apps/staking/staking.go
+++ b/go/consensus/cometbft/apps/staking/staking.go
@@ -134,11 +134,11 @@ func (app *Application) BeginBlock(ctx *api.Context) error {
 }
 
 // ExecuteMessage implements api.MessageSubscriber.
-func (app *Application) ExecuteMessage(ctx *api.Context, kind, msg any) (any, error) {
-	switch kind {
+func (app *Application) ExecuteMessage(ctx *api.Context, msg api.Message) (any, error) {
+	switch msg.Kind {
 	case roothashApi.RuntimeMessageStaking:
 		state := stakingState.NewMutableState(ctx.State())
-		m := msg.(*message.StakingMessage)
+		m := msg.Data.(*message.StakingMessage)
 		switch {
 		case m.Transfer != nil:
 			return app.transfer(ctx, state, m.Transfer)
@@ -153,11 +153,11 @@ func (app *Application) ExecuteMessage(ctx *api.Context, kind, msg any) (any, er
 		}
 	case governanceApi.MessageValidateParameterChanges:
 		// A change parameters proposal is about to be submitted. Validate changes.
-		return app.changeParameters(ctx, msg, false)
+		return app.changeParameters(ctx, msg.Data, false)
 	case governanceApi.MessageChangeParameters:
 		// A change parameters proposal has just been accepted and closed. Validate and apply
 		// changes.
-		return app.changeParameters(ctx, msg, true)
+		return app.changeParameters(ctx, msg.Data, true)
 	default:
 		return nil, staking.ErrInvalidArgument
 	}

--- a/go/consensus/cometbft/apps/staking/transactions.go
+++ b/go/consensus/cometbft/apps/staking/transactions.go
@@ -762,7 +762,11 @@ func (app *Application) withdraw(
 			Amount:      withdraw.Amount.Clone(),
 		}
 
-		_, err = app.md.Publish(ctx, stakingApi.MessageAccountHook, wh)
+		_, err = app.md.Publish(ctx, api.Message{
+			Sender: staking.ModuleName,
+			Kind:   stakingApi.MessageAccountHook,
+			Data:   wh,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("%w: hook invocation failed: %w", staking.ErrForbidden, err)
 		}

--- a/go/consensus/cometbft/apps/staking/transactions.go
+++ b/go/consensus/cometbft/apps/staking/transactions.go
@@ -254,7 +254,7 @@ func (app *Application) burnImpl(
 	return nil
 }
 
-func (app *Application) addEscrow(ctx *api.Context, state *stakingState.MutableState, escrow *staking.Escrow) (*staking.AddEscrowResult, error) {
+func (app *Application) addEscrow(ctx *api.Context, state *stakingState.MutableState, escrow *staking.Escrow, runtimeMsg bool) (*staking.AddEscrowResult, error) {
 	if ctx.IsCheckOnly() {
 		return nil, nil
 	}
@@ -269,7 +269,7 @@ func (app *Application) addEscrow(ctx *api.Context, state *stakingState.MutableS
 	}
 
 	// Check if escrow messages are allowed.
-	if ctx.IsMessageExecution() && !params.AllowEscrowMessages {
+	if runtimeMsg && !params.AllowEscrowMessages {
 		return nil, staking.ErrForbidden
 	}
 
@@ -373,7 +373,7 @@ func (app *Application) addEscrow(ctx *api.Context, state *stakingState.MutableS
 	}, nil
 }
 
-func (app *Application) reclaimEscrow(ctx *api.Context, state *stakingState.MutableState, reclaim *staking.ReclaimEscrow) (*staking.ReclaimEscrowResult, error) {
+func (app *Application) reclaimEscrow(ctx *api.Context, state *stakingState.MutableState, reclaim *staking.ReclaimEscrow, runtimeMsg bool) (*staking.ReclaimEscrowResult, error) {
 	// No sense if there is nothing to reclaim.
 	if reclaim.Shares.IsZero() {
 		return nil, staking.ErrInvalidArgument
@@ -393,7 +393,7 @@ func (app *Application) reclaimEscrow(ctx *api.Context, state *stakingState.Muta
 	}
 
 	// Check if escrow messages are allowed.
-	if ctx.IsMessageExecution() && !params.AllowEscrowMessages {
+	if runtimeMsg && !params.AllowEscrowMessages {
 		return nil, staking.ErrForbidden
 	}
 

--- a/go/consensus/cometbft/apps/staking/transactions_test.go
+++ b/go/consensus/cometbft/apps/staking/transactions_test.go
@@ -100,12 +100,12 @@ func TestReservedAddresses(t *testing.T) {
 	_ = q.FromInt64(1_000)
 
 	// NOTE: We need to specify escrow amount since that is checked before the check for reserved address.
-	escrowResult, err := app.addEscrow(txCtx, stakeState, &staking.Escrow{Amount: *q.Clone()})
+	escrowResult, err := app.addEscrow(txCtx, stakeState, &staking.Escrow{Amount: *q.Clone()}, false)
 	require.EqualError(err, "staking: forbidden by policy", "adding escrow for reserved address should error")
 	require.Nil(escrowResult, "escrow result should be nil on error")
 
 	// NOTE: We need to specify reclaim escrow shares since that is checked before the check for reserved address.
-	reclaimResult, err := app.reclaimEscrow(txCtx, stakeState, &staking.ReclaimEscrow{Shares: *q.Clone()})
+	reclaimResult, err := app.reclaimEscrow(txCtx, stakeState, &staking.ReclaimEscrow{Shares: *q.Clone()}, false)
 	require.EqualError(err, "staking: forbidden by policy", "reclaim escrow for reserved address should error")
 	require.Nil(reclaimResult, "reclaim escrow result should be nil on error")
 
@@ -757,7 +757,7 @@ func TestAddEscrow(t *testing.T) {
 		defer txCtx.Close()
 		txCtx.SetTxSigner(tc.txSigner)
 
-		result, err := app.addEscrow(txCtx, stakeState, tc.escrow)
+		result, err := app.addEscrow(txCtx, stakeState, tc.escrow, false)
 		require.ErrorIs(err, tc.err, tc.msg)
 		require.EqualValues(tc.result, result, tc.msg)
 	}
@@ -795,7 +795,7 @@ func TestAllowEscrowMessages(t *testing.T) {
 
 	// Add escrow transaction should be allowed.
 	txCtx.SetTxSigner(pk1)
-	result, err := app.addEscrow(txCtx, stakeState, &staking.Escrow{Account: addr1, Amount: *quantity.NewFromUint64(10)})
+	result, err := app.addEscrow(txCtx, stakeState, &staking.Escrow{Account: addr1, Amount: *quantity.NewFromUint64(10)}, false)
 	require.NoError(err, "add escrow transaction should work")
 	require.EqualValues(&staking.AddEscrowResult{
 		Owner:     addr1,
@@ -805,7 +805,7 @@ func TestAllowEscrowMessages(t *testing.T) {
 	}, result, "add escrow result should be correct")
 
 	// Reclaim escrow transaction should be allowed.
-	reclaimResult, err := app.reclaimEscrow(txCtx, stakeState, &staking.ReclaimEscrow{Account: addr1, Shares: *quantity.NewFromUint64(1)})
+	reclaimResult, err := app.reclaimEscrow(txCtx, stakeState, &staking.ReclaimEscrow{Account: addr1, Shares: *quantity.NewFromUint64(1)}, false)
 	require.NoError(err, "reclaim escrow transaction should work")
 	require.EqualValues(&staking.ReclaimEscrowResult{
 		Owner:           addr1,
@@ -816,14 +816,13 @@ func TestAllowEscrowMessages(t *testing.T) {
 		DebondEndTime:   beacon.EpochTime(0),
 	}, reclaimResult, "reclaim escrow result should be correct")
 
-	txCtx = txCtx.WithMessageExecution()
 	// Add escrow message should not be allowed.
-	result, err = app.addEscrow(txCtx, stakeState, &staking.Escrow{Account: addr1, Amount: *quantity.NewFromUint64(10)})
+	result, err = app.addEscrow(txCtx, stakeState, &staking.Escrow{Account: addr1, Amount: *quantity.NewFromUint64(10)}, true)
 	require.Equal(staking.ErrForbidden, err, "add escrow message should be denied")
 	require.Nil(result, "ailed add escrow result should be nil")
 
 	// Reclaim escrow message should not be allowed.
-	reclaimResult, err = app.reclaimEscrow(txCtx, stakeState, &staking.ReclaimEscrow{Account: addr1, Shares: *quantity.NewFromUint64(1)})
+	reclaimResult, err = app.reclaimEscrow(txCtx, stakeState, &staking.ReclaimEscrow{Account: addr1, Shares: *quantity.NewFromUint64(1)}, true)
 	require.Error(staking.ErrForbidden, err, "reclaim escrow transaction should work")
 	require.Nil(reclaimResult, "ailed add escrow result should be nil")
 
@@ -833,7 +832,7 @@ func TestAllowEscrowMessages(t *testing.T) {
 	require.NoError(err, "setting staking consensus parameters should not error")
 
 	// Escrow message should be allowed.
-	result, err = app.addEscrow(txCtx, stakeState, &staking.Escrow{Account: addr1, Amount: *quantity.NewFromUint64(10)})
+	result, err = app.addEscrow(txCtx, stakeState, &staking.Escrow{Account: addr1, Amount: *quantity.NewFromUint64(10)}, true)
 	require.NoError(err, "add escrow message should be allowed")
 	require.EqualValues(&staking.AddEscrowResult{
 		Owner:     addr1,
@@ -842,7 +841,7 @@ func TestAllowEscrowMessages(t *testing.T) {
 		NewShares: *quantity.NewFromUint64(10),
 	}, result, "add escrow result should be correct")
 
-	reclaimResult, err = app.reclaimEscrow(txCtx, stakeState, &staking.ReclaimEscrow{Account: addr1, Shares: *quantity.NewFromUint64(2)})
+	reclaimResult, err = app.reclaimEscrow(txCtx, stakeState, &staking.ReclaimEscrow{Account: addr1, Shares: *quantity.NewFromUint64(2)}, true)
 	require.NoError(err, "reclaim escrow message should work")
 	require.EqualValues(&staking.ReclaimEscrowResult{
 		Owner:           addr1,

--- a/go/consensus/cometbft/apps/vault/action.go
+++ b/go/consensus/cometbft/apps/vault/action.go
@@ -76,10 +76,14 @@ func (app *Application) executeAction(ctx *api.Context, vlt *vault.Vault, action
 		}))
 	case action.ExecuteMessage != nil:
 		// Execute a message with vault as the caller.
-		_, err := app.md.Publish(ctx, api.MessageExecuteSubcall, &api.SubcallInfo{
-			Caller: vlt.Address(),
-			Method: action.ExecuteMessage.Method,
-			Body:   action.ExecuteMessage.Body,
+		_, err := app.md.Publish(ctx, api.Message{
+			Sender: vault.ModuleName,
+			Kind:   api.MessageExecuteSubcall,
+			Data: &api.SubcallInfo{
+				Caller: vlt.Address(),
+				Method: action.ExecuteMessage.Method,
+				Body:   action.ExecuteMessage.Body,
+			},
 		})
 		return err
 	default:

--- a/go/consensus/cometbft/apps/vault/transactions_test.go
+++ b/go/consensus/cometbft/apps/vault/transactions_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+	"github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	abciAPI "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/api"
 	stakingState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/staking/state"
 	vaultState "github.com/oasisprotocol/oasis-core/go/consensus/cometbft/apps/vault/state"
@@ -202,15 +203,15 @@ func (nd *testMsgDispatcher) Subscribe(any, abciAPI.MessageSubscriber) {
 }
 
 // Implements MessageDispatcher.
-func (nd *testMsgDispatcher) Publish(_ *abciAPI.Context, kind, msg any) (any, error) {
-	switch kind {
+func (nd *testMsgDispatcher) Publish(_ *abciAPI.Context, msg api.Message) (any, error) {
+	switch msg.Kind {
 	case abciAPI.MessageExecuteSubcall:
 		// Simulate subcall execution.
-		info := msg.(*abciAPI.SubcallInfo)
+		info := msg.Data.(*abciAPI.SubcallInfo)
 		nd.delivered = append(nd.delivered, info)
 		return struct{}{}, nil
 	default:
-		panic(fmt.Errorf("message kind '%T' not implemented in tests", kind))
+		panic(fmt.Errorf("message kind '%T' not implemented in tests", msg.Kind))
 	}
 }
 

--- a/go/consensus/cometbft/apps/vault/vault.go
+++ b/go/consensus/cometbft/apps/vault/vault.go
@@ -103,18 +103,18 @@ func (app *Application) ExecuteTx(ctx *api.Context, tx *transaction.Transaction)
 }
 
 // ExecuteMessage implements api.MessageSubscriber.
-func (app *Application) ExecuteMessage(ctx *api.Context, kind, msg any) (any, error) {
-	switch kind {
+func (app *Application) ExecuteMessage(ctx *api.Context, msg api.Message) (any, error) {
+	switch msg.Kind {
 	case stakingApi.MessageAccountHook:
 		// Account hook invocation.
-		return app.invokeAccountHook(ctx, msg)
+		return app.invokeAccountHook(ctx, msg.Data)
 	case governanceApi.MessageValidateParameterChanges:
 		// A change parameters proposal is about to be submitted. Validate changes.
-		return app.changeParameters(ctx, msg, false)
+		return app.changeParameters(ctx, msg.Data, false)
 	case governanceApi.MessageChangeParameters:
 		// A change parameters proposal has just been accepted and closed. Validate and apply
 		// changes.
-		return app.changeParameters(ctx, msg, true)
+		return app.changeParameters(ctx, msg.Data, true)
 	default:
 		return nil, vault.ErrInvalidArgument
 	}


### PR DESCRIPTION
Application `roothash` uses a message execution context when processing and executing runtime messages. This context was introduced solely to reject runtime escrow messages when they are forbidden by consensus. Therefore, it should not be used in other applications. However, since the `vault` application can also process and execute messages, the current naming implies that it should use the aforementioned context as well. To avoid this ambiguity, we are renaming the message execution context to roothash execution context, emphasizing that only roothash messages are executed within this context.

UPDATE: Since renaming was a bad idea, this PR introduces sender of application messages and uses it to figure out the origin of the message and then decide if it comes from roothash or not.