### PR TITLE
go: Bump github.com/quic-go/quic-go to v0.59.1

### DIFF
--- a/.changelog/6544.internal.md
+++ b/.changelog/6544.internal.md
@@ -1,0 +1,1 @@
+go: Bump github.com/quic-go/quic-go to v0.59.1

--- a/go/go.mod
+++ b/go/go.mod
@@ -183,7 +183,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/quic-go/quic-go v0.59.0 // indirect
+	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/quic-go/webtransport-go v0.10.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -522,8 +522,8 @@ github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzM
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
-github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
+github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
+github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/quic-go/webtransport-go v0.10.0 h1:LqXXPOXuETY5Xe8ITdGisBzTYmUOy5eSj+9n4hLTjHI=
 github.com/quic-go/webtransport-go v0.10.0/go.mod h1:LeGIXr5BQKE3UsynwVBeQrU1TPrbh73MGoC6jd+V7ow=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=


### PR DESCRIPTION
```bash
pkg:golang/github.com/quic-go/quic-go@v0.59.0
1 known vulnerabilities affecting installed version
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ [CVE-2026-40898] CWE-770: Allocation of Resources Without Limits or Throttling                                                                                                                                     ┃
┣━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
┃ Description        ┃ quic-go is an implementation of the QUIC protocol in Go. Prior to version                                                                                                                     ┃
┃                    ┃ 0.59.1, an attacker can cause excessive memory allocation in quic-go's                                                                                                                        ┃
┃                    ┃ HTTP/3 client and server implementations by sending a QPACK-encoded HEADERS                                                                                                                   ┃
┃                    ┃ frame that decodes into a large trailer field section with many unique                                                                                                                        ┃
┃                    ┃ field names and/or large values. The implementation builds an `http.Header`                                                                                                                   ┃
┃                    ┃ for the corresponding `http.Request` or `http.Response`, while only                                                                                                                           ┃
┃                    ┃ enforcing limits on the size of the QPACK-compressed HEADERS frame, not on                                                                                                                    ┃
┃                    ┃ the decoded field section. This can lead to memory exhaustion. This is very                                                                                                                   ┃
┃                    ┃ similar to CVE-2025-64702. The difference is that this issue uses HTTP                                                                                                                        ┃
┃                    ┃ trailers, rather than HTTP headers, as the attack vector. A misbehaving or                                                                                                                    ┃
┃                    ┃ malicious peer can cause a denial-of-service (DoS) attack against quic-go's                                                                                                                   ┃
┃                    ┃ HTTP/3 servers or clients by triggering excessive memory allocation,                                                                                                                          ┃
┃                    ┃ potentially leading to crashes or resource exhaustion. This affects both                                                                                                                      ┃
┃                    ┃ servers and clients due to symmetric header construction. Version 0.59.1                                                                                                                      ┃
┃                    ┃ enforces RFC 9114 decoded field section size limits for trailers as well.                                                                                                                     ┃
┃                    ┃ It incrementally decodes QPACK entries and checks the field section size                                                                                                                      ┃
┃                    ┃ after each entry, aborting the stream if an entry causes the limit to be                                                                                                                      ┃
┃                    ┃ exceeded.                                                                                                                                                                                     ┃
┃                    ┃                                                                                                                                                                                               ┃
┃                    ┃ Sonatype's research suggests that this CVE's details differ from those                                                                                                                        ┃
┃                    ┃ defined at NVD. See https://guide.sonatype.com/vulnerability/CVE-2026-40898                                                                                                                   ┃
┃                    ┃ for details                                                                                                                                                                                   ┃
┣━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
┃ OSS Index ID       ┃ CVE-2026-40898                                                                                                                                                                                ┃
┣━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
┃ CVSS Score         ┃ 7.5/10 (High)                                                                                                                                                                                 ┃
┣━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
┃ CVSS Vector        ┃ CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H                                                                                                                                                  ┃
┣━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
┃ Link for more info ┃ https://guide.sonatype.com/vulnerability/CVE-2026-40898?component-type=golang&component-name=github.com%2Fquic-go%2Fquic-go&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.33 ┃
┗━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
```