### PR TITLE
go/consensus/cometbft/apps/roothash: Fix evidence removal round check

### DIFF
--- a/.changelog/6549.bugfix.md
+++ b/.changelog/6549.bugfix.md
@@ -1,0 +1,1 @@
+go/consensus/cometbft/apps/roothash: Fix evidence removal round check

--- a/go/consensus/cometbft/apps/roothash/state/state.go
+++ b/go/consensus/cometbft/apps/roothash/state/state.go
@@ -547,7 +547,7 @@ func (s *MutableState) RemoveExpiredEvidence(ctx context.Context, runtimeID comm
 		if rtID != hID {
 			break
 		}
-		if round > minRound {
+		if round >= minRound {
 			break
 		}
 		toDelete = append(toDelete, it.Key())


### PR DESCRIPTION
In general this is a breaking change, but not currently since slashing is disabled on our runtimes.