### PR TITLE
Backport 6526 to v26.0

### DIFF
--- a/go/consensus/cometbft/light/client.go
+++ b/go/consensus/cometbft/light/client.go
@@ -33,6 +33,12 @@ const (
 	// storeLowWatermark is the number of blocks to retain in the pruned store
 	// after pruning is triggered.
 	storeLowWatermark = 20_000
+
+	// numWitnesses is the number of libp2p backed CometBFT light-block witnesses to be instantiated.
+	numWitnesses = 2
+	// lcMaxRetryAttempts is the number of retry attempts the CometBFT light client does,
+	// before switching the primary provider.
+	lcMaxRetryAttempts = 5
 )
 
 // Config is the configuration for the light client.

--- a/go/consensus/cometbft/light/client.go
+++ b/go/consensus/cometbft/light/client.go
@@ -195,30 +195,3 @@ func (c *Client) getParameters(ctx context.Context, height int64) (*consensus.Pa
 		return p.getParameters(ctx, height)
 	})
 }
-
-func tryProviders[R any](
-	ctx context.Context,
-	providers []*Provider,
-	fn func(*Provider) (R, rpc.PeerFeedback, error),
-) (R, rpc.PeerFeedback, error) {
-	var (
-		result R
-		err    error
-	)
-	for _, provider := range providers {
-		if ctx.Err() != nil {
-			return result, nil, ctx.Err()
-		}
-
-		var pf rpc.PeerFeedback
-		result, pf, err = fn(provider)
-		if err == nil {
-			return result, pf, nil
-		}
-	}
-
-	// Trigger primary provider refresh if everything fails.
-	providers[0].RefreshPeer()
-
-	return result, nil, err
-}

--- a/go/consensus/cometbft/light/client.go
+++ b/go/consensus/cometbft/light/client.go
@@ -193,6 +193,8 @@ func (c *Client) VerifyParametersAt(ctx context.Context, height int64) (*cmttype
 		)
 	}
 
+	pf.RecordSuccess()
+
 	return &cmtparams, nil
 }
 

--- a/go/consensus/cometbft/light/provider.go
+++ b/go/consensus/cometbft/light/provider.go
@@ -341,3 +341,30 @@ func (p *Provider) LightBlockWithPeerID(ctx context.Context, height int64) (*cmt
 	}
 	return rsp.clb, string(pf.PeerID()), nil
 }
+
+func tryProviders[R any](
+	ctx context.Context,
+	providers []*Provider,
+	fn func(*Provider) (R, rpc.PeerFeedback, error),
+) (R, rpc.PeerFeedback, error) {
+	var (
+		result R
+		err    error
+	)
+	for _, provider := range providers {
+		if ctx.Err() != nil {
+			return result, nil, ctx.Err()
+		}
+
+		var pf rpc.PeerFeedback
+		result, pf, err = fn(provider)
+		if err == nil {
+			return result, pf, nil
+		}
+	}
+
+	// Trigger primary provider refresh if everything fails.
+	providers[0].RefreshPeer()
+
+	return result, nil, err
+}

--- a/go/consensus/cometbft/light/service.go
+++ b/go/consensus/cometbft/light/service.go
@@ -10,11 +10,8 @@ import (
 )
 
 const (
-	// numWitnesses is the number of libp2p backed CometBFT light-block witnesses to be instantiated.
-	numWitnesses = 2
-	// lcMaxRetryAttempts is the number of retry attempts the CometBFT light client does,
-	// before switching the primary provider.
-	lcMaxRetryAttempts = 5
+	// numProviders is the number of libp2p backed CometBFT light-block providers used by the light client service.
+	numProviders = 2
 )
 
 type ClientService struct {
@@ -69,8 +66,8 @@ func (c *ClientService) Validators(ctx context.Context, height int64) (*consensu
 // New creates a new CometBFT light client service backed by remote P2P peers.
 func New(ctx context.Context, chainContext string, p2p rpc.P2P) (*ClientService, error) {
 	pool := NewProviderPool(ctx, chainContext, p2p)
-	providers := make([]*Provider, 0, numWitnesses)
-	for range numWitnesses {
+	providers := make([]*Provider, 0, numProviders)
+	for range numProviders {
 		p := pool.NewProvider()
 		providers = append(providers, p)
 	}

--- a/go/consensus/cometbft/light/service.go
+++ b/go/consensus/cometbft/light/service.go
@@ -23,7 +23,7 @@ type ClientService struct {
 	providers []*Provider
 }
 
-// GetStatus implements api.LightService.
+// GetStatus implements [consensus.LightService].
 func (c *ClientService) GetStatus() (*consensus.LightClientStatus, error) {
 	status := &consensus.LightClientStatus{}
 
@@ -36,7 +36,7 @@ func (c *ClientService) GetStatus() (*consensus.LightClientStatus, error) {
 	return status, nil
 }
 
-// LightBlock implements the LightProvider interface.
+// LightBlock implements the [consensus.LightProvider] interface.
 func (c *ClientService) LightBlock(ctx context.Context, height int64) (*consensus.LightBlock, error) {
 	rsp, _, err := tryProviders(ctx, c.providers, func(p *Provider) (*lightBlock, rpc.PeerFeedback, error) {
 		return p.getLightBlock(ctx, height)
@@ -51,7 +51,7 @@ func (c *ClientService) LightBlock(ctx context.Context, height int64) (*consensu
 	return rsp.lb, nil
 }
 
-// Validators implements the LightProvider interface.
+// Validators implements the [consensus.LightProvider] interface.
 func (c *ClientService) Validators(ctx context.Context, height int64) (*consensus.Validators, error) {
 	validators, _, err := tryProviders(ctx, c.providers, func(p *Provider) (*consensus.Validators, rpc.PeerFeedback, error) {
 		return p.getValidators(ctx, height)
@@ -66,9 +66,7 @@ func (c *ClientService) Validators(ctx context.Context, height int64) (*consensu
 	return validators, nil
 }
 
-// New creates a new CometBFT light client service backed by the local full node.
-//
-// This light client is initialized with a trusted blocks obtained from the local consensus backend.
+// New creates a new CometBFT light client service backed by remote P2P peers.
 func New(ctx context.Context, chainContext string, p2p rpc.P2P) (*ClientService, error) {
 	pool := NewProviderPool(ctx, chainContext, p2p)
 	providers := make([]*Provider, 0, numWitnesses)

--- a/go/consensus/cometbft/light/service.go
+++ b/go/consensus/cometbft/light/service.go
@@ -9,11 +9,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/p2p/rpc"
 )
 
-const (
-	// numProviders is the number of libp2p backed CometBFT light-block providers used by the light client service.
-	numProviders = 2
-)
-
 type ClientService struct {
 	logger *logging.Logger
 
@@ -65,6 +60,10 @@ func (c *ClientService) Validators(ctx context.Context, height int64) (*consensu
 
 // New creates a new CometBFT light client service backed by remote P2P peers.
 func New(ctx context.Context, chainContext string, p2p rpc.P2P) (*ClientService, error) {
+	// The service should be able to fetch light blocks with arbitrary age.
+	// Since most of the nodes are pruning, we try to maintain more providers,
+	// to increase the likelihood of success.
+	const numProviders = 10
 	pool := NewProviderPool(ctx, chainContext, p2p)
 	providers := make([]*Provider, 0, numProviders)
 	for range numProviders {

--- a/go/consensus/cometbft/light/service.go
+++ b/go/consensus/cometbft/light/service.go
@@ -3,7 +3,6 @@ package light
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
@@ -35,11 +34,6 @@ func (c *ClientService) GetStatus() (*consensus.LightClientStatus, error) {
 	}
 
 	return status, nil
-}
-
-// TrustedLightBlock implements the LightClient interface.
-func (c *ClientService) TrustedLightBlock(int64) (*consensus.LightBlock, error) {
-	return nil, fmt.Errorf("light block not found")
 }
 
 // LightBlock implements the LightProvider interface.

--- a/go/control/api/api.go
+++ b/go/control/api/api.go
@@ -89,6 +89,9 @@ type Status struct {
 	Consensus *consensus.Status `json:"consensus,omitempty"`
 
 	// LightClient is the status overview of the light client service.
+	//
+	// TODO: Fix light client (service) status.
+	// See https://github.com/oasisprotocol/oasis-core/issues/6388.
 	LightClient *consensus.LightClientStatus `json:"light_client,omitempty"`
 
 	// Runtimes is the status overview for each runtime supported by the node.

--- a/go/runtime/registry/handler.go
+++ b/go/runtime/registry/handler.go
@@ -36,7 +36,7 @@ type RuntimeHostHandlerEnvironment interface {
 	GetNodeIdentity() (*identity.Identity, error)
 
 	// GetLightProvider returns the consensus light provider.
-	GetLightProvider() (consensus.LightProvider, error)
+	GetLightProvider() consensus.LightProvider
 
 	// GetRuntimeRegistry returns the runtime registry.
 	GetRuntimeRegistry() Registry
@@ -268,15 +268,12 @@ func (h *runtimeHostHandler) handleHostFetchConsensusBlock(
 	ctx context.Context,
 	rq *protocol.HostFetchConsensusBlockRequest,
 ) (*protocol.HostFetchConsensusBlockResponse, error) {
-	blk, err := h.consensus.Core().GetLightBlock(ctx, int64(rq.Height))
+	height := int64(rq.Height)
+	blk, err := h.consensus.Core().GetLightBlock(ctx, height)
 	if err != nil {
-		lc, err := h.env.GetLightProvider()
+		blk, err = h.env.GetLightProvider().LightBlock(ctx, height)
 		if err != nil {
-			return nil, err
-		}
-		blk, err = lc.LightBlock(ctx, int64(rq.Height))
-		if err != nil {
-			return nil, fmt.Errorf("light block fetch failure: %w", err)
+			return nil, fmt.Errorf("failed to fetch light block for height %d: %w", height, err)
 		}
 	}
 	return &protocol.HostFetchConsensusBlockResponse{Block: *blk}, nil
@@ -286,16 +283,12 @@ func (h *runtimeHostHandler) handleHostFetchConsensusValidators(
 	ctx context.Context,
 	rq *protocol.HostFetchConsensusValidatorsRequest,
 ) (*protocol.HostFetchConsensusValidatorsResponse, error) {
-	vs, err := h.consensus.Core().GetValidators(ctx, int64(rq.Height))
+	height := int64(rq.Height)
+	vs, err := h.consensus.Core().GetValidators(ctx, height)
 	if err != nil {
-		lp, err := h.env.GetLightProvider()
+		vs, err = h.env.GetLightProvider().Validators(ctx, height)
 		if err != nil {
-			return nil, err
-		}
-
-		vs, err = lp.Validators(ctx, int64(rq.Height))
-		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to fetch validator for height %d: %w", height, err)
 		}
 	}
 

--- a/go/worker/common/committee/runtime_host.go
+++ b/go/worker/common/committee/runtime_host.go
@@ -28,8 +28,8 @@ func (env *nodeEnvironment) GetNodeIdentity() (*identity.Identity, error) {
 }
 
 // GetLightProvider implements RuntimeHostHandlerEnvironment.
-func (env *nodeEnvironment) GetLightProvider() (consensusAPI.LightProvider, error) {
-	return env.n.LightProvider, nil
+func (env *nodeEnvironment) GetLightProvider() consensusAPI.LightProvider {
+	return env.n.LightProvider
 }
 
 // GetRuntimeRegistry implements RuntimeHostHandlerEnvironment.

--- a/go/worker/keymanager/handler.go
+++ b/go/worker/keymanager/handler.go
@@ -30,8 +30,8 @@ func (env *workerEnvironment) GetNodeIdentity() (*identity.Identity, error) {
 }
 
 // GetLightProvider implements RuntimeHostHandlerEnvironment.
-func (env *workerEnvironment) GetLightProvider() (consensusAPI.LightProvider, error) {
-	return env.w.commonWorker.LightProvider, nil
+func (env *workerEnvironment) GetLightProvider() consensusAPI.LightProvider {
+	return env.w.commonWorker.LightProvider
 }
 
 // GetRuntimeRegistry implements RuntimeHostHandlerEnvironment.


### PR DESCRIPTION
Backport improved light block fetching from the enclave  data availability, unable to find good peers).

We could also temporary set https://github.com/oasisprotocol/oasis-core/blob/8fc03cb84c32f2c171ab00307b2738d214d095e9/runtime/src/consensus/tendermint/verifier/mod.rs#L589  to something bigger, e.g. `50`.

See existing provider issues: https://oasisprotocol.slack.com/archives/C01KA8RRJBU/p1779804042396849?thread_ts=1779794271.075479&cid=C01KA8RRJBU

