### PR TITLE
go/storage/mkvs/node: Validate key bit depth

### DIFF
--- a/go/storage/mkvs/insert.go
+++ b/go/storage/mkvs/insert.go
@@ -77,7 +77,7 @@ func (t *tree) doInsert(
 	if err != nil {
 		return insertResult{}, err
 	}
-	_, keyRemainder := key.Split(bitDepth, keyBitLength)
+	_, keyRemainder := key.MustSplit(bitDepth, keyBitLength)
 
 	switch n := nd.(type) {
 	case nil:
@@ -138,7 +138,7 @@ func (t *tree) doInsert(
 
 		// Key mismatches the label at position cpLength. Split the edge and
 		// insert new leaf.
-		labelPrefix, labelSuffix := n.Label.Split(cpLength, n.LabelBitLength)
+		labelPrefix, labelSuffix := n.Label.MustSplit(cpLength, n.LabelBitLength)
 		n.Label = labelSuffix
 		n.LabelBitLength = n.LabelBitLength - cpLength
 
@@ -211,7 +211,7 @@ func (t *tree) doInsert(
 		}
 
 		var result insertResult
-		_, leafKeyRemainder := n.Key.Split(bitDepth, nodeKeyBitLength)
+		_, leafKeyRemainder := n.Key.MustSplit(bitDepth, nodeKeyBitLength)
 		cpLength := leafKeyRemainder.CommonPrefixLen(nodeKeyBitLength-bitDepth, keyRemainder, keyBitLength-bitDepth)
 
 		// Key mismatches the label at position cpLength. Split the edge.
@@ -219,7 +219,7 @@ func (t *tree) doInsert(
 		if err != nil {
 			return insertResult{}, err
 		}
-		labelPrefix, _ := leafKeyRemainder.Split(cpLength, leafKeyBitLength)
+		labelPrefix, _ := leafKeyRemainder.MustSplit(cpLength, leafKeyBitLength)
 		newLeaf := t.cache.newLeafNode(key, val)
 		result.insertedLeaf = newLeaf
 		var leafNode, left, right *node.Pointer

--- a/go/storage/mkvs/insert.go
+++ b/go/storage/mkvs/insert.go
@@ -56,7 +56,7 @@ type insertResult struct {
 	existed      bool
 }
 
-func (t *tree) doInsert(
+func (t *tree) doInsert( // nolint: gocyclo
 	ctx context.Context,
 	ptr *node.Pointer,
 	bitDepth node.Depth,

--- a/go/storage/mkvs/insert.go
+++ b/go/storage/mkvs/insert.go
@@ -73,7 +73,11 @@ func (t *tree) doInsert(
 		return insertResult{}, err
 	}
 
-	_, keyRemainder := key.Split(bitDepth, key.BitLength())
+	keyBitLength, err := key.BitLength()
+	if err != nil {
+		return insertResult{}, err
+	}
+	_, keyRemainder := key.Split(bitDepth, keyBitLength)
 
 	switch n := nd.(type) {
 	case nil:
@@ -86,14 +90,14 @@ func (t *tree) doInsert(
 		}
 		return result, nil
 	case *node.InternalNode:
-		cpLength := n.Label.CommonPrefixLen(n.LabelBitLength, keyRemainder, key.BitLength()-bitDepth)
+		cpLength := n.Label.CommonPrefixLen(n.LabelBitLength, keyRemainder, keyBitLength-bitDepth)
 		var result insertResult
 
 		if cpLength == n.LabelBitLength {
 			bitLength := bitDepth + n.LabelBitLength
 
 			// The current part of key matched the node's Label. Do recursion.
-			if key.BitLength() == bitLength {
+			if keyBitLength == bitLength {
 				// Key to insert ends exactly at this node. Add it to the
 				// existing internal node as LeafNode.
 				result, err = t.doInsert(ctx, n.LeafNode, bitLength, key, val)
@@ -108,7 +112,7 @@ func (t *tree) doInsert(
 				return insertResult{}, err
 			}
 
-			if key.BitLength() == bitLength {
+			if keyBitLength == bitLength {
 				n.LeafNode = result.newRoot
 			} else if key.GetBit(bitLength) {
 				n.Right = result.newRoot
@@ -151,7 +155,7 @@ func (t *tree) doInsert(
 		newLeaf := t.cache.newLeafNode(key, val)
 		var leafNode, left, right *node.Pointer
 
-		if key.BitLength()-bitDepth == cpLength {
+		if keyBitLength-bitDepth == cpLength {
 			// The key is a prefix of existing path.
 			leafNode = newLeaf
 			if labelSuffix.GetBit(0) {
@@ -201,17 +205,26 @@ func (t *tree) doInsert(
 			}, nil
 		}
 
+		nodeKeyBitLength, err := n.Key.BitLength()
+		if err != nil {
+			return insertResult{}, err
+		}
+
 		var result insertResult
-		_, leafKeyRemainder := n.Key.Split(bitDepth, n.Key.BitLength())
-		cpLength := leafKeyRemainder.CommonPrefixLen(n.Key.BitLength()-bitDepth, keyRemainder, key.BitLength()-bitDepth)
+		_, leafKeyRemainder := n.Key.Split(bitDepth, nodeKeyBitLength)
+		cpLength := leafKeyRemainder.CommonPrefixLen(nodeKeyBitLength-bitDepth, keyRemainder, keyBitLength-bitDepth)
 
 		// Key mismatches the label at position cpLength. Split the edge.
-		labelPrefix, _ := leafKeyRemainder.Split(cpLength, leafKeyRemainder.BitLength())
+		leafKeyBitLength, err := leafKeyRemainder.BitLength()
+		if err != nil {
+			return insertResult{}, err
+		}
+		labelPrefix, _ := leafKeyRemainder.Split(cpLength, leafKeyBitLength)
 		newLeaf := t.cache.newLeafNode(key, val)
 		result.insertedLeaf = newLeaf
 		var leafNode, left, right *node.Pointer
 
-		if key.BitLength()-bitDepth == cpLength {
+		if keyBitLength-bitDepth == cpLength {
 			// Inserted key is a prefix of the label.
 			leafNode = newLeaf
 			if leafKeyRemainder.GetBit(cpLength) {
@@ -221,7 +234,7 @@ func (t *tree) doInsert(
 				left = ptr
 				right = nil
 			}
-		} else if n.Key.BitLength()-bitDepth == cpLength {
+		} else if nodeKeyBitLength-bitDepth == cpLength {
 			// Label is a prefix of the inserted key.
 			leafNode = ptr
 			if keyRemainder.GetBit(cpLength) {

--- a/go/storage/mkvs/insert.go
+++ b/go/storage/mkvs/insert.go
@@ -90,7 +90,10 @@ func (t *tree) doInsert(
 		}
 		return result, nil
 	case *node.InternalNode:
-		cpLength := n.Label.CommonPrefixLen(n.LabelBitLength, keyRemainder, keyBitLength-bitDepth)
+		cpLength, err := n.Label.CommonPrefixLen(n.LabelBitLength, keyRemainder, keyBitLength-bitDepth)
+		if err != nil {
+			return insertResult{}, err
+		}
 		var result insertResult
 
 		if cpLength == n.LabelBitLength {
@@ -212,7 +215,10 @@ func (t *tree) doInsert(
 
 		var result insertResult
 		_, leafKeyRemainder := n.Key.MustSplit(bitDepth, nodeKeyBitLength)
-		cpLength := leafKeyRemainder.CommonPrefixLen(nodeKeyBitLength-bitDepth, keyRemainder, keyBitLength-bitDepth)
+		cpLength, err := leafKeyRemainder.CommonPrefixLen(nodeKeyBitLength-bitDepth, keyRemainder, keyBitLength-bitDepth)
+		if err != nil {
+			return insertResult{}, err
+		}
 
 		// Key mismatches the label at position cpLength. Split the edge.
 		leafKeyBitLength, err := leafKeyRemainder.BitLength()

--- a/go/storage/mkvs/insert.go
+++ b/go/storage/mkvs/insert.go
@@ -101,7 +101,7 @@ func (t *tree) doInsert(
 				// Key to insert ends exactly at this node. Add it to the
 				// existing internal node as LeafNode.
 				result, err = t.doInsert(ctx, n.LeafNode, bitLength, key, val)
-			} else if key.GetBit(bitLength) {
+			} else if key.MustGetBit(bitLength) {
 				// Insert recursively based on the bit value.
 				result, err = t.doInsert(ctx, n.Right, bitLength, key, val)
 			} else {
@@ -114,7 +114,7 @@ func (t *tree) doInsert(
 
 			if keyBitLength == bitLength {
 				n.LeafNode = result.newRoot
-			} else if key.GetBit(bitLength) {
+			} else if key.MustGetBit(bitLength) {
 				n.Right = result.newRoot
 			} else {
 				n.Left = result.newRoot
@@ -158,14 +158,14 @@ func (t *tree) doInsert(
 		if keyBitLength-bitDepth == cpLength {
 			// The key is a prefix of existing path.
 			leafNode = newLeaf
-			if labelSuffix.GetBit(0) {
+			if labelSuffix.MustGetBit(0) {
 				left = nil
 				right = ptr
 			} else {
 				left = ptr
 				right = nil
 			}
-		} else if keyRemainder.GetBit(cpLength) {
+		} else if keyRemainder.MustGetBit(cpLength) {
 			left = ptr
 			right = newLeaf
 		} else {
@@ -227,7 +227,7 @@ func (t *tree) doInsert(
 		if keyBitLength-bitDepth == cpLength {
 			// Inserted key is a prefix of the label.
 			leafNode = newLeaf
-			if leafKeyRemainder.GetBit(cpLength) {
+			if leafKeyRemainder.MustGetBit(cpLength) {
 				left = nil
 				right = ptr
 			} else {
@@ -237,14 +237,14 @@ func (t *tree) doInsert(
 		} else if nodeKeyBitLength-bitDepth == cpLength {
 			// Label is a prefix of the inserted key.
 			leafNode = ptr
-			if keyRemainder.GetBit(cpLength) {
+			if keyRemainder.MustGetBit(cpLength) {
 				left = nil
 				right = newLeaf
 			} else {
 				left = newLeaf
 				right = nil
 			}
-		} else if keyRemainder.GetBit(cpLength) {
+		} else if keyRemainder.MustGetBit(cpLength) {
 			left = ptr
 			right = newLeaf
 		} else {

--- a/go/storage/mkvs/iterator.go
+++ b/go/storage/mkvs/iterator.go
@@ -263,7 +263,10 @@ func (it *treeIterator) doNext(ptr *node.Pointer, bitDepth node.Depth, path, key
 		return nil
 	case *node.InternalNode:
 		newBitDepth := bitDepth + n.LabelBitLength
-		newPath := path.Merge(bitDepth, n.Label, n.LabelBitLength)
+		newPath, err := path.Merge(bitDepth, n.Label, n.LabelBitLength)
+		if err != nil {
+			return err
+		}
 
 		tryNext := func(next *node.Pointer, nextKey node.Key, parentState visitState) (bool, error) {
 			if err := it.doNext(next, newBitDepth, newPath, nextKey, visitBefore); err != nil {

--- a/go/storage/mkvs/iterator.go
+++ b/go/storage/mkvs/iterator.go
@@ -315,7 +315,7 @@ func (it *treeIterator) doNext(ptr *node.Pointer, bitDepth node.Depth, path, key
 				}
 			}
 
-			if !key.GetBit(newBitDepth) || takeFirst {
+			if !key.MustGetBit(newBitDepth) || takeFirst {
 				if ok, err := tryNext(n.Left, key, visitAtLeft); ok || err != nil {
 					return err
 				}

--- a/go/storage/mkvs/iterator.go
+++ b/go/storage/mkvs/iterator.go
@@ -276,15 +276,24 @@ func (it *treeIterator) doNext(ptr *node.Pointer, bitDepth node.Depth, path, key
 			return false, nil
 		}
 
-		advanceKeyToRight := func(k node.Key) node.Key {
-			k, _ = k.Split(newBitDepth, k.BitLength())
-			return k.AppendBit(newBitDepth, true)
+		advanceKeyToRight := func(k node.Key) (node.Key, error) {
+			keyBitLength, err := k.BitLength()
+			if err != nil {
+				return nil, err
+			}
+			k, _ = k.Split(newBitDepth, keyBitLength)
+			return k.AppendBit(newBitDepth, true), nil
 		}
 
 		// Check if the key is longer than the current path but lexicographically smaller. In this
 		// case everything in this subtree will be larger so we need to take the first value.
-		takeFirst := newBitDepth > 0 && key.BitLength() >= newBitDepth && key.Compare(newPath) < 0
-		keyNotLonger := key.BitLength() <= newBitDepth
+		keyBitLength, err := key.BitLength()
+		if err != nil {
+			return err
+		}
+
+		takeFirst := newBitDepth > 0 && keyBitLength >= newBitDepth && key.Compare(newPath) < 0
+		keyNotLonger := keyBitLength <= newBitDepth
 
 		switch state {
 		case visitBefore:
@@ -304,14 +313,20 @@ func (it *treeIterator) doNext(ptr *node.Pointer, bitDepth node.Depth, path, key
 				if ok, err := tryNext(n.Left, key, visitAtLeft); ok || err != nil {
 					return err
 				}
-				key = advanceKeyToRight(key)
+				key, err = advanceKeyToRight(key)
+				if err != nil {
+					return err
+				}
 			}
 
 			if ok, err := tryNext(n.Right, key, visitAfter); ok || err != nil {
 				return err
 			}
 		case visitAtLeft:
-			key = advanceKeyToRight(key)
+			key, err = advanceKeyToRight(key)
+			if err != nil {
+				return err
+			}
 			if ok, err := tryNext(n.Right, key, visitAfter); ok || err != nil {
 				return err
 			}

--- a/go/storage/mkvs/iterator.go
+++ b/go/storage/mkvs/iterator.go
@@ -282,7 +282,7 @@ func (it *treeIterator) doNext(ptr *node.Pointer, bitDepth node.Depth, path, key
 				return nil, err
 			}
 			k, _ = k.Split(newBitDepth, keyBitLength)
-			return k.AppendBit(newBitDepth, true), nil
+			return k.AppendBit(newBitDepth, true)
 		}
 
 		// Check if the key is longer than the current path but lexicographically smaller. In this
@@ -306,7 +306,10 @@ func (it *treeIterator) doNext(ptr *node.Pointer, bitDepth node.Depth, path, key
 			fallthrough
 		case visitAt:
 			if keyNotLonger {
-				key = key.AppendBit(newBitDepth, false)
+				key, err = key.AppendBit(newBitDepth, false)
+				if err != nil {
+					return err
+				}
 			}
 
 			if !key.GetBit(newBitDepth) || takeFirst {

--- a/go/storage/mkvs/iterator.go
+++ b/go/storage/mkvs/iterator.go
@@ -38,7 +38,12 @@ func (t *tree) SyncIterate(ctx context.Context, request *syncer.IterateRequest) 
 	)
 	defer it.Close()
 
-	it.Seek(request.Key)
+	key := node.Key(request.Key)
+	if err := key.Validate(); err != nil {
+		return nil, err
+	}
+
+	it.Seek(key)
 	if it.Err() != nil {
 		return nil, it.Err()
 	}
@@ -246,7 +251,7 @@ func (it *treeIterator) Next() {
 	it.value = nil
 }
 
-func (it *treeIterator) doNext(ptr *node.Pointer, bitDepth node.Depth, path, key node.Key, state visitState) error {
+func (it *treeIterator) doNext(ptr *node.Pointer, bitDepth node.Depth, path, key node.Key, state visitState) error { // nolint: gocyclo
 	// Dereference the node, possibly making a remote request.
 	nd, err := it.tree.cache.derefNodePtr(it.ctx, ptr, it.tree.newFetcherSyncIterate(key, it.prefetch))
 	if err != nil {

--- a/go/storage/mkvs/iterator.go
+++ b/go/storage/mkvs/iterator.go
@@ -284,7 +284,7 @@ func (it *treeIterator) doNext(ptr *node.Pointer, bitDepth node.Depth, path, key
 			if err != nil {
 				return nil, err
 			}
-			k, _ = k.Split(newBitDepth, keyBitLength)
+			k, _ = k.MustSplit(newBitDepth, keyBitLength)
 			return k.AppendBit(newBitDepth, true)
 		}
 

--- a/go/storage/mkvs/lookup.go
+++ b/go/storage/mkvs/lookup.go
@@ -133,7 +133,12 @@ func (t *tree) doGet(
 		bitLength := bitDepth + n.LabelBitLength
 
 		// Does lookup key end here? Look into LeafNode.
-		if key.BitLength() == bitLength {
+		keyBitLength, err := key.BitLength()
+		if err != nil {
+			return nil, err
+		}
+		switch {
+		case keyBitLength == bitLength:
 			if opts.includeSiblings {
 				// Also fetch the left and right siblings.
 				_, err = t.doGet(ctx, n.Left, bitLength, key, opts, true)
@@ -153,43 +158,41 @@ func (t *tree) doGet(
 			}
 
 			return t.doGet(ctx, n.LeafNode, bitLength, key, opts, false)
-		}
-
-		// Lookup key is too short for the current n.Label. It's not stored.
-		if key.BitLength() < bitLength {
+		case keyBitLength < bitLength:
+			// Lookup key is too short for the current n.Label. It's not stored.
 			return nil, nil
-		}
+		default:
+			// Continue recursively based on a bit value.
+			fn := func(visit, other, leaf *node.Pointer) ([]byte, error) {
+				value, err := t.doGet(ctx, visit, bitLength, key, opts, false)
+				if err != nil {
+					return nil, err
+				}
 
-		// Continue recursively based on a bit value.
-		fn := func(visit, other, leaf *node.Pointer) ([]byte, error) {
-			value, err := t.doGet(ctx, visit, bitLength, key, opts, false)
-			if err != nil {
-				return nil, err
-			}
+				if opts.includeSiblings {
+					if pb := opts.proofBuilder; pb != nil && pb.Version() > 0 {
+						// In V0, the leaf node is included in internal node.
+						// Also fetch the leaf.
+						_, err = t.doGet(ctx, leaf, bitLength, key, opts, true)
+						if err != nil {
+							return nil, err
+						}
+					}
 
-			if opts.includeSiblings {
-				if pb := opts.proofBuilder; pb != nil && pb.Version() > 0 {
-					// In V0, the leaf node is included in internal node.
-					// Also fetch the leaf.
-					_, err = t.doGet(ctx, leaf, bitLength, key, opts, true)
+					// Also fetch the other sibling.
+					_, err = t.doGet(ctx, other, bitLength, key, opts, true)
 					if err != nil {
 						return nil, err
 					}
 				}
-
-				// Also fetch the other sibling.
-				_, err = t.doGet(ctx, other, bitLength, key, opts, true)
-				if err != nil {
-					return nil, err
-				}
+				return value, nil
 			}
-			return value, nil
-		}
-		switch key.GetBit(bitLength) {
-		case true:
-			return fn(n.Right, n.Left, n.LeafNode)
-		default:
-			return fn(n.Left, n.Right, n.LeafNode)
+			switch key.GetBit(bitLength) {
+			case true:
+				return fn(n.Right, n.Left, n.LeafNode)
+			default:
+				return fn(n.Left, n.Right, n.LeafNode)
+			}
 		}
 	case *node.LeafNode:
 		// Reached a leaf node, check if key matches.

--- a/go/storage/mkvs/lookup.go
+++ b/go/storage/mkvs/lookup.go
@@ -187,7 +187,7 @@ func (t *tree) doGet(
 				}
 				return value, nil
 			}
-			switch key.GetBit(bitLength) {
+			switch key.MustGetBit(bitLength) {
 			case true:
 				return fn(n.Right, n.Left, n.LeafNode)
 			default:

--- a/go/storage/mkvs/node/depth.go
+++ b/go/storage/mkvs/node/depth.go
@@ -11,6 +11,9 @@ type Depth uint16
 // DepthSize is the size of Depth in bytes.
 const DepthSize = int(unsafe.Sizeof(Depth(0)))
 
+// MaxDepth is the largest value representable by Depth.
+const MaxDepth = ^Depth(0)
+
 // ToBytes returns the number of bytes needed to fit given bits.
 func (dt Depth) ToBytes() int {
 	size := dt / 8

--- a/go/storage/mkvs/node/depth.go
+++ b/go/storage/mkvs/node/depth.go
@@ -6,8 +6,6 @@ import (
 )
 
 // Depth determines the maximum length of the key in bits.
-//
-// maxKeyLengthInBits = 2^size_of(Depth)*8
 type Depth uint16
 
 // DepthSize is the size of Depth in bytes.

--- a/go/storage/mkvs/node/key.go
+++ b/go/storage/mkvs/node/key.go
@@ -91,8 +91,22 @@ func (k Key) BitLength() (Depth, error) {
 }
 
 // GetBit returns the given bit of the key.
-func (k Key) GetBit(bit Depth) bool {
-	return k[bit/8]&(1<<(7-(bit%8))) != 0
+func (k Key) GetBit(bit Depth) (bool, error) {
+	if bit.ToBytes() > len(k[:]) {
+		return false, ErrInvalidKeyLength
+	}
+	return k[bit/8]&(1<<(7-(bit%8))) != 0, nil
+}
+
+// MustGetBit returns the given bit of the key.
+//
+// It panics if the bit is outside the key's length.
+func (k Key) MustGetBit(bit Depth) bool {
+	b, err := k.GetBit(bit)
+	if err != nil {
+		panic(err)
+	}
+	return b
 }
 
 // SetBit sets the bit at the given position bit to value val.

--- a/go/storage/mkvs/node/key.go
+++ b/go/storage/mkvs/node/key.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
-	"fmt"
 	"math"
 	"math/bits"
 )
@@ -144,9 +143,12 @@ func (k Key) MustSetBit(bit Depth, val bool) Key {
 // keyLen is the length of the key in bits and splitPoint is the index of the
 // first suffix bit.
 // This function is immutable and returns two new instances of Key.
-func (k Key) Split(splitPoint, keyLen Depth) (prefix, suffix Key) {
+func (k Key) Split(splitPoint, keyLen Depth) (prefix, suffix Key, err error) {
+	if keyLen.ToBytes() > len(k[:]) {
+		return nil, nil, ErrInvalidKeyLength
+	}
 	if splitPoint > keyLen {
-		panic(fmt.Sprintf("mkvs: splitPoint %+v greater than keyLen %+v", splitPoint, keyLen))
+		return nil, nil, ErrInvalidKeyLength
 	}
 	prefixLen := Depth(splitPoint.ToBytes())
 	suffixLen := Depth((keyLen - splitPoint).ToBytes())
@@ -168,6 +170,20 @@ func (k Key) Split(splitPoint, keyLen Depth) (prefix, suffix Key) {
 		}
 	}
 
+	return prefix, suffix, nil
+}
+
+// MustSplit performs bit-wise split of the key.
+//
+// keyLen is the length of the key in bits and splitPoint is the index of the
+// first suffix bit.
+// This function is immutable and returns two new instances of Key.
+// It panics if the split point or key length is outside the key's length.
+func (k Key) MustSplit(splitPoint, keyLen Depth) (prefix, suffix Key) {
+	prefix, suffix, err := k.Split(splitPoint, keyLen)
+	if err != nil {
+		panic(err)
+	}
 	return prefix, suffix
 }
 

--- a/go/storage/mkvs/node/key.go
+++ b/go/storage/mkvs/node/key.go
@@ -175,7 +175,10 @@ func (k Key) Merge(keyLen Depth, k2 Key, k2Len Depth) Key {
 // AppendBit appends the given bit to the key.
 //
 // This function is immutable and returns a new instance of Key.
-func (k Key) AppendBit(keyLen Depth, val bool) Key {
+func (k Key) AppendBit(keyLen Depth, val bool) (Key, error) {
+	if keyLen == MaxDepth {
+		return nil, ErrDepthOverflow
+	}
 	newKey := make(Key, (keyLen + 1).ToBytes())
 	copy(newKey[:len(k)], k[:])
 
@@ -185,7 +188,7 @@ func (k Key) AppendBit(keyLen Depth, val bool) Key {
 		newKey[keyLen/8] &^= 0x80 >> (keyLen % 8)
 	}
 
-	return newKey
+	return newKey, nil
 }
 
 // CommonPrefixLen computes length of common prefix of k and k2.

--- a/go/storage/mkvs/node/key.go
+++ b/go/storage/mkvs/node/key.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"math/bits"
 )
 
@@ -18,10 +19,15 @@ func (k Key) String() string {
 
 // MarshalBinary encodes a key length in bytes + key into binary form.
 func (k Key) MarshalBinary() (data []byte, err error) {
-	data = make([]byte, DepthSize+len(k))
-	binary.LittleEndian.PutUint16(data[0:DepthSize], uint16(len(k)))
+	keyLen := len(k)
+	if keyLen > math.MaxUint16 {
+		return nil, ErrMalformedKey
+	}
+	size := 2 + keyLen
+	data = make([]byte, size)
+	binary.LittleEndian.PutUint16(data[0:2], uint16(keyLen))
 	if k != nil {
-		copy(data[DepthSize:], k[:])
+		copy(data[2:], k[:])
 	}
 	return data, nil
 }
@@ -34,24 +40,25 @@ func (k *Key) UnmarshalBinary(data []byte) error {
 
 // SizedUnmarshalBinary decodes a binary marshaled key incl. length in bytes.
 func (k *Key) SizedUnmarshalBinary(data []byte) (int, error) {
-	if len(data) < DepthSize {
+	if len(data) < 2 {
 		return 0, ErrMalformedKey
 	}
 
-	keyLen := binary.LittleEndian.Uint16(data[0:DepthSize])
-	if len(data) < DepthSize+int(keyLen) {
-		return 1, ErrMalformedKey
+	keyLen := binary.LittleEndian.Uint16(data[0:2])
+	size := 2 + int(keyLen)
+	if len(data) < size {
+		return 0, ErrMalformedKey
 	}
 
 	if keyLen > 0 {
 		*k = make([]byte, keyLen)
-		copy(*k, data[DepthSize:DepthSize+int(keyLen)])
+		copy(*k, data[2:size])
 	} else if k != nil {
 		// If the key we are unmarshaling into is not nil, make sure that
 		// it is at least of size zero.
 		*k = []byte{}
 	}
-	return DepthSize + int(keyLen), nil
+	return size, nil
 }
 
 // Equal compares the key with some other key.

--- a/go/storage/mkvs/node/key.go
+++ b/go/storage/mkvs/node/key.go
@@ -147,11 +147,18 @@ func (k Key) Split(splitPoint, keyLen Depth) (prefix, suffix Key) {
 // keyLen is the length of the original key in bits and k2Len is the length of
 // another key in bits.
 // This function is immutable and returns a new instance of Key.
-func (k Key) Merge(keyLen Depth, k2 Key, k2Len Depth) Key {
-	keyLenBytes := int(keyLen) / 8
-	if keyLen%8 != 0 {
-		keyLenBytes++
+func (k Key) Merge(keyLen Depth, k2 Key, k2Len Depth) (Key, error) {
+	if keyLen.ToBytes() > len(k[:]) {
+		return nil, ErrInvalidKeyLength
 	}
+	if k2Len.ToBytes() > len(k2[:]) {
+		return nil, ErrInvalidKeyLength
+	}
+	if MaxDepth-keyLen < k2Len {
+		return nil, ErrDepthOverflow
+	}
+
+	keyLenBytes := keyLen.ToBytes()
 
 	newKey := make(Key, (keyLen + k2Len).ToBytes())
 	copy(newKey[:], k[:keyLenBytes])
@@ -169,7 +176,7 @@ func (k Key) Merge(keyLen Depth, k2 Key, k2Len Depth) Key {
 		}
 	}
 
-	return newKey
+	return newKey, nil
 }
 
 // AppendBit appends the given bit to the key.

--- a/go/storage/mkvs/node/key.go
+++ b/go/storage/mkvs/node/key.go
@@ -247,12 +247,19 @@ func (k Key) AppendBit(keyLen Depth, val bool) (Key, error) {
 //
 // Additionally, keyBitLen and k2bitLen are key lengths in bits of k and k2
 // respectively.
-func (k Key) CommonPrefixLen(keyBitLen Depth, k2 Key, k2bitLen Depth) Depth {
-	minKeyLen := min(len(k2), len(k))
+func (k Key) CommonPrefixLen(keyLen Depth, k2 Key, k2Len Depth) (Depth, error) {
+	if keyLen.ToBytes() > len(k[:]) {
+		return 0, ErrInvalidKeyLength
+	}
+	if k2Len.ToBytes() > len(k2[:]) {
+		return 0, ErrInvalidKeyLength
+	}
+
+	minLen := min(len(k2), len(k))
 
 	// Compute the common prefix byte-wise.
 	i := Depth(0)
-	for ; i < Depth(minKeyLen) && k[i] == k2[i]; i++ { //nolint:gosec
+	for ; i < Depth(minLen) && k[i] == k2[i]; i++ { //nolint:gosec
 	}
 
 	// Prefixes match i bytes and maybe some more bits below.
@@ -265,12 +272,12 @@ func (k Key) CommonPrefixLen(keyBitLen Depth, k2 Key, k2bitLen Depth) Depth {
 	}
 
 	// In any case, bitLength should never exceed length of the shorter key.
-	if bitLength > keyBitLen {
-		bitLength = keyBitLen
+	if bitLength > keyLen {
+		bitLength = keyLen
 	}
-	if bitLength > k2bitLen {
-		bitLength = k2bitLen
+	if bitLength > k2Len {
+		bitLength = k2Len
 	}
 
-	return bitLength
+	return bitLength, nil
 }

--- a/go/storage/mkvs/node/key.go
+++ b/go/storage/mkvs/node/key.go
@@ -111,8 +111,11 @@ func (k Key) MustGetBit(bit Depth) bool {
 
 // SetBit sets the bit at the given position bit to value val.
 //
-// This function is immutable and returns a new instance of Key
-func (k Key) SetBit(bit Depth, val bool) Key {
+// This function is immutable and returns a new instance of Key.
+func (k Key) SetBit(bit Depth, val bool) (Key, error) {
+	if bit.ToBytes() > len(k[:]) {
+		return nil, ErrInvalidKeyLength
+	}
 	kb := make(Key, len(k))
 	copy(kb[:], k[:])
 	mask := byte(1 << (7 - (bit % 8)))
@@ -120,6 +123,18 @@ func (k Key) SetBit(bit Depth, val bool) Key {
 		kb[bit/8] |= mask
 	} else {
 		kb[bit/8] &^= mask
+	}
+	return kb, nil
+}
+
+// MustSetBit sets the bit at the given position bit to value val.
+//
+// This function is immutable and returns a new instance of Key.
+// It panics if the bit is outside the key's length.
+func (k Key) MustSetBit(bit Depth, val bool) Key {
+	kb, err := k.SetBit(bit, val)
+	if err != nil {
+		panic(err)
 	}
 	return kb
 }

--- a/go/storage/mkvs/node/key.go
+++ b/go/storage/mkvs/node/key.go
@@ -82,8 +82,12 @@ func ToMapKey(k []byte) string {
 }
 
 // BitLength returns the length of the key in bits.
-func (k Key) BitLength() Depth {
-	return Depth(len(k[:]) * 8)
+func (k Key) BitLength() (Depth, error) {
+	depth := len(k[:]) * 8
+	if depth > int(MaxDepth) {
+		return 0, ErrDepthOverflow
+	}
+	return Depth(depth), nil
 }
 
 // GetBit returns the given bit of the key.

--- a/go/storage/mkvs/node/key.go
+++ b/go/storage/mkvs/node/key.go
@@ -16,6 +16,15 @@ func (k Key) String() string {
 	return hex.EncodeToString(k[:])
 }
 
+// Validate checks that the key does not exceed the maximum supported depth.
+func (k Key) Validate() error {
+	depth := len(k[:]) * 8
+	if depth > int(MaxDepth) {
+		return ErrDepthOverflow
+	}
+	return nil
+}
+
 // MarshalBinary encodes a key length in bytes + key into binary form.
 func (k Key) MarshalBinary() (data []byte, err error) {
 	keyLen := len(k)

--- a/go/storage/mkvs/node/key_test.go
+++ b/go/storage/mkvs/node/key_test.go
@@ -30,7 +30,7 @@ func TestSetBit(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.key.SetBit(tc.bit, tc.val); !got.Equal(tc.want) {
+			if got := tc.key.MustSetBit(tc.bit, tc.val); !got.Equal(tc.want) {
 				t.Errorf("%08b.SetBit(%d, %t) = %08b, want %08b", tc.key, tc.bit, tc.val, got, tc.want)
 			}
 		})

--- a/go/storage/mkvs/node/key_test.go
+++ b/go/storage/mkvs/node/key_test.go
@@ -62,7 +62,7 @@ func TestKeyAppendSplitMerge(t *testing.T) {
 
 	// byte-aligned split
 	key = Key{0xaa, 0xbb, 0xcc, 0xdd}
-	p, s := key.Split(16, 32)
+	p, s := key.MustSplit(16, 32)
 	require.Equal(t, Key{0xaa, 0xbb}, p)
 	require.Equal(t, Key{0xcc, 0xdd}, s)
 
@@ -74,10 +74,10 @@ func TestKeyAppendSplitMerge(t *testing.T) {
 
 	// empty/full splits
 	key = Key{0xaa, 0xbb, 0xcc, 0xdd}
-	p, s = key.Split(0, 32)
+	p, s = key.MustSplit(0, 32)
 	require.Equal(t, Key{}, p)
 	require.Equal(t, key, s)
-	p, s = key.Split(32, 32)
+	p, s = key.MustSplit(32, 32)
 	require.Equal(t, key, p)
 	require.Equal(t, Key{}, s)
 
@@ -91,7 +91,7 @@ func TestKeyAppendSplitMerge(t *testing.T) {
 
 	// non byte-aligned split
 	key = Key{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef}
-	p, s = key.Split(17, 64)
+	p, s = key.MustSplit(17, 64)
 	require.Equal(t, Key{0x01, 0x23, 0x00}, p)
 	require.Equal(t, Key{0x8a, 0xcf, 0x13, 0x57, 0x9b, 0xde}, s)
 
@@ -102,7 +102,7 @@ func TestKeyAppendSplitMerge(t *testing.T) {
 
 	// non byte-aligned key length split.
 	key = Key{0xff, 0xff, 0xff, 0xff}
-	p, s = key.Split(21, 29)
+	p, s = key.MustSplit(21, 29)
 	// Check that split cleans the last 3 unused bits!
 	require.Equal(t, Key{0xff, 0xff, 0xf8}, p)
 	require.Equal(t, Key{0xff}, s)

--- a/go/storage/mkvs/node/key_test.go
+++ b/go/storage/mkvs/node/key_test.go
@@ -42,17 +42,23 @@ func TestKeyAppendSplitMerge(t *testing.T) {
 
 	// append a single bit
 	key = Key{0xf0}
-	newKey = key.AppendBit(4, true)
+	newKey, err := key.AppendBit(4, true)
+	require.NoError(t, err)
 	require.Equal(t, Key{0xf8}, newKey)
 	key = Key{0xff}
-	newKey = key.AppendBit(4, false)
+	newKey, err = key.AppendBit(4, false)
+	require.NoError(t, err)
 	require.Equal(t, Key{0xf7}, newKey)
 	key = Key{0xff}
-	newKey = key.AppendBit(8, true)
+	newKey, err = key.AppendBit(8, true)
+	require.NoError(t, err)
 	require.Equal(t, Key{0xff, 0x80}, newKey)
 	key = Key{0xff}
-	newKey = key.AppendBit(8, false)
+	newKey, err = key.AppendBit(8, false)
+	require.NoError(t, err)
 	require.Equal(t, Key{0xff, 0x00}, newKey)
+	_, err = key.AppendBit(MaxDepth, false)
+	require.Error(t, err)
 
 	// byte-aligned split
 	key = Key{0xaa, 0xbb, 0xcc, 0xdd}

--- a/go/storage/mkvs/node/key_test.go
+++ b/go/storage/mkvs/node/key_test.go
@@ -68,7 +68,8 @@ func TestKeyAppendSplitMerge(t *testing.T) {
 
 	// byte-aligned merge
 	key = Key{0xaa, 0xbb}
-	newKey = key.Merge(16, Key{0xcc, 0xdd}, 16)
+	newKey, err = key.Merge(16, Key{0xcc, 0xdd}, 16)
+	require.NoError(t, err)
 	require.Equal(t, Key{0xaa, 0xbb, 0xcc, 0xdd}, newKey)
 
 	// empty/full splits
@@ -81,9 +82,11 @@ func TestKeyAppendSplitMerge(t *testing.T) {
 	require.Equal(t, Key{}, s)
 
 	// empty merges
-	newKey = Key{}.Merge(0, Key{0xaa, 0xbb}, 16)
+	newKey, err = Key{}.Merge(0, Key{0xaa, 0xbb}, 16)
+	require.NoError(t, err)
 	require.Equal(t, Key{0xaa, 0xbb}, newKey)
-	newKey = Key{0xaa, 0xbb}.Merge(16, Key{}, 0)
+	newKey, err = Key{0xaa, 0xbb}.Merge(16, Key{}, 0)
+	require.NoError(t, err)
 	require.Equal(t, Key{0xaa, 0xbb}, newKey)
 
 	// non byte-aligned split
@@ -93,7 +96,8 @@ func TestKeyAppendSplitMerge(t *testing.T) {
 	require.Equal(t, Key{0x8a, 0xcf, 0x13, 0x57, 0x9b, 0xde}, s)
 
 	// ...and merge
-	newKey = p.Merge(17, s, 64-17)
+	newKey, err = p.Merge(17, s, 64-17)
+	require.NoError(t, err)
 	require.Equal(t, key, newKey)
 
 	// non byte-aligned key length split.
@@ -104,19 +108,32 @@ func TestKeyAppendSplitMerge(t *testing.T) {
 	require.Equal(t, Key{0xff}, s)
 
 	// ...and merge
-	newKey = p.Merge(21, s, 8)
+	newKey, err = p.Merge(21, s, 8)
+	require.NoError(t, err)
 	// Merge doesn't obtain original key, because the split cleaned unused bits!
 	require.Equal(t, Key{0xff, 0xff, 0xff, 0xf8}, newKey)
 
 	// Special case with zero-length key.
 	key = Key{0x80}
-	newKey = key.Merge(0, Key{0xf0}, 4)
+	newKey, err = key.Merge(0, Key{0xf0}, 4)
+	require.NoError(t, err)
 	require.Equal(t, Key{0xf0}, newKey)
 
 	// Special case with extra bytes.
 	key = Key{0x41, 0x6b, 0x00}
-	newKey = key.Merge(16, Key{0x37}, 8)
+	newKey, err = key.Merge(16, Key{0x37}, 8)
+	require.NoError(t, err)
 	require.Equal(t, Key{0x41, 0x6b, 0x37}, newKey)
+
+	// Overflow.
+	key = Key{0x41}
+	_, err = key.Merge(9, key, 1)
+	require.Error(t, err)
+	_, err = key.Merge(1, key, 9)
+	require.Error(t, err)
+	longKey := Key(make([]byte, MaxDepth.ToBytes()))
+	_, err = key.Merge(1, longKey, MaxDepth)
+	require.Error(t, err)
 }
 
 func TestKeyCommonPrefixLen(t *testing.T) {

--- a/go/storage/mkvs/node/key_test.go
+++ b/go/storage/mkvs/node/key_test.go
@@ -138,17 +138,27 @@ func TestKeyAppendSplitMerge(t *testing.T) {
 
 func TestKeyCommonPrefixLen(t *testing.T) {
 	key := Key{}
-	require.Equal(t, Depth(0), key.CommonPrefixLen(0, Key{}, 0))
+	length, err := key.CommonPrefixLen(0, Key{}, 0)
+	require.NoError(t, err)
+	require.Equal(t, Depth(0), length)
 
 	key = Key{0xff, 0xff}
-	require.Equal(t, Depth(16), key.CommonPrefixLen(16, Key{0xff, 0xff, 0xff}, 24))
+	length, err = key.CommonPrefixLen(16, Key{0xff, 0xff, 0xff}, 24)
+	require.NoError(t, err)
+	require.Equal(t, Depth(16), length)
 
 	key = Key{0xff, 0xff, 0xff}
-	require.Equal(t, Depth(16), key.CommonPrefixLen(24, Key{0xff, 0xff}, 16))
+	length, err = key.CommonPrefixLen(24, Key{0xff, 0xff}, 16)
+	require.NoError(t, err)
+	require.Equal(t, Depth(16), length)
 
 	key = Key{0xff, 0xff, 0xff}
-	require.Equal(t, Depth(24), key.CommonPrefixLen(24, Key{0xff, 0xff, 0xff}, 24))
+	length, err = key.CommonPrefixLen(24, Key{0xff, 0xff, 0xff}, 24)
+	require.NoError(t, err)
+	require.Equal(t, Depth(24), length)
 
 	key = Key{0xab, 0xcd, 0xef, 0xff}
-	require.Equal(t, Depth(23), key.CommonPrefixLen(32, Key{0xab, 0xcd, 0xee, 0xff}, 32))
+	length, err = key.CommonPrefixLen(32, Key{0xab, 0xcd, 0xee, 0xff}, 32)
+	require.NoError(t, err)
+	require.Equal(t, Depth(23), length)
 }

--- a/go/storage/mkvs/node/node.go
+++ b/go/storage/mkvs/node/node.go
@@ -21,6 +21,9 @@ var (
 	// ErrMalformedKey is the error when a malformed key is encountered
 	// during deserialization.
 	ErrMalformedKey = errors.New("mkvs: malformed key")
+	// ErrInvalidKeyLength is the error when a key length exceeds the key's
+	// capacity.
+	ErrInvalidKeyLength = errors.New("mkvs: invalid key length")
 	// ErrDepthOverflow is the error when the depth would exceed the maximum
 	// value.
 	ErrDepthOverflow = errors.New("mkvs: depth overflow")

--- a/go/storage/mkvs/node/node.go
+++ b/go/storage/mkvs/node/node.go
@@ -21,6 +21,9 @@ var (
 	// ErrMalformedKey is the error when a malformed key is encountered
 	// during deserialization.
 	ErrMalformedKey = errors.New("mkvs: malformed key")
+	// ErrDepthOverflow is the error when the depth would exceed the maximum
+	// value.
+	ErrDepthOverflow = errors.New("mkvs: depth overflow")
 )
 
 const (

--- a/go/storage/mkvs/remove.go
+++ b/go/storage/mkvs/remove.go
@@ -90,7 +90,7 @@ func (t *tree) doRemove(
 			return ptr, false, nil, nil
 		case keyBitLength == bitLength:
 			n.LeafNode, changed, existing, err = t.doRemove(ctx, n.LeafNode, bitLength, key)
-		case key.GetBit(bitLength):
+		case key.MustGetBit(bitLength):
 			n.Right, changed, existing, err = t.doRemove(ctx, n.Right, bitLength, key)
 		default:
 			n.Left, changed, existing, err = t.doRemove(ctx, n.Left, bitLength, key)

--- a/go/storage/mkvs/remove.go
+++ b/go/storage/mkvs/remove.go
@@ -137,7 +137,10 @@ func (t *tree) doRemove(
 			// If child is an internal node, also fix the label.
 			switch inode := ndChild.(type) {
 			case *node.InternalNode:
-				inode.Label = n.Label.Merge(n.LabelBitLength, inode.Label, inode.LabelBitLength)
+				inode.Label, err = n.Label.Merge(n.LabelBitLength, inode.Label, inode.LabelBitLength)
+				if err != nil {
+					return nil, false, nil, err
+				}
 				inode.LabelBitLength += n.LabelBitLength
 				if inode.Clean {
 					// Node was clean so old node is eligible for removal.

--- a/go/storage/mkvs/remove.go
+++ b/go/storage/mkvs/remove.go
@@ -68,6 +68,11 @@ func (t *tree) doRemove(
 		return nil, false, nil, err
 	}
 
+	keyBitLength, err := key.BitLength()
+	if err != nil {
+		return nil, false, nil, err
+	}
+
 	switch n := nd.(type) {
 	case nil:
 		// Remove from nil node.
@@ -79,14 +84,15 @@ func (t *tree) doRemove(
 
 		var changed bool
 		var existing []byte
-		if key.BitLength() < bitLength {
+		switch {
+		case keyBitLength < bitLength:
 			// Lookup key is too short for the current n.Label, so it doesn't exist.
 			return ptr, false, nil, nil
-		} else if key.BitLength() == bitLength {
+		case keyBitLength == bitLength:
 			n.LeafNode, changed, existing, err = t.doRemove(ctx, n.LeafNode, bitLength, key)
-		} else if key.GetBit(bitLength) {
+		case key.GetBit(bitLength):
 			n.Right, changed, existing, err = t.doRemove(ctx, n.Right, bitLength, key)
-		} else {
+		default:
 			n.Left, changed, existing, err = t.doRemove(ctx, n.Left, bitLength, key)
 		}
 		if err != nil {


### PR DESCRIPTION
Working with `Key` type can be problematic as its bit size can overflow the maximum value when `[]byte` is converted to `Key`. 