### PR TITLE
go: Clean up before key manager access policy

### DIFF
--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -14,7 +14,6 @@ import (
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
@@ -45,8 +44,6 @@ var (
 	// ErrAttestationFromFuture is the error returned when the TEE attestation appears
 	// to be from the future.
 	ErrAttestationFromFuture = errors.New("node: TEE attestation from the future")
-
-	teeHashContext = []byte("oasis-core/node: TEE RAK binding")
 
 	// AttestationSignatureContext is the signature context used for TEE attestation signatures.
 	AttestationSignatureContext = signature.NewContext("oasis-core/node: TEE attestation signature")
@@ -563,14 +560,6 @@ type CapabilityTEE struct {
 
 	// Attestation.
 	Attestation []byte `json:"attestation"`
-}
-
-// HashRAK computes the expected report data hash bound to a given public RAK.
-func HashRAK(rak signature.PublicKey) hash.Hash {
-	hData := make([]byte, 0, len(teeHashContext)+signature.PublicKeySize)
-	hData = append(hData, teeHashContext...)
-	hData = append(hData, rak[:]...)
-	return hash.NewFromBytes(hData)
 }
 
 // Verify verifies the node's TEE capabilities, at the provided timestamp and height.

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -547,6 +547,27 @@ func (h *TEEHardware) FromString(str string) error {
 	return nil
 }
 
+// CapabilityTEEVerifyParams contains parameters required to verify a TEE attestation.
+type CapabilityTEEVerifyParams struct {
+	// Features are the TEE features and defaults advertised by the consensus layer.
+	Features *TEEFeatures
+
+	// Time is the current consensus time.
+	Time time.Time
+
+	// Height is the current consensus height.
+	Height uint64
+
+	// Constraints are the serialized TEE constraints.
+	Constraints []byte
+
+	// NodeID is the node identity the TEE capability must be bound to.
+	NodeID signature.PublicKey
+
+	// IsFeatureVersion261 is true for consensus at version 26.1 or higher.
+	IsFeatureVersion261 bool
+}
+
 // CapabilityTEE represents the node's TEE capability.
 type CapabilityTEE struct {
 	// TEE hardware type.
@@ -563,7 +584,7 @@ type CapabilityTEE struct {
 }
 
 // Verify verifies the node's TEE capabilities, at the provided timestamp and height.
-func (c *CapabilityTEE) Verify(teeCfg *TEEFeatures, ts time.Time, height uint64, constraints []byte, nodeID signature.PublicKey, isFeatureVersion261 bool) error {
+func (c *CapabilityTEE) Verify(params CapabilityTEEVerifyParams) error {
 	switch c.Hardware {
 	case TEEHardwareIntelSGX:
 		// Parse SGX remote attestation.
@@ -571,21 +592,29 @@ func (c *CapabilityTEE) Verify(teeCfg *TEEFeatures, ts time.Time, height uint64,
 		if err := cbor.Unmarshal(c.Attestation, &sa); err != nil {
 			return fmt.Errorf("node: malformed SGX attestation: %w", err)
 		}
-		if err := sa.ValidateBasic(teeCfg); err != nil {
+		if err := sa.ValidateBasic(params.Features); err != nil {
 			return fmt.Errorf("node: malformed SGX attestation: %w", err)
 		}
 
 		// Parse SGX constraints.
 		var sc SGXConstraints
-		if err := cbor.Unmarshal(constraints, &sc); err != nil {
+		if err := cbor.Unmarshal(params.Constraints, &sc); err != nil {
 			return fmt.Errorf("node: malformed SGX constraints: %w", err)
 		}
-		if err := sc.ValidateBasic(teeCfg, isFeatureVersion261); err != nil {
+		if err := sc.ValidateBasic(params.Features, params.IsFeatureVersion261); err != nil {
 			return fmt.Errorf("node: malformed SGX constraints: %w", err)
 		}
 
 		// Verify SGX remote attestation.
-		return sa.Verify(teeCfg, ts, height, &sc, c.RAK, c.REK, nodeID)
+		return sa.Verify(
+			params.Features,
+			params.Time,
+			params.Height,
+			&sc,
+			c.RAK,
+			c.REK,
+			params.NodeID,
+		)
 	default:
 		return ErrInvalidTEEHardware
 	}

--- a/go/common/node/sgx.go
+++ b/go/common/node/sgx.go
@@ -286,6 +286,15 @@ func (sa *SGXAttestation) verifyAttestationSignature(
 	return nil
 }
 
+// HashRAK computes the expected report data hash bound to a given public RAK.
+func HashRAK(rak signature.PublicKey) hash.Hash {
+	const teeHashContext = "oasis-core/node: TEE RAK binding"
+	hData := make([]byte, 0, len(teeHashContext)+signature.PublicKeySize)
+	hData = append(hData, teeHashContext...)
+	hData = append(hData, rak[:]...)
+	return hash.NewFromBytes(hData)
+}
+
 // HashAttestation hashes the required data that needs to be signed by RAK producing the attestation
 // signature. The hash is computed as follows:
 //

--- a/go/consensus/cometbft/apps/scheduler/scheduler.go
+++ b/go/consensus/cometbft/apps/scheduler/scheduler.go
@@ -437,14 +437,14 @@ func isSuitableExecutorWorker(
 			if nrt.Capabilities.TEE.Hardware != rt.TEEHardware {
 				return false
 			}
-			if err := nrt.Capabilities.TEE.Verify(
-				registryParams.TEEFeatures,
-				ctx.Now(),
-				uint64(ctx.LastHeight()),
-				activeDeployment.TEE,
-				n.node.ID,
-				isFeatureVersion261,
-			); err != nil {
+			if err := nrt.Capabilities.TEE.Verify(node.CapabilityTEEVerifyParams{
+				Features:            registryParams.TEEFeatures,
+				Time:                ctx.Now(),
+				Height:              uint64(ctx.LastHeight()),
+				Constraints:         activeDeployment.TEE,
+				NodeID:              n.node.ID,
+				IsFeatureVersion261: isFeatureVersion261,
+			}); err != nil {
 				ctx.Logger().Warn("failed to verify node TEE attestation",
 					"err", err,
 					"node_id", n.node.ID,

--- a/go/oasis-node/cmd/debug/byzantine/steps_test.go
+++ b/go/oasis-node/cmd/debug/byzantine/steps_test.go
@@ -31,5 +31,13 @@ func TestFakeCapabilitySGX(t *testing.T) {
 
 	ias.SetSkipVerify()
 	ias.SetAllowDebugEnclaves()
-	require.NoError(t, fakeCapabilitiesSGX.TEE.Verify(&teeCfg, time.Now(), 1, cs, nodeID, true), "fakeCapabilitiesSGX not valid")
+	err = fakeCapabilitiesSGX.TEE.Verify(node.CapabilityTEEVerifyParams{
+		Features:            &teeCfg,
+		Time:                time.Now(),
+		Height:              1,
+		Constraints:         cs,
+		NodeID:              nodeID,
+		IsFeatureVersion261: true,
+	})
+	require.NoError(t, err, "fakeCapabilitiesSGX not valid")
 }

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -199,8 +199,15 @@ func (n *Node) initRuntimeWorkers(genesisDoc *genesisAPI.Document) error {
 	}
 
 	// Initialize runtime provisioner.
+	policyProvider := &runtimeRegistry.QuotePolicyProvider{Consensus: n.Consensus}
 	var err error
-	n.Provisioner, err = provisioner.New(n.dataDir, n.commonStore, n.Identity, n.Consensus, genesisDoc)
+	n.Provisioner, err = provisioner.New(
+		n.dataDir,
+		n.commonStore,
+		n.Identity,
+		genesisDoc,
+		policyProvider,
+	)
 	if err != nil {
 		return err
 	}

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -840,7 +840,14 @@ func VerifyNodeRuntimeEnclaveIDs(
 			continue
 		}
 
-		if err := rt.Capabilities.TEE.Verify(teeCfg, ts, height, rtVersionInfo.TEE, nodeID, isFeatureVersion261); err != nil {
+		if err := rt.Capabilities.TEE.Verify(node.CapabilityTEEVerifyParams{
+			Features:            teeCfg,
+			Time:                ts,
+			Height:              height,
+			Constraints:         rtVersionInfo.TEE,
+			NodeID:              nodeID,
+			IsFeatureVersion261: isFeatureVersion261,
+		}); err != nil {
 			logger.Error("VerifyNodeRuntimeEnclaveIDs: failed to validate attestation",
 				"node_id", nodeID,
 				"runtime_id", rt.ID,

--- a/go/runtime/host/host.go
+++ b/go/runtime/host/host.go
@@ -7,6 +7,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
+	"github.com/oasisprotocol/oasis-core/go/common/sgx/quote"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/runtime/bundle"
 	"github.com/oasisprotocol/oasis-core/go/runtime/bundle/component"
@@ -36,6 +37,12 @@ type Config struct {
 
 	// Log is the runtime log handle to use for writing logs to this runtime.
 	Log *log.Log
+}
+
+// QuotePolicyProvider provides quote policies for provisioned components.
+type QuotePolicyProvider interface {
+	// Get returns the applicable quote policy, or nil if there is none.
+	Get(ctx context.Context, runtimeID common.Namespace, compID component.ID, version version.Version) (*quote.Policy, error)
 }
 
 // Provisioner is the runtime provisioner interface.

--- a/go/runtime/host/provisioner/provisioner.go
+++ b/go/runtime/host/provisioner/provisioner.go
@@ -1,22 +1,15 @@
 package provisioner
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/oasisprotocol/oasis-core/go/common"
-	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
-	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/persistent"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx/pcs"
-	sgxQuote "github.com/oasisprotocol/oasis-core/go/common/sgx/quote"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-core/go/config"
-	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	genesisAPI "github.com/oasisprotocol/oasis-core/go/genesis/api"
 	cmdFlags "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common/flags"
-	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	"github.com/oasisprotocol/oasis-core/go/runtime/bundle/component"
 	rtConfig "github.com/oasisprotocol/oasis-core/go/runtime/config"
 	runtimeHost "github.com/oasisprotocol/oasis-core/go/runtime/host"
@@ -39,8 +32,8 @@ func New(
 	dataDir string,
 	commonStore *persistent.CommonStore,
 	identity *identity.Identity,
-	consensus consensus.Service,
 	genesisDoc *genesisAPI.Document,
+	policyProvider sgxCommon.QuotePolicyProvider,
 ) (runtimeHost.Provisioner, error) {
 	// Configure host environment information.
 	hostInfo, err := createHostInfo(genesisDoc)
@@ -53,8 +46,6 @@ func New(
 	if err != nil {
 		return nil, err
 	}
-
-	policyProvider := &quotePolicyProvider{consensus}
 
 	// Create runtime provisioner.
 	return createProvisioner(dataDir, commonStore, identity, hostInfo, qs, policyProvider)
@@ -201,38 +192,4 @@ func createProvisioner(
 	provisioner := hostComposite.NewProvisioner(provisioners)
 
 	return provisioner, nil
-}
-
-// quotePolicyProvider is a provider backed by the latest runtime descriptors on
-// the consensus layer.
-type quotePolicyProvider struct {
-	cs consensus.Service
-}
-
-func (p *quotePolicyProvider) Get(
-	ctx context.Context,
-	runtimeID common.Namespace,
-	compID component.ID,
-	version version.Version,
-) (*sgxQuote.Policy, error) {
-	if !compID.IsRONL() { // ROFL components have no policy on the consensus.
-		return nil, nil
-	}
-
-	rt, err := p.cs.Registry().GetRuntime(ctx, &registry.GetRuntimeQuery{
-		Height:           consensus.HeightLatest,
-		ID:               runtimeID,
-		IncludeSuspended: true,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to query runtime descriptor: %w", err)
-	}
-	if d := rt.DeploymentForVersion(version); d != nil {
-		var sc node.SGXConstraints
-		if err = cbor.Unmarshal(d.TEE, &sc); err != nil {
-			return nil, fmt.Errorf("malformed runtime SGX constraints: %w", err)
-		}
-		return sc.Policy, nil
-	}
-	return nil, nil
 }

--- a/go/runtime/host/provisioner/provisioner.go
+++ b/go/runtime/host/provisioner/provisioner.go
@@ -19,7 +19,6 @@ import (
 	hostProtocol "github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 	hostSandbox "github.com/oasisprotocol/oasis-core/go/runtime/host/sandbox"
 	hostSgx "github.com/oasisprotocol/oasis-core/go/runtime/host/sgx"
-	sgxCommon "github.com/oasisprotocol/oasis-core/go/runtime/host/sgx/common"
 	hostTdx "github.com/oasisprotocol/oasis-core/go/runtime/host/tdx"
 )
 
@@ -33,7 +32,7 @@ func New(
 	commonStore *persistent.CommonStore,
 	identity *identity.Identity,
 	genesisDoc *genesisAPI.Document,
-	policyProvider sgxCommon.QuotePolicyProvider,
+	policyProvider runtimeHost.QuotePolicyProvider,
 ) (runtimeHost.Provisioner, error) {
 	// Configure host environment information.
 	hostInfo, err := createHostInfo(genesisDoc)
@@ -78,7 +77,7 @@ func createProvisioner(
 	identity *identity.Identity,
 	hostInfo *hostProtocol.HostInfo,
 	qs pcs.QuoteService,
-	policyProvider sgxCommon.QuotePolicyProvider,
+	policyProvider runtimeHost.QuotePolicyProvider,
 ) (runtimeHost.Provisioner, error) {
 	var err error
 	var insecureNoSandbox bool

--- a/go/runtime/host/provisioner/provisioner.go
+++ b/go/runtime/host/provisioner/provisioner.go
@@ -203,11 +203,22 @@ func createProvisioner(
 	return provisioner, nil
 }
 
+// quotePolicyProvider is a provider backed by the latest runtime descriptors on
+// the consensus layer.
 type quotePolicyProvider struct {
 	cs consensus.Service
 }
 
-func (p *quotePolicyProvider) Get(ctx context.Context, runtimeID common.Namespace, version version.Version) (*sgxQuote.Policy, error) {
+func (p *quotePolicyProvider) Get(
+	ctx context.Context,
+	runtimeID common.Namespace,
+	compID component.ID,
+	version version.Version,
+) (*sgxQuote.Policy, error) {
+	if !compID.IsRONL() { // ROFL components have no policy on the consensus.
+		return nil, nil
+	}
+
 	rt, err := p.cs.Registry().GetRuntime(ctx, &registry.GetRuntimeQuery{
 		Height:           consensus.HeightLatest,
 		ID:               runtimeID,

--- a/go/runtime/host/sgx/common/common.go
+++ b/go/runtime/host/sgx/common/common.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 
-	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/identity"
@@ -16,18 +15,10 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx/pcs"
 	sgxQuote "github.com/oasisprotocol/oasis-core/go/common/sgx/quote"
-	"github.com/oasisprotocol/oasis-core/go/common/version"
-	"github.com/oasisprotocol/oasis-core/go/runtime/bundle/component"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/sandbox"
 )
-
-// QuotePolicyProvider provides quote policies for provisioned components.
-type QuotePolicyProvider interface {
-	// Get returns the applicable quote policy, or nil if there is none.
-	Get(ctx context.Context, runtimeID common.Namespace, compID component.ID, version version.Version) (*sgxQuote.Policy, error)
-}
 
 // EndorseCapabilityTEE endorses the given CapabilityTEE and submits the signed endorsement to the
 // runtime over the given connection.

--- a/go/runtime/host/sgx/common/common.go
+++ b/go/runtime/host/sgx/common/common.go
@@ -17,15 +17,16 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/sgx/pcs"
 	sgxQuote "github.com/oasisprotocol/oasis-core/go/common/sgx/quote"
 	"github.com/oasisprotocol/oasis-core/go/common/version"
+	"github.com/oasisprotocol/oasis-core/go/runtime/bundle/component"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/sandbox"
 )
 
-// QuotePolicyProvider provides quote policies.
+// QuotePolicyProvider provides quote policies for provisioned components.
 type QuotePolicyProvider interface {
-	// Get returns the quote policy for the specified RONL deployment.
-	Get(ctx context.Context, runtimeID common.Namespace, version version.Version) (*sgxQuote.Policy, error)
+	// Get returns the applicable quote policy, or nil if there is none.
+	Get(ctx context.Context, runtimeID common.Namespace, compID component.ID, version version.Version) (*sgxQuote.Policy, error)
 }
 
 // EndorseCapabilityTEE endorses the given CapabilityTEE and submits the signed endorsement to the

--- a/go/runtime/host/sgx/ecdsa.go
+++ b/go/runtime/host/sgx/ecdsa.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common/sgx/aesm"
 	"github.com/oasisprotocol/oasis-core/go/common/sgx/pcs"
-	"github.com/oasisprotocol/oasis-core/go/runtime/bundle/component"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host"
 	"github.com/oasisprotocol/oasis-core/go/runtime/host/protocol"
 	sgxCommon "github.com/oasisprotocol/oasis-core/go/runtime/host/sgx/common"
@@ -55,17 +54,12 @@ func (ec *teeStateECDSA) Update(ctx context.Context, sp *sgxProvisioner, conn pr
 	}
 
 	var pcsQuotePolicy *pcs.QuotePolicy
-	switch ec.cfg.Component.Kind {
-	case component.RONL:
-		quotePolicy, err := sp.policyProvider.Get(ctx, ec.cfg.ID, ec.cfg.Component.Version)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch RONL quote policy: %w", err)
-		}
-		if quotePolicy != nil {
-			pcsQuotePolicy = quotePolicy.PCS
-		}
-	default:
-		// No policy.
+	quotePolicy, err := sp.policyProvider.Get(ctx, ec.cfg.ID, ec.cfg.Component.ID(), ec.cfg.Component.Version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch quote policy: %w", err)
+	}
+	if quotePolicy != nil {
+		pcsQuotePolicy = quotePolicy.PCS
 	}
 
 	quoteBundle, err := sp.pcs.ResolveQuote(ctx, rawQuote, pcsQuotePolicy)

--- a/go/runtime/host/sgx/provisioner.go
+++ b/go/runtime/host/sgx/provisioner.go
@@ -58,7 +58,7 @@ type Config struct {
 
 	// PCS is the Intel Provisioning Certification Service quote service.
 	PCS pcs.QuoteService
-	// QuotePolicy provides the quote policy for RONL deployments.
+	// QuotePolicy provides quote policies for provisioned components.
 	QuotePolicy sgxCommon.QuotePolicyProvider
 	// Identity is the node identity.
 	Identity *identity.Identity

--- a/go/runtime/host/sgx/provisioner.go
+++ b/go/runtime/host/sgx/provisioner.go
@@ -59,7 +59,7 @@ type Config struct {
 	// PCS is the Intel Provisioning Certification Service quote service.
 	PCS pcs.QuoteService
 	// QuotePolicy provides quote policies for provisioned components.
-	QuotePolicy sgxCommon.QuotePolicyProvider
+	QuotePolicy host.QuotePolicyProvider
 	// Identity is the node identity.
 	Identity *identity.Identity
 
@@ -88,7 +88,7 @@ type sgxProvisioner struct {
 	sandbox        host.Provisioner
 	pcs            pcs.QuoteService
 	aesm           *aesm.Client
-	policyProvider sgxCommon.QuotePolicyProvider
+	policyProvider host.QuotePolicyProvider
 	identity       *identity.Identity
 	store          *persistent.CommonStore
 

--- a/go/runtime/host/tdx/qemu.go
+++ b/go/runtime/host/tdx/qemu.go
@@ -56,7 +56,7 @@ type QemuConfig struct {
 	// PCS is the Intel Provisioning Certification Service quote service.
 	PCS pcs.QuoteService
 	// QuotePolicy provides quote policies for provisioned components.
-	QuotePolicy sgxCommon.QuotePolicyProvider
+	QuotePolicy host.QuotePolicyProvider
 	// Identity is the node identity.
 	Identity *identity.Identity
 
@@ -79,7 +79,7 @@ type qemuProvisioner struct {
 
 	sandbox     host.Provisioner
 	pcs         pcs.QuoteService
-	quotePolicy sgxCommon.QuotePolicyProvider
+	quotePolicy host.QuotePolicyProvider
 	identity    *identity.Identity
 	cidPool     *CidPool
 

--- a/go/runtime/host/tdx/qemu.go
+++ b/go/runtime/host/tdx/qemu.go
@@ -55,7 +55,7 @@ type QemuConfig struct {
 
 	// PCS is the Intel Provisioning Certification Service quote service.
 	PCS pcs.QuoteService
-	// QuotePolicy provides the quote policy for RONL deployments.
+	// QuotePolicy provides quote policies for provisioned components.
 	QuotePolicy sgxCommon.QuotePolicyProvider
 	// Identity is the node identity.
 	Identity *identity.Identity

--- a/go/runtime/host/tdx/qemu.go
+++ b/go/runtime/host/tdx/qemu.go
@@ -433,15 +433,9 @@ func (p *qemuProvisioner) updateCapabilityTEE(ctx context.Context, hp *sandbox.H
 	rekPub := rspRep.RuntimeCapabilityTEERakReportResponse.RekPub
 	rawQuote := rspRep.RuntimeCapabilityTEERakReportResponse.Report
 
-	var quotePolicy *sgxQuote.Policy
-	switch hp.Config.Component.Kind {
-	case component.RONL:
-		quotePolicy, err = p.quotePolicy.Get(ctx, hp.Config.ID, hp.Config.Component.Version)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch RONL quote policy: %w", err)
-		}
-	default:
-		// No policy, use fallback.
+	quotePolicy, err := p.quotePolicy.Get(ctx, hp.Config.ID, hp.Config.Component.ID(), hp.Config.Component.Version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch quote policy: %w", err)
 	}
 
 	// Use the fallback policy for ROFL components and RONL components with no TDX policy so that provisioning can proceed.

--- a/go/runtime/registry/policy_provider.go
+++ b/go/runtime/registry/policy_provider.go
@@ -1,0 +1,49 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/sgx/quote"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+	"github.com/oasisprotocol/oasis-core/go/runtime/bundle/component"
+)
+
+// QuotePolicyProvider is a provider backed by the latest runtime descriptors on
+// the consensus layer.
+type QuotePolicyProvider struct {
+	Consensus consensus.Service
+}
+
+func (p *QuotePolicyProvider) Get(
+	ctx context.Context,
+	runtimeID common.Namespace,
+	compID component.ID,
+	version version.Version,
+) (*quote.Policy, error) {
+	if !compID.IsRONL() { // ROFL components have no policy on the consensus.
+		return nil, nil
+	}
+
+	rt, err := p.Consensus.Registry().GetRuntime(ctx, &registry.GetRuntimeQuery{
+		Height:           consensus.HeightLatest,
+		ID:               runtimeID,
+		IncludeSuspended: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to query runtime descriptor: %w", err)
+	}
+	if d := rt.DeploymentForVersion(version); d != nil {
+		var sc node.SGXConstraints
+		if err = cbor.Unmarshal(d.TEE, &sc); err != nil {
+			return nil, fmt.Errorf("malformed runtime SGX constraints: %w", err)
+		}
+		return sc.Policy, nil
+	}
+	return nil, nil
+}

--- a/go/runtime/registry/policy_provider_test.go
+++ b/go/runtime/registry/policy_provider_test.go
@@ -1,0 +1,75 @@
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/node"
+	"github.com/oasisprotocol/oasis-core/go/common/sgx/pcs"
+	"github.com/oasisprotocol/oasis-core/go/common/sgx/quote"
+	"github.com/oasisprotocol/oasis-core/go/common/version"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+	"github.com/oasisprotocol/oasis-core/go/runtime/bundle/component"
+)
+
+// mockRegistry implements the part of registry.Backend used by the provider.
+// The embedded interface is nil, so any other method panics.
+type mockRegistry struct {
+	registry.Backend
+
+	rt *registry.Runtime
+}
+
+func (m *mockRegistry) GetRuntime(context.Context, *registry.GetRuntimeQuery) (*registry.Runtime, error) {
+	return m.rt, nil
+}
+
+// mockConsensus implements the part of consensus.Service used by the provider.
+// The embedded interface is nil, so any other method panics.
+type mockConsensus struct {
+	consensus.Service
+
+	registry registry.Backend
+}
+
+func (m *mockConsensus) Registry() registry.Backend {
+	return m.registry
+}
+
+func TestConsensusQuotePolicyProvider(t *testing.T) {
+	rtVersion := version.Version{Major: 1}
+	policy := &quote.Policy{
+		PCS: &pcs.QuotePolicy{TCBValidityPeriod: 30},
+	}
+
+	constraints := node.SGXConstraints{
+		Versioned: cbor.NewVersioned(node.LatestSGXConstraintsVersion),
+		Policy:    policy,
+	}
+	reg := &mockRegistry{
+		rt: &registry.Runtime{
+			Deployments: []*registry.VersionInfo{
+				{Version: rtVersion, TEE: cbor.Marshal(&constraints)},
+			},
+		},
+	}
+	provider := &QuotePolicyProvider{Consensus: &mockConsensus{registry: reg}}
+
+	t.Run("RONL", func(t *testing.T) {
+		p, err := provider.Get(context.Background(), common.Namespace{}, component.ID_RONL, rtVersion)
+		require.NoError(t, err)
+		require.Equal(t, policy, p, "RONL should get the policy from the runtime descriptor")
+	})
+
+	t.Run("ROFL", func(t *testing.T) {
+		compID := component.ID{Kind: component.ROFL, Name: "test"}
+		p, err := provider.Get(context.Background(), common.Namespace{}, compID, rtVersion)
+		require.NoError(t, err)
+		require.Nil(t, p, "ROFL has no policy on the consensus layer")
+	})
+}

--- a/go/worker/common/committee/node.go
+++ b/go/worker/common/committee/node.go
@@ -46,6 +46,13 @@ type NodeHooks interface {
 	Initialized() <-chan struct{}
 }
 
+// Config contains committee node specific configuration.
+type Config struct {
+	ChainContext string
+	Identity     *identity.Identity
+	TxPool       tpConfig.Config
+}
+
 // Node is a committee node.
 type Node struct {
 	*runtimeRegistry.RuntimeHostNode
@@ -628,16 +635,14 @@ func (n *Node) handleDispatchInfo() {
 }
 
 func NewNode(
-	chainContext string,
+	cfg Config,
 	runtime runtimeRegistry.Runtime,
 	provisioner host.Provisioner,
 	rtRegistry runtimeRegistry.Registry,
-	identity *identity.Identity,
 	keymanager keymanager.Backend,
 	consensus consensus.Service,
 	lightProvider consensus.LightProvider,
 	p2pHost p2pAPI.Service,
-	txPoolCfg tpConfig.Config,
 ) (*Node, error) {
 	metricsOnce.Do(func() {
 		prometheus.MustRegister(nodeCollectors...)
@@ -646,19 +651,19 @@ func NewNode(
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Prepare committee group services.
-	group, err := NewGroup(ctx, runtime.ID(), identity, consensus, p2pHost)
+	group, err := NewGroup(ctx, runtime.ID(), cfg.Identity, consensus, p2pHost)
 	if err != nil {
 		cancel()
 		return nil, err
 	}
 
-	txTopic := p2pProtocol.NewTopicKindTxID(chainContext, runtime.ID())
+	txTopic := p2pProtocol.NewTopicKindTxID(cfg.ChainContext, runtime.ID())
 
 	n := &Node{
-		ChainContext:    chainContext,
+		ChainContext:    cfg.ChainContext,
 		Runtime:         runtime,
 		RuntimeRegistry: rtRegistry,
-		Identity:        identity,
+		Identity:        cfg.Identity,
 		KeyManager:      keymanager,
 		Consensus:       consensus,
 		LightProvider:   lightProvider,
@@ -675,7 +680,7 @@ func NewNode(
 	}
 
 	// Prepare the key manager client wrapper.
-	n.KeyManagerClient = NewKeyManagerClientWrapper(p2pHost, consensus, chainContext, n.logger)
+	n.KeyManagerClient = NewKeyManagerClientWrapper(p2pHost, consensus, cfg.ChainContext, n.logger)
 
 	// Prepare the runtime host handler.
 	handler := runtimeRegistry.NewRuntimeHostHandler(&nodeEnvironment{n}, n.Runtime, consensus)
@@ -698,13 +703,13 @@ func NewNode(
 	n.services = service.NewGroup(notifier, lbNotifier, kmNotifier, n.roflNotifier)
 
 	// Prepare transaction pool.
-	n.TxPool = txpool.New(runtime.ID(), txPoolCfg, rhn.GetHostedRuntime(), runtime.History(), n)
+	n.TxPool = txpool.New(runtime.ID(), cfg.TxPool, rhn.GetHostedRuntime(), runtime.History(), n)
 
 	// Register transaction message handler as that is something that all workers must handle.
 	p2pHost.RegisterHandler(txTopic, &txMsgHandler{n})
 
 	// Register transaction sync service.
-	p2pHost.RegisterProtocolServer(txsync.NewServer(chainContext, runtime.ID(), n.TxPool))
+	p2pHost.RegisterProtocolServer(txsync.NewServer(cfg.ChainContext, runtime.ID(), n.TxPool))
 
 	return n, nil
 }

--- a/go/worker/common/worker.go
+++ b/go/worker/common/worker.go
@@ -146,17 +146,21 @@ func (w *Worker) registerRuntime(runtime runtimeRegistry.Runtime) error {
 		"runtime_id", id,
 	)
 
+	cfg := committee.Config{
+		ChainContext: w.ChainContext,
+		Identity:     w.Identity,
+		TxPool:       w.cfg.TxPool,
+	}
+
 	node, err := committee.NewNode(
-		w.ChainContext,
+		cfg,
 		runtime,
 		w.Provisioner,
 		w.RuntimeRegistry,
-		w.Identity,
 		w.KeyManager,
 		w.Consensus,
 		w.LightProvider,
 		w.P2P,
-		w.cfg.TxPool,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
**Trivial**.

First 3 commits were extracted from the https://github.com/oasisprotocol/oasis-core/pull/6474.

Since the https://github.com/oasisprotocol/oasis-core/pull/6474/changes/a2becf169a268ddeff934ac9fea6e60bf5493615 was scope creeping keymanager access policy I decided to do part of it here and simplify:
* Per component provisioner was overkill. Your node cannot be keymanager and compute at the same time, so you have one per-node provisioner, and policy provider.  This enables us to stop passing `willRegisterComputeRuntime` through layers once we add kma policy.
    * If/when this changes, e.g. we start passing ROFL policies for the local pre-validation, this can be implemented again.